### PR TITLE
server, driver: fixes #1343, ensure we fire 'test:after:run' events for tests which failed due to a before hook and have sibling tests

### DIFF
--- a/packages/driver/src/cypress/runner.coffee
+++ b/packages/driver/src/cypress/runner.coffee
@@ -234,6 +234,19 @@ isLastSuite = (suite, tests) ->
   .last()
   .value() is suite
 
+## we are the last test that will run in the suite
+## if we're the last test in the tests array or
+## if we failed from a hook and that hook was 'before'
+## since then mocha skips the remaining tests in the suite
+lastTestThatWillRunInSuite = (test, tests) ->
+  isLastTest(test, tests) or (test.failedFromHook and test.hookName is "before all")
+
+isLastTest = (test, tests) ->
+  test is _.last(tests)
+
+isRootSuite = (suite) ->
+  suite and suite.root
+
 overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, getTests) ->
   ## bail if our _runner doesnt have a hook.
   ## useful in tests
@@ -267,31 +280,35 @@ overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, getTests)
 
     switch name
       when "afterEach"
+        t = getTest()
+
         ## find all of the grep'd _tests which share
         ## the same parent suite as our current _test
-        tests = getAllSiblingTests(getTest().parent, getTestById)
+        tests = getAllSiblingTests(t.parent, getTestById)
 
         ## make sure this test isnt the last test overall but also
         ## isnt the last test in our grep'd parent suite's tests array
-        if @suite.root and (getTest() isnt _.last(allTests)) and (getTest() isnt _.last(tests))
+        if @suite.root and (t isnt _.last(allTests)) and (t isnt _.last(tests))
           changeFnToRunAfterHooks()
 
       when "afterAll"
-        ## find all of the grep'd _tests which share
+        ## find all of the grep'd allTests which share
         ## the same parent suite as our current _test
-        if getTest()
-          tests = getAllSiblingTests(getTest().parent, getTestById)
+        if t = getTest()
+          siblings = getAllSiblingTests(t.parent, getTestById)
 
-          ## if we're the very last test in the entire _tests
-          ## we wait until the root suite fires
-          ## else we wait until the very last possible moment by waiting
-          ## until the root suite is the parent of the current suite
-          ## since that will bubble up IF we're the last nested suite
-          ## else if we arent the last nested suite we fire if we're
-          ## the last test
-          if (@suite.root and getTest() is _.last(allTests)) or
-            (@suite.parent?.root and getTest() is _.last(tests)) or
-              (not isLastSuite(@suite, allTests) and getTest() is _.last(tests))
+          ## 1. if we're the very last test in the entire allTests
+          ##    we wait until the root suite fires
+          ## 2. else we wait until the very last possible moment by waiting
+          ##    until the root suite is the parent of the current suite
+          ##    since that will bubble up IF we're the last nested suite
+          ## 3. else if we arent the last nested suite we fire if we're
+          ##    the last test that will run
+          if (
+              (isRootSuite(@suite) and isLastTest(t, allTests)) or
+              (isRootSuite(@suite.parent) and lastTestThatWillRunInSuite(t, siblings)) or
+              (not isLastSuite(@suite, allTests) and lastTestThatWillRunInSuite(t, siblings))
+            )
             changeFnToRunAfterHooks()
 
     _runnerHook.call(@, name, fn)
@@ -429,21 +446,16 @@ afterEachFailed = (Cypress, test, err) ->
 
   Cypress.action("runner:test:end", wrap(test))
 
-hookFailed = (hook, err, hookName, getTestById, setTest) ->
+hookFailed = (hook, err, hookName, getTestById, getTest) ->
   ## finds the test by returning the first test from
   ## the parent or looping through the suites until
   ## it finds the first test
-  test = getTestFromHook(hook, hook.parent, getTestById)
+  test = getTest() or getTestFromHook(hook, hook.parent, getTestById)
   test.err = err
   test.state = "failed"
   test.duration = hook.duration
   test.hookName = hookName
   test.failedFromHook = true
-
-  ## make sure we set this test as the current
-  ## else its possible that our TEST_AFTER_RUN_EVENT
-  ## will never fire if this failed in a before hook
-  setTest(test)
 
   if hook.alreadyEmittedMocha
     ## TODO: won't this always hit right here???
@@ -452,7 +464,7 @@ hookFailed = (hook, err, hookName, getTestById, setTest) ->
   else
     Cypress.action("runner:test:end", wrap(test))
 
-_runnerListeners = (_runner, Cypress, _emissions, getTestById, setTest) ->
+_runnerListeners = (_runner, Cypress, _emissions, getTestById, getTest, setTest) ->
   _runner.on "start", ->
     Cypress.action("runner:start")
 
@@ -491,9 +503,14 @@ _runnerListeners = (_runner, Cypress, _emissions, getTestById, setTest) ->
     ## hooks do not have their own id, their
     ## commands need to grouped with the test
     ## and we can only associate them by this id
-    test = getTestFromHook(hook, hook.parent, getTestById)
+    test = getTest() or getTestFromHook(hook, hook.parent, getTestById)
     hook.id = test.id
     hook.ctx.currentTest = test
+
+    ## make sure we set this test as the current now
+    ## else its possible that our TEST_AFTER_RUN_EVENT
+    ## will never fire if this failed in a before hook
+    setTest(test)
 
     Cypress.action("runner:hook:start", wrap(hook))
 
