### PR TITLE
add renovate json file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ Thanks for taking the time to contribute! :smile:
   - [Branches](#branches)
   - [Pull Requests](#pull-requests)
   - [Testing](#testing)
+  - [Dependencies](#dependencies)
 - [Deployment](#deployment)
 
 ## CI status
@@ -337,6 +338,10 @@ The repository is setup with two main (protected) branches.
 This repository is exhaustively tested by [CircleCI](https://circleci.com/gh/cypress-io/cypress). Additionally we test the code by running it against various other example projects. See CI badges and links at the top of this document.
 
 To run local tests, consult the `README.md` of each package.
+
+### Dependencies
+
+We use [RenovateBot](https://renovatebot.com/) to automatically upgrade our dependencies. The bot keeps chugging using settings in [renovate.json](renovate.json) to open PRs and if they pass merge patches. Minor and major updates require manual merge.
 
 ## Deployment
 

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   },
   "rangeStrategy": "pin",
   "separateMultipleMajor": true,
+  "labels": "type: dependencies",
   "commitMessage": "{{semanticPrefix}}Update {{depName}} to {{newVersion}} 🌟",
   "prTitle": "{{semanticPrefix}}{{#if isPin}}Pin{{else}}Update{{/if}} dependency {{depName}} to version {{#if isRange}}{{newVersion}}{{else}}{{#if isMajor}}{{newVersionMajor}}.x{{else}}{{newVersion}}{{/if}}{{/if}} 🌟",
   "prHourlyLimit": 1,

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     "automerge": false
   },
   "rangeStrategy": "pin",
+  "separateMultipleMajor": true,
   "commitMessage": "{{semanticPrefix}}Update {{depName}} to {{newVersion}} 🌟",
   "prTitle": "{{semanticPrefix}}{{#if isPin}}Pin{{else}}Update{{/if}} dependency {{depName}} to version {{#if isRange}}{{newVersion}}{{else}}{{#if isMajor}}{{newVersionMajor}}.x{{else}}{{newVersion}}{{/if}}{{/if}} 🌟",
   "prHourlyLimit": 1,

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
   },
   "rangeStrategy": "pin",
   "separateMultipleMajor": true,
-  "labels": "type: dependencies",
+  "labels": ["type: dependencies"],
   "commitMessage": "{{semanticPrefix}}Update {{depName}} to {{newVersion}} 🌟",
   "prTitle": "{{semanticPrefix}}{{#if isPin}}Pin{{else}}Update{{/if}} dependency {{depName}} to version {{#if isRange}}{{newVersion}}{{else}}{{#if isMajor}}{{newVersionMajor}}.x{{else}}{{newVersion}}{{/if}}{{/if}} 🌟",
   "prHourlyLimit": 1,

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,22 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "automerge": true,
+  "major": {
+    "automerge": false
+  },
+  "minor": {
+    "automerge": false
+  },
+  "rangeStrategy": "pin",
+  "commitMessage": "{{semanticPrefix}}Update {{depName}} to {{newVersion}} 🌟",
+  "prTitle": "{{semanticPrefix}}{{#if isPin}}Pin{{else}}Update{{/if}} dependency {{depName}} to version {{#if isRange}}{{newVersion}}{{else}}{{#if isMajor}}{{newVersionMajor}}.x{{else}}{{newVersion}}{{/if}}{{/if}} 🌟",
+  "prHourlyLimit": 1,
+  "updateNotScheduled": false,
+  "timezone": "America/New_York",
+  "schedule": [
+    "after 10pm and before 5am on every weekday",
+    "every weekend"
+  ]
+}


### PR DESCRIPTION
- closes #2644

right now it should pin dependencies and start upgrading root dev dependencies only. Then I would work on adding monorepo packages subfolders

**Update:** I have tried Renovate with a monorepo setup similar to this one, and it just worked. Renovate has found all our package.json files and started pull requests correctly. See https://github.com/bahmutov/test-renovate-monorepo/pulls