### PR TITLE
Replace console.debug with console.log for logMemory

### DIFF
--- a/packages/server/lib/project.coffee
+++ b/packages/server/lib/project.coffee
@@ -67,7 +67,7 @@ class Project extends EE
 
     if process.env.CYPRESS_MEMORY
       logMemory = ->
-        console.debug("memory info", process.memoryUsage())
+        console.log("memory info", process.memoryUsage())
 
       @memoryCheck = setInterval(logMemory, 1000)
 


### PR DESCRIPTION
Changes the logMemory function to use console.log rather than console.debug. 

When I run cypress with CYPRESS_MEMORY=1, I get a TypeError that console.debug is not defined. I am using node v9.8.0.  