### PR TITLE
Yield details object from cy.screenshot()

### DIFF
--- a/packages/server/lib/automation/screenshot.coffee
+++ b/packages/server/lib/automation/screenshot.coffee
@@ -7,9 +7,9 @@ module.exports = (screenshotsFolder) ->
       log("capture %o", data)
 
       screenshots.capture(data, automate)
-      .then (imageOrBuffer) ->
-        if imageOrBuffer
-          screenshots.save(data, imageOrBuffer, screenshotsFolder)
+      .then (details) ->
+        if details
+          screenshots.save(data, details, screenshotsFolder)
       .catch (err) ->
         screenshots.clearMultipartState()
         throw err

--- a/packages/server/lib/modes/run.coffee
+++ b/packages/server/lib/modes/run.coffee
@@ -436,8 +436,8 @@ module.exports = {
       testId:    data.testId
       takenAt:   resp.takenAt
       path:      resp.path
-      height:    resp.height
-      width:     resp.width
+      height:    resp.dimensions.height
+      width:     resp.dimensions.width
     }
 
   runSpecs: (options = {}) ->


### PR DESCRIPTION
Fixes #1726 

Yielded object:

![screen shot 2018-05-17 at 2 47 14 pm](https://user-images.githubusercontent.com/1157043/40200307-f129196c-59e9-11e8-907c-2dd36088e7a3.png)

Console output:

![screen shot 2018-05-17 at 2 54 16 pm](https://user-images.githubusercontent.com/1157043/40200314-f6573a18-59e9-11e8-8d5f-915e73e851bf.png)
