### PR TITLE
Bump cachedir from 1.3.0 -> 2.1.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -42,7 +42,7 @@
     "@cypress/listr-verbose-renderer": "0.4.1",
     "@cypress/xvfb": "1.2.4",
     "bluebird": "3.5.0",
-    "cachedir": "1.3.0",
+    "cachedir": "2.1.0",
     "chalk": "2.4.2",
     "check-more-types": "2.24.0",
     "commander": "2.19.0",


### PR DESCRIPTION
- Breaking change: Drop support for Node.js < 6.x]
- Use os.homedir() instead of os-homedir module (reduced dependency and
size)