### PR TITLE
server: read record key from environment variable, close #820

### DIFF
--- a/cli/lib/exec/run.js
+++ b/cli/lib/exec/run.js
@@ -4,10 +4,12 @@ const spawn = require('./spawn')
 const verify = require('../tasks/verify')
 
 const processRunOptions = (options = {}) => {
+  debug('processing run options')
   const args = ['--run-project', options.project]
 
   //// if key is set use that - else attempt to find it by env var
   if (options.key == null) {
+    debug('--key is not set, looking up environment variable CYPRESS_RECORD_KEY')
     options.key = process.env.CYPRESS_RECORD_KEY || process.env.CYPRESS_CI_KEY
   }
 

--- a/packages/server/lib/cypress.coffee
+++ b/packages/server/lib/cypress.coffee
@@ -108,6 +108,7 @@ module.exports = {
 
   start: (argv = []) ->
     require("./logger").info("starting desktop app", args: argv)
+    log("starting cypress server")
 
     ## make sure we have the appData folder
     require("./util/app_data").ensure()
@@ -148,6 +149,9 @@ module.exports = {
         ## enable old CLI tools to record
         when options.record or options.ci
           options.mode = "record"
+          if not options.key
+            log("trying to read option key from environment")
+            options.key = process.env.CYPRESS_RECORD_KEY || process.env.CYPRESS_CI_KEY
 
         when options.runProject
           ## go into headless mode when told to run

--- a/packages/server/test/integration/cypress_spec.coffee
+++ b/packages/server/test/integration/cypress_spec.coffee
@@ -703,6 +703,7 @@ describe "lib/cypress", ->
   context "--record or --ci", ->
     afterEach ->
       delete process.env.CYPRESS_PROJECT_ID
+      delete process.env.CYPRESS_RECORD_KEY
 
     beforeEach ->
       @setup = =>
@@ -821,13 +822,26 @@ describe "lib/cypress", ->
       @setup()
 
       ## set the projectId to be todos even though
-      ## we are running the prisine project
+      ## we are running the pristine project
       process.env.CYPRESS_PROJECT_ID = @projectId
 
       @createRun.resolves()
       @sandbox.stub(api, "createInstance").resolves()
 
       cypress.start(["--run-project=#{@pristinePath}", "--record", "--key=token-123"])
+      .then =>
+        expect(errors.warning).not.to.be.called
+        @expectExitWith(3)
+
+    it "uses process.env.CYPRESS_RECORD_KEY", ->
+      @setup()
+
+      process.env.CYPRESS_RECORD_KEY = "token-123"
+
+      @createRun.resolves()
+      @sandbox.stub(api, "createInstance").resolves()
+
+      cypress.start(["--run-project=#{@todosPath}", "--record"])
       .then =>
         expect(errors.warning).not.to.be.called
         @expectExitWith(3)


### PR DESCRIPTION
when running in local mode using `scripts/start.js`, we are skipping CLI logic, so we cannot record runs.