### PR TITLE
Fix parsing environment variables with empty values

### DIFF
--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -22,7 +22,7 @@ const cwd = require('../cwd')
 
 const nestedObjectsInCurlyBracesRe = /\{(.+?)\}/g
 const nestedArraysInSquareBracketsRe = /\[(.+?)\]/g
-const everythingAfterFirstEqualRe = /=(.+)/
+const everythingAfterFirstEqualRe = /=(.*)/
 
 const whitelist = 'cwd appPath execPath apiKey smokeTest getKey generateKey runProject project spec reporter reporterOptions port env ci record updating ping key logs clearLogs returnPkg version mode headed config exit exitWithCode browser runMode outputPath parallel ciBuildId group inspectBrk'.split(' ')
 
@@ -143,9 +143,8 @@ const sanitizeAndConvertNestedArgs = function (str) {
   .replace(nestedObjectsInCurlyBracesRe, commasToPipes)
   .replace(nestedArraysInSquareBracketsRe, commasToPipes)
   .split(',')
-  .map((pair) => {
-    return pair.split(everythingAfterFirstEqualRe)
-  }).fromPairs()
+  .map((pair) => pair.split(everythingAfterFirstEqualRe))
+  .fromPairs()
   .mapValues(JSONOrCoerce)
   .value()
 }

--- a/packages/server/test/integration/cypress_spec.coffee
+++ b/packages/server/test/integration/cypress_spec.coffee
@@ -870,6 +870,21 @@ describe "lib/cypress", ->
 
           @expectExitWith(0)
 
+      it "parses environment variables with empty values", ->
+        cypress.start([
+          "--run-project=#{@todosPath}",
+          "--video=false"
+          "--env=FOO=,BAR=,BAZ=ipsum"
+        ])
+        .then =>
+          expect(openProject.getProject().cfg.env).to.deep.eq({
+            FOO: ''
+            BAR: ''
+            BAZ: 'ipsum'
+          })
+
+          @expectExitWith(0)
+
   ## most record mode logic is covered in e2e tests.
   ## we only need to cover the edge cases / warnings
   context "--record or --ci", ->


### PR DESCRIPTION
Fixes #3742

 * When parsing `--env` arguments containing variables with empty values (a valid pattern), Cypress crashed due to trying to `.split()` on an `undefined`.  For example, `cypress run --env="USERNAME=,PASSWORD="` would crash the application.
 * This commit changes the regular expression used to parse environment variables to use a `.*` rather than a `.+`.  This will initialize environment variables that are supplied without values to an empty string.  Since empty strings are falsy in JavaScript, this should work fine with users defaulting to hardcoded values in the case that environment variables aren't supplied (the use case that I was trying to create when I encountered this bug)

Previous behavior:

```sh
"USERNAME=,PASSWORD=".split(',').map(pair => pair.split(/=(.+)/))
// [["USERNAME="], ["PASSWORD="]]
```

New behavior:

```sh
"USERNAME=,PASSWORD=".split(',').map(pair => pair.split(/=(.*)/))
// [["USERNAME=", "", ""], ["PASSWORD=", "", ""]]
```

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->
