### PR TITLE
[WIP] Enable aliases names to contain the dot character

### DIFF
--- a/packages/driver/src/cy/commands/querying.coffee
+++ b/packages/driver/src/cy/commands/querying.coffee
@@ -126,9 +126,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
 
         options._log.set(obj)
 
-      ## we always want to strip everything after the first '.'
-      ## since we support alias propertys like '1' or 'all'
-      if aliasObj = cy.getAlias(selector.split(".")[0])
+      if aliasObj = cy.getAlias(selector)
         {subject, alias, command} = aliasObj
 
         return do resolveAlias = ->

--- a/packages/driver/src/cy/commands/querying.coffee
+++ b/packages/driver/src/cy/commands/querying.coffee
@@ -126,7 +126,14 @@ module.exports = (Commands, Cypress, cy, state, config) ->
 
         options._log.set(obj)
 
-      if aliasObj = cy.getAlias(selector)
+      ## We want to strip everything after the first '.'
+      ## only when it is potentially a number or 'all'
+      if selector.slice(1) in _.keys(cy.state("aliases"))
+         toSelect = selector
+      else
+         toSelect = selector.split(".")[0]
+
+      if aliasObj = cy.getAlias(toSelect)
         {subject, alias, command} = aliasObj
 
         return do resolveAlias = ->

--- a/packages/driver/src/cy/commands/querying.coffee
+++ b/packages/driver/src/cy/commands/querying.coffee
@@ -131,7 +131,8 @@ module.exports = (Commands, Cypress, cy, state, config) ->
       if selector.slice(1) in _.keys(cy.state("aliases"))
          toSelect = selector
       else
-         toSelect = selector.split(".")[0]
+         allParts = _.split(selector, '.')
+         toSelect = _.join(_.dropRight(allParts, 1), '.')
 
       if aliasObj = cy.getAlias(toSelect)
         {subject, alias, command} = aliasObj

--- a/packages/driver/src/cy/xhrs.coffee
+++ b/packages/driver/src/cy/xhrs.coffee
@@ -41,8 +41,8 @@ create = (state) ->
       [alias, prop] = alias.split(".")
 
       if prop and not validAliasApiRe.test(prop)
