### PR TITLE
convert regular array of elements to jquery

### DIFF
--- a/packages/driver/src/cy/commands/actions/check.coffee
+++ b/packages/driver/src/cy/commands/actions/check.coffee
@@ -1,5 +1,4 @@
 _ = require("lodash")
-$ = require("jquery")
 Promise = require("bluebird")
 
 $dom = require("../../../dom")
@@ -53,7 +52,7 @@ checkOrUncheck = (type, subject, values = [], options = {}) ->
   ## blow up if any member of the subject
   ## isnt a checkbox or radio
   checkOrUncheckEl = (el, index) =>
-    $el = $(el)
+    $el = $dom.wrap(el)
 
     if not isAcceptableElement($el)
       node   = $dom.stringify($el)

--- a/packages/driver/src/cy/commands/actions/click.coffee
+++ b/packages/driver/src/cy/commands/actions/click.coffee
@@ -1,5 +1,4 @@
 _ = require("lodash")
-$ = require("jquery")
 Promise = require("bluebird")
 
 $Mouse = require("../../../cypress/mouse")
@@ -42,7 +41,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
       win = state("window")
 
       click = (el, index) =>
-        $el = $(el)
+        $el = $dom.wrap(el)
 
         domEvents = {}
         $previouslyFocusedEl = null
@@ -217,7 +216,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
       dblclicks = []
 
       dblclick = (el, index) =>
-        $el = $(el)
+        $el = $dom.wrap(el)
 
         ## we want to add this delay delta to our
         ## runnables timeout so we prevent it from

--- a/packages/driver/src/cy/commands/actions/select.coffee
+++ b/packages/driver/src/cy/commands/actions/select.coffee
@@ -1,5 +1,4 @@
 _ = require("lodash")
-$ = require("jquery")
 Promise = require("bluebird")
 
 $dom = require("../../../dom")
@@ -72,7 +71,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
           ## push the value in values array if its
           ## found within the valueOrText
           value = $elements.getNativeProp(el, "value")
-          optEl = $(el)
+          optEl = $dom.wrap(el)
 
           if value in valueOrText
             optionEls.push optEl

--- a/packages/driver/src/cy/commands/actions/type.coffee
+++ b/packages/driver/src/cy/commands/actions/type.coffee
@@ -1,5 +1,4 @@
 _ = require("lodash")
-$ = require("jquery")
 Promise = require("bluebird")
 moment = require("moment")
 
@@ -161,7 +160,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
 
       getDefaultButtons = (form) ->
         form.find("input, button").filter (__, el) ->
-          $el = $(el)
+          $el = $dom.wrap(el)
           ($dom.isSelector($el, "input") and $dom.isType($el, "submit")) or
           ($dom.isSelector($el, "button") and not $dom.isType($el, "button"))
 
@@ -387,7 +386,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
       ## blow up if any member of the subject
       ## isnt a textarea or text-like
       clear = (el, index) ->
-        $el = $(el)
+        $el = $dom.wrap(el)
 
         if options.log
           ## figure out the options which actually change the behavior of clicks

--- a/packages/driver/src/cy/commands/connectors.coffee
+++ b/packages/driver/src/cy/commands/connectors.coffee
@@ -1,5 +1,4 @@
 _ = require("lodash")
-$ = require("jquery")
 Promise = require("bluebird")
 
 $dom = require("../../dom")
@@ -320,7 +319,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
         return if endEarly
 
         if $dom.isElement(el)
-          el = $(el)
+          el = $dom.wrap(el)
 
         callback = ->
           ret = fn.call(ctx, el, index, subject)

--- a/packages/driver/src/cy/ensures.coffee
+++ b/packages/driver/src/cy/ensures.coffee
@@ -4,6 +4,12 @@ $utils = require("../cypress/utils")
 
 VALID_POSITIONS = "topLeft top topRight left center right bottomLeft bottom bottomRight".split(" ")
 
+## TODO: in 4.0 we should accept a new validation type called 'elements'
+## which accepts an array of elements (and they all have to be elements!!)
+## this would fix the TODO below, and also ensure that commands understand
+## they may need to work with both element arrays, or specific items
+## such as a single element, a single document, or single window
+
 returnFalse = -> return false
 
 create = (state, expect) ->

--- a/packages/driver/src/cy/jquery.coffee
+++ b/packages/driver/src/cy/jquery.coffee
@@ -1,6 +1,7 @@
 $ = require("jquery")
 
 $dom = require("../dom")
+$utils = require("../cypress/utils")
 
 remoteJQueryisNotSameAsGlobal = (remoteJQuery) ->
   remoteJQuery and (remoteJQuery isnt $)
@@ -13,7 +14,12 @@ create = (state) ->
     getRemotejQueryInstance: (subject) ->
       remoteJQuery = jquery()
 
-      if $dom.isElement(subject) and remoteJQueryisNotSameAsGlobal(remoteJQuery)
+      ## we make assumptions that you cannot have
+      ## an array of mixed types, so we only look at
+      ## the first item (if there's an array)
+      firstSubject = $utils.unwrapFirst(subject)
+
+      if $dom.isElement(firstSubject) and remoteJQueryisNotSameAsGlobal(remoteJQuery)
         remoteSubject = remoteJQuery(subject)
 
         return remoteSubject

--- a/packages/driver/src/cypress/cy.coffee
+++ b/packages/driver/src/cypress/cy.coffee
@@ -68,7 +68,7 @@ create = (specWindow, Cypress, Cookies, state, config, log) ->
 
   $$ = (selector, context) ->
     context ?= state("document")
