### PR TITLE
[low priority] fix out of center running animation

### DIFF
--- a/packages/reporter/src/runnables/runnables.scss
+++ b/packages/reporter/src/runnables/runnables.scss
@@ -71,6 +71,7 @@
       line-height: 18px;
       margin-right: 5px;
       width: 12px;
+      text-align: center;
     }
 
     &.suite .collapsible-indicator  {


### PR DESCRIPTION
This is a minor visual glitch. 

I am super sensitive of animations which are out of center. They are driving me nuts. So this change fixes the running animation to be centered all the time without shifting one pixel off center.

The animation is used to mark the current running action. It is reproduceable on chrome and electron on each version currently in use with cypress.

before
![before](https://user-images.githubusercontent.com/1239401/39781075-70f4a734-530e-11e8-93f9-244319e9e17d.gif)

after
![after](https://user-images.githubusercontent.com/1239401/39781085-777e308e-530e-11e8-8f82-ca93f2c87f3e.gif)

