### PR TITLE
#763 driver contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,27 @@ Thanks for taking the time to contribute! :smile:
 - [Request features](https://github.com/cypress-io/cypress/issues/new) by opening an issue.
 - Write Code for one of our core packages. [Please thoroughly read our writing code guide](#writing-code).
 
+## Table of Contents
+
+- [CI Status](#ci-status)
+- [Code of Conduct](#code-of-conduct)
+- [Contributing Bug Reports & Feature Requests](#contributing-bug-reports--feature-requests)
+  - [Bug Reports](#bug-reports)
+  - [Feature Requests](#feature-requests)
+- [Writing Code](#writing-code)
+  - [What you need to know before getting started](#what-you-need-to-know-before-getting-started)
+  - [Requirements](#requirements)
+  - [Getting Started](#getting-started)
+  - [Coding Style](#coding-style)
+  - [Tests](#tests)
+  - [Working in a specific package](#packages)
+    - [Desktop-Gui](#desktop-gui)
+    - [Driver](#driver)
+- [Writing Documentation](#writing-documentation)
+- [Committing Code](#committing-code)
+  - [Pull Requests](#pull-requests)
+- [Deployment](#deployment)
+
 ## CI status
 
 Build status | Description
@@ -28,24 +49,6 @@ Build status | Description
 [![CircleCI](https://circleci.com/gh/cypress-io/docsearch-scraper.svg?style=svg&circle-token=8087137233788ec1eab4f79d4451392ca53183b2)](https://circleci.com/gh/cypress-io/docsearch-scraper) | [docsearch-scraper](https://github.com/cypress-io/docsearch-scraper)
 [![Docker Build Status](https://img.shields.io/docker/build/cypress/base.svg)](https://hub.docker.com/r/cypress/base/) | [cypress-docker-images](https://github.com/cypress-io/cypress-docker-images)
 [![Build status](https://ci.appveyor.com/api/projects/status/ln8tg3dv42nk916c?svg=true)](https://ci.appveyor.com/project/cypress-io/cypress) | Windows CI
-
-## Table of Contents
-
-- [Code of Conduct](#code-of-conduct)
-- [Contributing Bug Reports & Feature Requests](#contributing-bug-reports--feature-requests)
-  - [Bug Reports](#bug-reports)
-  - [Feature Requests](#feature-requests)
-- [Writing Code](#writing-code)
-  - [What you need to know before getting started](#what-you-need-to-know-before-getting-started)
-  - [Requirements](#requirements)
-  - [Getting Started](#getting-started)
-  - [Coding Style](#coding-style)
-  - [Tests](#tests)
-  - [Packages](#packages)
-- [Writing Documentation](#writing-documentation)
-- [Committing Code](#committing-code)
-  - [Pull Requests](#pull-requests)
-- [Deployment](#deployment)
 
 ## Code of Conduct
 
@@ -110,9 +113,9 @@ Have a feature you'd like to see in Cypress? This describes how to file an effec
 - Align your expectations around timelines and priorities
 - Describe your problem, not your solution
 
-### Understand our Roadmap
+### Understand our roadmap
 
-We have a cohesive vision for Cypress in the long term and a general roadmap that extends into the future. While the specifics of how we get there are flexible, many milestones are well-established.
+We have a cohesive vision for Cypress in the long term and a general [roadmap](https://on.cypress.io/roadmap) that extends into the future. While the specifics of how we get there are flexible, many milestones are well-established.
 
 Feature requests are an important part of what we plan in our roadmap, but we ultimately build only features which make sense as part of the long term plan.
 
@@ -166,9 +169,11 @@ Here is a list of the core packages in this repository with a short description,
 [static]() | Serves static assets used in the Cypress GUI.
 [ts]() | A centralized version of typescript.
 
+We try to tag all issues with a `pkg/` tag describing the appropriate package the work is required in. For example, the [`pkg/driver`](https://github.com/cypress-io/cypress/labels/pkg%2Fdriver) label is tagged on issues that require work in the `driver` package.
+
 ### Requirements
 
-You must have [`node`](https://nodejs.org/en/) and [`npm`](https://www.npmjs.com/) installed to run the project. We use [avn](https://github.com/wbyoung/avn) utility to switch to the right version in each folder. Currently, Cypress should be developed using the version specified in root [.node-version](.node-version) file.
+You must have [`node`](https://nodejs.org/en/) and [`npm`](https://www.npmjs.com/) installed to run the project. We use [avn](https://github.com/wbyoung/avn), a utility to switch to the right npm version, in each folder. Currently, Cypress should be developed using the version specified in root [.node-version](.node-version) file.
 
 ### Getting Started
 
@@ -199,16 +204,15 @@ Each package is responsible for building itself and testing itself and can do so
 Task | Purpose
 ---- | -------
 `build` | Build the package
-`build-dev` | Build all assets for development (if makes sense)
 `build-prod` | Build all assets for production (if makes sense)
-`watch-dev` | Watch source files and build development assets when they are saved. This may also run a server for serving files and run tests related to a saved file.
 `start` | Run a server for serving files
 `clean` | Remove any assets created by `build-dev` or `build-prod`
-`clean-deps` | Remove any dependencies installed (usually by npm or bower)
+`clean-deps` | Remove any dependencies installed (usually by `npm`)
 `test` | Runs all tests once
 `test-watch` | Run all tests in watch mode
+`watch` | Watch source files and build development assets when they are saved. This may also run a server for serving files and run tests related to a saved file.
 
-Not every package requires or makes use of every script, so it is simply omitted from that package's `package.json` and not run. For most packages, there are unit, integration and e2e tests, which can be triggered by `npm run test-unit`, `npm run test-integration` and `npm run test-e2e` respectively.
+Not every package requires or makes use of every script, so it is simply omitted from that package's `package.json` and not run.
 
 You can run `npm run all <script name>` from the root directory to run a script in every package that utilizes that script. Many times, you may only be working on one or two packages at a time, so it won't be necessary or desirable to run a script for every package. You can use the `--packages` option to specify in which package(s) to run the script.
 
@@ -268,13 +272,11 @@ We use [eslint](https://eslint.org/) to lint all JavaScript code and follow rule
 
 ### Tests
 
-TODO: switch this from saying to run all the tests, and instead run the test for a given package.
+ For most packages, there are unit, integration and e2e tests, which can be triggered by `npm run test-unit`, `npm run test-integration` and `npm run test-e2e` respectively.
 
-Our true e2e tests are in packages/server, which test the full stack all together. To run those - do XYZ.
+Our true e2e tests are in `packages/server`, which test the full stack all together.
 
-Mention difference in packages for unit, integration, and e2e tests.
-
-Make a note these are really long, and we spin up like 16 instances to do it all.
+The best source of truth in figuring out how to run tests for each package is our [`circle.yml`](.circle.yml) file found in the root `cypress` directory. The tasks defined in our [`circle.yml`](.circle.yml) are all run before anything is deployed.
 
 Since it is generally best to do single runs of tests serially instead of in parallel, this repo has some convenience scripts to run all the tests for all the packages sequentially:
 
@@ -294,11 +296,10 @@ have pulled the image `cypress/internal:chrome61` (see
 [circle.yml](circle.yml) for the current image name).
 
 The image will start and will map the root of the repository to
-`/cypress-monorepo` inside the image. Now you can modify the files using your
+`/cypress` inside the image. Now you can modify the files using your
 favorite environment and rerun tests inside the docker environment.
 
-**hint** sometimes building inside the image has problems with `node-sass`
-library
+**hint** sometimes building inside the image has problems with `node-sass` library
 
 ```text
 Error: Missing binding /cypress-monorepo/packages/desktop-gui/node_modules/node-sass/vendor/linux-x64-48/binding.node
@@ -319,15 +320,40 @@ cd packages/desktop-gui
 npm rebuild node-sass
 ```
 
-### Packages
+### Working in a specific package
 
 #### Desktop-Gui
 
-##### Connecting to the API
+##### Developing
 
 Currently, if you want to work on the code around logging in, viewing runs, and setting up new projects to record, this requires connecting to a locally running API server.
 
 Our API server is only accessible to cypress employees at the moment. If you want to work with the code, we recommend working within the Cypress tests for the Desktop-Gui. There are lots of tests mocking our API server around logging in, seeing runs, and setting up projects.
+
+#### Driver
+
+##### Developing
+
+It should be noted that for developing in the `driver`, you need to watch the files using one of the following methods:
+
+- In the `cypress` root directory run `npm run watch`: This will run the watch task for all packages that have one.
+- In the `cypress/packages/runner` directory run `npm run watch`: This will run the watch task for the runner, which bundles the driver.
+
+##### Testing
+
+###### From the Cypress Test Runner:
+
+- In the `cypress` root directory, run `npm install` & `npm start`.
+- When the Cypress Test Runner opens, manually add the directory `cypress/packages/driver/test`.
+- In the `cypress/packages/driver` directory, run `npm start`.
+- Click into the `test` directory from the Cypress Test Runner.
+- Select any test file you want to run.
+
+###### From the terminal:
+
+- In the `cypress` directory: run `npm install`.
+- In the `cypress/packages/driver` directory, run `npm start` & `npm run test-integration`.
+- The Cypress Test Runner should spawn and run through each test file individually.
 
 
 ## Writing Documentation
@@ -347,7 +373,7 @@ The repository is setup with two main (protected) branches.
 ### Pull Requests
 
 - When opening a PR for a specific issue already open, please use the `address #[issue number]` or `closes #[issue number]` syntax in the pull request description.
-- Please check the "Allow edits from maintainers" checkbox when submitting your PR. This will make it easier for the maintainers to make minor adjustments, to help with tests or any other changes we may need. 
+- Please check the "Allow edits from maintainers" checkbox when submitting your PR. This will make it easier for the maintainers to make minor adjustments, to help with tests or any other changes we may need.
 ![Allow edits from maintainers checkbox](https://user-images.githubusercontent.com/1271181/31393427-b3105d44-ada9-11e7-80f2-0dac51e3919e.png)
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -8,40 +8,40 @@
 </p>
 
 <h3 align="center">
-  Automated testing for the modern web
+  The web has evolved. Finally, testing has too.
 </h3>
 
 <p align="center">
-  Cypress is a next generation testing tool that helps developers write tests while building apps.
+  Fast, easy and reliable testing for anything that runs in a browser.
 </p>
 
-Build status | Description
-:--- | :---
-[![CircleCI](https://circleci.com/gh/cypress-io/cypress/tree/develop.svg?style=svg)](https://circleci.com/gh/cypress-io/cypress/tree/develop) | `develop` branch
+<p align="center">
+  [![npm](https://img.shields.io/npm/dm/cypress.svg)]()
+  [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/cypress-io/cypress)
 
-# Cypress
+</p>
 
-This is the Cypress monorepo, containing all packages that make up the Cypress app. See [Issue #256](https://github.com/cypress-io/cypress/issues/256) for details.
+<iframe src="https://player.vimeo.com/video/237527670" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
-This monorepo is made up of various packages, all of which are found under the `packages` directory. They are discrete modules with different responsibilities, but each is necessary for the Cypress app and is not necessarily useful outside of the Cypress app.
+## Installing
 
-Some, like `https-proxy` and `launcher`, run solely in node and support the Cypress server. Others, like `desktop-gui` and `runner`, create the GUI parts of the Cypress app. All packages can require each other using `const server = require('@packages/server')` syntax.
+[![npm version](https://badge.fury.io/js/cypress.svg)](https://badge.fury.io/js/cypress)
 
-## Documentation
+Please follow our [Installation Instructions](https://on.cypress.io/installing-cypress).
 
-- [Main Docs](https://on.cypress.io)
-- [Roadmap](https://on.cypress.io/roadmap)
-- [Changelog](https://on.cypress.io/changelog)
+## Contributing
 
-## Development
+ [![CircleCI](https://circleci.com/gh/cypress-io/cypress/tree/develop.svg?style=svg)](https://circleci.com/gh/cypress-io/cypress/tree/develop) - `develop` branch
 
 Please see our [Contributing Guideline](/CONTRIBUTING.md) which explains repo organization, linting, testing, and other steps.
 
 ## Deployment
 
-Please see our [deployment document](DEPLOY.md).
+Please see our [Deployment Document](DEPLOY.md).
 
 ## License
+
+[![license](https://img.shields.io/github/license/cypress-io/cypress.svg)](https://github.com/cypress-io/cypress/blob/master/LICENSE)
 
 This project is licensed under the terms of the [MIT license](/LICENSE.md).
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+<p align="center">
+  <img src="https://cloud.githubusercontent.com/assets/1268976/20607953/d7ae489c-b24a-11e6-9cc4-91c6c74c5e88.png"/>
+</p>
+<p align="center">
+  <a href="https://on.cypress.io">Documentation</a> |
+  <a href="https://on.cypress.io/changelog">Changelog</a> |
+  <a href="https://github.com/cypress-io/cypress/projects">Roadmap</a>
+</p>
+
+<h3 align="center">
+  Automated testing for the modern web
+</h3>
+
+<p align="center">
+  Cypress is a next generation testing tool that helps developers write tests while building apps.
+</p>
+
 Build status | Description
 :--- | :---
 [![CircleCI](https://circleci.com/gh/cypress-io/cypress/tree/develop.svg?style=svg)](https://circleci.com/gh/cypress-io/cypress/tree/develop) | `develop` branch

--- a/circle.yml
+++ b/circle.yml
@@ -188,7 +188,6 @@ jobs:
       - run: npm run test-mocha-snapshot
       # run unit tests from individual packages
       - run: npm run all test -- --package cli
-      - run: npm run all test -- --package coffee
       - run: npm run all test -- --package desktop-gui
       - run: npm run all test -- --package electron
       - run: npm run all test -- --package extension

--- a/circle.yml
+++ b/circle.yml
@@ -188,7 +188,6 @@ jobs:
       - run: npm run test-mocha-snapshot
       # run unit tests from individual packages
       - run: npm run all test -- --package cli
-      - run: npm run all test -- --package desktop-gui
       - run: npm run all test -- --package electron
       - run: npm run all test -- --package extension
       - run: npm run all test -- --package https-proxy

--- a/packages/coffee/package.json
+++ b/packages/coffee/package.json
@@ -8,8 +8,6 @@
   "files": [
     "register.js"
   ],
-  "scripts": {
-    "test": "echo 'Nothing to test for the coffee package'"
-  },
+  "scripts": {},
   "devDependencies": {}
 }

--- a/packages/desktop-gui/package.json
+++ b/packages/desktop-gui/package.json
@@ -11,7 +11,6 @@
     "clean": "zunder clean",
     "clean-deps": "rm -rf node_modules",
     "lint": "$(bin-up eslint) --fix lib/*.js src/*.js* src/**/*.js*",
-    "test": "echo 'No unit tests to run, but there are e2e tests'",
     "test-integration": "node ../../scripts/run-cypress-tests.js"
   },
   "files": [


### PR DESCRIPTION
- Move CI status within the TOC
- Add ‘driver’ to ‘Working in specific package’ section
- some minor link / wording fixes
- added wording around our labels.
- close #763 
- Add ‘why cypress’ video to readme
- Add a bunch of badges
- Add ‘install cypress’ section that refers to docs
- Add a nice logo at the top.
- close #768 