### PR TITLE
Update script injection to handle case where only DOCTYPE declaration in document

### DIFF
--- a/packages/server/lib/util/rewriter.js
+++ b/packages/server/lib/util/rewriter.js
@@ -11,6 +11,7 @@
 const inject = require('./inject')
 const security = require('./security')
 
+const doctypeRe = /(<\!doctype.*?>)/i
 const headRe = /(<head(?!er).*?>)/i
 const bodyRe = /(<body.*?>)/i
 const htmlRe = /(<html.*?>)/i
@@ -44,6 +45,10 @@ const rewriteHtml = function (html, domainName, wantsInjection, wantsSecurityRem
 
     case !htmlRe.test(html):
       return replace(htmlRe, `$1 <head> ${htmlToInject} </head>`)
+
+    case !doctypeRe.test(html):
+      // if only <!DOCTYPE> content, inject <head> after doctype
+      return `${html}<head> ${htmlToInject} </head>`
 
     default:
       return `<head> ${htmlToInject} </head>${html}`

--- a/packages/server/test/integration/http_requests_spec.coffee
+++ b/packages/server/test/integration/http_requests_spec.coffee
@@ -2013,6 +2013,24 @@ describe "Routes", ->
           expect(res.body).to.include "<head> <script"
           expect(res.body).to.include "</head><div>hello from bar!</div>"
 
+      it "injects after DOCTYPE declaration when no other content", ->
+        nock(@server._remoteOrigin)
+        .get("/bar")
+        .reply 200, "<!DOCTYPE>", {
+          "Content-Type": "text/html"
+        }
+
+        @rp({
+          url: "http://www.google.com/bar"
+          headers: {
+            "Cookie": "__cypress.initial=true"
+          }
+        })
+        .then (res) ->
+          expect(res.statusCode).to.eq(200)
+
+          expect(res.body).to.include "<!DOCTYPE><head> <script"
+
       it "injects superdomain even when head tag is missing", ->
         nock(@server._remoteOrigin)
         .get("/bar")


### PR DESCRIPTION
- Needs to write the head element AFTER the Doctype declaration, not
before.
- close #2617 