### PR TITLE
cli: pass timeout 5 seconds for XVFB, close #1628

### DIFF
--- a/cli/lib/exec/xvfb.js
+++ b/cli/lib/exec/xvfb.js
@@ -7,6 +7,7 @@ const debugXvfb = require('debug')('cypress:xvfb')
 const { throwFormErrorText, errors } = require('../errors')
 
 const xvfb = Promise.promisifyAll(new Xvfb({
+  timeout: 5000, // milliseconds
   onStderrData (data) {
     if (debugXvfb.enabled) {
       debugXvfb(data.toString())

--- a/cli/package.json
+++ b/cli/package.json
@@ -27,7 +27,7 @@
   "types": "types",
   "dependencies": {
     "@cypress/listr-verbose-renderer": "0.4.1",
-    "@cypress/xvfb": "1.1.3",
+    "@cypress/xvfb": "1.2.3",
     "@types/blob-util": "1.3.3",
     "@types/bluebird": "3.5.18",
     "@types/chai": "4.0.8",


### PR DESCRIPTION
Use latest `@cypress/xvfb`, pass longer timeout, more debug messages from XVFB module