### PR TITLE
WIP: Feature flags 1054

### DIFF
--- a/packages/desktop-gui/src/project-nav/browsers.jsx
+++ b/packages/desktop-gui/src/project-nav/browsers.jsx
@@ -2,6 +2,8 @@ import React, { Component } from 'react'
 import { observer } from 'mobx-react'
 import Tooltip from '@cypress/react-tooltip'
 import Dropdown from '../dropdown/dropdown'
+import _ from 'lodash'
+import featureMaybe from 'feature-maybe'
 
 import projectsApi from '../projects/projects-api'
 
@@ -10,10 +12,15 @@ export default class Browsers extends Component {
   render () {
     const project = this.props.project
 
+    // not sure how to observe resolvedConfig better
+    const experimentalFeatures = _.get(project, 'resolvedConfig.experimentalFeatures.value', {})
+    this.feature = featureMaybe(experimentalFeatures)
+
     if (!project.browsers.length) return null
 
     return (
       <ul className='browsers nav navbar-nav navbar-right'>
+        {this._browsersFeature()}
         {this._closeBrowserBtn()}
         <Dropdown
           className='browsers-list'
@@ -27,6 +34,12 @@ export default class Browsers extends Component {
         />
       </ul>
     )
+  }
+
+  _browsersFeature () {
+    return this.feature('browsers')
+    .map(() => (<div>Browsers:</div>))
+    .getOrElse()
   }
 
   _closeBrowserBtn () {

--- a/packages/server/lib/config.coffee
+++ b/packages/server/lib/config.coffee
@@ -28,6 +28,7 @@ configKeys = toWords """
   baseUrl                         fixturesFolder
   chromeWebSecurity               integrationFolder
   environmentVariables            pluginsFile
+  experimentalFeatures
   hosts                           screenshotsFolder
   numTestsKeptInMemory            supportFile
   port                            supportFolder
@@ -90,6 +91,7 @@ defaults = {
   screenshotsFolder:             "cypress/screenshots"
   namespace:                     "__cypress"
   pluginsFile:                    "cypress/plugins"
+  experimentalFeatures:          {}
 
   ## deprecated
   javascripts:                   []
@@ -101,6 +103,7 @@ validationRules = {
   chromeWebSecurity: v.isBoolean
   defaultCommandTimeout: v.isNumber
   env: v.isPlainObject
+  experimentalFeatures: v.isPlainObject
   execTimeout: v.isNumber
   fileServerFolder: v.isString
   fixturesFolder: v.isStringOrFalse

--- a/packages/server/lib/project.coffee
+++ b/packages/server/lib/project.coffee
@@ -6,6 +6,8 @@ path        = require("path")
 glob        = require("glob")
 Promise     = require("bluebird")
 commitInfo  = require("@cypress/commit-info")
+featureMaybe = require('feature-maybe')
+
 la          = require("lazy-ass")
 check       = require("check-more-types")
 cwd         = require("./cwd")
@@ -74,6 +76,12 @@ class Project extends EE
 
     @getConfig(options)
     .then (cfg) =>
+      @feature = featureMaybe(cfg.experimentalFeatures)
+      # use feature flags based on the project
+      @feature('browsers')
+        .map () ->
+          console.log('experimental feature "browsers" enabled')
+
       process.chdir(@projectRoot)
 
       @server.open(cfg, @)


### PR DESCRIPTION
A jump off point for discussion (I did not even make `feature-maybe` public)

1. project's config in `cypress.json` gets new property like

```json
{
  "videoRecording": true,
  "experimentalFeatures": {
    "browsers": true
  }
}
```
2. In `packages/server` we add `feature` function as as a property of the project instance. It is set _after_ project is opened and reads the `cypress.json` file. This might be too late for some features ⚠️

3. One can use `project.feature` like this
```
# use feature flags based on the project
@feature('browsers')
    .map () ->
       console.log('experimental feature "browsers" enabled')
```
4. for example from `packages/desktop-gui` we can render something different depending on the experimental feature by wrapping around resolved config from the project. Not sure how MobX can be used better here

```js
render () {
  const project = this.props.project

  // not sure how to observe resolvedConfig better
  const experimentalFeatures = _.get(project, 'resolvedConfig.experimentalFeatures.value', {})
  this.feature = featureMaybe(experimentalFeatures)

  return (
     <ul className='browsers nav navbar-nav navbar-right'>
        {this._browsersFeature()}
         ...
      </ul>
  )
}

_browsersFeature () {
    return this.feature('browsers')
    .map(() => (<div>Browsers:</div>))
    .getOrElse()
}
```

closes #1054 