### PR TITLE
cli: fixes #838 start cypress in dev by routing through the CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,6 +180,10 @@ option to see more details.
 
 This outputs a lot of debugging lines. To focus on an individual module run with `DEBUG=cypress:launcher` for instance.
 
+When running `npm start` this routes through the CLI and eventually calls `npm run dev` with the proper arguments. This enables Cypress day to day development to match the logic of the built binary + CLI integration.
+
+If you want to bypass the CLI entirely you can use the `npm run dev` task and pass arguments directly.
+
 #### Tasks
 
 Each package is responsible for building itself and testing itself and can do so using whatever tools are appropriate, but each conforms to a standard set of npm scripts so that building, watching, testing, etc. can be orchestrated from the root of this repo. Here are the npm scripts supported and what they mean:

--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -118,7 +118,7 @@ module.exports = {
     .option('-P, --project <project-path>', text('project'))
     .option('--group', text('group'), coerceFalse)
     .option('--group-id <group-id>', text('groupId'))
-    .option('--dev', text('dev'))
+    .option('--dev', text('dev'), coerceFalse)
     .action((opts) => {
       debug('running Cypress')
       require('./exec/run')
@@ -137,7 +137,7 @@ module.exports = {
     .option('-d, --detached [bool]', text('detached'), coerceFalse)
     .option('-P, --project <project path>', text('project'))
     .option('--global', text('global'))
-    .option('--dev', text('dev'))
+    .option('--dev', text('dev'), coerceFalse)
     .action((opts) => {
       debug('opening Cypress')
       require('./exec/open')

--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -15,7 +15,7 @@ const parseOpts = (opts) => {
     'project', 'spec', 'reporter', 'reporterOptions', 'path', 'destination',
     'port', 'env', 'cypressVersion', 'config', 'record', 'key',
     'browser', 'detached', 'headed',
-    'group', 'groupId', 'global')
+    'group', 'groupId', 'global', 'dev')
 
   if (opts.project) {
     opts.project = path.resolve(opts.project)
@@ -46,6 +46,7 @@ const descriptions = {
   headed: 'displays the Electron browser instead of running headlessly',
   group: 'flag to group individual runs by using common --group-id',
   groupId: 'optional common id to group runs by, extracted from CI environment variables by default',
+  dev: 'runs cypress in development and bypasses binary check',
 }
 
 const knownCommands = ['version', 'run', 'open', 'install', 'verify', '-v', '--version', 'help', '-h', '--help']
@@ -117,6 +118,7 @@ module.exports = {
     .option('-P, --project <project-path>', text('project'))
     .option('--group', text('group'), coerceFalse)
     .option('--group-id <group-id>', text('groupId'))
+    .option('--dev', text('dev'))
     .action((opts) => {
       debug('running Cypress')
       require('./exec/run')
@@ -135,6 +137,7 @@ module.exports = {
     .option('-d, --detached [bool]', text('detached'), coerceFalse)
     .option('-P, --project <project path>', text('project'))
     .option('--global', text('global'))
+    .option('--dev', text('dev'))
     .action((opts) => {
       debug('opening Cypress')
       require('./exec/open')

--- a/cli/lib/exec/open.js
+++ b/cli/lib/exec/open.js
@@ -30,12 +30,19 @@ module.exports = {
     debug('opening from options %j', options)
     debug('command line arguments %j', args)
 
-    return verify.start()
-    .then(() => {
+    function open () {
       return spawn.start(args, {
+        dev: options.dev,
         detached: Boolean(options.detached),
         stdio: 'inherit',
       })
-    })
+    }
+
+    if (options.dev) {
+      return open()
+    }
+
+    return verify.start()
+    .then(open)
   },
 }

--- a/cli/lib/exec/run.js
+++ b/cli/lib/exec/run.js
@@ -84,12 +84,6 @@ const processRunOptions = (options = {}) => {
   return args
 }
 
-const run = (options) => () => {
-  const args = processRunOptions(options)
-  debug('run to spawn.start args %j', args)
-  return spawn.start(args)
-}
-
 module.exports = {
   processRunOptions,
   // resolves with the number of failed tests
@@ -102,7 +96,21 @@ module.exports = {
       project: process.cwd(),
     })
 
+    function run () {
+      const args = processRunOptions(options)
+
+      debug('run to spawn.start args %j', args)
+
+      return spawn.start(args, {
+        dev: options.dev,
+      })
+    }
+
+    if (options.dev) {
+      return run()
+    }
+
     return verify.start()
-    .then(run(options))
+    .then(run)
   },
 }

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -30,9 +30,20 @@ module.exports = {
 
     const spawn = () => {
       return new Promise((resolve, reject) => {
-        const cypressPath = info.getPathToExecutable()
+        let cypressPath = info.getPathToExecutable()
+
+        if (options.dev) {
+          // if we're in dev then reset
+          // the launch cmd to be 'npm run dev'
+          cypressPath = 'npm'
+          args.unshift('run', 'dev')
+        }
+
         debug('spawning Cypress %s', cypressPath)
-        debug('spawn args %j', args)
+        debug('spawn args %j', args, options)
+
+        // strip dev out of child process options
+        options = _.omit(options, 'dev')
 
         const child = cp.spawn(cypressPath, args, options)
         child.on('close', resolve)

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -1,6 +1,7 @@
 const _ = require('lodash')
 const os = require('os')
 const cp = require('child_process')
+const path = require('path')
 const Promise = require('bluebird')
 const devNull = require('dev-null')
 const debug = require('debug')('cypress:cli')
@@ -35,8 +36,8 @@ module.exports = {
         if (options.dev) {
           // if we're in dev then reset
           // the launch cmd to be 'npm run dev'
-          cypressPath = 'npm'
-          args.unshift('run', 'dev')
+          cypressPath = 'node'
+          args.unshift(path.resolve(__dirname, '..', '..', '..', 'scripts', 'start.js'))
         }
 
         debug('spawning Cypress %s', cypressPath)

--- a/cli/test/lib/exec/open_spec.js
+++ b/cli/test/lib/exec/open_spec.js
@@ -21,11 +21,12 @@ describe('exec open', function () {
     })
 
     it('calls spawn with correct options', function () {
-      return open.start()
+      return open.start({ dev: true })
       .then(() => {
         expect(spawn.start).to.be.calledWith([], {
           detached: false,
           stdio: 'inherit',
+          dev: true,
         })
       })
     })

--- a/cli/test/lib/exec/run_spec.js
+++ b/cli/test/lib/exec/run_spec.js
@@ -39,16 +39,17 @@ describe('exec run', function () {
 
   context('.start', function () {
     beforeEach(function () {
-      this.sandbox.stub(spawn, 'start')
+      this.sandbox.stub(spawn, 'start').resolves()
       this.sandbox.stub(verify, 'start').resolves()
     })
 
     describe('group and group-id', () => {
       it('spawns with --group true', function () {
-        return run.start({ group: true })
+        return run.start({ group: true, dev: true })
         .then(() => {
           expect(spawn.start).to.be.calledWith(
-            ['--run-project', process.cwd(), '--group', true]
+            ['--run-project', process.cwd(), '--group', true],
+            { dev: true }
           )
         })
       })

--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -37,6 +37,15 @@ describe('exec spawn', function () {
       })
     })
 
+    it('uses npm command when running in dev mode', function () {
+      this.spawnedProcess.on.withArgs('close').yieldsAsync(0)
+
+      return spawn.start('--foo', { dev: true, foo: 'bar' })
+      .then(() => {
+        expect(cp.spawn).to.be.calledWithMatch('npm', ['run', 'dev', '--foo'], { foo: 'bar' })
+      })
+    })
+
     it('starts xvfb when needed', function () {
       this.spawnedProcess.on.withArgs('close').yieldsAsync(0)
 

--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -2,6 +2,7 @@ require('../../spec_helper')
 
 const cp = require('child_process')
 const os = require('os')
+const path = require('path')
 
 const info = require(`${lib}/tasks/info`)
 const xvfb = require(`${lib}/exec/xvfb`)
@@ -40,9 +41,11 @@ describe('exec spawn', function () {
     it('uses npm command when running in dev mode', function () {
       this.spawnedProcess.on.withArgs('close').yieldsAsync(0)
 
+      const p = path.resolve('..', 'scripts', 'start.js')
+
       return spawn.start('--foo', { dev: true, foo: 'bar' })
       .then(() => {
-        expect(cp.spawn).to.be.calledWithMatch('npm', ['run', 'dev', '--foo'], { foo: 'bar' })
+        expect(cp.spawn).to.be.calledWithMatch('node', [p, '--foo'], { foo: 'bar' })
       })
     })
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.5.0"
   },
   "scripts": {
-    "start": "./cli/bin/cypress open --dev",
+    "start": "node ./cli/bin/cypress open --dev --global",
     "dev": "node ./scripts/start.js",
     "watch": "npm run all watch",
     "deps": "deps-ok",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "node": ">=6.5.0"
   },
   "scripts": {
-    "start": "node ./scripts/start.js",
+    "start": "./cli/bin/cypress open --dev",
+    "dev": "node ./scripts/start.js",
     "watch": "npm run all watch",
     "deps": "deps-ok",
     "prebuild": "npm run deps",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "server": "node index.js --mode server",
+    "start": "node ../../cli/bin/cypress open --dev --global",
+    "dev": "node index.js",
     "repl": "node repl.js",
     "clean-deps": "rm -rf node_modules",
     "test": "node ./test/scripts/run.js",

--- a/packages/server/test/integration/cli_spec.coffee
+++ b/packages/server/test/integration/cli_spec.coffee
@@ -33,14 +33,14 @@ describe "CLI Interface", ->
     @currentTest.timeout(20000)
 
   it "writes out ping value and exits", (done) ->
-    cp.exec "npm start -- --smoke-test --ping=12345", {env: env}, (err, stdout, stderr) ->
+    cp.exec "npm run dev -- --smoke-test --ping=12345", {env: env}, (err, stdout, stderr) ->
       done(err) if err
 
       expect(clean(stdout)).to.eq("12345")
       done()
 
   it "writes out package.json and exits", (done) ->
-    cp.exec "npm start -- --return-pkg", {env: env}, (err, stdout, stderr) ->
+    cp.exec "npm run dev -- --return-pkg", {env: env}, (err, stdout, stderr) ->
       done(err) if err
 
       json = JSON.parse(clean(stdout))
@@ -59,16 +59,16 @@ describe "CLI Interface", ->
       beforeEach ->
         ## run the start script directly
         ## instead of going through npm wrapper
-        @start = pkg.scripts.start
+        @dev = pkg.scripts.dev
 
       it "exits with code 22", (done) ->
-        s = cp.exec("#{@start} --exit-with-code=22")
+        s = cp.exec("#{@dev} --exit-with-code=22")
         s.on "close", (code) ->
           expect(code).to.eq(22)
           done()
 
       it "exits with code 0", (done) ->
-        s = cp.exec("#{@start} --exit-with-code=0")
+        s = cp.exec("#{@dev} --exit-with-code=0")
         s.on "close", (code) ->
           expect(code).to.eq(0)
           done()
@@ -88,13 +88,13 @@ describe "CLI Interface", ->
 
       it "npm slurps up or not exit value on failure", (done) ->
         expectedCode = if isNpmSlurpingCode() then 1 else 10
-        s = cp.exec("npm start -- --exit-with-code=10")
+        s = cp.exec("npm run dev -- --exit-with-code=10")
         s.on "close", (code) ->
           expect(code).to.eq(expectedCode)
           done()
 
       it "npm passes on 0 exit code", (done) ->
-        s = cp.exec("npm start -- --exit-with-code=0")
+        s = cp.exec("npm run dev -- --exit-with-code=0")
         s.on "close", (code) ->
           expect(code).to.eq(0)
           done()


### PR DESCRIPTION
- matches how we run in production better to keep parity and consistency