### PR TITLE
Allow visiting the same page that has a hash

### DIFF
--- a/packages/driver/src/cy/commands/navigation.coffee
+++ b/packages/driver/src/cy/commands/navigation.coffee
@@ -564,6 +564,9 @@ module.exports = (Commands, Cypress, cy, state, config) ->
         ## for this, and so we need to resolve onLoad immediately
         ## and bypass the actual visit resolution stuff
         if bothUrlsMatchAndRemoteHasHash(current, remote)
+          if current.hash is remote.hash
+            return Promise.resolve()
+
           return changeIframeSrc(remote.href, "hashchange")
           .then(onLoad)
 

--- a/packages/driver/test/cypress/integration/commands/navigation_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/navigation_spec.coffee
@@ -440,6 +440,11 @@ describe "src/cy/commands/navigation", ->
         .visit("http://localhost:3500/fixtures/generic.html")
         .visit("http://localhost:3500/fixtures/dimensions.html")
 
+    it "can visit the same page with hashes", ->
+      cy
+        .visit("http://localhost:3500/fixtures/generic.html#foo")
+        .visit("http://localhost:3500/fixtures/generic.html#foo")
+
     it "resolves the subject to the remote iframe window", ->
       cy.visit("/fixtures/jquery.html").then (win) ->
         expect(win).to.eq cy.state("$autIframe").prop("contentWindow")


### PR DESCRIPTION
- Fixes #1311 

Interested if there is a better way to pass through the visit here, when you pin the command the console output is pretty bad:

<img width="671" alt="screen shot 2019-01-15 at 12 54 23 pm" src="https://user-images.githubusercontent.com/7514489/51206198-9af91480-18ab-11e9-9d32-bed96131bd76.png">
