### PR TITLE
Do not crash if onBeforeLog returns false

### DIFF
--- a/packages/driver/src/cypress/log.coffee
+++ b/packages/driver/src/cypress/log.coffee
@@ -488,7 +488,7 @@ create = (Cypress, cy, state, config) ->
     ## dont trigger log if this function
     ## explicitly returns false
     if _.isFunction(onBeforeLog)
-      return if onBeforeLog.call(cy, log) is false
+      return log if onBeforeLog.call(cy, log) is false
 
     ## set the log on the command
     state("current")?.log(log)


### PR DESCRIPTION
I am running into out-of-memory crashes as described in #882 when using the interactive UI. My tests run fine in headless mode.

These crashes are making it impossible for me to use the interactive UI for developing my tests. However we writing new tests, I mostly care about the last few log entries anyway. Therefore my idea was to suppress the logging of earlier commands using ```onBeforeLog``` with something like the following:

```js
before(() => {
  Cypress.state('onBeforeLog', function () {
    return Cypress._logGate;
  })
});

it('runs a long test', function () {
  cy.then(function () {
    Cypress._logGate = false;
  })
  ... long list of commands ...
  cy.then(function () {
    Cypress._logGate = true;
  })
  cy.contains("Text I really care about").click();
});
```

This approach fails because the log function does not return a log object in case ```onBeforeLog``` returns false.