### PR TITLE
fix: Incorrect type for 'then' returning a wrapped 'undefined'

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -824,8 +824,8 @@ declare namespace Cypress {
      *
      * @see https://on.cypress.io/then
      */
-    then<S extends object | any[] | string | number | boolean>(fn: (this: ObjectLike, currentSubject: Subject) => Chainable<S>, options?: Partial<Timeoutable>): Chainable<S>
-    then<S extends object | any[] | string | number | boolean>(fn: (this: ObjectLike, currentSubject: Subject) => PromiseLike<S>, options?: Partial<Timeoutable>): Chainable<S>
+    then<S>(fn: (this: ObjectLike, currentSubject: Subject) => Chainable<S>, options?: Partial<Timeoutable>): Chainable<S>
+    then<S>(fn: (this: ObjectLike, currentSubject: Subject) => PromiseLike<S>, options?: Partial<Timeoutable>): Chainable<S>
     then<S extends object | any[] | string | number | boolean>(fn: (this: ObjectLike, currentSubject: Subject) => S, options?: Partial<Timeoutable>): Chainable<S>
     /**
      * Enables you to work with the subject yielded from the previous command.

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -162,3 +162,12 @@ cy.get('body').within(body => {
 cy.get('body').within({ log: false }, body => {
   body // $ExpectType JQuery<HTMLBodyElement>
 })
+
+cy
+  .get('body')
+  .then(() => {
+    return cy.wrap(undefined)
+  })
+  .then(subject => {
+    subject // $ExpectType undefined
+  })


### PR DESCRIPTION
It is valid to return a wrapped `undefined`. Example: `cy.wrap(undefined)` or `Promise.resolve(undefined)` or even `cy.wrap(null)`.

As it is before this PR, returning a wrapped `undefined` or `null` would result in a double-wrapped type

Fixes #1219