### PR TITLE
fix: typescript definition for scrollIntoView, close #1606

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -756,7 +756,7 @@ declare namespace Cypress {
      *
      * @see https://on.cypress.io/scrollintoview
      */
-    scrollIntoView(options?: Partial<ScrollIntoViewOptions>): Chainable<Subject>
+    scrollIntoView(options?: Partial<ScrollToOptions>): Chainable<Subject>
 
     /**
      * Scroll to a specific position.
@@ -1267,7 +1267,13 @@ declare namespace Cypress {
      *
      * @default 'swing'
      */
-    easing: 'swing' | 'linear'
+    easing: 'swing' | 'linear',
+    /**
+     * Amount to scroll after the element has been scrolled into view
+     *
+     * @default {top: 0, left: 0}
+     */
+    offset: Offset
   }
 
   interface SelectOptions extends Loggable, Timeoutable, Forceable {
@@ -3196,6 +3202,10 @@ declare namespace Cypress {
   type Encodings = 'ascii' | 'base64' | 'binary' | 'hex' | 'latin1' | 'utf8' | 'utf-8' | 'ucs2' | 'ucs-2' | 'utf16le' | 'utf-16le'
   type PositionType = "topLeft" | "top" | "topRight" | "left" | "center" | "right" | "bottomLeft" | "bottom" | "bottomRight"
   type ViewportPreset = 'macbook-15' | 'macbook-13' | 'macbook-11' | 'ipad-2' | 'ipad-mini' | 'iphone-6+' | 'iphone-6' | 'iphone-5' | 'iphone-4' | 'iphone-3'
+  interface Offset {
+    top: number,
+    left: number
+  }
 
   // Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
   type Diff<T extends string, U extends string> = ({[P in T]: P } & {[P in U]: never } & { [x: string]: never })[T]

--- a/cli/types/tests/kitchen-sink.ts
+++ b/cli/types/tests/kitchen-sink.ts
@@ -429,6 +429,13 @@ describe('Kitchen Sink', function() {
       // Cypress knows to scroll to the right and down
       cy.get('#scroll-both button').scrollIntoView()
         .should('be.visible')
+
+      // We can set scroll duration
+      cy.get('#scroll-both button').scrollIntoView({
+        duration: 1000,
+        easing: 'swing',
+        offset: {top: 0, left: 0}
+      })
     })
 
     it('cy.scrollTo() - scroll the window or element to a position', function() {


### PR DESCRIPTION
- use the right options type
- add `offset` property