### PR TITLE
Avoid modifying XHR proxy that no longer exists

### DIFF
--- a/packages/driver/src/cypress/server.coffee
+++ b/packages/driver/src/cypress/server.coffee
@@ -318,7 +318,7 @@ create = (options = {}) ->
         proxy = server.getProxyFor(@)
         ## Sometimes abort is called after the proxy
         ## objects have already been cleaned up (long
-        ## polling).  Don't try to abort it if it
+        ## polling).  Don't try to abort if it
         ## does not exist
         if proxy
           abortStack = server.getStack()

--- a/packages/driver/src/cypress/server.coffee
+++ b/packages/driver/src/cypress/server.coffee
@@ -315,12 +315,16 @@ create = (options = {}) ->
         ## to test this just use a regular XHR
         @aborted = true
 
-        abortStack = server.getStack()
-
         proxy = server.getProxyFor(@)
-        proxy.aborted = true
+        ## Sometimes abort is called after the proxy
+        ## objects have already been cleaned up (long
+        ## polling).  Don't try to abort it if it
+        ## does not exist
+        if proxy
+          abortStack = server.getStack()
+          proxy.aborted = true
 
-        options.onXhrAbort(proxy, abortStack)
+          options.onXhrAbort(proxy, abortStack)
 
         if _.isFunction(options.onAnyAbort)
           route = server.getRouteForXhr(@)


### PR DESCRIPTION
address #761 

### Problem

The `cannot set property 'aborted' of undefined` issue in #761 stems from trying to set `.aborted` on a proxy that no longer exists.  This seems to happen quite often with things that do long-polling like Firebase.  [This Firebase example](https://github.com/mihalik/cypress-firebase) has random failures almost every run prior to this update.  

## Solution

This update checks if a proxy exists before trying to abort it.  I am not 100% why the proxies no longer exist when `abort()` is called but this prevents an exception from being thrown in that state and allows the tests to complete successfully.  

_Feel free to reject if this is hiding a more fundamental issue._ 


