### PR TITLE
Replace hardcoded "/" in getPrefixedPathToSpec

### DIFF
--- a/packages/server/lib/project.coffee
+++ b/packages/server/lib/project.coffee
@@ -381,7 +381,7 @@ class Project extends EE
     ## /Users/bmann/Dev/cypress-app/.projects/cypress/integration/foo.coffee
     ##
     ## becomes /integration/foo.coffee
-    "/" + path.join(type, path.relative(
+    path.sep + path.join(type, path.relative(
       integrationFolder,
       path.resolve(projectRoot, pathToSpec)
     ))

--- a/packages/server/test/spec_helper.coffee
+++ b/packages/server/test/spec_helper.coffee
@@ -12,7 +12,6 @@ Promise          = require("bluebird")
 path             = require("path")
 cache            = require("../lib/cache")
 appData          = require("../lib/util/app_data")
-agent            = require("superagent")
 
 require("chai")
 .use(require("@cypress/sinon-chai"))

--- a/packages/server/test/unit/project_spec.coffee
+++ b/packages/server/test/unit/project_spec.coffee
@@ -519,6 +519,19 @@ describe "lib/project", ->
       .then (str) ->
         expect(str).to.eq("http://localhost:8888/__/#/tests/__all")
 
+  context "#getPrefixedPathToSpec", ->
+    it "prefixed path to spec", ->
+      expect(@project.getPrefixedPathToSpec({
+        integrationFolder: "/Users/bmann/Dev/cypress-app/.projects/cypress/integration",
+        projectRoot: "/Users/bmann/Dev/cypress-app"
+      }, "/Users/bmann/Dev/cypress-app/.projects/cypress/integration/foo.coffee")).to.eq("/integration/foo.coffee")
+  
+    it "prefixed path to spec for Windows path", ->
+      expect(@project.getPrefixedPathToSpec({
+        integrationFolder: "\\Users\\bmann\\Dev\\cypress-app\\.projects\\cypress\\integration",
+        projectRoot: "\\Users\\bmann\\Dev\\cypress-app"
+      }, "\\Users\\bmann\\Dev\\cypress-app\\.projects\\cypress\\integration\\foo.coffee")).to.eq("\\integration\\foo.coffee")
+
   context ".add", ->
     beforeEach ->
       @pristinePath = Fixtures.projectPath("pristine")


### PR DESCRIPTION
- add unit tests for getPrefixedPathToSpec
- remove unused “agent” import from spec-helpers
- close #2692 

This unit test is failing, I thought that updating the "/" to path.sep would resolve the path correctly for Windows paths, but it doesn't seem to be. 

```
#getPrefixedPathToSpec
      ✓ prefixed path to spec
      x) prefixed path to spec for Windows path
```