-        if alias + "." + prop in _.keys(cy.state("aliases"))
-           [alias, prop] = [alias + "." + prop, null]
+        if _.join([alias, prop], '.') in _.keys(cy.state("aliases"))
+           [alias, prop] = [_.join([alias, prop], '.'), null]
         else
           $utils.throwErrByPath "get.alias_invalid", {
             args: { prop }

--- a/packages/driver/src/cy/xhrs.coffee
+++ b/packages/driver/src/cy/xhrs.coffee
@@ -41,9 +41,12 @@ create = (state) ->
       [alias, prop] = alias.split(".")
 
       if prop and not validAliasApiRe.test(prop)
-        $utils.throwErrByPath "get.alias_invalid", {
-          args: { prop }
-        }
+        if alias + "." + prop in _.keys(cy.state("aliases"))
+           [alias, prop] = [alias + "." + prop, null]
+        else
+          $utils.throwErrByPath "get.alias_invalid", {
+            args: { prop }
+          }
 
       if prop is "0"
         $utils.throwErrByPath "get.alias_zero", {

--- a/packages/driver/test/cypress/integration/commands/agents_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/agents_spec.coffee
@@ -201,59 +201,115 @@ describe "src/cy/commands/agents", ->
               expect(@consoleProps["  1.2 matching arguments"]).to.eql(["foo", "baz"])
 
     describe ".as", ->
-      beforeEach ->
-        @logs = []
-        cy.on "log:added", (attrs, log) =>
-          @logs.push(log)
+      context "without dots", ->
+        beforeEach ->
+          @logs = []
+          cy.on "log:added", (attrs, log) =>
+            @logs.push(log)
 
-        @stub = cy.stub().as("myStub")
+          @stub = cy.stub().as("myStub")
 
-      it "returns stub", ->
-        expect(@stub).to.have.property("callCount")
+        it "returns stub", ->
+          expect(@stub).to.have.property("callCount")
 
-      it "updates instrument log with alias", ->
-        expect(@logs[0].get("alias")).to.eq("myStub")
-        expect(@logs[0].get("aliasType")).to.eq("agent")
+        it "updates instrument log with alias", ->
+          expect(@logs[0].get("alias")).to.eq("myStub")
+          expect(@logs[0].get("aliasType")).to.eq("agent")
 
-      it "includes alias in invocation log", ->
-        @stub()
-        expect(@logs[1].get("alias")).to.eql(["myStub"])
-        expect(@logs[1].get("aliasType")).to.eq("agent")
+        it "includes alias in invocation log", ->
+          @stub()
+          expect(@logs[1].get("alias")).to.eql(["myStub"])
+          expect(@logs[1].get("aliasType")).to.eq("agent")
 
-      it "includes alias in console props", ->
-        @stub()
-        consoleProps = @logs[1].get("consoleProps")()
-        expect(consoleProps["Alias"]).to.eql("myStub")
+        it "includes alias in console props", ->
+          @stub()
+          consoleProps = @logs[1].get("consoleProps")()
+          expect(consoleProps["Alias"]).to.eql("myStub")
 
-      it "updates the displayName of the agent", ->
-        expect(@myStub.displayName).to.eq("myStub")
+        it "updates the displayName of the agent", ->
+          expect(@myStub.displayName).to.eq("myStub")
 
-      it "stores the lookup as an alias", ->
-        expect(cy.state("aliases").myStub).to.be.defined
+        it "stores the lookup as an alias", ->
+          expect(cy.state("aliases").myStub).to.be.defined
 
-      it "stores the agent as the subject", ->
-        expect(cy.state("aliases").myStub.subject).to.eq(@stub)
+        it "stores the agent as the subject", ->
+          expect(cy.state("aliases").myStub.subject).to.eq(@stub)
 
-      it "assigns subject to runnable ctx", ->
-        expect(@myStub).to.eq(@stub)
+        it "assigns subject to runnable ctx", ->
+          expect(@myStub).to.eq(@stub)
 
-      it "retries until assertions pass", ->
-        cy.on "command:retry", _.after 2, =>
-          @myStub("foo")
-        
-        cy.get("@myStub").should("be.calledWith", "foo")
+        it "retries until assertions pass", ->
+          cy.on "command:retry", _.after 2, =>
+            @myStub("foo")
+          
+          cy.get("@myStub").should("be.calledWith", "foo")
 
-      describe "errors", ->
-        _.each [null, undefined, {}, [], 123], (value) =>
-          it "throws when passed: #{value}", ->
-            expect(=> cy.stub().as(value)).to.throw("cy.as() can only accept a string.")
+        describe "errors", ->
+          _.each [null, undefined, {}, [], 123], (value) =>
+            it "throws when passed: #{value}", ->
+              expect(=> cy.stub().as(value)).to.throw("cy.as() can only accept a string.")
 
-        it "throws on blank string", ->
-          expect(=> cy.stub().as("")).to.throw("cy.as() cannot be passed an empty string.")
+          it "throws on blank string", ->
+            expect(=> cy.stub().as("")).to.throw("cy.as() cannot be passed an empty string.")
 
-        _.each ["test", "runnable", "timeout", "slow", "skip", "inspect"], (blacklist) ->
-          it "throws on a blacklisted word: #{blacklist}", ->
-            expect(=> cy.stub().as(blacklist)).to.throw("cy.as() cannot be aliased as: '#{blacklist}'. This word is reserved.")
+          _.each ["test", "runnable", "timeout", "slow", "skip", "inspect"], (blacklist) ->
+            it "throws on a blacklisted word: #{blacklist}", ->
+              expect(=> cy.stub().as(blacklist)).to.throw("cy.as() cannot be aliased as: '#{blacklist}'. This word is reserved.")
+      
+      context "with dots", ->
+        beforeEach ->
+          @logs = []
+          cy.on "log:added", (attrs, log) =>
+            @logs.push(log)
+
+          @stub = cy.stub().as("my.stub")
+
+        it "returns stub", ->
+          expect(@stub).to.have.property("callCount")
+
+        it "updates instrument log with alias", ->
+          expect(@logs[0].get("alias")).to.eq("my.stub")
+          expect(@logs[0].get("aliasType")).to.eq("agent")
+
+        it "includes alias in invocation log", ->
+          @stub()
+          expect(@logs[1].get("alias")).to.eql(["my.stub"])
+          expect(@logs[1].get("aliasType")).to.eq("agent")
+
+        it "includes alias in console props", ->
+          @stub()
+          consoleProps = @logs[1].get("consoleProps")()
+          expect(consoleProps["Alias"]).to.eql("my.stub")
+
+        it "updates the displayName of the agent", ->
+          expect(@["my.stub"].displayName).to.eq("my.stub")
+
+        it "stores the lookup as an alias", ->
+          expect(cy.state("aliases")["my.stub"]).to.be.defined
+
+        it "stores the agent as the subject", ->
+          expect(cy.state("aliases")["my.stub"].subject).to.eq(@stub)
+
+        it "assigns subject to runnable ctx", ->
+          expect(@["my.stub"]).to.eq(@stub)
+
+        it "retries until assertions pass", ->
+          cy.on "command:retry", _.after 2, =>
+            @["my.stub"]("foo")
+          
+          cy.get("@my.stub").should("be.calledWith", "foo")
+
+        describe "errors", ->
+          _.each [null, undefined, {}, [], 123], (value) =>
+            it "throws when passed: #{value}", ->
+              expect(=> cy.stub().as(value)).to.throw("cy.as() can only accept a string.")
+
+          it "throws on blank string", ->
+            expect(=> cy.stub().as("")).to.throw("cy.as() cannot be passed an empty string.")
+
+          _.each ["test", "runnable", "timeout", "slow", "skip", "inspect"], (blacklist) ->
+            it "throws on a blacklisted word: #{blacklist}", ->
+              expect(=> cy.stub().as(blacklist)).to.throw("cy.as() cannot be aliased as: '#{blacklist}'. This word is reserved.")
 
     describe "logging", ->
       beforeEach ->

--- a/packages/driver/test/cypress/integration/commands/aliasing_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/aliasing_spec.coffee
@@ -89,6 +89,10 @@ describe "src/cy/commands/aliasing", ->
           .noop({}).as("baz").then (obj) ->
             expect(@baz).to.eq obj
 
+      it "assigns subject with dot to runnable ctx", ->
+        cy.noop({}).as("bar.baz").then (obj) ->
+          expect(@["bar.baz"]).to.eq obj
+
       describe "nested hooks", ->
         afterEach ->
           if not @bar
@@ -144,6 +148,13 @@ describe "src/cy/commands/aliasing", ->
 
         cy.get("div:first").as("@myAlias")
 
+      it "throws on alias starting with @ char and dots", (done) ->
+        cy.on "fail", (err) ->
+          expect(err.message).to.eq "'@my.alias' cannot be named starting with the '@' symbol. Try renaming the alias to 'my.alias', or something else that does not start with the '@' symbol."
+          done()
+
+        cy.get("div:first").as("@my.alias")
+
       it "does not throw on alias with @ char in non-starting position", () ->
         cy.get("div:first").as("my@Alias")
         cy.get("@my@Alias")
@@ -171,7 +182,6 @@ describe "src/cy/commands/aliasing", ->
           lastLog = @lastLog
 
           expect(lastLog.get("aliasType")).to.eq "primitive"
-
       it "sets aliasType to 'dom'", ->
         cy.get("body").find("button:first").click().as("button").then ->
           lastLog = @lastLog
@@ -211,11 +221,6 @@ describe "src/cy/commands/aliasing", ->
 
             expect(@logs[1].get("name")).to.eq("route")
             expect(@logs[1].get("alias")).to.eq("getFoo")
-
-      # it "does not alias previous logs when no matching chainerId", ->
-      #   cy
-      #     .get("div:first")
-      #     .noop({}).as("foo").then ->
 
   context "#replayCommandsFrom", ->
     describe "subject in document", ->
@@ -363,7 +368,7 @@ describe "src/cy/commands/aliasing", ->
           .get("body").as("b")
           .get("input:first").as("firstInput")
           .get("@lastDiv")
-
+      
       it "throws when alias is missing '@' but matches an available alias", (done) ->
         cy.on "fail", (err) ->
           expect(err.message).to.eq "Invalid alias: 'getAny'.\nYou forgot the '@'. It should be written as: '@getAny'."

--- a/packages/driver/test/cypress/integration/commands/aliasing_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/aliasing_spec.coffee
@@ -51,6 +51,11 @@ describe "src/cy/commands/aliasing", ->
 
       cy.get("@obj").should("deep.eq", { foo: "bar" })
 
+    it "allows dot in alias names", ->
+      cy.get("body").as("body.foo").then ->
+        expect(cy.get('@body.foo')).to.be.defined
+        expect(cy.state("aliases")['body.foo']).to.be.defined
+
     context "DOM subjects", ->
       it "assigns the remote jquery instance", ->
         obj = {}

--- a/packages/driver/test/cypress/integration/commands/aliasing_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/aliasing_spec.coffee
@@ -56,6 +56,15 @@ describe "src/cy/commands/aliasing", ->
         expect(cy.get('@body.foo')).to.be.defined
         expect(cy.state("aliases")['body.foo']).to.be.defined
 
+    it "recognizes dot and non dot with same alias names", ->
+      cy.get("body").as("body").then ->
+        expect(cy.get('@body')).to.be.defined
+        expect(cy.state("aliases")['body']).to.be.defined
+      cy.contains("foo").as("body.foo").then ->
+        expect(cy.get('@body.foo')).to.be.defined
+        expect(cy.get('@body.foo')).to.not.eq(cy.get('@body'))
+        expect(cy.state("aliases")['body.foo']).to.be.defined
+
     context "DOM subjects", ->
       it "assigns the remote jquery instance", ->
         obj = {}

--- a/packages/driver/test/cypress/integration/commands/querying_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/querying_spec.coffee
@@ -885,6 +885,16 @@ describe "src/cy/commands/querying", ->
             .get("@getUsers").then (xhr) ->
               expect(xhr.url).to.include "/users"
 
+        it "handles dots in alias name", ->
+          cy
+            .server()
+            .route(/users/, {}).as("get.users")
+            .visit("http://localhost:3500/fixtures/jquery.html")
+            .window().then { timeout: 2000 }, (win) ->
+              win.$.get("/users")
+            .get("@get.users").then (xhr) ->
+              expect(xhr.url).to.include "/users"
+
         it "returns null if no xhr is found", ->
           cy
             .server()

--- a/packages/driver/test/cypress/integration/commands/querying_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/querying_spec.coffee
@@ -732,18 +732,17 @@ describe "src/cy/commands/querying", ->
           expect(@lastLog.get("$el").get(0)).not.to.be.ok
 
       it "logs route aliases", ->
-        cy
-          .visit("http://localhost:3500/fixtures/jquery.html")
-          .server()
-          .route(/users/, {}).as("getUsers")
-          .window().then { timeout: 2000 }, (win) ->
-            win.$.get("/users")
-          .get("@getUsers").then ->
-            expect(@lastLog.pick("message", "referencesAlias", "aliasType")).to.deep.eq {
-              message: "@getUsers"
-              referencesAlias: {name: "getUsers"}
-              aliasType: "route"
-            }
+        cy.visit("http://localhost:3500/fixtures/jquery.html")
+        cy.server()
+        cy.route(/users/, {}).as("get.users")
+        cy.window().then { timeout: 2000 }, (win) ->
+          win.$.get("/users")
+        cy.get("@get.users").then ->
+          expect(@lastLog.pick("message", "referencesAlias", "aliasType")).to.deep.eq {
+            message: "@get.users"
+            referencesAlias: {name: "get.users"}
+            aliasType: "route"
+          }
 
       it "logs primitive aliases", (done) ->
         cy.on "log:added", (attrs, log) ->
@@ -886,14 +885,13 @@ describe "src/cy/commands/querying", ->
               expect(xhr.url).to.include "/users"
 
         it "handles dots in alias name", ->
-          cy
-            .server()
-            .route(/users/, {}).as("get.users")
-            .visit("http://localhost:3500/fixtures/jquery.html")
-            .window().then { timeout: 2000 }, (win) ->
-              win.$.get("/users")
-            .get("@get.users").then (xhr) ->
-              expect(xhr.url).to.include "/users"
+          cy.server()
+          cy.route(/users/, {}).as("get.users")
+          cy.visit("http://localhost:3500/fixtures/jquery.html")
+          cy.window().then { timeout: 2000 }, (win) ->
+            win.$.get("/users")
+          cy.get("@get.users").then (xhr) ->
+            expect(xhr.url).to.include "/users"
 
         it "returns null if no xhr is found", ->
           cy
@@ -917,6 +915,20 @@ describe "src/cy/commands/querying", ->
               expect(xhrs).to.be.an("array")
               expect(xhrs[0].url).to.include "/users?num=1"
               expect(xhrs[1].url).to.include "/users?num=2"
+
+        it "returns an array of xhrs when dots in alias name", ->
+          cy.visit("http://localhost:3500/fixtures/jquery.html")
+          cy.server()
+          cy.route(/users/, {}).as("get.users")
+          cy.window().then { timeout: 2000 }, (win) ->
+            Promise.all([
+              win.$.get("/users", {num: 1})
+              win.$.get("/users", {num: 2})
+            ])
+          cy.get("@get.users.all").then (xhrs) ->
+            expect(xhrs).to.be.an("array")
+            expect(xhrs[0].url).to.include "/users?num=1"
+            expect(xhrs[1].url).to.include "/users?num=2"
 
         it "returns the 1st xhr", ->
           cy
@@ -943,6 +955,18 @@ describe "src/cy/commands/querying", ->
               ])
             .get("@getUsers.2").then (xhr2) ->
               expect(xhr2.url).to.include "/users?num=2"
