### PR TITLE
Move dependency-check into release step

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -10,10 +10,11 @@
     "node": ">=4.0.0"
   },
   "scripts": {
+    "check-dependencies": "dependency-check . --no-dev"
     "test": "npm run test-unit",
     "test-unit": "npm run dtslint && npm run unit",
     "test-watch": "npm run unit -- --watch",
-    "test-dependencies": "bin-up deps-ok && dependency-check . --no-dev",
+    "test-dependencies": "bin-up deps-ok",
     "test-debug": "node --inspect --debug-brk $(bin-up _mocha)",
     "test-cov": "nyc npm run unit",
     "unit": "BLUEBIRD_DEBUG=1 NODE_ENV=test bin-up mocha --reporter mocha-multi-reporters --reporter-options configFile=../mocha-reporter-config.json",
@@ -22,7 +23,7 @@
     "prebuild": "npm run test-dependencies && node ./scripts/start-build.js",
     "build": "node ./scripts/build.js",
     "prerelease": "npm run build",
-    "release": "cd build && releaser --no-node --no-changelog",
+    "release": "npm run check-dependencies && cd build && releaser --no-node --no-changelog",
     "size": "t=\"$(npm pack .)\"; wc -c \"${t}\"; tar tvf \"${t}\"; rm \"${t}\";"
   },
   "nyc": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -10,7 +10,7 @@
     "node": ">=4.0.0"
   },
   "scripts": {
-    "check-dependencies": "dependency-check . --no-dev"
+    "check-dependencies": "dependency-check . --no-dev",
     "test": "npm run test-unit",
     "test-unit": "npm run dtslint && npm run unit",
     "test-watch": "npm run unit -- --watch",


### PR DESCRIPTION
Currently, we run `dependency-check` as part of our prebuild step.  

The dependency-check developers have [suggested](https://github.com/maxogden/dependency-check/issues/89#issuecomment-398940325) that this is incorrect, and that we should be running the check as part of our release step.

This PR makes that change.  Fixes #1997.
