### PR TITLE
[WIP] send _slow prop to reporter

### DIFF
--- a/packages/driver/src/cypress/runner.js
+++ b/packages/driver/src/cypress/runner.js
@@ -18,7 +18,7 @@ const TEST_AFTER_RUN_EVENT = 'runner:test:after:run'
 
 const ERROR_PROPS = 'message type name stack fileName lineNumber columnNumber host uncaught actual expected showDiff isPending'.split(' ')
 const RUNNABLE_LOGS = 'routes agents commands'.split(' ')
-const RUNNABLE_PROPS = 'id title root hookName hookId err state failedFromHookId body speed type duration wallClockStartedAt wallClockDuration timings'.split(' ')
+const RUNNABLE_PROPS = 'id title root hookName hookId err state failedFromHookId body speed type duration wallClockStartedAt wallClockDuration timings _slow'.split(' ')
 
 // ## initial payload
 // {

--- a/packages/server/lib/reporter.coffee
+++ b/packages/server/lib/reporter.coffee
@@ -59,6 +59,7 @@ createRunnable = (obj, parent) ->
   runnable.duration = obj.duration
   runnable.state    = obj.state ? "skipped" ## skipped by default
   runnable.body     ?= body
+  runnable._slow    = obj._slow
 
   runnable.parent = parent if parent
 


### PR DESCRIPTION
fix #447

send the `_slow` runnable property to the reporter, which will allow users to set the slow threshold in `support/index.js` via:

```js
Cypress.mocha.getRunner().on('test', (test) => {
	test.slow(20000)
})

```

- [ ] add test

we should eventually add a config option in the config, but maybe this PR is good for now
