### PR TITLE
Add strong typed definition for Cypress.moment().

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -70,6 +70,7 @@
     "lodash": "4.17.10",
     "log-symbols": "2.2.0",
     "minimist": "1.2.0",
+    "moment": "2.22.2",
     "ramda": "0.24.1",
     "request": "2.87.0",
     "request-progress": "0.3.1",

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -10,12 +10,14 @@
 /// <reference path="./blob-util.d.ts" />
 /// <reference path="./bluebird.d.ts" />
 /// <reference path="./minimatch.d.ts" />
+/// <reference path="./moment.d.ts" />
 
 /// <reference types="chai" />
 /// <reference types="chai-jquery" />
 /// <reference types="jquery" />
 /// <reference types="lodash" />
 /// <reference types="mocha" />
+/// <reference types="moment" />
 /// <reference types="sinon" />
 /// <reference types="sinon-chai" />
 
@@ -100,7 +102,7 @@ declare namespace Cypress {
      * @example
      *    const todaysDate = Cypress.moment().format("MMM DD, YYYY")
      */
-    moment: (...args: any[]) => any // perhaps we want to add moment as a dependency for types?
+    moment: Moment.MomentStatic
     /**
      * Cypress automatically includes Bluebird and exposes it as Cypress.Promise.
      *

--- a/cli/types/moment.d.ts
+++ b/cli/types/moment.d.ts
@@ -1,0 +1,11 @@
+// Shim definition to export a namespace. Cypress is actually a global module
+// so import/export isn't allowed there. We import here and define a global module
+// so that Cypress can get and use the Moment type
+// tslint:disable-next-line:no-implicit-dependencies
+import * as moment from 'moment'
+export = Moment
+export as namespace Moment
+
+declare namespace Moment {
+  type MomentStatic = typeof moment
+}

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -5,6 +5,14 @@ namespace CypressLodashTests {
   })
 }
 
+namespace CypressMomentTests {
+  Cypress.moment() // $ExpectType Moment
+  Cypress.moment('1982-08-23') // $ExpectType Moment
+  Cypress.moment(Date()) // $ExpectType Moment
+  Cypress.moment(Date()).format() // $ExpectType string
+  Cypress.moment().startOf('week') // $ExpectType Moment
+}
+
 namespace CypressJqueryTests {
   Cypress.$ // $ExpectType JQueryStatic
   Cypress.$('selector') // $ExpectType JQuery<HTMLElement>
@@ -21,8 +29,6 @@ namespace CypressConfigTests {
   Cypress.config('baseUrl', null) // $ExpectType void
   Cypress.config({ baseUrl: '.', }) // $ExpectType void
 }
-
-Cypress.moment()
 
 namespace CypressEnvTests {
   // Just making sure these are valid - no real type safety


### PR DESCRIPTION
The `Cypress.moment` field isn't strongly typed currently, which means no nice completion/checks when using it from tests written in TypeScript. This adds the TS definition for that.