### PR TITLE
Upgrade commit info dependency to fall back on environment variables to get Git commit

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -73,6 +73,7 @@
     "https-proxy-agent": "^1.0.0",
     "inquirer": "3.0.6",
     "istanbul": "^0.4.2",
+    "mocked-env": "1.2.4",
     "mockery": "^1.4.0",
     "nock": "9.0.22",
     "nodemon": "^1.8.7",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -97,7 +97,7 @@
   },
   "dependencies": {
     "@cypress/browserify-preprocessor": "1.1.2",
-    "@cypress/commit-info": "2.0.0",
+    "@cypress/commit-info": "2.1.1",
     "@cypress/icons": "0.5.4",
     "@cypress/mocha-teamcity-reporter": "^1.0.0",
     "@ffmpeg-installer/ffmpeg": "1.0.15",

--- a/packages/server/test/scripts/run.js
+++ b/packages/server/test/scripts/run.js
@@ -10,7 +10,7 @@ const options = minimist(process.argv.slice(2))
 
 let run = options._[0]
 
-if (run.includes('--inspect-brk')) {
+if (run && run.includes('--inspect-brk')) {
   run = options._[1]
 }
 

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -16,7 +16,7 @@ expectsCommitParams = (params) ->
 expectsCommitDefaults = (existing, expected) ->
   expect(ciProvider.commitDefaults(existing), "CI providers default git params").to.deep.eq(expected)
 
-describe.only "lib/util/ci_provider", ->
+describe "lib/util/ci_provider", ->
   resetEnv = null
 
   afterEach ->
@@ -30,6 +30,26 @@ describe.only "lib/util/ci_provider", ->
     expectsName(null)
     expectsCiParams(null)
     expectsCommitParams(null)
+
+  it "does not extract from commit environment variables yet", ->
+    # see fallback environment variables
+    # https://github.com/cypress-io/commit-info#fallback-environment-variables
+    # BUT those defaults are NOT used by "ci_provider"
+    # instead they are used in the "record" module
+    # this test just confirms that these defaults are not considered
+    env = {
+      COMMIT_INFO_BRANCH: "my-branch-221",
+      COMMIT_INFO_MESSAGE: "best commit ever",
+      COMMIT_INFO_EMAIL: "user@company.com",
+      COMMIT_INFO_AUTHOR: "Agent Smith",
+      COMMIT_INFO_SHA: "0123456",
+      COMMIT_INFO_REMOTE: "remote repo"
+    }
+    resetEnv = mockedEnv(env, {clear: true})
+
+    expectsName(null) # we don't know CI
+    expectsCiParams(null) # we don't know CI params
+    expectsCommitParams(null) # we don't know CI-specific params
 
   it "appveyor", ->
     resetEnv = mockedEnv({

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -1,4 +1,5 @@
 R = require("ramda")
+mockedEnv = require("mocked-env")
 require("../spec_helper")
 
 ciProvider = require("#{root}lib/util/ci_provider")
@@ -15,36 +16,40 @@ expectsCommitParams = (params) ->
 expectsCommitDefaults = (existing, expected) ->
   expect(ciProvider.commitDefaults(existing), "CI providers default git params").to.deep.eq(expected)
 
-resetEnv = ->
-  process.env = {}
-
 describe "lib/util/ci_provider", ->
+  resetEnv = null
+
   beforeEach ->
-    resetEnv()
+    resetEnv?()
+
+  afterEach ->
+    resetEnv?()
 
   it "null when unknown", ->
-    resetEnv()
+    resetEnv = mockedEnv({}, {clear: true})
 
     expectsName(null)
     expectsCiParams(null)
     expectsCommitParams(null)
 
   it "appveyor", ->
-    process.env.APPVEYOR = true
+    resetEnv = mockedEnv({
+      APPVEYOR: "true"
 
-    process.env.APPVEYOR_JOB_ID = "appveyorJobId2"
-    process.env.APPVEYOR_ACCOUNT_NAME = "appveyorAccountName"
-    process.env.APPVEYOR_PROJECT_SLUG = "appveyorProjectSlug"
-    process.env.APPVEYOR_BUILD_VERSION = "appveyorBuildVersion"
-    process.env.APPVEYOR_BUILD_NUMBER = "appveyorBuildNumber"
-    process.env.APPVEYOR_PULL_REQUEST_NUMBER = "appveyorPullRequestNumber"
-    process.env.APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH = "appveyorPullRequestHeadRepoBranch"
+      APPVEYOR_JOB_ID: "appveyorJobId2"
+      APPVEYOR_ACCOUNT_NAME: "appveyorAccountName"
+      APPVEYOR_PROJECT_SLUG: "appveyorProjectSlug"
+      APPVEYOR_BUILD_VERSION: "appveyorBuildVersion"
+      APPVEYOR_BUILD_NUMBER: "appveyorBuildNumber"
+      APPVEYOR_PULL_REQUEST_NUMBER: "appveyorPullRequestNumber"
+      APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH: "appveyorPullRequestHeadRepoBranch"
 
-    process.env.APPVEYOR_REPO_COMMIT = "repoCommit"
-    process.env.APPVEYOR_REPO_COMMIT_MESSAGE = "repoCommitMessage"
-    process.env.APPVEYOR_REPO_BRANCH = "repoBranch"
-    process.env.APPVEYOR_REPO_COMMIT_AUTHOR = "repoCommitAuthor"
-    process.env.APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL = "repoCommitAuthorEmail"
+      APPVEYOR_REPO_COMMIT: "repoCommit"
+      APPVEYOR_REPO_COMMIT_MESSAGE: "repoCommitMessage"
+      APPVEYOR_REPO_BRANCH: "repoBranch"
+      APPVEYOR_REPO_COMMIT_AUTHOR: "repoCommitAuthor"
+      APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL: "repoCommitAuthorEmail"
+    }, {clear: true})
 
     expectsName("appveyor")
     expectsCiParams({
@@ -66,22 +71,26 @@ describe "lib/util/ci_provider", ->
 
     resetEnv()
 
-    process.env.APPVEYOR = true
-    process.env.APPVEYOR_REPO_COMMIT_MESSAGE = "repoCommitMessage"
-    process.env.APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED = "repoCommitMessageExtended"
+    resetEnv = mockedEnv({
+      APPVEYOR: "true"
+      APPVEYOR_REPO_COMMIT_MESSAGE: "repoCommitMessage"
+      APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED: "repoCommitMessageExtended"
+    }, {clear: true})
 
     expectsCommitParams({
       message: "repoCommitMessage\nrepoCommitMessageExtended"
     })
 
-  it "bamboo", ->
-    process.env["bamboo.buildNumber"] = "123"
+  it.only "bamboo", ->
+    resetEnv = mockedEnv({
+      "bamboo.buildNumber": "123"
 
-    process.env["bamboo.resultsUrl"] = "bamboo.resultsUrl"
-    process.env["bamboo.buildResultsUrl"] = "bamboo.buildResultsUrl"
-    process.env["bamboo.planRepository.repositoryUrl"] = "bamboo.planRepository.repositoryUrl"
+      "bamboo.resultsUrl": "bamboo.resultsUrl"
+      "bamboo.buildResultsUrl": "bamboo.buildResultsUrl"
+      "bamboo.planRepository.repositoryUrl": "bamboo.planRepository.repositoryUrl"
 
-    process.env["bamboo.planRepository.branch"] = "bamboo.planRepository.branch"
+      "bamboo.planRepository.branch": "bamboo.planRepository.branch"
+    }, {clear: true})
 
     expectsName("bamboo")
     expectsCiParams({

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -173,7 +173,6 @@ describe "lib/util/ci_provider", ->
       BUILDKITE_MESSAGE: "buildKiteMessage"
       BUILDKITE_BUILD_CREATOR: "buildKiteBuildCreator"
       BUILDKITE_BUILD_CREATOR_EMAIL: "buildKiteCreatorEmail"
-      BUILDKITE_REPO: "buildkiteRepo"
       BUILDKITE_PIPELINE_DEFAULT_BRANCH: "buildkitePipelineDefaultBranch"
     }, {clear: true})
 

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -81,7 +81,7 @@ describe "lib/util/ci_provider", ->
       message: "repoCommitMessage\nrepoCommitMessageExtended"
     })
 
-  it.only "bamboo", ->
+  it "bamboo", ->
     resetEnv = mockedEnv({
       "bamboo.buildNumber": "123"
 
@@ -104,16 +104,18 @@ describe "lib/util/ci_provider", ->
     })
 
   it "bitbucket", ->
-    process.env.CI = "1"
+    resetEnv = mockedEnv({
+      CI: "1"
 
-    # build information
-    process.env.BITBUCKET_BUILD_NUMBER = "bitbucketBuildNumber"
-    process.env.BITBUCKET_REPO_OWNER = "bitbucketRepoOwner"
-    process.env.BITBUCKET_REPO_SLUG = "bitbucketRepoSlug"
+      # build information
+      BITBUCKET_BUILD_NUMBER: "bitbucketBuildNumber"
+      BITBUCKET_REPO_OWNER: "bitbucketRepoOwner"
+      BITBUCKET_REPO_SLUG: "bitbucketRepoSlug"
 
-    # git information
-    process.env.BITBUCKET_COMMIT = "bitbucketCommit"
-    process.env.BITBUCKET_BRANCH = "bitbucketBranch"
+      # git information
+      BITBUCKET_COMMIT: "bitbucketCommit"
+      BITBUCKET_BRANCH: "bitbucketBranch"
+    }, {clear: true})
 
     expectsName("bitbucket")
     expectsCiParams({
@@ -134,25 +136,27 @@ describe "lib/util/ci_provider", ->
     })
 
   it "buildkite", ->
-    process.env.BUILDKITE = true
+    resetEnv = mockedEnv({
+      BUILDKITE: "true"
 
-    process.env.BUILDKITE_REPO = "buildkiteRepo"
-    process.env.BUILDKITE_JOB_ID = "buildkiteJobId"
-    process.env.BUILDKITE_SOURCE = "buildkiteSource"
-    process.env.BUILDKITE_BUILD_ID = "buildkiteBuildId"
-    process.env.BUILDKITE_BUILD_URL = "buildkiteBuildUrl"
-    process.env.BUILDKITE_BUILD_NUMBER = "buildkiteBuildNumber"
-    process.env.BUILDKITE_PULL_REQUEST = "buildkitePullRequest"
-    process.env.BUILDKITE_PULL_REQUEST_REPO = "buildkitePullRequestRepo"
-    process.env.BUILDKITE_PULL_REQUEST_BASE_BRANCH = "buildkitePullRequestBaseBranch"
+      BUILDKITE_REPO: "buildkiteRepo"
+      BUILDKITE_JOB_ID: "buildkiteJobId"
+      BUILDKITE_SOURCE: "buildkiteSource"
+      BUILDKITE_BUILD_ID: "buildkiteBuildId"
+      BUILDKITE_BUILD_URL: "buildkiteBuildUrl"
+      BUILDKITE_BUILD_NUMBER: "buildkiteBuildNumber"
+      BUILDKITE_PULL_REQUEST: "buildkitePullRequest"
+      BUILDKITE_PULL_REQUEST_REPO: "buildkitePullRequestRepo"
+      BUILDKITE_PULL_REQUEST_BASE_BRANCH: "buildkitePullRequestBaseBranch"
 
-    process.env.BUILDKITE_COMMIT = "buildKiteCommit"
-    process.env.BUILDKITE_BRANCH = "buildKiteBranch"
-    process.env.BUILDKITE_MESSAGE = "buildKiteMessage"
-    process.env.BUILDKITE_BUILD_CREATOR = "buildKiteBuildCreator"
-    process.env.BUILDKITE_BUILD_CREATOR_EMAIL = "buildKiteCreatorEmail"
-    process.env.BUILDKITE_REPO = "buildkiteRepo"
-    process.env.BUILDKITE_PIPELINE_DEFAULT_BRANCH = "buildkitePipelineDefaultBranch"
+      BUILDKITE_COMMIT: "buildKiteCommit"
+      BUILDKITE_BRANCH: "buildKiteBranch"
+      BUILDKITE_MESSAGE: "buildKiteMessage"
+      BUILDKITE_BUILD_CREATOR: "buildKiteBuildCreator"
+      BUILDKITE_BUILD_CREATOR_EMAIL: "buildKiteCreatorEmail"
+      BUILDKITE_REPO: "buildkiteRepo"
+      BUILDKITE_PIPELINE_DEFAULT_BRANCH: "buildkitePipelineDefaultBranch"
+    }, {clear: true})
 
     expectsName("buildkite")
     expectsCiParams({
@@ -177,23 +181,25 @@ describe "lib/util/ci_provider", ->
     })
 
   it "circle", ->
-    process.env.CIRCLECI = true
+    resetEnv = mockedEnv({
+      CIRCLECI: "true"
 
-    process.env.CIRCLE_JOB = "circleJob"
-    process.env.CIRCLE_BUILD_NUM = "circleBuildNum"
-    process.env.CIRCLE_BUILD_URL = "circleBuildUrl"
-    process.env.CIRCLE_PR_NUMBER = "circlePrNumber"
-    process.env.CIRCLE_PR_REPONAME = "circlePrReponame"
-    process.env.CIRCLE_PR_USERNAME = "circlePrUsername"
-    process.env.CIRCLE_COMPARE_URL = "circleCompareUrl"
-    process.env.CIRCLE_WORKFLOW_ID = "circleWorkflowId"
-    process.env.CIRCLE_PULL_REQUEST = "circlePullRequest"
-    process.env.CIRCLE_REPOSITORY_URL = "circleRepositoryUrl"
-    process.env.CI_PULL_REQUEST = "ciPullRequest"
+      CIRCLE_JOB: "circleJob"
+      CIRCLE_BUILD_NUM: "circleBuildNum"
+      CIRCLE_BUILD_URL: "circleBuildUrl"
+      CIRCLE_PR_NUMBER: "circlePrNumber"
+      CIRCLE_PR_REPONAME: "circlePrReponame"
+      CIRCLE_PR_USERNAME: "circlePrUsername"
+      CIRCLE_COMPARE_URL: "circleCompareUrl"
+      CIRCLE_WORKFLOW_ID: "circleWorkflowId"
+      CIRCLE_PULL_REQUEST: "circlePullRequest"
+      CIRCLE_REPOSITORY_URL: "circleRepositoryUrl"
+      CI_PULL_REQUEST: "ciPullRequest"
 
-    process.env.CIRCLE_SHA1 = "circleSha"
-    process.env.CIRCLE_BRANCH = "circleBranch"
-    process.env.CIRCLE_USERNAME = "circleUsername"
+      CIRCLE_SHA1: "circleSha"
+      CIRCLE_BRANCH: "circleBranch"
+      CIRCLE_USERNAME: "circleUsername"
+    }, {clear: true})
 
     expectsName("circle")
     expectsCiParams({
@@ -215,22 +221,24 @@ describe "lib/util/ci_provider", ->
       authorName: "circleUsername"
     })
 
-  it "codeshipBasic", ->
-    process.env.CODESHIP = "TRUE"
-    process.env.CI_NAME = "codeship"
+  it.only "codeshipBasic", ->
+    resetEnv = mockedEnv({
+      CODESHIP: "TRUE"
+      CI_NAME: "codeship"
 
-    process.env.CI_BUILD_ID = "ciBuildId"
-    process.env.CI_REPO_NAME = "ciRepoName"
-    process.env.CI_BUILD_URL = "ciBuildUrl"
-    process.env.CI_PROJECT_ID = "ciProjectId"
-    process.env.CI_BUILD_NUMBER = "ciBuildNumber"
-    process.env.CI_PULL_REQUEST = "ciPullRequest"
+      CI_BUILD_ID: "ciBuildId"
+      CI_REPO_NAME: "ciRepoName"
+      CI_BUILD_URL: "ciBuildUrl"
+      CI_PROJECT_ID: "ciProjectId"
+      CI_BUILD_NUMBER: "ciBuildNumber"
+      CI_PULL_REQUEST: "ciPullRequest"
 
-    process.env.CI_COMMIT_ID = "ciCommitId"
-    process.env.CI_BRANCH = "ciBranch"
-    process.env.CI_COMMIT_MESSAGE = "ciCommitMessage"
-    process.env.CI_COMMITTER_NAME = "ciCommitterName"
-    process.env.CI_COMMITTER_EMAIL = "ciCommitterEmail"
+      CI_COMMIT_ID: "ciCommitId"
+      CI_BRANCH: "ciBranch"
+      CI_COMMIT_MESSAGE: "ciCommitMessage"
+      CI_COMMITTER_NAME: "ciCommitterName"
+      CI_COMMITTER_EMAIL: "ciCommitterEmail"
+    }, {clear: true})
 
     expectsName("codeshipBasic")
     expectsCiParams({
@@ -250,17 +258,19 @@ describe "lib/util/ci_provider", ->
     })
 
   it "codeshipPro", ->
-    process.env.CI_NAME = "codeship"
+    resetEnv = mockedEnv({
+      CI_NAME: "codeship"
 
-    process.env.CI_BUILD_ID = "ciBuildId"
-    process.env.CI_REPO_NAME = "ciRepoName"
-    process.env.CI_PROJECT_ID = "ciProjectId"
+      CI_BUILD_ID: "ciBuildId"
+      CI_REPO_NAME: "ciRepoName"
+      CI_PROJECT_ID: "ciProjectId"
 
-    process.env.CI_COMMIT_ID = "ciCommitId"
-    process.env.CI_BRANCH = "ciBranch"
-    process.env.CI_COMMIT_MESSAGE = "ciCommitMessage"
-    process.env.CI_COMMITTER_NAME = "ciCommitterName"
-    process.env.CI_COMMITTER_EMAIL = "ciCommitterEmail"
+      CI_COMMIT_ID: "ciCommitId"
+      CI_BRANCH: "ciBranch"
+      CI_COMMIT_MESSAGE: "ciCommitMessage"
+      CI_COMMITTER_NAME: "ciCommitterName"
+      CI_COMMITTER_EMAIL: "ciCommitterEmail"
+    }, {clear: true})
 
     expectsName("codeshipPro")
     expectsCiParams({
@@ -277,19 +287,21 @@ describe "lib/util/ci_provider", ->
     })
 
   it "drone", ->
-    process.env.DRONE = true
+    resetEnv = mockedEnv({
+      DRONE: "true"
 
-    process.env.DRONE_JOB_NUMBER = "droneJobNumber"
-    process.env.DRONE_BUILD_LINK = "droneBuildLink"
-    process.env.DRONE_BUILD_NUMBER = "droneBuildNumber"
-    process.env.DRONE_PULL_REQUEST = "dronePullRequest"
+      DRONE_JOB_NUMBER: "droneJobNumber"
+      DRONE_BUILD_LINK: "droneBuildLink"
+      DRONE_BUILD_NUMBER: "droneBuildNumber"
+      DRONE_PULL_REQUEST: "dronePullRequest"
 
-    process.env.DRONE_COMMIT_SHA = "droneCommitSha"
-    process.env.DRONE_COMMIT_BRANCH = "droneCommitBranch"
-    process.env.DRONE_COMMIT_MESSAGE = "droneCommitMessage"
-    process.env.DRONE_COMMIT_AUTHOR = "droneCommitAuthor"
-    process.env.DRONE_COMMIT_AUTHOR_EMAIL = "droneCommitAuthorEmail"
-    process.env.DRONE_REPO_BRANCH = "droneRepoBranch"
+      DRONE_COMMIT_SHA: "droneCommitSha"
+      DRONE_COMMIT_BRANCH: "droneCommitBranch"
+      DRONE_COMMIT_MESSAGE: "droneCommitMessage"
+      DRONE_COMMIT_AUTHOR: "droneCommitAuthor"
+      DRONE_COMMIT_AUTHOR_EMAIL: "droneCommitAuthorEmail"
+      DRONE_REPO_BRANCH: "droneRepoBranch"
+    }, {clear: true})
 
     expectsName("drone")
     expectsCiParams({
@@ -308,27 +320,29 @@ describe "lib/util/ci_provider", ->
     })
 
   it "gitlab", ->
-    process.env.GITLAB_CI = true
+    resetEnv = mockedEnv({
+      GITLAB_CI: "true"
 
-    # Gitlab has job id and build id as synonyms
-    process.env.CI_BUILD_ID = "ciJobId"
-    process.env.CI_JOB_ID = "ciJobId"
-    process.env.CI_JOB_URL = "ciJobUrl"
+      # Gitlab has job id and build id as synonyms
+      CI_BUILD_ID: "ciJobId"
+      CI_JOB_ID: "ciJobId"
+      CI_JOB_URL: "ciJobUrl"
 
-    process.env.CI_PIPELINE_ID = "ciPipelineId"
-    process.env.CI_PIPELINE_URL = "ciPipelineUrl"
+      CI_PIPELINE_ID: "ciPipelineId"
+      CI_PIPELINE_URL: "ciPipelineUrl"
 
-    process.env.GITLAB_HOST = "gitlabHost"
-    process.env.CI_PROJECT_ID = "ciProjectId"
-    process.env.CI_PROJECT_URL = "ciProjectUrl"
-    process.env.CI_REPOSITORY_URL = "ciRepositoryUrl"
-    process.env.CI_ENVIRONMENT_URL = "ciEnvironmentUrl"
+      GITLAB_HOST: "gitlabHost"
+      CI_PROJECT_ID: "ciProjectId"
+      CI_PROJECT_URL: "ciProjectUrl"
+      CI_REPOSITORY_URL: "ciRepositoryUrl"
+      CI_ENVIRONMENT_URL: "ciEnvironmentUrl"
 
-    process.env.CI_COMMIT_SHA = "ciCommitSha"
-    process.env.CI_COMMIT_REF_NAME = "ciCommitRefName"
-    process.env.CI_COMMIT_MESSAGE = "ciCommitMessage"
-    process.env.GITLAB_USER_NAME = "gitlabUserName"
-    process.env.GITLAB_USER_EMAIL = "gitlabUserEmail"
+      CI_COMMIT_SHA: "ciCommitSha"
+      CI_COMMIT_REF_NAME: "ciCommitRefName"
+      CI_COMMIT_MESSAGE: "ciCommitMessage"
+      GITLAB_USER_NAME: "gitlabUserName"
+      GITLAB_USER_EMAIL: "gitlabUserEmail"
+    }, {clear: true})
 
     expectsName("gitlab")
     expectsCiParams({
@@ -351,28 +365,30 @@ describe "lib/util/ci_provider", ->
       authorEmail: "gitlabUserEmail"
     })
 
-    resetEnv()
-
-    process.env.CI_SERVER_NAME = "GitLab CI"
-
-    expectsName("gitlab")
-
-    resetEnv()
-
-    process.env.CI_SERVER_NAME = "GitLab"
+    resetEnv = mockedEnv({
+      CI_SERVER_NAME: "GitLab CI"
+    }, {clear: true})
 
     expectsName("gitlab")
 
-  it "jenkins", ->
-    process.env.JENKINS_URL = true
+    resetEnv = mockedEnv({
+      CI_SERVER_NAME: "GitLab"
+    }, {clear: true})
 
-    process.env.BUILD_ID = "buildId"
-    process.env.BUILD_URL = "buildUrl"
-    process.env.BUILD_NUMBER = "buildNumber"
-    process.env.ghprbPullId = "gbprbPullId"
+    expectsName("gitlab")
 
-    process.env.GIT_COMMIT = "gitCommit"
-    process.env.GIT_BRANCH = "gitBranch"
+  it.only "jenkins", ->
+    resetEnv = mockedEnv({
+      JENKINS_URL: "true"
+
+      BUILD_ID: "buildId"
+      BUILD_URL: "buildUrl"
+      BUILD_NUMBER: "buildNumber"
+      ghprbPullId: "gbprbPullId"
+
+      GIT_COMMIT: "gitCommit"
+      GIT_BRANCH: "gitBranch"
+    }, {clear: true})
 
     expectsName("jenkins")
     expectsCiParams({
@@ -386,20 +402,24 @@ describe "lib/util/ci_provider", ->
       branch: "gitBranch"
     })
 
-    resetEnv()
-    process.env.JENKINS_HOME = "/path/to/jenkins"
+    resetEnv = mockedEnv({
+      JENKINS_HOME: "/path/to/jenkins"
+    }, {clear: true})
     expectsName("jenkins")
 
-    resetEnv()
-    process.env.JENKINS_VERSION = "1.2.3"
+    resetEnv = mockedEnv({
+      JENKINS_VERSION: "1.2.3"
+    }, {clear: true})
     expectsName("jenkins")
 
-    resetEnv()
-    process.env.HUDSON_HOME = "/path/to/jenkins"
+    resetEnv = mockedEnv({
+      HUDSON_HOME: "/path/to/jenkins"
+    }, {clear: true})
     expectsName("jenkins")
 
-    resetEnv()
-    process.env.HUDSON_URL = true
+    resetEnv = mockedEnv({
+      HUDSON_URL: "true"
+    }, {clear: true})
     expectsName("jenkins")
 
   it "semaphore", ->

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -16,13 +16,12 @@ expectsCommitParams = (params) ->
 expectsCommitDefaults = (existing, expected) ->
   expect(ciProvider.commitDefaults(existing), "CI providers default git params").to.deep.eq(expected)
 
-describe "lib/util/ci_provider", ->
+describe.only "lib/util/ci_provider", ->
   resetEnv = null
 
-  beforeEach ->
-    resetEnv?()
-
   afterEach ->
+    # we need to reset environment
+    # to avoid affecting tests in other suites
     resetEnv?()
 
   it "null when unknown", ->
@@ -221,7 +220,7 @@ describe "lib/util/ci_provider", ->
       authorName: "circleUsername"
     })
 
-  it.only "codeshipBasic", ->
+  it "codeshipBasic", ->
     resetEnv = mockedEnv({
       CODESHIP: "TRUE"
       CI_NAME: "codeship"
@@ -377,7 +376,7 @@ describe "lib/util/ci_provider", ->
 
     expectsName("gitlab")
 
-  it.only "jenkins", ->
+  it "jenkins", ->
     resetEnv = mockedEnv({
       JENKINS_URL: "true"
 
@@ -423,26 +422,28 @@ describe "lib/util/ci_provider", ->
     expectsName("jenkins")
 
   it "semaphore", ->
-    process.env.SEMAPHORE = true
+    resetEnv = mockedEnv({
+      SEMAPHORE: "true"
 
-    process.env.SEMAPHORE_BRANCH_ID = "semaphoreBranchId"
-    process.env.SEMAPHORE_BUILD_NUMBER = "semaphoreBuildNumber"
-    process.env.SEMAPHORE_CURRENT_JOB = "semaphoreCurrentJob"
-    process.env.SEMAPHORE_CURRENT_THREAD = "semaphoreCurrentThread"
-    process.env.SEMAPHORE_EXECUTABLE_UUID = "semaphoreExecutableUuid"
-    process.env.SEMAPHORE_JOB_COUNT = "semaphoreJobCount"
-    process.env.SEMAPHORE_JOB_UUID = "semaphoreJobUuid"
-    process.env.SEMAPHORE_PLATFORM = "semaphorePlatform"
-    process.env.SEMAPHORE_PROJECT_DIR = "semaphoreProjectDir"
-    process.env.SEMAPHORE_PROJECT_HASH_ID = "semaphoreProjectHashId"
-    process.env.SEMAPHORE_PROJECT_NAME = "semaphoreProjectName"
-    process.env.SEMAPHORE_PROJECT_UUID = "semaphoreProjectUuid"
-    process.env.SEMAPHORE_REPO_SLUG = "semaphoreRepoSlug"
-    process.env.SEMAPHORE_TRIGGER_SOURCE = "semaphoreTriggerSource"
-    process.env.PULL_REQUEST_NUMBER = "pullRequestNumber"
+      SEMAPHORE_BRANCH_ID: "semaphoreBranchId"
+      SEMAPHORE_BUILD_NUMBER: "semaphoreBuildNumber"
+      SEMAPHORE_CURRENT_JOB: "semaphoreCurrentJob"
+      SEMAPHORE_CURRENT_THREAD: "semaphoreCurrentThread"
+      SEMAPHORE_EXECUTABLE_UUID: "semaphoreExecutableUuid"
+      SEMAPHORE_JOB_COUNT: "semaphoreJobCount"
+      SEMAPHORE_JOB_UUID: "semaphoreJobUuid"
+      SEMAPHORE_PLATFORM: "semaphorePlatform"
+      SEMAPHORE_PROJECT_DIR: "semaphoreProjectDir"
+      SEMAPHORE_PROJECT_HASH_ID: "semaphoreProjectHashId"
+      SEMAPHORE_PROJECT_NAME: "semaphoreProjectName"
+      SEMAPHORE_PROJECT_UUID: "semaphoreProjectUuid"
+      SEMAPHORE_REPO_SLUG: "semaphoreRepoSlug"
+      SEMAPHORE_TRIGGER_SOURCE: "semaphoreTriggerSource"
+      PULL_REQUEST_NUMBER: "pullRequestNumber"
 
-    process.env.REVISION = "revision"
-    process.env.BRANCH_NAME = "branchName"
+      REVISION: "revision"
+      BRANCH_NAME: "branchName"
+    }, {clear: true})
 
     expectsName("semaphore")
     expectsCiParams({
@@ -468,40 +469,42 @@ describe "lib/util/ci_provider", ->
     })
 
   it "shippable", ->
-    process.env.SHIPPABLE = "true"
+    resetEnv = mockedEnv({
+      SHIPPABLE: "true"
 
-    # build environment variables
-    process.env.SHIPPABLE_BUILD_ID = "buildId"
-    process.env.SHIPPABLE_BUILD_NUMBER = "buildNumber"
-    process.env.SHIPPABLE_COMMIT_RANGE = "commitRange"
-    process.env.SHIPPABLE_CONTAINER_NAME = "containerName"
-    process.env.SHIPPABLE_JOB_ID = "jobId"
-    process.env.SHIPPABLE_JOB_NUMBER = "jobNumber"
-    process.env.SHIPPABLE_REPO_SLUG = "repoSlug"
+      # build environment variables
+      SHIPPABLE_BUILD_ID: "buildId"
+      SHIPPABLE_BUILD_NUMBER: "buildNumber"
+      SHIPPABLE_COMMIT_RANGE: "commitRange"
+      SHIPPABLE_CONTAINER_NAME: "containerName"
+      SHIPPABLE_JOB_ID: "jobId"
+      SHIPPABLE_JOB_NUMBER: "jobNumber"
+      SHIPPABLE_REPO_SLUG: "repoSlug"
 
-    # additional information
-    process.env.IS_FORK = "isFork"
-    process.env.IS_GIT_TAG = "isGitTag"
-    process.env.IS_PRERELEASE = "isPrerelease"
-    process.env.IS_RELEASE = "isRelease"
-    process.env.REPOSITORY_URL = "repositoryUrl"
-    process.env.REPO_FULL_NAME = "repoFullName"
-    process.env.REPO_NAME = "repoName"
-    process.env.BUILD_URL = "buildUrl"
+      # additional information
+      IS_FORK: "isFork"
+      IS_GIT_TAG: "isGitTag"
+      IS_PRERELEASE: "isPrerelease"
+      IS_RELEASE: "isRelease"
+      REPOSITORY_URL: "repositoryUrl"
+      REPO_FULL_NAME: "repoFullName"
+      REPO_NAME: "repoName"
+      BUILD_URL: "buildUrl"
 
-    # pull request variables
-    process.env.BASE_BRANCH = "baseBranch"
-    process.env.HEAD_BRANCH = "headBranch"
-    process.env.IS_PULL_REQUEST = "isPullRequest"
-    process.env.PULL_REQUEST = "pullRequest"
-    process.env.PULL_REQUEST_BASE_BRANCH = "pullRequestBaseBranch"
-    process.env.PULL_REQUEST_REPO_FULL_NAME = "pullRequestRepoFullName"
+      # pull request variables
+      BASE_BRANCH: "baseBranch"
+      HEAD_BRANCH: "headBranch"
+      IS_PULL_REQUEST: "isPullRequest"
+      PULL_REQUEST: "pullRequest"
+      PULL_REQUEST_BASE_BRANCH: "pullRequestBaseBranch"
+      PULL_REQUEST_REPO_FULL_NAME: "pullRequestRepoFullName"
 
-    # git information
-    process.env.COMMIT = "commit"
-    process.env.BRANCH = "branch"
-    process.env.COMMITTER = "committer"
-    process.env.COMMIT_MESSAGE = "commitMessage"
+      # git information
+      COMMIT: "commit"
+      BRANCH: "branch"
+      COMMITTER: "committer"
+      COMMIT_MESSAGE: "commitMessage"
+    }, {clear: true})
 
     expectsName("shippable")
     expectsCiParams({
@@ -538,30 +541,36 @@ describe "lib/util/ci_provider", ->
     })
 
   it "snap", ->
-    process.env.SNAP_CI = true
+    resetEnv = mockedEnv({
+      SNAP_CI: "true"
+    }, {clear: true})
 
     expectsName("snap")
     expectsCiParams(null)
     expectsCommitParams(null)
 
   it "teamcity", ->
-    process.env.TEAMCITY_VERSION = true
+    resetEnv = mockedEnv({
+      TEAMCITY_VERSION: "true"
+    }, {clear: true})
 
     expectsName("teamcity")
     expectsCiParams(null)
     expectsCommitParams(null)
 
   it "teamfoundation", ->
-    process.env.TF_BUILD = true
+    resetEnv = mockedEnv({
+      TF_BUILD: "true"
 
-    process.env.BUILD_BUILDID = "buildId"
-    process.env.BUILD_BUILDNUMBER = "buildNumber"
-    process.env.BUILD_CONTAINERID = "containerId"
+      BUILD_BUILDID: "buildId"
+      BUILD_BUILDNUMBER: "buildNumber"
+      BUILD_CONTAINERID: "containerId"
 
-    process.env.BUILD_SOURCEVERSION = "commit"
-    process.env.BUILD_SOURCEBRANCHNAME = "branch"
-    process.env.BUILD_SOURCEVERSIONMESSAGE = "message"
-    process.env.BUILD_SOURCEVERSIONAUTHOR = "name"
+      BUILD_SOURCEVERSION: "commit"
+      BUILD_SOURCEBRANCHNAME: "branch"
+      BUILD_SOURCEVERSIONMESSAGE: "message"
+      BUILD_SOURCEVERSIONAUTHOR: "name"
+    }, {clear: true})
 
     expectsName("teamfoundation")
     expectsCiParams({
@@ -577,21 +586,23 @@ describe "lib/util/ci_provider", ->
     })
 
   it "travis", ->
-    process.env.TRAVIS = true
+    resetEnv = mockedEnv({
+      TRAVIS: "true"
 
-    process.env.TRAVIS_JOB_ID = "travisJobId"
-    process.env.TRAVIS_BUILD_ID = "travisBuildId"
-    process.env.TRAVIS_REPO_SLUG = "travisRepoSlug"
-    process.env.TRAVIS_JOB_NUMBER = "travisJobNumber"
-    process.env.TRAVIS_EVENT_TYPE = "travisEventType"
-    process.env.TRAVIS_COMMIT_RANGE = "travisCommitRange"
-    process.env.TRAVIS_BUILD_NUMBER = "travisBuildNumber"
-    process.env.TRAVIS_PULL_REQUEST = "travisPullRequest"
-    process.env.TRAVIS_PULL_REQUEST_BRANCH = "travisPullRequestBranch"
+      TRAVIS_JOB_ID: "travisJobId"
+      TRAVIS_BUILD_ID: "travisBuildId"
+      TRAVIS_REPO_SLUG: "travisRepoSlug"
+      TRAVIS_JOB_NUMBER: "travisJobNumber"
+      TRAVIS_EVENT_TYPE: "travisEventType"
+      TRAVIS_COMMIT_RANGE: "travisCommitRange"
+      TRAVIS_BUILD_NUMBER: "travisBuildNumber"
+      TRAVIS_PULL_REQUEST: "travisPullRequest"
+      TRAVIS_PULL_REQUEST_BRANCH: "travisPullRequestBranch"
 
-    process.env.TRAVIS_COMMIT = "travisCommit"
-    process.env.TRAVIS_BRANCH = "travisBranch"
-    process.env.TRAVIS_COMMIT_MESSAGE = "travisCommitMessage"
+      TRAVIS_COMMIT: "travisCommit"
+      TRAVIS_BRANCH: "travisBranch"
+      TRAVIS_COMMIT_MESSAGE: "travisCommitMessage"
+    }, {clear: true})
 
     expectsName("travis")
     expectsCiParams({
@@ -611,20 +622,26 @@ describe "lib/util/ci_provider", ->
       message: "travisCommitMessage"
     })
 
-    resetEnv()
-    process.env.TRAVIS = true
-    process.env.TRAVIS_BRANCH = "travisBranch"
+    resetEnv = mockedEnv({
+      TRAVIS: "true"
+      TRAVIS_BRANCH: "travisBranch"
+    }, {clear: true})
+
     expectsCommitParams({
       branch: "travisBranch"
     })
 
   it "wercker", ->
-    process.env.WERCKER = true
+    resetEnv = mockedEnv({
+      WERCKER: "true"
+    }, {clear: true})
 
     expectsName("wercker")
     expectsCiParams(null)
     expectsCommitParams(null)
 
-    resetEnv()
-    process.env.WERCKER_MAIN_PIPELINE_STARTED = true
+    resetEnv = mockedEnv({
+      WERCKER_MAIN_PIPELINE_STARTED: "true"
+    }, {clear: true})
+
     expectsName("wercker")


### PR DESCRIPTION
- closes #2848

Uses a new version of the library `@cypress/commit-info` to extract Git commit info from environment variables as a fallback is `.git` folder is missing or there is no `git` command available