### PR TITLE
ci: use Node 8.2.1 to build binary on Windows CI #1390

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,7 @@ steps:
       # print the user login name
       - "whoami"
       # this should load NVM
+      - "ls -la ~"
       - "source ~/.bashrc"
       # use same Node.js version as the one included in Electron
       - "nvm install 8.2.1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,10 +8,8 @@ steps:
     command:
       # print the user login name
       - "whoami"
-      # this should load NVM
-      - "ls -la ~"
-      - 'export NVM_DIR="$HOME/.nvm"'
-      - '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"'
+      # install NVM
+      - "curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash"
       # use same Node.js version as the one included in Electron
       - "nvm install 8.2.1"
       - "node --version"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,8 @@ steps:
       # assuming we have installed the same Node.js version
       # as the one included in Electron
       - "node --version"
+      # make sure we are using correct version of Node to build
+      - "npm run check-node-version"
       - "npm --version"
       - "security find-identity -p codesigning"
       - "security list-keychains"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,17 +6,8 @@ env:
 steps:
   - label: "install tools"
     command:
-      # print the user login name
-      - "whoami"
-      - "bash --login"
-      # print current shell
-      - "echo $0"
-      # load NVM
-      - '[ -n "$PS1" ] && source ~/.bash_profile'
-      # assuming NVM has been installed
-      # https://github.com/creationix/nvm
-      # use same Node.js version as the one included in Electron
-      - "nvm install 8.2.1"
+      # assuming we have installed the same Node.js version
+      # as the one included in Electron
       - "node --version"
       - "npm --version"
       - "security find-identity -p codesigning"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,6 +8,10 @@ steps:
     command:
       # print the user login name
       - "whoami"
+      # print current shell
+      - "echo $0"
+      # load NVM
+      - '[ -n "$PS1" ] && source ~/.bash_profile'
       # assuming NVM has been installed
       # https://github.com/creationix/nvm
       # use same Node.js version as the one included in Electron

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,10 @@ env:
 steps:
   - label: "install tools"
     command:
+      # print the user login name
+      - "whoami"
+      # this should load NVM
+      - "source ~/.bashrc"
       # use same Node.js version as the one included in Electron
       - "nvm install 8.2.1"
       - "node --version"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,8 @@ steps:
       - "whoami"
       # this should load NVM
       - "ls -la ~"
-      - "source ~/.bashrc"
+      - 'export NVM_DIR="$HOME/.nvm"'
+      - '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"'
       # use same Node.js version as the one included in Electron
       - "nvm install 8.2.1"
       - "node --version"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,6 +8,7 @@ steps:
     command:
       # print the user login name
       - "whoami"
+      - "bash --login"
       # print current shell
       - "echo $0"
       # load NVM

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,8 +8,8 @@ steps:
     command:
       # print the user login name
       - "whoami"
-      # install NVM
-      - "curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash"
+      # assuming NVM has been installed
+      # https://github.com/creationix/nvm
       # use same Node.js version as the one included in Electron
       - "nvm install 8.2.1"
       - "node --version"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,7 @@ env:
 steps:
   - label: "install tools"
     command:
+      # use same Node.js version as the one included in Electron
       - "nvm install 8.2.1"
       - "node --version"
       - "npm --version"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,7 @@ env:
 steps:
   - label: "install tools"
     command:
+      - "nvm install 8.2.1"
       - "node --version"
       - "npm --version"
       - "security find-identity -p codesigning"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ branches:
     - /win*/
 
 # https://www.appveyor.com/docs/lang/nodejs-iojs/
-# Test against the latest version of this Node.js version
 environment:
+  # Test against the same version of Node.js version as included in Electron
   nodejs_version: "8.2.1"
   # encode secure variables which will NOT be used
   # in pull requests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
 # https://www.appveyor.com/docs/lang/nodejs-iojs/
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "6"
+  nodejs_version: "8.2.1"
   # encode secure variables which will NOT be used
   # in pull requests
   # https://www.appveyor.com/docs/build-configuration/#secure-variables

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,7 @@ environment:
 # Install scripts. (runs after repo cloning)
 install:
   - ps: Install-Product node $env:nodejs_version
+  - npm run check-node-version
   # NPM v3 has flaky permission issues on Windows
   - npm install -g npm@5
   - npm install -g @bahmutov/print-env

--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,7 @@ jobs:
       - run:
           name: print global NPM cache path
           command: echo $(npm -g bin)
+      - run: npm run check-node-version
 
       ## make sure the TERM is set to 'xterm' in node
       ## else colors (and tests) will fail

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "binary-release": "node ./scripts/binary.js release",
     "test-scripts": "mocha --reporter spec scripts/unit/*spec.js",
     "test-mocha": "mocha --reporter spec scripts/spec.js",
-    "test-mocha-snapshot": "mocha scripts/mocha-snapshot-spec.js"
+    "test-mocha-snapshot": "mocha scripts/mocha-snapshot-spec.js",
+    "check-node-version": "node scripts/check-node-version.js"
   },
   "lint-staged": {
     "*.js": [

--- a/scripts/check-node-version.js
+++ b/scripts/check-node-version.js
@@ -1,0 +1,20 @@
+// TODO make this check a 3rd party little tool
+
+// we want to ensure we are building using the same major version
+// as the one specified in ../.node-version file
+const read = require('fs').readFileSync
+const join = require('path').join
+
+const nodeVersionNeededString = read(join(__dirname, '..', '.node-version'), 'utf8')
+const nodeVersionNeeded = nodeVersionNeededString.split('.')
+
+const nodeVersion = process.versions.node.split('.')
+
+// check just major version for now
+if (nodeVersionNeeded[0] !== nodeVersion[0]) {
+  /* eslint-disable no-console */
+  console.error('🛑 .node-version specified %s', nodeVersionNeededString)
+  console.error('but current Node is %s', process.versions.node)
+  /* eslint-enable no-console */
+  process.exit(1)
+}


### PR DESCRIPTION
- [x] appveyor
- [x] buildkite
- [x] check the current Node major against `.node-version` file