### PR TITLE
No dev deps in windows binary 2896

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - npm run check-node-version
   # NPM v3 has flaky permission issues on Windows
-  - npm install -g npm@5
+  - npm install -g npm@6
   - npm install -g @bahmutov/print-env
   # Output useful info for debugging.
   - node --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ branches:
 
 # https://www.appveyor.com/docs/lang/nodejs-iojs/
 environment:
+  # use latest version of Node 8 with NPM 6
   nodejs_version: "8"
   # encode secure variables which will NOT be used
   # in pull requests
@@ -34,8 +35,6 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm run check-node-version
-  # NPM v3 has flaky permission issues on Windows
-  # - npm install -g npm@6
   - npm install -g @bahmutov/print-env
   # Output useful info for debugging.
   - node --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,7 @@ branches:
 
 # https://www.appveyor.com/docs/lang/nodejs-iojs/
 environment:
-  # Test against the same version of Node.js version as included in Electron
-  nodejs_version: "8.2.1"
+  nodejs_version: "8"
   # encode secure variables which will NOT be used
   # in pull requests
   # https://www.appveyor.com/docs/build-configuration/#secure-variables
@@ -36,7 +35,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - npm run check-node-version
   # NPM v3 has flaky permission issues on Windows
-  - npm install -g npm@6
+  # - npm install -g npm@6
   - npm install -g @bahmutov/print-env
   # Output useful info for debugging.
   - node --version

--- a/circle.yml
+++ b/circle.yml
@@ -676,6 +676,7 @@ workflows:
             branches:
               only:
                 - develop
+                - no-dev-deps-in-windows-binary-2896
           requires:
             - build
       - test-next-version:

--- a/circle.yml
+++ b/circle.yml
@@ -606,48 +606,48 @@ workflows:
           requires:
             - build
       # unit, integration and e2e tests
-      - unit-tests:
-          requires:
-            - build
-      - server-unit-tests:
-          requires:
-            - build
-      - server-integration-tests:
-          requires:
-            - build
-      - server-e2e-tests-1:
-          requires:
-            - build
-      - server-e2e-tests-2:
-          requires:
-            - build
-      - server-e2e-tests-3:
-          requires:
-            - build
-      - server-e2e-tests-4:
-          requires:
-            - build
-      - server-e2e-tests-5:
-          requires:
-            - build
-      - server-e2e-tests-6:
-          requires:
-            - build
-      - server-e2e-tests-7:
-          requires:
-            - build
-      - server-e2e-tests-8:
-          requires:
-            - build
-      - 3x-driver-integration-tests:
-          requires:
-            - build
-      - 2x-desktop-gui-integration-tests:
-          requires:
-            - build
-      - run-launcher:
-          requires:
-            - build
+    #   - unit-tests:
+    #       requires:
+    #         - build
+    #   - server-unit-tests:
+    #       requires:
+    #         - build
+    #   - server-integration-tests:
+    #       requires:
+    #         - build
+    #   - server-e2e-tests-1:
+    #       requires:
+    #         - build
+    #   - server-e2e-tests-2:
+    #       requires:
+    #         - build
+    #   - server-e2e-tests-3:
+    #       requires:
+    #         - build
+    #   - server-e2e-tests-4:
+    #       requires:
+    #         - build
+    #   - server-e2e-tests-5:
+    #       requires:
+    #         - build
+    #   - server-e2e-tests-6:
+    #       requires:
+    #         - build
+    #   - server-e2e-tests-7:
+    #       requires:
+    #         - build
+    #   - server-e2e-tests-8:
+    #       requires:
+    #         - build
+    #   - 3x-driver-integration-tests:
+    #       requires:
+    #         - build
+    #   - 2x-desktop-gui-integration-tests:
+    #       requires:
+    #         - build
+    #   - run-launcher:
+    #       requires:
+    #         - build
       # various testing scenarios, like building full binary
       # and testing it on a real project
       - test-against-staging:

--- a/circle.yml
+++ b/circle.yml
@@ -606,48 +606,48 @@ workflows:
           requires:
             - build
       # unit, integration and e2e tests