-    new $.fn.init(selector, context)
+    $dom.query(selector, context)
 
   queue = $CommandQueue.create()
 
@@ -291,15 +291,23 @@ create = (specWindow, Cypress, Cookies, state, config, log) ->
     .then (subject) ->
       state("commandIntermediateValue", undefined)
 
+      ## we may be given a regular array here so
+      ## we need to re-wrap the array in jquery
+      ## if that's the case if the first item
+      ## in this subject is a jquery element.
+      ## we want to do this because in 3.1.2 there
+      ## was a regression when wrapping an array of elements
+      firstSubject = $utils.unwrapFirst(subject)
+
       ## if ret is a DOM element and its not an instance of our own jQuery
-      if subject and $dom.isElement(subject) and not $utils.isInstanceOf(subject, $)
+      if subject and $dom.isElement(firstSubject) and not $utils.isInstanceOf(subject, $)
         ## set it back to our own jquery object
         ## to prevent it from being passed downstream
         ## TODO: enable turning this off
         ## wrapSubjectsInJquery: false
         ## which will just pass subjects downstream
         ## without modifying them
-        subject = $(subject)
+        subject = $dom.wrap(subject)
 
       command.set({ subject: subject })
 

--- a/packages/driver/src/cypress/utils.coffee
+++ b/packages/driver/src/cypress/utils.coffee
@@ -3,6 +3,7 @@ _ = require("lodash")
 moment = require("moment")
 Promise = require("bluebird")
 
+$jquery = require("../dom/jquery")
 $Location = require("./location")
 $errorMessages = require("./error_messages")
 
@@ -30,6 +31,17 @@ module.exports = {
 
   logInfo: (msgs...) ->
     console.info(msgs...)
+
+  unwrapFirst: (val) ->
+    ## this method returns the first item in an array
+    ## and if its still a jquery object, then we return
+    ## the first() jquery element
+    item = [].concat(val)[0]
+
+    if $jquery.isJquery(item)
+      return item.first()
+
+    return item
 
   appendErrMsg: (err, message) ->
     ## preserve stack

--- a/packages/driver/src/dom/index.coffee
+++ b/packages/driver/src/dom/index.coffee
@@ -7,7 +7,7 @@ $coordinates = require("./coordinates")
 
 { isWindow, getWindowByElement } = $window
 { isDocument } = $document
-{ wrap, unwrap, isJquery } = $jquery
+{ wrap, unwrap, isJquery, query } = $jquery
 { isVisible, isHidden, getReasonIsHidden } = $visibility
 { isType, isFocusable, isElement, isScrollable, stringify, getElements, getContainsSelector, getFirstDeepestElement, isDetached, isAttached, isTextLike, isSelector, isDescendent,  getFirstFixedOrStickyPositionParent, getFirstStickyPositionParent,  getFirstScrollableParent } = $elements
 { getCoordsByPosition, getElementPositioning, getElementCoordinatesByPosition, getElementAtPointFromViewport, getElementCoordinatesByPositionRelativeToXY } = $coordinates
@@ -22,6 +22,8 @@ isDom = (obj) ->
 ## can be tucked away behind these interfaces.
 module.exports = {
   wrap
+
+  query
 
   unwrap
 

--- a/packages/driver/src/dom/jquery.coffee
+++ b/packages/driver/src/dom/jquery.coffee
@@ -3,7 +3,7 @@ _ = require("lodash")
 
 ## wrap the object in jquery
 wrap = (obj) ->
-  if isJquery(obj) then obj else $(obj)
+  $(obj)
 
 query = (selector, context) ->
   new $.fn.init(selector, context)

--- a/packages/driver/src/dom/jquery.coffee
+++ b/packages/driver/src/dom/jquery.coffee
@@ -5,6 +5,9 @@ _ = require("lodash")
 wrap = (obj) ->
   if isJquery(obj) then obj else $(obj)
 
+query = (selector, context) ->
+  new $.fn.init(selector, context)
+
 ## pull out the raw elements if this is wrapped
 unwrap = (obj) ->
   if isJquery(obj)
@@ -22,6 +25,8 @@ isJquery = (obj) ->
 ## to avoid circular dependencies
 module.exports = {
   wrap
+
+  query
 
   unwrap
 

--- a/packages/driver/test/cypress/integration/commands/actions/check_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/check_spec.coffee
@@ -86,7 +86,7 @@ describe "src/cy/commands/actions/check", ->
     it "can check a collection", ->
       cy.get("[name=colors]").check().then ($inputs) ->
         $inputs.each (i, el) ->
-          expect($(el)).to.be.checked
+          expect(dom.wrap(el)).to.be.checked
 
     it "can check a specific value from a collection", ->
       cy.get("[name=colors]").check("blue").then ($inputs) ->

--- a/packages/driver/test/cypress/integration/commands/actions/check_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/check_spec.coffee
@@ -86,7 +86,7 @@ describe "src/cy/commands/actions/check", ->
     it "can check a collection", ->
       cy.get("[name=colors]").check().then ($inputs) ->
         $inputs.each (i, el) ->
-          expect(dom.wrap(el)).to.be.checked
+          expect($(el)).to.be.checked
 
     it "can check a specific value from a collection", ->
       cy.get("[name=colors]").check("blue").then ($inputs) ->


### PR DESCRIPTION
- fixes #2820 
- this fixes a situation where arrays of elements were not being
converted to their pre 3.1.2 behavior (which is to become jquery
instances)
- made notes of the anticipated behavior in 4.0