### PR TITLE
Update request lib for security vulnerability in extend

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -169,7 +169,7 @@
     "ramda": "^0.24.0",
     "randomstring": "^1.1.5",
     "replacestream": "^4.0.3",
-    "request": "2.87.0",
+    "request": "2.88.0",
     "request-promise": "4.1.1",
     "return-deep-diff": "^0.2.9",
     "sanitize-filename": "^1.6.1",


### PR DESCRIPTION
extend has a security vulnerabitlity and is used by request < 2.88
https://hackerone.com/reports/381185

https://github.com/cypress-io/cypress/pull/2485 failed testing as it bumps to a major version. 
This is just a minor version so it should not break things.

Fixes https://github.com/cypress-io/cypress/issues/2455 ?
<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->
