### PR TITLE
Add ability to point built binary at staging, close #813

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -584,6 +584,43 @@ jobs:
           working_directory: test-binary
           command: $(npm bin)/cypress verify
 
+  # install NPM + binary zip and run against staging API
+  "test-binary-against-staging":
+    <<: *defaults
+    steps:
+      - restore_cache:
+          key: cypress-monorepo-{{ .Branch }}-{{ .Revision }}
+      - attach_workspace:
+          at: /tmp/urls
+      # make sure we have cypress.zip received
+      - run: ls -l /tmp/urls/cypress.zip
+      # build NPM package
+      - run:
+          command: npm run build
+          working_directory: cli
+      - run:
+          name: Cloning test project
+          command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/cypress-test-tiny
+      - run:
+          name: Installing xvfb-maybe
+          command: npm i cypress-io/xvfb-maybe
+          working_directory: /tmp/cypress-test-tiny
+      - run:
+          # install from the built NPM package folder
+          # and from binary zip
+          name: Install Cypress
+          working_directory: /tmp/cypress-test-tiny
+          # force installing the freshly built binary
+          command: CYPRESS_BINARY_VERSION=/tmp/urls/cypress.zip npm i /home/person/cypress-monorepo/cli/build
+      - run:
+          name: Run test project
+          working_directory: /tmp/cypress-test-tiny
+          command: |
+            CYPRESS_ENV=staging \
+            CYPRESS_PROJECT_ID=$STAGING_PROJECT_ID \
+            CYPRESS_RECORD_KEY=$STAGING_RECORD_ID \
+            $(npm bin)/xvfb-maybe node_modules/.bin/cypress run --record
+
 workflows:
   version: 2
   build_and_test:
@@ -651,7 +688,7 @@ workflows:
             branches:
               only:
                 - develop
-                - bump-via-commit-537
+                - staging-813
           requires:
             - build
       - build-binary:
@@ -659,7 +696,7 @@ workflows:
             branches:
               only:
                 - develop
-                - bump-via-commit-537
+                - staging-813
           requires:
             - build
       - test-next-version:
@@ -675,7 +712,15 @@ workflows:
             branches:
               only:
                 - develop
-                - binary-path-701
+          requires:
+            - build-npm-package
+            - build-binary
+      - test-binary-against-staging:
+          filters:
+            branches:
+              only:
+                - develop
+                - staging-813
           requires:
             - build-npm-package
             - build-binary

--- a/circle.yml
+++ b/circle.yml
@@ -602,10 +602,6 @@ jobs:
           name: Cloning test project
           command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/cypress-test-tiny
       - run:
-          name: Installing xvfb-maybe
-          command: npm i cypress-io/xvfb-maybe
-          working_directory: /tmp/cypress-test-tiny
-      - run:
           name: Install Cypress
           working_directory: /tmp/cypress-test-tiny
           # force installing the freshly built binary
@@ -617,7 +613,7 @@ jobs:
             CYPRESS_ENV=staging \
             CYPRESS_PROJECT_ID=$STAGING_PROJECT_ID \
             CYPRESS_RECORD_KEY=$STAGING_RECORD_ID \
-            $(npm bin)/xvfb-maybe node_modules/.bin/cypress run --record
+            $(npm bin)/cypress run --record
 
 workflows:
   version: 2

--- a/circle.yml
+++ b/circle.yml
@@ -514,12 +514,14 @@ jobs:
               --version $NEXT_DEV_VERSION
       - run: cat npm-package-url.json
       - run: mkdir /tmp/urls
+      - run: cp cli/build/cypress-$NEXT_DEV_VERSION.tgz /tmp/urls/cypress.tgz
       - run: cp npm-package-url.json /tmp/urls
       - run: ls /tmp/urls
       - persist_to_workspace:
           root: /tmp/urls
           paths:
             - npm-package-url.json
+            - cypress.tgz
 
   "test-next-version":
     <<: *defaults
@@ -592,12 +594,10 @@ jobs:
           key: cypress-monorepo-{{ .Branch }}-{{ .Revision }}
       - attach_workspace:
           at: /tmp/urls
