### PR TITLE
Do not format fixture on run

### DIFF
--- a/packages/server/lib/fixture.coffee
+++ b/packages/server/lib/fixture.coffee
@@ -7,7 +7,6 @@ Promise   = require("bluebird")
 jsonlint  = require("jsonlint")
 beautify  = require("js-beautify").html
 pretty    = require("js-object-pretty-print").pretty
-formatter = require("jsonlint/lib/formatter").formatter
 cwd       = require("./cwd")
 
 fs = Promise.promisifyAll(fs)
@@ -90,21 +89,6 @@ module.exports = {
   parseJson: (p, fixture) ->
     fs.readFileAsync(p, "utf8")
     .bind(@)
-    .then (str) ->
-      ## format the json
-      formatted = formatter.formatJson(str, "  ")
-
-      ## if we didnt change then return the str
-      if formatted is str
-        return str
-      else
-        ## if last character is a new line
-        ## then append this to the formatted str
-        if lastCharacterIsNewLine(str)
-          formatted += "\n"
-        ## write the file back even if there were errors
-        ## so we write back the formatted version of the str
-        fs.writeFileAsync(p, formatted).return(formatted)
     .then(jsonlint.parse)
     .catch (err) ->
       throw new Error("'#{fixture}' is not valid JSON.\n#{err.message}")

--- a/packages/server/lib/fixture.coffee
+++ b/packages/server/lib/fixture.coffee
@@ -5,8 +5,6 @@ check     = require("syntax-error")
 coffee    = require("../../../packages/coffee")
 Promise   = require("bluebird")
 jsonlint  = require("jsonlint")
-beautify  = require("js-beautify").html
-pretty    = require("js-object-pretty-print").pretty
 cwd       = require("./cwd")
 
 fs = Promise.promisifyAll(fs)
@@ -105,9 +103,6 @@ module.exports = {
         throw e
 
       return obj
-    .then (obj) ->
-      str = pretty(obj, 2)
-      fs.writeFileAsync(p, str).return(obj)
     .catch (err) ->
       throw new Error("'#{fixture}' is not a valid JavaScript object.#{err.toString()}")
 
@@ -129,16 +124,6 @@ module.exports = {
   parseHtml: (p, fixture) ->
     fs.readFileAsync(p, "utf8")
     .bind(@)
-    .then (str) ->
-      html = beautify str, {
-        indent_size: 2
-        extra_liners: []
-      }
-
-      if lastCharacterIsNewLine(str)
-        html += "\n"
-
-      fs.writeFileAsync(p, html).return(html)
 
   parse: (p, fixture, encoding = "utf8") ->
     fs.readFileAsync(p, encoding)

--- a/packages/server/lib/fixture.coffee
+++ b/packages/server/lib/fixture.coffee
@@ -121,9 +121,6 @@ module.exports = {
     .then (str) ->
       str = coffee.compile(str, {bare: true})
       eval(str)
-    .then (obj) ->
-      str = pretty(obj, 2)
-      fs.writeFileAsync(p, str).return(obj)
     .catch (err) ->
       throw new Error("'#{fixture} is not a valid CoffeeScript object.\n#{err.toString()}")
     .finally ->

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -108,8 +108,6 @@
     "http-status-codes": "^1.0.6",
     "human-interval": "^0.1.5",
     "image-size": "^0.5.0",
-    "js-beautify": "^1.5.10",
-    "js-object-pretty-print": "^0.1.4",
     "jsonlint": "^1.6.2",
     "konfig": "^0.2.0",
     "lazy-ass": "^1.6.0",

--- a/packages/server/test/unit/fixture_spec.coffee
+++ b/packages/server/test/unit/fixture_spec.coffee
@@ -110,7 +110,7 @@ describe.only "lib/fixture", ->
           }
         ]
 
-    it.only "does not reformat empty objects", ->
+    it "does not reformat empty objects", ->
       fn = =>
         fixture.get(@fixturesFolder, "empty_objects")
 
@@ -171,19 +171,14 @@ describe.only "lib/fixture", ->
           users: []
         }
 
-    it "rewrites file as formatted valid coffee object", ->
+    it "does not rewrite coffee files", ->
       fixture.get(@fixturesFolder, "no_format.coffee").then =>
         fs.readFileAsync(@fixturesFolder + "/no_format.coffee", "utf8").then (str) ->
           expect(str).to.eq """
             [
-              {
-                id: 1
-              },
-              {
-                id: 2
-              }
+              {id: 1}
+              {id: 2}
             ]
-
           """
 
     it "throws on bad coffee object", ->
@@ -346,11 +341,7 @@ describe.only "lib/fixture", ->
     it "does not remove trailing new lines on .coffee", ->
       fixture.get(@fixturesFolder, "trailing_new_line.coffee").then (str) =>
         fs.readFileAsync(@fixturesFolder + "/trailing_new_line.coffee", "utf8").then (str2) ->
-          expect(str2).to.eq """
-            {
-              foo: "bar"
-            }\n
-          """
+          expect(str2).to.eq '{ foo: "bar" }\n'
 
     it "does not remove trailing new lines on .html", ->
       fixture.get(@fixturesFolder, "trailing_new_line.html").then (str) =>

--- a/packages/server/test/unit/fixture_spec.coffee
+++ b/packages/server/test/unit/fixture_spec.coffee
@@ -200,25 +200,25 @@ describe.only "lib/fixture", ->
           <!doctype html>
           <html>
           <head>
-            <title>index.html</title>
+          <title>index.html</title>
           </head>
           <body>
-            index
+          index
           </body>
           </html>
         """
 
-    it "rewrites file as formatted html", ->
+    it "does not rewrite file as formatted html", ->
       fixture.get(@fixturesFolder, "index.html").then =>
         fs.readFileAsync(@fixturesFolder + "/index.html", "utf8").then (str) ->
           expect(str).to.eq """
           <!doctype html>
           <html>
           <head>
-            <title>index.html</title>
+          <title>index.html</title>
           </head>
           <body>
-            index
+          index
           </body>
           </html>
         """
@@ -346,8 +346,4 @@ describe.only "lib/fixture", ->
     it "does not remove trailing new lines on .html", ->
       fixture.get(@fixturesFolder, "trailing_new_line.html").then (str) =>
         fs.readFileAsync(@fixturesFolder + "/trailing_new_line.html", "utf8").then (str2) ->
-          expect(str2).to.eq """
-            <html>
-            <body>foo</body>
-            </html>\n
-          """
+          expect(str2).to.eq '<html><body>foo</body></html>\n'

--- a/packages/server/test/unit/fixture_spec.coffee
+++ b/packages/server/test/unit/fixture_spec.coffee
@@ -14,7 +14,7 @@ isWindows = () ->
 
 fs = Promise.promisifyAll(fs)
 
-describe "lib/fixture", ->
+describe.only "lib/fixture", ->
   beforeEach ->
     FixturesHelper.scaffold()
 
@@ -50,8 +50,8 @@ describe "lib/fixture", ->
         """
         'bad_json.json' is not valid JSON.
         Parse error on line 2:
-        {  "bad": "json""should": "not parse
-        ----------------^
+        {  "bad": "json"  "should": "not parse
+        ------------------^
         Expecting 'EOF', '}', ':', ',', ']', got 'STRING'
         """
 
@@ -69,28 +69,24 @@ describe "lib/fixture", ->
           # on other platforms can match the error directly
           expect(eol.auto(err.message)).to.eq eol.auto(e)
 
-    it "reformats json and writes back even on parse error", ->
+    it "does not reformat json on parse error", ->
       fixture.get(@fixturesFolder, "bad_json.json")
       .then ->
         throw new Error("should have failed but did not")
       .catch (err) =>
-        ## ensure the bad_json file was rewritten even though there was a parse error
+        ## ensure the bad_json file was kept as before
         fs.readFileAsync(@fixturesFolder + "/bad_json.json", "utf8").then (str) ->
           expect(str).to.eq """
             {
-              "bad": "json""should": "not parse"
+              "bad": "json"
+              "should": "not parse"
             }
             """
 
-    it "reformats json and writes this back", ->
+    it "does not reformat json or write fixture file", ->
       fixture.get(@fixturesFolder, "no_format.json").then (obj) =>
         fs.readFileAsync(@fixturesFolder + "/no_format.json", "utf8").then (json) ->
-          expect(json).to.eq """
-            {
-              "id": 1,
-              "name": "brian"
-            }
-          """
+          expect(json).to.eq '{"id": 1, "name": "brian"}'
 
     it "does not remove string whitespace", ->
       fixture.get(@fixturesFolder, "words.json").then (obj) =>
@@ -114,7 +110,7 @@ describe "lib/fixture", ->
           }
         ]
 
-    it "reformats empty objects", ->
+    it.only "does not reformat empty objects", ->
       fn = =>
         fixture.get(@fixturesFolder, "empty_objects")
 
@@ -123,10 +119,10 @@ describe "lib/fixture", ->
           expect(str).to.eq """
             {
               "empty": {
-                "object": {\n      \n    },
-                "array": [\n      \n    ],
-                "object2": {\n      \n    },
-                "array2": [\n      \n    ]
+                "object": {},
+                "array": [],
+                "object2": {\n\n    },
+                "array2": [\n\n    ]
               }
             }
           """
@@ -336,11 +332,7 @@ describe "lib/fixture", ->
     it "does not remove trailing new lines on .json", ->
       fixture.get(@fixturesFolder, "trailing_new_line.json").then (str) =>
         fs.readFileAsync(@fixturesFolder + "/trailing_new_line.json", "utf8").then (str2) ->
-          expect(str2).to.eq """
-            {
-              "foo": "bar"
-            }\n
-          """
+          expect(str2).to.eq '{"foo": "bar"}\n'
 
     it "does not remove trailing new lines on .js", ->
       fixture.get(@fixturesFolder, "trailing_new_line.js").then (str) =>

--- a/packages/server/test/unit/fixture_spec.coffee
+++ b/packages/server/test/unit/fixture_spec.coffee
@@ -14,7 +14,7 @@ isWindows = () ->
 
 fs = Promise.promisifyAll(fs)
 
-describe.only "lib/fixture", ->
+describe "lib/fixture", ->
   beforeEach ->
     FixturesHelper.scaffold()
 

--- a/packages/server/test/unit/fixture_spec.coffee
+++ b/packages/server/test/unit/fixture_spec.coffee
@@ -137,16 +137,10 @@ describe.only "lib/fixture", ->
           posts: []
         }
 
-    it "rewrites file as a formated valid JS object", ->
+    it "does not rewrite file as a formated valid JS object", ->
       fixture.get(@fixturesFolder, "no_format.js").then (obj) =>
         fs.readFileAsync(@fixturesFolder + "/no_format.js", "utf8").then (str) ->
-          expect(str).to.eq """
-            {
-              foo: "bar",
-              baz: "quux"
-            }
-
-          """
+          expect(str).to.eq '{foo: "bar", baz: "quux"}'
 
     it "throws on a bad JS object", ->
       e =
@@ -332,11 +326,7 @@ describe.only "lib/fixture", ->
     it "does not remove trailing new lines on .js", ->
       fixture.get(@fixturesFolder, "trailing_new_line.js").then (str) =>
         fs.readFileAsync(@fixturesFolder + "/trailing_new_line.js", "utf8").then (str2) ->
-          expect(str2).to.eq """
-            {
-              foo: "bar"
-            }\n
-          """
+          expect(str2).to.eq '{foo: "bar"}\n'
 
     it "does not remove trailing new lines on .coffee", ->
       fixture.get(@fixturesFolder, "trailing_new_line.coffee").then (str) =>


### PR DESCRIPTION
Stop formatting and saving fixtures. Let the users use their own favorite formatting tools.