### PR TITLE
Fix bailIfRecursive callback invocation

### DIFF
--- a/packages/driver/src/cypress/server.coffee
+++ b/packages/driver/src/cypress/server.coffee
@@ -368,7 +368,7 @@ create = (options = {}) ->
             return if isCalled
             isCalled = true
             try
-              return fn.apply(arguments)
+              return fn.apply(null, arguments)
             finally
               isCalled = false
 

--- a/packages/driver/test/cypress/integration/e2e/server_spec.coffee
+++ b/packages/driver/test/cypress/integration/e2e/server_spec.coffee
@@ -1,0 +1,8 @@
+describe "server", ->
+  it "passes event argument to xhr.onreadystatechange", (done) ->
+    cy.window().then (win) ->
+      xhr = new win.XMLHttpRequest()
+      xhr.onreadystatechange = (e) ->
+        expect(e).to.be.an.instanceof(win.Event)
+        done()
+      xhr.open("GET", "http://example.com")


### PR DESCRIPTION
Closes #2925

`fn.apply` shouldn't be called with `arguments` and no prior `this` value as this results in `arguments` being assigned as `this` for the function on which `.apply` is called...
