### PR TITLE
Fix for issue-1226 - preserve styles for empty style tags - css-in-js

### DIFF
--- a/packages/driver/src/cy/snapshots.coffee
+++ b/packages/driver/src/cy/snapshots.coffee
@@ -48,7 +48,7 @@ getStylesFor = (doc, $$, stylesheets, location) ->
     else
       ## otherwise, it's a style tag, and we can just grab its content
       styleRules = if stylesheet.sheet
-      then Array.prototype.slice.call(stylesheet.sheet.rules).map((rule) -> rule.cssText).join("")
+      then Array.prototype.slice.call(stylesheet.sheet.cssRules).map((rule) -> rule.cssText).join("")
       else $$(stylesheet).text()
 
       makePathsAbsoluteToDoc(doc, styleRules)

--- a/packages/driver/src/cy/snapshots.coffee
+++ b/packages/driver/src/cy/snapshots.coffee
@@ -47,9 +47,9 @@ getStylesFor = (doc, $$, stylesheets, location) ->
       }
     else
       ## otherwise, it's a style tag, and we can just grab its content
-      styleRules = $$(stylesheet).text() ||
-        if stylesheet.sheet && stylesheet.sheet.rules
-        then Array.prototype.slice.call(stylesheet.sheet.rules).map((rule) -> rule.cssText).join("")
+      styleRules = if stylesheet.sheet
+      then Array.prototype.slice.call(stylesheet.sheet.rules).map((rule) -> rule.cssText).join("")
+      else $$(stylesheet).text()
 
       makePathsAbsoluteToDoc(doc, styleRules)
 

--- a/packages/driver/src/cy/snapshots.coffee
+++ b/packages/driver/src/cy/snapshots.coffee
@@ -47,7 +47,11 @@ getStylesFor = (doc, $$, stylesheets, location) ->
       }
     else
       ## otherwise, it's a style tag, and we can just grab its content
-      makePathsAbsoluteToDoc(doc, $$(stylesheet).text())
+      styleRules = $$(stylesheet).text() ||
+        if stylesheet.sheet && stylesheet.sheet.rules
+        then Array.prototype.slice.call(stylesheet.sheet.rules).map((rule) -> rule.cssText).join("")
+
+      makePathsAbsoluteToDoc(doc, styleRules)
 
 getDocumentStylesheets = (document) ->
   _.reduce document.styleSheets, (memo, stylesheet) ->

--- a/packages/driver/test/cypress/integration/cy/snapshot_spec.coffee
+++ b/packages/driver/test/cypress/integration/cy/snapshot_spec.coffee
@@ -73,6 +73,14 @@ describe "src/cy/snapshot", ->
       { headStyles } = cy.createSnapshot(@$el)
       expect(headStyles[0]).to.include(".foo { color: red }")
 
+    it "provides contents of style tags in head for injected rules", ->
+      styleEl = document.createElement("style");
+      $(styleEl).appendTo(cy.$$("head"))
+      styleEl.sheet.insertRule(".foo { color: red; }", 0)
+
+      { headStyles } = cy.createSnapshot(@$el)
+      expect(headStyles[0]).to.include(".foo { color: red; }")
+
     it "provides contents of local stylesheet links in head", (done) ->
       onLoad = ->
         ## need to for appended stylesheet to load

--- a/packages/driver/test/cypress/integration/cy/snapshot_spec.coffee
+++ b/packages/driver/test/cypress/integration/cy/snapshot_spec.coffee
@@ -71,7 +71,7 @@ describe "src/cy/snapshot", ->
       $("<style>.foo { color: red }</style>").appendTo(cy.$$("head"))
 
       { headStyles } = cy.createSnapshot(@$el)
-      expect(headStyles[0]).to.include(".foo { color: red }")
+      expect(headStyles[0]).to.include(".foo { color: red; }")
 
     it "provides contents of style tags in head for injected rules", ->
       styleEl = document.createElement("style");
@@ -157,7 +157,7 @@ describe "src/cy/snapshot", ->
       $("<style>.foo { color: red }</style>").appendTo(cy.$$("body"))
 
       {bodyStyles} = cy.createSnapshot(@$el)
-      expect(bodyStyles[bodyStyles.length - 1]).to.include(".foo { color: red }")
+      expect(bodyStyles[bodyStyles.length - 1]).to.include(".foo { color: red; }")
 
     it "provides contents of local stylesheet links in body", (done) ->
       onLoad = ->
@@ -206,9 +206,8 @@ describe "src/cy/snapshot", ->
       { headStyles } = cy.createSnapshot(@$el)
       expect(headStyles[0].replace(/\s+/gm, "")).to.include """
         @font-face {
-          font-family: 'Some Font';
-          src: url('http://localhost:3500/fonts/some-font.eot');
-          src: url('http://localhost:3500/fonts/some-font.eot?#iefix') format('embedded-opentype'), url('http://localhost:3500/fonts/some-font.woff2') format('woff2'), url('http://localhost:3500/fonts/some-font.woff') format('woff'), url('http://localhost:3500/fonts/some-font.ttf') format('truetype'), url('http://localhost:3500/fonts/some-font.svg#glyphicons_halflingsregular') format('svg');
+          font-family: "Some Font";
+          src: url('http://localhost:3500/fonts/some-font.eot?#iefix') format("embedded-opentype"), url('http://localhost:3500/fonts/some-font.woff2') format("woff2"), url('http://localhost:3500/fonts/some-font.woff') format("woff"), url('http://localhost:3500/fonts/some-font.ttf') format("truetype"), url('http://localhost:3500/fonts/some-font.svg#glyphicons_halflingsregular') format("svg");
         }
       """.replace(/\s+/gm, "")
 


### PR DESCRIPTION
closes #1226 