### PR TITLE
server: fixes #802 and fixes #380 and fixes #402 and fixes #493 and fixes #1161

### DIFF
--- a/packages/server/__snapshots__/domain_spec.coffee
+++ b/packages/server/__snapshots__/domain_spec.coffee
@@ -7,14 +7,20 @@ Started video recording: /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
   localhost
     ✓ can visit
 
+  com.au
+    ✓ can visit
 
-  1 passing
+  herokuapp.com
+    ✓ can visit
+
+
+  3 passing
 
 
   (Tests Finished)
 
-  - Tests:           1
-  - Passes:          1
+  - Tests:           3
+  - Passes:          3
   - Failures:        0
   - Pending:         0
   - Duration:        10 seconds

--- a/packages/server/lib/util/cors.coffee
+++ b/packages/server/lib/util/cors.coffee
@@ -13,6 +13,7 @@ module.exports = {
 
     ## if we couldn't get a parsed domain
     if not parsed = parseDomain(hostname, {
+      privateTlds: true ## use the public suffix
       customTlds: localHostOrIpAddressRe
     })
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -131,7 +131,7 @@
     "opn": "cypress-io/opn#2f4e9a216ca7bdb95dfae9d46d99ddf004b3cbb5",
     "ospath": "^1.1.0",
     "p-queue": "^1.0.0",
-    "parse-domain": "^0.2.1",
+    "parse-domain": "2.0.0",
     "pluralize": "^3.0.0",
     "pretty-error": "^2.1.0",
     "progress": "^1.1.8",

--- a/packages/server/test/e2e/domain_spec.coffee
+++ b/packages/server/test/e2e/domain_spec.coffee
@@ -1,5 +1,10 @@
 e2e = require("../support/helpers/e2e")
 
+HOSTS = [
+  "app.localhost=127.0.0.1"
+  "foo.bar.baz.com.au=127.0.0.1"
+].join(",")
+
 describe "e2e domain", ->
   e2e.setup({
     servers: {
@@ -11,7 +16,7 @@ describe "e2e domain", ->
   it "passing", ->
     e2e.exec(@, {
       spec: "domain_spec.coffee"
-      hosts: "app.localhost=127.0.0.1"
+      hosts: HOSTS
       snapshot: true
       expectedExitCode: 0
     })

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/domain_spec.coffee
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/domain_spec.coffee
@@ -1,3 +1,12 @@
 describe "localhost", ->
   it "can visit", ->
     cy.visit("http://app.localhost:4848")
+
+describe "com.au", ->
+  it "can visit", ->
+    cy.visit("http://foo.bar.baz.com.au:4848")
+
+describe "herokuapp.com", ->
+  it "can visit", ->
+    cy.visit("https://example.herokuapp.com")
+    cy.contains("Example Heroku App")

--- a/packages/server/test/unit/cors_spec.coffee
+++ b/packages/server/test/unit/cors_spec.coffee
@@ -36,6 +36,14 @@ describe "lib/util/cors", ->
         tld: "local"
       })
 
+    ## public suffix example of a private tld
+    it "parses https://example.herokuapp.com", ->
+      @isEq("https://example.herokuapp.com", {
+        port: "443"
+        domain: "example"
+        tld: "herokuapp.com"
+      })
+
   context ".urlMatchesOriginPolicyProps", ->
     beforeEach ->
       @isFalse = (url, props) =>
@@ -64,6 +72,18 @@ describe "lib/util/cors", ->
         @isTrue("https://google.com:443", @props)
         @isTrue("https://foo.google.com:443", @props)
         @isTrue("https://foo.bar.google.com:443", @props)
+
+    describe "public suffix", ->
+      beforeEach ->
+        @props = cors.parseUrlIntoDomainTldPort("https://example.gitlab.io")
+
+      it "does not match", ->
+        @isFalse("http://example.gitlab.io", @props)
+        @isFalse("https://foo.gitlab.io:443", @props)
+
+      it "matches", ->
+        @isTrue("https://example.gitlab.io:443", @props)
+        @isTrue("https://foo.example.gitlab.io:443", @props)
 
     describe "localhost", ->
       beforeEach ->


### PR DESCRIPTION
- use the public suffix when parsing tld’s so that document.domain is
set correctly