### PR TITLE
types for auth in cy.visit, close #1897

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -37,7 +37,10 @@ declare namespace Cypress {
   interface ObjectLike {
     [key: string]: any
   }
-
+  interface Auth {
+    username: string
+    password: string
+  }
   /**
    * Several libraries are bundled with Cypress by default.
    *
@@ -1399,6 +1402,21 @@ declare namespace Cypress {
      * @default {true}
      */
     failOnStatusCode: boolean
+
+    /**
+     * Cypress will automatically apply the right authorization headers
+     * if you’re attempting to visit an application that requires
+     * Basic Authentication.
+     *
+     * @example
+     *    cy.visit('https://www.acme.com/', {
+     *      auth: {
+     *        username: 'wile',
+     *        password: 'coyote'
+     *      }
+     *    })
+     */
+    auth: Auth
   }
 
   /**

--- a/cli/types/tests/kitchen-sink.ts
+++ b/cli/types/tests/kitchen-sink.ts
@@ -1527,6 +1527,7 @@ describe('Kitchen Sink', function() {
   })
 })
 
+// extra code that is not in the kitchensink that type checks edge cases
 cy.wrap('foo').then(subject => {
   subject // $ExpectType string
   return cy.wrap(subject)
@@ -1536,4 +1537,11 @@ cy.wrap('foo').then(subject => {
 
 Cypress.minimatch('/users/1/comments', '/users/*/comments', {
   matchBase: true,
+})
+
+cy.visit('https://www.acme.com/', {
+  auth: {
+    username: 'wile',
+    password: 'coyote'
+  }
 })

--- a/cli/types/tsconfig.json
+++ b/cli/types/tsconfig.json
@@ -9,9 +9,11 @@
     "noImplicitThis": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "types": [],
     "noEmit": true,
-      "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true
   },
   "include": [
       "**/*.ts"


### PR DESCRIPTION
- adds `auth` object to `cy.visit`
- closes #1897 
