### PR TITLE
Make ffmpeg faster, encoded file more accessible.

### DIFF
--- a/packages/server/lib/video.coffee
+++ b/packages/server/lib/video.coffee
@@ -118,6 +118,11 @@ module.exports = {
       .outputOptions([
         "-preset fast"
         "-crf #{videoCompression}"
+        "-movflags faststart"
+        "-profile:v baseline"
+        "-level:v 3.0"
+        "-tune zerolatency"
+        "-threads 0"
       ])
       .save(cname)
       .on "codecData", (data) ->


### PR DESCRIPTION
I propose adding several flags to the ffmpeg command to improve cross-platform playback and marginally improve encode time:
```
  "-movflags faststart" > position the quicktime moov atom at the beginning of the file for faster startup - see [0]
  "-profile:v baseline" > pick an h264 type that is viewable on more devices at the expense of file size - see [1]
  "-level:v 3.0" > defines baseline level 3.0 see [1]
  "-tune zerolatency" > enables sliced threads (probably better for short encodes) see [2]
  "-threads 0" > allow the ffmpeg process to use all threads possible for encoding
```

[0] https://ffmpeg.org/ffmpeg-all.html#toc-mov_002c-mp4_002c-ismv

[1] https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/StreamingMediaGuide/FrequentlyAskedQuestions/FrequentlyAskedQuestions.html

[2] https://stackoverflow.com/questions/33624016/why-sliced-thread-affect-so-much-on-realtime-encoding-using-ffmpeg-x264