-    #   - unit-tests:
-    #       requires:
-    #         - build
-    #   - server-unit-tests:
-    #       requires:
-    #         - build
-    #   - server-integration-tests:
-    #       requires:
-    #         - build
-    #   - server-e2e-tests-1:
-    #       requires:
-    #         - build
-    #   - server-e2e-tests-2:
-    #       requires:
-    #         - build
-    #   - server-e2e-tests-3:
-    #       requires:
-    #         - build
-    #   - server-e2e-tests-4:
-    #       requires:
-    #         - build
-    #   - server-e2e-tests-5:
-    #       requires:
-    #         - build
-    #   - server-e2e-tests-6:
-    #       requires:
-    #         - build
-    #   - server-e2e-tests-7:
-    #       requires:
-    #         - build
-    #   - server-e2e-tests-8:
-    #       requires:
-    #         - build
-    #   - 3x-driver-integration-tests:
-    #       requires:
-    #         - build
-    #   - 2x-desktop-gui-integration-tests:
-    #       requires:
-    #         - build
-    #   - run-launcher:
-    #       requires:
-    #         - build
+      - unit-tests:
+          requires:
+            - build
+      - server-unit-tests:
+          requires:
+            - build
+      - server-integration-tests:
+          requires:
+            - build
+      - server-e2e-tests-1:
+          requires:
+            - build
+      - server-e2e-tests-2:
+          requires:
+            - build
+      - server-e2e-tests-3:
+          requires:
+            - build
+      - server-e2e-tests-4:
+          requires:
+            - build
+      - server-e2e-tests-5:
+          requires:
+            - build
+      - server-e2e-tests-6:
+          requires:
+            - build
+      - server-e2e-tests-7:
+          requires:
+            - build
+      - server-e2e-tests-8:
+          requires:
+            - build
+      - 3x-driver-integration-tests:
+          requires:
+            - build
+      - 2x-desktop-gui-integration-tests:
+          requires:
+            - build
+      - run-launcher:
+          requires:
+            - build
       # various testing scenarios, like building full binary
       # and testing it on a real project
       - test-against-staging:
@@ -676,7 +676,6 @@ workflows:
             branches:
               only:
                 - develop
-                - no-dev-deps-in-windows-binary-2896
           requires:
             - build
       - test-next-version:

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "plist": "^2.1.0",
     "pluralize": "^6.0.0",
     "prefixed-list": "^1.0.1",
+    "pretty-ms": "4.0.0",
     "print-arch": "^1.0.0",
     "ramda": "^0.24.1",
     "shelljs": "^0.7.8",

--- a/scripts/binary/util/packages.coffee
+++ b/scripts/binary/util/packages.coffee
@@ -103,7 +103,7 @@ removeDevDependencies = (packageFolder) ->
   fs.readJsonAsync(packagePath)
   .then (json) ->
     delete json.devDependencies
-    fs.writeJsonAsync(packagePath)
+    fs.writeJsonAsync(packagePath, json, {spaces: 2})
 
 retryGlobbing = (pathToPackages, delay = 1000) ->
   retryGlob = ->
@@ -152,7 +152,7 @@ npmInstallAll = (pathToPackages) ->
       retryNpmInstall(packageFolder)
   .then ->
     end = new Date()
-    console.log("Finished NPM Installing", prettyMes(end - started))
+    console.log("Finished NPM Installing", prettyMs(end - started))
 
 removePackageJson = (filename) ->
   if filename.endsWith("/package.json") then path.dirname(filename) else filename

--- a/scripts/binary/util/packages.coffee
+++ b/scripts/binary/util/packages.coffee
@@ -19,14 +19,14 @@ DEFAULT_PATHS = "package.json".split(" ")
 pathToPackageJson = (pkg) ->
   path.join(pkg, "package.json")
 
-npmRun = (args, cwd) ->
+npmRun = (args, cwd, env = {}) ->
   command = "npm " + args.join(" ")
   console.log(command)
   if cwd
     console.log("in folder:", cwd)
 
   la(check.maybe.string(cwd), "invalid CWD string", cwd)
-  execa("npm", args, { stdio: "inherit", cwd })
+  execa("npm", args, { stdio: "inherit", cwd, env })
   # if everything is ok, resolve with nothing
   .then R.always(undefined)
   .catch (result) ->
@@ -114,9 +114,10 @@ npmInstallAll = (pathToPackages) ->
     console.log("installing %s", pkg)
     console.log("NODE_ENV is %s", process.env.NODE_ENV)
 
