### PR TITLE
Introduce CYPRESS_DOWNLOAD_BASE_URL to specify a base download url

### DIFF
--- a/cli/__snapshots__/download_spec.js
+++ b/cli/__snapshots__/download_spec.js
@@ -20,3 +20,19 @@ https://download.cypress.io/desktop?platform=OS&arch=ARCH
 exports['specific version desktop url 1'] = `
 https://download.cypress.io/desktop/0.20.2?platform=OS&arch=ARCH
 `
+
+exports['base url from CYPRESS_DOWNLOAD_BASE_URL 1'] = `
+https://cypress.example.com/desktop/0.20.2?platform=OS&arch=ARCH
+`
+
+exports['base url from CYPRESS_DOWNLOAD_BASE_URL with trailing slash 1'] = `
+https://cypress.example.com/desktop/0.20.2?platform=OS&arch=ARCH
+`
+
+exports['base url from CYPRESS_DOWNLOAD_BASE_URL with subdirectory 1'] = `
+https://cypress.example.com/example/desktop/0.20.2?platform=OS&arch=ARCH
+`
+
+exports['base url from CYPRESS_DOWNLOAD_BASE_URL with subdirectory and trailing slash 1'] = `
+https://cypress.example.com/example/desktop/0.20.2?platform=OS&arch=ARCH
+`

--- a/cli/__snapshots__/download_spec.js
+++ b/cli/__snapshots__/download_spec.js
@@ -21,18 +21,18 @@ exports['specific version desktop url 1'] = `
 https://download.cypress.io/desktop/0.20.2?platform=OS&arch=ARCH
 `
 
-exports['base url from CYPRESS_DOWNLOAD_BASE_URL 1'] = `
+exports['base url from CYPRESS_DOWNLOAD_MIRROR 1'] = `
 https://cypress.example.com/desktop/0.20.2?platform=OS&arch=ARCH
 `
 
-exports['base url from CYPRESS_DOWNLOAD_BASE_URL with trailing slash 1'] = `
+exports['base url from CYPRESS_DOWNLOAD_MIRROR with trailing slash 1'] = `
 https://cypress.example.com/desktop/0.20.2?platform=OS&arch=ARCH
 `
 
-exports['base url from CYPRESS_DOWNLOAD_BASE_URL with subdirectory 1'] = `
+exports['base url from CYPRESS_DOWNLOAD_MIRROR with subdirectory 1'] = `
 https://cypress.example.com/example/desktop/0.20.2?platform=OS&arch=ARCH
 `
 
-exports['base url from CYPRESS_DOWNLOAD_BASE_URL with subdirectory and trailing slash 1'] = `
+exports['base url from CYPRESS_DOWNLOAD_MIRROR with subdirectory and trailing slash 1'] = `
 https://cypress.example.com/example/desktop/0.20.2?platform=OS&arch=ARCH
 `