-      # make sure we have cypress.zip received
+      # make sure we have the binary
       - run: ls -l /tmp/urls/cypress.zip
-      # build NPM package
-      - run:
-          command: npm run build
-          working_directory: cli
+      # make sure we have the NPM package
+      - run: ls -l /tmp/urls/cypress.tgz
       - run:
           name: Cloning test project
           command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/cypress-test-tiny
@@ -606,12 +606,10 @@ jobs:
           command: npm i cypress-io/xvfb-maybe
           working_directory: /tmp/cypress-test-tiny
       - run:
-          # install from the built NPM package folder
-          # and from binary zip
           name: Install Cypress
           working_directory: /tmp/cypress-test-tiny
           # force installing the freshly built binary
-          command: CYPRESS_BINARY_VERSION=/tmp/urls/cypress.zip npm i /home/person/cypress-monorepo/cli/build
+          command: CYPRESS_BINARY_VERSION=/tmp/urls/cypress.zip npm i /tmp/urls/cypress.tgz
       - run:
           name: Run test project
           working_directory: /tmp/cypress-test-tiny

--- a/circle.yml
+++ b/circle.yml
@@ -461,6 +461,22 @@ jobs:
             - binary-url.json
             - cypress.zip
 
+  "test-against-staging":
+    <<: *defaults
+    steps:
+      - restore_cache:
+          key: cypress-monorepo-{{ .Branch }}-{{ .Revision }}
+      - run:
+          name: Cloning test project
+          command: git clone git@github.com:cypress-io/cypress-test-tiny.git /tmp/cypress-test-tiny
+      - run:
+          name: Run test project
+          command: |
+            CYPRESS_ENV=staging \
+            CYPRESS_PROJECT_ID=$STAGING_PROJECT_ID \
+            npm start -- --run-project /tmp/cypress-test-tiny \
+            --record --key $STAGING_RECORD_ID
+
   "build-npm-package":
     <<: *defaults
     steps:
@@ -621,6 +637,9 @@ workflows:
           requires:
             - build
       - run-launcher:
+          requires:
+            - build
+      - test-against-staging:
           requires:
             - build
       - build-npm-package:

--- a/circle.yml
+++ b/circle.yml
@@ -478,7 +478,6 @@ jobs:
             CYPRESS_ENV=staging \
             CYPRESS_PROJECT_ID=$STAGING_PROJECT_ID \
             CYPRESS_RECORD_KEY=$STAGING_RECORD_ID \
-            DEBUG=cypress:* \
             $(npm bin)/xvfb-maybe npm start -- --run-project /tmp/cypress-test-tiny \
             --record
 

--- a/circle.yml
+++ b/circle.yml
@@ -468,7 +468,7 @@ jobs:
           key: cypress-monorepo-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Installing xvfb-maybe
-          command: npm i -g cypress-io/xvfb-maybe
+          command: npm i cypress-io/xvfb-maybe
       - run:
           name: Cloning test project
           command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/cypress-test-tiny
@@ -479,7 +479,7 @@ jobs:
             CYPRESS_PROJECT_ID=$STAGING_PROJECT_ID \
             CYPRESS_RECORD_KEY=$STAGING_RECORD_ID \
             DEBUG=cypress:* \
-            xvfb-maybe npm start -- --run-project /tmp/cypress-test-tiny \
+            $(npm bin)/xvfb-maybe npm start -- --run-project /tmp/cypress-test-tiny \
             --record
 
   "build-npm-package":

--- a/circle.yml
+++ b/circle.yml
@@ -474,8 +474,10 @@ jobs:
           command: |
             CYPRESS_ENV=staging \
             CYPRESS_PROJECT_ID=$STAGING_PROJECT_ID \
+            CYPRESS_RECORD_KEY=$STAGING_RECORD_ID \
+            DEBUG=cypress:* \
             npm start -- --run-project /tmp/cypress-test-tiny \
-            --record --key $STAGING_RECORD_ID
+            --record
 
   "build-npm-package":
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -468,7 +468,7 @@ jobs:
           key: cypress-monorepo-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Cloning test project
