### PR TITLE
Style CI badges as list items

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ npm install cypress --save-dev
 
 ## Contributing
 
-[![CircleCI](https://circleci.com/gh/cypress-io/cypress/tree/develop.svg?style=svg)](https://circleci.com/gh/cypress-io/cypress/tree/develop) - `develop` branch [![CircleCI](https://circleci.com/gh/cypress-io/cypress/tree/master.svg?style=svg)](https://circleci.com/gh/cypress-io/cypress/tree/master) - `master` branch
+- [![CircleCI](https://circleci.com/gh/cypress-io/cypress/tree/develop.svg?style=svg)](https://circleci.com/gh/cypress-io/cypress/tree/develop) - `develop` branch
+- [![CircleCI](https://circleci.com/gh/cypress-io/cypress/tree/master.svg?style=svg)](https://circleci.com/gh/cypress-io/cypress/tree/master) - `master` branch
 
 Please see our [Contributing Guideline](/CONTRIBUTING.md) which explains repo organization, linting, testing, and other steps.
 


### PR DESCRIPTION
This change moves your CI badges into a list, making them easier to read and matching the style of your docs README:

https://github.com/cypress-io/cypress-documentation/blob/develop/readme.md

Thanks for the great documentation.