+
+        it "returns the 2nd xhr when dots in alias", ->
+          cy.visit("http://localhost:3500/fixtures/jquery.html")
+          cy.server()
+          cy.route(/users/, {}).as("get.users")
+          cy.window().then { timeout: 2000 }, (win) ->
+            Promise.all([
+              win.$.get("/users", {num: 1})
+              win.$.get("/users", {num: 2})
+            ])
+          cy.get("@get.users.2").then (xhr2) ->
+            expect(xhr2.url).to.include "/users?num=2"
 
         it "returns the 3rd xhr as null", ->
           cy

--- a/packages/driver/test/cypress/integration/commands/waiting_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/waiting_spec.coffee
@@ -379,7 +379,7 @@ describe "src/cy/commands/waiting", ->
           Cypress.config("requestTimeout", 200)
 
           cy.on "fail", (err) ->
-            expect(err.message).to.include "cy.wait() timed out waiting 200ms for the 3rd request to the route: 'getUsers'. No request ever occurred."
+            expect(err.message).to.include "cy.wait() timed out waiting 200ms for the 3rd request to the route: 'get.users'. No request ever occurred."
             done()
 
           cy.on "command:retry", =>
@@ -390,10 +390,9 @@ describe "src/cy/commands/waiting", ->
             win = cy.state("window")
             win.$.get("/users", {num: response})
 
