### PR TITLE
WIP: cli: allow parameter --app pointing at existing Cypress app folder

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -1,7 +1,15 @@
 const minimist = require('minimist')
 const debug = require('debug')('cypress:cli')
-const args = minimist(process.argv.slice(2))
+const args = minimist(process.argv.slice(2), {
+  string: 'app',
+})
 const util = require('./lib/util')
+const path = require('path')
+
+let getInstallationDir
+if (args.app) {
+  getInstallationDir = () => path.resolve(args.app)
+}
 
 // we're being used from the command line
 switch (args.exec) {
@@ -18,7 +26,10 @@ switch (args.exec) {
     debug('verifying Cypress')
 
     require('./lib/tasks/verify')
-    .start({ force: true }) // always force verification
+    .start({
+      getInstallationDir,
+      force: true, // always force verification
+    })
     .catch(util.logErrorExit1)
 
     break


### PR DESCRIPTION
First step for reusing existing Cypress binary installs - adding a CLI parameter `--app` that points at existing Cypress binary folder in to verify.