### PR TITLE
Add option to upload video on tests passing. Addresses #460

### DIFF
--- a/packages/server/lib/config.coffee
+++ b/packages/server/lib/config.coffee
@@ -17,7 +17,7 @@ cypressEnvRe = /^(cypress_)/i
 dashesOrUnderscoresRe = /^(_-)+/
 
 folders = "fileServerFolder videosFolder supportFolder fixturesFolder integrationFolder screenshotsFolder unitFolder supportFile".split(" ")
-configKeys = "port reporter reporterOptions baseUrl execTimeout defaultCommandTimeout pageLoadTimeout requestTimeout responseTimeout numTestsKeptInMemory screenshotOnHeadlessFailure waitForAnimations animationDistanceThreshold watchForFileChanges trashAssetsBeforeHeadlessRuns chromeWebSecurity videoRecording videoCompression uploadVideoOnlyOnFailure viewportWidth viewportHeight supportFile fileServerFolder supportFolder fixturesFolder integrationFolder videosFolder screenshotsFolder environmentVariables hosts".split(" ")
+configKeys = "port reporter reporterOptions baseUrl execTimeout defaultCommandTimeout pageLoadTimeout requestTimeout responseTimeout numTestsKeptInMemory screenshotOnHeadlessFailure waitForAnimations animationDistanceThreshold watchForFileChanges trashAssetsBeforeHeadlessRuns chromeWebSecurity videoRecording videoCompression videoUploadOnPassing viewportWidth viewportHeight supportFile fileServerFolder supportFolder fixturesFolder integrationFolder videosFolder screenshotsFolder environmentVariables hosts".split(" ")
 
 isCypressEnvLike = (key) ->
   cypressEnvRe.test(key) and key isnt "CYPRESS_ENV"
