### PR TITLE
Make extension have a static ID so it can be whitelisted

### DIFF
--- a/packages/extension/app/manifest.json
+++ b/packages/extension/app/manifest.json
@@ -8,6 +8,7 @@
     "https://*/*",
     "<all_urls>"
   ],
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAugoxpSqfoblTYUGvyXZpmBgjYQUY9k2Hx3PaDwquyaTH6GBxitwVMSu5sZuDYgPHpGYoF4ol6A4PZHhd6JvfuUDS9ZrxTW0XzP+dSS9AwmJo3uLuP88zBs4mhpje1+WE5NGM0pTzyCXYTPoyzyPRmToALWD96cahSGuhG8bSmaBw3py+16qNKm8SOlANbUvHtEaTpmrSWBUIq7YV8SIPLtR8G47vjqPTE1yEsBQ3GAgllhi0cJolwk/629fRLr3KVckICmU6spXD/jVhIgAeyHhFuFGYNuubzbel8trBVw5Q/HE5F6j66sBvEvW64tH4lPxnM5JPv0qie5wouPiT0wIDAQAB",
   "icons": {
     "16":  "icons/icon_16x16.png",
     "48":  "icons/icon_48x48.png",

--- a/packages/extension/test/unit/extension_spec.coffee
+++ b/packages/extension/test/unit/extension_spec.coffee
@@ -1,5 +1,6 @@
 require("../spec_helper")
 
+exec      = require("child_process").exec
 fs        = require("fs-extra")
 path      = require("path")
 Promise   = require("bluebird")
@@ -8,6 +9,7 @@ extension = require("../../index")
 cwd       = process.cwd()
 
 fs = Promise.promisifyAll(fs)
+exec = Promise.promisify(exec)
 
 describe "Extension", ->
   context ".getCookieUrl", ->
@@ -87,3 +89,13 @@ describe "Extension", ->
           fs.readFileAsync(@src, "utf8")
         .then (str2) ->
           expect(str).to.eq(str2)
+
+  context "manifest", ->
+    it "has a key that resolves to the static extension ID", ->
+      fs.readJsonAsync(path.join(cwd, "app/manifest.json"))
+      .then (manifest) ->
+        cmd = "echo \"#{manifest.key}\" | openssl base64 -d -A | shasum -a 256 | head -c32 | tr 0-9a-f a-p"
+        exec(cmd)
+        .then (stdout) ->
+          expect(stdout).to.eq("caljajdfkjjjdehjdoimjkkakekklcck")
+


### PR DESCRIPTION
Fixes #3673
Fixes #1239

This PR makes the extension have a static ID so it can be whitelisted.

The extension ID for Cypress is: `caljajdfkjjjdehjdoimjkkakekklcck`