### PR TITLE
bump tough-cookie

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -184,7 +184,7 @@
     "tar-fs": "1.16.3",
     "term-size": "1.2.0",
     "through": "2.3.8",
-    "tough-cookie": "2.5.0",
+    "tough-cookie": "3.0.1",
     "trash": "4.3.0",
     "underscore": "1.9.1",
     "underscore.string": "3.3.5",


### PR DESCRIPTION
- breaking change: no longer supports node version < 6
- bugfixes