### PR TITLE
Separate bump next version command

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -6,6 +6,14 @@ and publish NPM module `cypress` if you are a member of `cypress` NPM organizati
 **important** see the [publishing](#publishing) section for how to build, test and publish a 
 new official version of the binary and `cypress` NPM package.
 
+### Set next version on CIs
+
+We build NPM package and binary on all major platforms (Linux, Mac, Windows) on different CI
+providers. In order to set the version while building we have to set the environment variable
+with the new version on each CI provider *before starting the build*.
+
+Use script command `npm run set-next-ci-version` to do this.
+
 ### Building the NPM package
 
 Building a new NPM package is very quick. 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
   # https://ci.appveyor.com/tools/encrypt
   _ci_json:
     secure: tf3fK5S5Gh5HGUcDo3eGw7nqdcFU/4A+2s3JJovmn/eA0p9dEspjPFp7G1I9BxdUc4OoCeJ3dSSrCQ1BPIzb/bzK6aQqAZQWNcJ1sanoIiF0QUPbiW40Js3xpWylIh8qutVoaWtZz5a1ygg9sJmAYR7qB5+aQqQNA55TBKkUCydXpnDBfWuagb6d/7cblULsXasvvji3RIoxWTKd8HmaD/xxqONjPAJ3IJsiDTaWc5S9bAgV8/IYa7YZaQm5vpTTsWU5IGwkA1l9yMu7j+7BSNK9esvAYyKsx7kUV9jiVFo=
-  _aws_credentials_json:
+  aws_credentials_json:
     secure: ttGzd2/rW+i8H+pozcFxzZKU07B5INL8+LjD4vCOKes+tI6EaKhrLvAQ9xT7r+e1oTWbC8olZQ96ZZ8P5Ve8pIpG8oe1ITMs5f50iXaKULfwIcJOm+G8a3pkMRZOWa0wGs7/sKtRSyIpMFRfCOIl8TePBKEgeRtVzixBqSuyYLn/u2dz0z8uHeJDq/H1kJlI
   CF_DOMAIN: "cypress.io"
   CF_EMAIL:

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     ]
   },
   "devDependencies": {
-    "@cypress/bumpercar": "^1.3.0",
+    "@cypress/bumpercar": "1.4.0",
     "@cypress/env-or-json-file": "^2.0.0",
     "@cypress/npm-run-all": "^4.0.4",
     "@cypress/questions-remain": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prepush": "npm run stop-only",
     "stop-only": "stop-only packages --exclude-dir .cy --exclude-dir .projects --exclude-dir node_modules --exclude-dir dist --exclude-dir dist-test --exclude-dir fixtures --exclude-dir lib --exclude-dir bower_components",
     "bump": "node ./scripts/binary.js bump",
+    "set-next-ci-version": "node ./scripts/binary.js setNextVersion",
     "binary-build": "node ./scripts/binary.js build",
     "binary-zip": "node ./scripts/binary.js zip",
     "binary-upload": "node ./scripts/binary.js upload",

--- a/scripts/binary/ask.coffee
+++ b/scripts/binary/ask.coffee
@@ -3,6 +3,8 @@ fs       = require("fs-extra")
 glob     = require("glob")
 Promise  = require("bluebird")
 inquirer = require("inquirer")
+la       = require("lazy-ass")
+check    = require("check-more-types")
 
 glob = Promise.promisify(glob)
 
@@ -74,17 +76,24 @@ getReleases = (releases) ->
       }
   }]
 
-getNextVersion = ({ version }) ->
-  [{
-    name: "nextVersion"
-    type: "input"
-    message: "Bump next version to...? (currently: #{version})"
-    default: ->
+getNextVersion = ({ version } = {}) ->
+  if check.unemptyString(version)
+    message = "Bump next version to...? (currently: #{version})"
+    defaultVersion = () ->
       a = version.split(".")
       v = a[a.length - 1]
       v = Number(v) + 1
       a.splice(a.length - 1, 1, v)
       a.join(".")
+  else
+    message ="Bump next version to ...?"
+    defaultVersion = () -> "1.0.0"
+
+  [{
+    name: "nextVersion"
+    type: "input"
+    message: message
+    default: defaultVersion
   }]
 
 getVersions = (releases) ->
@@ -177,6 +186,7 @@ whichBumpTask = ->
   .get("task")
 
 nextVersion = (version) ->
+
   prompt(getNextVersion(version))
   .get("nextVersion")
 

--- a/scripts/binary/ask.coffee
+++ b/scripts/binary/ask.coffee
@@ -5,6 +5,7 @@ Promise  = require("bluebird")
 inquirer = require("inquirer")
 la       = require("lazy-ass")
 check    = require("check-more-types")
+path     = require("path")
 
 glob = Promise.promisify(glob)
 
@@ -77,17 +78,16 @@ getReleases = (releases) ->
   }]
 
 getNextVersion = ({ version } = {}) ->
