### PR TITLE
Change hard-coded forward slash in watch path to platform specific path delimiter

### DIFF
--- a/packages/server/lib/socket.coffee
+++ b/packages/server/lib/socket.coffee
@@ -73,7 +73,7 @@ class Socket
     ## need to take into account integrationFolder may be different so
     ## integration/foo_spec.js becomes cypress/my-integration-folder/foo_spec.js
     debug("watch test file %o", originalFilePath)
-    filePath = path.join(config.integrationFolder, originalFilePath.replace("integration/", ""))
+    filePath = path.join(config.integrationFolder, originalFilePath.replace("integration#{path.sep}", ""))
     filePath = path.relative(config.projectRoot, filePath)
 
     ## bail if this is special path like "__all"

--- a/packages/server/test/unit/socket_spec.coffee
+++ b/packages/server/test/unit/socket_spec.coffee
@@ -450,16 +450,16 @@ describe "lib/socket", ->
           expect(preprocessor.removeFile).to.be.calledWithMatch("test1.js", @cfg)
 
       it "sets #testFilePath", ->
-        @socket.watchTestFileByPath(@cfg, "integration/test1.js").then =>
-          expect(@socket.testFilePath).to.eq "tests/test1.js"
+        @socket.watchTestFileByPath(@cfg, "integration#{path.sep}test1.js").then =>
+          expect(@socket.testFilePath).to.eq "tests#{path.sep}test1.js"
 
       it "can normalizes leading slash", ->
-        @socket.watchTestFileByPath(@cfg, "/integration/test1.js").then =>
-          expect(@socket.testFilePath).to.eq "tests/test1.js"
+        @socket.watchTestFileByPath(@cfg, "#{path.sep}integration#{path.sep}test1.js").then =>
+          expect(@socket.testFilePath).to.eq "tests#{path.sep}test1.js"
 
       it "watches file by path", ->
-        @socket.watchTestFileByPath(@cfg, "integration/test2.coffee")
-        expect(preprocessor.getFile).to.be.calledWith("tests/test2.coffee", @cfg)
+        @socket.watchTestFileByPath(@cfg, "integration#{path.sep}test2.coffee")
+        expect(preprocessor.getFile).to.be.calledWith("tests#{path.sep}test2.coffee", @cfg)
 
       it "triggers watched:file:changed event when preprocessor 'file:updated' is received", (done) ->
         sinon.stub(fs, "statAsync").resolves()


### PR DESCRIPTION
address  #712

- Fixes broken watch path on Windows when using any trans-piled code (ts, cucumber etc...)
- update related unit tests

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->
