### PR TITLE
#2694 - Visiting PKI protected domains with cy.visit() - Exploratory PR

### DIFF
--- a/packages/driver/src/cy/commands/navigation.coffee
+++ b/packages/driver/src/cy/commands/navigation.coffee
@@ -260,7 +260,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
     Cypress.backend(
       "resolve:url",
       url,
-      _.pick(options, "failOnStatusCode", "auth")
+      _.pick(options, "failOnStatusCode", "auth", "cert", "key")
     )
     .then (resp = {}) ->
       switch

--- a/packages/driver/test/cypress/integration/commands/navigation_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/navigation_spec.coffee
@@ -534,6 +534,18 @@ describe "src/cy/commands/navigation", ->
         .then ->
           expect(backend).to.be.calledWithMatch("resolve:url", "http://localhost:3500/timeout", { auth })
 
+
+    it "passes certificate key and crt options", ->
+      backend = cy.spy(Cypress, "backend")
+
+      cert = 'a-cert'
+      key = 'a-key'
+
+      cy
+        .visit("http://localhost:3500/timeout", { cert, key })
+        .then ->
+          expect(backend).to.be.calledWithMatch("resolve:url", "http://localhost:3500/timeout", { cert, key })
+
     describe "when only hashes are changing", ->
       it "short circuits the visit if the page will not refresh", ->
         count = 0

--- a/packages/driver/test/cypress/integration/commands/navigation_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/navigation_spec.coffee
@@ -534,7 +534,6 @@ describe "src/cy/commands/navigation", ->
         .then ->
           expect(backend).to.be.calledWithMatch("resolve:url", "http://localhost:3500/timeout", { auth })
 
-
     it "passes certificate key and crt options", ->
       backend = cy.spy(Cypress, "backend")
 

--- a/packages/server/lib/server.coffee
+++ b/packages/server/lib/server.coffee
@@ -456,8 +456,8 @@ class Server
           ## rewrite these contents
           auth: options.auth
           gzip: false
-          url: urlFile ? urlStr,
-          cert: options.cert || undefined,
+          url: urlFile ? urlStr
+          cert: options.cert || undefined
           key: options.key || undefined
           headers: {
             accept: "text/html,*/*"

--- a/packages/server/lib/server.coffee
+++ b/packages/server/lib/server.coffee
@@ -456,7 +456,9 @@ class Server
           ## rewrite these contents
           auth: options.auth
           gzip: false
-          url: urlFile ? urlStr
+          url: urlFile ? urlStr,
+          cert: options.cert || undefined,
+          key: options.key || undefined
           headers: {
             accept: "text/html,*/*"
           }


### PR DESCRIPTION
## Issue

Hello! We are really enjoying using Cypress at the BBC, but some of our domains under test are protected with PKI, and we receive SSL errors when accessing them with `cy.visit()` because we can't pass our certificates through.

When researching this we noticed an issue had been raised a few days ago (not by us) - https://github.com/cypress-io/cypress/issues/2694 so we thought we'd try and have a go at adding support for certificate protected domains.

This PR resolves the issue for us, but we haven't contributed to Cypress before so this is **a very naive implementation** (which is why I haven't named the branch after the issue or proposed any documentation changes). I'm sure there's some context or complexities we're missing and would welcome your thoughts :)

## Proposal

We felt that it may be useful to allow users to pass in `key` and `cert` options to `cy.visit()` which would contain their PKI credentials. These options can then be passed alongside existing ones so that, if a cert/key has been provided, they are included in the options provided to `request` as per [their docs](https://www.npmjs.com/package/request#tlsssl-protocol).

## Usage
This PR would allow users to do something along the lines of:

```
# Export CYPRESS prefixed environment variables containing the contents of the crt/key files

export CYPRESS_CERT=$(cat /path/to/your/certificate.crt)
export CYPRESS_KEY=$(cat /path/to/your/certificate.key)
```

```javascript
# index_spec.js

describe(('when accessing a PKI cert protected domain') => {
  it(('should not reject with an error') => {
      const options = {
          cert: Cypress.env('CERT'),
          key: Cypress.env('KEY')
      }
      
      cy.visit('https://cert-protected-domain', options)
  })
});
```
This approach seemed like the simplest way to get this working (and it worked for us) but I'm sure there's other options (e.g. plugins that use `fs` to read certs from the filesystem) that might be more suitable.

I hope this is useful and that we can look at ways of implementing this so that we can use Cypress more widely.
