### PR TITLE
Fix UI bug where test label was the contents of double quotes from test title

### DIFF
--- a/packages/driver/src/cypress/runner.coffee
+++ b/packages/driver/src/cypress/runner.coffee
@@ -807,7 +807,7 @@ create = (specWindow, mocha, Cypress, cy) ->
       test.wallClockStartedAt ?= wallClockStartedAt
 
       ## if this isnt a hook, then the name is 'test'
-      hookName = getHookName(runnable) or "test"
+      hookName = if runnable.type is "hook" then getHookName(runnable) else "test"
 
       ## if we haven't yet fired this event for this test
       ## that means that we need to reset the previous state

--- a/packages/driver/test/cypress/integration/cypress/runner_spec.coffee
+++ b/packages/driver/test/cypress/integration/cypress/runner_spec.coffee
@@ -5,6 +5,12 @@ Cypress.on "test:after:run", (test) ->
     pending.push(test)
 
 describe "src/cypress/runner", ->
+  it 'handles "double quotes" in test name', (done) ->
+    cy.once "log:added", (log) ->
+      expect(log.hookName).to.equal("test")
+      done()
+    cy.wrap({})
+
   context "pending tests", ->
     it "is not pending", ->
 


### PR DESCRIPTION
- Fixes #1157 

Would love any feedback on if/where to add tests, `runner_spec.coffee` didn't seem appropriate but might be a good place in the server?
