### PR TITLE
new Buffer is deprecated and unsafe

### DIFF
--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -250,7 +250,7 @@ describe('lib/exec/spawn', function () {
     })
 
     it('writes everything on win32', function () {
-      const buf1 = new Buffer('asdf')
+      const buf1 = Buffer.from('asdf')
 
       this.spawnedProcess.stdin.pipe.withArgs(process.stdin)
       this.spawnedProcess.stdout.pipe.withArgs(process.stdout)
@@ -268,9 +268,9 @@ describe('lib/exec/spawn', function () {
     })
 
     it('does not write to process.stderr when from xlib or libudev', function () {
-      const buf1 = new Buffer('Xlib: something foo')
-      const buf2 = new Buffer('libudev something bar')
-      const buf3 = new Buffer('asdf')
+      const buf1 = Buffer.from('Xlib: something foo')
+      const buf2 = Buffer.from('libudev something bar')
+      const buf3 = Buffer.from('asdf')
 
       this.spawnedProcess.stderr.on
       .withArgs('data')
@@ -295,8 +295,8 @@ describe('lib/exec/spawn', function () {
     })
 
     it('does not write to process.stderr when from high sierra warnings', function () {
-      const buf1 = new Buffer('2018-05-19 15:30:30.287 Cypress[7850:32145] *** WARNING: Textured Window')
-      const buf2 = new Buffer('asdf')
+      const buf1 = Buffer.from('2018-05-19 15:30:30.287 Cypress[7850:32145] *** WARNING: Textured Window')
+      const buf2 = Buffer.from('asdf')
 
       this.spawnedProcess.stderr.on
       .withArgs('data')

--- a/packages/https-proxy/test/helpers/proxy.coffee
+++ b/packages/https-proxy/test/helpers/proxy.coffee
@@ -39,7 +39,7 @@ module.exports = {
         if req.url.includes("replace")
           write = res.write
           res.write = (chunk) ->
-            chunk = new Buffer(chunk.toString().replace("https server", "replaced content"))
+            chunk = Buffer.from(chunk.toString().replace("https server", "replaced content"))
 
             write.call(@, chunk)
 

--- a/packages/server/lib/controllers/proxy.coffee
+++ b/packages/server/lib/controllers/proxy.coffee
@@ -363,7 +363,7 @@ module.exports = {
       if (a = remoteState.auth) and resMatchesOriginPolicy()
         ## and no existing Authentication headers
         if not req.headers["authorization"]
-          base64 = new Buffer(a.username + ":" + a.password).toString("base64")
+          base64 = Buffer.from(a.username + ":" + a.password).toString("base64")
           req.headers["authorization"] = "Basic #{base64}"
 
       rq = request.create(opts)

--- a/packages/server/lib/controllers/xhrs.coffee
+++ b/packages/server/lib/controllers/xhrs.coffee
@@ -47,7 +47,7 @@ module.exports = {
         if _.isObject(data)
           data = JSON.stringify(data)
 
-        chunk = new Buffer(data, encoding)
+        chunk = Buffer.from(data, encoding)
 
         headers["content-length"] = chunk.length
 

--- a/packages/server/test/integration/http_requests_spec.coffee
+++ b/packages/server/test/integration/http_requests_spec.coffee
@@ -1395,7 +1395,7 @@ describe "Routes", ->
       it "sends with Transfer-Encoding: chunked without Content-Length", ->
         nock(@server._remoteOrigin)
         .get("/login")
-        .reply 200, new Buffer("foo"), {
+        .reply 200, Buffer.from("foo"), {
           "Content-Type": "text/html"
         }
 
@@ -1706,7 +1706,7 @@ describe "Routes", ->
         username = "u"
         password = "p"
 
-        base64 = new Buffer(username + ":" + password).toString("base64")
+        base64 = Buffer.from(username + ":" + password).toString("base64")
 
         @server._remoteAuth = {
           username

--- a/packages/server/test/integration/server_spec.coffee
+++ b/packages/server/test/integration/server_spec.coffee
@@ -620,7 +620,7 @@ describe "Server", ->
         username = "u"
         password = "p"
 
-        base64 = new Buffer(username + ":" + password).toString("base64")
+        base64 = Buffer.from(username + ":" + password).toString("base64")
 
         auth = {
           username

--- a/packages/server/test/unit/screenshots_spec.coffee
+++ b/packages/server/test/unit/screenshots_spec.coffee
@@ -32,7 +32,7 @@ describe "lib/screenshots", ->
       viewport: { width: 40, height: 40 }
     }
 
-    @buffer = new Buffer("image 1 data buffer")
+    @buffer = Buffer.from("image 1 data buffer")
 
     @jimpImage = {
       id: 1
@@ -168,21 +168,21 @@ describe "lib/screenshots", ->
         @jimpImage2 = clone(@jimpImage, {
           id: 2
           bitmap: {
-            data: new Buffer("image 2 data buffer")
+            data: Buffer.from("image 2 data buffer")
           }
         })
 
         @jimpImage3 = clone(@jimpImage, {
           id: 3
           bitmap: {
-            data: new Buffer("image 3 data buffer")
+            data: Buffer.from("image 3 data buffer")
           }
         })
 
         @jimpImage4 = clone(@jimpImage, {
           id: 4
           bitmap: {
-            data: new Buffer("image 4 data buffer")
+            data: Buffer.from("image 4 data buffer")
           }
         })
 


### PR DESCRIPTION
#### What does it do?
This PR replaces all `new Buffer` with `Buffer.from`. We should not use Buffer constructor which is deprecated and unsafe.

#### Any helpful background information?
The behavior of new Buffer() is different depending on the type of the first argument, security and reliability issues can be inadvertently introduced into applications when argument validation or Buffer initialization is not performed.

To make the creation of Buffer instances more reliable and less error-prone, the various forms of the new Buffer() constructor have been deprecated and replaced by separate Buffer.from(), Buffer.alloc(), and Buffer.allocUnsafe() methods.

Check this out: 
* https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe
* https://github.com/nodejs/Release#end-of-life-releases