### PR TITLE
Collapse duplicate events in reporter

### DIFF
--- a/packages/reporter/src/commands/command-model.js
+++ b/packages/reporter/src/commands/command-model.js
@@ -1,4 +1,4 @@
-import { action, observable } from 'mobx'
+import { action, computed, observable } from 'mobx'
 
 import Err from '../lib/err-model'
 import Instrument from '../instruments/instrument-model'
@@ -13,8 +13,23 @@ export default class Command extends Instrument {
   @observable number
   @observable numElements
   @observable visible = true
+  @observable duplicates = []
+  @observable isDuplicate = false
 
   _prevState = null
+
+  @computed get displayMessage () {
+    return this.renderProps.message || this.message
+  }
+
+  @computed get numDuplicates () {
+    // and one to include self so it's the total number of same events
+    return this.duplicates.length + 1
+  }
+
+  @computed get hasDuplicates () {
+    return this.numDuplicates > 1
+  }
 
   constructor (props) {
     super(props)
@@ -39,6 +54,23 @@ export default class Command extends Instrument {
     this.visible = props.visible
 
     this._checkLongRunning()
+  }
+
+  isMatchingEvent (command) {
+    return command.event && this.matches(command)
+  }
+
+  addDuplicate (command) {
+    command.isDuplicate = true
+    this.duplicates.push(command)
+  }
+
+  matches (command) {
+    return (
+      command.type === this.type &&
+      command.name === this.name &&
+      command.displayMessage === this.displayMessage
+    )
   }
 
   // the following several methods track if the command's state has been

--- a/packages/reporter/src/commands/command.spec.jsx
+++ b/packages/reporter/src/commands/command.spec.jsx
@@ -1,4 +1,4 @@
-import { mount, shallow } from 'enzyme'
+import { shallow } from 'enzyme'
 import _ from 'lodash'
 import React from 'react'
 import sinon from 'sinon'

--- a/packages/reporter/src/commands/command.spec.jsx
+++ b/packages/reporter/src/commands/command.spec.jsx
@@ -1,4 +1,4 @@
-import { shallow } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 import _ from 'lodash'
 import React from 'react'
 import sinon from 'sinon'
@@ -13,13 +13,15 @@ const model = (props) => {
   return _.extend({
     event: false,
     id: 'c1',
-    message: 'The message',
+    displayMessage: 'The message',
     name: 'The name',
     number: 1,
     numElements: 0,
     renderProps: {},
     state: 'passed',
     type: 'parent',
+    hasDuplicates: false,
+    duplicates: [],
   }, props)
 }
 
@@ -102,7 +104,7 @@ describe('<Command />', () => {
     })
 
     it('renders with the scaled class when it has a renderProps message over 100 chars long', () => {
-      const component = shallow(<Command model={model({ renderProps: { message: longText } })} />)
+      const component = shallow(<Command model={model({ displayMessage: longText })} />)
       expect(component).to.have.className('command-scaled')
     })
 
@@ -130,28 +132,18 @@ describe('<Command />', () => {
   })
 
   context('message', () => {
-    it('renders the message', () => {
+    it('renders the displayMessage', () => {
       const component = shallow(<Command model={model()} />)
       expect(component.find(Message).first().shallow().find('.command-message-text').html()).to.contain('The message')
     })
 
-    it('renders the renderProps message when specified', () => {
-      const component = shallow(<Command model={model({ renderProps: { message: 'The display message' } })} />)
-      expect(component.find(Message).first().shallow().find('.command-message-text').html()).to.contain('The display message')
-    })
-
-    it('does not truncate the renderProps message when over 100 chars', () => {
-      const component = shallow(<Command model={model({ renderProps: { message: longText } })} />)
+    it('does not truncate the message when over 100 chars', () => {
+      const component = shallow(<Command model={model({ displayMessage: longText })} />)
       expect(component.find(Message).first().shallow().find('.command-message-text').html()).to.contain(longText)
     })
 
-    it('renders markdown in message', () => {
-      const component = shallow(<Command model={model({ message: withMarkdown })} />)
-      expect(component.find(Message).first().shallow().find('.command-message-text').html()).to.contain(fromMarkdown)
-    })
-
-    it('renders markdown in renderProps message', () => {
-      const component = shallow(<Command model={model({ renderProps: { message: withMarkdown } })} />)
+    it('renders markdown', () => {
+      const component = shallow(<Command model={model({ displayMessage: withMarkdown })} />)
       expect(component.find(Message).first().shallow().find('.command-message-text').html()).to.contain(fromMarkdown)
     })
 
@@ -436,6 +428,41 @@ describe('<Command />', () => {
           })
         })
       })
+    })
+  })
+
+  context('duplicates', () => {
+    const withDuplicates = { hasDuplicates: true, numDuplicates: 5 }
+
+    it('renders with command-has-duplicates class if it has duplicates', () => {
+      const component = shallow(<Command model={model(withDuplicates)} />)
+      expect(component).to.have.className('command-has-duplicates')
+    })
+
+    it('renders without command-has-duplicates class if no duplicates', () => {
+      const component = shallow(<Command model={model()} />)
+      expect(component).not.to.have.className('command-has-duplicates')
+    })
+
+    it('renders with command-is-duplicate class if it is a duplicate', () => {
+      const component = shallow(<Command model={model({ isDuplicate: true })} />)
+      expect(component).to.have.className('command-is-duplicate')
+    })
+
+    it('renders without command-is-duplicate class if it is not a duplicate', () => {
+      const component = shallow(<Command model={model()} />)
+      expect(component).not.to.have.className('command-is-duplicate')
+    })
+
+    it('displays number of duplicates', () => {
+      const component = shallow(<Command model={model({ hasDuplicates: true, numDuplicates: 5 })} />)
+      expect(component.find('.num-duplicates')).to.have.text('5')
+    })
+
+    it('opens after clicking expander', () => {
+      const component = shallow(<Command model={model(withDuplicates)} />)
+      component.find('.command-expander').simulate('click', { stopPropagation: () => {} })
+      expect(component).to.have.className('command-is-open')
     })
   })
 })

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -422,6 +422,10 @@
         @extend .#{$fa-css-prefix}-caret-down;
       }
     }
