### PR TITLE
Fix launcher transpile

### DIFF
--- a/packages/example/cypress/integration/examples/assertions.spec.js
+++ b/packages/example/cypress/integration/examples/assertions.spec.js
@@ -33,18 +33,19 @@ context('Assertions', () => {
       cy.get('.assertions-p').find('p')
       .should(($p) => {
         // return an array of texts from all of the p's
-        let texts = $p.map((i, el) => // https://on.cypress.io/$
+        // @ts-ignore TS6133 unused variable
+        const texts = $p.map((i, el) => // https://on.cypress.io/$
           Cypress.$(el).text())
 
         // jquery map returns jquery object
         // and .get() convert this to simple array
-        texts = texts.get()
+        const paragraphs = texts.get()
 
         // array should have length of 3
-        expect(texts).to.have.length(3)
+        expect(paragraphs).to.have.length(3)
 
         // set this specific subject
-        expect(texts).to.deep.eq([
+        expect(paragraphs).to.deep.eq([
           'Some text from first p',
           'More text from second p',
           'And even more text from third p',

--- a/packages/example/cypress/integration/examples/cypress_api.spec.js
+++ b/packages/example/cypress/integration/examples/cypress_api.spec.js
@@ -18,6 +18,7 @@ context('Cypress.Commands', () => {
       method = method || 'log'
 
       // log the subject to the console
+      // @ts-ignore TS7017
       console[method]('The subject is', subject)
 
       // whatever we return becomes the new subject
@@ -26,6 +27,7 @@ context('Cypress.Commands', () => {
       return subject
     })
 
+    // @ts-ignore TS2339
     cy.get('button').console('info').then(($button) => {
       // subject is still $button
     })
@@ -84,9 +86,6 @@ context('Cypress.Server', () => {
     Cypress.Server.defaults({
       delay: 0,
       force404: false,
-      whitelist (xhr) {
-        // handle custom logic for whitelisting
-      },
     })
   })
 })

--- a/packages/example/cypress/integration/examples/misc.spec.js
+++ b/packages/example/cypress/integration/examples/misc.spec.js
@@ -54,9 +54,24 @@ context('Misc', () => {
     cy.focused().should('have.id', 'description')
   })
 
-  it('cy.screenshot() - take a screenshot', () => {
-    // https://on.cypress.io/screenshot
-    cy.screenshot('my-image')
+  context('Cypress.Screenshot', function () {
+    it('cy.screenshot() - take a screenshot', () => {
+      // https://on.cypress.io/screenshot
+      cy.screenshot('my-image')
+    })
+
+    it('Cypress.Screenshot.defaults() - change default config of screenshots', function () {
+      Cypress.Screenshot.defaults({
+        blackout: ['.foo'],
+        capture: 'viewport',
+        clip: { x: 0, y: 0, width: 200, height: 200 },
+        scale: false,
+        disableTimersAndAnimations: true,
+        screenshotOnRunFailure: true,
+        beforeScreenshot () { },
+        afterScreenshot () { },
+      })
+    })
   })
 
   it('cy.wrap() - wrap an object', () => {

--- a/packages/example/cypress/integration/examples/navigation.spec.js
+++ b/packages/example/cypress/integration/examples/navigation.spec.js
@@ -45,9 +45,11 @@ context('Navigation', () => {
       timeout: 50000, // increase total time for the visit to resolve
       onBeforeLoad (contentWindow) {
         // contentWindow is the remote page's window object
+        expect(typeof contentWindow === 'object').to.be.true
       },
       onLoad (contentWindow) {
         // contentWindow is the remote page's window object
+        expect(typeof contentWindow === 'object').to.be.true
       },
     })
     })

--- a/packages/example/cypress/integration/examples/spies_stubs_clocks.spec.js
+++ b/packages/example/cypress/integration/examples/spies_stubs_clocks.spec.js
@@ -21,7 +21,14 @@ context('Spies, Stubs, and Clock', () => {
     cy.visit('https://example.cypress.io/commands/spies-stubs-clocks')
 
     let obj = {
-      foo () {},
+      /**
+       * prints both arguments to the console
+       * @param a {string}
+       * @param b {string}
+      */
+      foo (a, b) {
+        console.log('a', a, 'b', b)
+      },
     }
 
     let stub = cy.stub(obj, 'foo').as('foo')

--- a/packages/example/cypress/integration/examples/utilities.spec.js
+++ b/packages/example/cypress/integration/examples/utilities.spec.js
@@ -46,15 +46,35 @@ context('Utilities', () => {
 
   it('Cypress.minimatch - test out glob patterns against strings', () => {
     // https://on.cypress.io/minimatch
-    Cypress.minimatch('/users/1/comments', '/users/*/comments', {
+    let matching = Cypress.minimatch('/users/1/comments', '/users/*/comments', {
       matchBase: true,
     })
+    expect(matching, 'matching wildcard').to.be.true
+
+    matching = Cypress.minimatch("/users/1/comments/2", "/users/*/comments", {
+      matchBase: true
+    })
+    expect(matching, 'comments').to.be.false
+
+    // ** matches against all downstream path segments
+    matching = Cypress.minimatch("/foo/bar/baz/123/quux?a=b&c=2", "/foo/**", {
+      matchBase: true
+    })
+    expect(matching, 'comments').to.be.true
+
+    // whereas * matches only the next path segment
+
+    matching = Cypress.minimatch("/foo/bar/baz/123/quux?a=b&c=2", "/foo/*", {
+      matchBase: false
+    })
+    expect(matching, 'comments').to.be.false
   })
 
 
   it('Cypress.moment() - format or parse dates using a moment method', () => {
     // https://on.cypress.io/moment
-    let time = Cypress.moment().utc('2014-04-25T19:38:53.196Z').format('h:mm A')
+    const time = Cypress.moment().utc('2014-04-25T19:38:53.196Z').format('h:mm A')
+    expect(time).to.be.a('string')
 
     cy.get('.utility-moment').contains('3:38 PM')
       .should('have.class', 'badge')
@@ -65,8 +85,12 @@ context('Utilities', () => {
     // https://on.cypress.io/promise
     let waited = false
 
+    /**
+     * @return Bluebird<string>
+     */
     function waitOneSecond () {
       // return a promise that resolves after 1 second
+      // @ts-ignore TS2351 (new Cypress.Promise)
       return new Cypress.Promise((resolve, reject) => {
         setTimeout(() => {
           // set waited to true
@@ -81,6 +105,7 @@ context('Utilities', () => {
     cy.then(() =>
     // return a promise to cy.then() that
     // is awaited until it resolves
+      // @ts-ignore TS7006
       waitOneSecond().then((str) => {
         expect(str).to.eq('foo')
         expect(waited).to.be.true

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -25,7 +25,7 @@
   ],
   "devDependencies": {
     "@cypress/releaser": "0.1.12",
-    "@types/bluebird": "^3.5.3",
+    "@types/bluebird": "3.5.21",
     "@types/chai": "^3.5.2",
     "@types/debug": "0.0.29",
     "@types/execa": "^0.7.0",


### PR DESCRIPTION
This pins the types bluebird package version to be compatible with TypeScript 2.6 we are using in the launcher project. See which versions of this package are compatible with different typescript versions by looking at tags

```
$ npm info @types/bluebird
...
dist-tags:
latest: 3.5.22  ts2.2: 3.5.5    ts2.5: 3.5.21   ts2.8: 3.5.22   ts3.1: 3.5.22   
ts2.0: 3.5.5    ts2.3: 3.5.21   ts2.6: 3.5.21   ts2.9: 3.5.22   
ts2.1: 3.5.5    ts2.4: 3.5.21   ts2.7: 3.5.21   ts3.0: 3.5.22
```