### PR TITLE
build: commit to test projects using commit-message-install format

### DIFF
--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -42,7 +42,7 @@
     "sinon-chai": "^2.8.0",
     "tslint": "5.7.0",
     "tslint-config-standard": "6.0.1",
-    "typescript": "^2.5.2",
+    "typescript": "2.5.2",
     "@types/ramda": "0.24.14"
   },
   "dependencies": {

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -10,8 +10,8 @@
     "test": "node test"
   },
   "devDependencies": {
-    "ts-node": "^3.0.4",
-    "typescript": "^2.3.2"
+    "ts-node": "3.3.0",
+    "typescript": "2.3.2"
   },
   "dependencies": {
     "debug": "^2.6.8"

--- a/scripts/test-other-projects.js
+++ b/scripts/test-other-projects.js
@@ -56,11 +56,26 @@ bump.version(npm, binary, platform, cliOptions.provider)
       subject += ` ${shortSha}`
     }
 
+    // instructions for installing this binary
+    // using https://github.com/bahmutov/commit-message-install
+    const commitMessageInstructions = {
+      platform: os.platform(),
+      env: {
+        CYPRESS_BINARY_VERSION: result.binary,
+      },
+      packages: result.versionName,
+    }
+    const jsonBlock = `\`\`\`json\n${
+      JSON.stringify(commitMessageInstructions, null, 2)}\n`
+      + '```'
+
+    const footer = 'Use tool `commit-message-install` to install from above block'
     let message = stripIndent`
       ${subject}
 
-      NPM package: ${result.versionName}
-      Binary: ${result.binary}
+      ${jsonBlock}
+
+      ${footer}
     `
     if (process.env.CIRCLE_BUILD_URL) {
       message += '\n'


### PR DESCRIPTION
Form different commit message to each test project to install specific binary and npm version without using environment variables. The test projects will install it using https://github.com/bahmutov/commit-message-install