### PR TITLE
Extract Bitbucket Pipeline and TeamFoundation environment variables

### DIFF
--- a/packages/server/__snapshots__/cypress_spec.coffee.js
+++ b/packages/server/__snapshots__/cypress_spec.coffee.js
@@ -60,6 +60,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 
 - appveyor
 - bamboo
+- bitbucket
 - buildkite
 - circle
 - codeship
@@ -86,6 +87,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 
 - appveyor
 - bamboo
+- bitbucket
 - buildkite
 - circle
 - codeship
@@ -113,6 +115,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 
 - appveyor
 - bamboo
+- bitbucket
 - buildkite
 - circle
 - codeship

--- a/packages/server/__snapshots__/cypress_spec.coffee.js
+++ b/packages/server/__snapshots__/cypress_spec.coffee.js
@@ -69,6 +69,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 - jenkins
 - semaphore
 - shippable
+- teamfoundation
 - travis
 
 Because the ciBuildId could not be auto-detected you must pass the --ci-build-id flag manually.
@@ -96,6 +97,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 - jenkins
 - semaphore
 - shippable
+- teamfoundation
 - travis
 
 Because the ciBuildId could not be auto-detected you must pass the --ci-build-id flag manually.
@@ -124,6 +126,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 - jenkins
 - semaphore
 - shippable
+- teamfoundation
 - travis
 
 Because the ciBuildId could not be auto-detected you must pass the --ci-build-id flag manually.

--- a/packages/server/lib/util/ci_provider.coffee
+++ b/packages/server/lib/util/ci_provider.coffee
@@ -28,9 +28,12 @@ isJenkins = ->
 isWercker = ->
   process.env.WERCKER or process.env.WERCKER_MAIN_PIPELINE_STARTED
 
+# top level detection of CI providers by environment variable
+# or a predicate function
 CI_PROVIDERS = {
   "appveyor":       "APPVEYOR"
   "bamboo":         "bamboo.buildNumber"
+  "bitbucket":      "BITBUCKET_BUILD_NUMBER"
   "buildkite":      "BUILDKITE"
   "circle":         "CIRCLECI"
   "codeship":       isCodeship
@@ -76,6 +79,11 @@ _providerCiParams = ->
       "bamboo.buildNumber"
       "bamboo.buildResultsUrl"
       "bamboo.planRepository.repositoryUrl"
+    ])
+    bitbucket: extract([
+      "BITBUCKET_REPO_SLUG"
+      "BITBUCKET_REPO_OWNER"
+      "BITBUCKET_BUILD_NUMBER"
     ])
     buildkite: extract([
       "BUILDKITE_REPO"
@@ -196,6 +204,10 @@ _providerCommitParams = ->
       # authorEmail: ???
       # remoteOrigin: ???
       # defaultBranch: ???
+    }
+    bitbucket: {
+      sha: env.BITBUCKET_COMMIT
+      branch: env.BITBUCKET_BRANCH
     }
     buildkite: {
       sha: env.BUILDKITE_COMMIT

--- a/packages/server/lib/util/ci_provider.coffee
+++ b/packages/server/lib/util/ci_provider.coffee
@@ -168,7 +168,11 @@ _providerCiParams = ->
     ])
     snap: null
     teamcity: null
