### PR TITLE
Fix bug in proxy where HTTPS_PROXY became 'undefined'

### DIFF
--- a/packages/server/lib/util/proxy.ts
+++ b/packages/server/lib/util/proxy.ts
@@ -12,7 +12,7 @@ const copyLowercaseEnvToUppercase = (name: string) => {
 }
 
 const normalizeEnvironmentProxy = () => {
-  if (!process.env.HTTPS_PROXY && typeof process.env.HTTP_PROXY !== 'undefined') {
+  if (!process.env.HTTPS_PROXY && process.env.HTTP_PROXY) {
     // request library will use HTTP_PROXY as a fallback for HTTPS urls, but
     // proxy-from-env will not, so let's just force it to fall back like this
     process.env.HTTPS_PROXY = process.env.HTTP_PROXY

--- a/packages/server/lib/util/proxy.ts
+++ b/packages/server/lib/util/proxy.ts
@@ -12,7 +12,7 @@ const copyLowercaseEnvToUppercase = (name: string) => {
 }
 
 const normalizeEnvironmentProxy = () => {
-  if (!process.env.HTTPS_PROXY) {
+  if (!process.env.HTTPS_PROXY && typeof process.env.HTTP_PROXY !== 'undefined') {
     // request library will use HTTP_PROXY as a fallback for HTTPS urls, but
     // proxy-from-env will not, so let's just force it to fall back like this
     process.env.HTTPS_PROXY = process.env.HTTP_PROXY

--- a/packages/server/lib/util/proxy.ts
+++ b/packages/server/lib/util/proxy.ts
@@ -12,6 +12,10 @@ const copyLowercaseEnvToUppercase = (name: string) => {
 }
 
 const normalizeEnvironmentProxy = () => {
+  if (process.env.HTTP_PROXY === 'false' || process.env.HTTP_PROXY === '0' || !process.env.HTTP_PROXY) {
+    delete process.env.HTTP_PROXY
+  }
+
   if (!process.env.HTTPS_PROXY && process.env.HTTP_PROXY) {
     // request library will use HTTP_PROXY as a fallback for HTTPS urls, but
     // proxy-from-env will not, so let's just force it to fall back like this
@@ -27,7 +31,7 @@ const normalizeEnvironmentProxy = () => {
 export const loadSystemProxySettings = () => {
   ['NO_PROXY', 'HTTP_PROXY', 'HTTPS_PROXY'].forEach(copyLowercaseEnvToUppercase)
 
-  if (process.env.HTTP_PROXY) {
+  if (typeof process.env.HTTP_PROXY !== 'undefined') {
     normalizeEnvironmentProxy()
 
     return

--- a/packages/server/test/spec_helper.coffee
+++ b/packages/server/test/spec_helper.coffee
@@ -38,6 +38,7 @@ hasOnly = false
 
     backup.apply(@, arguments)
 
+originalEnv = process.env
 env = _.clone(process.env)
 
 sinon.usingPromise(Promise)
@@ -78,6 +79,8 @@ before ->
   appData.ensure()
 
 beforeEach ->
+  @originalEnv = originalEnv
+
   nock.disableNetConnect()
   nock.enableNetConnect(/localhost/)
 
@@ -91,6 +94,4 @@ afterEach ->
   nock.cleanAll()
   nock.enableNetConnect()
 
-  ## if we set process.env = env, process.env loses the "special" getters and setters
-  ## just assign the enumerable props of env back to process.env instead
-  Object.assign(process.env, env)
+  process.env = _.clone(env)

--- a/packages/server/test/spec_helper.coffee
+++ b/packages/server/test/spec_helper.coffee
@@ -91,4 +91,6 @@ afterEach ->
   nock.cleanAll()
   nock.enableNetConnect()
 
-  process.env = _.clone(env)
+  ## if we set process.env = env, process.env loses the "special" getters and setters
+  ## just assign the enumerable props of env back to process.env instead
+  Object.assign(process.env, env)

--- a/packages/server/test/unit/args_spec.coffee
+++ b/packages/server/test/unit/args_spec.coffee
@@ -304,14 +304,12 @@ describe "lib/util/args", ->
 
   context "with proxy", ->
     beforeEach ->
-      @beforeEnv = Object.assign({}, process.env)
       delete process.env.HTTP_PROXY
       delete process.env.HTTPS_PROXY
       delete process.env.NO_PROXY
       delete process.env.http_proxy
       delete process.env.https_proxy
       delete process.env.no_proxy
-
 
     it "sets options from environment", ->
       process.env.HTTP_PROXY = "http://foo-bar.baz:123"
@@ -337,6 +335,17 @@ describe "lib/util/args", ->
       expect(options.proxyBypassList).to.eq "d,e,f"
       expect(options.proxyBypassList).to.eq process.env.NO_PROXY
 
+    it "doesn't mess with env vars if Windows registry doesn't have proxy", ->
+      sinon.stub(getWindowsProxyUtil, "getWindowsProxy").returns()
+      sinon.stub(os, "platform").returns("win32")
+      options = @setup()
+      expect(options.proxySource).to.be.undefined
+      expect(options.proxyServer).to.be.undefined
+      expect(options.proxyBypassList).to.be.undefined
+      expect(process.env.HTTP_PROXY).to.be.undefined
+      expect(process.env.HTTPS_PROXY).to.be.undefined
+      expect(process.env.NO_PROXY).to.eq "localhost"
+
     it "sets a default NO_PROXY", ->
       process.env.HTTP_PROXY = "http://foo-bar.baz:123"
       options = @setup()
@@ -361,6 +370,3 @@ describe "lib/util/args", ->
       expect(options.proxySource).to.be.undefined
       expect(options.proxyServer).to.eq process.env.HTTP_PROXY
       expect(options.proxyBypassList).to.eq process.env.NO_PROXY
-
-    afterEach ->
-      Object.assign(process.env, @beforeEnv)

--- a/packages/server/test/unit/args_spec.coffee
+++ b/packages/server/test/unit/args_spec.coffee
@@ -335,6 +335,20 @@ describe "lib/util/args", ->
       expect(options.proxyBypassList).to.eq "d,e,f"
       expect(options.proxyBypassList).to.eq process.env.NO_PROXY
 
+    ['', 'false', '0'].forEach (override) ->
+      it "doesn't load from Windows registry if HTTP_PROXY overridden with string '#{override}'", ->
+        sinon.stub(getWindowsProxyUtil, "getWindowsProxy").returns()
+        sinon.stub(os, "platform").returns("win32")
+        process.env.HTTP_PROXY = override
+        options = @setup()
+        expect(getWindowsProxyUtil.getWindowsProxy).to.not.beCalled
+        expect(options.proxySource).to.be.undefined
+        expect(options.proxyServer).to.be.undefined
+        expect(options.proxyBypassList).to.be.undefined
+        expect(process.env.HTTP_PROXY).to.be.undefined
+        expect(process.env.HTTPS_PROXY).to.be.undefined
+        expect(process.env.NO_PROXY).to.eq "localhost"
+
     it "doesn't mess with env vars if Windows registry doesn't have proxy", ->
       sinon.stub(getWindowsProxyUtil, "getWindowsProxy").returns()
       sinon.stub(os, "platform").returns("win32")

--- a/packages/server/test/unit/args_spec.coffee
+++ b/packages/server/test/unit/args_spec.coffee
@@ -304,6 +304,7 @@ describe "lib/util/args", ->
 
   context "with proxy", ->
     beforeEach ->
+      process.env = @originalEnv
       delete process.env.HTTP_PROXY
       delete process.env.HTTPS_PROXY
       delete process.env.NO_PROXY


### PR DESCRIPTION
This is the bug causing the failing AppVeyor build, basically the agent was always trying to use a proxy set to string `"undefined"` when no proxy is defined, making the request fail catastrophically every time.

Appveyor build: https://ci.appveyor.com/project/cypress-io/cypress-test-example-repos/builds/23690466

The issue causing the actual crash was that `socket.io` was somehow ACK'ing with a circular reference because of the error:

```
Mon, 08 Apr 2019 19:51:45 GMT socket.io-parser decoded 210["backend:request","http:request",{"url":"https://jsonplaceholder.cypress.io/users","method":"GET","gzip":true,"timeout":30000,"followRedirect":true}] as {"type":2,"nsp":"/","id":10,"data":["backend:request","http:request",{"url":"https://jsonplaceholder.cypress.io/users","method":"GET","gzip":true,"timeout":30000,"followRedirect":true}]}
Mon, 08 Apr 2019 19:51:45 GMT socket.io:socket got packet {"type":2,"nsp":"/","id":10,"data":["backend:request","http:request",{"url":"https://jsonplaceholder.cypress.io/users","method":"GET","gzip":true,"timeout":30000,"followRedirect":true}]}
Mon, 08 Apr 2019 19:51:45 GMT socket.io:socket emitting event ["backend:request","http:request",{"url":"https://jsonplaceholder.cypress.io/users","method":"GET","gzip":true,"timeout":30000,"followRedirect":true}]
Mon, 08 Apr 2019 19:51:45 GMT socket.io:socket attaching ack callback to event
Mon, 08 Apr 2019 19:51:45 GMT socket.io:socket dispatching an event ["backend:request","http:request",{"url":"https://jsonplaceholder.cypress.io/users","method":"GET","gzip":true,"timeout":30000,"followRedirect":true},null]
.......some more Cypress logs here........
Mon, 08 Apr 2019 19:51:47 GMT socket.io:socket sending ack [Circular]
RangeError: Maximum call stack size exceeded
```

This is known to crash socket.io: https://github.com/socketio/socket.io-parser/pull/80

I fixed the proxy issue where `process.env.HTTPS_PROXY` was becoming `"undefined"` and added a test, but I'm still unsure as to how this manifested into the circular ack bug we got here.