### PR TITLE
Build osx on circle 2958

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ executors:
   # executor to run on Mac OS
   mac:
     macos:
-      xcode: "9.1.0"
+      xcode: "9.0.1"
     environment:
       PLATFORM: mac
 

--- a/circle.yml
+++ b/circle.yml
@@ -610,9 +610,18 @@ jobs:
 
 workflows:
   version: 2
-  build_and_test:
+
+  mac-build-and-test:
     jobs:
-      - mac-os-build
+      - build:
+          executor: mac
+
+  linux-build-and-test:
+    jobs:
+      #
+      # Linux builds
+      #
+
       # - build
       # - lint:
       #     requires:

--- a/circle.yml
+++ b/circle.yml
@@ -603,7 +603,9 @@ jobs:
             $(npm bin)/cypress run --record
 
   mac-os-build:
-    executor: mac
+    executor:
+      macos:
+        xcode: "10.1.0"
     steps:
       - run: security find-identity -p codesigning
       - run: security list-keychains

--- a/circle.yml
+++ b/circle.yml
@@ -619,12 +619,12 @@ jobs:
   #     - run: security list-keychains
 
 workflows:
-  mac-build-and-test:
+  linux:
     jobs:
       - build:
           name: Linux build
 
-  linux-build-and-test:
+  mac:
     jobs:
       - build:
           executor: mac

--- a/circle.yml
+++ b/circle.yml
@@ -24,11 +24,15 @@ executors:
   cy-doc:
     docker:
       - image: cypress/browsers:chrome64
+    environment:
+      PLATFORM: linux
 
   # executor to run on Mac OS
   mac:
     macos:
       xcode: "10.1.0"
+    environment:
+      PLATFORM: mac
 
 jobs:
   ## code checkout and NPM installs
@@ -402,14 +406,14 @@ jobs:
           command: node index.js
           working_directory: packages/launcher
 
-  "build-binary":
+  build-binary:
     <<: *defaults
     steps:
       - attach_workspace:
           at: ~/
       - run: $(npm bin)/print-arch
-      - run: npm run binary-build -- --platform linux --version $NEXT_DEV_VERSION
-      - run: npm run binary-zip -- --platform linux
+      - run: npm run binary-build -- --platform $PLATFORM --version $NEXT_DEV_VERSION
+      - run: npm run binary-zip -- --platform $PLATFORM
       - run: ls -l *.zip
       - run:
           name: upload unique binary
@@ -689,6 +693,7 @@ workflows:
             branches:
               only:
                 - develop
+                - build-osx-on-circle-2958
           requires:
             - build
       - test-next-version:
@@ -724,5 +729,15 @@ workflows:
       - lint:
           name: Mac lint
           executor: mac
+          requires:
+            - Mac build
+      # maybe run unit tests?
+      - build-binary:
+          name: Mac binary
+          filters:
+            branches:
+              only:
+                - develop
+                - build-osx-on-circle-2958
           requires:
             - Mac build

--- a/circle.yml
+++ b/circle.yml
@@ -53,37 +53,37 @@ jobs:
 
       # need to restore a separate cache for each package.json
       - restore_cache:
-          key: v5-{{ .Branch }}-cli-deps
+          key: v5-{{ arch }}-{{ .Branch }}-cli-deps
       - restore_cache:
-          key: v5-{{ .Branch }}-root-deps
+          key: v5-{{ arch }}-{{ .Branch }}-root-deps
       - restore_cache:
-          key: v5-{{ .Branch }}-deps-coffee
+          key: v5-{{ arch }}-{{ .Branch }}-deps-coffee
       - restore_cache:
-          key: v5-{{ .Branch }}-deps-desktop-gui
+          key: v5-{{ arch }}-{{ .Branch }}-deps-desktop-gui
       - restore_cache:
-          key: v5-{{ .Branch }}-deps-driver
+          key: v5-{{ arch }}-{{ .Branch }}-deps-driver
       - restore_cache:
-          key: v5-{{ .Branch }}-deps-example
+          key: v5-{{ arch }}-{{ .Branch }}-deps-example
       - restore_cache:
-          key: v7-{{ .Branch }}-deps-electron
+          key: v7-{{ arch }}-{{ .Branch }}-deps-electron
       - restore_cache:
-          key: v5-{{ .Branch }}-deps-extension
+          key: v5-{{ arch }}-{{ .Branch }}-deps-extension
       - restore_cache:
-          key: v5-{{ .Branch }}-deps-https-proxy
+          key: v5-{{ arch }}-{{ .Branch }}-deps-https-proxy
       - restore_cache:
-          key: v5-{{ .Branch }}-deps-launcher
+          key: v5-{{ arch }}-{{ .Branch }}-deps-launcher
       - restore_cache:
-          key: v5-{{ .Branch }}-deps-reporter
+          key: v5-{{ arch }}-{{ .Branch }}-deps-reporter
       - restore_cache:
-          key: v5-{{ .Branch }}-deps-runner
+          key: v5-{{ arch }}-{{ .Branch }}-deps-runner
       - restore_cache:
-          key: v5-{{ .Branch }}-deps-server
+          key: v5-{{ arch }}-{{ .Branch }}-deps-server
       - restore_cache:
-          key: v5-{{ .Branch }}-deps-socket
+          key: v5-{{ arch }}-{{ .Branch }}-deps-socket
       - restore_cache:
-          key: v5-{{ .Branch }}-deps-static
+          key: v5-{{ arch }}-{{ .Branch }}-deps-static
       - restore_cache:
-          key: v5-{{ .Branch }}-deps-ts
+          key: v5-{{ arch }}-{{ .Branch }}-deps-ts
 
       # show what is already cached globally
       - run: ls $(npm -g bin)
@@ -105,69 +105,69 @@ jobs:
 
       # save each node_modules folder per package
       - save_cache:
-          key: v5-{{ .Branch }}-cli-deps-{{ checksum "cli/package.json" }}
+          key: v5-{{ arch }}-{{ .Branch }}-cli-deps-{{ checksum "cli/package.json" }}
           paths:
             - cli/node_modules
       - save_cache:
-          key: v5-{{ .Branch }}-root-deps-{{ checksum "package.json" }}
+          key: v5-{{ arch }}-{{ .Branch }}-root-deps-{{ checksum "package.json" }}
           paths:
             - node_modules
       - save_cache:
-          key: v5-{{ .Branch }}-deps-coffee-{{ checksum "packages/coffee/package.json" }}
+          key: v5-{{ arch }}-{{ .Branch }}-deps-coffee-{{ checksum "packages/coffee/package.json" }}
           paths:
             - packages/coffee/node_modules
       - save_cache:
-          key: v5-{{ .Branch }}-deps-desktop-gui-{{ checksum "packages/desktop-gui/package.json" }}
+          key: v5-{{ arch }}-{{ .Branch }}-deps-desktop-gui-{{ checksum "packages/desktop-gui/package.json" }}
           paths:
             - packages/desktop-gui/node_modules
       - save_cache:
-          key: v5-{{ .Branch }}-deps-driver-{{ checksum "packages/driver/package.json" }}
+          key: v5-{{ arch }}-{{ .Branch }}-deps-driver-{{ checksum "packages/driver/package.json" }}
           paths:
             - packages/driver/node_modules
       - save_cache:
-          key: v5-{{ .Branch }}-deps-example-{{ checksum "packages/example/package.json" }}
+          key: v5-{{ arch }}-{{ .Branch }}-deps-example-{{ checksum "packages/example/package.json" }}
           paths:
             - packages/example/node_modules
       - save_cache:
-          key: v7-{{ .Branch }}-deps-electron-{{ checksum "packages/electron/package.json" }}
+          key: v7-{{ arch }}-{{ .Branch }}-deps-electron-{{ checksum "packages/electron/package.json" }}
           paths:
             - packages/electron/node_modules
             - ~/.cache/electron
             - ~/.electron
       - save_cache:
-          key: v5-{{ .Branch }}-deps-extension-{{ checksum "packages/extension/package.json" }}
+          key: v5-{{ arch }}-{{ .Branch }}-deps-extension-{{ checksum "packages/extension/package.json" }}
           paths:
             - packages/extension/node_modules
       - save_cache:
-          key: v5-{{ .Branch }}-deps-https-proxy-{{ checksum "packages/https-proxy/package.json" }}
+          key: v5-{{ arch }}-{{ .Branch }}-deps-https-proxy-{{ checksum "packages/https-proxy/package.json" }}
           paths:
             - packages/https-proxy/node_modules
       - save_cache:
-          key: v5-{{ .Branch }}-deps-launcher-{{ checksum "packages/launcher/package.json" }}
+          key: v5-{{ arch }}-{{ .Branch }}-deps-launcher-{{ checksum "packages/launcher/package.json" }}
           paths:
             - packages/launcher/node_modules
       - save_cache:
-          key: v5-{{ .Branch }}-deps-reporter-{{ checksum "packages/reporter/package.json" }}
+          key: v5-{{ arch }}-{{ .Branch }}-deps-reporter-{{ checksum "packages/reporter/package.json" }}
           paths:
             - packages/reporter/node_modules
       - save_cache:
-          key: v5-{{ .Branch }}-deps-runner-{{ checksum "packages/runner/package.json" }}
+          key: v5-{{ arch }}-{{ .Branch }}-deps-runner-{{ checksum "packages/runner/package.json" }}
           paths:
             - packages/runner/node_modules
       - save_cache:
-          key: v5-{{ .Branch }}-deps-server-{{ checksum "packages/server/package.json" }}
+          key: v5-{{ arch }}-{{ .Branch }}-deps-server-{{ checksum "packages/server/package.json" }}
           paths:
             - packages/server/node_modules
       - save_cache:
-          key: v5-{{ .Branch }}-deps-socket-{{ checksum "packages/socket/package.json" }}
+          key: v5-{{ arch }}-{{ .Branch }}-deps-socket-{{ checksum "packages/socket/package.json" }}
           paths:
             - packages/socket/node_modules
       - save_cache:
-          key: v5-{{ .Branch }}-deps-static-{{ checksum "packages/static/package.json" }}
+          key: v5-{{ arch }}-{{ .Branch }}-deps-static-{{ checksum "packages/static/package.json" }}
           paths:
             - packages/static/node_modules
       - save_cache:
