### PR TITLE
now with the s in https as an optional

### DIFF
--- a/cli/lib/tasks/download.js
+++ b/cli/lib/tasks/download.js
@@ -19,7 +19,7 @@ const isString = (s) =>
   typeof s === 'string'
 
 const isUrl = (s) =>
-  isString(s) && /^https:/.test(s)
+  isString(s) && /^https?:/.test(s)
 
 const prepend = (urlPath) => {
   const endpoint = url.resolve(baseUrl, urlPath)


### PR DESCRIPTION
fixes problem alternative downloads only working with https links.