### PR TITLE
Update nodemon to remove malware

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -75,7 +75,7 @@
     "istanbul": "^0.4.2",
     "mockery": "^1.4.0",
     "nock": "9.0.22",
-    "nodemon": "^1.8.1",
+    "nodemon": "^1.8.7",
     "npm-install-version": "^6.0.2",
     "obfuscator": "^0.5.0",
     "plist": "^1.1.0",


### PR DESCRIPTION
Our corporate antivirus caught this- nodemon plus multiple downstream dependencies are updating due to a vulnerability in the dependency "event-stream". More info can be found here: dominictarr/event-stream#116 and https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident.