### PR TITLE
bump cachedir to 1.3.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -46,7 +46,7 @@
     "@types/sinon": "4.0.0",
     "@types/sinon-chai": "2.7.29",
     "bluebird": "3.5.0",
-    "cachedir": "1.2.0",
+    "cachedir": "1.3.0",
     "chalk": "2.4.1",
     "check-more-types": "2.24.0",
     "commander": "2.11.0",


### PR DESCRIPTION
- bump cachedir to 1.3.0 which adds FreeBSD support (see https://github.com/LinusU/node-cachedir/pull/7)
- close #1942 