-          command: git clone git@github.com:cypress-io/cypress-test-tiny.git /tmp/cypress-test-tiny
+          command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/cypress-test-tiny
       - run:
           name: Run test project
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -467,6 +467,9 @@ jobs:
       - restore_cache:
           key: cypress-monorepo-{{ .Branch }}-{{ .Revision }}
       - run:
+          name: Installing xvfb-maybe
+          command: npm i -g cypress-io/xvfb-maybe
+      - run:
           name: Cloning test project
           command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/cypress-test-tiny
       - run:
@@ -476,7 +479,7 @@ jobs:
             CYPRESS_PROJECT_ID=$STAGING_PROJECT_ID \
             CYPRESS_RECORD_KEY=$STAGING_RECORD_ID \
             DEBUG=cypress:* \
-            npm start -- --run-project /tmp/cypress-test-tiny \
+            xvfb-maybe npm start -- --run-project /tmp/cypress-test-tiny \
             --record
 
   "build-npm-package":

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "postinstall": "echo 'root postinstall' && npm run link && npm run all install && npm run build",
     "clean-deps": "npm run all clean-deps",
     "docker": "./scripts/run-docker-local.sh",
-    "lint-js": "eslint --fix scripts/*.js",
+    "lint-js": "eslint --fix scripts/*.js packages/ts/*.js",
     "lint-coffee": "coffeelint scripts/**/*.coffee",
     "lint": "npm run lint-js && npm run lint-coffee",
     "pretest": "npm run lint && npm run all lint && npm run test-scripts",

--- a/packages/ts/register.js
+++ b/packages/ts/register.js
@@ -3,11 +3,8 @@ let tsNode
 
 // in development we should have TypeScript hook installed
 // in production or staging we are likely to be running
-// built Electron app without ts-node hook
-function likelyToHaveTypeScript (env) {
-  return env !== 'production' &&
-    env !== 'staging'
-}
+// built Electron app without ts-node hook. Assume the
+// build has been done correctly
 
 try {
   tsNode = require('ts-node')
@@ -30,10 +27,6 @@ try {
   // do we need to prevent any other TypeScript hooks?
   // like @packages/coffee/register.js does?
 } catch (e) {
-  if (likelyToHaveTypeScript(process.env.CYPRESS_ENV)) {
-    log('Could not require ts-node in environment %s', process.env.CYPRESS_ENV)
-    throw e
-  }
   // continue running without TypeScript require hook
-  log('Running without ts-node hook in environment %s', process.env.CYPRESS_ENV)
+  log('Running without ts-node hook in environment "%s"', process.env.CYPRESS_ENV)
 }

--- a/scripts/binary/build.coffee
+++ b/scripts/binary/build.coffee
@@ -138,7 +138,7 @@ buildCypressApp = (platform, version, options = {}) ->
     })
     .then =>
       str = """
-      process.env.CYPRESS_ENV = 'production'
+      process.env.CYPRESS_ENV = process.env.CYPRESS_ENV || 'production'
       require('./packages/server')
       """
 

--- a/scripts/binary/build.coffee
+++ b/scripts/binary/build.coffee
@@ -45,6 +45,8 @@ logBuiltAllJs = () ->
 # for example
 #   skipClean - do not delete "dist" folder before build
 buildCypressApp = (platform, version, options = {}) ->
+  la(check.unemptyString(version), "missing version to build", version)
+
   distDir = _.partial(meta.distDir, platform)
   buildDir = _.partial(meta.buildDir, platform)
   buildAppDir = _.partial(meta.buildAppDir, platform)
@@ -58,8 +60,10 @@ buildCypressApp = (platform, version, options = {}) ->
     execa("node", ["index.js", "--version"], {
       cwd: dir
     }).then (result) ->
-      # TODO validate version string
-      console.log(result.stdout)
+      console.log('built version', result.stdout)
+      la(check.unemptyString(result.stdout), 'missing output', result)
+      la(result.stdout == version, "different version reported",
+        result.stdout, "from input version to build", version)
 
   canBuildInDocker = ->
     platform is "linux" and os.platform() is "darwin"


### PR DESCRIPTION
No longer hardcode `CYPRESS_ENV=production` in the built binary application