### PR TITLE
fix cli: global binary cache reuse

### DIFF
--- a/cli/lib/tasks/install.js
+++ b/cli/lib/tasks/install.js
@@ -181,8 +181,9 @@ const start = (options = {}) => {
     logger.log()
   }
 
-  const installDir = state.getVersionDir(util.pkgVersion())
+  const installDir = state.getVersionDir(pkgVersion)
   const cacheDir = state.getCacheDir()
+  const binaryDir = state.getBinaryDir(pkgVersion)
 
   return fs.ensureDirAsync(cacheDir)
   .catch({ code: 'EACCES' }, (err) => {
@@ -192,7 +193,7 @@ const start = (options = {}) => {
     ${err.message}
     `)
   })
-  .then(() => state.getBinaryPkgVersionAsync(installDir))
+  .then(() => state.getBinaryPkgVersionAsync(binaryDir))
   .then((binaryVersion) => {
 
     if (!binaryVersion) {

--- a/cli/test/lib/tasks/install_spec.js
+++ b/cli/test/lib/tasks/install_spec.js
@@ -119,6 +119,8 @@ describe('/lib/tasks/install', function () {
         })
 
         it('logs noop message', function () {
+          expect(state.getBinaryPkgVersionAsync).to.be.calledWith('/cache/Cypress/1.2.3/Cypress.app')
+
           expect(download.start).not.to.be.called
 
           snapshot(


### PR DESCRIPTION
closes #1813

`state.getBinaryPkgVersionAsync` was called with a wrong argument.

It should called with the path to the binary directory `/cache/Cypress/1.2.3/Cypress.app` instead of the cache install directory `/cache/Cypress/1.2.3`.