### PR TITLE
Add rel="noopener" where appropriate, remove where not

### DIFF
--- a/packages/extension/app/newtab.html
+++ b/packages/extension/app/newtab.html
@@ -14,10 +14,10 @@
     <p>Please note:</p>
     <ul>
       <li>Any opened tabs will be closed when Cypress is stopped.</li>
-      <li>Tests currently running will fail while another tab has focus.</li>
+      <li>Tests currently running may fail while another tab has focus.</li>
       <li>Cookies and session from other sites will be cleared.</li>
     </ul>
-    <a href="https://on.cypress.io/guides/browser-management" target="_blank">Read more about browser management</a>
+    <a href="https://on.cypress.io/launching-browsers" target="_blank">Read more about browser management</a>
   </div>
 </body>
 </html>

--- a/packages/extension/app/popup.html
+++ b/packages/extension/app/popup.html
@@ -13,7 +13,7 @@
         <a href="https://on.cypress.io" target="_blank">Docs</a>
       </li>
       <li>
-        <a href="https://gitter.im/cypress-io/cypress" target="_blank">Chat</a>
+        <a href="https://on.cypress.io/chat" target="_blank" rel="noopener noreferrer">Chat</a>
       </li>
     </ul>
   </body>

--- a/packages/runner/src/errors/automation-disconnected.jsx
+++ b/packages/runner/src/errors/automation-disconnected.jsx
@@ -9,7 +9,7 @@ export default ({ onReload }) => (
         <i className='fa fa-refresh'></i> Reload the Browser
       </button>
       <div className='helper-line'>
-        <a href='https://on.cypress.io/guides/browser-management' target='_blank' rel='noopener noreferrer'>
+        <a href='https://on.cypress.io/launching-browsers' target='_blank'>
           <i className='fa fa-question-circle'></i>
           Why am I seeing this message?
         </a>

--- a/packages/runner/src/errors/no-automation.jsx
+++ b/packages/runner/src/errors/no-automation.jsx
@@ -23,7 +23,7 @@ const noBrowsers = () => (
         We couldn't find any supported browsers capable of running Cypress on your machine.
       </small>
     </p>
-    <a href='https://www.google.com/chrome/browser/desktop' target='_blank' className='btn btn-primary btn-lg' rel='noopener noreferrer'>
+    <a href='https://www.google.com/chrome/browser/desktop' className='btn btn-primary btn-lg' target='_blank' rel='noopener noreferrer'>
       <i className='fa fa-chrome'></i>
       Download Chrome
     </a>
@@ -63,7 +63,7 @@ export default ({ browsers, onLaunchBrowser }) => (
       <p>Whoops, we can't run your tests.</p>
       {browsers.length ? browserPicker(browsers, onLaunchBrowser) : noBrowsers()}
       <div className='helper-line'>
-        <a className='helper-docs-link' href='https://on.cypress.io/guides/browser-management' target='_blank' rel='noopener noreferrer'>
+        <a className='helper-docs-link' href='https://on.cypress.io/launching-browsers' target='_blank'>
           <i className='fa fa-question-circle'></i> Why am I seeing this message?
         </a>
       </div>

--- a/packages/runner/src/header/header.jsx
+++ b/packages/runner/src/header/header.jsx
@@ -65,7 +65,7 @@ export default class Header extends Component {
 }`}
               </pre>{/* eslint-enable indent */}
               <p>
-                <a href='https://on.cypress.io/viewport' target='_blank' rel="noopener noreferrer">
+                <a href='https://on.cypress.io/viewport' target='_blank'>
                   <i className='fa fa-info-circle'></i>
                   Read more about viewport here.
                 </a>

--- a/packages/runner/src/iframe/visit-failure.js
+++ b/packages/runner/src/iframe/visit-failure.js
@@ -79,7 +79,7 @@ export default (props) => {
       </svg>
       <p>Sorry, we could not load:</p>
       <p>
-        <a href="${props.url}" target="_blank">${props.url}</a>
+        <a href="${props.url}" target="_blank" rel="noopener noreferrer">${props.url}</a>
       </p>
       ${getStatus()}
     </div>

--- a/packages/runner/src/selector-playground/selector-playground.jsx
+++ b/packages/runner/src/selector-playground/selector-playground.jsx
@@ -99,7 +99,7 @@ class SelectorPlayground extends Component {
             </button>
           </Tooltip>
         </div>
-        <a className='selector-info' href='https://on.cypress.io/selector-playground' target="_blank" rel="noopener noreferrer">
+        <a className='selector-info' href='https://on.cypress.io/selector-playground' target="_blank">
           <i className='fa fa-question-circle'></i>{' '}
           Learn more
         </a>


### PR DESCRIPTION
- close #3951 
- Update urls to use most recent on.cypress.io links
- Update wording of newtab to say tests *may* fail due to focus, as
opposed to *will* fail (as was the case in the past)