### PR TITLE
Allow separate request and response timeout overrides in cy.wait

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -1514,13 +1514,13 @@ declare namespace Cypress {
      *
      * @see https://on.cypress.io/wait
      */
-    wait(alias: string, options?: Partial<Loggable & Timeoutable>): Chainable<WaitXHR>
+    wait(alias: string, options?: Partial<Loggable & Timeoutable & TimeoutableXHR>): Chainable<WaitXHR>
     /**
      * Wait for list of XHR requests to complete.
      *
      * @see https://on.cypress.io/wait
      */
-    wait(alias: string[], options?: Partial<Loggable & Timeoutable>): Chainable<WaitXHR[]>
+    wait(alias: string[], options?: Partial<Loggable & Timeoutable & TimeoutableXHR>): Chainable<WaitXHR[]>
 
     /**
      * Get the window object of the page that is currently active.
@@ -1645,6 +1645,26 @@ declare namespace Cypress {
      * @see https://docs.cypress.io/guides/references/configuration.html#Timeouts
      */
     timeout: number
+  }
+
+  /**
+   * Options that control how long the Test Runner waits for an XHR request and response to succeed
+   */
+  interface TimeoutableXHR {
+    /**
+     * Time to wait for the request (ms)
+     *
+     * @default {@link Timeoutable#timeout}
+     * @see https://docs.cypress.io/guides/references/configuration.html#Timeouts
+     */
+    requestTimeout: number,
+    /**
+     * Time to wait for the response (ms)
+     *
+     * @default {@link Timeoutable#timeout}
+     * @see https://docs.cypress.io/guides/references/configuration.html#Timeouts
+     */
+    responseTimeout: number
   }
 
   /**

--- a/packages/driver/src/cy/commands/waiting.coffee
+++ b/packages/driver/src/cy/commands/waiting.coffee
@@ -101,17 +101,19 @@ module.exports = (Commands, Cypress, cy, state, config) ->
       ## but slice out the error since we may set
       ## the error related to a previous xhr
       timeout = options.timeout
+      requestTimeout = options.requestTimeout ? timeout
+      responseTimeout = options.responseTimeout ? timeout
 
       [ index, num ] = getNumRequests(state, alias)
 
       waitForRequest = ->
         options = _.omit(options, "_runnableTimeout")
-        options.timeout = timeout ? Cypress.config("requestTimeout")
+        options.timeout = requestTimeout ? Cypress.config("requestTimeout")
         checkForXhr(alias, "request", index, num, options)
 
       waitForResponse = ->
         options = _.omit(options, "_runnableTimeout")
-        options.timeout = timeout ? Cypress.config("responseTimeout")
+        options.timeout = responseTimeout ? Cypress.config("responseTimeout")
         checkForXhr(alias, "response", index, num, options)
 
       ## if we were only waiting for the request

--- a/packages/driver/test/cypress/integration/commands/waiting_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/waiting_spec.coffee
@@ -110,6 +110,17 @@ describe "src/cy/commands/waiting", ->
           .wait("@fetch").then ->
             expect(cy.timeout()).to.eq 199
 
+      it "waits for requestTimeout override", (done) ->
+        cy.on "command:retry", (options) ->
+          expect(options.type).to.eq("request")
+          expect(options.timeout).to.eq(199)
+          done()
+
+        cy
+          .server()
+          .route("GET", "*", {}).as("fetch")
+          .wait("@fetch", {requestTimeout: 199})
+
       it "waits for responseTimeout", (done) ->
         Cypress.config("responseTimeout", 299)
 
@@ -124,6 +135,41 @@ describe "src/cy/commands/waiting", ->
             win.$.get("/foo")
             null
           .wait("@fetch")
+
+      it "waits for responseTimeout override", (done) ->
+        cy.on "command:retry", (options) ->
+          expect(options.type).to.eq("response")
+          expect(options.timeout).to.eq(299)
+          done()
+
+        cy
+          .server({delay: 100})
+          .route("GET", "*", {}).as("fetch")
+          .window().then (win) ->
+            win.$.get("/foo")
+            null
+          .wait("@fetch", {responseTimeout: 299})
+
+      it "waits for requestTimeout and responseTimeout override", (done) ->
+        retryCount = 0
+        cy.on "command:retry", (options) ->
+          retryCount++
+          if retryCount == 1
+            expect(options.type).to.eq("request")
+            expect(options.timeout).to.eq(100)
+
+            ## trigger request to move onto response timeout verification
+            win = cy.state("window")
+            win.$.get("/foo")
+          else if retryCount == 2
+            expect(options.type).to.eq("response")
+            expect(options.timeout).to.eq(299)
+            done()
+
+        cy
+          .server({delay: 100})
+          .route("GET", "*", {}).as("fetch")
+          .wait("@fetch", {requestTimeout: 100, responseTimeout: 299})
 
       ## https://github.com/cypress-io/cypress/issues/369
       it "does not mutate 2nd route methods when using shorthand route", ->


### PR DESCRIPTION
Address #2446 by adding two new options `requestTimeout` and `responseTimeout` to the XHR `cy.wait` command. 