-          key: v5-{{ .Branch }}-deps-ts-{{ checksum "packages/ts/package.json" }}
+          key: v5-{{ arch }}-{{ .Branch }}-deps-ts-{{ checksum "packages/ts/package.json" }}
           paths:
             - packages/ts/node_modules
 

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,11 @@ defaults: &defaults
         COLUMNS: 100
         LINES: 24
 
+executors:
+  mac:
+    macos:
+      xcode: "10.1.0"
+
 jobs:
   ## code checkout and NPM installs
   build:
@@ -597,108 +602,115 @@ jobs:
             CYPRESS_ENV=staging \
             $(npm bin)/cypress run --record
 
+  mac-os-build:
+    executor: mac
+    steps:
+      - run: security find-identity -p codesigning
+      - run: security list-keychains
+
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
-      - lint:
-          requires:
-            - build
-      # unit, integration and e2e tests
-      - unit-tests:
-          requires:
-            - build
-      - server-unit-tests:
-          requires:
-            - build
-      - server-integration-tests:
-          requires:
-            - build
-      - server-e2e-tests-1:
-          requires:
-            - build
-      - server-e2e-tests-2:
-          requires:
-            - build
-      - server-e2e-tests-3:
-          requires:
-            - build
-      - server-e2e-tests-4:
-          requires:
-            - build
-      - server-e2e-tests-5:
-          requires:
-            - build
-      - server-e2e-tests-6:
-          requires:
-            - build
-      - server-e2e-tests-7:
-          requires:
-            - build
-      - server-e2e-tests-8:
-          requires:
-            - build
-      - 3x-driver-integration-tests:
-          requires:
-            - build
-      - 2x-desktop-gui-integration-tests:
-          requires:
-            - build
-      - run-launcher:
-          requires:
-            - build
-      # various testing scenarios, like building full binary
-      # and testing it on a real project
-      - test-against-staging:
-          filters:
-            branches:
-              only:
-                - develop
-          requires:
-            - build
-      - test-kitchensink-against-staging:
-          filters:
-            branches:
-              only:
-                - develop
-          requires:
-            - build
-      - build-npm-package:
-          filters:
-            branches:
-              only:
-                - develop
-          requires:
-            - build
-      - build-binary:
-          filters:
-            branches:
-              only:
-                - develop
-          requires:
-            - build
-      - test-next-version:
-          filters:
-            branches:
-              only:
-                - develop
-          requires:
-            - build-npm-package
-            - build-binary
-      - test-next-version-locally:
-          filters:
-            branches:
-              only:
-                - develop
-          requires:
-            - build-npm-package
-            - build-binary
-      - test-binary-against-staging:
-          filters:
-            branches:
-              only:
-                - develop
-          requires:
-            - build-npm-package
-            - build-binary
+      - mac-os-build
+      # - build
+      # - lint:
+      #     requires:
+      #       - build
+      # # unit, integration and e2e tests
+      # - unit-tests:
+      #     requires:
+      #       - build
+      # - server-unit-tests:
+      #     requires:
+      #       - build
+      # - server-integration-tests:
+      #     requires:
+      #       - build
+      # - server-e2e-tests-1:
+      #     requires:
+      #       - build
+      # - server-e2e-tests-2:
+      #     requires:
+      #       - build
+      # - server-e2e-tests-3:
+      #     requires:
+      #       - build
+      # - server-e2e-tests-4:
+      #     requires:
+      #       - build
+      # - server-e2e-tests-5:
+      #     requires:
+      #       - build
+      # - server-e2e-tests-6:
+      #     requires:
+      #       - build
+      # - server-e2e-tests-7:
+      #     requires:
+      #       - build
+      # - server-e2e-tests-8:
+      #     requires:
+      #       - build
+      # - 3x-driver-integration-tests:
+      #     requires:
+      #       - build
+      # - 2x-desktop-gui-integration-tests:
+      #     requires:
+      #       - build
+      # - run-launcher:
+      #     requires:
+      #       - build
+      # # various testing scenarios, like building full binary
+      # # and testing it on a real project
+      # - test-against-staging:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - develop
+      #     requires:
+      #       - build
+      # - test-kitchensink-against-staging:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - develop
+      #     requires:
+      #       - build
+      # - build-npm-package:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - develop
+      #     requires:
+      #       - build
+      # - build-binary:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - develop
+      #     requires:
+      #       - build
+      # - test-next-version:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - develop
+      #     requires:
+      #       - build-npm-package
+      #       - build-binary
+      # - test-next-version-locally:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - develop
+      #     requires:
+      #       - build-npm-package
+      #       - build-binary
+      # - test-binary-against-staging:
+          # filters:
+          #   branches:
+          #     only:
+          #       - develop
+          # requires:
+            # - build-npm-package
+            # - build-binary

--- a/circle.yml
+++ b/circle.yml
@@ -3,21 +3,26 @@ version: 2.1
 defaults: &defaults
   parallelism: 1
   working_directory: ~/cypress
-  docker:
-    # the Docker image with Cypress dependencies and Chrome browser
-    - image: cypress/browsers:chrome64
-      environment:
-        ## set specific timezone
-        TZ: "/usr/share/zoneinfo/America/New_York"
+  # docker:
+  #   # the Docker image with Cypress dependencies and Chrome browser
+  #   - image: cypress/browsers:chrome64
+  environment:
+    ## set specific timezone
+    TZ: "/usr/share/zoneinfo/America/New_York"
 
-        ## store artifacts here
-        CIRCLE_ARTIFACTS: /tmp/artifacts
+    ## store artifacts here
+    CIRCLE_ARTIFACTS: /tmp/artifacts
 
-        ## set so that e2e tests are consistent
-        COLUMNS: 100
-        LINES: 24
+    ## set so that e2e tests are consistent
+    COLUMNS: 100
+    LINES: 24
 
 executors:
+  # the Docker image with Cypress dependencies and Chrome browser
+  cy-doc:
+    docker:
+      - image: cypress/browsers:chrome64
+
   mac:
     macos:
       xcode: "10.1.0"
@@ -26,6 +31,11 @@ jobs:
   ## code checkout and NPM installs
   build:
     <<: *defaults
+    parameters:
+      executor:
+        type: executor
+        default: cy-doc
+    executor: <<parameters.executor>>
     steps:
       - checkout
 
@@ -188,441 +198,438 @@ jobs:
           paths:
             - cypress
 
-  lint:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run: npm run lint
-      - run: npm run all lint
+  # lint:
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run: npm run lint
+  #     - run: npm run all lint
 
-  "unit-tests":
-    <<: *defaults
-    parallelism: 1
-    steps:
-      - attach_workspace:
-          at: ~/
-      # make sure mocha runs
-      - run: npm run test-mocha
-      # make sure our snapshots are compared correctly
-      - run: npm run test-mocha-snapshot
-      # run unit tests from individual packages
-      - run: npm run all test -- --package cli
-      - run: npm run all test -- --package electron
-      - run: npm run all test -- --package extension
-      - run: npm run all test -- --package https-proxy
-      - run: npm run all test -- --package launcher
-      # how to pass Mocha reporter through zunder?
-      - run: npm run all test -- --package reporter
-      - run: npm run all test -- --package runner
-      - run: npm run all test -- --package socket
-      - run: npm run all test -- --package static
-      - store_test_results:
-          path: /tmp/cypress
+  # "unit-tests":
+  #   <<: *defaults
+  #   parallelism: 1
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     # make sure mocha runs
+  #     - run: npm run test-mocha
+  #     # make sure our snapshots are compared correctly
+  #     - run: npm run test-mocha-snapshot
+  #     # run unit tests from individual packages
+  #     - run: npm run all test -- --package cli
+  #     - run: npm run all test -- --package electron
+  #     - run: npm run all test -- --package extension
+  #     - run: npm run all test -- --package https-proxy
+  #     - run: npm run all test -- --package launcher
+  #     # how to pass Mocha reporter through zunder?
+  #     - run: npm run all test -- --package reporter
+  #     - run: npm run all test -- --package runner
+  #     - run: npm run all test -- --package socket
+  #     - run: npm run all test -- --package static
+  #     - store_test_results:
+  #         path: /tmp/cypress
 
-  "server-unit-tests":
-    <<: *defaults
-    parallelism: 2
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run: npm run all test-unit -- --package server
-      - store_test_results:
-          path: /tmp/cypress
+  # "server-unit-tests":
+  #   <<: *defaults
+  #   parallelism: 2
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run: npm run all test-unit -- --package server
+  #     - store_test_results:
+  #         path: /tmp/cypress
 
-  "server-integration-tests":
-    <<: *defaults
-    parallelism: 2
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run: npm run all test-integration -- --package server
-      - store_test_results:
-          path: /tmp/cypress
+  # "server-integration-tests":
+  #   <<: *defaults
+  #   parallelism: 2
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run: npm run all test-integration -- --package server
+  #     - store_test_results:
+  #         path: /tmp/cypress
 
-  "server-e2e-tests-1":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          command: npm run test-e2e -- --chunk 1
-          working_directory: packages/server
-      - store_test_results:
-          path: /tmp/cypress
+  # "server-e2e-tests-1":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run:
+  #         command: npm run test-e2e -- --chunk 1
+  #         working_directory: packages/server
+  #     - store_test_results:
+  #         path: /tmp/cypress
 
-  "server-e2e-tests-2":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          command: npm run test-e2e -- --chunk 2
-          working_directory: packages/server
-      - store_test_results:
-          path: /tmp/cypress
+  # "server-e2e-tests-2":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run:
+  #         command: npm run test-e2e -- --chunk 2
+  #         working_directory: packages/server
+  #     - store_test_results:
+  #         path: /tmp/cypress
 
-  "server-e2e-tests-3":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          command: npm run test-e2e -- --chunk 3
-          working_directory: packages/server
-      - store_test_results:
-          path: /tmp/cypress
+  # "server-e2e-tests-3":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run:
+  #         command: npm run test-e2e -- --chunk 3
+  #         working_directory: packages/server
+  #     - store_test_results:
+  #         path: /tmp/cypress
 
-  "server-e2e-tests-4":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          command: npm run test-e2e -- --chunk 4
-          working_directory: packages/server
-      - store_test_results:
-          path: /tmp/cypress
+  # "server-e2e-tests-4":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run:
+  #         command: npm run test-e2e -- --chunk 4
+  #         working_directory: packages/server
+  #     - store_test_results:
+  #         path: /tmp/cypress
 
-  "server-e2e-tests-5":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          command: npm run test-e2e -- --chunk 5
-          working_directory: packages/server
-      - store_test_results:
-          path: /tmp/cypress
+  # "server-e2e-tests-5":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run:
+  #         command: npm run test-e2e -- --chunk 5
+  #         working_directory: packages/server
+  #     - store_test_results:
+  #         path: /tmp/cypress
 
-  "server-e2e-tests-6":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          command: npm run test-e2e -- --chunk 6
-          working_directory: packages/server
-      - store_test_results:
-          path: /tmp/cypress
+  # "server-e2e-tests-6":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run:
+  #         command: npm run test-e2e -- --chunk 6
+  #         working_directory: packages/server
+  #     - store_test_results:
+  #         path: /tmp/cypress
 
-  "server-e2e-tests-7":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          command: npm run test-e2e -- --chunk 7
-          working_directory: packages/server
-      - store_test_results:
-          path: /tmp/cypress
+  # "server-e2e-tests-7":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run:
+  #         command: npm run test-e2e -- --chunk 7
+  #         working_directory: packages/server
+  #     - store_test_results:
+  #         path: /tmp/cypress
 
-  "server-e2e-tests-8":
-      <<: *defaults
-      steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          command: npm run test-e2e -- --chunk 8
-          working_directory: packages/server
-      - store_test_results:
-          path: /tmp/cypress
+  # "server-e2e-tests-8":
+  #     <<: *defaults
+  #     steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run:
+  #         command: npm run test-e2e -- --chunk 8
+  #         working_directory: packages/server
+  #     - store_test_results:
+  #         path: /tmp/cypress
 
-  "driver-integration-tests-3x":
-    <<: *defaults
-    parallelism: 3
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          command: npm start
-          background: true
-          working_directory: packages/driver
-      - run:
-          command: $(npm bin)/wait-on http://localhost:3500
-          working_directory: packages/driver
-      - run:
-          command: |
-            CYPRESS_KONFIG_ENV=production \
-            CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-            npm run cypress:run -- --record --parallel --group 3x-driver-chrome --browser chrome
-          working_directory: packages/driver
-      - store_test_results:
-          path: /tmp/cypress
-      - store_artifacts:
-          path: /tmp/artifacts
+  # "driver-integration-tests-3x":
+  #   <<: *defaults
+  #   parallelism: 3
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run:
+  #         command: npm start
+  #         background: true
+  #         working_directory: packages/driver
+  #     - run:
+  #         command: $(npm bin)/wait-on http://localhost:3500
+  #         working_directory: packages/driver
+  #     - run:
+  #         command: |
+  #           CYPRESS_KONFIG_ENV=production \
+  #           CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
+  #           npm run cypress:run -- --record --parallel --group 3x-driver-chrome --browser chrome
+  #         working_directory: packages/driver
+  #     - store_test_results:
+  #         path: /tmp/cypress
+  #     - store_artifacts:
+  #         path: /tmp/artifacts
 
-  "desktop-gui-integration-tests-2x":
-    <<: *defaults
-    parallelism: 2
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          command: npm run build-prod
-          working_directory: packages/desktop-gui
-      - run:
-          command: |
-            CYPRESS_KONFIG_ENV=production \
-            CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-            npm run cypress:run -- --record --parallel --group 2x-desktop-gui
-          working_directory: packages/desktop-gui
-      - store_test_results:
-          path: /tmp/cypress
-      - store_artifacts:
-          path: /tmp/artifacts
+  # "desktop-gui-integration-tests-2x":
+  #   <<: *defaults
+  #   parallelism: 2
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run:
+  #         command: npm run build-prod
+  #         working_directory: packages/desktop-gui
+  #     - run:
+  #         command: |
+  #           CYPRESS_KONFIG_ENV=production \
+  #           CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
+  #           npm run cypress:run -- --record --parallel --group 2x-desktop-gui
+  #         working_directory: packages/desktop-gui
+  #     - store_test_results:
+  #         path: /tmp/cypress
+  #     - store_artifacts:
+  #         path: /tmp/artifacts
 
-  "reporter-integration-tests":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          command: npm run build-prod
-          working_directory: packages/reporter
-      - run:
-          command: |
-            CYPRESS_KONFIG_ENV=production \
-            CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-            npm run cypress:run -- --record --parallel --group reporter
-          working_directory: packages/reporter
-      - store_test_results:
-          path: /tmp/cypress
-      - store_artifacts:
-          path: /tmp/artifacts
+  # "reporter-integration-tests":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run:
+  #         command: npm run build-prod
+  #         working_directory: packages/reporter
+  #     - run:
+  #         command: |
+  #           CYPRESS_KONFIG_ENV=production \
+  #           CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
+  #           npm run cypress:run -- --record --parallel --group reporter
+  #         working_directory: packages/reporter
+  #     - store_test_results:
+  #         path: /tmp/cypress
+  #     - store_artifacts:
+  #         path: /tmp/artifacts
 
-  "run-launcher":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          command: node index.js
-          working_directory: packages/launcher
+  # "run-launcher":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run:
+  #         command: node index.js
+  #         working_directory: packages/launcher
 
-  "build-binary":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run: $(npm bin)/print-arch
-      - run: npm run binary-build -- --platform linux --version $NEXT_DEV_VERSION
-      - run: npm run binary-zip -- --platform linux
-      - run: ls -l *.zip
-      - run:
-          name: upload unique binary
-          command: |
-            node scripts/binary.js upload-unique-binary \
-              --file cypress.zip \
-              --version $NEXT_DEV_VERSION
-      - run: cat binary-url.json
-      - run: mkdir /tmp/urls
-      - run: cp binary-url.json /tmp/urls
-      - run: cp cypress.zip /tmp/urls
-      - run: ls /tmp/urls
-      - persist_to_workspace:
-          root: /tmp/urls
-          paths:
-            - binary-url.json
-            - cypress.zip
+  # "build-binary":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run: $(npm bin)/print-arch
+  #     - run: npm run binary-build -- --platform linux --version $NEXT_DEV_VERSION
+  #     - run: npm run binary-zip -- --platform linux
+  #     - run: ls -l *.zip
+  #     - run:
+  #         name: upload unique binary
+  #         command: |
+  #           node scripts/binary.js upload-unique-binary \
+  #             --file cypress.zip \
+  #             --version $NEXT_DEV_VERSION
+  #     - run: cat binary-url.json
+  #     - run: mkdir /tmp/urls
+  #     - run: cp binary-url.json /tmp/urls
+  #     - run: cp cypress.zip /tmp/urls
+  #     - run: ls /tmp/urls
+  #     - persist_to_workspace:
+  #         root: /tmp/urls
+  #         paths:
+  #           - binary-url.json
+  #           - cypress.zip
 
-  "test-kitchensink-against-staging":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Cloning test project
-          command: git clone https://github.com/cypress-io/cypress-example-kitchensink.git /tmp/repo
-      - run:
-          name: Install prod dependencies
-          command: npm install --production
-          working_directory: /tmp/repo
-      - run:
-          name: Example server
-          command: npm start
-          working_directory: /tmp/repo
-          background: true
-      - run:
-          name: Run Kitchensink example project
-          command: |
-            CYPRESS_PROJECT_ID=$TEST_KITCHENSINK_PROJECT_ID \
-            CYPRESS_RECORD_KEY=$TEST_KITCHENSINK_RECORD_KEY \
-            CYPRESS_ENV=staging \
-            CYPRESS_video=false \
-            npm run cypress:run -- --project /tmp/repo --record
+  # "test-kitchensink-against-staging":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run:
+  #         name: Cloning test project
+  #         command: git clone https://github.com/cypress-io/cypress-example-kitchensink.git /tmp/repo
+  #     - run:
+  #         name: Install prod dependencies
+  #         command: npm install --production
+  #         working_directory: /tmp/repo
+  #     - run:
+  #         name: Example server
+  #         command: npm start
+  #         working_directory: /tmp/repo
+  #         background: true
+  #     - run:
+  #         name: Run Kitchensink example project
+  #         command: |
+  #           CYPRESS_PROJECT_ID=$TEST_KITCHENSINK_PROJECT_ID \
+  #           CYPRESS_RECORD_KEY=$TEST_KITCHENSINK_RECORD_KEY \
+  #           CYPRESS_ENV=staging \
+  #           CYPRESS_video=false \
+  #           npm run cypress:run -- --project /tmp/repo --record
 
-  "test-against-staging":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Cloning test project
-          command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/repo
-      - run:
-          name: Run test project
-          command: |
-            CYPRESS_PROJECT_ID=$TEST_TINY_PROJECT_ID \
-            CYPRESS_RECORD_KEY=$TEST_TINY_RECORD_KEY \
-            CYPRESS_ENV=staging \
-            npm run cypress:run -- --project /tmp/repo --record
+  # "test-against-staging":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run:
+  #         name: Cloning test project
+  #         command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/repo
+  #     - run:
+  #         name: Run test project
+  #         command: |
+  #           CYPRESS_PROJECT_ID=$TEST_TINY_PROJECT_ID \
+  #           CYPRESS_RECORD_KEY=$TEST_TINY_RECORD_KEY \
+  #           CYPRESS_ENV=staging \
+  #           npm run cypress:run -- --project /tmp/repo --record
 
