### PR TITLE
Lower minimum viewport bound

### DIFF
--- a/packages/driver/src/cy/commands/window.coffee
+++ b/packages/driver/src/cy/commands/window.coffee
@@ -155,7 +155,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
 
       widthAndHeightAreWithinBounds = (width, height) ->
         _.every [width, height], (val) ->
-          val >= 200 and val <= 3000
+          val >= 20 and val <= 3000
 
       switch
         when _.isString(presetOrWidth) and _.isBlank(presetOrWidth)

--- a/packages/driver/src/cypress/error_messages.coffee
+++ b/packages/driver/src/cypress/error_messages.coffee
@@ -799,7 +799,7 @@ module.exports = {
 
   viewport:
     bad_args:  "#{cmd('viewport')} can only accept a string preset or a width and height as numbers."
-    dimensions_out_of_range: "#{cmd('viewport')} width and height must be between 200px and 3000px."
+    dimensions_out_of_range: "#{cmd('viewport')} width and height must be between 20px and 3000px."
     empty_string: "#{cmd('viewport')} cannot be passed an empty string."
     invalid_orientation: "#{cmd('viewport')} can only accept '{{all}}' as valid orientations. Your orientation was: '{{orientation}}'"
     missing_preset: "#{cmd('viewport')} could not find a preset for: '{{preset}}'. Available presets are: {{presets}}"

--- a/packages/driver/test/cypress/integration/commands/window_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/window_spec.coffee
@@ -612,26 +612,26 @@ describe "src/cy/commands/window", ->
       it "throws when passed negative numbers", (done) ->
         cy.on "fail", (err) =>
           expect(@logs.length).to.eq(1)
-          expect(err.message).to.eq "cy.viewport() width and height must be between 200px and 3000px."
+          expect(err.message).to.eq "cy.viewport() width and height must be between 20px and 3000px."
           done()
 
         cy.viewport(800, -600)
 
-      it "throws when passed width less than 200", (done) ->
+      it "throws when passed width less than 20", (done) ->
         cy.on "fail", (err) =>
           expect(@logs.length).to.eq(1)
-          expect(err.message).to.eq "cy.viewport() width and height must be between 200px and 3000px."
+          expect(err.message).to.eq "cy.viewport() width and height must be between 20px and 3000px."
           done()
 
-        cy.viewport(199, 600)
+        cy.viewport(19, 600)
 
-      it "does not throw when passed width equal to 200", ->
-        cy.viewport(200, 600)
+      it "does not throw when passed width equal to 20", ->
+        cy.viewport(20, 600)
 
       it "throws when passed height greater than than 3000", (done) ->
         cy.on "fail", (err) =>
           expect(@logs.length).to.eq(1)
-          expect(err.message).to.eq "cy.viewport() width and height must be between 200px and 3000px."
+          expect(err.message).to.eq "cy.viewport() width and height must be between 20px and 3000px."
           done()
 
         cy.viewport(1000, 3001)


### PR DESCRIPTION
This PR fixes https://github.com/cypress-io/cypress/issues/1444.

Lowers the current minimum lower bound on `cy.viewport` from `200` to `20` pixels. 
