### PR TITLE
Add selector playground configuration methods

### DIFF
--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -17,6 +17,7 @@
     "@cypress/bower-kendo-ui": "0.0.2",
     "@cypress/sinon-chai": "1.1.0",
     "@cypress/underscore.inflection": "^1.0.0",
+    "@cypress/unique-selector": "0.4.2",
     "angular": "^1.3.1",
     "backbone": "^1.3.3",
     "basic-auth": "^2.0.0",

--- a/packages/driver/src/cypress.coffee
+++ b/packages/driver/src/cypress.coffee
@@ -24,8 +24,8 @@ $LocalStorage = require("./cypress/local_storage")
 $Mocha = require("./cypress/mocha")
 $Runner = require("./cypress/runner")
 $Server = require("./cypress/server")
+$SelectorPlayground = require("./cypress/selector_playground")
 $utils = require("./cypress/utils")
-selectorPlaygroundMethods = require("./cypress/selector_playground")
 
 proxies = {
   runner: "getStartTime getTestsState getEmissions setNumLogs countByTestState getDisplayPropsForLog getConsolePropsForLogById getSnapshotPropsForLogById getErrorByTestId setStartTime resumeAtTest normalizeAll".split(" ")
@@ -127,7 +127,6 @@ class $Cypress
     @state = $SetterGetter.create({})
     @config = $SetterGetter.create(config)
     @env = $SetterGetter.create(env)
-    @SelectorPlayground = selectorPlaygroundMethods(@state)
 
     @Cookies = $Cookies.create(config.namespace, d)
 
@@ -451,6 +450,7 @@ class $Cypress
   Mocha: $Mocha
   Runner: $Runner
   Server: $Server
+  SelectorPlayground: $SelectorPlayground
   utils: $utils
   _: _
   moment: moment

--- a/packages/driver/src/cypress.coffee
+++ b/packages/driver/src/cypress.coffee
@@ -25,6 +25,7 @@ $Mocha = require("./cypress/mocha")
 $Runner = require("./cypress/runner")
 $Server = require("./cypress/server")
 $utils = require("./cypress/utils")
+selectorPlaygroundMethods = require("./cypress/selector_playground")
 
 proxies = {
   runner: "getStartTime getTestsState getEmissions setNumLogs countByTestState getDisplayPropsForLog getConsolePropsForLogById getSnapshotPropsForLogById getErrorByTestId setStartTime resumeAtTest normalizeAll".split(" ")
@@ -126,6 +127,7 @@ class $Cypress
     @state = $SetterGetter.create({})
     @config = $SetterGetter.create(config)
     @env = $SetterGetter.create(env)
+    @SelectorPlayground = selectorPlaygroundMethods(@state)
 
     @Cookies = $Cookies.create(config.namespace, d)
 

--- a/packages/driver/src/cypress/error_messages.coffee
+++ b/packages/driver/src/cypress/error_messages.coffee
@@ -626,15 +626,6 @@ module.exports = {
     invalid_duration: "#{cmd('scrollTo')} must be called with a valid duration. Duration may be either a number (ms) or a string representing a number (ms). Your duration was: {{duration}}"
     animation_failed: "#{cmd('scrollTo')} failed."
 
-  select:
-    disabled: "#{cmd('select')} failed because this element is currently disabled:\n\n{{node}}"
-    invalid_element: "#{cmd('select')} can only be called on a <select>. Your subject is a: {{node}}"
-    invalid_multiple: "#{cmd('select')} was called with an array of arguments but does not have a 'multiple' attribute set."
-    multiple_elements: "#{cmd('select')} can only be called on a single <select>. Your subject contained {{num}} elements."
-    multiple_matches: "#{cmd('select')} matched more than one option by value or text: {{value}}"
-    no_matches: "#{cmd('select')} failed because it could not find a single <option> with value or text matching: '{{value}}'"
-    option_disabled: "#{cmd('select')} failed because this <option> you are trying to select is currently disabled:\n\n{{node}}"
-
   screenshot:
     timed_out: "#{cmd('screenshot')} timed out waiting '{{timeout}}ms' to complete."
 

--- a/packages/driver/src/cypress/error_messages.coffee
+++ b/packages/driver/src/cypress/error_messages.coffee
@@ -638,6 +638,11 @@ module.exports = {
     no_matches: "#{cmd('select')} failed because it could not find a single <option> with value or text matching: '{{value}}'"
     option_disabled: "#{cmd('select')} failed because this <option> you are trying to select is currently disabled:\n\n{{node}}"
 
+  selector_playground:
+    defaults_invalid_arg: "Cypress.SelectorPlayground.defaults() must be called with an object. You passed: {{arg}}"
+    defaults_invalid_priority: "Cypress.SelectorPlayground.defaults() called with invalid 'selectorPriority' property. It must be an array. You passed: {{arg}}"
+    defaults_invalid_on_element: "Cypress.SelectorPlayground.defaults() called with invalid 'onElement' property. It must be a function. You passed: {{arg}}"
+
   server:
     invalid_argument: "#{cmd('server')} accepts only an object literal as its argument."
     unavailable: "The XHR server is unavailable or missing. This should never happen and likely is a bug. Open an issue if you see this message."

--- a/packages/driver/src/cypress/selector_playground.coffee
+++ b/packages/driver/src/cypress/selector_playground.coffee
@@ -1,37 +1,60 @@
 _ = require("lodash")
+uniqueSelector = require("@cypress/unique-selector").default
+
 $utils = require("./utils")
 
-defaults = {}
+SELECTOR_PRIORITIES = "data-cy data-test data-testid id class tag attributes nth-child".split(" ")
 
-module.exports = ->
-  return {
-    defaults: (props) ->
-      if not _.isPlainObject(props)
-        $utils.throwErrByPath("selector_playground.defaults_invalid_arg", {
-          args: { arg: $utils.stringify(props) }
+reset = -> {
+  onElement: null
+  selectorPriority: SELECTOR_PRIORITIES
+}
+
+defaults = reset()
+
+module.exports = {
+  reset: ->
+    ## for testing purposes
+    defaults = reset()
+
+  getSelectorPriority: ->
+    defaults.selectorPriority
+
+  getOnElement: ->
+    defaults.onElement
+
+  getSelector: ($el) ->
+    ## if we have a callback, and it returned truthy
+    if defaults.onElement and (selector = defaults.onElement($el))
+      ## and it returned a string
+      if _.isString(selector)
+        ## use this!
+        return selector
+
+    ## else use uniqueSelector with the priorities
+    uniqueSelector($el.get(0), {
+      selectorTypes: defaults.selectorPriority
+    })
+
+  defaults: (props) ->
+    if not _.isPlainObject(props)
+      $utils.throwErrByPath("selector_playground.defaults_invalid_arg", {
+        args: { arg: $utils.stringify(props) }
+      })
+
+    if priority = props.selectorPriority
+      if not _.isArray(priority)
+        $utils.throwErrByPath("selector_playground.defaults_invalid_priority", {
+          args: { arg: $utils.stringify(priority) }
         })
 
-      if priority = props.selectorPriority
-        if not _.isArray(priority)
-          $utils.throwErrByPath("selector_playground.defaults_invalid_priority", {
-            args: { arg: $utils.stringify(priority) }
-          })
+      defaults.selectorPriority = priority
 
-        defaults.selectorPriority = priority
+    if onElement = props.onElement
+      if not _.isFunction(onElement)
+        $utils.throwErrByPath("selector_playground.defaults_invalid_on_element", {
+          args: { arg: $utils.stringify(onElement) }
+        })
 
-      if onElement = props.onElement
-        if not _.isFunction(onElement)
-          $utils.throwErrByPath("selector_playground.defaults_invalid_on_element", {
-            args: { arg: $utils.stringify(onElement) }
-          })
-
-        defaults.onElement = onElement
-
-    ## these methods are used internally by the runner and for testing
-    _selectorPriority: ->
-      defaults.selectorPriority
-
-    _onElement: ->
-      defaults.onElement
-
-  }
+      defaults.onElement = onElement
+}

--- a/packages/driver/src/cypress/selector_playground.coffee
+++ b/packages/driver/src/cypress/selector_playground.coffee
@@ -1,0 +1,37 @@
+_ = require("lodash")
+$utils = require("./utils")
+
+defaults = {}
+
+module.exports = ->
+  return {
+    defaults: (props) ->
+      if not _.isPlainObject(props)
+        $utils.throwErrByPath("selector_playground.defaults_invalid_arg", {
+          args: { arg: $utils.stringify(props) }
+        })
+
+      if priority = props.selectorPriority
+        if not _.isArray(priority)
+          $utils.throwErrByPath("selector_playground.defaults_invalid_priority", {
+            args: { arg: $utils.stringify(priority) }
+          })
+
+        defaults.selectorPriority = priority
+
+      if onElement = props.onElement
+        if not _.isFunction(onElement)
+          $utils.throwErrByPath("selector_playground.defaults_invalid_on_element", {
+            args: { arg: $utils.stringify(onElement) }
+          })
+
+        defaults.onElement = onElement
+
+    ## these methods are used internally by the runner and for testing
+    _selectorPriority: ->
+      defaults.selectorPriority
+
+    _onElement: ->
+      defaults.onElement
+
+  }

--- a/packages/driver/test/cypress/integration/cypress/selector_playground_spec.coffee
+++ b/packages/driver/test/cypress/integration/cypress/selector_playground_spec.coffee
@@ -1,0 +1,37 @@
+selectorPlaygroundMethods = require("../../../../src/cypress/selector_playground")
+
+describe "src/cypress/selector_playground", ->
+  context ".defaults", ->
+    beforeEach ->
+      @SelectorPlayground = selectorPlaygroundMethods()
+
+    it "does nothing if not called with selectorPriority or onElement", ->
+      @SelectorPlayground.defaults({})
+      expect(@SelectorPlayground._selectorPriority()).to.be.undefined
+      expect(@SelectorPlayground._onElement()).to.be.undefined
+
+    it "sets selector:playground:priority if selectorPriority specified", ->
+      @SelectorPlayground.defaults({
+        selectorPriority: ["foo"]
+      })
+      expect(@SelectorPlayground._selectorPriority()).to.eql(["foo"])
+
+    it "sets selector:playground:on:element if onElement specified", ->
+      onElement = ->
+      @SelectorPlayground.defaults({ onElement })
+      expect(@SelectorPlayground._onElement()).to.equal(onElement)
+
+    it "throws if not passed an object", ->
+      expect =>
+        @SelectorPlayground.defaults()
+      .to.throw("Cypress.SelectorPlayground.defaults() must be called with an object. You passed: ")
+
+    it "throws if selectorPriority is not an array", ->
+      expect =>
+        @SelectorPlayground.defaults({ selectorPriority: "foo" })
+      .to.throw("Cypress.SelectorPlayground.defaults() called with invalid 'selectorPriority' property. It must be an array. You passed: foo")
+
+    it "throws if onElement is not a function", ->
+      expect =>
+        @SelectorPlayground.defaults({ onElement: "foo" })
+      .to.throw("Cypress.SelectorPlayground.defaults() called with invalid 'onElement' property. It must be a function. You passed: foo")

--- a/packages/driver/test/cypress/integration/cypress/selector_playground_spec.coffee
+++ b/packages/driver/test/cypress/integration/cypress/selector_playground_spec.coffee
@@ -1,37 +1,74 @@
-selectorPlaygroundMethods = require("../../../../src/cypress/selector_playground")
+{ SelectorPlayground, $ } = Cypress
+
+SELECTOR_DEFAULTS = [
+  "data-cy", "data-test", "data-testid", "id", "class", "tag", "attributes", "nth-child"
+]
 
 describe "src/cypress/selector_playground", ->
-  context ".defaults", ->
-    beforeEach ->
-      @SelectorPlayground = selectorPlaygroundMethods()
+  beforeEach ->
+    ## reset state since this is a singleton
+    SelectorPlayground.reset()
 
-    it "does nothing if not called with selectorPriority or onElement", ->
-      @SelectorPlayground.defaults({})
-      expect(@SelectorPlayground._selectorPriority()).to.be.undefined
-      expect(@SelectorPlayground._onElement()).to.be.undefined
+  it "has defaults", ->
+    expect(SelectorPlayground.getSelectorPriority()).to.deep.eq(SELECTOR_DEFAULTS)
+    expect(SelectorPlayground.getOnElement()).to.be.null
+
+  context ".defaults", ->
+    it "is noop if not called with selectorPriority or onElement", ->
+      SelectorPlayground.defaults({})
+      expect(SelectorPlayground.getSelectorPriority()).to.deep.eq(SELECTOR_DEFAULTS)
+      expect(SelectorPlayground.getOnElement()).to.be.null
 
     it "sets selector:playground:priority if selectorPriority specified", ->
-      @SelectorPlayground.defaults({
+      SelectorPlayground.defaults({
         selectorPriority: ["foo"]
       })
-      expect(@SelectorPlayground._selectorPriority()).to.eql(["foo"])
+      expect(SelectorPlayground.getSelectorPriority()).to.eql(["foo"])
 
     it "sets selector:playground:on:element if onElement specified", ->
       onElement = ->
-      @SelectorPlayground.defaults({ onElement })
-      expect(@SelectorPlayground._onElement()).to.equal(onElement)
+      SelectorPlayground.defaults({ onElement })
+      expect(SelectorPlayground.getOnElement()).to.equal(onElement)
 
     it "throws if not passed an object", ->
       expect =>
-        @SelectorPlayground.defaults()
+        SelectorPlayground.defaults()
       .to.throw("Cypress.SelectorPlayground.defaults() must be called with an object. You passed: ")
 
     it "throws if selectorPriority is not an array", ->
       expect =>
-        @SelectorPlayground.defaults({ selectorPriority: "foo" })
+        SelectorPlayground.defaults({ selectorPriority: "foo" })
       .to.throw("Cypress.SelectorPlayground.defaults() called with invalid 'selectorPriority' property. It must be an array. You passed: foo")
 
     it "throws if onElement is not a function", ->
       expect =>
-        @SelectorPlayground.defaults({ onElement: "foo" })
+        SelectorPlayground.defaults({ onElement: "foo" })
       .to.throw("Cypress.SelectorPlayground.defaults() called with invalid 'onElement' property. It must be a function. You passed: foo")
+
+  context ".getSelector", ->
+    it "uses defaults.selectorPriority", ->
+      $div = $("<div data-cy='main button 123' data-foo-bar-baz='quux' data-test='qwerty' data-foo='bar' />")
+
+      Cypress.$("body").append($div)
+
+      expect(SelectorPlayground.getSelector($div)).to.eq("[data-cy=\"main button 123\"]")
+
+      SelectorPlayground.defaults({
+        selectorPriority: ['data-foo']
+      })
+
+      expect(SelectorPlayground.getSelector($div)).to.eq("[data-foo=bar]")
+
+      SelectorPlayground.defaults({
+        onElement: ($el) ->
+          return "quux"
+      })
+
+      expect(SelectorPlayground.getSelector($div)).to.eq("quux")
+
+      SelectorPlayground.defaults({
+        onElement: ($el) ->
+          return null
+      })
+
+      expect(SelectorPlayground.getSelector($div)).to.eq("[data-foo=bar]")

--- a/packages/driver/test/unit_old/cypress/utils_spec.coffee
+++ b/packages/driver/test/unit_old/cypress/utils_spec.coffee
@@ -115,6 +115,7 @@ describe "$Cypress.utils API", ->
       it "null", ->
         expect(@str(null)).to.eq "null"
 
+      ## QUESTION: is this really the behavior we want? wouldn't 'undefined' be better?
       it "undefined", ->
         expect(@str(undefined)).to.eq ""
 

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@cypress/react-tooltip": "0.3.2",
     "@cypress/releaser": "0.1.12",
-    "@cypress/unique-selector": "^0.3.7",
+    "@cypress/unique-selector": "^0.4.0",
     "bin-up": "^1.1.0",
     "bluebird": "3.5.0",
     "chai": "^3.5.0",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@cypress/react-tooltip": "0.3.2",
     "@cypress/releaser": "0.1.12",
-    "@cypress/unique-selector": "^0.4.0",
+    "@cypress/unique-selector": "^0.4.1",
     "bin-up": "^1.1.0",
     "bluebird": "3.5.0",
     "chai": "^3.5.0",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "@cypress/react-tooltip": "0.3.2",
     "@cypress/releaser": "0.1.12",
-    "@cypress/unique-selector": "^0.4.1",
     "bin-up": "^1.1.0",
     "bluebird": "3.5.0",
     "chai": "^3.5.0",

--- a/packages/runner/src/iframe/aut-iframe.js
+++ b/packages/runner/src/iframe/aut-iframe.js
@@ -255,7 +255,9 @@ export default class AutIframe {
 
     this._highlightedEl = el
 
-    const selector = dom.getBestSelector(el)
+    const Cypress = eventManager.getCypress()
+
+    const selector = Cypress.SelectorPlayground.getSelector($el)
 
     dom.addOrUpdateSelectorPlaygroundHighlight({
       $el,

--- a/packages/runner/src/lib/dom.js
+++ b/packages/runner/src/lib/dom.js
@@ -1,9 +1,7 @@
 import _ from 'lodash'
 import { $ } from '@packages/driver'
-import getUniqueSelector from '@cypress/unique-selector'
 import Promise from 'bluebird'
 
-import eventManager from '../lib/event-manager'
 import selectorPlaygroundHighlight from '../selector-playground/highlight'
 
 const resetStyles = `
@@ -341,21 +339,6 @@ function getOuterSize (el) {
   }
 }
 
-function getBestSelector (el) {
-  const Cypress = eventManager.getCypress()
-  const onElement = Cypress.SelectorPlayground._onElement()
-  if (onElement) {
-    const selector = onElement(el)
-    if (_.isString(selector)) return selector
-  }
-
-  const selectorPriority = Cypress.SelectorPlayground._selectorPriority()
-
-  return getUniqueSelector(el, {
-    selectorTypes: selectorPriority || ['data-cy', 'data-test', 'data-testid', 'id', 'class', 'tag', 'attributes', 'nth-child'],
-  })
-}
-
 function isInViewport (win, el) {
   let rect = el.getBoundingClientRect()
 
@@ -399,7 +382,6 @@ export default {
   addElementBoxModelLayers,
   addHitBoxLayer,
   addOrUpdateSelectorPlaygroundHighlight,
-  getBestSelector,
   getElementsForSelector,
   getOuterSize,
   scrollIntoView,

--- a/packages/runner/src/lib/dom.js
+++ b/packages/runner/src/lib/dom.js
@@ -3,6 +3,7 @@ import { $ } from '@packages/driver'
 import getUniqueSelector from '@cypress/unique-selector'
 import Promise from 'bluebird'
 
+import eventManager from '../lib/event-manager'
 import selectorPlaygroundHighlight from '../selector-playground/highlight'
 
 const resetStyles = `
@@ -341,8 +342,17 @@ function getOuterSize (el) {
 }
 
 function getBestSelector (el) {
+  const Cypress = eventManager.getCypress()
+  const onElement = Cypress.SelectorPlayground._onElement()
+  if (onElement) {
+    const selector = onElement(el)
+    if (_.isString(selector)) return selector
+  }
+
+  const selectorPriority = Cypress.SelectorPlayground._selectorPriority()
+
   return getUniqueSelector(el, {
-    selectorTypes: ['ID', 'Class', 'Tag', 'Attributes', 'NthChild'],
+    selectorTypes: selectorPriority || ['data-cy', 'data-test', 'data-testid', 'id', 'class', 'tag', 'attributes', 'nth-child'],
   })
 }
 

--- a/packages/runner/src/selector-playground/selector-playground.scss
+++ b/packages/runner/src/selector-playground/selector-playground.scss
@@ -15,5 +15,7 @@ $cy-tooltip-border-color: #333;
 }
 
 .tooltip {
+  font-family: sans-serif;
+  font-size: 14px;
   max-width: 400px !important;
 }


### PR DESCRIPTION
Fixes #1135

Adds the following API:

```javascript
Cypress.SelectorPlayground.defaults({
  selectorPriority: ['data-cy', 'data-test', 'id', 'class', 'nth-child'],
  onElement (el) {
    // return your own selector here
  },
})
```

Docs PR: https://github.com/cypress-io/cypress-documentation/pull/423