-  if check.unemptyString(version)
-    message = "Bump next version to...? (currently: #{version})"
-    defaultVersion = () ->
-      a = version.split(".")
-      v = a[a.length - 1]
-      v = Number(v) + 1
-      a.splice(a.length - 1, 1, v)
-      a.join(".")
-  else
-    message ="Bump next version to ...?"
-    defaultVersion = () -> "1.0.0"
+  if not version
+    version = require(path.join(__dirname, "..", "..", "package.json")).version
+
+  message = "Bump next version to...? (currently: #{version})"
+  defaultVersion = () ->
+    a = version.split(".")
+    v = a[a.length - 1]
+    v = Number(v) + 1
+    a.splice(a.length - 1, 1, v)
+    a.join(".")
 
   [{
     name: "nextVersion"

--- a/scripts/binary/bump.coffee
+++ b/scripts/binary/bump.coffee
@@ -90,7 +90,6 @@ remapMain = (projectsByProvider) ->
 # make flat list of objects
 # {repo, provider}
 PROJECTS = remapProjects(_PROVIDERS)
-MAIN_PROJECTS = remapMain(_PROVIDERS)
 
 getCiConfig = ->
   key = path.join("scripts", "support", ".ci.json")
@@ -150,18 +149,21 @@ getFilterByProvider = (providerName) ->
 
 module.exports = {
   nextVersion: (version) ->
-    console.table("All possible projects", MAIN_PROJECTS)
+    MAIN_PROJECTS = remapMain(_PROVIDERS)
+    console.log("Setting next version to build", version)
+    console.table("In these projects", MAIN_PROJECTS)
 
     la(check.unemptyString(version),
       "missing next version to set", version)
 
-    updateProject = (project, provider) ->
-      console.log("setting %s environment variables in project %s", provider, project)
+    setNextDevVersion = (project, provider) ->
+      console.log("setting env var NEXT_DEV_VERSION to %s on %s in project %s",
+        version, provider, project)
       car.updateProjectEnv(project, provider, {
         NEXT_DEV_VERSION: version,
       })
 
-    awaitEachProjectAndProvider(MAIN_PROJECTS, updateProject)
+    awaitEachProjectAndProvider(MAIN_PROJECTS, setNextDevVersion)
 
   # in each project, set a couple of environment variables
   version: (nameOrUrl, binaryVersionOrUrl, platform, providerName) ->

--- a/scripts/binary/index.coffee
+++ b/scripts/binary/index.coffee
@@ -47,7 +47,8 @@ askMissingOptions = (properties = []) ->
     nextVersion: ask.nextVersion
     commit: ask.toCommit
   }
-  return questionsRemain(_.pick(questions, properties))
+  pickedQuestions = _.pick(questions, properties)
+  questionsRemain(pickedQuestions)
 
 ## hack for @packages/server modifying cwd
 process.chdir(cwd)
@@ -104,6 +105,15 @@ deploy = {
           ask.whichVersion(meta.distDir(""))
           .then (v) ->
             bump.version(v)
+
+  ## sets environment variable on each CI provider
+  ## to NEXT version to build
+  setNextVersion: ->
+    options = @parseOptions(process.argv)
+
+    askMissingOptions(['nextVersion'])(options)
+    .then ({nextVersion}) ->
+      bump.nextVersion(nextVersion)
 
   release: ->
     ## read off the argv

--- a/scripts/binary/util/upload.coffee
+++ b/scripts/binary/util/upload.coffee
@@ -22,7 +22,7 @@ formHashFromEnvironment = () ->
   throw new Error("Do not know how to form unique build hash on this CI")
 
 getS3Credentials = () ->
-  key = path.join('scripts', 'support', '.aws-credentials.json')
+  key = path.join('scripts', 'support', 'aws-credentials.json')
   config = configFromEnvOrJsonFile(key)
 
   if !config


### PR DESCRIPTION
Getting error setting Buildkite variable
```
Error attempting to update the variable { NEXT_DEV_VERSION: '1.1.0' } for cypress-io/cypress on buildkite
error response data
{ message: 'Validation Failed',
  errors: 
   [ { field: 'env',
       code: '"_aws_credentials_json" is not a valid environment variable name (only a-z, A-Z, 0-9 and underscores are allowed)',
       value: [Object] } ] }
```

Possible solutions:
- only patch some variables and not all of them. Not sure if this is possible
- rename `_aws_credentials_json` to NOT start with `_`