### PR TITLE
escape text before interpolating in getContainsSelector

### DIFF
--- a/packages/driver/src/dom/elements.coffee
+++ b/packages/driver/src/dom/elements.coffee
@@ -193,10 +193,8 @@ getElements = ($el) ->
     els
 
 getContainsSelector = (text, filter = "") ->
-  if _.isString(text)
-    text = $utils.escapeQuotes(text)
-
-  "#{filter}:not(script):contains('#{text}'), #{filter}[type='submit'][value~='#{text}']"
+  escapedText = $utils.escapeQuotes(text)
+  "#{filter}:not(script):contains('#{escapedText}'), #{filter}[type='submit'][value~='#{escapedText}']"
 
 priorityElement = "input[type='submit'], button, a, label"
 

--- a/packages/driver/test/cypress/integration/commands/querying_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/querying_spec.coffee
@@ -1422,10 +1422,16 @@ describe "src/cy/commands/querying", ->
 
     describe "special characters", ->
       _.each "' \" [ ] { } . @ # $ % ^ & * ( ) , ; :".split(" "), (char) ->
-        it "finds content with character: #{char}", ->
+        it "finds content by string with character: #{char}", ->
           span = $("<span>special char #{char} content</span>").appendTo cy.$$("body")
 
           cy.contains("span", char).then ($span) ->
+            expect($span.get(0)).to.eq span.get(0)
+
+        it "finds content by regex with character: #{char}", ->
+          span = $("<span>special char #{char} content</span>").appendTo cy.$$("body")
+
+          cy.contains("span", new RegExp(_.escapeRegExp(char))).then ($span) ->
             expect($span.get(0)).to.eq span.get(0)
 
     describe ".log", ->


### PR DESCRIPTION
even if it’s a regex, this selector is still passed to sizzle and needs to be valid, which means quotes must be escaped

closes #1322