### PR TITLE
Add arch to commit message install

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -586,7 +586,7 @@ jobs:
             - npm-package-url.json
             - cypress.tgz
 
-  "test-next-version":
+  "test-binary-and-npm-against-other-projects":
     <<: *defaults
     steps:
       - attach_workspace:
@@ -801,7 +801,7 @@ linux-workflow: &linux-workflow
               - add-arch-to-commit-message-install
         requires:
           - build
-    - test-next-version:
+    - test-binary-and-npm-against-other-projects:
         filters:
           branches:
             only:

--- a/circle.yml
+++ b/circle.yml
@@ -620,7 +620,7 @@ jobs:
               --binary /tmp/urls/binary-url.json \
               --provider circle
 
-  "test-next-version-locally":
+  "test-npm-module-and-verify-binary":
     <<: *defaults
     steps:
       - attach_workspace:
@@ -810,7 +810,7 @@ linux-workflow: &linux-workflow
         requires:
           - build-npm-package
           - build-binary
-    - test-next-version-locally:
+    - test-npm-module-and-verify-binary:
         filters:
           branches:
             only:

--- a/circle.yml
+++ b/circle.yml
@@ -789,6 +789,7 @@ linux-workflow: &linux-workflow
             only:
               - develop
               - issue-716-ffmpeg-packaging
+              - add-arch-to-commit-message-install
         requires:
           - build
     - build-binary:
@@ -797,6 +798,7 @@ linux-workflow: &linux-workflow
             only:
               - develop
               - issue-716-ffmpeg-packaging
+              - add-arch-to-commit-message-install
         requires:
           - build
     - test-next-version:
@@ -804,6 +806,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
+              - add-arch-to-commit-message-install
         requires:
           - build-npm-package
           - build-binary

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "check-more-types": "2.24.0",
     "cloudflare-cli": "3.2.1",
     "coffeelint": "1.16.2",
-    "commit-message-install": "1.10.1",
+    "commit-message-install": "2.2.0",
     "common-tags": "1.8.0",
     "console.table": "0.10.0",
     "debug": "3.1.0",

--- a/scripts/test-other-projects.js
+++ b/scripts/test-other-projects.js
@@ -16,11 +16,13 @@ const { npm, binary } = getNameAndBinary(process.argv)
 la(is.unemptyString(npm), 'missing npm url')
 la(is.unemptyString(binary), 'missing binary url')
 const platform = os.platform()
+const arch = os.arch()
 
 console.log('bumping versions for other projects')
-console.log('npm:', npm)
-console.log('binary:', binary)
-console.log('platform:', platform)
+console.log(' npm:', npm)
+console.log(' binary:', binary)
+console.log(' platform:', platform)
+console.log(' arch:', arch)
 
 const cliOptions = minimist(process.argv, {
   string: 'provider',
@@ -87,13 +89,29 @@ if (commitInfo) {
 const env = {
   CYPRESS_INSTALL_BINARY: binary,
 }
-const commitMessageInstructions = getInstallJson(
-  npm,
+
+// also pass "status" object that points back at this repo and this commit
+// so that other projects can report their test success as GitHub commit status check
+let status = null
+const commit = commitInfo && commitInfo.sha
+if (commit && is.commitId(commit)) {
+  // commit is full 40 character hex string
+  status = {
+    owner: 'cypress-io',
+    repo: 'cypress',
+    sha: commit
+  }
+}
+
+const commitMessageInstructions = getInstallJson({
+  packages: npm,
   env,
   platform,
-  shortNpmVersion, // use as version as branch name on test projects
-  commitInfo && commitInfo.sha
-)
+  arch,
+  branch: shortNpmVersion, // use as version as branch name on test projects
+  commit,
+  status
+})
 const jsonBlock = toMarkdownJsonBlock(commitMessageInstructions)
 const footer = 'Use tool `commit-message-install` to install from above block'
 let message = `${subject}\n\n${jsonBlock}\n${footer}\n`

--- a/scripts/test-other-projects.js
+++ b/scripts/test-other-projects.js
@@ -1,5 +1,3 @@
-require('@packages/coffee/register')
-
 const la = require('lazy-ass')
 const is = require('check-more-types')
 const { getNameAndBinary, getJustVersion } = require('./utils')
@@ -94,12 +92,13 @@ const env = {
 // so that other projects can report their test success as GitHub commit status check
 let status = null
 const commit = commitInfo && commitInfo.sha
+
 if (commit && is.commitId(commit)) {
   // commit is full 40 character hex string
   status = {
     owner: 'cypress-io',
     repo: 'cypress',
-    sha: commit
+    sha: commit,
   }
 }
 
@@ -110,7 +109,7 @@ const commitMessageInstructions = getInstallJson({
   arch,
   branch: shortNpmVersion, // use as version as branch name on test projects
   commit,
-  status
+  status,
 })
 const jsonBlock = toMarkdownJsonBlock(commitMessageInstructions)
 const footer = 'Use tool `commit-message-install` to install from above block'

--- a/scripts/test-other-projects.js
+++ b/scripts/test-other-projects.js
@@ -1,3 +1,5 @@
+require('@packages/coffee/register')
+
 const la = require('lazy-ass')
 const is = require('check-more-types')
 const { getNameAndBinary, getJustVersion } = require('./utils')


### PR DESCRIPTION
- add `arch` and `status` fields to the commit message when testing other projects
- status is needed to enable GitHub commit status checks for this build
- renamed a couple of test jobs

Example commit message with this change in https://github.com/cypress-io/cypress-test-node-versions/commit/61c24b20006e1de91a8cff77de726d485191bb0d

<img width="1011" alt="Screen Shot 2019-04-09 at 11 39 31 AM" src="https://user-images.githubusercontent.com/2212006/55814270-2c97ad00-5abc-11e9-8a6d-27fcec214130.png">
