### PR TITLE
Fix regression causing browsers not to be launched in open mode

### DIFF
--- a/packages/desktop-gui/cypress/fixtures/browsers.json
+++ b/packages/desktop-gui/cypress/fixtures/browsers.json
@@ -2,6 +2,7 @@
   {
     "name": "chrome",
     "displayName": "Chrome",
+    "family": "chrome",
     "version": "50.0.2661.86",
     "path": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
     "majorVersion": "50"
@@ -9,6 +10,7 @@
   {
     "name": "chromium",
     "displayName": "Chromium",
+    "family": "chrome",
     "version": "49.0.2609.0",
     "path": "/Users/bmann/Downloads/chrome-mac/Chromium.app/Contents/MacOS/Chromium",
     "majorVersion": "49"
@@ -16,6 +18,7 @@
   {
     "name": "canary",
     "displayName": "Canary",
+    "family": "chrome",
     "version": "48.0",
     "path": "/Users/bmann/Downloads/chrome-mac/Canary.app/Contents/MacOS/Canary",
     "majorVersion": "48"

--- a/packages/desktop-gui/cypress/fixtures/config.json
+++ b/packages/desktop-gui/cypress/fixtures/config.json
@@ -6,6 +6,7 @@
     {
       "name": "chrome",
       "displayName": "Chrome",
+      "family": "chrome",
       "version": "50.0.2661.86",
       "path": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
       "majorVersion": "50"
@@ -13,6 +14,7 @@
     {
       "name": "chromium",
       "displayName": "Chromium",
+      "family": "chrome",
       "version": "49.0.2609.0",
       "path": "/Users/bmann/Downloads/chrome-mac/Chromium.app/Contents/MacOS/Chromium",
       "majorVersion": "49"
@@ -20,11 +22,12 @@
     {
       "name": "canary",
       "displayName": "Canary",
+      "family": "chrome",
       "version": "48.0",
       "path": "/Users/bmann/Downloads/chrome-mac/Canary.app/Contents/MacOS/Canary",
       "majorVersion": "48"
     }
-  ],  
+  ],
   "clientRoute": "/__/",
   "clientUrl": "http://localhost:2020/__/",
   "clientUrlDisplay": "http://localhost:2020",

--- a/packages/desktop-gui/cypress/integration/project_nav_spec.coffee
+++ b/packages/desktop-gui/cypress/integration/project_nav_spec.coffee
@@ -148,6 +148,14 @@ describe "Project Nav", ->
         it "displays stop browser button", ->
           cy.get(".close-browser").should("be.visible")
 
+        it "sends the required parameters to launch a browser", ->
+          browserArg = @ipc.launchBrowser.getCall(0).args[0].browser
+          expect(browserArg).to.have.all.keys([
+            "family", "name", "path", "version", "majorVersion", "displayName", "info", "isChosen"
+          ])
+          expect(browserArg.path).to.include('/')
+          expect(browserArg.family).to.equal('chrome')
+
         describe "stop browser", ->
           beforeEach ->
             cy.get(".close-browser").click()

--- a/packages/desktop-gui/src/lib/browser-model.js
+++ b/packages/desktop-gui/src/lib/browser-model.js
@@ -3,6 +3,7 @@ import { computed, observable } from 'mobx'
 export default class Browser {
   @observable displayName
   @observable name
+  @observable family
   @observable version
   @observable path
   @observable majorVersion
@@ -12,6 +13,7 @@ export default class Browser {
   constructor (browser) {
     this.displayName = browser.displayName
     this.name = browser.name
+    this.family = browser.family
     this.version = browser.version
     this.path = browser.path
     this.majorVersion = browser.majorVersion

--- a/packages/desktop-gui/src/projects/projects-api.js
+++ b/packages/desktop-gui/src/projects/projects-api.js
@@ -71,6 +71,10 @@ const runSpec = (project, spec, browser) => {
     project.browserOpening()
 
     ipc.launchBrowser({ browser, spec: spec.file }, (err, data = {}) => {
+      if (err) {
+        return project.setError(err)
+      }
+
       if (data.browserOpened) {
         project.browserOpened()
       }


### PR DESCRIPTION
This fixes the bug that was introduced in #3225 which means that browsers cannot be launched in open mode.

Also adds a test to `desktop-gui` to ensure a browser is always launched with the necessary properties.