### PR TITLE
fix dtslint file name rule

### DIFF
--- a/cli/types/tslint.json
+++ b/cli/types/tslint.json
@@ -1,5 +1,12 @@
 {
+  // settings for linting TypeScript files in this folder
+  // using https://github.com/Microsoft/dtslint
+
+  // to force full checking you may need to reinstall dtsint with `npm i dtslint`
+  // and then run `npm run dtslint`. This will force installing different versions
+  // of TypeScript (2.0, 2.1, 2.2, ... next) and will run lint check against every version.
   "extends": "dtslint/dtslint.json",
+  // disable some rules that we do not need
   "rules": {
     "semicolon": [true, "never"],
     "no-namespace": false,
@@ -10,6 +17,7 @@
     "unified-signatures": false,
     "only-arrow-functions": false,
     "no-unnecessary-generics": false,
-    "export-just-namespace": false
+    "export-just-namespace": false,
+    "file-name-casing": false
   }
 }


### PR DESCRIPTION
fixes CI build that had error

```
Installing to /root/cypress/cli/node_modules/dtslint/typescript-installs/next...
Installed!

Error: /root/cypress/cli/types/blob-util.d.ts:1:1
ERROR: 1:1  file-name-casing  File name must be camelCase

/root/cypress/cli/types/tests/chainer-examples.ts:1:1
ERROR: 1:1  file-name-casing  File name must be camelCase

/root/cypress/cli/types/tests/cypress-tests.ts:1:1
ERROR: 1:1  file-name-casing  File name must be camelCase

/root/cypress/cli/types/tests/kitchen-sink.ts:1:1
ERROR: 1:1  file-name-casing  File name must be camelCase
```