### PR TITLE
Reduce the number of log printed when install cypress in docker

### DIFF
--- a/cli/lib/util.js
+++ b/cli/lib/util.js
@@ -159,7 +159,7 @@ const util = {
 
   setTaskTitle (task, title, renderer) {
     // only update the renderer title when not running in CI
-    if (renderer === 'default') {
+    if (renderer === 'default' && task.title !== title) {
       task.title = title
     }
   },


### PR DESCRIPTION
Attempt to close [cypress-io#1243](https://github.com/cypress-io/cypress/issues/1243) (More like a temp fix)
I am currently running `npm install` inside docker and the log for cypress is ridiculous long. I hope this can reduce the log length to 100 instead of thousands.
However, I dont have any experiences in library development. Im not sure how I can test if this code actually works. All i know is that I didnt break any existing tests.
So if you know how to test this code, please let me know how or you can help me test it and let me know the result.
Thank you