### PR TITLE
fixes stack overflow, for angular 4 apps

### DIFF
--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -30,6 +30,7 @@
     "chai": "3.5.0",
     "chai-as-promised": "6.0.0",
     "chokidar-cli": "^1.2.0",
+    "clone": "^2.1.1",
     "compression": "^1.1.0",
     "cors": "^2.7.1",
     "debug": "^2.6.8",
@@ -54,6 +55,7 @@
     "sinon": "3.2.0",
     "underscore": "^1.8.3",
     "underscore.string": "3.3.4",
-    "url-parse": "^1.1.7"
+    "url-parse": "^1.1.7",
+    "zone.js": "^0.8.18"
   }
 }

--- a/packages/driver/src/cypress/log.coffee
+++ b/packages/driver/src/cypress/log.coffee
@@ -15,7 +15,7 @@ parentOrChildRe = /parent|child/
 ERROR_PROPS     = "message type name stack fileName lineNumber columnNumber host uncaught actual expected showDiff".split(" ")
 SNAPSHOT_PROPS  = "id snapshots $el url coords highlightAttr scrollBy viewportWidth viewportHeight".split(" ")
 DISPLAY_PROPS   = "id alias aliasType callCount displayName end err event functionName hookName instrument isStubbed message method name numElements numResponses referencesAlias renderProps state testId type url visible".split(" ")
-BLACKLIST_PROPS = "snapshots zone".split(" ").map((key) -> new RegExp(key))
+BLACKLIST_PROPS = "snapshots".split(" ")
 
 delay = null
 counter = 0
@@ -36,7 +36,7 @@ toSerializedJSON = (attrs) ->
   isElement  = $dom.isElement
 
   stringify = (value, key) ->
-    return null if BLACKLIST_PROPS.some((r) -> r.test(key))
+    return null if key in BLACKLIST_PROPS
 
     switch
       when _.isArray(value)

--- a/packages/driver/src/cypress/log.coffee
+++ b/packages/driver/src/cypress/log.coffee
@@ -14,7 +14,7 @@ parentOrChildRe = /parent|child/
 ERROR_PROPS     = "message type name stack fileName lineNumber columnNumber host uncaught actual expected showDiff".split(" ")
 SNAPSHOT_PROPS  = "id snapshots $el url coords highlightAttr scrollBy viewportWidth viewportHeight".split(" ")
 DISPLAY_PROPS   = "id alias aliasType callCount displayName end err event functionName hookName instrument isStubbed message method name numElements numResponses referencesAlias renderProps state testId type url visible".split(" ")
-BLACKLIST_PROPS = "snapshots".split(" ")
+BLACKLIST_PROPS = "snapshots zone".split(" ").map((key) -> new RegExp(key))
 
 delay = null
 counter = 0
@@ -35,7 +35,7 @@ toSerializedJSON = (attrs) ->
   isElement  = $dom.isElement
 
   stringify = (value, key) ->
-    return null if key in BLACKLIST_PROPS
+    return null if BLACKLIST_PROPS.some((r) -> r.test(key))
 
     switch
       when _.isArray(value)

--- a/packages/driver/src/cypress/log.coffee
+++ b/packages/driver/src/cypress/log.coffee
@@ -1,5 +1,6 @@
 _ = require("lodash")
 $ = require("jquery")
+clone = require("clone")
 
 $Snapshots = require("../cy/snapshots")
 $Events = require("./events")
@@ -51,7 +52,12 @@ toSerializedJSON = (attrs) ->
         value.toString()
 
       when _.isObject(value)
-        _.mapValues(value, stringify)
+        ## clone to nuke circular references
+        ## and blow away anything that throws
+        try
+          _.mapValues(clone(value), stringify)
+        catch err
+          null
 
       else
         value

--- a/packages/driver/test/cypress/fixtures/zonejs.html
+++ b/packages/driver/test/cypress/fixtures/zonejs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Zone.js</title>
+</head>
+<body>
+  <div id="react-container"></div>
+  <script src="/node_modules/zone.js/dist/zone.js"></script>
+</body>

--- a/packages/driver/test/cypress/integration/e2e/zonejs_spec.coffee
+++ b/packages/driver/test/cypress/integration/e2e/zonejs_spec.coffee
@@ -1,0 +1,18 @@
+## https://github.com/cypress-io/cypress/issues/741
+describe "zone.js", ->
+  it "can serialize XHRs without blowing out the stack", ->
+    cy
+    .visit("/fixtures/zonejs.html")
+    .window().then (win) ->
+      new Promise (resolve, reject) ->
+        xhr = new win.XMLHttpRequest()
+
+        xhr.open("HEAD", "/")
+        xhr.send()
+
+        xhr.onload = ->
+          try
+            Cypress.Log.toSerializedJSON(xhr)
+            resolve()
+          catch err
+            reject(err)


### PR DESCRIPTION
zone js messing around with xsh requests, and creates circular dependencies, this causes stack overflow when cypress trying to stringily such objects, I just added additional stop word, to break this cycle 