### PR TITLE
Spawn GitHub login with a new user agent to dismiss warning banner

### DIFF
--- a/packages/server/lib/gui/windows.coffee
+++ b/packages/server/lib/gui/windows.coffee
@@ -285,7 +285,12 @@ module.exports = {
     .then (url) ->
       if options.type is "GITHUB_LOGIN"
         ## remove the GitHub warning banner about an outdated browser
-        win.webContents.setUserAgent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36")
+        ## TODO: remove this once we have upgraded Electron or added native browser auth
+        newUserAgent = win.webContents.getUserAgent()
+        .replace(/Chrome\/\d+\.\d+\.\d+\.\d+/, 'Chrome/72.0.3626.121')
+        .replace(/Electron\/\d+\.\d+\.\d+/, 'Electron/4.0.5')
+        debug('changing user agent to ', newUserAgent)
+        win.webContents.setUserAgent(newUserAgent)
 
       ## navigate the window here!
       win.loadURL(url)

--- a/packages/server/lib/gui/windows.coffee
+++ b/packages/server/lib/gui/windows.coffee
@@ -283,12 +283,9 @@ module.exports = {
     Promise
     .resolve(options.url)
     .then (url) ->
-      # if width and height
-      #   ## width and height are truthy when
-      #   ## transparent: true is sent
-      #   win.webContents.once "dom-ready", ->
-      #     win.setSize(width, height)
-      #     win.show()
+      if options.type is "GITHUB_LOGIN"
+        ## remove the GitHub warning banner about an outdated browser
+        win.webContents.setUserAgent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36")
 
       ## navigate the window here!
       win.loadURL(url)

--- a/packages/server/test/unit/gui/windows_spec.coffee
+++ b/packages/server/test/unit/gui/windows_spec.coffee
@@ -77,8 +77,7 @@ describe "lib/gui/windows", ->
 
     it "updates the user agent for GITHUB_LOGIN", ->
       options = {
-        type: "GITHUB_LOGIN",
-        url: "about:blank"
+        type: "GITHUB_LOGIN"
       }
 
       sinon.stub(user, "getLoginUrl").resolves("about:blank")

--- a/packages/server/test/unit/gui/windows_spec.coffee
+++ b/packages/server/test/unit/gui/windows_spec.coffee
@@ -10,6 +10,8 @@ user          = require("#{root}../lib/user")
 Windows       = require("#{root}../lib/gui/windows")
 savedState    = require("#{root}../lib/saved_state")
 
+DEFAULT_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Cypress/0.0.0 Chrome/59.0.3071.115 Electron/1.8.2 Safari/537.36"
+
 describe "lib/gui/windows", ->
   beforeEach ->
     Windows.reset()
@@ -21,6 +23,8 @@ describe "lib/gui/windows", ->
     @win.getPosition = sinon.stub().returns([3, 4])
     @win.webContents = new EE()
     @win.webContents.openDevTools = sinon.stub()
+    @win.webContents.setUserAgent = sinon.stub()
+    @win.webContents.getUserAgent = sinon.stub().returns(DEFAULT_USER_AGENT)
     @win.isDestroyed = sinon.stub().returns(false)
 
     sinon.stub(Windows, "_newBrowserWindow").returns(@win)
@@ -70,6 +74,20 @@ describe "lib/gui/windows", ->
         })
 
         expect(win.loadURL).to.be.calledWith(cyDesktop.getPathToIndex())
+
+    it "updates the user agent for GITHUB_LOGIN", ->
+      options = {
+        type: "GITHUB_LOGIN",
+        url: "about:blank"
+      }
+
+      sinon.stub(user, "getLoginUrl").resolves("about:blank")
+      @win.loadURL.throws()
+
+      Windows.open("/path/to/project", options).catch =>
+        newUserAgent = @win.webContents.setUserAgent.getCall(0).args[0]
+        expected = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Cypress/0.0.0 Chrome/72.0.3626.121 Electron/4.0.5 Safari/537.36"
+        expect(newUserAgent).to.eq(expected)
 
     it "resolves with code on GITHUB_LOGIN for will-navigate", ->
       options = {


### PR DESCRIPTION
- close #1251 

This removes the GitHub warning banner about an outdated browser in our Electron pop-up by replacing the user agent string of Electron with a new Chrome UA: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36"

I was only able to replicate the warning banner on Windows, and this fixes it there.