--- a/cli/lib/tasks/download.js
+++ b/cli/lib/tasks/download.js
@@ -16,8 +16,8 @@ const util = require('../util')
 const defaultBaseUrl = 'https://download.cypress.io/'
 
 const getBaseUrl = () => {
-  if (util.getEnv('CYPRESS_DOWNLOAD_BASE_URL')) {
-    let baseUrl = util.getEnv('CYPRESS_DOWNLOAD_BASE_URL')
+  if (util.getEnv('CYPRESS_DOWNLOAD_MIRROR')) {
+    let baseUrl = util.getEnv('CYPRESS_DOWNLOAD_MIRROR')
     if (!baseUrl.endsWith('/')) {
       baseUrl += '/'
     }

--- a/cli/lib/tasks/download.js
+++ b/cli/lib/tasks/download.js
@@ -13,10 +13,23 @@ const { throwFormErrorText, errors } = require('../errors')
 const fs = require('../fs')
 const util = require('../util')
 
-const baseUrl = 'https://download.cypress.io/'
+const defaultBaseUrl = 'https://download.cypress.io/'
+
+const getBaseUrl = () => {
+  if (util.getEnv('CYPRESS_DOWNLOAD_BASE_URL')) {
+    let baseUrl = util.getEnv('CYPRESS_DOWNLOAD_BASE_URL')
+    if (!baseUrl.endsWith('/')) {
+      baseUrl += '/'
+    }
+
+    return baseUrl
+  }
+
+  return defaultBaseUrl
+}
 
 const prepend = (urlPath) => {
-  const endpoint = url.resolve(baseUrl, urlPath)
+  const endpoint = url.resolve(getBaseUrl(), urlPath)
   const platform = os.platform()
   const arch = os.arch()
   return `${endpoint}?platform=${platform}&arch=${arch}`

--- a/cli/test/lib/tasks/download_spec.js
+++ b/cli/test/lib/tasks/download_spec.js
@@ -71,29 +71,29 @@ describe('lib/tasks/download', function () {
     })
   })
 
-  context('download base url from CYPRESS_DOWNLOAD_BASE_URL env var', () => {
+  context('download base url from CYPRESS_DOWNLOAD_MIRROR env var', () => {
     it('env var', () => {
-      process.env.CYPRESS_DOWNLOAD_BASE_URL = 'https://cypress.example.com'
+      process.env.CYPRESS_DOWNLOAD_MIRROR = 'https://cypress.example.com'
       const url = download.getUrl('0.20.2')
-      snapshot('base url from CYPRESS_DOWNLOAD_BASE_URL', normalize(url))
+      snapshot('base url from CYPRESS_DOWNLOAD_MIRROR', normalize(url))
     })
 
     it('env var with trailing slash', () => {
-      process.env.CYPRESS_DOWNLOAD_BASE_URL = 'https://cypress.example.com/'
+      process.env.CYPRESS_DOWNLOAD_MIRROR = 'https://cypress.example.com/'
       const url = download.getUrl('0.20.2')
-      snapshot('base url from CYPRESS_DOWNLOAD_BASE_URL with trailing slash', normalize(url))
+      snapshot('base url from CYPRESS_DOWNLOAD_MIRROR with trailing slash', normalize(url))
     })
 
     it('env var with subdirectory', () => {
-      process.env.CYPRESS_DOWNLOAD_BASE_URL = 'https://cypress.example.com/example'
+      process.env.CYPRESS_DOWNLOAD_MIRROR = 'https://cypress.example.com/example'
       const url = download.getUrl('0.20.2')
-      snapshot('base url from CYPRESS_DOWNLOAD_BASE_URL with subdirectory', normalize(url))
+      snapshot('base url from CYPRESS_DOWNLOAD_MIRROR with subdirectory', normalize(url))
     })
 
     it('env var with subdirectory and trailing slash', () => {
-      process.env.CYPRESS_DOWNLOAD_BASE_URL = 'https://cypress.example.com/example/'
+      process.env.CYPRESS_DOWNLOAD_MIRROR = 'https://cypress.example.com/example/'
       const url = download.getUrl('0.20.2')
-      snapshot('base url from CYPRESS_DOWNLOAD_BASE_URL with subdirectory and trailing slash', normalize(url))
+      snapshot('base url from CYPRESS_DOWNLOAD_MIRROR with subdirectory and trailing slash', normalize(url))
     })
   })
 

--- a/cli/test/lib/tasks/download_spec.js
+++ b/cli/test/lib/tasks/download_spec.js
@@ -71,6 +71,32 @@ describe('lib/tasks/download', function () {
     })
   })
 
+  context('download base url from CYPRESS_DOWNLOAD_BASE_URL env var', () => {
+    it('env var', () => {
+      process.env.CYPRESS_DOWNLOAD_BASE_URL = 'https://cypress.example.com'
+      const url = download.getUrl('0.20.2')
+      snapshot('base url from CYPRESS_DOWNLOAD_BASE_URL', normalize(url))
+    })
+
+    it('env var with trailing slash', () => {
+      process.env.CYPRESS_DOWNLOAD_BASE_URL = 'https://cypress.example.com/'
+      const url = download.getUrl('0.20.2')
+      snapshot('base url from CYPRESS_DOWNLOAD_BASE_URL with trailing slash', normalize(url))
+    })
+
+    it('env var with subdirectory', () => {
+      process.env.CYPRESS_DOWNLOAD_BASE_URL = 'https://cypress.example.com/example'
+      const url = download.getUrl('0.20.2')
+      snapshot('base url from CYPRESS_DOWNLOAD_BASE_URL with subdirectory', normalize(url))
+    })
+
+    it('env var with subdirectory and trailing slash', () => {
+      process.env.CYPRESS_DOWNLOAD_BASE_URL = 'https://cypress.example.com/example/'
+      const url = download.getUrl('0.20.2')
+      snapshot('base url from CYPRESS_DOWNLOAD_BASE_URL with subdirectory and trailing slash', normalize(url))
+    })
+  })
+
   it('saves example.zip to options.downloadDestination', function () {
     nock('https://aws.amazon.com')
     .get('/some.zip')

--- a/cli/test/spec_helper.js
+++ b/cli/test/spec_helper.js
@@ -21,6 +21,7 @@ delete process.env.CYPRESS_INSTALL_BINARY
 delete process.env.CYPRESS_CACHE_FOLDER
 delete process.env.CYPRESS_BINARY_VERSION
 delete process.env.CYPRESS_SKIP_BINARY_INSTALL
+delete process.env.CYPRESS_DOWNLOAD_MIRROR
 delete process.env.DISPLAY
 
 // enable running specs with --silent w/out affecting logging in tests


### PR DESCRIPTION
In a corporate environment it may be necessary to download cypress through a proxy host because `https://download.cypress.io` isn't directly accessible. While it is possible to host specific, previously downloaded binaries and passing `CYPRESS_INSTALL_BINARY` to the installation, this loses the flexibility to provide current versions for different operating systems without maintenance.

This PR introduces a `CYPRESS_DOWNLOAD_BASE_URL` env variable which allows to override the base url which is currently hardcoded to `https://download.cypress.io/`. For example, when installing the package with `CYPRESS_DOWNLOAD_BASE_URL=https://example.org/cypress` it will attempt to download from `https://example.org/cypress/desktop/0.20.2?platform=OS&arch=ARCH`.

A proxy like [Nexus](https://github.com/sonatype/nexus-public) or some kind of web server configured as reverse proxy can be used to forward (and cache) requests to `https://download.cypress.io` and provide cypress to all clients inside the network.