@@ -44,7 +44,7 @@ defaults = {
   execTimeout:                   60000
   videoRecording:                true
   videoCompression:              32
-  uploadVideoOnlyOnFailure:      false
+  videoUploadOnPassing:          true
   chromeWebSecurity:             true
   waitForAnimations:             true
   animationDistanceThreshold:    5
@@ -89,7 +89,7 @@ validationRules = {
   trashAssetsBeforeHeadlessRuns: v.isBoolean
   videoCompression: v.isNumberOrFalse
   videoRecording: v.isBoolean
-  uploadVideoOnlyOnFailure: v.isBoolean
+  videoUploadOnPassing: v.isBoolean
   videosFolder: v.isString
   viewportHeight: v.isNumber
   viewportWidth: v.isNumber

--- a/packages/server/lib/config.coffee
+++ b/packages/server/lib/config.coffee
@@ -17,7 +17,7 @@ cypressEnvRe = /^(cypress_)/i
 dashesOrUnderscoresRe = /^(_-)+/
 
 folders = "fileServerFolder videosFolder supportFolder fixturesFolder integrationFolder screenshotsFolder unitFolder supportFile".split(" ")
-configKeys = "port reporter reporterOptions baseUrl execTimeout defaultCommandTimeout pageLoadTimeout requestTimeout responseTimeout numTestsKeptInMemory screenshotOnHeadlessFailure waitForAnimations animationDistanceThreshold watchForFileChanges trashAssetsBeforeHeadlessRuns chromeWebSecurity videoRecording videoCompression viewportWidth viewportHeight supportFile fileServerFolder supportFolder fixturesFolder integrationFolder videosFolder screenshotsFolder environmentVariables hosts".split(" ")
+configKeys = "port reporter reporterOptions baseUrl execTimeout defaultCommandTimeout pageLoadTimeout requestTimeout responseTimeout numTestsKeptInMemory screenshotOnHeadlessFailure waitForAnimations animationDistanceThreshold watchForFileChanges trashAssetsBeforeHeadlessRuns chromeWebSecurity videoRecording videoCompression uploadVideoOnlyOnFailure viewportWidth viewportHeight supportFile fileServerFolder supportFolder fixturesFolder integrationFolder videosFolder screenshotsFolder environmentVariables hosts".split(" ")
 
 isCypressEnvLike = (key) ->
   cypressEnvRe.test(key) and key isnt "CYPRESS_ENV"
@@ -44,6 +44,7 @@ defaults = {
   execTimeout:                   60000
   videoRecording:                true
   videoCompression:              32
+  uploadVideoOnlyOnFailure:      false
   chromeWebSecurity:             true
   waitForAnimations:             true
   animationDistanceThreshold:    5
@@ -88,6 +89,7 @@ validationRules = {
   trashAssetsBeforeHeadlessRuns: v.isBoolean
   videoCompression: v.isNumberOrFalse
   videoRecording: v.isBoolean
+  uploadVideoOnlyOnFailure: v.isBoolean
   videosFolder: v.isString
   viewportHeight: v.isNumber
   viewportWidth: v.isNumber

--- a/packages/server/lib/modes/headless.coffee
+++ b/packages/server/lib/modes/headless.coffee
@@ -151,13 +151,13 @@ module.exports = {
     screenshots.forEach (screenshot) ->
       console.log(format(screenshot))
 
-  postProcessRecording: (end, name, cname, videoCompression, uploadVideoOnlyOnFailure, isFailure) ->
+  postProcessRecording: (end, name, cname, videoCompression, videoUploadOnPassing, isFailure) ->
     ## once this ended promises resolves
     ## then begin processing the file
     end()
     .then ->
       ## dont process anything if videoCompress is off
-      return if videoCompression is false or (uploadVideoOnlyOnFailure is true and isFailure is false)
+      return if videoCompression is false or (videoUploadOnPassing is false and isFailure is false)
 
       console.log("")
       console.log("")
@@ -299,7 +299,7 @@ module.exports = {
       project.on "socket:connected", fn
 
   waitForTestsToFinishRunning: (options = {}) ->
-    { project, headed, screenshots, started, end, name, cname, videoCompression, uploadVideoOnlyOnFailure, outputPath } = options
+    { project, headed, screenshots, started, end, name, cname, videoCompression, videoUploadOnPassing, outputPath } = options
 
     @listenForProjectEnd(project, headed)
     .then (obj) =>
@@ -347,7 +347,7 @@ module.exports = {
       openProject.closeBrowser()
       .then =>
         if end
-          @postProcessRecording(end, name, cname, videoCompression, uploadVideoOnlyOnFailure, !!isFailure)
+          @postProcessRecording(end, name, cname, videoCompression, videoUploadOnPassing, !!isFailure)
           .then(finish)
           ## TODO: add a catch here
         else
@@ -457,11 +457,11 @@ module.exports = {
       .then (started) =>
         Promise.props({
           stats:      @waitForTestsToFinishRunning({
-            headed:                   options.headed
-            project:                  options.project
-            videoCompression:         options.videoCompression
-            uploadVideoOnlyOnFailure: options.uploadVideoOnlyOnFailure
-            outputPath:               options.outputPath
+            headed:               options.headed
+            project:              options.project
+            videoCompression:     options.videoCompression
+            videoUploadOnPassing: options.videoUploadOnPassing
+            outputPath:           options.outputPath
             end
             name
             cname
@@ -511,16 +511,16 @@ module.exports = {
           @trashAssets(config)
           .then =>
             @runTests({
-              id:                       id
-              project:                  project
-              videosFolder:             config.videosFolder
-              videoRecording:           config.videoRecording
-              videoCompression:         config.videoCompression
-              uploadVideoOnlyOnFailure: config.uploadVideoOnlyOnFailure
-              spec:                     options.spec
-              headed:                   options.headed
-              browser:                  options.browser
-              outputPath:               options.outputPath
+              id:                   id
+              project:              project
+              videosFolder:         config.videosFolder
+              videoRecording:       config.videoRecording
+              videoCompression:     config.videoCompression
+              videoUploadOnPassing: config.videoUploadOnPassing
+              spec:                 options.spec
+              headed:               options.headed
+              browser:              options.browser
+              outputPath:           options.outputPath
             })
           .get("stats")
           .finally =>

--- a/packages/server/lib/modes/record.coffee
+++ b/packages/server/lib/modes/record.coffee
@@ -169,7 +169,7 @@ module.exports = {
     .then (resp = {}) =>
       @upload({
         video:          stats.video
-        uploadVideo:    !stats.config.uploadVideoOnlyOnFailure or stats.failures
+        uploadVideo:    stats.config.videoUploadOnPassing or stats.failures != 0
         screenshots:    stats.screenshots
         videoUrl:       resp.videoUploadUrl
         screenshotUrls: resp.screenshotUploadUrls

--- a/packages/server/lib/modes/record.coffee
+++ b/packages/server/lib/modes/record.coffee
@@ -95,7 +95,7 @@ module.exports = {
         null
 
   upload: (options = {}) ->
-    {video, screenshots, videoUrl, screenshotUrls} = options
+    {video, uploadVideo, screenshots, videoUrl, screenshotUrls} = options
 
     uploads = []
     count   = 0
@@ -118,7 +118,7 @@ module.exports = {
         .catch(fail)
       )
 
-    if videoUrl
+    if videoUrl and uploadVideo
       send(video, videoUrl)
 
     if screenshotUrls
@@ -169,6 +169,7 @@ module.exports = {
     .then (resp = {}) =>
       @upload({
         video:          stats.video
+        uploadVideo:    !stats.config.uploadVideoOnlyOnFailure or stats.failures
         screenshots:    stats.screenshots
         videoUrl:       resp.videoUploadUrl
         screenshotUrls: resp.screenshotUploadUrls

--- a/packages/server/test/unit/config_spec.coffee
+++ b/packages/server/test/unit/config_spec.coffee
@@ -306,6 +306,15 @@ describe "lib/config", ->
           @setup({videoRecording: 42})
           @expectValidationFails("be a boolean")
 
+      context "uploadVideoOnlyOnFailure", ->
+        it "passes if a boolean", ->
+          @setup({uploadVideoOnlyOnFailure: false})
+          @expectValidationPasses()
+
+        it "fails if not a boolean", ->
+          @setup({uploadVideoOnlyOnFailure: 99})
+          @expectValidationFails("be a boolean")
+
       context "videosFolder", ->
         it "passes if a string", ->
           @setup({videosFolder: "_videos"})
@@ -480,6 +489,9 @@ describe "lib/config", ->
     it "videoCompression=32", ->
       @defaults "videoCompression", 32
 
+    it "uploadVideoOnlyOnFailure=false", ->
+      @defaults "uploadVideoOnlyOnFailure", false
+
     it "trashAssetsBeforeHeadlessRuns=32", ->
       @defaults "trashAssetsBeforeHeadlessRuns", true
 
@@ -617,6 +629,7 @@ describe "lib/config", ->
             fileServerFolder:           { value: "", from: "default" },
             videoRecording:             { value: true, from: "default" }
             videoCompression:           { value: 32, from: "default" }
+            uploadVideoOnlyOnFailure:   { value: false, from: "default" }
             videosFolder:               { value: "cypress/videos", from: "default" },
             supportFile:                { value: "cypress/support", from: "default" },
             fixturesFolder:             { value: "cypress/fixtures", from: "default" },
@@ -670,6 +683,7 @@ describe "lib/config", ->
             fileServerFolder:           { value: "", from: "default" },
             videoRecording:             { value: true, from: "default" }
             videoCompression:           { value: 32, from: "default" }
+            uploadVideoOnlyOnFailure:   { value: false, from: "default" }
             videosFolder:               { value: "cypress/videos", from: "default" },
             supportFile:                { value: "cypress/support", from: "default" },
             fixturesFolder:             { value: "cypress/fixtures", from: "default" },

--- a/packages/server/test/unit/config_spec.coffee
+++ b/packages/server/test/unit/config_spec.coffee
@@ -306,13 +306,13 @@ describe "lib/config", ->
           @setup({videoRecording: 42})
           @expectValidationFails("be a boolean")
 
-      context "uploadVideoOnlyOnFailure", ->
+      context "videoUploadOnPassing", ->
         it "passes if a boolean", ->
-          @setup({uploadVideoOnlyOnFailure: false})
+          @setup({videoUploadOnPassing: false})
           @expectValidationPasses()
 
         it "fails if not a boolean", ->
-          @setup({uploadVideoOnlyOnFailure: 99})
+          @setup({videoUploadOnPassing: 99})
           @expectValidationFails("be a boolean")
 
       context "videosFolder", ->
@@ -489,8 +489,8 @@ describe "lib/config", ->
     it "videoCompression=32", ->
       @defaults "videoCompression", 32
 
-    it "uploadVideoOnlyOnFailure=false", ->
-      @defaults "uploadVideoOnlyOnFailure", false
+    it "videoUploadOnPassing=true", ->
+      @defaults "videoUploadOnPassing", true
 
     it "trashAssetsBeforeHeadlessRuns=32", ->
       @defaults "trashAssetsBeforeHeadlessRuns", true
@@ -629,7 +629,7 @@ describe "lib/config", ->
             fileServerFolder:           { value: "", from: "default" },
             videoRecording:             { value: true, from: "default" }
             videoCompression:           { value: 32, from: "default" }
-            uploadVideoOnlyOnFailure:   { value: false, from: "default" }
+            videoUploadOnPassing:       { value: true, from: "default" }
             videosFolder:               { value: "cypress/videos", from: "default" },
             supportFile:                { value: "cypress/support", from: "default" },
             fixturesFolder:             { value: "cypress/fixtures", from: "default" },
@@ -683,7 +683,7 @@ describe "lib/config", ->
             fileServerFolder:           { value: "", from: "default" },
             videoRecording:             { value: true, from: "default" }
             videoCompression:           { value: 32, from: "default" }
-            uploadVideoOnlyOnFailure:   { value: false, from: "default" }
+            videoUploadOnPassing:       { value: true, from: "default" }
             videosFolder:               { value: "cypress/videos", from: "default" },
             supportFile:                { value: "cypress/support", from: "default" },
             fixturesFolder:             { value: "cypress/fixtures", from: "default" },

--- a/packages/server/test/unit/modes/headless_spec.coffee
+++ b/packages/server/test/unit/modes/headless_spec.coffee
@@ -159,28 +159,28 @@ describe "lib/modes/headless", ->
     it "calls video process with name, cname and videoCompression", ->
       end = -> Promise.resolve()
 
-      headless.postProcessRecording(end, "foo", "foo-compress", 32, false, false)
+      headless.postProcessRecording(end, "foo", "foo-compress", 32, true, false)
       .then ->
         expect(video.process).to.be.calledWith("foo", "foo-compress", 32)
 
     it "does not call video process when videoCompression is false", ->
       end = -> Promise.resolve()
 
-      headless.postProcessRecording(end, "foo", "foo-compress", false, false, false)
+      headless.postProcessRecording(end, "foo", "foo-compress", false, true, false)
       .then ->
         expect(video.process).not.to.be.called
 
-    it "calls video process if there are failing tests and we have set to only upload videos if tests fail", ->
+    it "calls video process if there are failing tests and we have set not to upload video on passing", ->
       end = -> Promise.resolve()
 
-      headless.postProcessRecording(end, "foo", "foo-compress", 32, true, true)
+      headless.postProcessRecording(end, "foo", "foo-compress", 32, false, true)
       .then ->
         expect(video.process).to.be.calledWith("foo", "foo-compress", 32)
 
-    it "does not call video process if there are no failing tests and we have set to only upload videos if tests fail", ->
+    it "does not call video process if there are no failing tests and we have set not to upload video on passing", ->
       end = -> Promise.resolve()
 
-      headless.postProcessRecording(end, "foo", "foo-compress", false, true, false)
+      headless.postProcessRecording(end, "foo", "foo-compress", false, false, false)
       .then ->
         expect(video.process).not.to.be.called
 
@@ -281,14 +281,14 @@ describe "lib/modes/headless", ->
         name: "foo.mp4"
         cname: "foo-compressed.mp4"
         videoCompression: 32
-        uploadVideoOnlyOnFailure: false
+        videoUploadOnPassing: true
         gui: false
         screenshots
         started
         end
       })
       .then (obj) ->
-        expect(headless.postProcessRecording).to.be.calledWith(end, "foo.mp4", "foo-compressed.mp4", 32, false, true)
+        expect(headless.postProcessRecording).to.be.calledWith(end, "foo.mp4", "foo-compressed.mp4", 32, true, true)
 
         results = headless.collectTestResults(obj)
         expect(headless.displayStats).to.be.calledWith(results)
@@ -326,14 +326,14 @@ describe "lib/modes/headless", ->
         name: "foo.mp4"
         cname: "foo-compressed.mp4"
         videoCompression: 32
-        uploadVideoOnlyOnFailure: false
+        videoUploadOnPassing: true
         gui: false
         screenshots
         started
         end
       })
       .then (obj) ->
-        expect(headless.postProcessRecording).to.be.calledWith(end, "foo.mp4", "foo-compressed.mp4", 32, false, true)
+        expect(headless.postProcessRecording).to.be.calledWith(end, "foo.mp4", "foo-compressed.mp4", 32, true, true)
 
         results = headless.collectTestResults(obj)
         expect(headless.displayStats).to.be.calledWith(results)

--- a/packages/server/test/unit/modes/headless_spec.coffee
+++ b/packages/server/test/unit/modes/headless_spec.coffee
@@ -159,14 +159,28 @@ describe "lib/modes/headless", ->
     it "calls video process with name, cname and videoCompression", ->
       end = -> Promise.resolve()
 
-      headless.postProcessRecording(end, "foo", "foo-compress", 32)
+      headless.postProcessRecording(end, "foo", "foo-compress", 32, false, false)
       .then ->
         expect(video.process).to.be.calledWith("foo", "foo-compress", 32)
 
     it "does not call video process when videoCompression is false", ->
       end = -> Promise.resolve()
 
-      headless.postProcessRecording(end, "foo", "foo-compress", false)
+      headless.postProcessRecording(end, "foo", "foo-compress", false, false, false)
+      .then ->
+        expect(video.process).not.to.be.called
+
+    it "calls video process if there are failing tests and we have set to only upload videos if tests fail", ->
+      end = -> Promise.resolve()
+
+      headless.postProcessRecording(end, "foo", "foo-compress", 32, true, true)
+      .then ->
+        expect(video.process).to.be.calledWith("foo", "foo-compress", 32)
+
+    it "does not call video process if there are no failing tests and we have set to only upload videos if tests fail", ->
+      end = -> Promise.resolve()
+
+      headless.postProcessRecording(end, "foo", "foo-compress", false, true, false)
       .then ->
         expect(video.process).not.to.be.called
 
@@ -267,13 +281,14 @@ describe "lib/modes/headless", ->
         name: "foo.mp4"
         cname: "foo-compressed.mp4"
         videoCompression: 32
+        uploadVideoOnlyOnFailure: false
         gui: false
         screenshots
         started
         end
       })
       .then (obj) ->
-        expect(headless.postProcessRecording).to.be.calledWith(end, "foo.mp4", "foo-compressed.mp4", 32)
+        expect(headless.postProcessRecording).to.be.calledWith(end, "foo.mp4", "foo-compressed.mp4", 32, false, true)
 
         results = headless.collectTestResults(obj)
         expect(headless.displayStats).to.be.calledWith(results)
@@ -311,13 +326,14 @@ describe "lib/modes/headless", ->
         name: "foo.mp4"
         cname: "foo-compressed.mp4"
         videoCompression: 32
+        uploadVideoOnlyOnFailure: false
         gui: false
         screenshots
         started
         end
       })
       .then (obj) ->
-        expect(headless.postProcessRecording).to.be.calledWith(end, "foo.mp4", "foo-compressed.mp4", 32)
+        expect(headless.postProcessRecording).to.be.calledWith(end, "foo.mp4", "foo-compressed.mp4", 32, false, true)
 
         results = headless.collectTestResults(obj)
         expect(headless.displayStats).to.be.calledWith(results)

--- a/packages/server/test/unit/modes/record_spec.coffee
+++ b/packages/server/test/unit/modes/record_spec.coffee
@@ -252,6 +252,7 @@ describe "lib/modes/record", ->
             name: "foo"
             path: "path/to/screenshot"
           }]
+          uploadVideo: true
           videoUrl: resp.videoUploadUrl
           screenshotUrls: resp.screenshotUploadUrls
         })


### PR DESCRIPTION
Compressing and uploading a video to the dashboard is an expensive operation. If there have been no failures, we are not usually interested in the video as it will reveal nothing interesting, so it makes sense that we may want the video to only be compressed and uploaded if there have been any failures.

This PR adds a new `uploadVideoOnlyOnFailure` config setting that if set to true will disable compressing and uploading the video unless there have been some failures. It defaults to `false` to keep the current functionality.

Includes unit tests for the new functionality. I did not add any integration tests for the upload feature because I saw this comment in the code:

```
## TODO: add tests around uploadingAssets + upload
```

so it seems that there are no tests for this capability yet