### PR TITLE
fix: Type definitions for .then

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -49,7 +49,7 @@
     "@types/minimatch": "3.0.3",
     "@types/mocha": "2.2.44",
     "@types/sinon": "7.0.0",
-    "@types/sinon-chai": "2.7.29",
+    "@types/sinon-chai": "3.2.2",
     "bluebird": "3.5.0",
     "cachedir": "1.3.0",
     "chalk": "2.4.1",

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -1329,19 +1329,37 @@ declare namespace Cypress {
      *
      * @see https://on.cypress.io/then
      */
-    then<S>(fn: (this: ObjectLike, currentSubject: Subject) => Chainable<S>, options?: Partial<Timeoutable>): Chainable<S>
+    then<S>(fn: (this: ObjectLike, currentSubject: Subject) => Chainable<S>): Chainable<S>
+    /**
+     * Enables you to work with the subject yielded from the previous command.
+     *
+     * @see https://on.cypress.io/then
+     */
+    then<S>(options: Partial<Timeoutable>, fn: (this: ObjectLike, currentSubject: Subject) => Chainable<S>): Chainable<S>
     /**
      * Enables you to work with the subject yielded from the previous command / promise.
      *
      * @see https://on.cypress.io/then
      */
-    then<S>(fn: (this: ObjectLike, currentSubject: Subject) => PromiseLike<S>, options?: Partial<Timeoutable>): Chainable<S>
+    then<S>(fn: (this: ObjectLike, currentSubject: Subject) => PromiseLike<S>): Chainable<S>
     /**
      * Enables you to work with the subject yielded from the previous command / promise.
      *
      * @see https://on.cypress.io/then
      */
-    then<S extends object | any[] | string | number | boolean>(fn: (this: ObjectLike, currentSubject: Subject) => S, options?: Partial<Timeoutable>): Chainable<S>
+    then<S>(options: Partial<Timeoutable>, fn: (this: ObjectLike, currentSubject: Subject) => PromiseLike<S>): Chainable<S>
+    /**
+     * Enables you to work with the subject yielded from the previous command / promise.
+     *
+     * @see https://on.cypress.io/then
+     */
+    then<S extends object | any[] | string | number | boolean>(fn: (this: ObjectLike, currentSubject: Subject) => S): Chainable<S>
+    /**
+     * Enables you to work with the subject yielded from the previous command / promise.
+     *
+     * @see https://on.cypress.io/then
+     */
+    then<S extends object | any[] | string | number | boolean>(options: Partial<Timeoutable>, fn: (this: ObjectLike, currentSubject: Subject) => S): Chainable<S>
     /**
      * Enables you to work with the subject yielded from the previous command.
      *
@@ -1350,7 +1368,16 @@ declare namespace Cypress {
      *    cy.get('.nav').then(($nav) => {})  // Yields .nav as first arg
      *    cy.location().then((loc) => {})   // Yields location object as first arg
      */
-    then(fn: (this: ObjectLike, currentSubject: Subject) => void, options?: Partial<Timeoutable>): Chainable<Subject>
+    then(fn: (this: ObjectLike, currentSubject: Subject) => void): Chainable<Subject>
+    /**
+     * Enables you to work with the subject yielded from the previous command.
+     *
+     * @see https://on.cypress.io/then
+     * @example
+     *    cy.get('.nav').then(($nav) => {})  // Yields .nav as first arg
+     *    cy.location().then((loc) => {})   // Yields location object as first arg
+     */
+    then(options: Partial<Timeoutable>, fn: (this: ObjectLike, currentSubject: Subject) => void): Chainable<Subject>
 
     /**
      * Move time after overriding a native time function with [cy.clock()](https://on.cypress.io/clock).

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -112,18 +112,37 @@ cy.wrap(['bar', 'baz'])
     first // $ExpectType any
   })
 
-cy.wrap({ foo: 'bar' })
-  .then(s => {
-    s // $ExpectType { foo: string; }
-    return s
+describe('then', () => {
+  it('should have the correct type signature', () => {
+    cy.wrap({ foo: 'bar' })
+      .then(s => {
+        s // $ExpectType { foo: string; }
+        return s
+      })
+      .then(s => {
+        s // $ExpectType { foo: string; }
+      })
+      .then(s => s.foo)
+      .then(s => {
+        s // $ExpectType string
+      })
   })
-  .then(s => {
-    s // $ExpectType { foo: string; }
+
+  it('should have the correct type signature with options', () => {
+    cy.wrap({ foo: 'bar' })
+      .then({ timeout: 5000 }, s => {
+        s // $ExpectType { foo: string; }
+        return s
+      })
+      .then({ timeout: 5000 }, s => {
+        s // $ExpectType { foo: string; }
+      })
+      .then({ timeout: 5000 }, s => s.foo)
+      .then({ timeout: 5000 }, s => {
+        s // $ExpectType string
+      })
   })
-  .then(s => s.foo)
-  .then(s => {
-    s // $ExpectType string
-  })
+})
 
 cy.wait(['@foo', '@bar'])
   .then(([first, second]) => {


### PR DESCRIPTION
Fixes #3075

The previous type definitions assumed `options` were an optional second parameter, but `options` is actually an optional primary parameter.
