### PR TITLE
prevent cross origin errors

### DIFF
--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -44,7 +44,7 @@
     "jquery.scrollto": "^2.1.2",
     "js-cookie": "2.1.1",
     "jsdom": "^11.0.0",
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "lolex": "^3.0.0",
     "method-override": "^2.3.1",
     "minimatch": "^3.0.0",

--- a/packages/driver/src/cy/assertions.coffee
+++ b/packages/driver/src/cy/assertions.coffee
@@ -12,6 +12,8 @@ bTagOpen = /\*\*/g
 bTagClosed = /\*\*/g
 stackTracesRe = / at .*\n/gm
 
+IS_DOM_TYPES = [$dom.isElement, $dom.isDocument, $dom.isWindow]
+
 functionHadArguments = (current) ->
   fn = current and current.get("args") and current.get("args")[0]
   fn and _.isFunction(fn) and fn.length > 0
@@ -27,9 +29,12 @@ isDomSubjectAndMatchesValue = (value, subject) ->
     ## no difference
     _.difference(els1, els2).length is 0
 
-  $dom.isDom(value) and
-    $dom.isDom(subject) and
-      allElsAreTheSame()
+  ## iterate through each dom type until we
+  ## find the function for this particular value
+  if isDomTypeFn = _.find(IS_DOM_TYPES, _.iteratee(value))
+    ## then check that subject also matches this
+    ## and that all the els are the same
+    return isDomTypeFn(subject) and allElsAreTheSame()
 
 ## Rules:
 ## 1. always remove value

--- a/packages/driver/src/cy/assertions.coffee
+++ b/packages/driver/src/cy/assertions.coffee
@@ -14,6 +14,10 @@ stackTracesRe = / at .*\n/gm
 
 IS_DOM_TYPES = [$dom.isElement, $dom.isDocument, $dom.isWindow]
 
+invokeWith = (value) ->
+  return (fn) ->
+    fn(value)
+
 functionHadArguments = (current) ->
   fn = current and current.get("args") and current.get("args")[0]
   fn and _.isFunction(fn) and fn.length > 0
@@ -31,7 +35,7 @@ isDomSubjectAndMatchesValue = (value, subject) ->
 
   ## iterate through each dom type until we
   ## find the function for this particular value
-  if isDomTypeFn = _.find(IS_DOM_TYPES, _.iteratee(value))
+  if isDomTypeFn = _.find(IS_DOM_TYPES, invokeWith(value))
     ## then check that subject also matches this
     ## and that all the els are the same
     return isDomTypeFn(subject) and allElsAreTheSame()

--- a/packages/driver/src/dom/document.coffee
+++ b/packages/driver/src/dom/document.coffee
@@ -1,8 +1,13 @@
+$jquery = require("./jquery")
+
 docNode = Node.DOCUMENT_NODE
 
 isDocument = (obj) ->
   try
-    !!((obj and obj.nodeType is docNode) or (obj and obj[0] and obj[0].nodeType is docNode))
+    if $jquery.isJquery(obj)
+      obj = obj[0]
+
+    Boolean(obj and obj.nodeType is docNode)
   catch
     false
 

--- a/packages/driver/src/dom/elements.coffee
+++ b/packages/driver/src/dom/elements.coffee
@@ -238,7 +238,10 @@ isSvg = (el) ->
 
 isElement = (obj) ->
   try
-    !!(obj and obj[0] and _.isElement(obj[0])) or _.isElement(obj)
+    if $jquery.isJquery(obj)
+      obj = obj[0]
+
+    Boolean(obj and _.isElement(obj))
   catch
     false
 

--- a/packages/driver/src/dom/window.coffee
+++ b/packages/driver/src/dom/window.coffee
@@ -1,4 +1,4 @@
-$ = require("jquery")
+$jquery = require("./jquery")
 $document = require("./document")
 
 getWindowByElement = (el) ->
@@ -14,7 +14,10 @@ getWindowByDocument = (doc) ->
 
 isWindow = (obj) ->
   try