-  "build-npm-package":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: bump NPM version
-          command: npm --no-git-tag-version version $NEXT_DEV_VERSION
-      - run:
-          name: build NPM package
-          working_directory: cli
-          command: npm run build
-      - run:
-          name: list NPM package contents
-          working_directory: cli/build
-          command: npm run size
-      - run:
-          name: pack NPM package
-          working_directory: cli/build
-          command: npm pack
-      - run:
-          name: list created NPM package
-          working_directory: cli/build
-          command: ls -l
-      # created file should have filename cypress-<version>.tgz
-      - run:
-          name: upload NPM package
-          command: |
-            node scripts/binary.js upload-npm-package \
-              --file cli/build/cypress-$NEXT_DEV_VERSION.tgz \
-              --version $NEXT_DEV_VERSION
-      - run: cat npm-package-url.json
-      - run: mkdir /tmp/urls
-      - run: cp cli/build/cypress-$NEXT_DEV_VERSION.tgz /tmp/urls/cypress.tgz
-      - run: cp npm-package-url.json /tmp/urls
-      - run: ls /tmp/urls
-      - persist_to_workspace:
-          root: /tmp/urls
-          paths:
-            - npm-package-url.json
-            - cypress.tgz
+  # "build-npm-package":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - run:
+  #         name: bump NPM version
+  #         command: npm --no-git-tag-version version $NEXT_DEV_VERSION
+  #     - run:
+  #         name: build NPM package
+  #         working_directory: cli
+  #         command: npm run build
+  #     - run:
+  #         name: list NPM package contents
+  #         working_directory: cli/build
+  #         command: npm run size
+  #     - run:
+  #         name: pack NPM package
+  #         working_directory: cli/build
+  #         command: npm pack
+  #     - run:
+  #         name: list created NPM package
+  #         working_directory: cli/build
+  #         command: ls -l
+  #     # created file should have filename cypress-<version>.tgz
+  #     - run:
+  #         name: upload NPM package
+  #         command: |
+  #           node scripts/binary.js upload-npm-package \
+  #             --file cli/build/cypress-$NEXT_DEV_VERSION.tgz \
+  #             --version $NEXT_DEV_VERSION
+  #     - run: cat npm-package-url.json
+  #     - run: mkdir /tmp/urls
+  #     - run: cp cli/build/cypress-$NEXT_DEV_VERSION.tgz /tmp/urls/cypress.tgz
+  #     - run: cp npm-package-url.json /tmp/urls
+  #     - run: ls /tmp/urls
+  #     - persist_to_workspace:
+  #         root: /tmp/urls
+  #         paths:
+  #           - npm-package-url.json
+  #           - cypress.tgz
 
