### PR TITLE
Allow .localhost tld to be parsed correctly

### DIFF
--- a/packages/server/__snapshots__/domain_spec.coffee
+++ b/packages/server/__snapshots__/domain_spec.coffee
@@ -1,0 +1,35 @@
+exports['e2e domain passing 1'] = `
+Started video recording: /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
+
+  (Tests Starting)
+
+
+  localhost
+    ✓ can visit
+
+
+  1 passing
+
+
+  (Tests Finished)
+
+  - Tests:           1
+  - Passes:          1
+  - Failures:        0
+  - Pending:         0
+  - Duration:        10 seconds
+  - Screenshots:     0
+  - Video Recorded:  true
+  - Cypress Version: 1.2.3
+
+
+  (Video)
+
+  - Started processing:   Compressing to 32 CRF
+  - Finished processing:  /foo/bar/.projects/e2e/cypress/videos/abc123.mp4 (0 seconds)
+
+
+  (All Done)
+
+`
+

--- a/packages/server/lib/util/cors.coffee
+++ b/packages/server/lib/util/cors.coffee
@@ -3,7 +3,7 @@ url         = require("url")
 debug       = require("debug")("cypress:server:cors")
 parseDomain = require("parse-domain")
 
-localHostOrIpAddressRe = /localhost|\.localhost|\.local|^[\d\.]+$/
+localHostOrIpAddressRe = /.?localhost|\.local|^[\d\.]+$/
 
 module.exports = {
   parseUrlIntoDomainTldPort: (str) ->

--- a/packages/server/lib/util/cors.coffee
+++ b/packages/server/lib/util/cors.coffee
@@ -3,7 +3,7 @@ url         = require("url")
 debug       = require("debug")("cypress:server:cors")
 parseDomain = require("parse-domain")
 
-localHostOrIpAddressRe = /localhost|\.local|^[\d\.]+$/
+localHostOrIpAddressRe = /localhost|\.localhost|\.local|^[\d\.]+$/
 
 module.exports = {
   parseUrlIntoDomainTldPort: (str) ->

--- a/packages/server/test/e2e/domain_spec.coffee
+++ b/packages/server/test/e2e/domain_spec.coffee
@@ -1,0 +1,17 @@
+e2e = require("../support/helpers/e2e")
+
+describe "e2e domain", ->
+  e2e.setup({
+    servers: {
+      port: 4848
+      static: true
+    }
+  })
+
+  it "passing", ->
+    e2e.exec(@, {
+      spec: "domain_spec.coffee"
+      hosts: "app.localhost=127.0.0.1"
+      snapshot: true
+      expectedExitCode: 0
+    })

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/domain_spec.coffee
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/domain_spec.coffee
@@ -1,0 +1,3 @@
+describe "localhost", ->
+  it "can visit", ->
+    cy.visit("http://app.localhost:4848")

--- a/packages/server/test/unit/cors_spec.coffee
+++ b/packages/server/test/unit/cors_spec.coffee
@@ -15,6 +15,27 @@ describe "lib/util/cors", ->
         tld: "com"
       })
 
+    it "parses http://localhost:8080", ->
+      @isEq("http://localhost:8080", {
+        port: "8080"
+        domain: ""
+        tld: "localhost"
+      })
+
+    it "parses http://app.localhost:8080", ->
+      @isEq("http://app.localhost:8080", {
+        port: "8080"
+        domain: "app"
+        tld: "localhost"
+      })
+
+    it "parses http://app.local:8080", ->
+      @isEq("http://app.local:8080", {
+        port: "8080"
+        domain: "app"
+        tld: "local"
+      })
+
   context ".urlMatchesOriginPolicyProps", ->
     beforeEach ->
       @isFalse = (url, props) =>
@@ -54,6 +75,18 @@ describe "lib/util/cors", ->
 
       it "matches", ->
         @isTrue("http://localhost:4200", @props)
+
+    describe "app.localhost", ->
+      beforeEach ->
+        @props = cors.parseUrlIntoDomainTldPort("http://app.localhost:4200")
+
+      it "does not match", ->
+        @isFalse("http://app.localhost:4201", @props)
+        @isFalse("http://app.localhoss:4200", @props)
+
+      it "matches", ->
+        @isTrue("http://app.localhost:4200", @props)
+        @isTrue("http://name.app.localhost:4200", @props)
 
     describe "local", ->
       beforeEach ->


### PR DESCRIPTION
Closes #451

Currently `parseDomain` returns an invalid response when passed a domain ending in `.localhost`. For example, `www.ourapp.localhost` returns:
```
domain: "loc"
subdomain: "www.ourapp"
tld: "local"
```

This PR adds `.localhost` to the `customTlds` list so that the domain is parsed correctly:
```
domain: "ourapp"
subdomain: "www"
tld: "localhost"
```

This PR closes #451 