### PR TITLE
fix inline wrapping element coordinates

### DIFF
--- a/packages/driver/src/dom/coordinates.js
+++ b/packages/driver/src/dom/coordinates.js
@@ -5,13 +5,22 @@ const getElementAtPointFromViewport = (doc, x, y) => {
 }
 
 const getElementPositioning = ($el) => {
+  /**
+   * @type {HTMLElement}
+   */
   const el = $el[0]
 
   const win = $window.getWindowByElement(el)
 
   // properties except for width / height
   // are relative to the top left of the viewport
-  const rect = el.getBoundingClientRect()
+
+  // we use the first of getClientRects in order to account for inline elements
+  // that span multiple lines. Which would cause us to click in the center and thus miss
+  // This should be the same as using getBoundingClientRect()
+  // for elements with a single rect
+  // const rect = el.getBoundingClientRect()
+  const rect = el.getClientRects()[0]
 
   const center = getCenterCoordinates(rect)
 

--- a/packages/driver/src/dom/coordinates.js
+++ b/packages/driver/src/dom/coordinates.js
@@ -20,7 +20,7 @@ const getElementPositioning = ($el) => {
   // This should be the same as using getBoundingClientRect()
   // for elements with a single rect
   // const rect = el.getBoundingClientRect()
-  const rect = el.getClientRects()[0]
+  const rect = el.getClientRects()[0] || el.getBoundingClientRect()
 
   const center = getCenterCoordinates(rect)
 

--- a/packages/driver/test/cypress/fixtures/dom.html
+++ b/packages/driver/test/cypress/fixtures/dom.html
@@ -478,6 +478,16 @@
         <li>baz</li>
         <li>quux</li>
       </ul>
+
+      <div id="overflow-link" style="width:260px"><p>
+
+        this is some text that will <span class="wrapped" style="color:rgb(0, 0, 192)">wrap to a newline</span>
+        and cause the click to miss
+        
+      </p>
+      </div>
+
+
       <div id="massively-long-div" style="height: 500px; width: 200px; background-color: gray;"></div>
       <div id="form-header-region">
         <div>

--- a/packages/driver/test/cypress/integration/commands/actions/click_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/click_spec.coffee
@@ -420,6 +420,10 @@ describe "src/cy/commands/actions/click", ->
         expect(onClick).to.be.calledOnce
 
     describe "actionability", ->
+
+      it 'can click on inline elements that wrap lines', ->
+        cy.get('#overflow-link').find('.wrapped').click()
+
       it "can click elements which are hidden until scrolled within parent container", ->
         cy.get("#overflow-auto-container").contains("quux").click()
 

--- a/packages/driver/test/cypress/integration/dom/coordinates_spec.coffee
+++ b/packages/driver/test/cypress/integration/dom/coordinates_spec.coffee
@@ -155,7 +155,7 @@ describe "src/dom/coordinates", ->
         expect(obj.x).to.eq(159)
         expect(obj.y).to.eq(124)
 
-  context.only "span spanning multiple lines", ->
+  context "span spanning multiple lines", ->
     it 'gets first dom rect in multiline text', ->
       $ '
       <div style="width:150px; margin-top:100px">

--- a/packages/driver/test/cypress/integration/dom/coordinates_spec.coffee
+++ b/packages/driver/test/cypress/integration/dom/coordinates_spec.coffee
@@ -164,6 +164,26 @@ describe "src/dom/coordinates", ->
       '
       .appendTo $ 'body'
 
-      obj = Cypress.dom.getElementCoordinatesByPosition(cy.$$("#multiple"), 'center').fromViewport
+      $el = cy.$$("#multiple")
+      el = $el[0]
 
-      expect({x: obj.x, y: obj.y}).to.be.close({x:122, y:152})
+      cy.stub(el, 'getClientRects', ->
+        [
+          {
+          top: 100
+          left: 100
+          width: 50
+          height: 40
+          },
+          {
+          top: 200
+          left: 50
+          width: 10
+          height: 10
+          }
+      ]
+
+      ).as 'getClientRects'
+      obj = Cypress.dom.getElementCoordinatesByPosition($el, 'center').fromViewport
+
+      expect({x: obj.x, y: obj.y}).to.deep.eq({x:125, y:120})

--- a/packages/driver/test/cypress/integration/dom/coordinates_spec.coffee
+++ b/packages/driver/test/cypress/integration/dom/coordinates_spec.coffee
@@ -32,12 +32,12 @@ describe "src/dom/coordinates", ->
         value: 20
       })
 
-      cy.stub(@$button.get(0), "getBoundingClientRect").returns({
+      cy.stub(@$button.get(0), "getClientRects").returns([{
         top: 100.9
         left: 60.9
         width: 50
         height: 40
-      })
+      }])
 
       { fromViewport, fromWindow } = Cypress.dom.getElementPositioning(@$button)
 
@@ -154,3 +154,16 @@ describe "src/dom/coordinates", ->
         ## padding is added to the line-height but width includes the padding
         expect(obj.x).to.eq(159)
         expect(obj.y).to.eq(124)
+
+  context "span spanning multiple lines", ->
+    it 'gets first dom rect in multiline text', ->
+      $ '
+      <div style="width:150px; margin-top:100px">
+      this is some long text with a single <span id="multiple" style="color:darkblue"> span that spans lines</span> making it tricky to click
+      </div>
+      '
+      .appendTo $ 'body'
+
+      obj = Cypress.dom.getElementCoordinatesByPosition(cy.$$("#multiple"), 'center').fromViewport
+
+      expect({x: obj.x, y: obj.y}).to.deep.eq({x:122, y:152})

--- a/packages/driver/test/cypress/integration/dom/coordinates_spec.coffee
+++ b/packages/driver/test/cypress/integration/dom/coordinates_spec.coffee
@@ -155,7 +155,7 @@ describe "src/dom/coordinates", ->
         expect(obj.x).to.eq(159)
         expect(obj.y).to.eq(124)
 
-  context "span spanning multiple lines", ->
+  context.only "span spanning multiple lines", ->
     it 'gets first dom rect in multiline text', ->
       $ '
       <div style="width:150px; margin-top:100px">
@@ -166,4 +166,4 @@ describe "src/dom/coordinates", ->
 
       obj = Cypress.dom.getElementCoordinatesByPosition(cy.$$("#multiple"), 'center').fromViewport
 
-      expect({x: obj.x, y: obj.y}).to.deep.eq({x:122, y:152})
+      expect({x: obj.x, y: obj.y}).to.be.close({x:122, y:152})


### PR DESCRIPTION
fix #210

## before (miss)

![18-12-21_17 37 56](https://user-images.githubusercontent.com/14625260/50366379-5053d900-0547-11e9-95d2-0ee7838cd5a4.png)


## after

![18-12-21_17 38 36](https://user-images.githubusercontent.com/14625260/50366372-48943480-0547-11e9-8339-4d5084846971.png)

