### PR TITLE
allow relative paths in CYPRESS_* env vars

### DIFF
--- a/cli/__snapshots__/verify_spec.js
+++ b/cli/__snapshots__/verify_spec.js
@@ -175,11 +175,11 @@ Opening Cypress...
 `
 
 exports['darwin: error when invalid CYPRESS_RUN_BINARY 1'] = `
-Note: You have set the environment variable: CYPRESS_RUN_BINARY=/custom/:
+Note: You have set the environment variable: CYPRESS_RUN_BINARY=/custom:
 
       This overrides the default Cypress binary path used.
 
-Error: Could not run binary set by environment variable CYPRESS_RUN_BINARY=/custom/
+Error: Could not run binary set by environment variable CYPRESS_RUN_BINARY=/custom
 
 Ensure the environment variable is a path to the Cypress binary, matching **/Contents/MacOS/Cypress
 ----------
@@ -190,11 +190,11 @@ Cypress Version: 1.2.3
 `
 
 exports['linux: error when invalid CYPRESS_RUN_BINARY 1'] = `
-Note: You have set the environment variable: CYPRESS_RUN_BINARY=/custom/:
+Note: You have set the environment variable: CYPRESS_RUN_BINARY=/custom:
 
       This overrides the default Cypress binary path used.
 
-Error: Could not run binary set by environment variable CYPRESS_RUN_BINARY=/custom/
+Error: Could not run binary set by environment variable CYPRESS_RUN_BINARY=/custom
 
 Ensure the environment variable is a path to the Cypress binary, matching **/Cypress
 ----------
@@ -205,11 +205,11 @@ Cypress Version: 1.2.3
 `
 
 exports['win32: error when invalid CYPRESS_RUN_BINARY 1'] = `
-Note: You have set the environment variable: CYPRESS_RUN_BINARY=/custom/:
+Note: You have set the environment variable: CYPRESS_RUN_BINARY=/custom:
 
       This overrides the default Cypress binary path used.
 
-Error: Could not run binary set by environment variable CYPRESS_RUN_BINARY=/custom/
+Error: Could not run binary set by environment variable CYPRESS_RUN_BINARY=/custom
 
 Ensure the environment variable is a path to the Cypress binary, matching **/Cypress.exe
 ----------

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -49,7 +49,7 @@ module.exports = {
     let executable = state.getPathToExecutable(state.getBinaryDir())
 
     if (util.getEnv('CYPRESS_RUN_BINARY')) {
-      executable = util.getEnv('CYPRESS_RUN_BINARY')
+      executable = path.resolve(util.getEnv('CYPRESS_RUN_BINARY'))
     }
 
     debug('needs XVFB?', needsXvfb)

--- a/cli/lib/exec/versions.js
+++ b/cli/lib/exec/versions.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird')
 const debug = require('debug')('cypress:cli')
+const path = require('path')
 
 const util = require('../util')
 const state = require('../tasks/state')
@@ -9,7 +10,7 @@ const getVersions = () => {
   return Promise.try(() => {
 
     if (util.getEnv('CYPRESS_RUN_BINARY')) {
-      let envBinaryPath = util.getEnv('CYPRESS_RUN_BINARY')
+      let envBinaryPath = path.resolve(util.getEnv('CYPRESS_RUN_BINARY'))
       return state.parseRealPlatformBinaryFolderAsync(envBinaryPath)
       .then((envBinaryDir) => {
         if (!envBinaryDir) {

--- a/cli/lib/tasks/install.js
+++ b/cli/lib/tasks/install.js
@@ -265,7 +265,8 @@ const start = (options = {}) => {
     })
     .then((pathToLocalFile) => {
       if (pathToLocalFile) {
-        debug('found local file at', needVersion)
+        const absolutePath = path.resolve(needVersion)
+        debug('found local file at', absolutePath)
         debug('skipping download')
 
         const rendererOptions = getRendererOptions()
@@ -274,7 +275,7 @@ const start = (options = {}) => {
             throttle: 100,
             onProgress: null,
           },
-          zipFilePath: needVersion,
+          zipFilePath: absolutePath,
           installDir,
           rendererOptions,
         })], rendererOptions).run()

--- a/cli/lib/tasks/state.js
+++ b/cli/lib/tasks/state.js
@@ -56,7 +56,7 @@ const getCacheDir = () => {
   if (util.getEnv('CYPRESS_CACHE_FOLDER')) {
     const envVarCacheDir = util.getEnv('CYPRESS_CACHE_FOLDER')
     debug('using environment variable CYPRESS_CACHE_FOLDER %s', envVarCacheDir)
-    cache_directory = envVarCacheDir
+    cache_directory = path.resolve(envVarCacheDir)
   }
   return cache_directory
 }

--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -1,6 +1,7 @@
 const _ = require('lodash')
 const cp = require('child_process')
 const chalk = require('chalk')
+const path = require('path')
 const Listr = require('listr')
 const debug = require('debug')('cypress:cli')
 const verbose = require('@cypress/listr-verbose-renderer')
@@ -202,7 +203,7 @@ const start = (options = {}) => {
   const checkEnvVar = () => {
     debug('checking environment variables')
     if (util.getEnv('CYPRESS_RUN_BINARY')) {
-      const envBinaryPath = util.getEnv('CYPRESS_RUN_BINARY')
+      const envBinaryPath = path.resolve(util.getEnv('CYPRESS_RUN_BINARY'))
       debug('CYPRESS_RUN_BINARY exists, =', envBinaryPath)
       logger.log(stripIndent`
         ${chalk.yellow('Note:')} You have set the environment variable: ${chalk.white('CYPRESS_RUN_BINARY=')}${chalk.cyan(envBinaryPath)}:

--- a/cli/test/lib/tasks/install_spec.js
+++ b/cli/test/lib/tasks/install_spec.js
@@ -3,6 +3,7 @@ const os = require('os')
 const path = require('path')
 const chalk = require('chalk')
 const Promise = require('bluebird')
+const mockfs = require('mock-fs')
 const snapshot = require('snap-shot-it')
 
 const stdout = require('../../support/stdout')
@@ -106,6 +107,24 @@ describe('/lib/tasks/install', function () {
         .then(() => {
           expect(unzip.start).to.be.calledWithMatch({
             zipFilePath: version,
+            installDir,
+          })
+        })
+      })
+
+      it('can install local binary zip file from relative path', function () {
+        const version = './cypress-resources/file.zip'
+        mockfs({
+          [version]: 'asdf',
+        })
+        process.env.CYPRESS_INSTALL_BINARY = version
+
+        const installDir = state.getVersionDir()
+        return install.start()
+        .then(() => {
+          expect(download.start).not.to.be.called
+          expect(unzip.start).to.be.calledWithMatch({
+            zipFilePath: path.resolve(version),
             installDir,
           })
         })

--- a/cli/test/lib/tasks/state_spec.js
+++ b/cli/test/lib/tasks/state_spec.js
@@ -156,6 +156,12 @@ describe('lib/tasks/state', function () {
       const ret = state.getCacheDir()
       expect(ret).to.equal('/path/to/dir')
     })
+
+    it('CYPRESS_CACHE_FOLDER resolves from relative path', () => {
+      process.env.CYPRESS_CACHE_FOLDER = './local-cache/folder'
+      const ret = state.getCacheDir()
+      expect(ret).to.eql(path.resolve('local-cache/folder'))
+    })
   })
   context('.parseRealPlatformBinaryFolderAsync', function () {
     beforeEach(function () {


### PR DESCRIPTION
close #1960 
just making sure to use `path.resolve` on env vars so users can give relative paths