### PR TITLE
Downgrade parse-domain@2.1.7 -> 2.0.0

### DIFF
--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -53,7 +53,7 @@
     "moment": "2.24.0",
     "morgan": "1.9.1",
     "npm-install-version": "6.0.2",
-    "parse-domain": "2.1.7",
+    "parse-domain": "2.0.0",
     "setimmediate": "1.0.5",
     "sinon": "3.3.0",
     "text-mask-addons": "3.8.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -167,7 +167,7 @@
     "opn": "cypress-io/opn#2f4e9a216ca7bdb95dfae9d46d99ddf004b3cbb5",
     "ospath": "1.2.2",
     "p-queue": "1.2.0",
-    "parse-domain": "2.1.7",
+    "parse-domain": "2.0.0",
     "pluralize": "3.1.0",
     "pumpify": "1.5.1",
     "ramda": "0.24.1",

--- a/packages/server/test/unit/cors_spec.coffee
+++ b/packages/server/test/unit/cors_spec.coffee
@@ -58,6 +58,14 @@ describe "lib/util/cors", ->
         tld: "nl"
       })
 
+    ## https://github.com/cypress-io/cypress/issues/3717
+    it "parses http://dev.classea12.beta.gouv.fr", ->
+      @isEq("http://dev.classea12.beta.gouv.fr", {
+        port: "80"
+        domain: "beta"
+        tld: "gouv.fr"
+      })
+
     it "parses http://www.local.nl:8080", ->
       @isEq("http://www.local.nl:8080", {
         port: "8080"


### PR DESCRIPTION
Fixes #3717 

A regression in `parse-domain` since `2.1.0` is causing tests to fail for some users with public suffixes. This will add a unit test for the behavior that is broken to ensure we don't accidentally upgrade as well as reverts it back to `2.0.0`.