### PR TITLE
issue-3540: Get rid of stripping trailing slashes from baseUrl

### DIFF
--- a/packages/server/lib/config.coffee
+++ b/packages/server/lib/config.coffee
@@ -229,10 +229,6 @@ module.exports = {
       return
     .value()
 
-    if url = config.baseUrl
-      ## always strip trailing slashes
-      config.baseUrl = _.trimEnd(url, "/")
-
     _.defaults(config, defaults)
 
     ## split out our own app wide env from user env variables


### PR DESCRIPTION
issue-3540: Get rid of stripping trailing slashes from baseUrl.
closes #3540

![obraz](https://user-images.githubusercontent.com/905878/53119606-c4126200-3547-11e9-9a4d-8f25b491a521.png)
