### PR TITLE
Issue 962 - Skip invalid cookies instead of crashing

### DIFF
--- a/packages/server/lib/controllers/proxy.coffee
+++ b/packages/server/lib/controllers/proxy.coffee
@@ -190,9 +190,12 @@ module.exports = {
 
       ## always proxy the cookies coming from the incomingRes
       if cookies = headers["set-cookie"]
-        for cookie in cookies
-          try res.append("Set-Cookie", cookie)
-          catch e then logger.warn "not proxying invalid cookie", cookie: cookie
+        ## normalize into array
+        for c in [].concat(cookies)
+          try
+            res.append("Set-Cookie", c)
+          catch err
+            ## noop
 
       if redirectRe.test(statusCode)
         newUrl = headers.location

--- a/packages/server/lib/controllers/proxy.coffee
+++ b/packages/server/lib/controllers/proxy.coffee
@@ -190,7 +190,9 @@ module.exports = {
 
       ## always proxy the cookies coming from the incomingRes
       if cookies = headers["set-cookie"]
-        res.append("Set-Cookie", cookies)
+        for cookie in cookies
+          try res.append("Set-Cookie", cookie)
+          catch e then logger.warn "not proxying invalid cookie", cookie: cookie
 
       if redirectRe.test(statusCode)
         newUrl = headers.location

--- a/packages/server/test/integration/http_requests_spec.coffee
+++ b/packages/server/test/integration/http_requests_spec.coffee
@@ -1478,6 +1478,25 @@ describe "Routes", ->
             "__cypress.initial=true; Domain=localhost; Path=/"
           ]
 
+      it "ignores invalid cookies", ->
+        nock(@server._remoteOrigin)
+        .get("/invalid")
+        .reply 200, "OK", {
+          "set-cookie": [
+            "foo=bar; Path=/"
+             "___utmvmXluIZsM=fidJKOsDSdm; path=/; Max-Age=900" ## this is okay
+             "___utmvbXluIZsM=bZM\n    XtQOGalF: VtR; path=/; Max-Age=900" ## should ignore this
+           ]
+        }
+
+        @rp("http://localhost:8080/invalid")
+        .then (res) ->
+          expect(res.statusCode).to.eq(200)
+          expect(res.headers["set-cookie"]).to.deep.eq [
+            "foo=bar; Path=/"
+             "___utmvmXluIZsM=fidJKOsDSdm; path=/; Max-Age=900"
+          ]
+
       it "forwards other headers from incoming responses", ->
         nock(@server._remoteOrigin)
         .get("/auth")


### PR DESCRIPTION
Fixes #962 (verified locally on my use-case but might break some other things)

I can see that all proxy unit tests are commented out at the moment. 

Can definitely add some for this. Should I? 😃 