### PR TITLE
add chrome flag --disable-blink-features=RootLayerScrolling to prevent AUT shaking in some versions of Chrome

### DIFF
--- a/packages/server/lib/browsers/chrome.coffee
+++ b/packages/server/lib/browsers/chrome.coffee
@@ -39,6 +39,7 @@ defaultArgs = [
   "--enable-automation"
   "--disable-infobars"
   "--disable-device-discovery-notifications"
+  "--disable-blink-features=RootLayerScrolling"
 
   ## the following come frome chromedriver
   ## https://code.google.com/p/chromium/codesearch#chromium/src/chrome/test/chromedriver/chrome_launcher.cc&sq=package:chromium&l=70


### PR DESCRIPTION
- addresses #1620 (still would like Chrome permanent fix before closing
though)