### PR TITLE
Upgrade snap shot it to v6 in CLI package

### DIFF
--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -39,10 +39,10 @@ const binaryNotExecutable = (executable) => {
     description: `Cypress cannot run because the binary does not have executable permissions: ${executable}`,
     solution: stripIndent`\n
     Reasons this may happen:
-      
+
     - node was installed as 'root' or with 'sudo'
     - the cypress npm package as 'root' or with 'sudo'
-    
+
     Please check that you have the appropriate user permissions.
   `,
   }
@@ -53,7 +53,7 @@ const notInstalledCI = (executable) => {
     description: 'The cypress npm package is installed, but the Cypress binary is missing.',
     solution: stripIndent`\n
     We expected the binary to be installed here: ${chalk.cyan(executable)}
- 
+
     Reasons it may be missing:
 
     - You're caching 'node_modules' but are not caching this path: ${util.getCacheDir()}
@@ -176,6 +176,10 @@ function addPlatformInformation (info) {
   })
 }
 
+/**
+ * Forms nice error message with error and platform information,
+ * and if possible a way to solve it. Resolves with a string.
+*/
 function formErrorText (info, msg) {
   const hr = '----------'
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -22,7 +22,7 @@
     "test-dependencies": "npm run check-deps && dependency-check . --no-dev",
     "test-debug": "node --inspect --debug-brk $(bin-up _mocha)",
     "test-cov": "nyc npm run unit",
-    "unit": "BLUEBIRD_DEBUG=1 NODE_ENV=test SNAPSHOT_SKIP_SORTING=1 bin-up mocha --reporter mocha-multi-reporters --reporter-options configFile=../mocha-reporter-config.json",
+    "unit": "BLUEBIRD_DEBUG=1 NODE_ENV=test bin-up mocha --reporter mocha-multi-reporters --reporter-options configFile=../mocha-reporter-config.json",
     "lint": "bin-up eslint --fix *.js scripts/*.js bin/* lib/*.js lib/**/*.js test/*.js test/**/*.js",
     "dtslint": "dtslint types",
     "prebuild": "npm run test-dependencies && node ./scripts/start-build.js",

--- a/cli/package.json
+++ b/cli/package.json
@@ -22,7 +22,7 @@
     "test-dependencies": "npm run check-deps && dependency-check . --no-dev",
     "test-debug": "node --inspect --debug-brk $(bin-up _mocha)",
     "test-cov": "nyc npm run unit",
-    "unit": "BLUEBIRD_DEBUG=1 NODE_ENV=test bin-up mocha --reporter mocha-multi-reporters --reporter-options configFile=../mocha-reporter-config.json",
+    "unit": "BLUEBIRD_DEBUG=1 NODE_ENV=test SNAPSHOT_SKIP_SORTING=1 bin-up mocha --reporter mocha-multi-reporters --reporter-options configFile=../mocha-reporter-config.json",
     "lint": "bin-up eslint --fix *.js scripts/*.js bin/* lib/*.js lib/**/*.js test/*.js test/**/*.js",
     "dtslint": "dtslint types",
     "prebuild": "npm run test-dependencies && node ./scripts/start-build.js",
@@ -97,7 +97,7 @@
     "proxyquire": "2.0.1",
     "shelljs": "0.7.8",
     "sinon": "7.2.2",
-    "snap-shot-it": "5.0.1"
+    "snap-shot-it": "6.3.0"
   },
   "files": [
     "bin",

--- a/cli/test/lib/cli_spec.js
+++ b/cli/test/lib/cli_spec.js
@@ -21,7 +21,7 @@ describe('cli', () => {
     os.platform.returns('darwin')
     // sinon.stub(util, 'exit')
     sinon.stub(util, 'logErrorExit1')
-    this.exec = args => {
+    this.exec = (args) => {
       return cli.init(`node test ${args}`.split(' '))
     }
   })
@@ -29,13 +29,13 @@ describe('cli', () => {
   context('unknown option', () => {
     // note it shows help for that specific command
     it('shows help', () => {
-      return execa('bin/cypress', ['open', '--foo']).then(result => {
+      return execa('bin/cypress', ['open', '--foo']).then((result) => {
         snapshot('shows help for open --foo 1', result)
       })
     })
 
     it('shows help for run command', () => {
-      return execa('bin/cypress', ['run', '--foo']).then(result => {
+      return execa('bin/cypress', ['run', '--foo']).then((result) => {
         snapshot('shows help for run --foo 1', result)
       })
     })
@@ -79,12 +79,12 @@ describe('cli', () => {
     beforeEach(() => {
       sinon.stub(state, 'getBinaryDir').returns(binaryDir)
     })
-    it('reports package version', done => {
+    it('reports package version', (done) => {
       sinon.stub(util, 'pkgVersion').returns('1.2.3')
       sinon
-        .stub(state, 'getBinaryPkgVersionAsync')
-        .withArgs(binaryDir)
-        .resolves('X.Y.Z')
+      .stub(state, 'getBinaryPkgVersionAsync')
+      .withArgs(binaryDir)
+      .resolves('X.Y.Z')
 
       this.exec('version')
       process.exit.callsFake(() => {
@@ -93,7 +93,7 @@ describe('cli', () => {
       })
     })
 
-    it('reports package and binary message', done => {
+    it('reports package and binary message', (done) => {
       sinon.stub(util, 'pkgVersion').returns('1.2.3')
       sinon.stub(state, 'getBinaryPkgVersionAsync').resolves('X.Y.Z')
 
@@ -104,7 +104,7 @@ describe('cli', () => {
       })
     })
 
-    it('handles non-existent binary version', done => {
+    it('handles non-existent binary version', (done) => {
       sinon.stub(util, 'pkgVersion').returns('1.2.3')
       sinon.stub(state, 'getBinaryPkgVersionAsync').resolves(null)
 
@@ -115,7 +115,7 @@ describe('cli', () => {
       })
     })
 
-    it('handles non-existent binary --version', done => {
+    it('handles non-existent binary --version', (done) => {
       sinon.stub(util, 'pkgVersion').returns('1.2.3')
       sinon.stub(state, 'getBinaryPkgVersionAsync').resolves(null)
 
@@ -126,7 +126,7 @@ describe('cli', () => {
       })
     })
 
-    it('handles non-existent binary -v', done => {
+    it('handles non-existent binary -v', (done) => {
       sinon.stub(util, 'pkgVersion').returns('1.2.3')
       sinon.stub(state, 'getBinaryPkgVersionAsync').resolves(null)
 
@@ -144,23 +144,23 @@ describe('cli', () => {
       sinon.stub(util, 'exit').withArgs(0)
     })
 
-    it('calls run.start with options + exits with code', done => {
+    it('calls run.start with options + exits with code', (done) => {
       run.start.resolves(10)
       this.exec('run')
 
-      util.exit.callsFake(code => {
+      util.exit.callsFake((code) => {
         expect(code).to.eq(10)
         done()
       })
     })
 
-    it('run.start with options + catches errors', done => {
+    it('run.start with options + catches errors', (done) => {
       const err = new Error('foo')
 
       run.start.rejects(err)
       this.exec('run')
 
-      util.logErrorExit1.callsFake(e => {
+      util.logErrorExit1.callsFake((e) => {
         expect(e).to.eq(err)
         done()
       })
@@ -174,7 +174,7 @@ describe('cli', () => {
     it('calls run with spec', () => {
       this.exec('run --spec cypress/integration/foo_spec.js')
       expect(run.start).to.be.calledWith({
-        spec: 'cypress/integration/foo_spec.js'
+        spec: 'cypress/integration/foo_spec.js',
       })
     })
 
@@ -186,14 +186,14 @@ describe('cli', () => {
     it('calls run with env variables', () => {
       this.exec('run --env foo=bar,host=http://localhost:8888')
       expect(run.start).to.be.calledWith({
-        env: 'foo=bar,host=http://localhost:8888'
+        env: 'foo=bar,host=http://localhost:8888',
       })
     })
 
     it('calls run with config', () => {
       this.exec('run --config watchForFileChanges=false,baseUrl=localhost')
       expect(run.start).to.be.calledWith({
-        config: 'watchForFileChanges=false,baseUrl=localhost'
+        config: 'watchForFileChanges=false,baseUrl=localhost',
       })
     })
 
@@ -254,7 +254,7 @@ describe('cli', () => {
       expect(run.start).to.be.calledWithMatch({ spec: 'foo,bar,baz' })
     })
 
-    it('warns with space-separated --specs', done => {
+    it('warns with space-separated --specs', (done) => {
       sinon.spy(logger, 'warn')
       this.exec('run --spec a b c d e f g --dev')
       snapshot(logger.warn.getCall(0).args[0])
@@ -289,13 +289,13 @@ describe('cli', () => {
       expect(open.start).to.be.calledWith({ port: '7878', global: true })
     })
 
-    it('calls open.start + catches errors', done => {
+    it('calls open.start + catches errors', (done) => {
       const err = new Error('foo')
 
       open.start.rejects(err)
       this.exec('open --port 7878')
 
-      util.logErrorExit1.callsFake(e => {
+      util.logErrorExit1.callsFake((e) => {
         expect(e).to.eq(err)
         done()
       })
@@ -314,13 +314,13 @@ describe('cli', () => {
     expect(install.start).to.be.calledWith({ force: true })
   })
 
-  it('install calls install.start + catches errors', done => {
+  it('install calls install.start + catches errors', (done) => {
     const err = new Error('foo')
 
     sinon.stub(install, 'start').rejects(err)
     this.exec('install')
 
-    util.logErrorExit1.callsFake(e => {
+    util.logErrorExit1.callsFake((e) => {
       expect(e).to.eq(err)
       done()
     })
@@ -331,17 +331,17 @@ describe('cli', () => {
       this.exec('verify')
       expect(verify.start).to.be.calledWith({
         force: true,
-        welcomeMessage: false
+        welcomeMessage: false,
       })
     })
 
-    it('verify calls verify.start + catches errors', done => {
+    it('verify calls verify.start + catches errors', (done) => {
       const err = new Error('foo')
 
       sinon.stub(verify, 'start').rejects(err)
       this.exec('verify')
 
-      util.logErrorExit1.callsFake(e => {
+      util.logErrorExit1.callsFake((e) => {
         expect(e).to.eq(err)
         done()
       })

--- a/cli/test/lib/cli_spec.js
+++ b/cli/test/lib/cli_spec.js
@@ -21,7 +21,7 @@ describe('cli', () => {
     os.platform.returns('darwin')
     // sinon.stub(util, 'exit')
     sinon.stub(util, 'logErrorExit1')
-    this.exec = (args) => {
+    this.exec = args => {
       return cli.init(`node test ${args}`.split(' '))
     }
   })
@@ -29,14 +29,14 @@ describe('cli', () => {
   context('unknown option', () => {
     // note it shows help for that specific command
     it('shows help', () => {
-      return execa('bin/cypress', ['open', '--foo']).then((result) => {
-        snapshot('shows help for open --foo', result)
+      return execa('bin/cypress', ['open', '--foo']).then(result => {
+        snapshot('shows help for open --foo 1', result)
       })
     })
 
     it('shows help for run command', () => {
-      return execa('bin/cypress', ['run', '--foo']).then((result) => {
-        snapshot('shows help for run --foo', result)
+      return execa('bin/cypress', ['run', '--foo']).then(result => {
+        snapshot('shows help for run --foo 1', result)
       })
     })
 
@@ -79,57 +79,60 @@ describe('cli', () => {
     beforeEach(() => {
       sinon.stub(state, 'getBinaryDir').returns(binaryDir)
     })
-    it('reports package version', (done) => {
+    it('reports package version', done => {
       sinon.stub(util, 'pkgVersion').returns('1.2.3')
-      sinon.stub(state, 'getBinaryPkgVersionAsync').withArgs(binaryDir).resolves('X.Y.Z')
+      sinon
+        .stub(state, 'getBinaryPkgVersionAsync')
+        .withArgs(binaryDir)
+        .resolves('X.Y.Z')
 
       this.exec('version')
       process.exit.callsFake(() => {
-        snapshot('cli version and binary version', logger.print())
+        snapshot('cli version and binary version 1', logger.print())
         done()
       })
     })
 
-    it('reports package and binary message', (done) => {
+    it('reports package and binary message', done => {
       sinon.stub(util, 'pkgVersion').returns('1.2.3')
       sinon.stub(state, 'getBinaryPkgVersionAsync').resolves('X.Y.Z')
 
       this.exec('version')
       process.exit.callsFake(() => {
-        snapshot('cli version and binary version', logger.print())
+        snapshot('cli version and binary version 2', logger.print())
         done()
       })
     })
 
-    it('handles non-existent binary version', (done) => {
+    it('handles non-existent binary version', done => {
       sinon.stub(util, 'pkgVersion').returns('1.2.3')
       sinon.stub(state, 'getBinaryPkgVersionAsync').resolves(null)
 
       this.exec('version')
       process.exit.callsFake(() => {
-        snapshot('cli version no binary version', logger.print())
+        snapshot('cli version no binary version 1', logger.print())
         done()
       })
     })
 
-    it('handles non-existent binary --version', (done) => {
+    it('handles non-existent binary --version', done => {
       sinon.stub(util, 'pkgVersion').returns('1.2.3')
       sinon.stub(state, 'getBinaryPkgVersionAsync').resolves(null)
 
       this.exec('--version')
       process.exit.callsFake(() => {
-        snapshot('cli --version no binary version', logger.print())
+        snapshot('cli --version no binary version 1', logger.print())
         done()
       })
     })
 
-    it('handles non-existent binary -v', (done) => {
+    it('handles non-existent binary -v', done => {
       sinon.stub(util, 'pkgVersion').returns('1.2.3')
       sinon.stub(state, 'getBinaryPkgVersionAsync').resolves(null)
 
       this.exec('-v')
       process.exit.callsFake(() => {
-        snapshot('cli -v no binary version', logger.print())
+        snapshot('cli -v no binary version 1', logger.print())
         done()
       })
     })
@@ -141,23 +144,23 @@ describe('cli', () => {
       sinon.stub(util, 'exit').withArgs(0)
     })
 
-    it('calls run.start with options + exits with code', (done) => {
+    it('calls run.start with options + exits with code', done => {
       run.start.resolves(10)
       this.exec('run')
 
-      util.exit.callsFake((code) => {
+      util.exit.callsFake(code => {
         expect(code).to.eq(10)
         done()
       })
     })
 
-    it('run.start with options + catches errors', (done) => {
+    it('run.start with options + catches errors', done => {
       const err = new Error('foo')
 
       run.start.rejects(err)
       this.exec('run')
 
-      util.logErrorExit1.callsFake((e) => {
+      util.logErrorExit1.callsFake(e => {
         expect(e).to.eq(err)
         done()
       })
@@ -170,7 +173,9 @@ describe('cli', () => {
 
     it('calls run with spec', () => {
       this.exec('run --spec cypress/integration/foo_spec.js')
-      expect(run.start).to.be.calledWith({ spec: 'cypress/integration/foo_spec.js' })
+      expect(run.start).to.be.calledWith({
+        spec: 'cypress/integration/foo_spec.js'
+      })
     })
 
     it('calls run with port with -p arg', () => {
@@ -180,12 +185,16 @@ describe('cli', () => {
 
     it('calls run with env variables', () => {
       this.exec('run --env foo=bar,host=http://localhost:8888')
-      expect(run.start).to.be.calledWith({ env: 'foo=bar,host=http://localhost:8888' })
+      expect(run.start).to.be.calledWith({
+        env: 'foo=bar,host=http://localhost:8888'
+      })
     })
 
     it('calls run with config', () => {
       this.exec('run --config watchForFileChanges=false,baseUrl=localhost')
-      expect(run.start).to.be.calledWith({ config: 'watchForFileChanges=false,baseUrl=localhost' })
+      expect(run.start).to.be.calledWith({
+        config: 'watchForFileChanges=false,baseUrl=localhost'
+      })
     })
 
     it('calls run with key', () => {
@@ -245,7 +254,7 @@ describe('cli', () => {
       expect(run.start).to.be.calledWithMatch({ spec: 'foo,bar,baz' })
     })
 
-    it('warns with space-separated --specs', (done) => {
+    it('warns with space-separated --specs', done => {
       sinon.spy(logger, 'warn')
       this.exec('run --spec a b c d e f g --dev')
       snapshot(logger.warn.getCall(0).args[0])
@@ -280,13 +289,13 @@ describe('cli', () => {
       expect(open.start).to.be.calledWith({ port: '7878', global: true })
     })
 
-    it('calls open.start + catches errors', (done) => {
+    it('calls open.start + catches errors', done => {
       const err = new Error('foo')
 
       open.start.rejects(err)
       this.exec('open --port 7878')
 
-      util.logErrorExit1.callsFake((e) => {
+      util.logErrorExit1.callsFake(e => {
         expect(e).to.eq(err)
         done()
       })
@@ -305,32 +314,34 @@ describe('cli', () => {
     expect(install.start).to.be.calledWith({ force: true })
   })
 
-  it('install calls install.start + catches errors', (done) => {
+  it('install calls install.start + catches errors', done => {
     const err = new Error('foo')
 
     sinon.stub(install, 'start').rejects(err)
     this.exec('install')
 
-    util.logErrorExit1.callsFake((e) => {
+    util.logErrorExit1.callsFake(e => {
       expect(e).to.eq(err)
       done()
     })
   })
   context('cypress verify', () => {
-
     it('verify calls verify.start with force: true', () => {
       sinon.stub(verify, 'start').resolves()
       this.exec('verify')
-      expect(verify.start).to.be.calledWith({ force: true, welcomeMessage: false })
+      expect(verify.start).to.be.calledWith({
+        force: true,
+        welcomeMessage: false
+      })
     })
 
-    it('verify calls verify.start + catches errors', (done) => {
+    it('verify calls verify.start + catches errors', done => {
       const err = new Error('foo')
 
       sinon.stub(verify, 'start').rejects(err)
       this.exec('verify')
 
-      util.logErrorExit1.callsFake((e) => {
+      util.logErrorExit1.callsFake(e => {
         expect(e).to.eq(err)
         done()
       })

--- a/cli/test/lib/errors_spec.js
+++ b/cli/test/lib/errors_spec.js
@@ -22,8 +22,9 @@ describe('errors', function () {
   context('.errors.formErrorText', function () {
     it('returns fully formed text message', () => {
       expect(missingXvfb).to.be.an('object')
+
       return formErrorText(missingXvfb)
-      .then(text => {
+      .then((text) => {
         expect(text).to.be.a('string')
         snapshot(text)
       })

--- a/cli/test/lib/errors_spec.js
+++ b/cli/test/lib/errors_spec.js
@@ -16,14 +16,12 @@ describe('errors', function () {
   describe('individual', () => {
     it('has the following errors', () => {
       return snapshot(Object.keys(errors))
-    }
-    )
+    })
   })
 
   context('.errors.formErrorText', function () {
     it('returns fully formed text message', () => {
       return snapshot(formErrorText(missingXvfb))
-    }
-    )
+    })
   })
 })

--- a/cli/test/lib/errors_spec.js
+++ b/cli/test/lib/errors_spec.js
@@ -21,7 +21,12 @@ describe('errors', function () {
 
   context('.errors.formErrorText', function () {
     it('returns fully formed text message', () => {
-      return snapshot(formErrorText(missingXvfb))
+      expect(missingXvfb).to.be.an('object')
+      return formErrorText(missingXvfb)
+      .then(text => {
+        expect(text).to.be.a('string')
+        snapshot(text)
+      })
     })
   })
 })

--- a/cli/test/lib/tasks/download_spec.js
+++ b/cli/test/lib/tasks/download_spec.js
@@ -52,13 +52,13 @@ describe('lib/tasks/download', function () {
     it('returns latest desktop url', () => {
       const url = download.getUrl()
 
-      snapshot('latest desktop url', normalize(url))
+      snapshot('latest desktop url 1', normalize(url))
     })
 
     it('returns specific desktop version url', () => {
       const url = download.getUrl('0.20.2')
 
-      snapshot('specific version desktop url', normalize(url))
+      snapshot('specific version desktop url 1', normalize(url))
     })
 
     it('returns input if it is already an https link', () => {
@@ -81,28 +81,28 @@ describe('lib/tasks/download', function () {
       process.env.CYPRESS_DOWNLOAD_MIRROR = 'https://cypress.example.com'
       const url = download.getUrl('0.20.2')
 
-      snapshot('base url from CYPRESS_DOWNLOAD_MIRROR', normalize(url))
+      snapshot('base url from CYPRESS_DOWNLOAD_MIRROR 1', normalize(url))
     })
 
     it('env var with trailing slash', () => {
       process.env.CYPRESS_DOWNLOAD_MIRROR = 'https://cypress.example.com/'
       const url = download.getUrl('0.20.2')
 
-      snapshot('base url from CYPRESS_DOWNLOAD_MIRROR with trailing slash', normalize(url))
+      snapshot('base url from CYPRESS_DOWNLOAD_MIRROR with trailing slash 1', normalize(url))
     })
 
     it('env var with subdirectory', () => {
       process.env.CYPRESS_DOWNLOAD_MIRROR = 'https://cypress.example.com/example'
       const url = download.getUrl('0.20.2')
 
-      snapshot('base url from CYPRESS_DOWNLOAD_MIRROR with subdirectory', normalize(url))
+      snapshot('base url from CYPRESS_DOWNLOAD_MIRROR with subdirectory 1', normalize(url))
     })
 
     it('env var with subdirectory and trailing slash', () => {
       process.env.CYPRESS_DOWNLOAD_MIRROR = 'https://cypress.example.com/example/'
       const url = download.getUrl('0.20.2')
 
-      snapshot('base url from CYPRESS_DOWNLOAD_MIRROR with subdirectory and trailing slash', normalize(url))
+      snapshot('base url from CYPRESS_DOWNLOAD_MIRROR with subdirectory and trailing slash 1', normalize(url))
     })
   })
 
@@ -200,7 +200,7 @@ describe('lib/tasks/download', function () {
     .catch((err) => {
       logger.error(err)
 
-      return snapshot('download status errors', normalize(ctx.stdout.toString()))
+      return snapshot('download status errors 1', normalize(ctx.stdout.toString()))
     })
   })
 })

--- a/cli/test/lib/tasks/install_spec.js
+++ b/cli/test/lib/tasks/install_spec.js
@@ -68,7 +68,7 @@ describe('/lib/tasks/install', function () {
           expect(download.start).not.to.be.called
 
           snapshot(
-            'skip installation',
+            'skip installation 1',
             normalize(this.stdout.toString())
           )
         })
@@ -92,7 +92,7 @@ describe('/lib/tasks/install', function () {
           })
 
           snapshot(
-            'specify version in env vars',
+            'specify version in env vars 1',
             normalize(this.stdout.toString())
           )
         })
@@ -150,7 +150,7 @@ describe('/lib/tasks/install', function () {
           return install.start()
           .then(() => {
             return snapshot(
-              'version already installed - cypress install',
+              'version already installed - cypress install 1',
               normalize(this.stdout.toString())
             )
           })
@@ -162,7 +162,7 @@ describe('/lib/tasks/install', function () {
           return install.start()
           .then(() => {
             snapshot(
-              'version already installed - postInstall',
+              'version already installed - postInstall 1',
               normalize(this.stdout.toString())
             )
           })
@@ -186,7 +186,7 @@ describe('/lib/tasks/install', function () {
           })
 
           snapshot(
-            'continues installing on failure',
+            'continues installing on failure 1',
             normalize(this.stdout.toString())
           )
         })
@@ -215,7 +215,7 @@ describe('/lib/tasks/install', function () {
           )
 
           snapshot(
-            'installs without existing installation',
+            'installs without existing installation 1',
             normalize(this.stdout.toString())
           )
         })
@@ -238,7 +238,7 @@ describe('/lib/tasks/install', function () {
           })
 
           snapshot(
-            'installed version does not match needed version',
+            'installed version does not match needed version 1',
             normalize(this.stdout.toString())
           )
         })
@@ -262,7 +262,7 @@ describe('/lib/tasks/install', function () {
           })
 
           snapshot(
-            'forcing true always installs',
+            'forcing true always installs 1',
             normalize(this.stdout.toString())
           )
         })
@@ -287,7 +287,7 @@ describe('/lib/tasks/install', function () {
           })
 
           snapshot(
-            'warning installing as global',
+            'warning installing as global 1',
             normalize(this.stdout.toString())
           )
         })
@@ -304,7 +304,7 @@ describe('/lib/tasks/install', function () {
 
         it('uses verbose renderer', function () {
           snapshot(
-            'installing in ci',
+            'installing in ci 1',
             normalize(this.stdout.toString())
           )
         })
@@ -327,7 +327,7 @@ describe('/lib/tasks/install', function () {
             logger.error(err)
 
             snapshot(
-              'invalid cache directory',
+              'invalid cache directory 1',
               normalize(this.stdout.toString())
             )
           })
@@ -390,7 +390,7 @@ describe('/lib/tasks/install', function () {
             logger.error(err)
 
             snapshot(
-              'error for removed CYPRESS_BINARY_VERSION',
+              'error for removed CYPRESS_BINARY_VERSION 1',
               normalize(this.stdout.toString())
             )
           })
@@ -403,7 +403,7 @@ describe('/lib/tasks/install', function () {
       return install.start()
       .then(() => {
         return snapshot(
-          'silent install',
+          'silent install 1',
           normalize(`[no output]${this.stdout.toString()}`)
         )
       })

--- a/cli/test/lib/tasks/install_spec.js
+++ b/cli/test/lib/tasks/install_spec.js
@@ -79,6 +79,7 @@ describe('/lib/tasks/install', function () {
 
       it('warns when specifying cypress version in env', function () {
         const version = '0.12.1'
+
         process.env.CYPRESS_INSTALL_BINARY = version
 
         return install.start()
@@ -100,10 +101,12 @@ describe('/lib/tasks/install', function () {
 
       it('can install local binary zip file without download', function () {
         const version = '/tmp/local/file.zip'
+
         process.env.CYPRESS_INSTALL_BINARY = version
         sinon.stub(fs, 'pathExistsAsync').withArgs(version).resolves(true)
 
         const installDir = state.getVersionDir()
+
         return install.start()
         .then(() => {
           expect(unzip.start).to.be.calledWithMatch({
@@ -115,12 +118,14 @@ describe('/lib/tasks/install', function () {
 
       it('can install local binary zip file from relative path', function () {
         const version = './cypress-resources/file.zip'
+
         mockfs({
           [version]: 'asdf',
         })
         process.env.CYPRESS_INSTALL_BINARY = version
 
         const installDir = state.getVersionDir()
+
         return install.start()
         .then(() => {
           expect(download.start).not.to.be.called
@@ -159,6 +164,7 @@ describe('/lib/tasks/install', function () {
 
         it('logs when already installed when run from postInstall', function () {
           util.isPostInstall.returns(true)
+
           return install.start()
           .then(() => {
             snapshot(
@@ -316,6 +322,7 @@ describe('/lib/tasks/install', function () {
           sinon.stub(state, 'getCacheDir').returns('/invalid/cache/dir')
 
           const err = new Error('EACCES: permission denied, mkdir \'/invalid\'')
+
           err.code = 'EACCES'
           fs.ensureDirAsync.rejects(err)
 
@@ -339,6 +346,7 @@ describe('/lib/tasks/install', function () {
           state.getBinaryPkgVersionAsync.resolves('1.2.3')
           util.pkgVersion.returns('1.2.3')
           process.env.CYPRESS_INSTALL_BINARY = 'www.cypress.io/cannot-download/2.4.5'
+
           return install.start()
           .then(() => {
             expect(download.start).to.not.be.called
@@ -348,6 +356,7 @@ describe('/lib/tasks/install', function () {
           state.getBinaryPkgVersionAsync.resolves('1.2.3')
           util.pkgVersion.returns('4.0.0')
           process.env.CYPRESS_INSTALL_BINARY = 'www.cypress.io/cannot-download/2.4.5'
+
           return install.start()
           .then(() => {
             expect(download.start).to.not.be.called
@@ -360,6 +369,7 @@ describe('/lib/tasks/install', function () {
           util.pkgVersion.returns('1.2.3')
 
           process.env.CYPRESS_INSTALL_BINARY = '/path/to/zip.zip'
+
           return install.start()
           .then(() => {
             expect(unzip.start).to.not.be.called
@@ -371,6 +381,7 @@ describe('/lib/tasks/install', function () {
           state.getBinaryPkgVersionAsync.resolves('1.2.3')
           util.pkgVersion.returns('4.0.0')
           process.env.CYPRESS_INSTALL_BINARY = '/path/to/zip.zip'
+
           return install.start()
           .then(() => {
             expect(unzip.start).to.not.be.called
@@ -400,6 +411,7 @@ describe('/lib/tasks/install', function () {
 
     it('is silent when log level is silent', function () {
       process.env.npm_config_loglevel = 'silent'
+
       return install.start()
       .then(() => {
         return snapshot(

--- a/cli/test/lib/tasks/unzip_spec.js
+++ b/cli/test/lib/tasks/unzip_spec.js
@@ -45,7 +45,7 @@ describe('lib/tasks/unzip', function () {
     .catch((err) => {
       logger.error(err)
 
-      snapshot('unzip error', normalize(ctx.stdout.toString()))
+      snapshot('unzip error 1', normalize(ctx.stdout.toString()))
     })
   })
 

--- a/cli/test/lib/tasks/unzip_spec.js
+++ b/cli/test/lib/tasks/unzip_spec.js
@@ -15,7 +15,6 @@ const normalize = require('../../support/normalize')
 const version = '1.2.3'
 const installDir = path.join(os.tmpdir(), 'Cypress', version)
 
-
 describe('lib/tasks/unzip', function () {
   require('mocha-banner').register()
   beforeEach(function () {
@@ -60,6 +59,7 @@ describe('lib/tasks/unzip', function () {
     })
     .then(() => {
       expect(onProgress).to.be.called
+
       return fs.statAsync(installDir)
     })
   })

--- a/cli/test/lib/tasks/verify_spec.js
+++ b/cli/test/lib/tasks/verify_spec.js
@@ -78,7 +78,7 @@ context('lib/tasks/verify', () => {
       logger.error(err)
 
       snapshot(
-        'no version of Cypress installed',
+        'no version of Cypress installed 1',
         normalize(stdout.toString())
       )
     })
@@ -115,7 +115,7 @@ context('lib/tasks/verify', () => {
     })
     .catch(() => {
       return snapshot(
-        'warning installed version does not match verified version',
+        'warning installed version does not match verified version 1',
         normalize(stdout.toString())
       )
     })
@@ -130,7 +130,7 @@ context('lib/tasks/verify', () => {
     .catch((err) => {
       logger.error(err)
 
-      snapshot('executable cannot be found', normalize(stdout.toString()))
+      snapshot('executable cannot be found 1', normalize(stdout.toString()))
     })
   })
 
@@ -145,7 +145,7 @@ context('lib/tasks/verify', () => {
 
     it('shows full path to executable when verifying', () => {
       return verify.start({ force: true }).then(() => {
-        snapshot('verification with executable', normalize(stdout.toString()))
+        snapshot('verification with executable 1', normalize(stdout.toString()))
       })
     })
 
@@ -175,7 +175,7 @@ context('lib/tasks/verify', () => {
       })
       .then(() => {
         return snapshot(
-          'fails verifying Cypress',
+          'fails verifying Cypress 1',
           normalize(slice(stdout.toString()))
         )
       })
@@ -204,7 +204,7 @@ context('lib/tasks/verify', () => {
 
     it('finds ping value in the verbose output', () => {
       return verify.start().then(() => {
-        snapshot('verbose stdout output', normalize(stdout.toString()))
+        snapshot('verbose stdout output 1', normalize(stdout.toString()))
       })
     })
   })
@@ -225,7 +225,7 @@ context('lib/tasks/verify', () => {
       stdout = Stdout.capture()
       logger.error(err)
 
-      return snapshot('no Cypress executable', normalize(stdout.toString()))
+      return snapshot('no Cypress executable 1', normalize(stdout.toString()))
     })
   })
 
@@ -247,7 +247,7 @@ context('lib/tasks/verify', () => {
       logger.error(err)
 
       return snapshot(
-        'Cypress non-executable permissions',
+        'Cypress non-executable permissions 1',
         normalize(stdout.toString())
       )
     })
@@ -262,7 +262,7 @@ context('lib/tasks/verify', () => {
 
     return verify.start().then(() => {
       return snapshot(
-        'current version has not been verified',
+        'current version has not been verified 1',
         normalize(stdout.toString())
       )
     })
@@ -277,7 +277,7 @@ context('lib/tasks/verify', () => {
 
     return verify.start().then(() => {
       return snapshot(
-        'different version installed',
+        'different version installed 1',
         normalize(stdout.toString())
       )
     })
@@ -294,7 +294,7 @@ context('lib/tasks/verify', () => {
 
     return verify.start().then(() => {
       return snapshot(
-        'silent verify',
+        'silent verify 1',
         normalize(`[no output]${stdout.toString()}`)
       )
     })
@@ -312,7 +312,7 @@ context('lib/tasks/verify', () => {
       welcomeMessage: false,
     })
     .then(() => {
-      return snapshot('no welcome message', normalize(stdout.toString()))
+      return snapshot('no welcome message 1', normalize(stdout.toString()))
     })
   })
 
@@ -339,7 +339,7 @@ context('lib/tasks/verify', () => {
       stdout = Stdout.capture()
       logger.error(err)
 
-      return snapshot('fails with no stderr', normalize(stdout.toString()))
+      return snapshot('fails with no stderr 1', normalize(stdout.toString()))
     })
   })
 
@@ -376,7 +376,7 @@ context('lib/tasks/verify', () => {
 
         logger.error(err)
 
-        snapshot('xvfb fails', normalize(slice(stdout.toString())))
+        snapshot('xvfb fails 1', normalize(slice(stdout.toString())))
       })
     })
   })
@@ -393,7 +393,7 @@ context('lib/tasks/verify', () => {
 
     it('uses verbose renderer', () => {
       return verify.start().then(() => {
-        snapshot('verifying in ci', normalize(stdout.toString()))
+        snapshot('verifying in ci 1', normalize(stdout.toString()))
       })
     })
 
@@ -407,7 +407,7 @@ context('lib/tasks/verify', () => {
       })
       .catch((err) => {
         logger.error(err)
-        snapshot('error binary not found in ci', normalize(stdout.toString()))
+        snapshot('error binary not found in ci 1', normalize(stdout.toString()))
       })
     })
   })
@@ -430,7 +430,7 @@ context('lib/tasks/verify', () => {
 
       return verify.start().then(() => {
         expect(util.exec.firstCall.args[0]).to.equal(realEnvBinaryPath)
-        snapshot('valid CYPRESS_RUN_BINARY', normalize(stdout.toString()))
+        snapshot('valid CYPRESS_RUN_BINARY 1', normalize(stdout.toString()))
       })
     })
     ;['darwin', 'linux', 'win32'].forEach((platform) => {
@@ -446,7 +446,7 @@ context('lib/tasks/verify', () => {
         .catch((err) => {
           logger.error(err)
           snapshot(
-            `${platform}: error when invalid CYPRESS_RUN_BINARY`,
+            `${platform}: error when invalid CYPRESS_RUN_BINARY 1`,
             normalize(stdout.toString())
           )
         })

--- a/cli/test/lib/util_spec.js
+++ b/cli/test/lib/util_spec.js
@@ -58,7 +58,7 @@ describe('util', () => {
         foo: 'bar',
       }
 
-      snapshot('others_unchanged', normalizeModuleOptions(options))
+      snapshot('others_unchanged 1', normalizeModuleOptions(options))
     })
 
     it('passes string env unchanged', () => {
@@ -66,7 +66,7 @@ describe('util', () => {
         env: 'foo=bar',
       }
 
-      snapshot('env_as_string', normalizeModuleOptions(options))
+      snapshot('env_as_string 1', normalizeModuleOptions(options))
     })
 
     it('converts environment object', () => {
@@ -78,7 +78,7 @@ describe('util', () => {
         },
       }
 
-      snapshot('env_as_object', normalizeModuleOptions(options))
+      snapshot('env_as_object 1', normalizeModuleOptions(options))
     })
 
     it('converts config object', () => {
@@ -89,7 +89,7 @@ describe('util', () => {
         },
       }
 
-      snapshot('config_as_object', normalizeModuleOptions(options))
+      snapshot('config_as_object 1', normalizeModuleOptions(options))
     })
 
     it('converts reporterOptions object', () => {
@@ -100,7 +100,7 @@ describe('util', () => {
         },
       }
 
-      snapshot('reporter_options_as_object', normalizeModuleOptions(options))
+      snapshot('reporter_options_as_object 1', normalizeModuleOptions(options))
     })
 
     it('converts specs array', () => {
@@ -110,7 +110,7 @@ describe('util', () => {
         ],
       }
 
-      snapshot('spec_as_array', normalizeModuleOptions(options))
+      snapshot('spec_as_array 1', normalizeModuleOptions(options))
     })
 
     it('does not convert spec when string', () => {
@@ -118,7 +118,7 @@ describe('util', () => {
         spec: 'x,y,z',
       }
 
-      snapshot('spec_as_string', normalizeModuleOptions(options))
+      snapshot('spec_as_string 1', normalizeModuleOptions(options))
     })
   })
 

--- a/cli/test/mocha.opts
+++ b/cli/test/mocha.opts
@@ -1,4 +1,4 @@
-test/**/download_spec.js
+test/**/install_spec.js
 --timeout 10000
 --reporter spec
 --recursive

--- a/cli/test/mocha.opts
+++ b/cli/test/mocha.opts
@@ -1,4 +1,4 @@
-test/**/install_spec.js
+test/**/unzip_spec.js
 --timeout 10000
 --reporter spec
 --recursive

--- a/cli/test/mocha.opts
+++ b/cli/test/mocha.opts
@@ -1,4 +1,4 @@
-test/**/errors_spec.js
+test/**/download_spec.js
 --timeout 10000
 --reporter spec
 --recursive

--- a/cli/test/mocha.opts
+++ b/cli/test/mocha.opts
@@ -1,4 +1,4 @@
-test/**/util_spec.js
+test/**/errors_spec.js
 --timeout 10000
 --reporter spec
 --recursive

--- a/cli/test/mocha.opts
+++ b/cli/test/mocha.opts
@@ -1,4 +1,4 @@
-test/**/unzip_spec.js
+test/**/verify_spec.js
 --timeout 10000
 --reporter spec
 --recursive

--- a/cli/test/mocha.opts
+++ b/cli/test/mocha.opts
@@ -1,4 +1,4 @@
-test/**/verify_spec.js
+test/**/*_spec.js
 --timeout 10000
 --reporter spec
 --recursive

--- a/cli/test/mocha.opts
+++ b/cli/test/mocha.opts
@@ -1,4 +1,4 @@
-test/**/cli_spec.js
+test/**/util_spec.js
 --timeout 10000
 --reporter spec
 --recursive

--- a/cli/test/mocha.opts
+++ b/cli/test/mocha.opts
@@ -1,4 +1,4 @@
-test/**/*_spec.js
+test/**/cli_spec.js
 --timeout 10000
 --reporter spec
 --recursive

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "print-arch": "1.0.0",
     "ramda": "0.24.1",
     "shelljs": "0.7.8",
-    "snap-shot-it": "5.0.1",
+    "snap-shot-it": "6.3.0",
     "stop-only": "3.0.1",
     "strip-ansi": "4.0.0",
     "terminal-banner": "1.1.0",

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -18,6 +18,7 @@
     "lint-js": "bin-up eslint --fix *.js",
     "lint-ts": "tslint --project . --fix --format stylish lib/*.ts lib/**/*.ts",
     "format-ts": "prettier --no-semi --single-quote --write lib/*.ts lib/**/*.ts",
+    "build": "tsc",
     "build-js": "tsc",
     "size": "t=\"$(npm pack .)\"; wc -c \"${t}\"; tar tvf \"${t}\"; rm \"${t}\";"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -83,7 +83,7 @@
     "react": "15.6.2",
     "repl.history": "0.1.4",
     "run-sequence": "1.2.2",
-    "snap-shot-it": "5.0.1",
+    "snap-shot-it": "6.3.0",
     "ssestream": "1.0.1",
     "stream-to-promise": "1.1.1",
     "supertest": "0.15.0",

--- a/packages/server/test/integration/cypress_spec.coffee
+++ b/packages/server/test/integration/cypress_spec.coffee
@@ -991,7 +991,7 @@ describe "lib/cypress", ->
       ])
       .then =>
         @expectExitWithErr("INDETERMINATE_CI_BUILD_ID")
-        snapshotConsoleLogs("INDETERMINATE_CI_BUILD_ID-group")
+        snapshotConsoleLogs("INDETERMINATE_CI_BUILD_ID-group 1")
 
     it "errors and exits when using --parallel but ciBuildId could not be generated", ->
       sinon.stub(ciProvider, "provider").returns(null)
@@ -1004,7 +1004,7 @@ describe "lib/cypress", ->
       ])
       .then =>
         @expectExitWithErr("INDETERMINATE_CI_BUILD_ID")
-        snapshotConsoleLogs("INDETERMINATE_CI_BUILD_ID-parallel")
+        snapshotConsoleLogs("INDETERMINATE_CI_BUILD_ID-parallel 1")
 
     it "errors and exits when using --parallel and --group but ciBuildId could not be generated", ->
       sinon.stub(ciProvider, "provider").returns(null)
@@ -1018,7 +1018,7 @@ describe "lib/cypress", ->
       ])
       .then =>
         @expectExitWithErr("INDETERMINATE_CI_BUILD_ID")
-        snapshotConsoleLogs("INDETERMINATE_CI_BUILD_ID-parallel-group")
+        snapshotConsoleLogs("INDETERMINATE_CI_BUILD_ID-parallel-group 1")
 
     it "errors and exits when using --ci-build-id with no group or parallelization", ->
       cypress.start([
@@ -1029,7 +1029,7 @@ describe "lib/cypress", ->
       ])
       .then =>
         @expectExitWithErr("INCORRECT_CI_BUILD_ID_USAGE")
-        snapshotConsoleLogs("INCORRECT_CI_BUILD_ID_USAGE")
+        snapshotConsoleLogs("INCORRECT_CI_BUILD_ID_USAGE 1")
 
     it "errors and exits when using --ci-build-id without recording", ->
       cypress.start([
@@ -1038,7 +1038,7 @@ describe "lib/cypress", ->
       ])
       .then =>
         @expectExitWithErr("RECORD_PARAMS_WITHOUT_RECORDING")
-        snapshotConsoleLogs("RECORD_PARAMS_WITHOUT_RECORDING-ciBuildId")
+        snapshotConsoleLogs("RECORD_PARAMS_WITHOUT_RECORDING-ciBuildId 1")
 
     it "errors and exits when using --group without recording", ->
       cypress.start([
@@ -1047,7 +1047,7 @@ describe "lib/cypress", ->
       ])
       .then =>
         @expectExitWithErr("RECORD_PARAMS_WITHOUT_RECORDING")
-        snapshotConsoleLogs("RECORD_PARAMS_WITHOUT_RECORDING-group")
+        snapshotConsoleLogs("RECORD_PARAMS_WITHOUT_RECORDING-group 1")
 
     it "errors and exits when using --parallel without recording", ->
       cypress.start([
@@ -1056,7 +1056,7 @@ describe "lib/cypress", ->
       ])
       .then =>
         @expectExitWithErr("RECORD_PARAMS_WITHOUT_RECORDING")
-        snapshotConsoleLogs("RECORD_PARAMS_WITHOUT_RECORDING-parallel")
+        snapshotConsoleLogs("RECORD_PARAMS_WITHOUT_RECORDING-parallel 1")
 
     it "errors and exits when using --group and --parallel without recording", ->
       cypress.start([
@@ -1066,7 +1066,7 @@ describe "lib/cypress", ->
       ])
       .then =>
         @expectExitWithErr("RECORD_PARAMS_WITHOUT_RECORDING")
-        snapshotConsoleLogs("RECORD_PARAMS_WITHOUT_RECORDING-group-parallel")
+        snapshotConsoleLogs("RECORD_PARAMS_WITHOUT_RECORDING-group-parallel 1")
 
     it "errors and exits when group name is not unique and explicitly passed ciBuildId", ->
       err = new Error()
@@ -1089,7 +1089,7 @@ describe "lib/cypress", ->
       ])
       .then =>
         @expectExitWithErr("DASHBOARD_RUN_GROUP_NAME_NOT_UNIQUE")
-        snapshotConsoleLogs("DASHBOARD_RUN_GROUP_NAME_NOT_UNIQUE")
+        snapshotConsoleLogs("DASHBOARD_RUN_GROUP_NAME_NOT_UNIQUE 1")
 
     it "errors and exits when parallel group params are different", ->
       sinon.stub(system, "info").returns({
@@ -1123,7 +1123,7 @@ describe "lib/cypress", ->
       ])
       .then =>
         @expectExitWithErr("DASHBOARD_PARALLEL_GROUP_PARAMS_MISMATCH")
-        snapshotConsoleLogs("DASHBOARD_PARALLEL_GROUP_PARAMS_MISMATCH")
+        snapshotConsoleLogs("DASHBOARD_PARALLEL_GROUP_PARAMS_MISMATCH 1")
 
     it "errors and exits when parallel is not allowed", ->
       err = new Error()
@@ -1147,7 +1147,7 @@ describe "lib/cypress", ->
       ])
       .then =>
         @expectExitWithErr("DASHBOARD_PARALLEL_DISALLOWED")
-        snapshotConsoleLogs("DASHBOARD_PARALLEL_DISALLOWED")
+        snapshotConsoleLogs("DASHBOARD_PARALLEL_DISALLOWED 1")
 
     it "errors and exits when parallel is required", ->
       err = new Error()
@@ -1171,7 +1171,7 @@ describe "lib/cypress", ->
       ])
       .then =>
         @expectExitWithErr("DASHBOARD_PARALLEL_REQUIRED")
-        snapshotConsoleLogs("DASHBOARD_PARALLEL_REQUIRED")
+        snapshotConsoleLogs("DASHBOARD_PARALLEL_REQUIRED 1")
 
     it "errors and exits when run is already complete", ->
       err = new Error()
@@ -1194,7 +1194,7 @@ describe "lib/cypress", ->
       ])
       .then =>
         @expectExitWithErr("DASHBOARD_ALREADY_COMPLETE")
-        snapshotConsoleLogs("DASHBOARD_ALREADY_COMPLETE")
+        snapshotConsoleLogs("DASHBOARD_ALREADY_COMPLETE 1")
 
     it "errors and exits when run is stale", ->
       err = new Error()
@@ -1218,7 +1218,7 @@ describe "lib/cypress", ->
       ])
       .then =>
         @expectExitWithErr("DASHBOARD_STALE_RUN")
-        snapshotConsoleLogs("DASHBOARD_STALE_RUN")
+        snapshotConsoleLogs("DASHBOARD_STALE_RUN 1")
 
   context "--return-pkg", ->
     beforeEach ->

--- a/packages/server/test/unit/plugins/preprocessor_spec.coffee
+++ b/packages/server/test/unit/plugins/preprocessor_spec.coffee
@@ -3,7 +3,6 @@ require("../../spec_helper")
 EE = require("events")
 Fixtures = require("../../support/helpers/fixtures")
 path = require("path")
-snapshot = require("snap-shot-it")
 appData = require("#{root}../lib/util/app_data")
 { toHashName } = require("#{root}../lib/util/saved_state")
 

--- a/packages/server/test/unit/scaffold_spec.coffee
+++ b/packages/server/test/unit/scaffold_spec.coffee
@@ -310,16 +310,16 @@ describe "lib/scaffold", ->
         @cfg.pluginsFile = path.join(@cfg.projectRoot, "cypress/plugins/index.js")
 
     it "returns tree-like structure of scaffolded", ->
-      snapshot(scaffold.fileTree(@cfg))
+      scaffold.fileTree(@cfg).then(snapshot)
 
     it "leaves out fixtures if configured to false", ->
       @cfg.fixturesFolder = false
-      snapshot(scaffold.fileTree(@cfg))
+      scaffold.fileTree(@cfg).then(snapshot)
 
     it "leaves out support if configured to false", ->
       @cfg.supportFile = false
-      snapshot(scaffold.fileTree(@cfg))
+      scaffold.fileTree(@cfg).then(snapshot)
 
     it "leaves out plugins if configured to false", ->
       @cfg.pluginsFile = false
-      snapshot(scaffold.fileTree(@cfg))
+      scaffold.fileTree(@cfg).then(snapshot)


### PR DESCRIPTION
upgraded in:

- [x] root
- [x] cli
- [x] packages/server

`snap-shot-it` v5 to v6 is breaking change

- proper escaping of most Unicode characters.
- stop adding " 1" index to named snapshots like `snapshot('my variable', foo)`
- by default saves snapshot values sorted alphabetically in the snapshot file to better show related snapshots

Thus we need to do this upgrade carefully to avoid accidentally changing saved snapshots.

In this upgrade, I have only update CLI package to use `snap-shot-it@6`

- in each spec file I have changed each named snapshot to `<name> 1` to artificially match the snapshot names with index " 1" like before. This is to avoid recreating the snapshots
- I have ran all tests - the snapshot files do not show any changes, this this **pull request does not have changed snapshots**

**warning:** if you actually add a snapshot or change a test, the snapshot file will be saved again and will show a lot of Git changes. This is because the Unicode characters will be escaped properly (see comment below) and the snapshots will be sorted alphabetically

PS: I have added `npm run build` in `packages/launcher` because we run `build` script in every package - and the launcher was not built...