### PR TITLE
allow .its to yield undefined

### DIFF
--- a/packages/driver/src/cy/assertions.coffee
+++ b/packages/driver/src/cy/assertions.coffee
@@ -276,6 +276,12 @@ create = (state, queue, retryFn) ->
         cmd.skip()
 
     assertions = (memo, fn, i) =>
+      ## HACK: bluebird .reduce will not call the callback
+      ## if given an undefined initial value, so in order to
+      ## support undefined subjects, we wrap the initial value
+      ## in an Array and unwrap it if index = 0
+      if i is 0
+        memo = memo[0]
       fn(memo).then (subject) ->
         subjects[i] = subject
 
@@ -291,7 +297,7 @@ create = (state, queue, retryFn) ->
     state("overrideAssert", overrideAssert)
 
     Promise
-    .reduce(fns, assertions, subject)
+    .reduce(fns, assertions, [subject])
     .then ->
       restore()
 

--- a/packages/driver/src/cy/commands/connectors.coffee
+++ b/packages/driver/src/cy/commands/connectors.coffee
@@ -183,7 +183,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
         ## if the property does not EXIST on the subject
         ## then throw a specific error message
         try
-          fail(prop) if prop not of getValue(memo, prop)
+          memo[prop]
         catch e
           ## if the value is null or undefined then it does
           ## not have properties which causes us to throw

--- a/packages/driver/test/cypress/integration/commands/connectors_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/connectors_spec.coffee
@@ -755,14 +755,14 @@ describe "src/cy/commands/connectors", ->
           cy.noop({}).its("foo")
 
         it "retries when yielded undefined value", ->
-          obj = {}
+          obj = {foo:''}
 
-          obj.foo = undefined
-
-          setTimeout ()->
-            obj.foo = true
-          , 10
-
+          cy.stub(obj, 'foo').get(
+            cy.stub()
+              .onCall(0).returns(undefined)
+              .onCall(1).returns(undefined)
+              .onCall(2).returns(true)
+          )
           cy.wrap(obj).its('foo').should('eq', true)
 
         it "can handle getter that throws", (done) ->

--- a/packages/driver/test/cypress/integration/commands/connectors_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/connectors_spec.coffee
@@ -765,33 +765,6 @@ describe "src/cy/commands/connectors", ->
 
           cy.wrap(obj).its('foo').should('eq', true)
 
