### PR TITLE
convert dom element to jQuery element in order to properly check contains assertion

### DIFF
--- a/packages/driver/src/cy/chai.coffee
+++ b/packages/driver/src/cy/chai.coffee
@@ -143,6 +143,11 @@ chai.use (chai, u) ->
 
         selector = ":contains('#{escText}'), [type='submit'][value~='#{escText}']"
 
+        ## the assert checks below only work if $dom.isJquery(obj)
+        ## https://github.com/cypress-io/cypress/issues/3549
+        if not ($dom.isJquery(obj)) 
+          obj = $(obj)
+
         @assert(
           obj.is(selector) or !!obj.find(selector).length
           'expected #{this} to contain #{exp}'

--- a/packages/driver/src/cy/chai.coffee
+++ b/packages/driver/src/cy/chai.coffee
@@ -1,3 +1,5 @@
+## tests in driver/test/cypress/integration/commands/assertions_spec.coffee
+
 _ = require("lodash")
 $ = require("jquery")
 chai = require("chai")

--- a/packages/driver/test/cypress/integration/commands/assertions_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/assertions_spec.coffee
@@ -754,6 +754,11 @@ describe "src/cy/commands/assertions", ->
       it "calls super when not DOM element", ->
         cy.noop("foobar").should("contain", "oob")
 
+      ## https://github.com/cypress-io/cypress/issues/3549
+      it "is true when DOM el and not jQuery el contains text", ->
+        cy.get("div").then ($el) ->
+          cy.wrap($el[1]).should("contain", "Nested Find")
+
       it "escapes quotes", ->
         $span = "<span id=\"escape-quotes\">shouldn't and can\"t</span>"
 


### PR DESCRIPTION
- close #3549 
- obj.is and obj.find is not a function when used on regular el - needs
to be jQuery el

**Tests**
- [x] Write test

I can't figure out where the tests for these chai overrides are. Any help?