### PR TITLE
extract CI provider for azure ci

### DIFF
--- a/packages/server/__snapshots__/cypress_spec.coffee.js
+++ b/packages/server/__snapshots__/cypress_spec.coffee.js
@@ -59,6 +59,7 @@ In order to use either of these features a ciBuildId must be determined.
 The ciBuildId is automatically detected if you are running Cypress in any of the these CI providers:
 
 - appveyor
+- azure
 - bamboo
 - bitbucket
 - buildkite
@@ -88,6 +89,7 @@ In order to use either of these features a ciBuildId must be determined.
 The ciBuildId is automatically detected if you are running Cypress in any of the these CI providers:
 
 - appveyor
+- azure
 - bamboo
 - bitbucket
 - buildkite
@@ -118,6 +120,7 @@ In order to use either of these features a ciBuildId must be determined.
 The ciBuildId is automatically detected if you are running Cypress in any of the these CI providers:
 
 - appveyor
+- azure
 - bamboo
 - bitbucket
 - buildkite

--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -71,7 +71,7 @@ const isWercker = () => {
  */
 const CI_PROVIDERS = {
   'appveyor': 'APPVEYOR',
-  azure: isAzureCi,
+  'azure': isAzureCi,
   'bamboo': 'bamboo.buildNumber',
   'bitbucket': 'BITBUCKET_BUILD_NUMBER',
   'buildkite': 'BUILDKITE',

--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -26,16 +26,18 @@ const extract = (envKeys) => {
  * Returns true if running on TeamFoundation server.
  * @see https://technet.microsoft.com/en-us/hh850448(v=vs.92)
  */
-const isTeamFoundation = () =>
-  process.env.TF_BUILD && process.env.TF_BUILD_BUILDNUMBER
+const isTeamFoundation = () => {
+  return process.env.TF_BUILD && process.env.TF_BUILD_BUILDNUMBER
+}
 
 /**
  * Returns true if running on Azure CI pipeline.
  * See environment variables in the issue #3657
  * @see https://github.com/cypress-io/cypress/issues/3657
 */
-const isAzureCi = () =>
-  process.env.TF_BUILD && process.env.AZURE_HTTP_USER_AGENT
+const isAzureCi = () => {
+  return process.env.TF_BUILD && process.env.AZURE_HTTP_USER_AGENT
+}
 
 const isCodeshipBasic = () => {
   return process.env.CI_NAME && (process.env.CI_NAME === 'codeship') && process.env.CODESHIP
@@ -123,7 +125,7 @@ const _providerCiParams = () => {
       'BUILD_BUILDID',
       'BUILD_BUILDNUMBER',
       'BUILD_CONTAINERID',
-      'BUILD_REPOSITORY_URI'
+      'BUILD_REPOSITORY_URI',
     ]),
     bamboo: extract([
       'bamboo.resultsUrl',
@@ -292,7 +294,7 @@ const _providerCommitParams = function () {
       branch: env.BUILD_SOURCEBRANCHNAME,
       message: env.BUILD_SOURCEVERSIONMESSAGE,
       authorName: env.BUILD_SOURCEVERSIONAUTHOR,
-      authorEmail: env.BUILD_REQUESTEDFOREMAIL
+      authorEmail: env.BUILD_REQUESTEDFOREMAIL,
     },
     bamboo: {
       // sha: ???

--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -22,6 +22,21 @@ const extract = (envKeys) => {
   return _.transform(envKeys, toCamelObject, {})
 }
 
+/**
+ * Returns true if running on TeamFoundation server.
+ * @see https://technet.microsoft.com/en-us/hh850448(v=vs.92)
+ */
+const isTeamFoundation = () =>
+  process.env.TF_BUILD && process.env.TF_BUILD_BUILDNUMBER
+
+/**
+ * Returns true if running on Azure CI pipeline.
+ * See environment variables in the issue #3657
+ * @see https://github.com/cypress-io/cypress/issues/3657
+*/
+const isAzureCi = () =>
+  process.env.TF_BUILD && process.env.AZURE_HTTP_USER_AGENT
+
 const isCodeshipBasic = () => {
   return process.env.CI_NAME && (process.env.CI_NAME === 'codeship') && process.env.CODESHIP
 }
@@ -46,10 +61,17 @@ const isWercker = () => {
   return process.env.WERCKER || process.env.WERCKER_MAIN_PIPELINE_STARTED
 }
 
-// top level detection of CI providers by environment variable
-// or a predicate function
+/**
+ * We detect CI providers by detecting an environment variable
+ * unique to the provider, or by calling a function that returns true
+ * for that provider.
+ *
+ * For example, AppVeyor CI has environment the
+ * variable "APPVEYOR" set during run
+ */
 const CI_PROVIDERS = {
   'appveyor': 'APPVEYOR',
+  azure: isAzureCi,
   'bamboo': 'bamboo.buildNumber',
   'bitbucket': 'BITBUCKET_BUILD_NUMBER',
   'buildkite': 'BUILDKITE',
@@ -63,7 +85,7 @@ const CI_PROVIDERS = {
   'shippable': 'SHIPPABLE',
   'snap': 'SNAP_CI',
   'teamcity': 'TEAMCITY_VERSION',
-  'teamfoundation': 'TF_BUILD',
+  'teamfoundation': isTeamFoundation,
   'travis': 'TRAVIS',
   'wercker': isWercker,
 }
@@ -96,6 +118,12 @@ const _providerCiParams = () => {
       'APPVEYOR_BUILD_VERSION',
       'APPVEYOR_PULL_REQUEST_NUMBER',
       'APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH',
+    ]),
+    azure: extract([
+      'BUILD_BUILDID',
+      'BUILD_BUILDNUMBER',
+      'BUILD_CONTAINERID',
+      'BUILD_REPOSITORY_URI'
     ]),
     bamboo: extract([
       'bamboo.resultsUrl',
@@ -258,6 +286,13 @@ const _providerCommitParams = function () {
       authorEmail: env.APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL,
       // remoteOrigin: ???
       // defaultBranch: ???
+    },
+    azure: {
+      sha: env.BUILD_SOURCEVERSION,
+      branch: env.BUILD_SOURCEBRANCHNAME,
+      message: env.BUILD_SOURCEVERSIONMESSAGE,
+      authorName: env.BUILD_SOURCEVERSIONAUTHOR,
+      authorEmail: env.BUILD_REQUESTEDFOREMAIL
     },
     bamboo: {
       // sha: ???

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -587,9 +587,43 @@ describe "lib/util/ci_provider", ->
     expectsCiParams(null)
     expectsCommitParams(null)
 
+  it "azure", ->
+    resetEnv = mockedEnv({
+      # these two variables tell us it is Azure CI
+      TF_BUILD: "true"
+      AZURE_HTTP_USER_AGENT: "VSTS_5e0090d5-c5b9-4fab-8fd8-ce288e9fb666_build_2_0"
+
+      BUILD_BUILDID: "buildId"
+      BUILD_BUILDNUMBER: "buildNumber"
+      BUILD_CONTAINERID: "containerId"
+      BUILD_REPOSITORY_URI: "buildRepositoryUri"
+
+      BUILD_SOURCEVERSION: "commit"
+      BUILD_SOURCEBRANCHNAME: "branch"
+      BUILD_SOURCEVERSIONMESSAGE: "message"
+      BUILD_SOURCEVERSIONAUTHOR: "name"
+      BUILD_REQUESTEDFOREMAIL: "email"
+    }, {clear: true})
+
+    expectsName("azure")
+    expectsCiParams({
+      buildBuildid: "buildId"
+      buildBuildnumber: "buildNumber"
+      buildContainerid: "containerId"
+      buildRepositoryUri: "buildRepositoryUri"
+    })
+    expectsCommitParams({
+      sha: "commit"
+      branch: "branch"
+      message: "message"
+      authorName: "name"
+      authorEmail: "email"
+    })
+
   it "teamfoundation", ->
     resetEnv = mockedEnv({
       TF_BUILD: "true"
+      TF_BUILD_BUILDNUMBER: "CIBuild_20130613.6"
 
       BUILD_BUILDID: "buildId"
       BUILD_BUILDNUMBER: "buildNumber"


### PR DESCRIPTION
- closes #3657 
- separates TeamFoundation from Azure CI
- sends Azure CI build variables when recording