-        it "cy.wrap(undefined) should retry", () ->
-          spy = cy.spy()
-
-          cy.wrap().should ->
-            spy()
-            expect(spy).to.be.calledTwice
-
-          cy.wrap(undefined).should ->
-            spy()
-            expect(spy.callCount).to.eq(4)
-
-        it "cy.then does not verify upcoming assertions", ->
-          cy.timeout(4000)
-          # obj = {foo: "bar"}
-
-          cy.wrap({foo:"bar"}).then (obj) ->
-            setTimeout ->
-              obj.foo = "baz"
-            , 1000
-
-            return obj
-          # cy.wrap(obj)
-          .then (obj) ->
-            cy.wrap(obj).should (obj) ->
-              console.log(obj)
-              expect(obj).to.deep.eq({foo: "baz"})
-
         it "can handle getter that throws", (done) ->
           spy = cy.spy((err)=>
             # throw new Error('sdf')

--- a/packages/driver/test/cypress/integration/commands/connectors_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/connectors_spec.coffee
@@ -518,7 +518,7 @@ describe "src/cy/commands/connectors", ->
           cy.on "fail", (err) =>
             lastLog = @lastLog
 
-            expect(err.message).to.include "cy.invoke() errored because the property: 'foo' does not exist on your subject."
+            expect(err.message).to.eq "Timed out retrying: Cannot call cy.invoke() because 'foo' is not a function. You probably want to use cy.its('foo')."
             expect(lastLog.get("error").message).to.include(err.message)
             done()
 
@@ -563,12 +563,11 @@ describe "src/cy/commands/connectors", ->
           cy.on "fail", (err) =>
             expect(@lastLog.invoke("consoleProps")).to.deep.eq {
               Command: "its"
-              Error: "CypressError: Timed out retrying: cy.its() errored because the property: 'baz' does not exist on your subject."
+              Error: "CypressError: Timed out retrying: cy.its() errored because the property: 'fizz' returned a 'undefined' value. You cannot access any properties such as 'buzz' on a 'undefined' value."
               Subject: {foo: "bar"}
             }
             done()
-
-          cy.noop({foo: "bar"}).its("baz")
+          cy.noop({foo: "bar"}).its("fizz.buzz")
 
     context "#its", ->
       beforeEach ->
@@ -752,21 +751,67 @@ describe "src/cy/commands/connectors", ->
 
           cy.wrap(obj).its("foo.bar.baz").should("eq", "baz")
 
-        it "throws when property does not exist on the subject", (done) ->
-          cy.on "fail", (err) =>
-            lastLog = @lastLog
-
-            expect(err.message).to.include "cy.its() errored because the property: 'foo' does not exist on your subject."
-            expect(lastLog.get("error").message).to.include(err.message)
-            done()
-
+        it "does not throw when property does not exist on the subject", ->
           cy.noop({}).its("foo")
+
+        it "retries when yielded undefined value", ->
+          obj = {}
+
+          obj.foo = undefined
+
+          setTimeout ()->
+            obj.foo = true
+          , 10
+
+          cy.wrap(obj).its('foo').should('eq', true)
+
+        it "cy.wrap(undefined) should retry", () ->
+          spy = cy.spy()
+
+          cy.wrap().should ->
+            spy()
+            expect(spy).to.be.calledTwice
+
+          cy.wrap(undefined).should ->
+            spy()
+            expect(spy.callCount).to.eq(4)
+
+        it "cy.then does not verify upcoming assertions", ->
+          cy.timeout(4000)
+          # obj = {foo: "bar"}
+
+          cy.wrap({foo:"bar"}).then (obj) ->
+            setTimeout ->
+              obj.foo = "baz"
+            , 1000
+
+            return obj
+          # cy.wrap(obj)
+          .then (obj) ->
+            cy.wrap(obj).should (obj) ->
+              console.log(obj)
+              expect(obj).to.deep.eq({foo: "baz"})
+
+        it "can handle getter that throws", (done) ->
+          spy = cy.spy((err)=>
+            # throw new Error('sdf')
+            # expect(false).to.eq(true)
+            expect(err.message).to.eq('Timed out retrying: some getter error')
+            done()
+            ).as('onFail')
+          cy.on 'fail', spy
+          obj = {}
+          Object.defineProperty obj, 'foo', {get: -> throw new Error('some getter error')}
+
+          cy.wrap(obj).its('foo')
+
+
 
         it "throws when reduced property does not exist on the subject", (done) ->
           cy.on "fail", (err) =>
             lastLog = @lastLog
 
-            expect(err.message).to.include "cy.its() errored because the property: 'baz' does not exist on your subject."
+            expect(err.message).to.include   "Timed out retrying: cy.its() errored because the property: 'baz' returned a 'undefined' value. You cannot access any properties such as 'fizz' on a 'undefined' value."
             expect(lastLog.get("error").message).to.include(err.message)
             expect(lastLog.get("error").message).to.include(err.message)
             done()
@@ -777,7 +822,7 @@ describe "src/cy/commands/connectors", ->
             }
           }
 
-          cy.noop(obj).its("foo.bar.baz")
+          cy.noop(obj).its("foo.bar.baz.fizz")
 
         [null, undefined].forEach (val) ->
           it "throws on reduced #{val} subject", (done) ->

--- a/packages/driver/test/cypress/integration/commands/misc_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/misc_spec.coffee
@@ -69,16 +69,17 @@ describe "src/cy/commands/misc", ->
       cy.wrap({}).then (subject) ->
         expect(subject).to.deep.eq {}
 
+    ## https://github.com/cypress-io/cypress/issues/3241
     it "cy.wrap(undefined) should retry", () ->
-      spy = cy.spy()
+      stub = cy.stub()
 
       cy.wrap().should ->
-        spy()
-        expect(spy).to.be.calledTwice
+        stub()
+        expect(stub).to.be.calledTwice
 
       cy.wrap(undefined).should ->
-        spy()
-        expect(spy.callCount).to.eq(4)
+        stub()
+        expect(stub.callCount).to.eq(4)
 
     it "can wrap jquery objects and continue to chain", ->
       @remoteWindow.$.fn.foo = "foo"

--- a/packages/driver/test/cypress/integration/commands/misc_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/misc_spec.coffee
@@ -69,6 +69,17 @@ describe "src/cy/commands/misc", ->
       cy.wrap({}).then (subject) ->
         expect(subject).to.deep.eq {}
 
+    it "cy.wrap(undefined) should retry", () ->
+      spy = cy.spy()
+
+      cy.wrap().should ->
+        spy()
+        expect(spy).to.be.calledTwice
+
+      cy.wrap(undefined).should ->
+        spy()
+        expect(spy.callCount).to.eq(4)
+
     it "can wrap jquery objects and continue to chain", ->
       @remoteWindow.$.fn.foo = "foo"
 


### PR DESCRIPTION
fix #1531 allow .its to yield undefined
fix #3241 undefined does not retry

~yes, this is a breaking change. But I think it makes a lot of sense~
maybe this is not a breaking change, since this makes test code fail less.


- [x] add tests
- [x] test case for getter throwing
~remove else clause that won't get hit~
- [x] allow cypress to retry undefined subject / test 