-  "test-next-version":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - attach_workspace:
-          at: /tmp/urls
-      - run: ls -la /tmp/urls
-      - run: cat /tmp/urls/*.json
-      - run: mkdir /tmp/testing
-      - run:
-          name: create dummy package
-          working_directory: /tmp/testing
-          command: npm init -y
-      - run:
-          # install NPM from unique urls
-          name: Install Cypress
-          command: |
-            node scripts/test-unique-npm-and-binary.js \
-              --npm /tmp/urls/npm-package-url.json \
-              --binary /tmp/urls/binary-url.json \
-              --cwd /tmp/testing
-      - run:
-          name: Verify Cypress binary
-          working_directory: /tmp/testing
-          command: $(npm bin)/cypress verify
-      - run:
-          name: Running other test projects with new NPM package and binary
-          command: |
-            node scripts/test-other-projects.js \
-              --npm /tmp/urls/npm-package-url.json \
-              --binary /tmp/urls/binary-url.json \
-              --provider circle
+  # "test-next-version":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - attach_workspace:
+  #         at: /tmp/urls
+  #     - run: ls -la /tmp/urls
+  #     - run: cat /tmp/urls/*.json
+  #     - run: mkdir /tmp/testing
+  #     - run:
+  #         name: create dummy package
+  #         working_directory: /tmp/testing
+  #         command: npm init -y
+  #     - run:
+  #         # install NPM from unique urls
+  #         name: Install Cypress
+  #         command: |
+  #           node scripts/test-unique-npm-and-binary.js \
+  #             --npm /tmp/urls/npm-package-url.json \
+  #             --binary /tmp/urls/binary-url.json \
+  #             --cwd /tmp/testing
+  #     - run:
+  #         name: Verify Cypress binary
+  #         working_directory: /tmp/testing
+  #         command: $(npm bin)/cypress verify
+  #     - run:
+  #         name: Running other test projects with new NPM package and binary
+  #         command: |
+  #           node scripts/test-other-projects.js \
+  #             --npm /tmp/urls/npm-package-url.json \
+  #             --binary /tmp/urls/binary-url.json \
+  #             --provider circle
 
-  "test-next-version-locally":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - attach_workspace:
-          at: /tmp/urls
-      # make sure we have cypress.zip received
-      - run: ls -l /tmp/urls/cypress.zip
-      # build NPM package
-      - run:
-          command: npm run build
-          working_directory: cli
-      - run: mkdir test-binary
-      - run:
-          name: Create new NPM package
-          working_directory: test-binary
-          command: npm init -y
-      - run:
-          # install NPM from built NPM package folder
-          name: Install Cypress
-          working_directory: test-binary
-          # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=/tmp/urls/cypress.zip npm i ../cli/build
-      - run:
-          name: Verify Cypress binary
-          working_directory: test-binary
-          command: $(npm bin)/cypress verify
+  # "test-next-version-locally":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - attach_workspace:
+  #         at: /tmp/urls
+  #     # make sure we have cypress.zip received
+  #     - run: ls -l /tmp/urls/cypress.zip
+  #     # build NPM package
+  #     - run:
+  #         command: npm run build
+  #         working_directory: cli
+  #     - run: mkdir test-binary
+  #     - run:
+  #         name: Create new NPM package
+  #         working_directory: test-binary
+  #         command: npm init -y
+  #     - run:
+  #         # install NPM from built NPM package folder
+  #         name: Install Cypress
+  #         working_directory: test-binary
+  #         # force installing the freshly built binary
+  #         command: CYPRESS_INSTALL_BINARY=/tmp/urls/cypress.zip npm i ../cli/build
+  #     - run:
+  #         name: Verify Cypress binary
+  #         working_directory: test-binary
+  #         command: $(npm bin)/cypress verify
 
-  # install NPM + binary zip and run against staging API
-  "test-binary-against-staging":
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - attach_workspace:
-          at: /tmp/urls
-      # make sure we have the binary
-      - run: ls -l /tmp/urls/cypress.zip
-      # make sure we have the NPM package
-      - run: ls -l /tmp/urls/cypress.tgz
-      - run:
-          name: Cloning test project
-          command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/cypress-test-tiny
-      - run:
-          name: Install Cypress
-          working_directory: /tmp/cypress-test-tiny
-          # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=/tmp/urls/cypress.zip npm i /tmp/urls/cypress.tgz
-      - run:
-          name: Run test project
-          working_directory: /tmp/cypress-test-tiny
-          command: |
-            CYPRESS_PROJECT_ID=$TEST_TINY_PROJECT_ID \
-            CYPRESS_RECORD_KEY=$TEST_TINY_RECORD_KEY \
-            CYPRESS_ENV=staging \
-            $(npm bin)/cypress run --record
+  # # install NPM + binary zip and run against staging API
+  # "test-binary-against-staging":
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: ~/
+  #     - attach_workspace:
+  #         at: /tmp/urls
+  #     # make sure we have the binary
+  #     - run: ls -l /tmp/urls/cypress.zip
+  #     # make sure we have the NPM package
+  #     - run: ls -l /tmp/urls/cypress.tgz
+  #     - run:
+  #         name: Cloning test project
+  #         command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/cypress-test-tiny
+  #     - run:
+  #         name: Install Cypress
+  #         working_directory: /tmp/cypress-test-tiny
+  #         # force installing the freshly built binary
+  #         command: CYPRESS_INSTALL_BINARY=/tmp/urls/cypress.zip npm i /tmp/urls/cypress.tgz
+  #     - run:
+  #         name: Run test project
+  #         working_directory: /tmp/cypress-test-tiny
+  #         command: |
+  #           CYPRESS_PROJECT_ID=$TEST_TINY_PROJECT_ID \
+  #           CYPRESS_RECORD_KEY=$TEST_TINY_RECORD_KEY \
+  #           CYPRESS_ENV=staging \
+  #           $(npm bin)/cypress run --record
 
-  mac-os-build:
-    executor: mac
-    steps:
-      - run: security find-identity -p codesigning
-      - run: security list-keychains
+  # mac-os-build:
+  #   executor: mac
+  #   steps:
+  #     - run: security find-identity -p codesigning
+  #     - run: security list-keychains
 
 workflows:
-  version: 2
-
   mac-build-and-test:
     jobs:
       - build:
-          executor: mac
+          name: Linux build
 
   linux-build-and-test:
     jobs:
-      #
-      # Linux builds
-      #
+      - build:
+          executor: mac
+          name: Mac build
 
-      # - build
       # - lint:
       #     requires:
       #       - build

--- a/circle.yml
+++ b/circle.yml
@@ -198,411 +198,411 @@ jobs:
       - run: npm run lint
       - run: npm run all lint
 
-  # "unit-tests":
-  #   <<: *defaults
-  #   parallelism: 1
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     # make sure mocha runs
-  #     - run: npm run test-mocha
-  #     # make sure our snapshots are compared correctly
-  #     - run: npm run test-mocha-snapshot
-  #     # run unit tests from individual packages
-  #     - run: npm run all test -- --package cli
-  #     - run: npm run all test -- --package electron
-  #     - run: npm run all test -- --package extension
-  #     - run: npm run all test -- --package https-proxy
-  #     - run: npm run all test -- --package launcher
-  #     # how to pass Mocha reporter through zunder?
-  #     - run: npm run all test -- --package reporter
-  #     - run: npm run all test -- --package runner
-  #     - run: npm run all test -- --package socket
-  #     - run: npm run all test -- --package static
-  #     - store_test_results:
-  #         path: /tmp/cypress
+  unit-tests:
+    <<: *defaults
+    parallelism: 1
+    steps:
+      - attach_workspace:
+          at: ~/
+      # make sure mocha runs
+      - run: npm run test-mocha
+      # make sure our snapshots are compared correctly
+      - run: npm run test-mocha-snapshot
+      # run unit tests from individual packages
+      - run: npm run all test -- --package cli
+      - run: npm run all test -- --package electron
+      - run: npm run all test -- --package extension
+      - run: npm run all test -- --package https-proxy
+      - run: npm run all test -- --package launcher
+      # how to pass Mocha reporter through zunder?
+      - run: npm run all test -- --package reporter
+      - run: npm run all test -- --package runner
+      - run: npm run all test -- --package socket
+      - run: npm run all test -- --package static
+      - store_test_results:
+          path: /tmp/cypress
 
-  # "server-unit-tests":
-  #   <<: *defaults
-  #   parallelism: 2
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run: npm run all test-unit -- --package server
-  #     - store_test_results:
-  #         path: /tmp/cypress
+  "server-unit-tests":
+    <<: *defaults
+    parallelism: 2
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: npm run all test-unit -- --package server
+      - store_test_results:
+          path: /tmp/cypress
 
-  # "server-integration-tests":
-  #   <<: *defaults
-  #   parallelism: 2
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run: npm run all test-integration -- --package server
-  #     - store_test_results:
-  #         path: /tmp/cypress
+  "server-integration-tests":
+    <<: *defaults
+    parallelism: 2
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: npm run all test-integration -- --package server
+      - store_test_results:
+          path: /tmp/cypress
 
-  # "server-e2e-tests-1":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         command: npm run test-e2e -- --chunk 1
-  #         working_directory: packages/server
-  #     - store_test_results:
-  #         path: /tmp/cypress
+  "server-e2e-tests-1":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          command: npm run test-e2e -- --chunk 1
+          working_directory: packages/server
+      - store_test_results:
+          path: /tmp/cypress
 
-  # "server-e2e-tests-2":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         command: npm run test-e2e -- --chunk 2
-  #         working_directory: packages/server
-  #     - store_test_results:
-  #         path: /tmp/cypress
+  "server-e2e-tests-2":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          command: npm run test-e2e -- --chunk 2
+          working_directory: packages/server
+      - store_test_results:
+          path: /tmp/cypress
 
-  # "server-e2e-tests-3":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         command: npm run test-e2e -- --chunk 3
-  #         working_directory: packages/server
-  #     - store_test_results:
-  #         path: /tmp/cypress
+  "server-e2e-tests-3":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          command: npm run test-e2e -- --chunk 3
+          working_directory: packages/server
+      - store_test_results:
+          path: /tmp/cypress
 
-  # "server-e2e-tests-4":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         command: npm run test-e2e -- --chunk 4
-  #         working_directory: packages/server
-  #     - store_test_results:
-  #         path: /tmp/cypress
+  "server-e2e-tests-4":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          command: npm run test-e2e -- --chunk 4
+          working_directory: packages/server
+      - store_test_results:
+          path: /tmp/cypress
 
-  # "server-e2e-tests-5":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         command: npm run test-e2e -- --chunk 5
-  #         working_directory: packages/server
-  #     - store_test_results:
-  #         path: /tmp/cypress
+  "server-e2e-tests-5":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          command: npm run test-e2e -- --chunk 5
+          working_directory: packages/server
+      - store_test_results:
+          path: /tmp/cypress
 
-  # "server-e2e-tests-6":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         command: npm run test-e2e -- --chunk 6
-  #         working_directory: packages/server
-  #     - store_test_results:
-  #         path: /tmp/cypress
+  "server-e2e-tests-6":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          command: npm run test-e2e -- --chunk 6
+          working_directory: packages/server
+      - store_test_results:
+          path: /tmp/cypress
 
-  # "server-e2e-tests-7":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         command: npm run test-e2e -- --chunk 7
-  #         working_directory: packages/server
-  #     - store_test_results:
-  #         path: /tmp/cypress
+  "server-e2e-tests-7":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          command: npm run test-e2e -- --chunk 7
+          working_directory: packages/server
+      - store_test_results:
+          path: /tmp/cypress
 
-  # "server-e2e-tests-8":
-  #     <<: *defaults
-  #     steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         command: npm run test-e2e -- --chunk 8
-  #         working_directory: packages/server
-  #     - store_test_results:
-  #         path: /tmp/cypress
+  "server-e2e-tests-8":
+      <<: *defaults
+      steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          command: npm run test-e2e -- --chunk 8
+          working_directory: packages/server
+      - store_test_results:
+          path: /tmp/cypress
 
-  # "driver-integration-tests-3x":
-  #   <<: *defaults
-  #   parallelism: 3
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         command: npm start
-  #         background: true
-  #         working_directory: packages/driver
-  #     - run:
-  #         command: $(npm bin)/wait-on http://localhost:3500
-  #         working_directory: packages/driver
-  #     - run:
-  #         command: |
-  #           CYPRESS_KONFIG_ENV=production \
-  #           CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-  #           npm run cypress:run -- --record --parallel --group 3x-driver-chrome --browser chrome
-  #         working_directory: packages/driver
-  #     - store_test_results:
-  #         path: /tmp/cypress
-  #     - store_artifacts:
-  #         path: /tmp/artifacts
+  "driver-integration-tests-3x":
+    <<: *defaults
+    parallelism: 3
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          command: npm start
+          background: true
+          working_directory: packages/driver
+      - run:
+          command: $(npm bin)/wait-on http://localhost:3500
+          working_directory: packages/driver
+      - run:
+          command: |
+            CYPRESS_KONFIG_ENV=production \
+            CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
+            npm run cypress:run -- --record --parallel --group 3x-driver-chrome --browser chrome
+          working_directory: packages/driver
+      - store_test_results:
+          path: /tmp/cypress
+      - store_artifacts:
+          path: /tmp/artifacts
 
-  # "desktop-gui-integration-tests-2x":
-  #   <<: *defaults
-  #   parallelism: 2
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         command: npm run build-prod
-  #         working_directory: packages/desktop-gui
-  #     - run:
-  #         command: |
-  #           CYPRESS_KONFIG_ENV=production \
-  #           CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-  #           npm run cypress:run -- --record --parallel --group 2x-desktop-gui
-  #         working_directory: packages/desktop-gui
-  #     - store_test_results:
-  #         path: /tmp/cypress
-  #     - store_artifacts:
-  #         path: /tmp/artifacts
+  "desktop-gui-integration-tests-2x":
+    <<: *defaults
+    parallelism: 2
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          command: npm run build-prod
+          working_directory: packages/desktop-gui
+      - run:
+          command: |
+            CYPRESS_KONFIG_ENV=production \
+            CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
+            npm run cypress:run -- --record --parallel --group 2x-desktop-gui
+          working_directory: packages/desktop-gui
+      - store_test_results:
+          path: /tmp/cypress
+      - store_artifacts:
+          path: /tmp/artifacts
 
-  # "reporter-integration-tests":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         command: npm run build-prod
-  #         working_directory: packages/reporter
-  #     - run:
-  #         command: |
-  #           CYPRESS_KONFIG_ENV=production \
-  #           CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-  #           npm run cypress:run -- --record --parallel --group reporter
-  #         working_directory: packages/reporter
-  #     - store_test_results:
-  #         path: /tmp/cypress
-  #     - store_artifacts:
-  #         path: /tmp/artifacts
+  "reporter-integration-tests":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          command: npm run build-prod
+          working_directory: packages/reporter
+      - run:
+          command: |
+            CYPRESS_KONFIG_ENV=production \
+            CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
+            npm run cypress:run -- --record --parallel --group reporter
+          working_directory: packages/reporter
+      - store_test_results:
+          path: /tmp/cypress
+      - store_artifacts:
+          path: /tmp/artifacts
 
-  # "run-launcher":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         command: node index.js
-  #         working_directory: packages/launcher
+  "run-launcher":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          command: node index.js
+          working_directory: packages/launcher
 
-  # "build-binary":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run: $(npm bin)/print-arch
-  #     - run: npm run binary-build -- --platform linux --version $NEXT_DEV_VERSION
-  #     - run: npm run binary-zip -- --platform linux
-  #     - run: ls -l *.zip
-  #     - run:
-  #         name: upload unique binary
-  #         command: |
-  #           node scripts/binary.js upload-unique-binary \
-  #             --file cypress.zip \
-  #             --version $NEXT_DEV_VERSION
-  #     - run: cat binary-url.json
-  #     - run: mkdir /tmp/urls
-  #     - run: cp binary-url.json /tmp/urls
-  #     - run: cp cypress.zip /tmp/urls
-  #     - run: ls /tmp/urls
-  #     - persist_to_workspace:
-  #         root: /tmp/urls
-  #         paths:
-  #           - binary-url.json
-  #           - cypress.zip
+  "build-binary":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: $(npm bin)/print-arch
+      - run: npm run binary-build -- --platform linux --version $NEXT_DEV_VERSION
+      - run: npm run binary-zip -- --platform linux
+      - run: ls -l *.zip
+      - run:
+          name: upload unique binary
+          command: |
+            node scripts/binary.js upload-unique-binary \
+              --file cypress.zip \
+              --version $NEXT_DEV_VERSION
+      - run: cat binary-url.json
+      - run: mkdir /tmp/urls
+      - run: cp binary-url.json /tmp/urls
+      - run: cp cypress.zip /tmp/urls
+      - run: ls /tmp/urls
+      - persist_to_workspace:
+          root: /tmp/urls
+          paths:
+            - binary-url.json
+            - cypress.zip
 
-  # "test-kitchensink-against-staging":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         name: Cloning test project
-  #         command: git clone https://github.com/cypress-io/cypress-example-kitchensink.git /tmp/repo
-  #     - run:
-  #         name: Install prod dependencies
-  #         command: npm install --production
-  #         working_directory: /tmp/repo
-  #     - run:
-  #         name: Example server
-  #         command: npm start
-  #         working_directory: /tmp/repo
-  #         background: true
-  #     - run:
-  #         name: Run Kitchensink example project
-  #         command: |
-  #           CYPRESS_PROJECT_ID=$TEST_KITCHENSINK_PROJECT_ID \
-  #           CYPRESS_RECORD_KEY=$TEST_KITCHENSINK_RECORD_KEY \
-  #           CYPRESS_ENV=staging \
-  #           CYPRESS_video=false \
-  #           npm run cypress:run -- --project /tmp/repo --record
+  "test-kitchensink-against-staging":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Cloning test project
+          command: git clone https://github.com/cypress-io/cypress-example-kitchensink.git /tmp/repo
+      - run:
+          name: Install prod dependencies
+          command: npm install --production
+          working_directory: /tmp/repo
+      - run:
+          name: Example server
+          command: npm start
+          working_directory: /tmp/repo
+          background: true
+      - run:
+          name: Run Kitchensink example project
+          command: |
+            CYPRESS_PROJECT_ID=$TEST_KITCHENSINK_PROJECT_ID \
+            CYPRESS_RECORD_KEY=$TEST_KITCHENSINK_RECORD_KEY \
+            CYPRESS_ENV=staging \
+            CYPRESS_video=false \
+            npm run cypress:run -- --project /tmp/repo --record
 
-  # "test-against-staging":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         name: Cloning test project
-  #         command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/repo
-  #     - run:
-  #         name: Run test project
-  #         command: |
-  #           CYPRESS_PROJECT_ID=$TEST_TINY_PROJECT_ID \
-  #           CYPRESS_RECORD_KEY=$TEST_TINY_RECORD_KEY \
-  #           CYPRESS_ENV=staging \
-  #           npm run cypress:run -- --project /tmp/repo --record
+  "test-against-staging":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Cloning test project
+          command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/repo
+      - run:
+          name: Run test project
+          command: |
+            CYPRESS_PROJECT_ID=$TEST_TINY_PROJECT_ID \
+            CYPRESS_RECORD_KEY=$TEST_TINY_RECORD_KEY \
+            CYPRESS_ENV=staging \
+            npm run cypress:run -- --project /tmp/repo --record
 
-  # "build-npm-package":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         name: bump NPM version
-  #         command: npm --no-git-tag-version version $NEXT_DEV_VERSION
-  #     - run:
-  #         name: build NPM package
-  #         working_directory: cli
-  #         command: npm run build
-  #     - run:
-  #         name: list NPM package contents
-  #         working_directory: cli/build
-  #         command: npm run size
-  #     - run:
-  #         name: pack NPM package
-  #         working_directory: cli/build
-  #         command: npm pack
-  #     - run:
-  #         name: list created NPM package
-  #         working_directory: cli/build
-  #         command: ls -l
-  #     # created file should have filename cypress-<version>.tgz
-  #     - run:
-  #         name: upload NPM package
-  #         command: |
-  #           node scripts/binary.js upload-npm-package \
-  #             --file cli/build/cypress-$NEXT_DEV_VERSION.tgz \
-  #             --version $NEXT_DEV_VERSION
-  #     - run: cat npm-package-url.json
-  #     - run: mkdir /tmp/urls
-  #     - run: cp cli/build/cypress-$NEXT_DEV_VERSION.tgz /tmp/urls/cypress.tgz
-  #     - run: cp npm-package-url.json /tmp/urls
-  #     - run: ls /tmp/urls
-  #     - persist_to_workspace:
-  #         root: /tmp/urls
-  #         paths:
-  #           - npm-package-url.json
-  #           - cypress.tgz
+  "build-npm-package":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: bump NPM version
+          command: npm --no-git-tag-version version $NEXT_DEV_VERSION
+      - run:
+          name: build NPM package
+          working_directory: cli
+          command: npm run build
+      - run:
+          name: list NPM package contents
+          working_directory: cli/build
+          command: npm run size
+      - run:
+          name: pack NPM package
+          working_directory: cli/build
+          command: npm pack
+      - run:
+          name: list created NPM package
+          working_directory: cli/build
+          command: ls -l
+      # created file should have filename cypress-<version>.tgz
+      - run:
+          name: upload NPM package
+          command: |
+            node scripts/binary.js upload-npm-package \
+              --file cli/build/cypress-$NEXT_DEV_VERSION.tgz \
+              --version $NEXT_DEV_VERSION
+      - run: cat npm-package-url.json
+      - run: mkdir /tmp/urls
+      - run: cp cli/build/cypress-$NEXT_DEV_VERSION.tgz /tmp/urls/cypress.tgz
+      - run: cp npm-package-url.json /tmp/urls
+      - run: ls /tmp/urls
+      - persist_to_workspace:
+          root: /tmp/urls
+          paths:
+            - npm-package-url.json
+            - cypress.tgz
 
-  # "test-next-version":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - attach_workspace:
-  #         at: /tmp/urls
-  #     - run: ls -la /tmp/urls
-  #     - run: cat /tmp/urls/*.json
-  #     - run: mkdir /tmp/testing
-  #     - run:
-  #         name: create dummy package
-  #         working_directory: /tmp/testing
-  #         command: npm init -y
-  #     - run:
-  #         # install NPM from unique urls
-  #         name: Install Cypress
-  #         command: |
-  #           node scripts/test-unique-npm-and-binary.js \
-  #             --npm /tmp/urls/npm-package-url.json \
-  #             --binary /tmp/urls/binary-url.json \
-  #             --cwd /tmp/testing
-  #     - run:
-  #         name: Verify Cypress binary
-  #         working_directory: /tmp/testing
-  #         command: $(npm bin)/cypress verify
-  #     - run:
-  #         name: Running other test projects with new NPM package and binary
-  #         command: |
-  #           node scripts/test-other-projects.js \
-  #             --npm /tmp/urls/npm-package-url.json \
-  #             --binary /tmp/urls/binary-url.json \
-  #             --provider circle
+  "test-next-version":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - attach_workspace:
+          at: /tmp/urls
+      - run: ls -la /tmp/urls
+      - run: cat /tmp/urls/*.json
+      - run: mkdir /tmp/testing
+      - run:
+          name: create dummy package
+          working_directory: /tmp/testing
+          command: npm init -y
+      - run:
+          # install NPM from unique urls
+          name: Install Cypress
+          command: |
+            node scripts/test-unique-npm-and-binary.js \
+              --npm /tmp/urls/npm-package-url.json \
+              --binary /tmp/urls/binary-url.json \
+              --cwd /tmp/testing
+      - run:
+          name: Verify Cypress binary
+          working_directory: /tmp/testing
+          command: $(npm bin)/cypress verify
+      - run:
+          name: Running other test projects with new NPM package and binary
+          command: |
+            node scripts/test-other-projects.js \
+              --npm /tmp/urls/npm-package-url.json \
+              --binary /tmp/urls/binary-url.json \
+              --provider circle
 
-  # "test-next-version-locally":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - attach_workspace:
-  #         at: /tmp/urls
-  #     # make sure we have cypress.zip received
-  #     - run: ls -l /tmp/urls/cypress.zip
-  #     # build NPM package
-  #     - run:
-  #         command: npm run build
-  #         working_directory: cli
-  #     - run: mkdir test-binary
-  #     - run:
-  #         name: Create new NPM package
-  #         working_directory: test-binary
-  #         command: npm init -y
-  #     - run:
-  #         # install NPM from built NPM package folder
-  #         name: Install Cypress
-  #         working_directory: test-binary
-  #         # force installing the freshly built binary
-  #         command: CYPRESS_INSTALL_BINARY=/tmp/urls/cypress.zip npm i ../cli/build
-  #     - run:
-  #         name: Verify Cypress binary
-  #         working_directory: test-binary
-  #         command: $(npm bin)/cypress verify
+  "test-next-version-locally":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - attach_workspace:
+          at: /tmp/urls
+      # make sure we have cypress.zip received
+      - run: ls -l /tmp/urls/cypress.zip
+      # build NPM package
+      - run:
+          command: npm run build
+          working_directory: cli
+      - run: mkdir test-binary
+      - run:
+          name: Create new NPM package
+          working_directory: test-binary
+          command: npm init -y
+      - run:
+          # install NPM from built NPM package folder
+          name: Install Cypress
+          working_directory: test-binary
+          # force installing the freshly built binary
+          command: CYPRESS_INSTALL_BINARY=/tmp/urls/cypress.zip npm i ../cli/build
+      - run:
+          name: Verify Cypress binary
+          working_directory: test-binary
+          command: $(npm bin)/cypress verify
 
-  # # install NPM + binary zip and run against staging API
-  # "test-binary-against-staging":
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - attach_workspace:
-  #         at: /tmp/urls
-  #     # make sure we have the binary
-  #     - run: ls -l /tmp/urls/cypress.zip
-  #     # make sure we have the NPM package
-  #     - run: ls -l /tmp/urls/cypress.tgz
-  #     - run:
-  #         name: Cloning test project
-  #         command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/cypress-test-tiny
-  #     - run:
-  #         name: Install Cypress
-  #         working_directory: /tmp/cypress-test-tiny
-  #         # force installing the freshly built binary
-  #         command: CYPRESS_INSTALL_BINARY=/tmp/urls/cypress.zip npm i /tmp/urls/cypress.tgz
-  #     - run:
-  #         name: Run test project
-  #         working_directory: /tmp/cypress-test-tiny
-  #         command: |
-  #           CYPRESS_PROJECT_ID=$TEST_TINY_PROJECT_ID \
-  #           CYPRESS_RECORD_KEY=$TEST_TINY_RECORD_KEY \
-  #           CYPRESS_ENV=staging \
-  #           $(npm bin)/cypress run --record
+  # install NPM + binary zip and run against staging API
+  "test-binary-against-staging":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - attach_workspace:
+          at: /tmp/urls
+      # make sure we have the binary
+      - run: ls -l /tmp/urls/cypress.zip
+      # make sure we have the NPM package
+      - run: ls -l /tmp/urls/cypress.tgz
+      - run:
+          name: Cloning test project
+          command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/cypress-test-tiny
+      - run:
+          name: Install Cypress
+          working_directory: /tmp/cypress-test-tiny
+          # force installing the freshly built binary
+          command: CYPRESS_INSTALL_BINARY=/tmp/urls/cypress.zip npm i /tmp/urls/cypress.tgz
+      - run:
+          name: Run test project
+          working_directory: /tmp/cypress-test-tiny
+          command: |
+            CYPRESS_PROJECT_ID=$TEST_TINY_PROJECT_ID \
+            CYPRESS_RECORD_KEY=$TEST_TINY_RECORD_KEY \
+            CYPRESS_ENV=staging \
+            $(npm bin)/cypress run --record
 
   # mac-os-build:
   #   executor: mac
@@ -613,116 +613,116 @@ jobs:
 workflows:
   linux:
     jobs:
-      - build:
-          name: Linux build
+      - build
       - lint:
           name: Linux lint
           requires:
-            - "Linux build"
+            - build
+      # unit, integration and e2e tests
+      - unit-tests:
+          requires:
+            - build
+      - server-unit-tests:
+          requires:
+            - build
+      - server-integration-tests:
+          requires:
+            - build
+      - server-e2e-tests-1:
+          requires:
+            - build
+      - server-e2e-tests-2:
+          requires:
+            - build
+      - server-e2e-tests-3:
+          requires:
+            - build
+      - server-e2e-tests-4:
+          requires:
+            - build
+      - server-e2e-tests-5:
+          requires:
+            - build
+      - server-e2e-tests-6:
+          requires:
+            - build
+      - server-e2e-tests-7:
+          requires:
+            - build
+      - server-e2e-tests-8:
+          requires:
+            - build
+      - driver-integration-tests-3x:
+          requires:
+            - build
+      - desktop-gui-integration-tests-2x:
+          requires:
+            - build
+      - run-launcher:
+          requires:
+            - build
+      # various testing scenarios, like building full binary
+      # and testing it on a real project
+      - test-against-staging:
+          filters:
+            branches:
+              only:
+                - develop
+          requires:
+            - build
+      - test-kitchensink-against-staging:
+          filters:
+            branches:
+              only:
+                - develop
+          requires:
+            - build
+      - build-npm-package:
+          filters:
+            branches:
+              only:
+                - develop
+          requires:
+            - build
+      - build-binary:
+          filters:
+            branches:
+              only:
+                - develop
+          requires:
+            - build
+      - test-next-version:
+          filters:
+            branches:
+              only:
+                - develop
+          requires:
+            - build-npm-package
+            - build-binary
+      - test-next-version-locally:
+          filters:
+            branches:
+              only:
+                - develop
+          requires:
+            - build-npm-package
+            - build-binary
+      - test-binary-against-staging:
+          filters:
+            branches:
+              only:
+                - develop
+          requires:
+            - build-npm-package
+            - build-binary
+
   mac:
     jobs:
       - build:
-          executor: mac
           name: Mac build
-      - lint:
           executor: mac
+      - lint:
           name: Mac lint
+          executor: mac
           requires:
-            - "Mac build"
-      # # unit, integration and e2e tests
-      # - unit-tests:
-      #     requires:
-      #       - build
-      # - server-unit-tests:
-      #     requires:
-      #       - build
-      # - server-integration-tests:
-      #     requires:
-      #       - build
-      # - server-e2e-tests-1:
-      #     requires:
-      #       - build
-      # - server-e2e-tests-2:
-      #     requires:
-      #       - build
-      # - server-e2e-tests-3:
-      #     requires:
-      #       - build
-      # - server-e2e-tests-4:
-      #     requires:
-      #       - build
-      # - server-e2e-tests-5:
-      #     requires:
-      #       - build
-      # - server-e2e-tests-6:
-      #     requires:
-      #       - build
-      # - server-e2e-tests-7:
-      #     requires:
-      #       - build
-      # - server-e2e-tests-8:
-      #     requires:
-      #       - build
-      # - driver-integration-tests-3x:
-      #     requires:
-      #       - build
-      # - desktop-gui-integration-tests-2x:
-      #     requires:
-      #       - build
-      # - run-launcher:
-      #     requires:
-      #       - build
-      # # various testing scenarios, like building full binary
-      # # and testing it on a real project
-      # - test-against-staging:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - develop
-      #     requires:
-      #       - build
-      # - test-kitchensink-against-staging:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - develop
-      #     requires:
-      #       - build
-      # - build-npm-package:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - develop
-      #     requires:
-      #       - build
-      # - build-binary:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - develop
-      #     requires:
-      #       - build
-      # - test-next-version:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - develop
-      #     requires:
-      #       - build-npm-package
-      #       - build-binary
-      # - test-next-version-locally:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - develop
-      #     requires:
-      #       - build-npm-package
-      #       - build-binary
-      # - test-binary-against-staging:
-          # filters:
-          #   branches:
-          #     only:
-          #       - develop
-          # requires:
-            # - build-npm-package
-            # - build-binary
+            - Mac build

--- a/circle.yml
+++ b/circle.yml
@@ -3,9 +3,11 @@ version: 2.1
 defaults: &defaults
   parallelism: 1
   working_directory: ~/cypress
-  # docker:
-  #   # the Docker image with Cypress dependencies and Chrome browser
-  #   - image: cypress/browsers:chrome64
+  parameters:
+    executor:
+      type: executor
+      default: cy-doc
+  executor: <<parameters.executor>>
   environment:
     ## set specific timezone
     TZ: "/usr/share/zoneinfo/America/New_York"
@@ -23,6 +25,7 @@ executors:
     docker:
       - image: cypress/browsers:chrome64
 
+  # executor to run on Mac OS
   mac:
     macos:
       xcode: "10.1.0"
@@ -31,11 +34,6 @@ jobs:
   ## code checkout and NPM installs
   build:
     <<: *defaults
-    parameters:
-      executor:
-        type: executor
-        default: cy-doc
-    executor: <<parameters.executor>>
     steps:
       - checkout
 
@@ -192,13 +190,13 @@ jobs:
           paths:
             - cypress
 
-  # lint:
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run: npm run lint
-  #     - run: npm run all lint
+  lint:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: npm run lint
+      - run: npm run all lint
 
   # "unit-tests":
   #   <<: *defaults
@@ -617,16 +615,20 @@ workflows:
     jobs:
       - build:
           name: Linux build
-
+      - lint:
+          name: Linux lint
+          requires:
+            - "Linux build"
   mac:
     jobs:
       - build:
           executor: mac
           name: Mac build
-
-      # - lint:
-      #     requires:
-      #       - build
+      - lint:
+          executor: mac
+          name: Mac lint
+          requires:
+            - "Mac build"
       # # unit, integration and e2e tests
       # - unit-tests:
       #     requires:

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ executors:
   # executor to run on Mac OS
   mac:
     macos:
-      xcode: "9.2.0"
+      xcode: "9.1.0"
     environment:
       PLATFORM: mac
 
@@ -40,7 +40,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-
       - run:
           name: Print working folder
           command: echo $PWD

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 defaults: &defaults
   parallelism: 1
@@ -16,6 +16,11 @@ defaults: &defaults
         ## set so that e2e tests are consistent
         COLUMNS: 100
         LINES: 24
+
+executors:
+  mac:
+    macos:
+      xcode: "10.1.0"
 
 jobs:
   ## code checkout and NPM installs
@@ -598,9 +603,7 @@ jobs:
             $(npm bin)/cypress run --record
 
   mac-os-build:
-    executor:
-      macos:
-        xcode: "10.1.0"
+    executor: mac
     steps:
       - run: security find-identity -p codesigning
       - run: security list-keychains

--- a/circle.yml
+++ b/circle.yml
@@ -17,11 +17,6 @@ defaults: &defaults
         COLUMNS: 100
         LINES: 24
 
-executors:
-  mac:
-    macos:
-      xcode: "10.1.0"
-
 jobs:
   ## code checkout and NPM installs
   build:

--- a/circle.yml
+++ b/circle.yml
@@ -611,8 +611,12 @@ jobs:
   mac-os-build:
     executor: mac
     steps:
-      - run: security find-identity -v -p codesigning
-      - run: security list-keychains
+      - run:
+          name: Show keychains
+          command: security list-keychains
+      - run:
+          name: Find code signing identity
+          command: security find-identity -v -p codesigning
 
 workflows:
   linux:
@@ -721,32 +725,34 @@ workflows:
             - build-npm-package
             - build-binary
 
-  mac:
-    jobs:
-      - build:
-          name: Mac build
-          executor: mac
-      - lint:
-          name: Mac lint
-          executor: mac
-          requires:
-            - Mac build
-      # maybe run unit tests?
-      - mac-os-build:
-          filters:
-            branches:
-              only:
-                - develop
-                - build-osx-on-circle-2958
+  # disable Mac build until we can figure CircleCI v2 story
+  # for code signing the built binary
+  # https://github.com/cypress-io/cypress/issues/2958
 
-      - build-binary:
-          name: Mac binary
-          executor: mac
-          filters:
-            branches:
-              only:
-                - develop
-                - build-osx-on-circle-2958
-          requires:
-            - Mac build
-            - mac-os-build
+  # mac:
+  #   jobs:
+  #     - build:
+  #         name: Mac build
+  #         executor: mac
+  #     - lint:
+  #         name: Mac lint
+  #         executor: mac
+  #         requires:
+  #           - Mac build
+  #     # maybe run unit tests?
+  #     - mac-os-build:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - develop
+
+  #     - build-binary:
+  #         name: Mac binary
+  #         executor: mac
+  #         filters:
+  #           branches:
+  #             only:
+  #               - develop
+  #         requires:
+  #           - Mac build
+  #           - mac-os-build

--- a/circle.yml
+++ b/circle.yml
@@ -734,6 +734,7 @@ workflows:
       # maybe run unit tests?
       - build-binary:
           name: Mac binary
+          executor: mac
           filters:
             branches:
               only:

--- a/circle.yml
+++ b/circle.yml
@@ -608,11 +608,11 @@ jobs:
             CYPRESS_ENV=staging \
             $(npm bin)/cypress run --record
 
-  # mac-os-build:
-  #   executor: mac
-  #   steps:
-  #     - run: security find-identity -p codesigning
-  #     - run: security list-keychains
+  mac-os-build:
+    executor: mac
+    steps:
+      - run: security find-identity -v -p codesigning
+      - run: security list-keychains
 
 workflows:
   linux:
@@ -732,6 +732,13 @@ workflows:
           requires:
             - Mac build
       # maybe run unit tests?
+      - mac-os-build:
+          filters:
+            branches:
+              only:
+                - develop
+                - build-osx-on-circle-2958
+
       - build-binary:
           name: Mac binary
           executor: mac
@@ -742,3 +749,4 @@ workflows:
                 - build-osx-on-circle-2958
           requires:
             - Mac build
+            - mac-os-build

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ executors:
   # executor to run on Mac OS
   mac:
     macos:
-      xcode: "10.1.0"
+      xcode: "9.2.0"
     environment:
       PLATFORM: mac
 

--- a/circle.yml
+++ b/circle.yml
@@ -58,13 +58,7 @@ jobs:
       ## See the following information
       ##   * http://andykdocs.de/development/Docker/Fixing+the+Docker+TERM+variable+issue
       ##   * https://unix.stackexchange.com/questions/43945/whats-the-difference-between-various-term-variables
-      - run:
-          name: Checking TERM and COLUMNS are set
-          command: |
-            node -e 'assert.ok(process.platform === "darwin" || process.env.TERM === "xterm", `process.env.TERM=${process.env.TERM} and must be set to "xterm" for Docker to work`)'
-            node -e 'assert.ok(process.env.COLUMNS === "100", `process.env.COLUMNS=${process.env.COLUMNS} must be set to 100 for snapshots to pass`)'
-            node -e 'console.log("stdout.isTTY?", process.stdout.isTTY)'
-            node -e 'console.log("stderr.isTTY?", process.stderr.isTTY)'
+      - run: npm run check-terminal
 
       # need to restore a separate cache for each package.json
       - restore_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -53,7 +53,7 @@ jobs:
           command: npm -v
       - run: npm run check-node-version
 
-      ## make sure the TERM is set to 'xterm' in node
+      ## make sure the TERM is set to 'xterm' in node (Linux only)
       ## else colors (and tests) will fail
       ## See the following information
       ##   * http://andykdocs.de/development/Docker/Fixing+the+Docker+TERM+variable+issue
@@ -61,7 +61,7 @@ jobs:
       - run:
           name: Checking TERM and COLUMNS are set
           command: |
-            node -e 'assert.ok(process.env.TERM === "xterm", `process.env.TERM=${process.env.TERM} and must be set to "xterm" for Docker to work`)'
+            node -e 'assert.ok(process.platform === "darwin" || process.env.TERM === "xterm", `process.env.TERM=${process.env.TERM} and must be set to "xterm" for Docker to work`)'
             node -e 'assert.ok(process.env.COLUMNS === "100", `process.env.COLUMNS=${process.env.COLUMNS} must be set to 100 for snapshots to pass`)'
             node -e 'console.log("stdout.isTTY?", process.stdout.isTTY)'
             node -e 'console.log("stderr.isTTY?", process.stderr.isTTY)'

--- a/circle.yml
+++ b/circle.yml
@@ -185,7 +185,8 @@ jobs:
         ## we update stop-only
     #   - run: npm run stop-only
       ## now go build all of subpackages
-      - run: npm run build
+      - run: npm run prebuild -- --serial
+      - run: npm run build -- --serial
 
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:

--- a/circle.yml
+++ b/circle.yml
@@ -328,7 +328,7 @@ jobs:
       - store_test_results:
           path: /tmp/cypress
 
-  "3x-driver-integration-tests":
+  "driver-integration-tests-3x":
     <<: *defaults
     parallelism: 3
     steps:
@@ -352,7 +352,7 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts
 
-  "2x-desktop-gui-integration-tests":
+  "desktop-gui-integration-tests-2x":
     <<: *defaults
     parallelism: 2
     steps:
@@ -651,10 +651,10 @@ workflows:
       # - server-e2e-tests-8:
       #     requires:
       #       - build
-      # - 3x-driver-integration-tests:
+      # - driver-integration-tests-3x:
       #     requires:
       #       - build
-      # - 2x-desktop-gui-integration-tests:
+      # - desktop-gui-integration-tests-2x:
       #     requires:
       #       - build
       # - run-launcher:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "decaffeinate-bulk": "bulk-decaffeinate",
     "check-deps": "node ./scripts/check-deps.js --verbose",
     "check-deps-pre": "node ./scripts/check-deps.js --verbose --prescript",
-    "prebuild": "npm run check-deps-pre",
+    "prebuild": "npm run check-deps-pre && npm run all prebuild",
     "build": "npm run all build",
     "all": "node ./scripts/run.js",
     "test": "echo '⚠️ This root monorepo is only for local development and new contributions. There are no tests.'",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "test-scripts": "mocha --reporter spec scripts/unit/*spec.js",
     "test-mocha": "mocha --reporter spec scripts/spec.js",
     "test-mocha-snapshot": "mocha scripts/mocha-snapshot-spec.js",
-    "check-node-version": "node scripts/check-node-version.js"
+    "check-node-version": "node scripts/check-node-version.js",
+    "effective:circle:config": "circleci config process circle.yml | sed /^#/d"
   },
   "lint-staged": {
     "*.js": [

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test-mocha": "mocha --reporter spec scripts/spec.js",
     "test-mocha-snapshot": "mocha scripts/mocha-snapshot-spec.js",
     "check-node-version": "node scripts/check-node-version.js",
+    "check-terminal": "node scripts/check-terminal.js",
     "effective:circle:config": "circleci config process circle.yml | sed /^#/d"
   },
   "lint-staged": {

--- a/packages/desktop-gui/package.json
+++ b/packages/desktop-gui/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "postinstall": "echo '@packages/desktop-gui needs: npm run build'",
-    "prebuild": "npm run check-deps-pre",
+    "prebuild": "npm run check-deps-pre && rebuild-node-sass",
     "build": "node ./scripts/build-dev.js",
     "prebuild-prod": "npm run check-deps-pre",
     "build-prod": "node ./scripts/build-prod.js",
@@ -47,6 +47,7 @@
     "prop-types": "^15.5.10",
     "rc-collapse": "^1.6.11",
     "react": "^15.6.1",
+    "rebuild-node-sass": "1.1.0",
     "react-bootstrap-modal": "3.0.1",
     "react-dom": "^15.6.1",
     "react-loader": "^2.4.0",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "postinstall": "echo '@packages/runner needs: npm run build'",
-    "prebuild": "npm run check-deps-pre rebuild-node-sass",
+    "prebuild": "npm run check-deps-pre && rebuild-node-sass",
     "build": "node ./scripts/build-dev.js",
     "prebuild-prod": "npm run check-deps-pre",
     "build-prod": "node ./scripts/build-prod.js",

--- a/scripts/check-node-version.js
+++ b/scripts/check-node-version.js
@@ -10,8 +10,13 @@ const nodeVersionNeeded = nodeVersionNeededString.split('.')
 
 const nodeVersion = process.versions.node.split('.')
 
+const isMac = process.platform === 'darwin'
+const isCircleCI = process.env.CIRCLECI === 'true'
+
+const isAllowedNodeMismatch = isMac && isCircleCI
+
 // check just major version for now
-if (nodeVersionNeeded[0] !== nodeVersion[0]) {
+if (nodeVersionNeeded[0] !== nodeVersion[0] && !isAllowedNodeMismatch) {
   /* eslint-disable no-console */
   console.error('🛑 .node-version specified %s', nodeVersionNeededString)
   console.error('but current Node is %s', process.versions.node)