+    # force installing only PRODUCTION dependencies
     # https://docs.npmjs.com/cli/install
     npmInstall = _.partial(npmRun, ["install", "--only=production", "--quiet"])
-    npmInstall(pkg)
+    npmInstall(pkg, {NODE_ENV: "production"})
     .catch {code: "EMFILE"}, ->
       Promise
       .delay(1000)

--- a/scripts/binary/util/packages.coffee
+++ b/scripts/binary/util/packages.coffee
@@ -11,6 +11,7 @@ execa = require("execa")
 R = require("ramda")
 os = require("os")
 prettyMs = require("pretty-ms")
+pluralize = require('pluralize')
 
 fs = Promise.promisifyAll(fs)
 glob = Promise.promisify(glob)
@@ -139,10 +140,15 @@ npmInstallAll = (pathToPackages) ->
       console.log(err, err.code)
       throw err
 
+  printFolders = (folders) ->
+    console.log("found %s", pluralize("folder", folders.length, true))
+
   ## only installs production dependencies
   retryGlobbing(pathToPackages)
-  .mapSeries(removeDevDependencies)
-  .mapSeries(retryNpmInstall)
+  .tap(printFolders)
+  .mapSeries (packageFolder) ->
+    removeDevDependencies(packageFolder)
+    .then retryNpmInstall
   .then ->
     end = new Date()
     console.log("Finished NPM Installing", prettyMes(end - started))

--- a/scripts/binary/util/packages.coffee
+++ b/scripts/binary/util/packages.coffee
@@ -94,6 +94,15 @@ forceNpmInstall = (packagePath, packageToInstall) ->
   la(check.unemptyString(packageToInstall), "missing package to install")
   npmRun(["install", "--force", packageToInstall], packagePath)
 
+removeDevDependencies = (packagePath) ->
+  la(check.unemptyString(packagePath), "expected package path", packagePath)
+  console.log("removing devDependencies from %s", packagePath)
+
+  fs.readJsonAsync(packagePath)
+  .then (json) ->
+    delete json.devDependencies
+    fs.writeJsonAsync(packagePath)
+
 retryGlobbing = (pathToPackages, delay = 1000) ->
   retryGlob = ->
     glob(pathToPackages)
@@ -131,6 +140,7 @@ npmInstallAll = (pathToPackages) ->
 
   ## only installs production dependencies
   retryGlobbing(pathToPackages)
+  .mapSeries(removeDevDependencies)
   .mapSeries(retryNpmInstall)
   .then ->
     end = new Date()

--- a/scripts/binary/util/packages.coffee
+++ b/scripts/binary/util/packages.coffee
@@ -111,8 +111,11 @@ npmInstallAll = (pathToPackages) ->
 
 
   retryNpmInstall = (pkg) ->
-    console.log("installing", pkg)
-    npmInstall = _.partial(npmRun, ["install", "--production", "--quiet"])
+    console.log("installing %s", pkg)
+    console.log("NODE_ENV is %s", process.env.NODE_ENV)
+
+    # https://docs.npmjs.com/cli/install
+    npmInstall = _.partial(npmRun, ["install", "--only=production", "--quiet"])
     npmInstall(pkg)
     .catch {code: "EMFILE"}, ->
       Promise

--- a/scripts/binary/util/packages.coffee
+++ b/scripts/binary/util/packages.coffee
@@ -148,7 +148,8 @@ npmInstallAll = (pathToPackages) ->
   .tap(printFolders)
   .mapSeries (packageFolder) ->
     removeDevDependencies(packageFolder)
-    .then retryNpmInstall
+    .then ->
+      retryNpmInstall(packageFolder)
   .then ->
     end = new Date()
     console.log("Finished NPM Installing", prettyMes(end - started))

--- a/scripts/binary/util/packages.coffee
+++ b/scripts/binary/util/packages.coffee
@@ -17,8 +17,9 @@ glob = Promise.promisify(glob)
 
 DEFAULT_PATHS = "package.json".split(" ")
 
-pathToPackageJson = (pkg) ->
-  path.join(pkg, "package.json")
+pathToPackageJson = (packageFolder) ->
+  la(check.unemptyString(packageFolder), "expected package path", packageFolder)
+  path.join(packageFolder, "package.json")
 
 npmRun = (args, cwd, env = {}) ->
   command = "npm " + args.join(" ")
