### PR TITLE
only include `--disable-blink-features=RootLayerScrolling` flag in chrome v66 and 67

### DIFF
--- a/packages/server/lib/browsers/chrome.coffee
+++ b/packages/server/lib/browsers/chrome.coffee
@@ -39,7 +39,6 @@ defaultArgs = [
   "--enable-automation"
   "--disable-infobars"
   "--disable-device-discovery-notifications"
-  "--disable-blink-features=RootLayerScrolling"
 
   ## http://www.chromium.org/Home/chromium-security/site-isolation
   ## https://github.com/cypress-io/cypress/issues/1951
@@ -113,6 +112,10 @@ module.exports = {
     if options.chromeWebSecurity is false
       args.push("--disable-web-security")
       args.push("--allow-running-insecure-content")
+
+    ## prevent AUT shaking in v66 & 67, bug flag breaks chrome in v68+
+    if options.browser.majorVersion === '66' || options.browser.majorVersion === '67'
+       args.push("--disable-blink-features=RootLayerScrolling")
 
     args
 

--- a/packages/server/lib/browsers/chrome.coffee
+++ b/packages/server/lib/browsers/chrome.coffee
@@ -9,6 +9,7 @@ appData   = require("../util/app_data")
 utils     = require("./utils")
 
 LOAD_EXTENSION = "--load-extension="
+CHROME_VERSIONS_WITH_BUGGY_ROOT_LAYER_SCROLLING = "66 67".split(" ")
 
 pathToExtension = extension.getPathToExtension()
 pathToTheme     = extension.getPathToTheme()
@@ -97,6 +98,12 @@ module.exports = {
       .return(extensionDest)
 
   _getArgs: (options = {}) ->
+    _.defaults(options, {
+      browser: {}
+    })
+
+    { majorVersion } = options.browser
+
     args = [].concat(defaultArgs)
 
     if os.platform() is "linux"
@@ -113,8 +120,11 @@ module.exports = {
       args.push("--disable-web-security")
       args.push("--allow-running-insecure-content")
 
-    ## prevent AUT shaking in v66 & 67, bug flag breaks chrome in v68+
-    if options.browser.majorVersion === '66' || options.browser.majorVersion === '67'
+    ## prevent AUT shaking in 66 & 67, but flag breaks chrome in 68+
+    ## https://github.com/cypress-io/cypress/issues/2037
+    ## https://github.com/cypress-io/cypress/issues/2215
+    ## https://github.com/cypress-io/cypress/issues/2223
+    if majorVersion in CHROME_VERSIONS_WITH_BUGGY_ROOT_LAYER_SCROLLING
        args.push("--disable-blink-features=RootLayerScrolling")
 
     args

--- a/packages/server/test/unit/browsers/chrome_spec.coffee
+++ b/packages/server/test/unit/browsers/chrome_spec.coffee
@@ -117,3 +117,23 @@ describe "lib/browsers/chrome", ->
       args = chrome._getArgs()
 
       expect(args).not.to.include("--user-agent=foo")
+
+    it "disables RootLayerScrolling in versions 66 or 67", ->
+      arg = "--disable-blink-features=RootLayerScrolling"
+
+      disabledRootLayerScrolling = (version, bool) ->
+        args = chrome._getArgs({
+          browser: {
+            majorVersion: version
+          }
+        })
+
+        if bool
+          expect(args).to.include(arg)
+        else
+          expect(args).not.to.include(arg)
+
+      disabledRootLayerScrolling("65", false)
+      disabledRootLayerScrolling("66", true)
+      disabledRootLayerScrolling("67", true)
+      disabledRootLayerScrolling("68", false)


### PR DESCRIPTION
- close #2037 
- close #2215
- close #2223