### PR TITLE
cli: print NODE_OPTIONS when DEBUG=cypress... is used, close #1673

### DIFF
--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -159,6 +159,7 @@ module.exports = {
     })
 
     debug('cli starts with arguments %j', args)
+    util.printNodeOptions()
 
     // if there are no arguments
     if (args.length <= 2) {

--- a/cli/lib/util.js
+++ b/cli/lib/util.js
@@ -7,6 +7,7 @@ const supportsColor = require('supports-color')
 const isInstalledGlobally = require('is-installed-globally')
 const pkg = require(path.join(__dirname, '..', 'package.json'))
 const logger = require('./logger')
+const debug = require('debug')('cypress:cli')
 
 const joinWithEq = (x, y) => `${x}=${y}`
 
@@ -36,8 +37,26 @@ function stdoutLineMatches (expectedLine, stdout) {
   return lines.some(lineMatches)
 }
 
+/**
+ * Prints NODE_OPTIONS using debug() module, but only
+ * if DEBUG=cypress... is set
+ */
+function printNodeOptions (log = debug) {
+  if (!log.enabled) {
+    return
+  }
+
+  if (process.env.NODE_OPTIONS) {
+    log('NODE_OPTIONS=%s', process.env.NODE_OPTIONS)
+  } else {
+    log('NODE_OPTIONS is not set')
+  }
+}
+
 const util = {
   normalizeModuleOptions,
+
+  printNodeOptions,
 
   isCi () {
     return isCi

--- a/cli/test/lib/util_spec.js
+++ b/cli/test/lib/util_spec.js
@@ -139,4 +139,60 @@ describe('util', function () {
     expect(process.exit).to.be.calledWith(1)
     expect(logger.error).to.be.calledWith('foo')
   })
+
+  context('.printNodeOptions', function () {
+    describe('NODE_OPTIONS is not set', function () {
+      beforeEach(function () {
+        this.node_options = process.env.NODE_OPTIONS
+        delete process.env.NODE_OPTIONS
+      })
+
+      afterEach(function () {
+        if (typeof this.node_options !== 'undefined') {
+          process.env.NODE_OPTIONS = this.node_options
+        }
+      })
+
+      it('does nothing if debug is not enabled', function () {
+        const log = this.sandbox.spy()
+        log.enabled = false
+        util.printNodeOptions(log)
+        expect(log).not.have.been.called
+      })
+
+      it('prints message when debug is enabled', function () {
+        const log = this.sandbox.spy()
+        log.enabled = true
+        util.printNodeOptions(log)
+        expect(log).to.be.calledWith('NODE_OPTIONS is not set')
+      })
+    })
+
+    describe('NODE_OPTIONS is set', function () {
+      beforeEach(function () {
+        this.node_options = process.env.NODE_OPTIONS
+        process.env.NODE_OPTIONS = 'foo'
+      })
+
+      afterEach(function () {
+        if (typeof this.node_options !== 'undefined') {
+          process.env.NODE_OPTIONS = this.node_options
+        }
+      })
+
+      it('does nothing if debug is not enabled', function () {
+        const log = this.sandbox.spy()
+        log.enabled = false
+        util.printNodeOptions(log)
+        expect(log).not.have.been.called
+      })
+
+      it('prints value when debug is enabled', function () {
+        const log = this.sandbox.spy()
+        log.enabled = true
+        util.printNodeOptions(log)
+        expect(log).to.be.calledWith('NODE_OPTIONS=%s', 'foo')
+      })
+    })
+  })
 })


### PR DESCRIPTION
- closes #1673 and allows easier tracking of options that can break Node execution (and thus Cypress run)