### PR TITLE
Allow timeout on hash

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -766,7 +766,7 @@ declare namespace Cypress {
      *
      * @see https://on.cypress.io/hash
      */
-    hash(options?: Partial<Loggable>): Chainable<string>
+    hash(options?: Partial<Loggable & Timeoutable>): Chainable<string>
 
     /**
      * Invoke a function on the previously yielded subject.


### PR DESCRIPTION
Allow timeout on hash according to the documentation (https://docs.cypress.io/api/commands/hash.html#Arguments).