-    !!(obj and $.isWindow(obj[0])) or $.isWindow(obj)
+    if $jquery.isJquery(obj)
+      obj = obj[0]
+
+    Boolean(obj and obj.window is obj)
   catch
     false
 

--- a/packages/driver/test/cypress/integration/issues/1436_spec.js
+++ b/packages/driver/test/cypress/integration/issues/1436_spec.js
@@ -10,7 +10,9 @@ describe('issue 1436', () => {
     })
   })
 
-  it('can visit jira', () => {
+  // 11/15/18 jira is throwing an error in one
+  // of their scripts and its causing this test to fail
+  it.skip('can visit jira', () => {
     // no javascript errors should have been thrown.
     // NOTE: this is potentially a bad idea because we don't
     // control Jira, and therefore they could push changes

--- a/packages/driver/test/cypress/integration/issues/2784_spec.js
+++ b/packages/driver/test/cypress/integration/issues/2784_spec.js
@@ -1,0 +1,19 @@
+// https://github.com/cypress-io/cypress/issues/2784
+describe('issue #2784', () => {
+  it('does not throw when embedding a cross origin iframe', () => {
+    cy.visit('/fixtures/generic.html')
+    cy.document().then((doc) => {
+      return new Cypress.Promise((resolve) => {
+        const iframe = doc.createElement('iframe')
+
+        iframe.onload = resolve
+        iframe.src = 'http://localhost:3501/fixtures/generic.html'
+        doc.body.appendChild(iframe)
+      })
+    })
+
+    // change the subject to be <window>
+    cy.window()
+    cy.get('a').should('be.visible')
+  })
+})

--- a/packages/driver/test/support/server.coffee
+++ b/packages/driver/test/support/server.coffee
@@ -17,103 +17,67 @@ niv.install("react-dom@16.0.0")
 niv.install("react@15.6.1")
 niv.install("react-dom@15.6.1")
 
-port = 3500
-app = express()
-server = http.Server(app)
+[3500, 3501].forEach (port) ->
+  app = express()
+  server = http.Server(app)
 
-app.set("port", port)
+  app.set("port", port)
 
-app.set("view engine", "html")
+  app.set("view engine", "html")
 
-app.use(require("morgan")({ format: "dev" }))
+  app.use(require("morgan")({ format: "dev" }))
 
-app.use(require("cors")())
-app.use(require("compression")())
-app.use(bodyParser.urlencoded({ extended: false }))
-app.use(bodyParser.json())
-app.use(require("method-override")())
+  app.use(require("cors")())
+  app.use(require("compression")())
+  app.use(bodyParser.urlencoded({ extended: false }))
+  app.use(bodyParser.json())
+  app.use(require("method-override")())
 
-# rewriteFixtures = (req, res) ->
-#   fixture = req.params[0]
-#
-#   ## if we have an html fixture
-#   if (ext = path.extname(fixture)) is ".html"
-#     pathToFile = path.join(__dirname, "fixtures", fixture)
-#
-#     ## read in the bytes
-#     fs.readFileAsync(pathToFile, "utf8")
-#     .then (str) ->
-#       ## and rewrite them using the server's rewriter
-#       res.send(rewriter.html(str, "localhost", "full"))
-#   else
-#     ## else just serve the file straight up
-#     res.sendFile("fixtures/#{fixture}", {
-#       root: __dirname
-#     })
+  app.head "/", (req, res) ->
+    res.sendStatus(200)
 
-app.head "/", (req, res) ->
-  res.sendStatus(200)
+  app.get "/timeout", (req, res) ->
+    Promise
+    .delay(req.query.ms ? 0)
+    .then ->
+      res.send "<html><body>timeout</body></html>"
 
-app.get "/timeout", (req, res) ->
-  Promise
-  .delay(req.query.ms ? 0)
-  .then ->
-    res.send "<html><body>timeout</body></html>"
+  app.get "/node_modules/*", (req, res) ->
+    res.sendFile(path.join("node_modules", req.params[0]), {
+      root: path.join(__dirname, "../..")
+    })
 
-app.get "/node_modules/*", (req, res) ->
-  res.sendFile(path.join("node_modules", req.params[0]), {
-    root: path.join(__dirname, "../..")
-  })
+  app.get "/xml", (req, res) ->
+    res.type("xml").send("<foo>bar</foo>")
 
-app.get "/xml", (req, res) ->
-  res.type("xml").send("<foo>bar</foo>")
+  app.get "/buffer", (req, res) ->
+    fs.readFile path.join(__dirname, "../cypress/fixtures/sample.pdf"), (err, bytes) ->
+      res.type("pdf")
+      res.send(bytes)
 
-app.get "/buffer", (req, res) ->
-  fs.readFile path.join(__dirname, "../cypress/fixtures/sample.pdf"), (err, bytes) ->
-    res.type("pdf")
-    res.send(bytes)
+  app.get "/basic_auth", (req, res) ->
+    user = auth(req)
 
-app.get "/basic_auth", (req, res) ->
-  user = auth(req)
+    if user and (user.name is "cypress" and user.pass is "password123")
+      res.send("<html><body>basic auth worked</body></html>")
+    else
+      res
+      .set("WWW-Authenticate", "Basic")
+      .sendStatus(401)
 
-  if user and (user.name is "cypress" and user.pass is "password123")
-    res.send("<html><body>basic auth worked</body></html>")
-  else
+  app.get "/status-404", (req, res) ->
     res
-    .set("WWW-Authenticate", "Basic")
-    .sendStatus(401)
+    .status(404)
+    .send("<html><body>not found</body></html>")
 
-app.get "/status-404", (req, res) ->
-  res
-  .status(404)
-  .send("<html><body>not found</body></html>")
+  app.get "/status-500", (req, res) ->
+    res
+    .status(500)
+    .send("<html><body>server error</body></html>")
 
-app.get "/status-500", (req, res) ->
-  res
-  .status(500)
-  .send("<html><body>server error</body></html>")
+  app.use(express.static(path.join(__dirname, "..", "cypress")))
 
-app.use(express.static(path.join(__dirname, "..", "cypress")))
+  app.use(require("errorhandler")())
 
-app.use(require("errorhandler")())
-
-server.listen app.get("port"), ->
-  console.log("Express server listening on port", app.get("port"))
-
-supportApp = express()
-supportServer = http.Server(app)
-
-supportApp.set("port", 3501)
-
-supportApp.set("view engine", "html")
-
-supportApp.use(require("morgan")({ format: "dev" }))
-
-supportApp.use(require("cors")())
-supportApp.use(require("compression")())
-supportApp.use(bodyParser.urlencoded({ extended: false }))
-supportApp.use(bodyParser.json())
-supportApp.use(require("method-override")())
-
-supportServer.listen supportApp.get("port"), ->
-  console.log("Express server listening on port", supportApp.get("port"))
+  server.listen app.get("port"), ->
+    console.log("Express server listening on port", app.get("port"))

--- a/packages/https-proxy/package.json
+++ b/packages/https-proxy/package.json
@@ -36,7 +36,7 @@
     "bluebird": "^3.4.0",
     "debug": "^2.6.8",
     "fs-extra": "^0.30.0",
-    "lodash": "^4.17.4",
+    "lodash": "4.17.11",
     "node-forge": "^0.6.39",
     "semaphore": "^1.0.5",
     "server-destroy-vvo": "1.0.1",

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -37,7 +37,7 @@
     "enzyme-adapter-react-16": "1.6.0",
     "font-awesome": "4.6.3",
     "jsdom": "9.4.1",
-    "lodash": "4.17.4",
+    "lodash": "4.17.11",
     "markdown-it": "6.1.1",
     "mobx": "3.1.15",
     "mobx-react": "4.2.1",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -36,7 +36,7 @@
     "enzyme-adapter-react-16": "1.6.0",
     "font-awesome": "4.6.3",
     "jsdom": "9.4.1",
-    "lodash": "4.17.4",
+    "lodash": "4.17.11",
     "mobx": "3.1.15",
     "mobx-react": "4.2.1",
     "prop-types": "15.6.2",


### PR DESCRIPTION
-fixes #2784 
-this prevents a situation where we accidentally iterate through a
cross origin <window> object and cause cross origin issues