### PR TITLE
Revert "Revert "fix: upgrade sinon types to min TS 2.8 (#2966)""

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -23,7 +23,7 @@
     "test-cov": "nyc npm run unit",
     "unit": "BLUEBIRD_DEBUG=1 NODE_ENV=test bin-up mocha --reporter mocha-multi-reporters --reporter-options configFile=../mocha-reporter-config.json",
     "lint": "bin-up eslint --fix *.js bin/* lib/*.js lib/**/*.js test/*.js test/**/*.js",
-    "dtslint": "echo 'disabling dtslint for now'",
+    "dtslint": "dtslint types",
     "prebuild": "npm run test-dependencies && node ./scripts/start-build.js",
     "build": "node ./scripts/build.js",
     "prerelease": "npm run build",

--- a/cli/package.json
+++ b/cli/package.json
@@ -48,7 +48,7 @@
     "@types/lodash": "4.14.87",
     "@types/minimatch": "3.0.3",
     "@types/mocha": "2.2.44",
-    "@types/sinon": "4.0.0",
+    "@types/sinon": "7.0.0",
     "@types/sinon-chai": "2.7.29",
     "bluebird": "3.5.0",
     "cachedir": "1.3.0",
@@ -96,7 +96,7 @@
     "nyc": "13.0.0",
     "proxyquire": "2.0.1",
     "shelljs": "0.7.8",
-    "sinon": "5.0.7",
+    "sinon": "7.2.2",
     "snap-shot-it": "^5.0.0"
   },
   "files": [

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -4,7 +4,7 @@
 //                 Mike Woudenberg <https://github.com/mikewoudenberg>
 //                 Robbert van Markus <https://github.com/rvanmarkus>
 //                 Nicholas Boll <https://github.com/nicholasboll>
-// TypeScript Version: 2.5
+// TypeScript Version: 2.8
 // Updated by the Cypress team: https://www.cypress.io/about/
 
 /// <reference path="./blob-util.d.ts" />
@@ -3926,8 +3926,8 @@ declare namespace Cypress {
 
   // Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
   type Diff<T extends string, U extends string> = ({[P in T]: P } & {[P in U]: never } & { [x: string]: never })[T]
-  // @ts-ignore TODO - remove this if possible. Seems a recent change to TypeScript broke this. Possibly https://github.com/Microsoft/TypeScript/pull/17912
-  type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>
+  // TODO - remove this if possible. Seems a recent change to TypeScript broke this. Possibly https://github.com/Microsoft/TypeScript/pull/17912
+  type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>> // tslint:disable-line
 }
 
 /**


### PR DESCRIPTION
This reverts commit cc3de8ff78ece0a66edbca5ec12dd67c408f36aa.

enables `dtslint` again and upgrades TS to 2.8

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->
