### PR TITLE
Fix tooltip styling

### DIFF
--- a/packages/reporter/src/lib/tooltip.scss
+++ b/packages/reporter/src/lib/tooltip.scss
@@ -2,4 +2,5 @@
 
 .tooltip {
   font-family: $muli;
+  word-wrap: break-word;
 }


### PR DESCRIPTION
Small CSS fix for issue #2980 

Rule `word-wrap: break-word;` is used in `tooltip.scss` file as proposed in #2980 