--- a/scripts/check-node-version.js
+++ b/scripts/check-node-version.js
@@ -10,13 +10,8 @@ const nodeVersionNeeded = nodeVersionNeededString.split('.')
 
 const nodeVersion = process.versions.node.split('.')
 
-const isMac = process.platform === 'darwin'
-const isCircleCI = process.env.CIRCLECI === 'true'
-
-const isAllowedNodeMismatch = isMac && isCircleCI
-
 // check just major version for now
-if (nodeVersionNeeded[0] !== nodeVersion[0] && !isAllowedNodeMismatch) {
+if (nodeVersionNeeded[0] !== nodeVersion[0]) {
   /* eslint-disable no-console */
   console.error('🛑 .node-version specified %s', nodeVersionNeededString)
   console.error('but current Node is %s', process.versions.node)

--- a/scripts/check-terminal.js
+++ b/scripts/check-terminal.js
@@ -4,9 +4,11 @@ const assert = require('assert')
 const isLinux = process.platform === 'linux'
 
 if (isLinux) {
-  assert.ok(process.env.TERM === "xterm", `process.env.TERM=${process.env.TERM} and must be set to "xterm" for Docker to work`)
+  assert.ok(process.env.TERM === 'xterm', `process.env.TERM=${process.env.TERM} and must be set to "xterm" for Docker to work`)
 }
-assert.ok(process.env.COLUMNS === "100", `process.env.COLUMNS=${process.env.COLUMNS} must be set to 100 for snapshots to pass`)
 
-console.log("stdout.isTTY?", process.stdout.isTTY)
-console.log("stderr.isTTY?", process.stderr.isTTY)
+assert.ok(process.env.COLUMNS === '100', `process.env.COLUMNS=${process.env.COLUMNS} must be set to 100 for snapshots to pass`)
+
+/* eslint-disable no-console */
+console.log('stdout.isTTY?', process.stdout.isTTY)
+console.log('stderr.isTTY?', process.stderr.isTTY)

--- a/scripts/check-terminal.js
+++ b/scripts/check-terminal.js
@@ -1,0 +1,12 @@
+// checks if the terminal has all the variables set (especially on Linux Docker)
+
+const assert = require('assert')
+const isLinux = process.platform === 'linux'
+
+if (isLinux) {
+  assert.ok(process.env.TERM === "xterm", `process.env.TERM=${process.env.TERM} and must be set to "xterm" for Docker to work`)
+}
+assert.ok(process.env.COLUMNS === "100", `process.env.COLUMNS=${process.env.COLUMNS} must be set to 100 for snapshots to pass`)
+
+console.log("stdout.isTTY?", process.stdout.isTTY)
+console.log("stderr.isTTY?", process.stderr.isTTY)

--- a/scripts/win-appveyor-build.js
+++ b/scripts/win-appveyor-build.js
@@ -17,6 +17,7 @@ shell.set('-e') // any error is fatal
 
 const isRightBranch = () => {
   const branch = process.env.APPVEYOR_REPO_BRANCH
+
   return branch === 'develop'
 }
 
@@ -49,9 +50,11 @@ shell.exec(`npm run binary-build -- --platform windows --version ${version}`)
 // make sure we are not including dev dependencies accidentally
 // TODO how to get the server package folder?
 const serverPackageFolder = 'C:/projects/cypress/dist/win32/packages/server'
+
 shell.echo(`Checking prod and dev dependencies in ${serverPackageFolder}`)
-shell.exec('npm ls --prod --depth 0 || true', {cwd: serverPackageFolder})
-const result = shell.exec('npm ls --dev --depth 0 || true', {cwd: serverPackageFolder})
+shell.exec('npm ls --prod --depth 0 || true', { cwd: serverPackageFolder })
+const result = shell.exec('npm ls --dev --depth 0 || true', { cwd: serverPackageFolder })
+
 if (result.stdout.includes('nodemon')) {
   console.error('Hmm, server package includes dev dependency "nodemon"')
   console.error('which means somehow we are including dev dependencies in the output bundle')


### PR DESCRIPTION
- part of work for #2958 

builds Cypress binary for Mac platform on CircleCI (instead of Buildkite), all jobs can now run on both linux and mac via executor parameter, both binaries are built. Blocked from completing this because cannot sign the Mac app using Fastlane (does not support Mac apps). See issue itself for links about the blocking issue.

Would like to land the work so far, even with Mac workflow disabled for now, since it makes the jobs more robust