### PR TITLE
fix _global.setTimeout being undefined when restoring the clock

### DIFF
--- a/packages/driver/src/cypress/clock.coffee
+++ b/packages/driver/src/cypress/clock.coffee
@@ -15,6 +15,19 @@ create = (win, now, methods) ->
     clock.tick(ms)
 
   restore = ->
+    _.each clock.methods, (method) ->
+      try
+        ## before restoring the clock, we need to
+        ## reset the hadOwnProperty in case a
+        ## the application code eradicated the
+        ## overridden clock method at a later time.
+        ## this is a property that lolex using internally
+        ## when restoring the global methods.
+        ## https://github.com/cypress-io/cypress/issues/2850
+        fn = clock[method]
+        if fn and fn.hadOwnProperty and win[method]
+          win[method].hadOwnProperty = true
+
     clock.uninstall()
 
   bind = (win) ->

--- a/packages/driver/test/cypress/integration/issues/2850_spec.js
+++ b/packages/driver/test/cypress/integration/issues/2850_spec.js
@@ -1,0 +1,37 @@
+// https://github.com/cypress-io/cypress/issues/2850
+describe('issue #2850: invoking cy.clock() before two visits', () => {
+  it('works the first time', () => {
+    cy.clock()
+    cy.visit('/fixtures/generic.html')
+    cy.window().then((win) => {
+      // override the setTimeout function now
+      win.setTimeout = () => {}
+    })
+  })
+
+  it('works the second time', () => {
+    cy.clock()
+    cy.visit('/fixtures/generic.html')
+  })
+
+  it('works the third time', () => {
+    cy.clock().then((clock) => {
+      cy.visit('/fixtures/generic.html')
+      cy.window().then((win) => {
+        // override the setTimeout function now
+        win.setTimeout = () => { }
+
+        // manually restore the clock
+        clock.restore()
+      })
+      cy.clock().then((clock2) => {
+        clock2.restore()
+      })
+    })
+  })
+
+  it('works the forth time', () => {
+    cy.clock()
+    cy.visit('/fixtures/generic.html')
+  })
+})


### PR DESCRIPTION
fixes #2850 

this fixes an edge case where the application under test changed the
clock at a later time and when we restored the clock, the global
function became undefined due to deleting the property off of window