### PR TITLE
#3423 Enable Cyrpess to type strings containing reserved words

### DIFF
--- a/packages/driver/src/cypress/keyboard.coffee
+++ b/packages/driver/src/cypress/keyboard.coffee
@@ -128,7 +128,7 @@ $Keyboard = {
 
         return
 
-  
+
     ## charCode = 27
     ## no keyPress
     ## no textInput
@@ -483,7 +483,7 @@ $Keyboard = {
 
           if $elements.isInput(el) or $elements.isTextarea(el)
             ml = el.maxLength
-  
+
           ## maxlength is -1 by default when omitted
           ## but could also be null or undefined :-/
           ## only cafe if we are trying to type a key
@@ -500,7 +500,7 @@ $Keyboard = {
     @simulateKey(el, "keyup", key, options)
 
   isSpecialChar: (chars) ->
-    !!@specialChars[chars]
+    chars in _.keys(@specialChars)
 
   handleSpecialChars: (el, chars, options) ->
     options.key = chars
@@ -514,7 +514,7 @@ $Keyboard = {
   }
 
   isModifier: (chars) ->
-    !!@modifierChars[chars]
+    chars in _.keys(@modifierChars)
 
   handleModifier: (el, chars, options) ->
     modifier = @modifierChars[chars]

--- a/packages/driver/test/cypress/integration/commands/actions/type_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/type_spec.coffee
@@ -2880,6 +2880,11 @@ describe "src/cy/commands/actions/type", ->
           .get(":text:first").type(" ")
           .should("have.value", " ")
 
+      it "allows typing special characters", ->
+        cy
+            .get(":text:first").type("{esc}")
+            .should("have.value", "")
+            
       _.each ["toString", "toLocaleString", "hasOwnProperty", "valueOf"
          "undefined", "null", "true", "false", "True", "False"], (val) =>
        it "allows typing reserved Javscript word (#{val})", ->

--- a/packages/driver/test/cypress/integration/commands/actions/type_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/type_spec.coffee
@@ -2880,8 +2880,17 @@ describe "src/cy/commands/actions/type", ->
           .get(":text:first").type(" ")
           .should("have.value", " ")
 
-      _.each ["toString", "toLocaleString", "hasOwnProperty", "valueOf"], (val) =>
+      _.each ["toString", "toLocaleString", "hasOwnProperty", "valueOf"
+         "undefined", "null", "true", "false", "True", "False"], (val) =>
        it "allows typing reserved Javscript word (#{val})", ->
+         cy
+           .get(":text:first").type(val)
+           .should("have.value", val)
+
+      _.each ["Ω≈ç√∫˜µ≤≥÷", "2.2250738585072011e-308", "田中さんにあげて下さい",
+         "<foo val=`bar' />", "⁰⁴⁵₀₁₂", "🐵 🙈 🙉 🙊",
+         "<script>alert(123)</script>", "$USER"], (val) =>
+       it "allows typing some naughtly strings (#{val})", ->
          cy
            .get(":text:first").type(val)
            .should("have.value", val)

--- a/packages/driver/test/cypress/integration/commands/actions/type_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/type_spec.coffee
@@ -2880,6 +2880,17 @@ describe "src/cy/commands/actions/type", ->
           .get(":text:first").type(" ")
           .should("have.value", " ")
 
+      _.each ["toString", "toLocaleString", "hasOwnProperty", "valueOf"], (val) =>
+       it "allows typing reserved Javscript word (#{val})", ->
+         cy
+           .get(":text:first").type(val)
+           .should("have.value", val)
+
+      it "allows typing special characters", ->
+        cy
+            .get(":text:first").type("{esc}")
+            .should("have.value", "")
+
       it "can type into input with invalid type attribute", ->
         cy.get(':text:first')
           .invoke('attr', 'type', 'asdf')


### PR DESCRIPTION
close #3423 

I have make Cypress to be able to type some Javascript reserved words such as "hasOwnProperty" and "toString".  In addition, I've added some tests taken from the big naughty list of strings.