-    teamfoundation: null
+    teamfoundation: extract([
+      "BUILD_BUILDID",
+      "BUILD_BUILDNUMBER",
+      "BUILD_CONTAINERID"
+    ])
     travis: extract([
       "TRAVIS_JOB_ID"
       "TRAVIS_BUILD_ID"
@@ -284,7 +288,12 @@ _providerCommitParams = ->
     }
     snap: null
     teamcity: null
-    teamfoundation: null
+    teamfoundation: {
+      sha: env.BUILD_SOURCEVERSION
+      branch: env.BUILD_SOURCEBRANCHNAME
+      message: env.BUILD_SOURCEVERSIONMESSAGE
+      authorName: env.BUILD_SOURCEVERSIONAUTHOR
+    }
     travis: {
       sha: env.TRAVIS_COMMIT
       ## for PRs, TRAVIS_BRANCH is the base branch being merged into

--- a/packages/server/lib/util/ci_provider.coffee
+++ b/packages/server/lib/util/ci_provider.coffee
@@ -320,15 +320,23 @@ commitParams = ->
   _get(_providerCommitParams)
 
 commitDefaults = (existingInfo) ->
+  debug("git commit existing info")
+  debug(existingInfo)
+
   commitParamsObj = commitParams() or {}
-  debug("commit params object")
+  debug("commit info from provider environment variables")
   debug(commitParamsObj)
 
   ## based on the existingInfo properties
   ## merge in the commitParams if null or undefined
   ## defaulting back to null if all fails
-  _.transform existingInfo, (memo, value, key) ->
+  combined = _.transform existingInfo, (memo, value, key) ->
     memo[key] = _.defaultTo(value ? commitParamsObj[key], null)
+
+  debug("combined git and environment variables from provider")
+  debug(combined)
+
+  return combined
 
 list = ->
   _.keys(CI_PROVIDERS)

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -94,6 +94,29 @@ describe "lib/util/ci_provider", ->
       branch: "bamboo.planRepository.branch"
     })
 
+  it.only "bitbucket", ->
+    process.env.CI = "1"
+
+    # build information
+    process.env.BITBUCKET_BUILD_NUMBER = "bitbucketBuildNumber"
+    process.env.BITBUCKET_REPO_OWNER = "bitbucketRepoOwner"
+    process.env.BITBUCKET_REPO_SLUG = "bitbucketRepoSlug"
+
+    # git information
+    process.env.BITBUCKET_COMMIT = "bitbucketCommit"
+    process.env.BITBUCKET_BRANCH = "bitbucketBranch"
+
+    expectsName("bitbucket")
+    expectsCiParams({
+      bitbucketBuildNumber: "bitbucketBuildNumber"
+      bitbucketRepoOwner: "bitbucketRepoOwner"
+      bitbucketRepoSlug: "bitbucketRepoSlug"
+    })
+    expectsCommitParams({
+      sha: "bitbucketCommit"
+      branch: "bitbucketBranch"
+    })
+
   it "buildkite", ->
     process.env.BUILDKITE = true
 

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -94,7 +94,7 @@ describe "lib/util/ci_provider", ->
       branch: "bamboo.planRepository.branch"
     })
 
-  it.only "bitbucket", ->
+  it "bitbucket", ->
     process.env.CI = "1"
 
     # build information
@@ -115,6 +115,13 @@ describe "lib/util/ci_provider", ->
     expectsCommitParams({
       sha: "bitbucketCommit"
       branch: "bitbucketBranch"
+    })
+    expectsCommitDefaults({
+      sha: null
+      branch: "gitFoundBranch"
+    }, {
+      sha: "bitbucketCommit"
+      branch: "gitFoundBranch"
     })
 
   it "buildkite", ->

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -448,9 +448,27 @@ describe "lib/util/ci_provider", ->
   it "teamfoundation", ->
     process.env.TF_BUILD = true
 
+    process.env.BUILD_BUILDID = "buildId"
+    process.env.BUILD_BUILDNUMBER = "buildNumber"
+    process.env.BUILD_CONTAINERID = "containerId"
+
+    process.env.BUILD_SOURCEVERSION = "commit"
+    process.env.BUILD_SOURCEBRANCHNAME = "branch"
+    process.env.BUILD_SOURCEVERSIONMESSAGE = "message"
+    process.env.BUILD_SOURCEVERSIONAUTHOR = "name"
+
     expectsName("teamfoundation")
-    expectsCiParams(null)
-    expectsCommitParams(null)
+    expectsCiParams({
+      buildBuildid: "buildId"
+      buildBuildnumber: "buildNumber"
+      buildContainerid: "containerId"
+    })
+    expectsCommitParams({
+      sha: "commit"
+      branch: "branch"
+      message: "message"
+      authorName: "name"
+    })
 
   it "travis", ->
     process.env.TRAVIS = true


### PR DESCRIPTION
- closes #2420
- closes #2433 (just main variables, have not checked parallelization)
- this exposed an issue https://github.com/cypress-io/cypress/issues/2439 that we can solve separately: this PR just extracts env variables for these two providers