### PR TITLE
Allow Headers on cy.visit()

### DIFF
--- a/packages/driver/src/cy/commands/navigation.coffee
+++ b/packages/driver/src/cy/commands/navigation.coffee
@@ -260,7 +260,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
     Cypress.backend(
       "resolve:url",
       url,
-      _.pick(options, "failOnStatusCode", "auth")
+      _.pick(options, "failOnStatusCode", "auth", "headers")
     )
     .then (resp = {}) ->
       switch
@@ -464,6 +464,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
         failOnStatusCode: true
         log: true
         timeout: config("pageLoadTimeout")
+        headers: {}
         onBeforeLoad: ->
         onLoad: ->
       })

--- a/packages/server/lib/server.coffee
+++ b/packages/server/lib/server.coffee
@@ -315,6 +315,16 @@ class Server
 
     originalUrl = urlStr
 
+    ## if we have headers in the options param
+    ## we add it to the headers array for the
+    ## final request
+    customHeaders = {
+      accept: "text/html,*/*"
+    }
+
+    if options.headers
+      customHeaders = Object.assign({}, customHeaders, options.headers);
+
     ## if we have a buffer for this url
     ## then just respond with its details
     ## so we are idempotant and do not make
@@ -436,9 +446,7 @@ class Server
           auth: options.auth
           gzip: false
           url: urlFile ? urlStr
-          headers: {
-            accept: "text/html,*/*"
-          }
+          headers: customHeaders
           followRedirect: (incomingRes) ->
             status = incomingRes.statusCode
             next = incomingRes.headers.location


### PR DESCRIPTION
## User Case
We have a website that serve a mobile / desktop template based on a header passed as a request parameter.
This header is usually add by our Varnish server depending on the User-agent in production.
We run tests on non-varnished dev environment.
We can't use UserAgent directly on our source code.
Usage of cy.request() is not interesting here because we want to display the result in Browser.

After talking on gitter.im and reading some Issues, I saw this request will be usefull for many people.

Note : 
Sorry, if I made a mistake in the code, i'm not a CoffeeJS pro.