### PR TITLE
Add logXhr option

### DIFF
--- a/cli/schema/cypress.schema.json
+++ b/cli/schema/cypress.schema.json
@@ -19,6 +19,11 @@
       },
       "description": "A String or Array of glob patterns used to ignore test files that would otherwise be shown in your list of tests. Cypress uses minimatch with the options: {dot: true, matchBase: true}. We suggest using http://globtester.com to test what files would match."
     },
+    "logXhr": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether Cypress will log xhr requests"
+    },
     "numTestsKeptInMemory": {
       "type": "number",
       "default": 50,

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -1058,6 +1058,11 @@ declare namespace Cypress {
      */
     ignoreTestFiles: string | string[]
     /**
+     * Whether Cypress will log xhr requests
+     * @default true
+     */
+    logXhr: boolean
+    /**
      * The number of tests for which snapshots and command data are kept in memory. Reduce this number if you are experiencing high memory consumption in your browser during a test run.
      * @default 50
      */

--- a/packages/desktop-gui/cypress/fixtures/config.json
+++ b/packages/desktop-gui/cypress/fixtures/config.json
@@ -43,6 +43,7 @@
   "javascripts": [
 
   ],
+  "logXhr": true,
   "morgan": true,
   "namespace": "__cypress",
   "numTestsKeptInMemory": 50,

--- a/packages/driver/src/cy/commands/xhr.coffee
+++ b/packages/driver/src/cy/commands/xhr.coffee
@@ -92,61 +92,62 @@ startXhrServer = (cy, state, config) ->
         numResponses = rl.get("numResponses")
         rl.set "numResponses", numResponses + 1
 
-      logs[xhr.id] = log = Cypress.log({
-        message:   ""
-        name:      "xhr"
-        displayName: getDisplayName(route)
-        alias:     alias
-        aliasType: "route"
-        type:      "parent"
-        event:     true
-        consoleProps: =>
-          consoleObj = {
-            Alias:         alias
-            Method:        xhr.method
-            URL:           xhr.url
-            "Matched URL": route?.url
-            Status:        xhr.statusMessage
-            Duration:      xhr.duration
-            "Stubbed":     if route and route.response? then "Yes" else "No"
-            Request:       xhr.request
-            Response:      xhr.response
-            XHR:           xhr._getXhr()
-          }
+      if false
+        logs[xhr.id] = log = Cypress.log({
+          message:   ""
+          name:      "xhr"
+          displayName: getDisplayName(route)
+          alias:     alias
+          aliasType: "route"
+          type:      "parent"
+          event:     true
+          consoleProps: =>
+            consoleObj = {
+              Alias:         alias
+              Method:        xhr.method
+              URL:           xhr.url
+              "Matched URL": route?.url
+              Status:        xhr.statusMessage
+              Duration:      xhr.duration
+              "Stubbed":     if route and route.response? then "Yes" else "No"
+              Request:       xhr.request
+              Response:      xhr.response
+              XHR:           xhr._getXhr()
+            }
 
-          if route and route.is404
-            consoleObj.Note = "This request did not match any of your routes. It was automatically sent back '404'. Setting cy.server({force404: false}) will turn off this behavior."
+            if route and route.is404
+              consoleObj.Note = "This request did not match any of your routes. It was automatically sent back '404'. Setting cy.server({force404: false}) will turn off this behavior."
 
-          consoleObj.groups = ->
-            [
-              {
-                name: "Initiator"
-                items: [stack]
-                label: false
-              }
-            ]
+            consoleObj.groups = ->
+              [
+                {
+                  name: "Initiator"
+                  items: [stack]
+                  label: false
+                }
+              ]
 
-          consoleObj
-        renderProps: ->
-          status = switch
-            when xhr.aborted
-              indicator = "aborted"
-              "(aborted)"
-            when xhr.status > 0
-              xhr.status
-            else
-              indicator = "pending"
-              "---"
+            consoleObj
+          renderProps: ->
+            status = switch
+              when xhr.aborted
+                indicator = "aborted"
+                "(aborted)"
+              when xhr.status > 0
+                xhr.status
+              else
+                indicator = "pending"
+                "---"
 
-          indicator ?= if /^2/.test(status) then "successful" else "bad"
+            indicator ?= if /^2/.test(status) then "successful" else "bad"
 
-          {
-            message: "#{xhr.method} #{status} #{_.truncate(stripOrigin(xhr.url), { length: 20 })}"
-            indicator: indicator
-          }
-      })
+            {
+              message: "#{xhr.method} #{status} #{_.truncate(stripOrigin(xhr.url), { length: 20 })}"
+              indicator: indicator
+            }
+        })
 
-      log.snapshot("request")
+        log.snapshot("request")
 
     onLoad: (xhr) =>
       setResponse(state, xhr)

--- a/packages/driver/src/cy/commands/xhr.coffee
+++ b/packages/driver/src/cy/commands/xhr.coffee
@@ -92,7 +92,7 @@ startXhrServer = (cy, state, config) ->
         numResponses = rl.get("numResponses")
         rl.set "numResponses", numResponses + 1
 
-      if false
+      if config('logXhr')
         logs[xhr.id] = log = Cypress.log({
           message:   ""
           name:      "xhr"

--- a/packages/server/lib/config.coffee
+++ b/packages/server/lib/config.coffee
@@ -89,6 +89,7 @@ defaults = {
   blacklistHosts:                null
   clientRoute:                   "/__/"
   xhrRoute:                      "/xhrs/"
+  logXhr:                        true
   socketIoRoute:                 "/__socket.io"
   socketIoCookie:                "__socket.io"
   reporterRoute:                 "/__cypress/reporter"


### PR DESCRIPTION
In some cases applications make large number XHR calls (100+). Cypress logs each of those calls in command log and stores snapshots of DOM at the time of call. Snapshots can be pretty big and a few hundreds of snapshots can easily take a few GBs of memory and slow down browser considerably. Large number of XHR logs in command log can also mean, that it is difficult to find specific logs of other events like commands, page navigation, ...

Developer should have option to disable logging XHR calls if he is facing these problems and does not need to see XHR logs.

This PR adds option logXhr to cypress config. Default value is true to keep current behaviour unchanged. If it is set to false, XHR call will not be displayed in command log and snapshots will not be created for them.