### PR TITLE
Fix TypeScript Omit definition

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ executors:
   # the Docker image with Cypress dependencies and Chrome browser
   cy-doc:
     docker:
-      - image: cypress/browsers:chrome67
+      - image: cypress/browsers:chrome64
     environment:
       PLATFORM: linux
 
@@ -619,7 +619,7 @@ jobs:
           name: Cloning kitchensink project
           command: git clone --depth 1 https://github.com/cypress-io/cypress-example-kitchensink.git /tmp/kitchensink
       - run:
-          command: npm ci
+          command: npm install
           working_directory: /tmp/kitchensink
       - run:
           name: Install Cypress

--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ executors:
   # the Docker image with Cypress dependencies and Chrome browser
   cy-doc:
     docker:
-      - image: cypress/browsers:chrome64
+      - image: cypress/browsers:chrome67
     environment:
       PLATFORM: linux
 

--- a/circle.yml
+++ b/circle.yml
@@ -608,6 +608,35 @@ jobs:
             CYPRESS_ENV=staging \
             $(npm bin)/cypress run --record
 
+  "test-binary-against-kitchensink":
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - attach_workspace:
+          at: /tmp/urls
+      - run:
+          name: Cloning kitchensink project
+          command: git clone --depth 1 https://github.com/cypress-io/cypress-example-kitchensink.git /tmp/kitchensink
+      - run:
+          command: npm ci
+          working_directory: /tmp/kitchensink
+      - run:
+          name: Install Cypress
+          working_directory: /tmp/kitchensink
+          # force installing the freshly built binary
+          command: CYPRESS_INSTALL_BINARY=/tmp/urls/cypress.zip npm i /tmp/urls/cypress.tgz
+      - run:
+          working_directory: /tmp/kitchensink
+          command: npm run build
+      - run:
+          working_directory: /tmp/kitchensink
+          command: npm start
+          background: true
+      - run:
+          working_directory: /tmp/kitchensink
+          command: npm run e2e
+
   mac-os-build:
     executor: mac
     steps:
@@ -690,6 +719,7 @@ workflows:
             branches:
               only:
                 - develop
+                - better-test-binary-against-kitchensink-3024
           requires:
             - build
       - build-binary:
@@ -697,7 +727,7 @@ workflows:
             branches:
               only:
                 - develop
-                - build-osx-on-circle-2958
+                - better-test-binary-against-kitchensink-3024
           requires:
             - build
       - test-next-version:
@@ -721,6 +751,15 @@ workflows:
             branches:
               only:
                 - develop
+          requires:
+            - build-npm-package
+            - build-binary
+      - test-binary-against-kitchensink:
+          filters:
+            branches:
+              only:
+                - develop
+                - better-test-binary-against-kitchensink-3024
           requires:
             - build-npm-package
             - build-binary

--- a/circle.yml
+++ b/circle.yml
@@ -719,7 +719,6 @@ workflows:
             branches:
               only:
                 - develop
-                - better-test-binary-against-kitchensink-3024
           requires:
             - build
       - build-binary:
@@ -727,7 +726,6 @@ workflows:
             branches:
               only:
                 - develop
-                - better-test-binary-against-kitchensink-3024
           requires:
             - build
       - test-next-version:
@@ -759,7 +757,6 @@ workflows:
             branches:
               only:
                 - develop
-                - better-test-binary-against-kitchensink-3024
           requires:
             - build-npm-package
             - build-binary

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -3933,10 +3933,9 @@ declare namespace Cypress {
     left: number
   }
 
-  // Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
+  // Diff taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
   type Diff<T extends string, U extends string> = ({[P in T]: P } & {[P in U]: never } & { [x: string]: never })[T]
-  // TODO - remove this if possible. Seems a recent change to TypeScript broke this. Possibly https://github.com/Microsoft/TypeScript/pull/17912
-  type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>> // tslint:disable-line
+  type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 }
 
 /**


### PR DESCRIPTION
- fixes #3024 
- adds a full test of the built binary against cypress-example-kitchensink including TypeScript check

note: I tried running `tsc --noEmit` against our types to catch the errors in `cli/types/index.d.ts` but that just spit bunch of weird TypeScript errors :(