### PR TITLE
Cli started cypress 1573

### DIFF
--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -36,7 +36,9 @@ module.exports = {
     debug('needs XVFB?', needsXvfb)
 
     // always push cwd into the args
-    args = [].concat(args, '--cwd', process.cwd())
+    // also pass a flag to let binary know it was not executed
+    // directly by the user, but through this NPM module
+    args = [].concat(args, '--run-from-cli', '--cwd', process.cwd())
 
     _.defaults(options, {
       detached: false,

--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -44,6 +44,7 @@ describe('exec spawn', function () {
       .then(() => {
         expect(cp.spawn).to.be.calledWithMatch('/path/to/cypress', [
           '--foo',
+          '--run-from-cli',
           '--cwd',
           cwd,
         ], {
@@ -62,6 +63,7 @@ describe('exec spawn', function () {
         expect(cp.spawn).to.be.calledWithMatch('node', [
           p,
           '--foo',
+          '--run-from-cli',
           '--cwd',
           cwd,
         ], {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "node ./cli/bin/cypress open --dev --global",
     "cypress:open": "node ./cli/bin/cypress open --dev --global",
     "cypress:run": "node ./cli/bin/cypress run --dev",
-    "dev": "node ./scripts/start.js",
+    "dev": "node ./scripts/start.js --run-from-cli",
     "watch": "npm run all watch",
     "deps": "deps-ok",
     "prebuild": "npm run deps",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -61,3 +61,9 @@ You can also run in `watch` mode
 ## runs and watches only this one test file
 npm run test-watch ./test/unit/api_spec.coffee
 ```
+
+To run a single end to end spec pass part of its name using `--spec` option. You can also turn on the debug output from the test script itself using `DEBUG=e2e` environment option
+
+```bash
+DEBUG=e2e npm run test-e2e -- --spec stdout_spec
+```

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -40,7 +40,7 @@ Since this is slow, it's better to drive your development with tests.
 
 * `npm run test-unit` executes unit tests in `test/unit`
 * `npm run test-integration` executes integration tests in `test/integration`
-* `npm run test-e2e` executes the large (slow) end to end tests in `test/e2e`
+* `npm run test-e2e` executes the large (slow) end-to-end tests in `test/e2e`
 
 Each of these tasks can run in "watch" mode by appending this word to the task:
 
@@ -62,7 +62,7 @@ You can also run in `watch` mode
 npm run test-watch ./test/unit/api_spec.coffee
 ```
 
-To run a single end to end spec pass part of its name using `--spec` option. You can also turn on the debug output from the test script itself using `DEBUG=e2e` environment option
+To run a single end-to-end spec, pass part of its name using the `--spec` option. You can also turn on the debug output from the test script itself using the `DEBUG=e2e` environment option.
 
 ```bash
 DEBUG=e2e npm run test-e2e -- --spec stdout_spec

--- a/packages/server/lib/cypress.coffee
+++ b/packages/server/lib/cypress.coffee
@@ -115,7 +115,8 @@ module.exports = {
 
     require("./logger").info("starting desktop app", args: argv)
 
-    if isCurrentlyRunningElectron() and not argsUtil.startedFromCLI(argv)
+    if @isCurrentlyRunningElectron() and not argsUtil.startedFromCLI(argv)
+      debug("Cypress started directly ⚠️")
       require("./errors").warning("OPENED_CYPRESS_DIRECTLY")
 
     ## make sure we have the appData folder

--- a/packages/server/lib/errors.coffee
+++ b/packages/server/lib/errors.coffee
@@ -349,10 +349,10 @@ API = {
       # QUESTION should we show different ways to run Cypress CLI depending on OS?
       when "OPENED_CYPRESS_DIRECTLY"
         """
-        Looks like you are running Cypress binary directly.
+        It looks like you are running the Cypress binary directly.
 
         This should only be done for DEVELOPMENT.
-        Please run Cypress via its NPM package
+        Please run Cypress via it's NPM package.
 
           > #{chalk.blue('npm install --save-dev cypress')}
           > #{chalk.blue('./node_modules/.bin/cypress open')}

--- a/packages/server/lib/errors.coffee
+++ b/packages/server/lib/errors.coffee
@@ -352,7 +352,7 @@ API = {
         It looks like you are running the Cypress binary directly.
 
         This should only be done for DEVELOPMENT.
-        Please run Cypress via it's NPM package.
+        Please run Cypress via its NPM package.
 
           > #{chalk.blue('npm install --save-dev cypress')}
           > #{chalk.blue('./node_modules/.bin/cypress open')}

--- a/packages/server/lib/errors.coffee
+++ b/packages/server/lib/errors.coffee
@@ -345,6 +345,20 @@ API = {
         We looked but did not find a #{chalk.blue('cypress.json')} file in this folder: #{chalk.blue(arg1)}
         """
 
+      # TODO once we have a doc on global vs local install, add link
+      # QUESTION should we show different ways to run Cypress CLI depending on OS?
+      when "OPENED_CYPRESS_DIRECTLY"
+        """
+        Looks like you are running Cypress binary directly.
+
+        This should only be done for DEVELOPMENT.
+        Please run Cypress via its NPM package
+
+          > #{chalk.blue('npm install --save-dev cypress')}
+          > #{chalk.blue('./node_modules/.bin/cypress open')}
+
+        """
+
   get: (type, arg1, arg2) ->
     msg = @getMsgByType(type, arg1, arg2)
     err = new Error(msg)

--- a/packages/server/lib/errors.coffee
+++ b/packages/server/lib/errors.coffee
@@ -351,11 +351,11 @@ API = {
         """
         It looks like you are running the Cypress binary directly.
 
-        This should only be done for DEVELOPMENT.
-        Please run Cypress via its NPM package.
+        This is not the recommended approach, and Cypress may not work correctly.
 
-          > #{chalk.blue('npm install --save-dev cypress')}
-          > #{chalk.blue('./node_modules/.bin/cypress open')}
+        Please install the 'cypress' NPM package and follow the instructions here:
+
+          https://on.cypress.io/installing-cypress
 
         """
 

--- a/packages/server/lib/util/args.coffee
+++ b/packages/server/lib/util/args.coffee
@@ -9,7 +9,7 @@ nestedObjectsInCurlyBracesRe = /\{(.+?)\}/g
 nestedArraysInSquareBracketsRe = /\[(.+?)\]/g
 everythingAfterFirstEqualRe = /=(.+)/
 
-whitelist = "cwd appPath execPath apiKey smokeTest getKey generateKey runProject project spec reporter reporterOptions port env ci record updating ping key logs clearLogs returnPkg version mode removeIds headed config exit exitWithCode browser headless outputPath group groupId parallel parallelId".split(" ")
+whitelist = "cwd appPath execPath apiKey smokeTest getKey generateKey runProject project spec reporter reporterOptions port env ci record updating ping key logs clearLogs returnPkg version mode removeIds headed config exit exitWithCode browser headless outputPath group groupId parallel parallelId runFromCli".split(" ")
 
 # returns true if the given string has double quote character "
 # only at the last position.
@@ -71,7 +71,13 @@ sanitizeAndConvertNestedArgs = (str) ->
   .mapValues(coerce)
   .value()
 
+startedFromCLI = (argv) ->
+  _.includes(argv, "--run-from-cli") ||
+  _.includes(argv, "--runFromCli=true")
+
 module.exports = {
+  startedFromCLI
+
   toObject: (argv) ->
     ## takes an array of args and converts
     ## to an object
@@ -92,6 +98,7 @@ module.exports = {
         "reporter-options": "reporterOptions"
         "output-path":      "outputPath"
         "group-id":         "groupId"
+        "run-from-cli":     "runFromCli"
       }
     })
 

--- a/packages/server/test/scripts/e2e.js
+++ b/packages/server/test/scripts/e2e.js
@@ -7,12 +7,16 @@ const cp = require('child_process')
 const minimist = require('minimist')
 const Promise = require('bluebird')
 const terminalBanner = require('terminal-banner').terminalBanner
+const debug = require('debug')('e2e')
 
 const humanTime = require('../../lib/util/human_time.coffee')
 
 const glob = Promise.promisify(require('glob'))
 
 const options = minimist(process.argv.slice(2))
+
+debug('e2e options')
+debug(options)
 
 if (options.browser) {
   process.env.BROWSER = options.browser

--- a/packages/server/test/support/helpers/e2e.coffee
+++ b/packages/server/test/support/helpers/e2e.coffee
@@ -170,7 +170,10 @@ module.exports = {
     return options
 
   args: (options = {}) ->
-    args = ["--run-project=#{options.project}"]
+    args = [
+      "--run-from-cli", # hides a user warning to go through NPM module
+      "--run-project=#{options.project}"
+    ]
 
     if options.spec
       args.push("--spec=#{options.spec}")


### PR DESCRIPTION
NPM package will always pass `--run-from-cli` flag, Cypress will detect if this flag is missing and will show a warning

<img width="631" alt="screen shot 2018-04-12 at 10 15 15 pm" src="https://user-images.githubusercontent.com/2212006/38714130-c2d3dae6-3ea2-11e8-9f0e-e20b81824fb5.png">

close #1573 