-          cy
-            .server()
-            .route(/users/, resp).as("getUsers")
-            .wait(["@getUsers", "@getUsers", "@getUsers"])
+          cy.server()
+          cy.route(/users/, resp).as("get.users")
+          cy.wait(["@get.users", "@get.users", "@get.users"])
 
         it "throws waiting for the 2nd response", (done) ->
           resp = {foo: "foo"}
@@ -517,15 +516,14 @@ describe "src/cy/commands/waiting", ->
             _.defer => win.$.get("/timeout?ms=2002")
 
           cy.on "fail", (err) ->
-            expect(err.message).to.include "cy.wait() timed out waiting 500ms for the 1st request to the route: 'getThree'. No request ever occurred."
+            expect(err.message).to.include "cy.wait() timed out waiting 500ms for the 1st request to the route: 'get.three'. No request ever occurred."
             done()
 
-          cy
-            .server()
-            .route("/timeout?ms=2001").as("getOne")
-            .route("/timeout?ms=2002").as("getTwo")
-            .route(/three/, {}).as("getThree")
-            .wait(["@getOne", "@getTwo", "@getThree"])
+          cy.server()
+          cy.route("/timeout?ms=2001").as("getOne")
+          cy.route("/timeout?ms=2002").as("getTwo")
+          cy.route(/three/, {}).as("get.three")
+          cy.wait(["@getOne", "@getTwo", "@get.three"])
 
         it "throws when waiting on the 3rd response on array of aliases", (done) ->
           Cypress.config("requestTimeout", 200)
