### PR TITLE
Banner to separate test output

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "test": "npm run test-unit",
-    "test-unit": "npm run dtslint && bin-up mocha --reporter mocha-multi-reporters --reporter-options configFile=../mocha-reporter-config.json",
+    "test-unit": "npm run dtslint && npm run unit",
     "test-watch": "bin-up mocha --watch",
     "test-dependencies": "bin-up deps-ok && dependency-check . --no-dev",
     "test-debug": "node --inspect --debug-brk $(bin-up _mocha)",
@@ -21,7 +21,8 @@
     "build": "node ./scripts/build.js",
     "prerelease": "npm run build",
     "release": "cd build && releaser --no-node --no-changelog",
-    "size": "t=\"$(npm pack .)\"; wc -c \"${t}\"; tar tvf \"${t}\"; rm \"${t}\";"
+    "size": "t=\"$(npm pack .)\"; wc -c \"${t}\"; tar tvf \"${t}\"; rm \"${t}\";",
+    "unit": "bin-up mocha --reporter mocha-multi-reporters --reporter-options configFile=../mocha-reporter-config.json"
   },
   "types": "types",
   "dependencies": {

--- a/cli/test/lib/cli_spec.js
+++ b/cli/test/lib/cli_spec.js
@@ -183,7 +183,7 @@ describe('cli', function () {
 
     it('calls run with relative --project folder', function () {
       this.sandbox.stub(path, 'resolve')
-        .withArgs('foo/bar').returns('/mock/absolute/foo/bar')
+      .withArgs('foo/bar').returns('/mock/absolute/foo/bar')
       this.exec('run --project foo/bar')
       expect(run.start).to.be.calledWith({ project: '/mock/absolute/foo/bar' })
     })
@@ -206,7 +206,7 @@ describe('cli', function () {
 
     it('calls open.start with relative --project folder', function () {
       this.sandbox.stub(path, 'resolve')
-        .withArgs('foo/bar').returns('/mock/absolute/foo/bar')
+      .withArgs('foo/bar').returns('/mock/absolute/foo/bar')
       this.exec('open --project foo/bar')
       expect(open.start).to.be.calledWith({ project: '/mock/absolute/foo/bar' })
     })

--- a/cli/test/lib/cli_spec.js
+++ b/cli/test/lib/cli_spec.js
@@ -13,6 +13,8 @@ const execa = require('execa-wrap')
 const path = require('path')
 
 describe('cli', function () {
+  require('mocha-banner').register()
+
   beforeEach(function () {
     logger.reset()
     this.sandbox.stub(process, 'exit')
@@ -191,7 +193,7 @@ describe('cli', function () {
       expect(run.start).to.be.calledWith({ project: '/tmp/foo/bar' })
     })
 
-    it('calls run with heded', function () {
+    it('calls run with headed', function () {
       this.exec('run --headed')
       expect(run.start).to.be.calledWith({ headed: true })
     })

--- a/cli/test/lib/tasks/download_spec.js
+++ b/cli/test/lib/tasks/download_spec.js
@@ -16,6 +16,8 @@ const stdout = require('../../support/stdout')
 const normalize = require('../../support/normalize')
 
 describe('download', function () {
+  require('mocha-banner').register()
+
   const rootFolder = '/home/user/git'
 
   beforeEach(function () {

--- a/cli/test/lib/tasks/install_spec.js
+++ b/cli/test/lib/tasks/install_spec.js
@@ -23,6 +23,8 @@ const downloadDestination = {
 }
 
 describe('install', function () {
+  require('mocha-banner').register()
+
   beforeEach(function () {
     this.stdout = stdout.capture()
 

--- a/cli/test/lib/tasks/unzip_spec.js
+++ b/cli/test/lib/tasks/unzip_spec.js
@@ -16,6 +16,7 @@ const normalize = require('../../support/normalize')
 const dest = info.getInstallationDir()
 
 describe('unzip', function () {
+  require('mocha-banner').register()
   beforeEach(function () {
     this.stdout = stdout.capture()
 
@@ -33,7 +34,8 @@ describe('unzip', function () {
   it('throws when cannot unzip', function () {
     const ctx = this
 
-    return unzip.start({
+    return unzip
+    .start({
       downloadDestination: path.join('test', 'fixture', 'bad_example.zip'),
       zipDestination: '/foo/bar/baz',
     })
@@ -43,15 +45,13 @@ describe('unzip', function () {
     .catch((err) => {
       logger.error(err)
 
-      snapshot(
-        'unzip error',
-        normalize(ctx.stdout.toString())
-      )
+      snapshot('unzip error', normalize(ctx.stdout.toString()))
     })
   })
 
   it('can really unzip', function () {
-    return unzip.start({
+    return unzip
+    .start({
       downloadDestination: path.join('test', 'fixture', 'example.zip'),
     })
     .then(() => {

--- a/cli/test/lib/tasks/verify_spec.js
+++ b/cli/test/lib/tasks/verify_spec.js
@@ -43,6 +43,7 @@ const slice = (str) => {
 }
 
 context('.verify', function () {
+  require('mocha-banner').register()
   beforeEach(function () {
     this.stdout = stdout.capture()
     this.cpstderr = new EE()

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "lodash": "^4.17.4",
     "make-empty-github-commit": "^1.2.0",
     "mocha": "^3.5.0",
+    "mocha-banner": "^1.1.0",
     "mocha-junit-reporter": "^1.13.0",
     "mocha-multi-reporters": "^1.1.5",
     "obfuscator": "^0.5.4",


### PR DESCRIPTION
for example added to CLI to suites that have a log of text output that is confusing and hard to separate.

Just add to these suites
```js
describe('some verbose stuff', () => {
  require('mocha-banner').register()
})
```
To get things like these
<img width="945" alt="screen shot 2018-01-12 at 4 29 10 pm" src="https://user-images.githubusercontent.com/2212006/34896148-aef5862e-f7b6-11e7-8e70-806e5d072fe0.png">
<img width="983" alt="screen shot 2018-01-12 at 4 29 28 pm" src="https://user-images.githubusercontent.com/2212006/34896156-b7448ce4-f7b6-11e7-9d81-01a77f6be114.png">

suites with short tests without much output are left alone (we do not require `mocha-banner` there)
<img width="964" alt="screen shot 2018-01-12 at 4 29 35 pm" src="https://user-images.githubusercontent.com/2212006/34896176-c7b220f0-f7b6-11e7-95f4-8375632af205.png">


