### PR TITLE
Update cli to display version via console

### DIFF
--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -90,8 +90,8 @@ function showVersions () {
   return require('./exec/versions')
   .getVersions()
   .then((versions = {}) => {
-    logger.log('Cypress package version:', versions.package)
-    logger.log('Cypress binary version:', versions.binary)
+    console.log('Cypress package version:', versions.package) // eslint-disable-line no-console
+    console.log('Cypress binary version:', versions.binary) // eslint-disable-line no-console
     process.exit(0)
   })
   .catch(util.logErrorExit1)


### PR DESCRIPTION
Currently cypress use the logger to display CLI version.
Logger do not generate output if the current logging level is lower than the configured disabling possibility to display version (this happen by default).

### Current
```
root@24e921bbf865:/usr/local/lib/node_modules/cypress# cypress version
root@24e921bbf865:/usr/local/lib/node_modules/cypress# 
```
with debug:
```
root@24e921bbf865:/usr/local/lib/node_modules/cypress# DEBUG=cypress:cli cypress version
  cypress:cli cli starts with arguments ["/usr/local/bin/node","/usr/local/bin/cypress","version"] +0ms
  cypress:cli NODE_OPTIONS is not set +0ms
  cypress:cli printing Cypress version +6ms
  cypress:cli Reading binary package.json from: /root/.cache/Cypress/3.1.0/Cypress/resources/app/package.json +0ms
root@24e921bbf865:/usr/local/lib/node_modules/cypress#
```

### After fix
```
root@24e921bbf865:/usr/local/lib/node_modules/cypress# cypress version
Cypress package version: 3.1.0
Cypress binary version: 3.1.0
root@24e921bbf865:/usr/local/lib/node_modules/cypress# 
```
with debug:
```
root@24e921bbf865:/usr/local/lib/node_modules/cypress# DEBUG=cypress:cli cypress version
  cypress:cli cli starts with arguments ["/usr/local/bin/node","/usr/local/bin/cypress","version"] +0ms
  cypress:cli NODE_OPTIONS is not set +0ms
  cypress:cli printing Cypress version +6ms
  cypress:cli Reading binary package.json from: /root/.cache/Cypress/3.1.0/Cypress/resources/app/package.json +0ms
Cypress package version: 3.1.0
Cypress binary version: 3.1.0
root@24e921bbf865:/usr/local/lib/node_modules/cypress#
```