### PR TITLE
Don’t truncate xhr urls in command log

### DIFF
--- a/packages/driver/src/cy/commands/xhr.coffee
+++ b/packages/driver/src/cy/commands/xhr.coffee
@@ -141,7 +141,7 @@ startXhrServer = (cy, state, config) ->
           indicator ?= if /^2/.test(status) then "successful" else "bad"
 
           {
-            message: "#{xhr.method} #{status} #{_.truncate(stripOrigin(xhr.url), { length: 20 })}"
+            message: "#{xhr.method} #{status} #{stripOrigin(xhr.url)}"
             indicator: indicator
           }
       })


### PR DESCRIPTION
Fixes #1995 

![screen shot 2018-06-21 at 9 32 54 am](https://user-images.githubusercontent.com/1157043/41722356-4978b160-7536-11e8-8380-fdc2c94c58c9.png)

![screen shot 2018-06-21 at 9 33 08 am](https://user-images.githubusercontent.com/1157043/41722357-498804f8-7536-11e8-8db9-9d6330e0dd04.png)
