### PR TITLE
remove 'dangerouslySetInnerHtml' from test error componant

### DIFF
--- a/packages/reporter/cypress/fixtures/runnables_errors.json
+++ b/packages/reporter/cypress/fixtures/runnables_errors.json
@@ -1,0 +1,37 @@
+{
+  "id": "r1",
+  "title": "",
+  "root": true,
+  "tests": [],
+  "suites": [
+    {
+      "id": "r2",
+      "title": "suite 1",
+      "root": false,
+      "tests": [
+        {
+          "id": "r3",
+          "title": "test 1",
+          "state": "failed",
+          "err": {
+            "name": "CommandError",
+            "message": "failed to visit",
+            "stack": "failed to visit\n\ncould not visit http: //localhost:3000"
+          },
+          "commands": [
+            {
+              "hookName": "test",
+              "id": "c1",
+              "instrument": "command",
+              "message": "http://localhost:3000",
+              "name": "visit",
+              "state": "failed",
+              "testId": "r3",
+              "type": "parent"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/reporter/cypress/integration/errors_spec.js
+++ b/packages/reporter/cypress/integration/errors_spec.js
@@ -1,0 +1,46 @@
+const { EventEmitter } = require('events')
+
+describe('test errors', function () {
+  beforeEach(function () {
+    cy.fixture('runnables_errors').as('runnablesErr')
+
+    // SET ERROR INFO
+    this.setError = function (err) {
+      this.runnablesErr.suites[0].tests[0].err = err
+
+      cy.get('.reporter').then(() => {
+        this.runner.emit('runnables:ready', this.runnablesErr)
+
+        this.runner.emit('reporter:start', {})
+      })
+    }
+
+    this.runner = new EventEmitter()
+
+    cy.visit('cypress/support/index.html').then((win) => {
+      win.render({
+        runner: this.runner,
+        specPath: '/foo/bar',
+      })
+    })
+  })
+
+  describe('command error', function () {
+    beforeEach(function () {
+      this.commandErr = {
+        name: 'CypressError',
+        message: 'cy.click() failed because this element:\n\n<button id="covered-button"></button>\n\nis being covered by another element:\n\n<span id="button-cover"></span>\n\nFix this problem, or use {force: true} to disable error checking.\n\nhttps://on.cypress.io/element-cannot-be-interacted-with',
+      }
+
+      this.setError(this.commandErr)
+    })
+
+    it('renders message and escapes html', () => {
+      cy.get('.test-error')
+      .should('contain', 'cy.click()')
+      .and('contain', '<button id="covered-button"></button>')
+      .and('contain', '<span id="button-cover"></span>')
+      .and('contain', 'https://on.cypress.io/element-cannot-be-interacted-with')
+    })
+  })
+})

--- a/packages/reporter/cypress/plugins/index.js
+++ b/packages/reporter/cypress/plugins/index.js
@@ -1,0 +1,1 @@
+module.exports = () => {}

--- a/packages/reporter/src/errors/test-error.jsx
+++ b/packages/reporter/src/errors/test-error.jsx
@@ -15,7 +15,7 @@ function TestError (props) {
       message='Printed output to your console'
       onClick={_onErrorClick}
     >
-      <pre className='test-error' dangerouslySetInnerHTML={{ __html: displayMessage }}></pre>
+      <pre className='test-error'>{displayMessage}</pre>
     </FlashOnClick>
   )
 }


### PR DESCRIPTION
- Fix #3861 
- The ‘dangerouslySetInnerHtml’ causes any html elements in the error message to be actually
rendered as html elements instead of printing within the err message - remove this.
- Will refactor this later as part of err-templates work
https://github.com/cypress-io/cypress/pull/3795
- Add simple test to ensure html is properly escaped for err messages