### PR TITLE
create separate groups of packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,10 +12,49 @@
   "rangeStrategy": "pin",
   "packageRules": [
     {
+      "packagePatterns": "^@cypress",
+      "groupName": "@cypress",
+      "schedule": "after 2am and before 4am"
+    },
+    {
       "packageNames": [
-        "node"
+        "check-dependencies",
+        "check-more-types",
+        "commit-message-install",
+        "console-table",
+        "execa-wrap",
+        "lazy-ass",
+        "make-empty-github-commit",
+        "mocha-banner",
+        "prefixed-list",
+        "snap-shot-it",
+        "terminal-banner"
       ],
+      "groupName": "Gleb's NPM packages",
+      "schedule": "after 2am and before 4am"
+    },
+    {
+      "packageNames": "node",
       "enabled": false
+    },
+    {
+      "packagePatterns": "^@types",
+      "groupName": "@types",
+      "schedule": "before 3am on Monday"
+    },
+    {
+      "packagePatterns": "^gulp",
+      "groupName": "gulp",
+      "schedule": "before 3am on Monday"
+    },
+    {
+      "packagePatterns": "^eslint",
+      "groupName": "eslint",
+      "schedule": "before 3am on Monday"
+    },
+    {
+      "packageNames": ["typescript", "ts-node", "tslint-config-standard"],
+      "groupName": "typescript"
     }
   ],
   "separateMultipleMajor": true,
@@ -27,8 +66,7 @@
   "updateNotScheduled": false,
   "timezone": "America/New_York",
   "schedule": [
-    "after 10pm and before 5am on every weekday",
-    "every weekend"
+    "before 3am on the first day of the month"
   ],
   "masterIssue": true
 }


### PR DESCRIPTION
- closes #3800 

- all dependencies by default updates once per month
- defined several groups that update weekly
- Gleb's dependencies and `@cypress` dependencies are grouped together and updated nightly