### PR TITLE
Update snapshot for browser path not found

### DIFF
--- a/packages/server/__snapshots__/2_browser_path_spec.coffee.js
+++ b/packages/server/__snapshots__/2_browser_path_spec.coffee.js
@@ -4,7 +4,7 @@ We could not identify a known browser at the path you provided: \`/this/aint/gon
 The output from the command we ran was:
 
  Command failed: /bin/sh -c /this/aint/gonna/be/found --version
-/bin/sh: 1: /this/aint/gonna/be/found: not found
+/bin/sh: /this/aint/gonna/be/found: No such file or directory
 
 
 `

--- a/packages/server/__snapshots__/2_browser_path_spec.coffee.js
+++ b/packages/server/__snapshots__/2_browser_path_spec.coffee.js
@@ -1,14 +1,3 @@
-exports['e2e launching browsers by path fails with bad browser path 1'] = `
-We could not identify a known browser at the path you provided: \`/this/aint/gonna/be/found\`
-
-The output from the command we ran was:
-
- Command failed: /bin/sh -c /this/aint/gonna/be/found --version
-/bin/sh: /this/aint/gonna/be/found: No such file or directory
-
-
-`
-
 exports['e2e launching browsers by path works with an installed browser path 1'] = `
 
 ====================================================================================================

--- a/packages/server/test/e2e/2_browser_path_spec.coffee
+++ b/packages/server/test/e2e/2_browser_path_spec.coffee
@@ -23,9 +23,11 @@ describe "e2e launching browsers by path", ->
       project: Fixtures.projectPath("e2e")
       spec: "simple_spec.coffee"
       browser: '/this/aint/gonna/be/found'
-      snapshot: true
       expectedExitCode: 1
     })
+    .then (res) =>
+      expect(res.stdout).to.contain("We could not identify a known browser at the path you provided: `/this/aint/gonna/be/found`")
+      expect(res.code).to.eq(1)
 
   it "works with an installed browser path", ->
     launcher.detect().then (browsers) =>


### PR DESCRIPTION
When I run `develop` with SNAPSHOT_UPDATE option, it prompts me of this change to the browser-path snapshot. @flotwig can you verify that this is the intended output for the snapshot? 