### PR TITLE
Allow text selection in UI

### DIFF
--- a/packages/reporter/src/runnables/runnables.scss
+++ b/packages/reporter/src/runnables/runnables.scss
@@ -15,7 +15,6 @@
 
   .runnables {
     padding-left: 0;
-    user-select: none;
   }
 
   .runnable {


### PR DESCRIPTION
Hi 👋

Is there is a reason why text in UI is not selectable?
Me and my colleagues would find it very useful, mostly for searching for the specific tests in source code.

UX is not perfect, as selecting text also expands/collapses details, but worth IMO :)

![2018-03-18 14 23 26](https://user-images.githubusercontent.com/697301/37566360-4755314c-2ab8-11e8-937f-54dd9adeb017.gif)