@@ -94,8 +95,8 @@ forceNpmInstall = (packagePath, packageToInstall) ->
   la(check.unemptyString(packageToInstall), "missing package to install")
   npmRun(["install", "--force", packageToInstall], packagePath)
 
-removeDevDependencies = (packagePath) ->
-  la(check.unemptyString(packagePath), "expected package path", packagePath)
+removeDevDependencies = (packageFolder) ->
+  packagePath = pathToPackageJson(packageFolder)
   console.log("removing devDependencies from %s", packagePath)
 
   fs.readJsonAsync(packagePath)

--- a/scripts/win-appveyor-build.js
+++ b/scripts/win-appveyor-build.js
@@ -12,13 +12,12 @@ const is = require('check-more-types')
 shell.set('-v') // verbose
 shell.set('-e') // any error is fatal
 
+// see what variables AppVeyor provides
 // https://www.appveyor.com/docs/environment-variables/
 
 const isRightBranch = () => {
   const branch = process.env.APPVEYOR_REPO_BRANCH
-  return branch === 'develop' ||
-    branch === 'win-build-shell' ||
-    branch === 'no-dev-deps-in-windows-binary-2896'
+  return branch === 'develop'
 }
 
 const isPullRequest = () => {

--- a/scripts/win-appveyor-build.js
+++ b/scripts/win-appveyor-build.js
@@ -49,12 +49,14 @@ shell.exec(`npm run binary-build -- --platform windows --version ${version}`)
 
 // make sure we are not including dev dependencies accidentally
 // https://github.com/cypress-io/cypress/issues/2896
-shell.exec('npm ls --prod --depth 0', {cwd: 'packages/server'})
-const result = shell.exec('npm ls --dev --depth 0', {cwd: 'packages/server'})
-if (result.stdout.includes('nodemon')) {
-  console.error('Hmm, server package includes dev dependency "nodemon"')
-  process.exit(1)
-}
+const serverPackageFolder = 'C:/projects/cypress/dist/win32/packages/server'
+shell.echo(`Checking prod and dev dependencies in ${serverPackageFolder}`)
+shell.exec('npm ls --prod --depth 0 || true', {cwd: serverPackageFolder})
+shell.exec('npm ls --dev --depth 0 || true', {cwd: serverPackageFolder})
+// if (result.stdout.includes('nodemon')) {
+//   console.error('Hmm, server package includes dev dependency "nodemon"')
+//   process.exit(1)
+// }
 
 shell.exec('npm run binary-zip')
 shell.ls('-l', '*.zip')

--- a/scripts/win-appveyor-build.js
+++ b/scripts/win-appveyor-build.js
@@ -48,15 +48,17 @@ shell.cat('npm-package-url.json')
 shell.exec(`npm run binary-build -- --platform windows --version ${version}`)
 
 // make sure we are not including dev dependencies accidentally
-// https://github.com/cypress-io/cypress/issues/2896
+// TODO how to get the server package folder?
 const serverPackageFolder = 'C:/projects/cypress/dist/win32/packages/server'
 shell.echo(`Checking prod and dev dependencies in ${serverPackageFolder}`)
 shell.exec('npm ls --prod --depth 0 || true', {cwd: serverPackageFolder})
-shell.exec('npm ls --dev --depth 0 || true', {cwd: serverPackageFolder})
-// if (result.stdout.includes('nodemon')) {
-//   console.error('Hmm, server package includes dev dependency "nodemon"')
-//   process.exit(1)
-// }
+const result = shell.exec('npm ls --dev --depth 0 || true', {cwd: serverPackageFolder})
+if (result.stdout.includes('nodemon')) {
+  console.error('Hmm, server package includes dev dependency "nodemon"')
+  console.error('which means somehow we are including dev dependencies in the output bundle')
+  console.error('see https://github.com/cypress-io/cypress/issues/2896')
+  process.exit(1)
+}
 
 shell.exec('npm run binary-zip')
 shell.ls('-l', '*.zip')


### PR DESCRIPTION
- closes #2896 

adds a check to prevent dev dependencies in `package/server` (see bottom of the code block)

```
✅ build completed
echo Checking prod and dev dependencies in C:/projects/cypress/dist/win32/packages/server
Checking prod and dev dependencies in C:/projects/cypress/dist/win32/packages/server
exec npm ls --prod --depth 0 || true { cwd: 'C:/projects/cypress/dist/win32/packages/server' }
@packages/server@0.0.0 C:\projects\cypress\dist\win32\packages\server
+-- @cypress/browserify-preprocessor@1.1.2
+-- @cypress/commit-info@2.0.0
+-- @cypress/icons@0.5.4
+-- @cypress/mocha-teamcity-reporter@1.0.0
+-- @ffmpeg-installer/ffmpeg@1.0.15
+-- @ffmpeg-installer/win32-ia32@4.0.4
+-- @ffmpeg-installer/win32-x64@4.0.3
+-- ansi_up@1.3.0
+-- bluebird@3.4.7
+-- browserify@13.3.0
+-- chai@1.10.0
+-- chalk@2.4.1
+-- check-more-types@2.24.0
+-- chokidar@1.6.0
+-- cjsxify@0.3.0
+-- clear-module@2.1.0
+-- cli-table2@0.2.0
+-- color-string@1.5.3
+-- common-tags@1.8.0
+-- compression@1.7.2
+-- concat-stream@1.6.2
+-- content-type@1.0.4
+-- cookie@0.2.4
+-- cookie-parser@1.4.3
+-- data-uri-to-buffer@0.0.4
+-- debug@2.6.9
+-- dependency-tree@6.3.0
+-- electron-context-menu@0.8.0
+-- electron-positioner@3.0.0
+-- errorhandler@1.1.1
+-- evil-dns@0.2.0
+-- execa@0.8.0
+-- express@4.16.2
+-- find-process@1.2.1
+-- fluent-ffmpeg@2.1.2
+-- fs-extra@4.0.3
+-- getos@2.8.4
+-- glob@7.1.2
+-- graceful-fs@4.1.15
+-- gulp-util@3.0.8
+-- hbs@4.0.0
+-- http-accept@0.1.6
+-- http-proxy@1.17.0
+-- http-status-codes@1.3.0
+-- human-interval@0.1.6
+-- image-size@0.5.5
+-- is-fork-pr@2.0.0
+-- jimp@0.2.28
+-- jsonlint@1.6.3
+-- konfig@0.2.1
+-- lazy-ass@1.6.0
+-- lockfile@1.0.4
+-- lodash@4.17.4
+-- log-symbols@2.2.0
+-- md5@2.2.1
+-- method-override@2.3.10
+-- mime@1.2.11
+-- minimatch@3.0.4
+-- minimist@1.2.0
+-- mocha@2.4.5
+-- mocha-junit-reporter@1.17.0
+-- moment@2.22.2
+-- morgan@1.3.0
+-- node-machine-id@1.1.10
+-- node-uuid@1.4.1
+-- node-webkit-updater@0.3.2 (github:cypress-io/node-webkit-updater#e74623726f381487f543e373e71515177a32daeb)
+-- opn@4.0.1 (github:cypress-io/opn#2f4e9a216ca7bdb95dfae9d46d99ddf004b3cbb5)
+-- ospath@1.2.2
+-- p-queue@1.2.0
+-- parse-domain@2.0.0
+-- pluralize@3.1.0
+-- pumpify@1.5.1
+-- ramda@0.24.1
+-- randomstring@1.1.5
+-- replacestream@4.0.3
+-- request@2.88.0
+-- request-promise@4.1.1
+-- return-deep-diff@0.2.9
+-- sanitize-filename@1.6.1
+-- semver@5.6.0
+-- send@0.14.2
+-- server-destroy@1.0.1
+-- shell-env@0.3.0
+-- signal-exit@3.0.2
+-- sinon@5.1.1
+-- string-to-stream@1.1.1
+-- strip-ansi@3.0.1
+-- supports-color@5.5.0
+-- syntax-error@1.4.0
+-- tar-fs@1.16.3
+-- term-size@1.2.0
+-- through@2.3.6
+-- tough-cookie@2.4.3
+-- trash@4.0.0
+-- underscore@1.9.1
+-- underscore.string@3.3.4
+-- url-parse@1.4.4
+-- widest-line@2.0.1
`-- winston@0.9.0
exec npm ls --dev --depth 0 || true { cwd: 'C:/projects/cypress/dist/win32/packages/server' }
@packages/server@0.0.0 C:\projects\cypress\dist\win32\packages\server
`-- (empty)
exec npm run binary-zip
```