### PR TITLE
Update charCode, which, and keyCode in key events

### DIFF
--- a/packages/driver/src/cypress/keyboard.coffee
+++ b/packages/driver/src/cypress/keyboard.coffee
@@ -335,16 +335,19 @@ $Keyboard = {
       when "keydown", "keyup"
         charCodeAt = options.charCode ? @getCharCode(key.toUpperCase())
 
+        ## zero
         charCode = 0
+        ## browser keycode
         keyCode  = charCodeAt
         which    = charCodeAt
 
       when "keypress"
         charCodeAt = options.charCode ? @getCharCode(key)
 
-        charCode = charCodeAt
-        keyCode  = charCodeAt
-        which    = charCodeAt
+        ## ASCII code
+        charCode = key.charCodeAt(0)
+        keyCode  = key.charCodeAt(0)
+        which    = key.charCodeAt(0)
 
       when "textInput"
         charCode  = 0

--- a/packages/driver/test/cypress/integration/e2e/keyboard_spec.coffee
+++ b/packages/driver/test/cypress/integration/e2e/keyboard_spec.coffee
@@ -22,3 +22,22 @@ describe "keyboard", ->
             expect(e.ctrlKey).to.be.false
 
           cy.get("input").type("s")
+
+    it "handles charCodes, keyCodes, and which for keyup, keydown, and keypress", ->
+      cy.window().then (win) ->
+        win.$("input").one "keyup", (e) ->
+          expect(e.charCode).to.equal(0)
+          expect(e.which).to.equal(190)
+          expect(e.keyCode).to.equal(190)
+
+        win.$("input").one "keydown", (e) ->
+          expect(e.charCode).to.equal(0)
+          expect(e.which).to.equal(190)
+          expect(e.keyCode).to.equal(190)
+
+        win.$("input").one "keypress", (e) ->
+          expect(e.charCode).to.equal(46)
+          expect(e.which).to.equal(46)
+          expect(e.keyCode).to.equal(46)
+
+        cy.get("input").type(".")


### PR DESCRIPTION
- Fixes #2105 

This is based on the good work on Unix Papa in [JavaScript Madness: Keyboard Events](https://unixpapa.com/js/key.html) specifically section `3.1. Classic Values Returned on Key Events`.