### PR TITLE
Update state(‘current’) args when a command is overwritten

### DIFF
--- a/packages/driver/src/cypress/commands.coffee
+++ b/packages/driver/src/cypress/commands.coffee
@@ -73,7 +73,13 @@ create = (Cypress, cy, state, config, log) ->
     ## store the backup again now
     commandBackups[name] = original
 
-    originalFn = original.fn
+    originalFn = (args...) ->
+      current = state("current")
+      storedArgs = args
+      if current.get("type") is "child"
+        storedArgs = args.slice(1)
+      current.set("args", storedArgs)
+      original.fn(args...)
 
     overridden = _.clone(original)
     overridden.fn = (args...) ->

--- a/packages/driver/test/cypress/integration/cypress/cy_spec.coffee
+++ b/packages/driver/test/cypress/integration/cypress/cy_spec.coffee
@@ -291,6 +291,9 @@ describe "driver/src/cypress/cy", ->
         ## yield the context
         return fn(@)
 
+      Cypress.Commands.overwrite "submit", (orig, subject) ->
+        return orig(subject, { foo: "foo" })
+
     it "can modify parent commands", ->
       cy.wrap("bar").then (str) ->
         expect(str).to.eq("foobar")
@@ -316,3 +319,7 @@ describe "driver/src/cypress/cy", ->
         Cypress.Commands.overwrite "foo", ->
 
       expect(fn).to.throw("Cannot overwite command for: 'foo'. An existing command does not exist by that name.")
+
+    it "updates state('current') with modified args", ->
+      cy.get("form").eq(0).submit().then =>
+        expect(cy.state("current").get("prev").get("args")[0].foo).to.equal("foo")

--- a/packages/server/test/e2e/6_visit_spec.coffee
+++ b/packages/server/test/e2e/6_visit_spec.coffee
@@ -49,7 +49,7 @@ onServer = (app) ->
 
 describe "e2e visit", ->
   require("mocha-banner").register()
-  
+
   context "low response timeout", ->
     e2e.setup({
       settings: {
@@ -106,6 +106,11 @@ describe "e2e visit", ->
         spec: "visit_non_html_content_type_failing_spec.coffee"
         snapshot: true
         expectedExitCode: 1
+      })
+
+    it "calls onBeforeLoad when overwriting cy.visit", ->
+      e2e.exec(@, {
+        spec: "issue_2196_spec.coffee"
       })
 
   context "normal response timeouts", ->

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/issue_2196_spec.coffee
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/issue_2196_spec.coffee
@@ -1,0 +1,13 @@
+onBeforeLoad = cy.stub()
+onLoad = cy.stub()
+
+Cypress.Commands.overwrite "visit", (originalVisit, url, options) ->
+  return originalVisit(url, { onBeforeLoad, onLoad })
+
+context "issue #2196: overwriting visit", ->
+  it "fires onBeforeLoad", ->
+    cy
+      .visit("http://localhost:3434/index.html")
+      .then ->
+        expect(onBeforeLoad).to.be.called
+        expect(onLoad).to.be.called


### PR DESCRIPTION
Closes #2196 