### PR TITLE
fix typo in scaffolded command.js

### DIFF
--- a/packages/example/cypress/support/commands.js
+++ b/packages/example/cypress/support/commands.js
@@ -21,5 +21,5 @@
 // Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
 //
 //
-// -- This is will overwrite an existing command --
+// -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })

--- a/packages/server/__snapshots__/scaffold_spec.coffee.js
+++ b/packages/server/__snapshots__/scaffold_spec.coffee.js
@@ -309,7 +309,7 @@ exports['lib/scaffold .support creates supportFolder and commands.js and index.j
 // Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
 //
 //
-// -- This is will overwrite an existing command --
+// -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 `

--- a/packages/server/lib/scaffold/support/commands.js
+++ b/packages/server/lib/scaffold/support/commands.js
@@ -21,5 +21,5 @@
 // Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
 //
 //
-// -- This is will overwrite an existing command --
+// -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })


### PR DESCRIPTION
<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->
Minor typo fix for the scaffolded command.js. 