### PR TITLE
Add more informative error messages when cypress verify hangs

### DIFF
--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -65,14 +65,14 @@ const runSmokeTest = (binaryDir) => {
 
     debug('smoke test command:', smokeTestCommand)
 
-    function smokeTestExec() {
-      var child = util.exec(cypressExecPath, args);
+    function smokeTestExec () {
+      let child = util.exec(cypressExecPath, args)
 
-      child.stderr.on('data', function(data) {
-        process.stderr.write(String(data));
-      });
+      child.stderr.on('data', function (data) {
+        process.stderr.write(String(data))
+      })
 
-      return child;
+      return child
     }
 
     return Promise.resolve(smokeTestExec())

--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -68,9 +68,9 @@ const runSmokeTest = (binaryDir) => {
     function smokeTestExec () {
       let child = util.exec(cypressExecPath, args)
 
-      child.stderr.on('data', function (data) {
-        process.stderr.write(String(data))
-      })
+      if (child.stderr) {
+        child.stderr.pipe(process.stderr)
+      }
 
       return child
     }

--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -66,7 +66,7 @@ const runSmokeTest = (binaryDir) => {
     debug('smoke test command:', smokeTestCommand)
 
     function smokeTestExec () {
-      let child = util.exec(cypressExecPath, args)
+      const child = util.exec(cypressExecPath, args)
 
       if (child.stderr) {
         child.stderr.pipe(process.stderr)

--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -65,7 +65,7 @@ const runSmokeTest = (binaryDir) => {
 
     debug('smoke test command:', smokeTestCommand)
 
-    return Promise.resolve(util.exec(cypressExecPath, args))
+    return Promise.resolve(util.exec(cypressExecPath, args, { stdio: ['pipe', 'pipe', process.stderr] }))
     .catch(onSmokeTestError)
     .then((result) => {
       const smokeTestReturned = result.stdout

--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -65,7 +65,17 @@ const runSmokeTest = (binaryDir) => {
 
     debug('smoke test command:', smokeTestCommand)
 
-    return Promise.resolve(util.exec(cypressExecPath, args, { stdio: ['pipe', 'pipe', process.stderr] }))
+    function smokeTestExec() {
+      var child = util.exec(cypressExecPath, args);
+
+      child.stderr.on('data', function(data) {
+        process.stderr.write(String(data));
+      });
+
+      return child;
+    }
+
+    return Promise.resolve(smokeTestExec())
     .catch(onSmokeTestError)
     .then((result) => {
       const smokeTestReturned = result.stdout


### PR DESCRIPTION
address #819

The purpose of this change is to add better visibility when `cypress run` hangs indefinitely on the verification step.

When running the smoke test, the child process's stderr contains useful information but it is currently being swallowed when the process doesn't exit. The proposed change writes the child's stderr to the parent's.

The result is that instead of seeing this:

```
Verifying Cypress can run
```
With no further output, I now see this:
```
Verifying Cypress can run
...
A JavaScript error occurred in the main process
Uncaught Exception:
Error: Failed to get 'appData' path
    at Object.<anonymous> (/tmp/lib/resources/electron.asar/browser/init.js:149:39)
    at Object.<anonymous> (/tmp/lib/resources/electron.asar/browser/init.js:173:3)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Function.Module.runMain (module.js:605:10)
    at startup (bootstrap_node.js:167:16)
    at bootstrap_node.js:589:3
```
And then, after googling and fixing my specific underlying problem (Electron's default `appData` path, `~/.config`, was read-only), if I do `cypress run` again it works fine.

This doesn't address the underlying issue of why `cypress --smoke-test` seems to be not exiting when this kind of failure happens, but it at least adds visibility so folks can self-serve and fix their specific problem more easily.

See also: https://github.com/cypress-io/cypress/issues/819#issuecomment-475308665.

### Validation

To validate this, I've made the change manually to the cypress CLI source within my own project. I cloned the cypress repo and fiddled around but couldn't figure out a good way to test it within here. 

This doesn't seem like it lends itself well to an automated test (cause it would be hanging on purpose)...what I wanted to do manually to reproduce the problem case is something like:

```
mkdir readonly
chmod 444 readonly
```
And then (on linux) set `XDG_CONFIG_HOME` (per [this](https://electronjs.org/docs/api/app#appgetpathname)) to tell Electron to use that as the appData path, and do `cypress run` (or maybe `cypress verify` for a smaller case).

Anyway, I read the contributing docs but couldn't figure out how to do that within this repo. I'm hoping that between feedback from the CI tests, and maintainers, I can get an idea if this change is legit and if there's anything else I should do to validate.




