### PR TITLE
Issue 3540: Fix baseUrl slash

### DIFF
--- a/packages/server/lib/config.coffee
+++ b/packages/server/lib/config.coffee
@@ -230,9 +230,10 @@ module.exports = {
     .value()
 
     if url = config.baseUrl
-      ## always strip trailing slashes and add one to end
+      ## replace multiple slashes at the end of string to single slash
       ## so http://localhost/// will be http://localhost/
-      config.baseUrl = _.trimEnd(url, "/") + "/"
+      ## https://regexr.com/48rvt
+      config.baseUrl = url.replace(/\/\/+$/, "/")
 
     _.defaults(config, defaults)
 

--- a/packages/server/lib/config.coffee
+++ b/packages/server/lib/config.coffee
@@ -229,10 +229,6 @@ module.exports = {
       return
     .value()
 
-    if url = config.baseUrl
-      ## always strip trailing slashes
-      config.baseUrl = _.trimEnd(url, "/")
-
     _.defaults(config, defaults)
 
     ## split out our own app wide env from user env variables

--- a/packages/server/lib/config.coffee
+++ b/packages/server/lib/config.coffee
@@ -229,6 +229,11 @@ module.exports = {
       return
     .value()
 
+    if url = config.baseUrl
+      ## always strip trailing slashes and add one to end
+      ## so http://localhost/// will be http://localhost/
+      config.baseUrl = _.trimEnd(url, "/") + "/"
+
     _.defaults(config, defaults)
 
     ## split out our own app wide env from user env variables

--- a/packages/server/test/unit/config_spec.coffee
+++ b/packages/server/test/unit/config_spec.coffee
@@ -792,7 +792,7 @@ describe "lib/config", ->
             userAgent:                  { value: null, from: "default" }
             reporter:                   { value: "spec", from: "default" },
             reporterOptions:            { value: null, from: "default" },
-            baseUrl:                    { value: "http://localhost:8080/", from: "config" },
+            baseUrl:                    { value: "http://localhost:8080", from: "config" },
             defaultCommandTimeout:      { value: 4000, from: "default" },
             pageLoadTimeout:            { value: 60000, from: "default" },
             requestTimeout:             { value: 5000, from: "default" },

--- a/packages/server/test/unit/config_spec.coffee
+++ b/packages/server/test/unit/config_spec.coffee
@@ -782,7 +782,7 @@ describe "lib/config", ->
             userAgent:                  { value: null, from: "default" }
             reporter:                   { value: "spec", from: "default" },
             reporterOptions:            { value: null, from: "default" },
-            baseUrl:                    { value: "http://localhost:8080", from: "config" },
+            baseUrl:                    { value: "http://localhost:8080/", from: "config" },
             defaultCommandTimeout:      { value: 4000, from: "default" },
             pageLoadTimeout:            { value: 60000, from: "default" },
             requestTimeout:             { value: 5000, from: "default" },

--- a/packages/server/test/unit/config_spec.coffee
+++ b/packages/server/test/unit/config_spec.coffee
@@ -509,9 +509,9 @@ describe "lib/config", ->
     it "namespace=__cypress", ->
       @defaults "namespace", "__cypress"
 
-    it "baseUrl=http://localhost:8000/test/", ->
-      @defaults "baseUrl", "http://localhost:8000/test/", {
-        baseUrl: "http://localhost:8000/test///"
+    it "baseUrl=http://localhost:8000/app/", ->
+      @defaults "baseUrl", "http://localhost:8000/app/", {
+        baseUrl: "http://localhost:8000/app///"
       }
 
     it "baseUrl=http://localhost:8000/app/", ->
@@ -519,14 +519,24 @@ describe "lib/config", ->
         baseUrl: "http://localhost:8000/app//"
       }
 
+    it "baseUrl=http://localhost:8000/app", ->
+      @defaults "baseUrl", "http://localhost:8000/app", {
+        baseUrl: "http://localhost:8000/app"
+      }
+
     it "baseUrl=http://localhost:8000/", ->
       @defaults "baseUrl", "http://localhost:8000/", {
-        baseUrl: "http://localhost:8000"
+        baseUrl: "http://localhost:8000//"
       }
 
     it "baseUrl=http://localhost:8000/", ->
       @defaults "baseUrl", "http://localhost:8000/", {
         baseUrl: "http://localhost:8000/"
+      }
+
+    it "baseUrl=http://localhost:8000", ->
+      @defaults "baseUrl", "http://localhost:8000", {
+        baseUrl: "http://localhost:8000"
       }
 
     it "javascripts=[]", ->

--- a/packages/server/test/unit/config_spec.coffee
+++ b/packages/server/test/unit/config_spec.coffee
@@ -509,9 +509,24 @@ describe "lib/config", ->
     it "namespace=__cypress", ->
       @defaults "namespace", "__cypress"
 
-    it "baseUrl=http://localhost:8000/app", ->
-      @defaults "baseUrl", "http://localhost:8000/app", {
+    it "baseUrl=http://localhost:8000/test/", ->
+      @defaults "baseUrl", "http://localhost:8000/test/", {
+        baseUrl: "http://localhost:8000/test///"
+      }
+
+    it "baseUrl=http://localhost:8000/app/", ->
+      @defaults "baseUrl", "http://localhost:8000/app/", {
         baseUrl: "http://localhost:8000/app//"
+      }
+
+    it "baseUrl=http://localhost:8000/", ->
+      @defaults "baseUrl", "http://localhost:8000/", {
+        baseUrl: "http://localhost:8000"
+      }
+
+    it "baseUrl=http://localhost:8000/", ->
+      @defaults "baseUrl", "http://localhost:8000/", {
+        baseUrl: "http://localhost:8000/"
       }
 
     it "javascripts=[]", ->


### PR DESCRIPTION
closes #3540 and #3545 

Tests:
```js
/// <reference types="Cypress" />

it('test url', function () {
    cy.visit('/')
    var baseUrl = Cypress.config('baseUrl')
    //baseUrl = baseUrl + '/'    // bug in Cypress - add slash
    cy.url().should('eq', Cypress.env('test_url'))
    cy.url().should('eq', baseUrl)
})

it('test url - copy paste from @jennifer-shehane', function () {
    cy.visit('/')
    cy.url().should('eq', Cypress.config('baseUrl'))
})
```

![obraz](https://user-images.githubusercontent.com/905878/53121397-10f83780-354c-11e9-8495-2474ced106e6.png)
