### PR TITLE
Fix parsing error in parseNestedValues

### DIFF
--- a/packages/server/lib/util/args.coffee
+++ b/packages/server/lib/util/args.coffee
@@ -8,11 +8,13 @@ cwd      = require("../cwd")
 whitelist = "appPath execPath apiKey smokeTest getKey generateKey runProject project spec ci record updating ping key logs clearLogs returnPkg version mode autoOpen removeIds headed config exitWithCode hosts browser headless outputPath group groupId".split(" ")
 whitelist = whitelist.concat(config.getConfigKeys())
 
+everythingAfterFirstEqualRe = /=(.+)/
+
 # returns true if the given string has double quote character "
 # only at the last position.
 hasStrayEndQuote = (s) ->
   quoteAt = s.indexOf('"')
-  quoteAt == s.length - 1
+  quoteAt is s.length - 1
 
 removeLastCharacter = (s) ->
   s.substr(0, s.length - 1)
@@ -44,7 +46,7 @@ parseNestedValues = (vals) ->
   .chain(vals)
   .split(",")
   .map (pair) ->
-    pair.split(/=(.+)/)
+    pair.split(everythingAfterFirstEqualRe)
   .fromPairs()
   .mapValues(coerce)
   .value()

--- a/packages/server/lib/util/args.coffee
+++ b/packages/server/lib/util/args.coffee
@@ -44,7 +44,7 @@ parseNestedValues = (vals) ->
   .chain(vals)
   .split(",")
   .map (pair) ->
-    pair.split("=")
+    pair.split(/=(.+)/)
   .fromPairs()
   .mapValues(coerce)
   .value()

--- a/packages/server/test/integration/cypress_spec.coffee
+++ b/packages/server/test/integration/cypress_spec.coffee
@@ -686,13 +686,14 @@ describe "lib/cypress", ->
           "--run-project=#{@todosPath}",
           "--videoRecording=false"
           "--env",
-          "version=0.12.1,foo=bar,host=http://localhost:8888"
+          "version=0.12.1,foo=bar,host=http://localhost:8888,baz=quux=dolor"
         ])
         .then =>
           expect(openProject.getProject().cfg.environmentVariables).to.deep.eq({
             version: "0.12.1"
             foo: "bar"
             host: "http://localhost:8888"
+            baz: "quux=dolor"
           })
 
           @expectExitWith(0)

--- a/packages/server/test/unit/args_spec.coffee
+++ b/packages/server/test/unit/args_spec.coffee
@@ -42,11 +42,12 @@ describe "lib/util/args", ->
 
   context "--env", ->
     it "converts to object literal", ->
-      options = @setup("--env", "foo=bar,version=0.12.1,host=localhost:8888")
+      options = @setup("--env", "foo=bar,version=0.12.1,host=localhost:8888,bar=qux=")
       expect(options.environmentVariables).to.deep.eq({
         foo: "bar"
         version: "0.12.1"
         host: "localhost:8888"
+        bar: "qux="
       })
 
   context "--config", ->
@@ -78,7 +79,7 @@ describe "lib/util/args", ->
   context ".toObject", ->
     beforeEach ->
       ## make sure it works with both --env=foo=bar and --config foo=bar
-      @obj = @setup("--get-key", "--hosts=*.foobar.com=127.0.0.1", "--env=foo=bar,baz=quux", "--config", "requestTimeout=1234,responseTimeout=9876")
+      @obj = @setup("--get-key", "--hosts=*.foobar.com=127.0.0.1", "--env=foo=bar,baz=quux,bar=foo=quz", "--config", "requestTimeout=1234,responseTimeout=9876")
 
     it "coerces booleans", ->
       expect(@setup("--foo=true").foo).be.true
@@ -93,10 +94,11 @@ describe "lib/util/args", ->
         getKey: true
         _hosts: "*.foobar.com=127.0.0.1"
         hosts: {"*.foobar.com": "127.0.0.1"}
-        _environmentVariables: "foo=bar,baz=quux"
+        _environmentVariables: "foo=bar,baz=quux,bar=foo=quz"
         environmentVariables: {
           foo: "bar"
           baz: "quux"
+          bar: "foo=quz"
         }
         config: {
           requestTimeout: 1234
@@ -114,7 +116,7 @@ describe "lib/util/args", ->
         "--hosts=*.foobar.com=127.0.0.1"
         "--requestTimeout=1234"
         "--responseTimeout=9876"
-        "--environmentVariables=foo=bar,baz=quux"
+        "--environmentVariables=foo=bar,baz=quux,bar=foo=quz"
       ])
 
   context "--updating", ->


### PR DESCRIPTION
Hello,

This is a fix for https://github.com/cypress-io/cypress/issues/620. Instead of splittings pairs on all occurrences of the `=` character, we split on the first one only. This makes it possible values to contain equal signs.