### PR TITLE
Add {home} and {end} to cy.type()

### DIFF
--- a/packages/driver/src/cypress/keyboard.coffee
+++ b/packages/driver/src/cypress/keyboard.coffee
@@ -20,6 +20,8 @@ keyStandardMap = {
   "{leftarrow}": "ArrowLeft",
   "{rightarrow}": "ArrowRight",
   "{uparrow}": "ArrowUp",
+  "{home}": "Home",
+  "{end}": "End",
   "{alt}": "Alt",
   "{ctrl}": "Control",
   "{meta}": "Meta",
@@ -211,6 +213,32 @@ $Keyboard = {
       options.setKey    = "{downarrow}"
       @ensureKey el, null, options, ->
         $selection.moveCursorDown(el)
+
+    ## charCode = 36
+    ## no keyPress
+    ## no textInput
+    ## no input
+    "{home}": (el, options) ->
+      options.charCode  = 36
+      options.keypress  = false
+      options.textInput = false
+      options.input     = false
+      options.setKey    = "{home}"
+      @ensureKey el, null, options, ->
+        $selection.moveCursorToStart(el)
+
+    ## charCode = 35
+    ## no keyPress
+    ## no textInput
+    ## no input
+    "{end}": (el, options) ->
+      options.charCode  = 35
+      options.keypress  = false
+      options.textInput = false
+      options.input     = false
+      options.setKey    = "{end}"
+      @ensureKey el, null, options, ->
+        $selection.moveCursorToEnd(el)
   }
 
   modifierChars: {

--- a/packages/driver/src/cypress/keyboard.coffee
+++ b/packages/driver/src/cypress/keyboard.coffee
@@ -225,7 +225,7 @@ $Keyboard = {
       options.input     = false
       options.setKey    = "{home}"
       @ensureKey el, null, options, ->
-        $selection.moveCursorToStart(el)
+        $selection.moveCursorToLineStart(el)
 
     ## charCode = 35
     ## no keyPress
@@ -238,7 +238,7 @@ $Keyboard = {
       options.input     = false
       options.setKey    = "{end}"
       @ensureKey el, null, options, ->
-        $selection.moveCursorToEnd(el)
+        $selection.moveCursorToLineEnd(el)
   }
 
   modifierChars: {

--- a/packages/driver/src/dom/selection.js
+++ b/packages/driver/src/dom/selection.js
@@ -374,6 +374,8 @@ const _moveCursorToLineStartOrEnd = function (el, toStart) {
   if ($elements.isContentEditable(el) || $elements.isInput(el) || $elements.isTextarea(el)) {
     const selection = _getSelectionByEl(el)
 
+    // the selection.modify API is non-standard, may work differently in other browsers, and is not in IE11.
+    // https://developer.mozilla.org/en-US/docs/Web/API/Selection/modify
     return $elements.callNativeMethod(selection, 'modify', 'move', toStart ? 'backward' : 'forward', 'lineboundary')
   }
 }

--- a/packages/driver/src/dom/selection.js
+++ b/packages/driver/src/dom/selection.js
@@ -371,18 +371,7 @@ const moveCursorToLineEnd = (el) => {
 }
 
 const _moveCursorToLineStartOrEnd = function (el, toStart) {
-  if ($elements.isTextarea(el) || $elements.isInput(el)) {
-    const { start, end } = getSelectionBounds(el)
-    const returnValue = toStart ? 0 : $elements.getNativeProp(el, 'value').length
-
-    if (start !== end) {
-      return _collapseInputOrTextArea(el, returnValue)
-    }
-
-    return setSelectionRange(el, returnValue, returnValue)
-  }
-
-  if ($elements.isContentEditable(el)) {
+  if ($elements.isContentEditable(el) || $elements.isInput(el) || $elements.isTextarea(el)) {
     const selection = _getSelectionByEl(el)
 
     return $elements.callNativeMethod(selection, 'modify', 'move', toStart ? 'backward' : 'forward', 'lineboundary')

--- a/packages/driver/src/dom/selection.js
+++ b/packages/driver/src/dom/selection.js
@@ -370,10 +370,10 @@ const moveCursorToEnd = (el) => {
   return _moveCursorToStartOrEnd(el, false)
 }
 
-const _moveCursorToStartOrEnd = function (el, start) {
+const _moveCursorToStartOrEnd = function (el, toStart) {
   if ($elements.isTextarea(el) || $elements.isInput(el)) {
     const { start, end } = getSelectionBounds(el)
-    const returnValue = start ? 0 : $elements.getNativeProp(el, 'value').length
+    const returnValue = toStart ? 0 : $elements.getNativeProp(el, 'value').length
 
     if (start !== end) {
       return _collapseInputOrTextArea(el, returnValue)
@@ -385,7 +385,7 @@ const _moveCursorToStartOrEnd = function (el, start) {
   if ($elements.isContentEditable(el)) {
     const selection = _getSelectionByEl(el)
 
-    return $elements.callNativeMethod(selection, 'modify', 'move', start ? 'backward' : 'forward', 'paragraphboundary')
+    return $elements.callNativeMethod(selection, 'modify', 'move', toStart ? 'backward' : 'forward', 'paragraphboundary')
   }
 }
 

--- a/packages/driver/src/dom/selection.js
+++ b/packages/driver/src/dom/selection.js
@@ -362,15 +362,15 @@ const _moveCursorUpOrDown = function (el, up) {
   }
 }
 
-const moveCursorToStart = (el) => {
-  return _moveCursorToStartOrEnd(el, true)
+const moveCursorToLineStart = (el) => {
+  return _moveCursorToLineStartOrEnd(el, true)
 }
 
-const moveCursorToEnd = (el) => {
-  return _moveCursorToStartOrEnd(el, false)
+const moveCursorToLineEnd = (el) => {
+  return _moveCursorToLineStartOrEnd(el, false)
 }
 
-const _moveCursorToStartOrEnd = function (el, toStart) {
+const _moveCursorToLineStartOrEnd = function (el, toStart) {
   if ($elements.isTextarea(el) || $elements.isInput(el)) {
     const { start, end } = getSelectionBounds(el)
     const returnValue = toStart ? 0 : $elements.getNativeProp(el, 'value').length
@@ -385,7 +385,7 @@ const _moveCursorToStartOrEnd = function (el, toStart) {
   if ($elements.isContentEditable(el)) {
     const selection = _getSelectionByEl(el)
 
-    return $elements.callNativeMethod(selection, 'modify', 'move', toStart ? 'backward' : 'forward', 'paragraphboundary')
+    return $elements.callNativeMethod(selection, 'modify', 'move', toStart ? 'backward' : 'forward', 'lineboundary')
   }
 }
 
@@ -606,8 +606,8 @@ module.exports = {
   moveCursorRight,
   moveCursorUp,
   moveCursorDown,
-  moveCursorToStart,
-  moveCursorToEnd,
+  moveCursorToLineStart,
+  moveCursorToLineEnd,
   replaceSelectionContents,
   isCollapsed,
   interceptSelect,

--- a/packages/driver/src/dom/selection.js
+++ b/packages/driver/src/dom/selection.js
@@ -379,8 +379,6 @@ const _moveCursorToStartOrEnd = function (el, start) {
       return _collapseInputOrTextArea(el, returnValue)
     }
 
-    //# Don't worry about moving past the end of the string
-    //# nothing will happen and there is no error.
     return setSelectionRange(el, returnValue, returnValue)
   }
 

--- a/packages/driver/src/dom/selection.js
+++ b/packages/driver/src/dom/selection.js
@@ -362,6 +362,35 @@ const _moveCursorUpOrDown = function (el, up) {
   }
 }
 
+const moveCursorToStart = (el) => {
+  return _moveCursorToStartOrEnd(el, true)
+}
+
+const moveCursorToEnd = (el) => {
+  return _moveCursorToStartOrEnd(el, false)
+}
+
+const _moveCursorToStartOrEnd = function (el, start) {
+  if ($elements.isTextarea(el) || $elements.isInput(el)) {
+    const { start, end } = getSelectionBounds(el)
+    const returnValue = start ? 0 : $elements.getNativeProp(el, 'value').length
+
+    if (start !== end) {
+      return _collapseInputOrTextArea(el, returnValue)
+    }
+
+    //# Don't worry about moving past the end of the string
+    //# nothing will happen and there is no error.
+    return setSelectionRange(el, returnValue, returnValue)
+  }
+
+  if ($elements.isContentEditable(el)) {
+    const selection = _getSelectionByEl(el)
+
+    return $elements.callNativeMethod(selection, 'modify', 'move', start ? 'backward' : 'forward', 'paragraphboundary')
+  }
+}
+
 const isCollapsed = function (el) {
   if ($elements.isTextarea(el) || $elements.isInput(el)) {
     const { start, end } = getSelectionBounds(el)
@@ -579,6 +608,8 @@ module.exports = {
   moveCursorRight,
   moveCursorUp,
   moveCursorDown,
+  moveCursorToStart,
+  moveCursorToEnd,
   replaceSelectionContents,
   isCollapsed,
   interceptSelect,

--- a/packages/driver/test/cypress/integration/commands/actions/type_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/type_spec.coffee
@@ -1403,6 +1403,40 @@ describe "src/cy/commands/actions/type", ->
             expect($input).to.have.value("fodo")
             done()
 
+      context "{home}", ->
+        it "sets which and keyCode to 36 and does not fire keypress events", (done) ->
+          cy.$$("#comments").on "keypress", ->
+            done("should not have received keypress")
+
+          cy.$$("#comments").on "keydown", (e) ->
+            expect(e.which).to.eq 36
+            expect(e.keyCode).to.eq 36
+            expect(e.key).to.eq "Home"
+            done()
+
+          cy.get("#comments").type("{home}").then ($input) ->
+            done()
+
+        it "does not fire textInput event", (done) ->
+          cy.$$("#comments").on "textInput", (e) ->
+            done("textInput should not have fired")
+
+          cy.get("#comments").type("{home}").then -> done()
+
+        it "does not fire input event", (done) ->
+          cy.$$("#comments").on "input", (e) ->
+            done("input should not have fired")
+
+          cy.get("#comments").type("{home}").then -> done()
+
+        it "can move the cursor to input start", ->
+          cy.get(":text:first").invoke("val", "bar").type("{home}n").then ($input) ->
+            expect($input).to.have.value("nbar")
+
+        it "does not move the cursor if already at bounds 0", ->
+          cy.get(":text:first").invoke("val", "bar").type("{selectall}{leftarrow}{home}n").then ($input) ->
+            expect($input).to.have.value("nbar")
+
       context "{uparrow}", ->
         beforeEach ->
           cy.$$("#comments").val("foo\nbar\nbaz")

--- a/packages/driver/test/cypress/integration/commands/actions/type_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/type_spec.coffee
@@ -1437,6 +1437,72 @@ describe "src/cy/commands/actions/type", ->
           cy.get(":text:first").invoke("val", "bar").type("{selectall}{leftarrow}{home}n").then ($input) ->
             expect($input).to.have.value("nbar")
 
+        it "should move the cursor to the start of each line in textarea", ->
+          cy.$$('textarea:first').get(0).value = 'foo\nbar\nbaz'
+
+          cy.get("textarea:first")
+          .type("{home}11{uparrow}{home}22{uparrow}{home}33").should('have.value', "33foo\n22bar\n11baz")
+
+        it "should move cursor to the start of each line in contenteditable", ->
+          cy.$$('[contenteditable]:first').get(0).innerHTML =
+            '<div>foo</div>' +
+            '<div>bar</div>' +
+            '<div>baz</div>'
+
+          cy.get("[contenteditable]:first")
+          .type("{home}11{uparrow}{home}22{uparrow}{home}33").then ($div) ->
+            expect($div.get(0).innerText).to.eql("33foo\n22bar\n11baz\n")
+
+      context "{end}", ->
+        it "sets which and keyCode to 35 and does not fire keypress events", (done) ->
+          cy.$$("#comments").on "keypress", ->
+            done("should not have received keypress")
+
+          cy.$$("#comments").on "keydown", (e) ->
+            expect(e.which).to.eq 35
+            expect(e.keyCode).to.eq 35
+            expect(e.key).to.eq "End"
+            done()
+
+          cy.get("#comments").type("{end}").then ($input) ->
+            done()
+
+        it "does not fire textInput event", (done) ->
+          cy.$$("#comments").on "textInput", (e) ->
+            done("textInput should not have fired")
+
+          cy.get("#comments").type("{end}").then -> done()
+
+        it "does not fire input event", (done) ->
+          cy.$$("#comments").on "input", (e) ->
+            done("input should not have fired")
+
+          cy.get("#comments").type("{end}").then -> done()
+
+        it "can move the cursor to input end", ->
+          cy.get(":text:first").invoke("val", "bar").type("{selectall}{leftarrow}{end}n").then ($input) ->
+            expect($input).to.have.value("barn")
+
+        it "does not move the cursor if already at end of bounds", ->
+          cy.get(":text:first").invoke("val", "bar").type("{selectall}{rightarrow}{end}n").then ($input) ->
+            expect($input).to.have.value("barn")
+
+        it "should move the cursor to the end of each line in textarea", ->
+          cy.$$('textarea:first').get(0).value = 'foo\nbar\nbaz'
+
+          cy.get("textarea:first")
+          .type("{end}11{uparrow}{end}22{uparrow}{end}33").should('have.value', "foo33\nbar22\nbaz11")
+
+        it "should move cursor to the end of each line in contenteditable", ->
+          cy.$$('[contenteditable]:first').get(0).innerHTML =
+            '<div>foo</div>' +
+            '<div>bar</div>' +
+            '<div>baz</div>'
+
+          cy.get("[contenteditable]:first")
+          .type("{end}11{uparrow}{end}22{uparrow}{end}33").then ($div) ->
+            expect($div.get(0).innerText).to.eql("foo33\nbar22\nbaz11\n")
+
       context "{uparrow}", ->
         beforeEach ->
           cy.$$("#comments").val("foo\nbar\nbaz")


### PR DESCRIPTION
PR close https://github.com/cypress-io/cypress/issues/2033 by implementing handlers for `Home` and `End` in function `type`.

I am creating a PR for Downshift library in which I am implementing keyboard handling for Home and End in the context of a Dropdown (Home highlights first option, End the last one). PR is [here](https://github.com/paypal/downshift/pull/646). I meant to write end-to-end tests as well. Since the repo uses Cypress, I found that it did not support `{home}` and `{enter}` so I found this issue in your repo and am trying to fix it.

Work is still in progress, I still mean to write UTs and E2Es. However, I appreciate early feedback on the implementation as well, since this could be my first commit in this repository.