+
+    .num-duplicates {
+      display: none;
+    }
   }
 
   .command-is-pinned,

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -420,8 +420,14 @@
     display: block;
   }
 
-  .command-is-duplicate .command-expander {
-    visibility: hidden;
+  .command-is-duplicate {
+    &:first-child {
+      border-top: solid 1px #e3e3e3;
+    }
+
+    .command-expander {
+      visibility: hidden;
+    }
   }
 
   .command-is-open {

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -53,26 +53,7 @@
 
   .command {
     cursor: pointer;
-    padding: 1px 5px;
     margin: 0;
-
-    &:hover {
-      background-color: #E0E5E7;
-      box-shadow: 0 1px 2px #ccc inset;
-    }
-
-    &:hover .command-controls i.fa-pause {
-      visibility: visible;
-    }
-
-    &.active {
-      background-color: #E1E1E1 !important;
-      box-shadow: 0 1px 6px #ccc inset;
-    }
-
-    &.highlight {
-      background-color: #FFB61C !important;
-    }
   }
 
   .command-scaled {
@@ -83,10 +64,10 @@
   .command-is-event {
     font-style: italic;
 
-    span {
+    .command-method,
+    .command-message {
       color: #9a9aaa !important;
     }
-
   }
 
   .command-type-parent {
@@ -116,6 +97,12 @@
     display: flex;
     flex-wrap: wrap;
     color: #777;
+    padding: 1px 5px;
+
+    &:hover {
+      background-color: #E0E5E7;
+      box-shadow: 0 1px 2px #ccc inset;
+    }
 
     .command-alias {
       border-radius: 10px;
@@ -355,15 +342,18 @@
     display: inline-block;
   }
 
-  .command-has-num-elements .num-elements {
+  .command-has-num-elements .num-elements,
+  .num-duplicates {
     display: none;
   }
 
   .command-has-num-elements.no-elements .num-elements,
-  .command-has-num-elements.multiple-elements .num-elements {
+  .command-has-num-elements.multiple-elements .num-elements,
+  .command-has-duplicates .num-duplicates {
     display: inline;
   }
 
+  .command-is-duplicate .num-duplicates,
   .command-name-assert.command-has-num-elements .num-elements {
     display: none;
   }
@@ -396,7 +386,53 @@
     }
   }
 
-  .command-is-pinned {
+  // TODO: still show pin if pinned
+
+  .command-expander {
+    color: #bcbccc;
+    display: none;
+    text-align: right;
+    padding-right: 8px;
+    width: 25px;
+
+    i {
+      @extend .#{$fa-css-prefix}-caret-right;
+    }
+
+    &:hover {
+      color: #999;
+    }
+  }
+
+  .command-has-duplicates,
+  .command-has-duplicates:hover {
+    .command-number {
+      display: block;
+    }
+
+    .command-number,
+    .command-pin {
+      display: none;
+    }
+  }
+
+  .command-has-duplicates .command-expander {
+    display: block;
+  }
+
+  .command-is-duplicate .command-expander {
+    visibility: hidden;
+  }
+
+  .command-is-open {
+    .command-expander {
+      i {
+        @extend .#{$fa-css-prefix}-caret-down;
+      }
+    }
+  }
+
+  .command-is-pinned > span > .command-wrapper {
     background: lighten($pinned, 40%);
     border-left: 2px solid $pinned;
     padding-left: 3px;
@@ -412,17 +448,6 @@
 
     .command-pin {
       color: $pinned;
-    }
-  }
-
-  &.is-running .command,
-  .command-other-pinned {
-    .command-number {
-      display: block !important;
-    }
-
-    .command-pin {
-      display: none !important;
     }
   }
 

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -375,19 +375,6 @@
     }
   }
 
-  .command-is-pinned,
-  .command:hover {
-    .command-number {
-      display: none;
-    }
-
-    .command-pin {
-      display: block;
-    }
-  }
-
-  // TODO: still show pin if pinned
-
   .command-expander {
     color: #bcbccc;
     display: none;
@@ -410,8 +397,7 @@
       display: block;
     }
 
-    .command-number,
-    .command-pin {
+    .command-number {
       display: none;
     }
   }
@@ -435,6 +421,34 @@
       i {
         @extend .#{$fa-css-prefix}-caret-down;
       }
+    }
+  }
+
+  .command-is-pinned,
+  .command:hover {
+    .command-number {
+      display: none;
+    }
+
+    .command-pin {
+      display: block;
+    }
+  }
+
+  .command-has-duplicates:hover .duplicates .command-pin,
+  .command-has-duplicates:hover > span > .command-wrapper .command-pin {
+    display: none;
+  }
+
+  .command-has-duplicates.command-is-pinned > span > .command-wrapper,
+  .command-is-duplicate.command-is-pinned > span > .command-wrapper,
+  .command-is-duplicate > span > .command-wrapper:hover {
+    .command-expander {
+      display: none;
+    }
+
+    .command-pin {
+      display: block;
     }
   }
 

--- a/packages/reporter/src/hooks/hook-model.js
+++ b/packages/reporter/src/hooks/hook-model.js
@@ -18,12 +18,17 @@ export default class Hook {
       command.number = this._currentNumber
       this._currentNumber++
     }
-    this.commands.push(command)
+    const lastCommand = _.last(this.commands)
+    if (lastCommand && lastCommand.isMatchingEvent(command)) {
+      lastCommand.addDuplicate(command)
+    } else {
+      this.commands.push(command)
+    }
   }
 
   commandMatchingErr (errToMatch) {
     return _(this.commands)
-      .filter(({ err }) => err.displayMessage === errToMatch.displayMessage)
-      .last()
+    .filter(({ err }) => err.displayMessage === errToMatch.displayMessage)
+    .last()
   }
 }

--- a/packages/reporter/src/hooks/hook-model.spec.js
+++ b/packages/reporter/src/hooks/hook-model.spec.js
@@ -1,3 +1,4 @@
+import sinon from 'sinon'
 import Hook from './hook-model'
 
 describe('Hook model', () => {
@@ -13,14 +14,14 @@ describe('Hook model', () => {
 
   context('#addCommand', () => {
     it('adds the command to its command collection', () => {
-      hook.addCommand({})
+      hook.addCommand({ isMatchingEvent: () => false })
       expect(hook.commands.length).to.equal(1)
       hook.addCommand({})
       expect(hook.commands.length).to.equal(2)
     })
 
     it('numbers commands incrementally when not events', () => {
-      const command1 = { event: false }
+      const command1 = { event: false, isMatchingEvent: () => false }
       hook.addCommand(command1)
       expect(command1.number).to.equal(1)
 
@@ -30,11 +31,11 @@ describe('Hook model', () => {
     })
 
     it('does not number event commands', () => {
-      const command1 = { event: false }
+      const command1 = { event: false, isMatchingEvent: () => false }
       hook.addCommand(command1)
       expect(command1.number).to.equal(1)
 
-      const command2 = { event: true }
+      const command2 = { event: true, isMatchingEvent: () => false }
       hook.addCommand(command2)
       expect(command2.number).to.be.undefined
 
@@ -42,13 +43,24 @@ describe('Hook model', () => {
       hook.addCommand(command3)
       expect(command3.number).to.equal(2)
     })
+
+    it('adds command as duplicate if it matches the last command', () => {
+      const addDuplicate = sinon.spy()
+      const command1 = { event: true, isMatchingEvent: () => true, addDuplicate }
+      hook.addCommand(command1)
+
+      const command2 = { event: true }
+      hook.addCommand(command2)
+
+      expect(addDuplicate).to.be.calledWith(command2)
+    })
   })
 
   context('#commandMatchingErr', () => {
     it('returns last command to match the error', () => {
-      const matchesButIsntLast = { err: { displayMessage: 'matching error message' } }
+      const matchesButIsntLast = { err: { displayMessage: 'matching error message' }, isMatchingEvent: () => false }
       hook.addCommand(matchesButIsntLast)
-      const doesntMatch = { err: { displayMessage: 'other error message' } }
+      const doesntMatch = { err: { displayMessage: 'other error message' }, isMatchingEvent: () => false }
       hook.addCommand(doesntMatch)
       const matches = { err: { displayMessage: 'matching error message' } }
       hook.addCommand(matches)
@@ -57,7 +69,7 @@ describe('Hook model', () => {
     })
 
     it('returns undefined when no match', () => {
-      const noMatch1 = { err: { displayMessage: 'some error message' } }
+      const noMatch1 = { err: { displayMessage: 'some error message' }, isMatchingEvent: () => false }
       hook.addCommand(noMatch1)
       const noMatch2 = { err: { displayMessage: 'other error message' } }
       hook.addCommand(noMatch2)

--- a/packages/reporter/src/test/test-model.spec.js
+++ b/packages/reporter/src/test/test-model.spec.js
@@ -81,7 +81,7 @@ describe('Test model', () => {
 
     it('adds the command to an existing hook if it already exists', () => {
       const test = new Test({})
-      test.addCommand({}, 'some hook')
+      test.addCommand({ isMatchingEvent: () => false }, 'some hook')
       expect(test.hooks.length).to.equal(1)
       expect(test.hooks[0].commands.length).to.equal(1)
       test.addCommand({}, 'some hook')

--- a/packages/runner/src/lib/shared.scss
+++ b/packages/runner/src/lib/shared.scss
@@ -2,8 +2,8 @@
 * These styles are shared between the runner and the reporter
 */
 
-.num-elements {
-  background-color: #476fc9;
+.num-elements,
+.num-duplicates {
   border-radius: 5px;
   color: #fff;
   display: none;
@@ -14,4 +14,12 @@
   text-align: center;
   vertical-align: baseline;
   white-space: nowrap;
+}
+
+.num-elements {
+  background-color: #476fc9;
+}
+
+.num-duplicates {
+  background-color: #999;
 }


### PR DESCRIPTION
Fixes #1580 

![screen shot 2018-04-16 at 3 21 24 pm](https://user-images.githubusercontent.com/1157043/38830402-30835014-418a-11e8-93a9-ec09d555c07b.png)

![screen shot 2018-04-17 at 2 02 27 pm](https://user-images.githubusercontent.com/1157043/38887914-1665af92-4248-11e8-8e51-ea1c57719000.png)

Duplicates can still be individually pinned and printed to console.