### PR TITLE
build: make empty commit in next version branch first, close #1070

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "lazy-ass": "^1.6.0",
     "lint-staged": "^4.1.3",
     "lodash": "^4.17.4",
-    "make-empty-github-commit": "^1.1.2",
+    "make-empty-github-commit": "^1.2.0",
     "mocha": "^3.5.0",
     "mocha-junit-reporter": "^1.13.0",
     "mocha-multi-reporters": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "check-more-types": "^2.24.0",
     "cloudflare-cli": "^2.1.0",
     "coffeelint": "^1.16.0",
-    "commit-message-install": "^1.4.0",
+    "commit-message-install": "^1.7.0",
     "common-tags": "^1.4.0",
     "console.table": "^0.9.1",
     "debug": "^2.6.8",

--- a/scripts/binary/index.coffee
+++ b/scripts/binary/index.coffee
@@ -100,7 +100,7 @@ deploy = {
     .then (task) ->
       switch task
         when "run"
-          bump.run()
+          bump.runTestProjects()
         when "version"
           ask.whichVersion(meta.distDir(""))
           .then (v) ->

--- a/scripts/test-other-projects.js
+++ b/scripts/test-other-projects.js
@@ -28,11 +28,11 @@ const cliOptions = minimist(process.argv, {
   },
 })
 
-const shorten = (s) =>
-  s.substr(0, 7)
+const shorten = (s) => s.substr(0, 7)
 
 const getShortCommit = () => {
-  const sha = process.env.APPVEYOR_REPO_COMMIT ||
+  const sha =
+    process.env.APPVEYOR_REPO_COMMIT ||
     process.env.CIRCLE_SHA1 ||
     process.env.BUILDKITE_COMMIT
   if (sha) {
@@ -98,9 +98,12 @@ if (process.env.APPVEYOR) {
 
 console.log('commit message')
 console.log(message)
-bump.run(message, cliOptions.provider)
-.catch((e) => {
+
+const onError = (e) => {
   console.error('could not bump test projects')
   console.error(e)
   process.exit(1)
-})
+}
+bump
+.runTestProjects(message, cliOptions.provider, shortNpmVersion)
+.catch(onError)

--- a/scripts/test-other-projects.js
+++ b/scripts/test-other-projects.js
@@ -76,7 +76,12 @@ if (shortSha) {
 const env = {
   CYPRESS_BINARY_VERSION: binary,
 }
-const commitMessageInstructions = getInstallJson(npm, env, platform)
+const commitMessageInstructions = getInstallJson(
+  npm,
+  env,
+  platform,
+  shortNpmVersion
+)
 const jsonBlock = toMarkdownJsonBlock(commitMessageInstructions)
 const footer = 'Use tool `commit-message-install` to install from above block'
 let message = `${subject}\n\n${jsonBlock}\n${footer}\n`


### PR DESCRIPTION
Seems now that I have implemented this we still need more work inside `cypress-test-example-repos`. Because we do NOT plan to create branches in the `cypress-test-example-repos` itself - instead we are creating branches like `1.2.0` in the `cypress-example-recipes` that are tested by the code in `cypress-test-example-repos`.

So in addition to this (this only works if we use branches for direct breaking changes in the repos), we also need to update code here to look at the commit message, extract version, see if the repo we have cloned has a branch with this name, switch to that branch and do install, run the tests. etc.

Opened https://github.com/cypress-io/cypress-test-example-repos/issues/10 - this should very simple
