### PR TITLE
Log options to cy.visit()

### DIFF
--- a/packages/driver/src/cy/commands/navigation.coffee
+++ b/packages/driver/src/cy/commands/navigation.coffee
@@ -13,6 +13,9 @@ hasVisitedAboutBlank  = null
 currentlyVisitingAboutBlank = null
 knownCommandCausedInstability = null
 
+REQUEST_URL_OPTS = ["auth", "failOnStatusCode", "method", "body", "headers"]
+VISIT_OPTS = ["url", "log", "onBeforeLoad", "onLoad", "timeout"].concat(REQUEST_URL_OPTS)
+
 reset = (test = {}) ->
   knownCommandCausedInstability = false
 
@@ -265,7 +268,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
     Cypress.backend(
       "resolve:url",
       url,
-      _.pick(options, "auth", "failOnStatusCode", "method", "body", "headers")
+      _.pick(options, REQUEST_URL_OPTS)
     )
     .then (resp = {}) ->
       switch
@@ -472,6 +475,11 @@ module.exports = (Commands, Cypress, cy, state, config) ->
       if not _.isString(url)
         $utils.throwErrByPath("visit.invalid_1st_arg")
 
+      consoleProps = {}
+
+      if not _.isEmpty(options)
+        consoleProps["Options"] = _.pick(options, VISIT_OPTS)
+
       _.defaults(options, {
         auth: null
         failOnStatusCode: true
@@ -489,8 +497,6 @@ module.exports = (Commands, Cypress, cy, state, config) ->
 
       if not _.isObject(options.headers)
         $utils.throwErrByPath("visit.invalid_headers")
-
-      consoleProps = {}
 
       if options.log
         message = url

--- a/packages/driver/test/cypress/integration/commands/navigation_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/navigation_spec.coffee
@@ -906,6 +906,27 @@ describe "src/cy/commands/navigation", ->
               "Note": "Because this visit was to the same hash, the page did not reload and the onBeforeLoad and onLoad callbacks did not fire."
           })
 
+      it "logs options if they are supplied", ->
+        cy.visit({
+          url: "http://localhost:3500/fixtures/generic.html"
+          headers: {
+            "foo": "bar"
+          },
+          notReal: "baz"
+        })
+        .then ->
+          expect(@lastLog.invoke("consoleProps")["Options"]).to.deep.eq({
+            url: "http://localhost:3500/fixtures/generic.html"
+            headers: {
+              "foo": "bar"
+            }
+          })
+
+      it "does not log options if they are not supplied", ->
+        cy.visit("http://localhost:3500/fixtures/generic.html")
+        .then ->
+          expect(@lastLog.invoke("consoleProps")["Options"]).to.be.undefined
+
     describe "errors", ->
       beforeEach ->
         Cypress.config("defaultCommandTimeout", 50)


### PR DESCRIPTION
Fixes #3721 

Now shows valid `options` in the console log when the visit command is clicked, if options were passed.

![image](https://user-images.githubusercontent.com/1151760/54540189-e8f2cd00-496d-11e9-8b22-52dce5580e0a.png)