@@ -587,7 +604,7 @@ _runnerListeners = (_runner, Cypress, _emissions, getTestById, setTest) ->
       ## if a hook fails (such as a before) then the test will never
       ## get run and we'll need to make sure we set the test so that
       ## the TEST_AFTER_RUN_EVENT fires correctly
-      hookFailed(runnable, runnable.err, hookName, getTestById, setTest)
+      hookFailed(runnable, runnable.err, hookName, getTestById, getTest)
 
 create = (specWindow, mocha, Cypress, cy) ->
   _id = 0
@@ -723,7 +740,7 @@ create = (specWindow, mocha, Cypress, cy) ->
     run: (fn) ->
       _startTime ?= moment().toJSON()
 
-      _runnerListeners(_runner, Cypress, _emissions, getTestById, setTest)
+      _runnerListeners(_runner, Cypress, _emissions, getTestById, getTest, setTest)
 
       _runner.run (failures) ->
         ## if we happen to make it all the way through
@@ -745,7 +762,7 @@ create = (specWindow, mocha, Cypress, cy) ->
 
       switch runnable.type
         when "hook"
-          test = runnable.ctx.currentTest
+          test = getTest() or getTestFromHook(runnable, runnable.parent, getTestById)
         when "test"
           test = runnable
 

--- a/packages/server/__snapshots__/caught_uncaught_hook_errors_spec.coffee
+++ b/packages/server/__snapshots__/caught_uncaught_hook_errors_spec.coffee
@@ -13,9 +13,18 @@ Started video recording: /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
     ✓ t6a
     ✓ t7a
 
+  s3a
+    2) "before all" hook for "t8a"
 
-  4 passing
-  1 failing
+  s4a
+    3) "before all" hook for "t10a"
+
+  s5a
+    ✓ fires all test:after:run events
+
+
+  5 passing
+  3 failing
 
   1) s1a "before each" hook for "t2a":
      CypressError: Timed out retrying: Expected to find element: '.does-not-exist', but never found it.
@@ -36,17 +45,29 @@ Because this error occurred during a 'before each' hook we are skipping the rema
       at stack trace line
       at stack trace line
 
+  2) s3a "before all" hook for "t8a":
+     Error: s3a before hook failed
+
+Because this error occurred during a 'before all' hook we are skipping the remaining tests in the current suite: 's3a'
+      at stack trace line
+
+  3) s4a "before all" hook for "t10a":
+     Error: s4a before hook failed
+
+Because this error occurred during a 'before all' hook we are skipping the remaining tests in the current suite: 's4a'
+      at stack trace line
+
 
 
 
   (Tests Finished)
 
-  - Tests:           4
-  - Passes:          4
-  - Failures:        1
+  - Tests:           5
+  - Passes:          5
+  - Failures:        3
   - Pending:         0
   - Duration:        10 seconds
-  - Screenshots:     1
+  - Screenshots:     3
   - Video Recorded:  true
   - Cypress Version: 1.2.3
 
@@ -54,6 +75,8 @@ Because this error occurred during a 'before each' hook we are skipping the rema
   (Screenshots)
 
   - /foo/bar/.projects/e2e/cypress/screenshots/s1a -- t2a -- before each hook.png (1280x720)
+  - /foo/bar/.projects/e2e/cypress/screenshots/s3a -- t8a -- before all hook.png (1280x720)
+  - /foo/bar/.projects/e2e/cypress/screenshots/s4a -- t10a -- before all hook.png (1280x720)
 
 
   (Video)

--- a/packages/server/test/e2e/caught_uncaught_hook_errors_spec.coffee
+++ b/packages/server/test/e2e/caught_uncaught_hook_errors_spec.coffee
@@ -15,7 +15,7 @@ describe "e2e caught and uncaught hooks errors", ->
     e2e.exec(@, {
       spec: "hook_caught_error_failing_spec.coffee"
       snapshot: true
-      expectedExitCode: 1
+      expectedExitCode: 3
     })
 
   it "failing2", ->

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/hook_caught_error_failing_spec.coffee
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/hook_caught_error_failing_spec.coffee
@@ -1,3 +1,8 @@
+testAfterRuns = []
+
+Cypress.on "test:after:run", (test) ->
+  testAfterRuns.push(test.title)
+
 ## this should run
 it "t1a", ->
 
@@ -15,3 +20,40 @@ describe "s2a", ->
   it "t5a", ->
   it "t6a", ->
   it "t7a", ->
+
+describe "s3a", ->
+  before ->
+    cy.wrap().then ->
+      throw new Error("s3a before hook failed")
+
+  after ->
+    ## it should not have fired test:after:run
+    ## for t8a yet
+    expect(testAfterRuns).to.deep.eq([
+      "t1a"
+      "t2a"
+      "t5a"
+      "t6a"
+      "t7a"
+    ])
+
+  it "t8a", ->
+  it "t9a", ->
+
+describe "s4a", ->
+  before ->
+    throw new Error("s4a before hook failed")
+
+  it "t10a", ->
+
+describe "s5a", ->
+  it "fires all test:after:run events", ->
+    expect(testAfterRuns).to.deep.eq([
+      "t1a"
+      "t2a"
+      "t5a"
+      "t6a"
+      "t7a"
+      "t8a"
+      "t10a"
+    ])


### PR DESCRIPTION
- add e2e test around this behavior
- cleanup runner code for clarity