### PR TITLE
Add context to UI log message such as x, y or position.

### DIFF
--- a/packages/driver/src/cy/commands/actions/scroll.coffee
+++ b/packages/driver/src/cy/commands/actions/scroll.coffee
@@ -223,8 +223,17 @@ module.exports = (Commands, Cypress, cy, state, config) ->
       if options.log
         deltaOptions = $utils.filterOutOptions(options, {duration: 0, easing: 'swing'})
 
+        messageArgs = []
+        if !position
+          messageArgs.push(x)
+          messageArgs.push(y)
+        else
+          messageArgs.push(position)
+        if deltaOptions
+          messageArgs.push($utils.stringify(deltaOptions))
+
         log = {
-          message: deltaOptions
+          message: messageArgs.join(', '),
           consoleProps: ->
             obj = {
               ## merge into consoleProps without mutating it

--- a/packages/driver/src/cy/commands/actions/scroll.coffee
+++ b/packages/driver/src/cy/commands/actions/scroll.coffee
@@ -235,7 +235,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
           messageArgs.push(deltaOptions)
 
         log = {
-          message: messageArgs.join(', '),
+          message: messageArgs.join(", "),
           consoleProps: ->
             ## merge into consoleProps without mutating it
             obj = {}

--- a/packages/driver/src/cy/commands/actions/scroll.coffee
+++ b/packages/driver/src/cy/commands/actions/scroll.coffee
@@ -221,7 +221,9 @@ module.exports = (Commands, Cypress, cy, state, config) ->
         $utils.throwErrByPath("scrollTo.invalid_target", {args: { x, y }})
 
       if options.log
-        deltaOptions = $utils.filterOutOptions(options, {duration: 0, easing: 'swing'})
+        deltaOptions = $utils.stringify(
+          $utils.filterOutOptions(options, {duration: 0, easing: 'swing'})
+        )
 
         messageArgs = []
         if !position
@@ -230,15 +232,23 @@ module.exports = (Commands, Cypress, cy, state, config) ->
         else
           messageArgs.push(position)
         if deltaOptions
-          messageArgs.push($utils.stringify(deltaOptions))
+          messageArgs.push(deltaOptions)
 
         log = {
           message: messageArgs.join(', '),
           consoleProps: ->
-            obj = {
-              ## merge into consoleProps without mutating it
-              "Scrolled Element": $dom.getElements(options.$el)
-            }
+            ## merge into consoleProps without mutating it
+            obj = {}
+
+            if position
+              obj.Position = position
+            else
+              obj.X = x
+              obj.Y = y
+            if deltaOptions
+              obj.Options = deltaOptions
+
+            obj["Scrolled Element"] = $dom.getElements(options.$el)
 
             return obj
         }

--- a/packages/driver/src/cy/commands/actions/scroll.coffee
+++ b/packages/driver/src/cy/commands/actions/scroll.coffee
@@ -226,11 +226,11 @@ module.exports = (Commands, Cypress, cy, state, config) ->
         )
 
         messageArgs = []
-        if !position
+        if position
+          messageArgs.push(position)
+        else
           messageArgs.push(x)
           messageArgs.push(y)
-        else
-          messageArgs.push(position)
         if deltaOptions
           messageArgs.push(deltaOptions)
 

--- a/packages/driver/test/cypress/integration/commands/actions/scroll_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/scroll_spec.coffee
@@ -423,13 +423,13 @@ describe "src/cy/commands/actions/scroll", ->
         cy.get("#scroll-to-both").scrollTo(25, { duration: 1 }).then ->
           lastLog = @lastLog
 
-          expect(lastLog.get("message")).to.eq "{duration: 1}"
+          expect(lastLog.get("message")).to.eq "25, 0, {duration: 1}"
 
       it "logs easing options", ->
         cy.get("#scroll-to-both").scrollTo(25, { easing: 'linear' }).then ->
           lastLog = @lastLog
 
-          expect(lastLog.get("message")).to.eq "{easing: linear}"
+          expect(lastLog.get("message")).to.eq "25, 0, {easing: linear}"
 
       it "snapshots immediately", ->
         cy.get("#scroll-to-both").scrollTo(25, { duration: 1 }).then ->
@@ -439,9 +439,12 @@ describe "src/cy/commands/actions/scroll", ->
           expect(lastLog.get("snapshots")[0]).to.be.an("object")
 
       it "#consoleProps", ->
-        cy.get("#scroll-to-both").scrollTo(25).then ($container) ->
+        cy.get("#scroll-to-both").scrollTo(25, {duration: 1}).then ($container) ->
           console = @lastLog.invoke("consoleProps")
           expect(console.Command).to.eq("scrollTo")
+          expect(console.X).to.eq(25)
+          expect(console.Y).to.eq(0)
+          expect(console.Options).to.eq('{duration: 1}')
           expect(console["Scrolled Element"]).to.eq $container.get(0)
 
   context "#scrollIntoView", ->

--- a/packages/driver/test/cypress/integration/commands/actions/scroll_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/scroll_spec.coffee
@@ -444,7 +444,7 @@ describe "src/cy/commands/actions/scroll", ->
           expect(console.Command).to.eq("scrollTo")
           expect(console.X).to.eq(25)
           expect(console.Y).to.eq(0)
-          expect(console.Options).to.eq('{duration: 1}')
+          expect(console.Options).to.eq("{duration: 1}")
           expect(console["Scrolled Element"]).to.eq $container.get(0)
 
   context "#scrollIntoView", ->


### PR DESCRIPTION
Addresses #725

The UI log for `scrollTo` was lacking context such as x, y or position. I added these to the log message by creating an array of message arguments that are then joined with `, `. If a user defines a position, we use the "friendly name" such as `center` or `bottom`. If a user defined x and y coordinates or scroll percentages then we will use that instead of `position`.

You can see the difference in the UI below.

Before:
[![https://gyazo.com/ec77f62ac1532a859363fd5ec9af9130](https://i.gyazo.com/ec77f62ac1532a859363fd5ec9af9130.png)](https://gyazo.com/ec77f62ac1532a859363fd5ec9af9130)
After:
[![https://gyazo.com/2c2ad7f336af101f673197a272e8eef8](https://i.gyazo.com/2c2ad7f336af101f673197a272e8eef8.png)](https://gyazo.com/2c2ad7f336af101f673197a272e8eef8)

I also added context to the console log:

[![https://gyazo.com/7317f47293387b531566d6082f79b73e](https://i.gyazo.com/7317f47293387b531566d6082f79b73e.png)](https://gyazo.com/7317f47293387b531566d6082f79b73e)

To reproduce this, run this PR against a test that uses scrollTo. I used the generated examples.