### PR TITLE
Fix engines 1373

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -711,6 +711,7 @@ workflows:
             branches:
               only:
                 - develop
+                - fix-engines-1373
           requires:
             - build
       - build-binary:
@@ -718,6 +719,7 @@ workflows:
             branches:
               only:
                 - develop
+                - fix-engines-1373
           requires:
             - build
       - test-next-version:
@@ -725,6 +727,7 @@ workflows:
             branches:
               only:
                 - develop
+                - fix-engines-1373
           requires:
             - build-npm-package
             - build-binary

--- a/cli/__snapshots__/build_spec.js
+++ b/cli/__snapshots__/build_spec.js
@@ -1,7 +1,7 @@
-exports['package.json build outputs expected engines property 1'] = {
+exports['package.json build outputs expected properties 1'] = {
   "name": "test",
   "engines": "test engines",
-  "version": "2.0.3",
+  "version": "x.y.z",
   "description": "Cypress.io end to end testing tool",
   "author": "Brian Mann",
   "homepage": "https://github.com/cypress-io/cypress",

--- a/cli/__snapshots__/build_spec.js
+++ b/cli/__snapshots__/build_spec.js
@@ -1,0 +1,21 @@
+exports['package.json build outputs expected engines property 1'] = {
+  "name": "test",
+  "engines": "test engines",
+  "version": "2.0.3",
+  "description": "Cypress.io end to end testing tool",
+  "author": "Brian Mann",
+  "homepage": "https://github.com/cypress-io/cypress",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/cypress-io/cypress/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cypress-io/cypress.git"
+  },
+  "types": "types",
+  "scripts": {
+    "postinstall": "node index.js --exec install",
+    "size": "t=\"$(npm pack .)\"; wc -c \"${t}\"; tar tvf \"${t}\"; rm \"${t}\";"
+  }
+}

--- a/cli/scripts/build.js
+++ b/cli/scripts/build.js
@@ -3,7 +3,8 @@ const path = require('path')
 
 const fs = require('../lib/fs')
 
-// grab the current version from the root monorepo package.json
+// grab the current version and a few other properties
+// from the root package.json
 const {
   version,
   description,
@@ -12,9 +13,9 @@ const {
   license,
   bugs,
   repository,
-  engines,
 } = require('@packages/root')
 
+// the rest of properties should come from the package.json in CLI folder
 const packageJsonSrc = path.join('package.json')
 const packageJsonDest = path.join('build', 'package.json')
 
@@ -32,7 +33,6 @@ function preparePackageForNpmRelease (json) {
     license,
     bugs,
     repository,
-    engines,
     types: 'types', // typescript types
     scripts: {
       postinstall: 'node index.js --exec install',

--- a/cli/scripts/build.js
+++ b/cli/scripts/build.js
@@ -43,10 +43,25 @@ function preparePackageForNpmRelease (json) {
   return json
 }
 
-fs.readJsonAsync(packageJsonSrc)
-.then(preparePackageForNpmRelease)
-.then((json) => {
-  return fs.outputJsonAsync(packageJsonDest, json, {
-    spaces: 2,
+function makeUserPackageFile () {
+  return fs.readJsonAsync(packageJsonSrc)
+  .then(preparePackageForNpmRelease)
+  .then((json) => {
+    return fs.outputJsonAsync(packageJsonDest, json, {
+      spaces: 2,
+    }).then(() => json) // returning package json object makes it easy to test
   })
-})
+}
+
+module.exports = makeUserPackageFile
+
+if (!module.parent) {
+  makeUserPackageFile()
+  .catch((err) => {
+    /* eslint-disable no-console */
+    console.error('Could not write user package file')
+    console.error(err)
+    /* eslint-enable no-console */
+    process.exit(-1)
+  })
+}

--- a/cli/test/lib/build_spec.js
+++ b/cli/test/lib/build_spec.js
@@ -1,0 +1,22 @@
+require('../spec_helper')
+
+const fs = require(`${lib}/fs`)
+const makeUserPackageFile = require('../../scripts/build')
+const snapshot = require('snap-shot-it')
+
+describe('package.json build', () => {
+  beforeEach(function () {
+    // stub package.json in CLI
+    // with a few test props
+    // the rest should come from root package.json file
+    this.sandbox.stub(fs, 'readJsonAsync').resolves({
+      name: 'test',
+      engines: 'test engines',
+    })
+    this.sandbox.stub(fs, 'outputJsonAsync').resolves()
+  })
+
+  it('outputs expected engines property', () => {
+    return makeUserPackageFile().then(snapshot)
+  })
+})

--- a/cli/test/lib/build_spec.js
+++ b/cli/test/lib/build_spec.js
@@ -3,6 +3,17 @@ require('../spec_helper')
 const fs = require(`${lib}/fs`)
 const makeUserPackageFile = require('../../scripts/build')
 const snapshot = require('snap-shot-it')
+const la = require('lazy-ass')
+const is = require('check-more-types')
+const R = require('ramda')
+
+const hasVersion = (json) =>
+  la(is.semver(json.version), 'cannot find version', json)
+
+const hasAuthor = (json) =>
+  la(json.author === 'Brian Mann', 'wrong author name', json)
+
+const changeVersion = R.assoc('version', 'x.y.z')
 
 describe('package.json build', () => {
   beforeEach(function () {
@@ -16,7 +27,15 @@ describe('package.json build', () => {
     this.sandbox.stub(fs, 'outputJsonAsync').resolves()
   })
 
-  it('outputs expected engines property', () => {
-    return makeUserPackageFile().then(snapshot)
+  it('author name and version', () => {
+    return makeUserPackageFile()
+    .tap(hasAuthor)
+    .tap(hasVersion)
+  })
+
+  it('outputs expected properties', () => {
+    return makeUserPackageFile()
+    .then(changeVersion)
+    .then(snapshot)
   })
 })

--- a/cli/test/lib/cypress_spec.js
+++ b/cli/test/lib/cypress_spec.js
@@ -46,10 +46,10 @@ describe('cypress', function () {
 
     it('calls run#start, passing in options', () =>
       cypress.run({ foo: 'foo' })
-        .then(getStartArgs)
-        .then((args) => {
-          expect(args.foo).to.equal('foo')
-        })
+      .then(getStartArgs)
+      .then((args) => {
+        expect(args.foo).to.equal('foo')
+      })
     )
 
     it('normalizes config object', () => {
@@ -58,20 +58,20 @@ describe('cypress', function () {
         watchForFileChanges: false,
       }
       return cypress.run({ config })
-        .then(getStartArgs)
-        .then(snapshot)
+      .then(getStartArgs)
+      .then(snapshot)
     })
 
     it('normalizes env option if passed an object', () =>
       cypress.run({ env: { foo: 'bar' } })
-        .then(getStartArgs)
-        .then(snapshot)
+      .then(getStartArgs)
+      .then(snapshot)
     )
 
     it('normalizes env option if passed an object with multiple properties', () =>
       cypress.run({ env: { foo: 'bar', another: 'one' } })
-        .then(getStartArgs)
-        .then(snapshot)
+      .then(getStartArgs)
+      .then(snapshot)
     )
 
     it('gets random tmp file and passes it to run#start', function () {


### PR DESCRIPTION
uses `engines` property from CLI folder package.json file. 
Command on Node 6 for example is working now
```
npm_config_engine_strict=1 npm i https://cdn.cypress.io/beta/npm/2.0.4/circle-fix-engines-1373-a97a6f3fa6ce03acd79c5664e036da90c2e35ece-14625/cypress.tgz --ignore-scripts
```
and the installed package has the expected engines
```
"engines": {
    "node": ">=4.0.0"
  }
```