### PR TITLE
De-emphasize a word in error message

### DIFF
--- a/packages/driver/src/cypress/error_messages.coffee
+++ b/packages/driver/src/cypress/error_messages.coffee
@@ -789,7 +789,7 @@ module.exports = {
       msg + if source and lineno then " (#{source}:#{lineno})" else ""
 
     fromApp: """
-      This error originated from *your* application code, not from Cypress.
+      This error originated from your application code, not from Cypress.
 
       When Cypress detects uncaught errors originating from your application it will automatically fail the current test.
 
@@ -799,7 +799,7 @@ module.exports = {
     """
 
     fromSpec: """
-      This error originated from *your* test code, not from Cypress.
+      This error originated from your test code, not from Cypress.
 
       When Cypress detects uncaught errors originating from your test code it will automatically fail the current test.
     """

--- a/packages/driver/test/cypress/integration/e2e/uncaught_errors_spec.coffee
+++ b/packages/driver/test/cypress/integration/e2e/uncaught_errors_spec.coffee
@@ -37,7 +37,7 @@ describe "uncaught errors", ->
     cy.on "uncaught:exception", (err, runnable) ->
       expect(err.name).to.eq("Uncaught ReferenceError")
       expect(err.message).to.include("foo is not defined")
-      expect(err.message).to.include("This error originated from *your* application code, not from Cypress.")
+      expect(err.message).to.include("This error originated from your application code, not from Cypress.")
       expect(err.message).to.include("https://on.cypress.io/uncaught-exception-from-application")
       expect(runnable is r).to.be.true
 

--- a/packages/server/__snapshots__/caught_uncaught_hook_errors_spec.coffee
+++ b/packages/server/__snapshots__/caught_uncaught_hook_errors_spec.coffee
@@ -87,7 +87,7 @@ Started video recording: /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
   1) s1b "before each" hook for "t2b":
      Uncaught ReferenceError: foo is not defined
 
-This error originated from *your* application code, not from Cypress.
+This error originated from your application code, not from Cypress.
 
 When Cypress detects uncaught errors originating from your application it will automatically fail the current test.
 
@@ -142,7 +142,7 @@ Started video recording: /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
   1)  "before each" hook for "t1c":
      Uncaught ReferenceError: foo is not defined
 
-This error originated from *your* application code, not from Cypress.
+This error originated from your application code, not from Cypress.
 
 When Cypress detects uncaught errors originating from your application it will automatically fail the current test.
 
@@ -203,7 +203,7 @@ Started video recording: /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
   1) uncaught hook error should continue to fire all mocha events s1 "before each" hook for "does not run":
      Uncaught ReferenceError: foo is not defined
 
-This error originated from *your* application code, not from Cypress.
+This error originated from your application code, not from Cypress.
 
 When Cypress detects uncaught errors originating from your application it will automatically fail the current test.
 

--- a/packages/server/__snapshots__/commands_outside_of_test_spec.coffee
+++ b/packages/server/__snapshots__/commands_outside_of_test_spec.coffee
@@ -20,7 +20,7 @@ Check your test file for errors.
 
 https://on.cypress.io/cannot-execute-commands-outside-test
 
-This error originated from *your* test code, not from Cypress.
+This error originated from your test code, not from Cypress.
 
 When Cypress detects uncaught errors originating from your test code it will automatically fail the current test.
 

--- a/packages/server/__snapshots__/js_error_handling_spec.coffee
+++ b/packages/server/__snapshots__/js_error_handling_spec.coffee
@@ -23,7 +23,7 @@ Started video recording: /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
   1) s1 without an afterEach hook t1:
      Uncaught ReferenceError: foo is not defined
 
-This error originated from *your* application code, not from Cypress.
+This error originated from your application code, not from Cypress.
 
 When Cypress detects uncaught errors originating from your application it will automatically fail the current test.
 
@@ -45,7 +45,7 @@ https://on.cypress.io/uncaught-exception-from-application
   3) s1 with an afterEach hook t4:
      Uncaught ReferenceError: foo is not defined
 
-This error originated from *your* application code, not from Cypress.
+This error originated from your application code, not from Cypress.
 
 When Cypress detects uncaught errors originating from your application it will automatically fail the current test.
 
@@ -73,7 +73,7 @@ It's possible to enable debugging these scripts by adding the 'crossorigin' attr
 
 https://on.cypress.io/cross-origin-script-error
 
-This error originated from *your* application code, not from Cypress.
+This error originated from your application code, not from Cypress.
 
 When Cypress detects uncaught errors originating from your application it will automatically fail the current test.
 

--- a/packages/server/__snapshots__/uncaught_spec_errors_spec.coffee
+++ b/packages/server/__snapshots__/uncaught_spec_errors_spec.coffee
@@ -12,7 +12,7 @@ Started video recording: /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
   1)  An uncaught error was detected outside of a test:
      Uncaught ReferenceError: foo is not defined
 
-This error originated from *your* test code, not from Cypress.
+This error originated from your test code, not from Cypress.
 
 When Cypress detects uncaught errors originating from your test code it will automatically fail the current test.
 
@@ -68,7 +68,7 @@ Started video recording: /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
   1)  An uncaught error was detected outside of a test:
      Uncaught ReferenceError: foo is not defined
 
-This error originated from *your* test code, not from Cypress.
+This error originated from your test code, not from Cypress.
 
 When Cypress detects uncaught errors originating from your test code it will automatically fail the current test.
 
@@ -127,7 +127,7 @@ Started video recording: /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
   1) foo bar:
      Uncaught ReferenceError: foo is not defined
 
-This error originated from *your* test code, not from Cypress.
+This error originated from your test code, not from Cypress.
 
 When Cypress detects uncaught errors originating from your test code it will automatically fail the current test.
       at stack trace line
@@ -181,7 +181,7 @@ Started video recording: /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
   1) foo "before all" hook for "does not run":
      Uncaught ReferenceError: foo is not defined
 
-This error originated from *your* test code, not from Cypress.
+This error originated from your test code, not from Cypress.
 
 When Cypress detects uncaught errors originating from your test code it will automatically fail the current test.
 

--- a/packages/server/__snapshots__/uncaught_support_file_spec.coffee
+++ b/packages/server/__snapshots__/uncaught_support_file_spec.coffee
@@ -12,7 +12,7 @@ Started video recording: /foo/bar/.projects/uncaught-support-file/cypress/videos
   1)  An uncaught error was detected outside of a test:
      Uncaught Error: bar
 
-This error originated from *your* test code, not from Cypress.
+This error originated from your test code, not from Cypress.
 
 When Cypress detects uncaught errors originating from your test code it will automatically fail the current test.
 


### PR DESCRIPTION
This is to change the tone/inflection of the message. The previous
message felt like it was bordering on aggressive.

Fixes #1025 