@@ -570,17 +568,16 @@ describe "src/cy/commands/waiting", ->
         resp1 = {foo: "foo"}
         resp2 = {bar: "bar"}
 
-        cy
-          .server()
-          .route(/users/, resp1).as("getUsers")
-          .route(/posts/, resp2).as("getPosts")
-          .window().then (win) ->
-            win.$.get("/users")
-            win.$.get("/posts")
-            null
-          .wait(["@getUsers", "@getPosts"]).spread (xhr1, xhr2) ->
-            expect(xhr1.responseBody).to.deep.eq resp1
-            expect(xhr2.responseBody).to.deep.eq resp2
+        cy.server()
+        cy.route(/users/, resp1).as("getUsers")
+        cy.route(/posts/, resp2).as("get.posts")
+        cy.window().then (win) ->
+          win.$.get("/users")
+          win.$.get("/posts")
+          null
+        cy.wait(["@getUsers", "@get.posts"]).spread (xhr1, xhr2) ->
+          expect(xhr1.responseBody).to.deep.eq resp1
+          expect(xhr2.responseBody).to.deep.eq resp2
 
     describe "multiple separate alias waits", ->
       before ->

--- a/packages/driver/test/cypress/integration/commands/xhr_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/xhr_spec.coffee
@@ -188,7 +188,7 @@ describe "src/cy/commands/xhr", ->
 
         cy
           .server()
-          .route({url: /timeout/}).as("getTimeout")
+          .route({url: /timeout/}).as("get.timeout")
           .window().then (win) ->
             xhr = new win.XMLHttpRequest
             xhr.open("GET", "/timeout?ms=100")
@@ -198,7 +198,7 @@ describe "src/cy/commands/xhr", ->
             xhr.onload = ->
               onloaded = true
             null
-          .wait("@getTimeout").then (xhr) ->
+          .wait("@get.timeout").then (xhr) ->
             expect(onloaded).to.be.true
             expect(onreadystatechanged).to.be.true
             expect(xhr.status).to.eq(200)


### PR DESCRIPTION
<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->
I have removed the constraint that the aliases' names cannot contain dots.  The issue is in querying.coffee.  The change is to prevent the characters at and after the dot being removed.

Addresses #3512