### PR TITLE
add metadata to the uploaded test runner binary

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -276,9 +276,9 @@ jobs:
       steps:
       - attach_workspace:
           at: ~/
-      - run: 
+      - run:
           environment:
-            DEBUG: test:proxy-performance 
+            DEBUG: test:proxy-performance
           command: npm run all test-performance -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -797,6 +797,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
+              - binary-metadata
         requires:
           - build
     - test-binary-and-npm-against-other-projects:
@@ -863,6 +864,7 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
+              - binary-metadata
         requires:
           - Mac build
 

--- a/circle.yml
+++ b/circle.yml
@@ -216,6 +216,8 @@ jobs:
           at: ~/
       # make sure mocha runs
       - run: npm run test-mocha
+      # test binary build code
+      - run: npm run test-scripts
       # make sure our snapshots are compared correctly
       - run: npm run test-mocha-snapshot
       # make sure packages with TypeScript can be transpiled to JS

--- a/circle.yml
+++ b/circle.yml
@@ -790,6 +790,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
+              - binary-metadata
         requires:
           - build
     - build-binary:
@@ -805,6 +806,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
+              - binary-metadata
         requires:
           - build-npm-package
           - build-binary

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "gulp-debug": "3.2.0",
     "gulp-rename": "1.4.0",
     "gulp-typescript": "3.2.4",
+    "hasha": "5.0.0",
     "human-interval": "0.1.6",
     "husky": "0.14.3",
     "inquirer": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "move-binaries": "node ./scripts/binary.js move-binaries",
     "binary-release": "node ./scripts/binary.js release",
     "test-scripts": "mocha -r packages/coffee/register -r packages/ts/register --reporter spec 'scripts/unit/**/*spec.js'",
+    "test-s3-api": "node -r ./packages/coffee/register -r ./packages/ts/register scripts/binary/s3-api-demo.ts",
     "test-mocha": "mocha --reporter spec scripts/spec.js",
     "test-mocha-snapshot": "mocha scripts/mocha-snapshot-spec.js",
     "check-node-version": "node scripts/check-node-version.js",

--- a/scripts/binary/move-binaries.ts
+++ b/scripts/binary/move-binaries.ts
@@ -195,7 +195,8 @@ export const moveBinaries = async (args = []) => {
     const destinationPath = getFullUploadName(options)
     console.log('copying test runner %s to %s', lastBuild.platformArch, destinationPath)
 
-    await s3helpers.copyS3(lastBuild.s3zipPath, destinationPath, aws.bucket, s3)
+    await s3helpers.copyS3(lastBuild.s3zipPath, destinationPath, aws.bucket,
+      'application/zip', 'public-read', s3)
 
     testRunners.push({
       platformArch: lastBuild.platformArch,

--- a/scripts/binary/s3-api-demo.ts
+++ b/scripts/binary/s3-api-demo.ts
@@ -9,10 +9,13 @@ const s3 = s3helpers.makeS3(aws)
 const bucket = aws.bucket
 const key = 'beta/binary/3.3.0/darwin-x64/circle-develop-455046b928c861d4457b2ec5426a51de1fda74fd-102212/cypress.zip'
 
+/*
+  a little demo showing how user metadata can be set and read on a S3 object.
+*/
+
 s3helpers.setUserMetadata(bucket, key, {
   user: 'bar'
 }, s3)
 .then(() => {
   return s3helpers.getUserMetadata(bucket, key, s3)
-})
-  .then(console.log, console.error)
+}).then(console.log, console.error)

--- a/scripts/binary/s3-api-demo.ts
+++ b/scripts/binary/s3-api-demo.ts
@@ -1,0 +1,12 @@
+// ignore TS errors - we are importing from CoffeeScript files
+// @ts-ignore
+import uploadUtils from './util/upload'
+import { s3helpers } from './s3-api'
+
+const aws = uploadUtils.getS3Credentials()
+const s3 = s3helpers.makeS3(aws)
+
+const bucket = aws.bucket
+const key = 'beta/binary/3.3.0/darwin-x64/circle-develop-455046b928c861d4457b2ec5426a51de1fda74fd-102212/cypress.zip'
+s3helpers.getUserMetadata(key, bucket, s3)
+  .then(console.log, console.error)

--- a/scripts/binary/s3-api-demo.ts
+++ b/scripts/binary/s3-api-demo.ts
@@ -8,5 +8,11 @@ const s3 = s3helpers.makeS3(aws)
 
 const bucket = aws.bucket
 const key = 'beta/binary/3.3.0/darwin-x64/circle-develop-455046b928c861d4457b2ec5426a51de1fda74fd-102212/cypress.zip'
-s3helpers.getUserMetadata(key, bucket, s3)
+
+s3helpers.setUserMetadata(bucket, key, {
+  user: 'bar'
+}, s3)
+.then(() => {
+  return s3helpers.getUserMetadata(bucket, key, s3)
+})
   .then(console.log, console.error)

--- a/scripts/binary/s3-api.ts
+++ b/scripts/binary/s3-api.ts
@@ -66,7 +66,7 @@ export const s3helpers = {
     })
   },
 
-  async copyS3 (sourceKey: string, destinationKey: string, bucket: string, s3: S3) {
+  copyS3 (sourceKey: string, destinationKey: string, bucket: string, s3: S3): Promise<S3.CopyObjectOutput> {
     return new Promise((resole, reject) => {
       debug('copying %s in bucket %s to %s', sourceKey, bucket, destinationKey)
 
@@ -81,6 +81,25 @@ export const s3helpers = {
 
         debug('result of copying')
         debug('%o', data)
+      })
+    })
+  },
+
+  getUserMetadata (key: string, bucket: string, s3: S3): Promise<S3.Metadata> {
+    return new Promise((resole, reject) => {
+      debug('getting user metadata from %s %s', bucket, key)
+
+      s3.headObject({
+        Bucket: bucket,
+        Key: key
+      }, (err, data) => {
+        if (err) {
+          return reject(err)
+        }
+
+        debug('user metadata')
+        debug('%o', data.Metadata)
+        resole(data.Metadata)
       })
     })
   }

--- a/scripts/binary/s3-api.ts
+++ b/scripts/binary/s3-api.ts
@@ -66,6 +66,9 @@ export const s3helpers = {
     })
   },
 
+  /**
+   * Copies one S3 object into another key, metadata is copied
+   */
   copyS3 (sourceKey: string, destinationKey: string, bucket: string, s3: S3): Promise<S3.CopyObjectOutput> {
     return new Promise((resolve, reject) => {
       debug('copying %s in bucket %s to %s', sourceKey, bucket, destinationKey)
@@ -73,7 +76,9 @@ export const s3helpers = {
       const params: S3.CopyObjectRequest = {
         Bucket: bucket,
         CopySource: bucket + '/' + sourceKey,
-        Key: destinationKey
+        Key: destinationKey,
+        // when we copy S3 object, copy the original metadata, if any
+        MetadataDirective: 'COPY'
       }
       s3.copyObject(params, (err, data) => {
         if (err) {

--- a/scripts/binary/s3-api.ts
+++ b/scripts/binary/s3-api.ts
@@ -1,0 +1,87 @@
+const debug = require("debug")("cypress:binary")
+import la from 'lazy-ass'
+import is from 'check-more-types'
+import S3 from 'aws-sdk/clients/s3'
+import {prop} from 'ramda'
+
+/**
+ * Utility object with methods that deal with S3.
+ * Useful for testing our code that calls S3 methods.
+ */
+export const s3helpers = {
+  makeS3 (aws) {
+    la(is.unemptyString(aws.key), 'missing aws key')
+    la(is.unemptyString(aws.secret), 'missing aws secret')
+
+    return new S3({
+      accessKeyId: aws.key,
+      secretAccessKey: aws.secret
+    })
+  },
+
+  verifyZipFileExists (zipFile: string, bucket: string, s3: S3): Promise<null> {
+    debug('checking S3 file %s', zipFile)
+    debug('bucket %s', bucket)
+
+    return new Promise((resolve, reject) => {
+      s3.headObject({
+        Bucket: bucket,
+        Key: zipFile
+      }, (err, data) => {
+        if (err) {
+          debug('error getting object %s', zipFile)
+          debug(err)
+
+          return reject(err)
+        }
+        debug('s3 data for %s', zipFile)
+        debug(data)
+        resolve()
+      })
+    })
+  },
+
+  /**
+   * Returns list of prefixes in a given folder
+   */
+  listS3Objects (uploadDir: string, bucket: string, s3: S3): Promise<string[]> {
+    la(is.unemptyString(uploadDir), 'invalid upload dir', uploadDir)
+
+    return new Promise((resolve, reject) => {
+      const prefix = uploadDir + '/'
+      s3.listObjectsV2({
+        Bucket: bucket,
+        Prefix: prefix,
+        Delimiter: '/'
+      }, (err, result) => {
+        if (err) {
+          return reject(err)
+        }
+
+        debug('AWS result in %s %s', bucket, prefix)
+        debug('%o', result)
+
+        resolve(result.CommonPrefixes.map(prop('Prefix')))
+      })
+    })
+  },
+
+  async copyS3 (sourceKey: string, destinationKey: string, bucket: string, s3: S3) {
+    return new Promise((resole, reject) => {
+      debug('copying %s in bucket %s to %s', sourceKey, bucket, destinationKey)
+
+      s3.copyObject({
+        Bucket: bucket,
+        CopySource: bucket + '/' + sourceKey,
+        Key: destinationKey
+      }, (err, data) => {
+        if (err) {
+          return reject(err)
+        }
+
+        debug('result of copying')
+        debug('%o', data)
+      })
+    })
+  }
+}

--- a/scripts/binary/s3-api.ts
+++ b/scripts/binary/s3-api.ts
@@ -125,7 +125,7 @@ export const s3helpers = {
    * with replaced metadata object.
   */
   setUserMetadata (bucket: string, key: string, metadata: S3.Metadata,
-      acl: S3.ObjectCannedACL, s3: S3): Promise<S3.CopyObjectOutput> {
+    contentType: S3.ContentType, acl: S3.ObjectCannedACL, s3: S3): Promise<S3.CopyObjectOutput> {
     la(hasOnlyStringValues(metadata),
       'metadata object can only have string values', metadata)
 
@@ -138,6 +138,7 @@ export const s3helpers = {
         Key: key,
         Metadata: metadata,
         MetadataDirective: 'REPLACE',
+        ContentType: contentType,
         ACL: acl
       }
       s3.copyObject(params, (err, data) => {

--- a/scripts/binary/s3-api.ts
+++ b/scripts/binary/s3-api.ts
@@ -120,8 +120,6 @@ export const s3helpers = {
   /**
    * Setting user metadata can be accomplished with copying the object back onto itself
    * with replaced metadata object.
-   *
-   * Hmm, does this need to fetch metadata and ACL first, then set it back?
   */
   setUserMetadata (bucket: string, key: string, metadata: S3.Metadata, s3: S3): Promise<S3.CopyObjectOutput> {
     return new Promise((resolve, reject) => {

--- a/scripts/binary/s3-api.ts
+++ b/scripts/binary/s3-api.ts
@@ -70,9 +70,13 @@ export const s3helpers = {
   },
 
   /**
-   * Copies one S3 object into another key, metadata is copied
+   * Copies one S3 object into another key, metadata is copied.
+   * For copying a public zip file use content 'application/zip'
+   * and ACL 'public-read'
    */
-  copyS3 (sourceKey: string, destinationKey: string, bucket: string, s3: S3): Promise<S3.CopyObjectOutput> {
+  copyS3 (sourceKey: string, destinationKey: string, bucket: string,
+    contentType: S3.ContentType, acl: S3.ObjectCannedACL,
+    s3: S3): Promise<S3.CopyObjectOutput> {
     return new Promise((resolve, reject) => {
       debug('copying %s in bucket %s to %s', sourceKey, bucket, destinationKey)
 
@@ -81,7 +85,9 @@ export const s3helpers = {
         CopySource: bucket + '/' + sourceKey,
         Key: destinationKey,
         // when we copy S3 object, copy the original metadata, if any
-        MetadataDirective: 'COPY'
+        MetadataDirective: 'COPY',
+        ContentType: contentType,
+        ACL: acl
       }
       s3.copyObject(params, (err, data) => {
         if (err) {

--- a/scripts/binary/s3-api.ts
+++ b/scripts/binary/s3-api.ts
@@ -120,6 +120,8 @@ export const s3helpers = {
   /**
    * Setting user metadata can be accomplished with copying the object back onto itself
    * with replaced metadata object.
+   *
+   * Hmm, does this need to fetch metadata and ACL first, then set it back?
   */
   setUserMetadata (bucket: string, key: string, metadata: S3.Metadata, s3: S3): Promise<S3.CopyObjectOutput> {
     return new Promise((resolve, reject) => {

--- a/scripts/binary/s3-api.ts
+++ b/scripts/binary/s3-api.ts
@@ -85,6 +85,12 @@ export const s3helpers = {
     })
   },
 
+  /**
+   * Returns user metadata for the given S3 object.
+   * Note: on S3 when adding user metadata, each key is prefixed with "x-amz-meta-"
+   * but the returned object has these prefixes stripped. Thus if we set
+   * a single "x-amz-meta-user: gleb", the resolved object will be simply {user: "gleb"}
+  */
   getUserMetadata (key: string, bucket: string, s3: S3): Promise<S3.Metadata> {
     return new Promise((resole, reject) => {
       debug('getting user metadata from %s %s', bucket, key)

--- a/scripts/binary/upload-unique-binary.coffee
+++ b/scripts/binary/upload-unique-binary.coffee
@@ -108,7 +108,9 @@ setChecksum = (filename, key) =>
     checksum,
     size: String(size)
   }
-  s3helpers.setUserMetadata(aws.bucket, key, metadata, s3)
+  # by default s3.copyObject does not preserve ACL when copying
+  # thus we need to reset it for our public files
+  s3helpers.setUserMetadata(aws.bucket, key, metadata, 'public-read', s3)
 
 uploadUniqueBinary = (args = []) ->
   options = minimist(args, {

--- a/scripts/binary/upload-unique-binary.coffee
+++ b/scripts/binary/upload-unique-binary.coffee
@@ -81,7 +81,7 @@ uploadFile = (options) ->
       console.log("renaming upload to", p.dirname, p.basename)
       la(check.unemptyString(p.basename), "missing basename")
       la(check.unemptyString(p.dirname), "missing dirname")
-      key = p.dirname + p.basename
+      key = p.dirname + uploadFileName
       p
     .pipe debug()
     .pipe publisher.publish(headers)

--- a/scripts/binary/upload-unique-binary.coffee
+++ b/scripts/binary/upload-unique-binary.coffee
@@ -103,9 +103,10 @@ setChecksum = (filename, key) =>
 
   aws = uploadUtils.getS3Credentials()
   s3 = s3helpers.makeS3(aws)
+  # S3 object metadata can only have string values
   metadata = {
     checksum,
-    size
+    size: String(size)
   }
   s3helpers.setUserMetadata(aws.bucket, key, metadata, s3)
 

--- a/scripts/binary/upload-unique-binary.coffee
+++ b/scripts/binary/upload-unique-binary.coffee
@@ -14,7 +14,7 @@ hasha = require('hasha')
 
 konfig = require('../binary/get-config')()
 uploadUtils = require("./util/upload")
-s3helpers = require("./s3-api")
+s3helpers = require("./s3-api").s3helpers
 
 # we zip the binary on every platform and upload under same name
 binaryExtension = ".zip"

--- a/scripts/binary/upload-unique-binary.coffee
+++ b/scripts/binary/upload-unique-binary.coffee
@@ -72,7 +72,14 @@ uploadFile = (options) ->
     headers = {}
     headers["Cache-Control"] = "no-cache"
 
-    key = null
+    # add custom metadata with checksums
+    # every value should be a string
+    checksum = hasha.fromFileSync(options.file)
+    size = fs.statSync(options.file).size
+    console.log('SHA256 checksum %s', checksum)
+    console.log('size', size)
+    headers["x-amz-meta-checksum"] = checksum
+    headers["x-amz-meta-size"] = String(size)
 
     gulp.src(options.file)
     .pipe rename (p) =>
@@ -81,34 +88,12 @@ uploadFile = (options) ->
       console.log("renaming upload to", p.dirname, p.basename)
       la(check.unemptyString(p.basename), "missing basename")
       la(check.unemptyString(p.dirname), "missing dirname")
-      key = p.dirname + uploadFileName
       p
     .pipe debug()
     .pipe publisher.publish(headers)
     .pipe awspublish.reporter()
     .on "error", reject
-    .on "end", () -> resolve(key)
-
-setChecksum = (filename, key) =>
-  console.log('setting checksum for file %s', filename)
-  console.log('on s3 object %s', key)
-
-  la(check.unemptyString(filename), 'expected filename', filename)
-  la(check.unemptyString(key), 'expected uploaded S3 key', key)
-
-  checksum = hasha.fromFileSync(filename)
-  size = fs.statSync(filename).size
-  console.log('SHA256 checksum %s', checksum)
-  console.log('size', size)
-
-  aws = uploadUtils.getS3Credentials()
-  s3 = s3helpers.makeS3(aws)
-  # S3 object metadata can only have string values
-  metadata = {
-    checksum,
-    size: String(size)
-  }
-  s3helpers.setUserMetadata(aws.bucket, key, metadata, s3)
+    .on "end", resolve
 
 uploadUniqueBinary = (args = []) ->
   options = minimist(args, {
@@ -140,8 +125,6 @@ uploadUniqueBinary = (args = []) ->
   options.platformArch = uploadUtils.getUploadNameByOsAndArch(platform)
 
   uploadFile(options)
-  .then (key) ->
-    setChecksum(options.file, key)
   .then () ->
     cdnUrl = getCDN({
       version: options.version,

--- a/scripts/binary/upload-unique-binary.coffee
+++ b/scripts/binary/upload-unique-binary.coffee
@@ -101,7 +101,7 @@ setChecksum = (filename, key) =>
   console.log('SHA256 checksum %s', checksum)
   console.log('size', size)
 
-  aws = uploadUtils.getAwsObj()
+  aws = uploadUtils.getS3Credentials()
   s3 = s3helpers.makeS3(aws)
   metadata = {
     checksum,

--- a/scripts/binary/upload-unique-binary.coffee
+++ b/scripts/binary/upload-unique-binary.coffee
@@ -110,7 +110,8 @@ setChecksum = (filename, key) =>
   }
   # by default s3.copyObject does not preserve ACL when copying
   # thus we need to reset it for our public files
-  s3helpers.setUserMetadata(aws.bucket, key, metadata, 'public-read', s3)
+  s3helpers.setUserMetadata(aws.bucket, key, metadata,
+    'application/zip', 'public-read', s3)
 
 uploadUniqueBinary = (args = []) ->
   options = minimist(args, {

--- a/scripts/binary/upload.coffee
+++ b/scripts/binary/upload.coffee
@@ -11,9 +11,7 @@ Promise = require("bluebird")
 meta    = require("./meta")
 la      = require("lazy-ass")
 check   = require("check-more-types")
-hasha   = require('hasha')
 uploadUtils = require("./util/upload")
-s3helpers   = require("./s3-api")
 
 fs = Promise.promisifyAll(fs)
 
@@ -142,7 +140,6 @@ module.exports = {
     if !fs.existsSync(zipFile)
       throw new Error("Cannot find zip file #{zipFile}")
 
-    # resolves with uploaded S3 key path
     upload = =>
       new Promise (resolve, reject) =>
         publisher = @getPublisher()
@@ -150,41 +147,19 @@ module.exports = {
         headers = {}
         headers["Cache-Control"] = "no-cache"
 
-        key = null
-
         gulp.src(zipFile)
         .pipe rename (p) =>
           # rename to standard filename zipName
           p.basename = path.basename(zipName, p.extname)
           p.dirname = @getUploadDirName({version, platform})
-          key = p.dirname + p.basename
           p
         .pipe debug()
         .pipe publisher.publish(headers)
         .pipe awspublish.reporter()
         .on "error", reject
-        .on "end", () -> resolve(key)
-
-    setChecksum = (key) =>
-      console.log('setting checksum for file %s', zipFile)
-      console.log('on s3 object %s', key)
-      la(check.unemptyString(key), 'expected uploaded S3 key', key)
-
-      checksum = hasha.fromFileSync(zipFile)
-      size = fs.statSync(zipFile).size
-      console.log('SHA256 checksum %s', checksum)
-      console.log('size', size)
-
-      aws = @getAwsObj()
-      s3 = s3helpers.makeS3(aws)
-      metadata = {
-        checksum,
-        size
-      }
-      s3helpers.setUserMetadata(aws.bucket, key, metadata, s3)
+        .on "end", resolve
 
     upload()
-    .then setChecksum
     .then ->
       uploadUtils.purgeDesktopAppFromCache({version, platform, zipName})
 }

--- a/scripts/unit/binary/move-binaries-spec.js
+++ b/scripts/unit/binary/move-binaries-spec.js
@@ -22,7 +22,7 @@ describe('move-binaries', () => {
 
       snapshot({
         path,
-        parsed
+        parsed,
       })
     })
   })
@@ -37,7 +37,7 @@ describe('move-binaries', () => {
 
     it('finds single matching path', () => {
       const paths = [
-        'beta/binary/3.3.0/darwin-x64/circle-develop-47e98fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/'
+        'beta/binary/3.3.0/darwin-x64/circle-develop-47e98fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/',
       ]
       const found = findBuildByCommit(sha, paths)
 
@@ -49,7 +49,7 @@ describe('move-binaries', () => {
         'beta/binary/3.3.0/darwin-x64/circle-develop-47e98fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/',
         // these are not matching
         'beta/binary/3.3.0/darwin-x64/circle-develop-ffff8fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/',
-        'beta/binary/3.3.0/darwin-x64/circle-develop-aaaa8fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/'
+        'beta/binary/3.3.0/darwin-x64/circle-develop-aaaa8fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/',
       ]
       const found = findBuildByCommit(sha, paths)
 
@@ -66,7 +66,7 @@ describe('move-binaries', () => {
         'beta/binary/3.3.0/darwin-x64/circle-develop-ffff8fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/',
         'beta/binary/3.3.0/darwin-x64/circle-develop-aaaa8fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/',
         // this one is matching, but not the latest one
-        'beta/binary/3.3.0/darwin-x64/circle-develop-47e98fa1d0b18867a74da91a719d0f1ae73fcbc7-2/'
+        'beta/binary/3.3.0/darwin-x64/circle-develop-47e98fa1d0b18867a74da91a719d0f1ae73fcbc7-2/',
       ]
       const found = findBuildByCommit(sha, paths)
 
@@ -107,13 +107,13 @@ describe('move-binaries', () => {
         'beta/binary/3.3.0/darwin-x64/circle-develop-9372bc3f67a6a83bd5ec8a69d7350f5a9b52ddf9-102246/',
         'beta/binary/3.3.0/darwin-x64/circle-develop-455046b928c861d4457b2ec5426a51de1fda74fd-102359/',
         'beta/binary/3.3.0/darwin-x64/circle-develop-ec36bf013224942f6198bf831d62af64b9b16cf5-102729/',
-        'beta/binary/3.3.0/darwin-x64/circle-issue-3996-6d539513e709ddd5aad866f6bf653280db6622cd-98450/'
+        'beta/binary/3.3.0/darwin-x64/circle-issue-3996-6d539513e709ddd5aad866f6bf653280db6622cd-98450/',
       ]
 
       // fake AWS config
       const aws = {
         bucket: 'cdn.cypress.io',
-        folder: 'desktop' // destination for test runner downloads
+        folder: 'desktop', // destination for test runner downloads
       }
 
       sinon.stub(uploadUtils, 'getS3Credentials').returns(aws)
@@ -123,33 +123,33 @@ describe('move-binaries', () => {
 
       sinon.stub(s3helpers, 'makeS3').returns(s3)
       sinon
-        .stub(s3helpers, 'listS3Objects')
-        .withArgs('beta/binary/3.3.0/darwin-x64', aws.bucket)
-        .resolves(darwinBuilds)
+      .stub(s3helpers, 'listS3Objects')
+      .withArgs('beta/binary/3.3.0/darwin-x64', aws.bucket)
+      .resolves(darwinBuilds)
 
       sinon
-        .stub(s3helpers, 'verifyZipFileExists')
-        .withArgs(`${latestMacBuild}cypress.zip`, aws.bucket)
-        .resolves()
+      .stub(s3helpers, 'verifyZipFileExists')
+      .withArgs(`${latestMacBuild}cypress.zip`, aws.bucket)
+      .resolves()
 
       // our method will ask user to confirm copying
       sinon.stub(moveBinaries.prompts, 'shouldCopy').resolves()
 
       sinon
-        .stub(s3helpers, 'copyS3')
-        .withArgs(
-          `${latestMacBuild}cypress.zip`,
-          'desktop/3.3.0/darwin-x64/cypress.zip',
-          aws.bucket
-        )
-        .resolves()
+      .stub(s3helpers, 'copyS3')
+      .withArgs(
+        `${latestMacBuild}cypress.zip`,
+        'desktop/3.3.0/darwin-x64/cypress.zip',
+        aws.bucket
+      )
+      .resolves()
 
       // first two arguments are sliced anyway
       const nodeName = null
       const scriptName = null
       const args = [nodeName, scriptName, '--sha', sha, '--version', version]
 
-      return move(args).then(result => {
+      return move(args).then((result) => {
         la(is.object(result), 'expected a result', result)
 
         snapshot('collected builds and copied desktop', result)

--- a/scripts/unit/binary/move-binaries-spec.js
+++ b/scripts/unit/binary/move-binaries-spec.js
@@ -2,6 +2,7 @@ const snapshot = require('snap-shot-it')
 const la = require('lazy-ass')
 const is = require('check-more-types')
 const uploadUtils = require('../../binary/util/upload')
+const s3helpers = require('../../binary/s3-api').s3helpers
 
 /* eslint-env mocha */
 /* global sinon */
@@ -21,7 +22,7 @@ describe('move-binaries', () => {
 
       snapshot({
         path,
-        parsed,
+        parsed
       })
     })
   })
@@ -36,7 +37,7 @@ describe('move-binaries', () => {
 
     it('finds single matching path', () => {
       const paths = [
-        'beta/binary/3.3.0/darwin-x64/circle-develop-47e98fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/',
+        'beta/binary/3.3.0/darwin-x64/circle-develop-47e98fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/'
       ]
       const found = findBuildByCommit(sha, paths)
 
@@ -48,7 +49,7 @@ describe('move-binaries', () => {
         'beta/binary/3.3.0/darwin-x64/circle-develop-47e98fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/',
         // these are not matching
         'beta/binary/3.3.0/darwin-x64/circle-develop-ffff8fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/',
-        'beta/binary/3.3.0/darwin-x64/circle-develop-aaaa8fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/',
+        'beta/binary/3.3.0/darwin-x64/circle-develop-aaaa8fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/'
       ]
       const found = findBuildByCommit(sha, paths)
 
@@ -65,7 +66,7 @@ describe('move-binaries', () => {
         'beta/binary/3.3.0/darwin-x64/circle-develop-ffff8fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/',
         'beta/binary/3.3.0/darwin-x64/circle-develop-aaaa8fa1d0b18867a74da91a719d0f1ae73fcbc7-101843/',
         // this one is matching, but not the latest one
-        'beta/binary/3.3.0/darwin-x64/circle-develop-47e98fa1d0b18867a74da91a719d0f1ae73fcbc7-2/',
+        'beta/binary/3.3.0/darwin-x64/circle-develop-47e98fa1d0b18867a74da91a719d0f1ae73fcbc7-2/'
       ]
       const found = findBuildByCommit(sha, paths)
 
@@ -106,13 +107,13 @@ describe('move-binaries', () => {
         'beta/binary/3.3.0/darwin-x64/circle-develop-9372bc3f67a6a83bd5ec8a69d7350f5a9b52ddf9-102246/',
         'beta/binary/3.3.0/darwin-x64/circle-develop-455046b928c861d4457b2ec5426a51de1fda74fd-102359/',
         'beta/binary/3.3.0/darwin-x64/circle-develop-ec36bf013224942f6198bf831d62af64b9b16cf5-102729/',
-        'beta/binary/3.3.0/darwin-x64/circle-issue-3996-6d539513e709ddd5aad866f6bf653280db6622cd-98450/',
+        'beta/binary/3.3.0/darwin-x64/circle-issue-3996-6d539513e709ddd5aad866f6bf653280db6622cd-98450/'
       ]
 
       // fake AWS config
       const aws = {
         bucket: 'cdn.cypress.io',
-        folder: 'desktop', // destination for test runner downloads
+        folder: 'desktop' // destination for test runner downloads
       }
 
       sinon.stub(uploadUtils, 'getS3Credentials').returns(aws)
@@ -120,35 +121,35 @@ describe('move-binaries', () => {
       // fake S3 api
       const s3 = {}
 
-      sinon.stub(moveBinaries.s3helpers, 'makeS3').returns(s3)
+      sinon.stub(s3helpers, 'makeS3').returns(s3)
       sinon
-      .stub(moveBinaries.s3helpers, 'listS3Objects')
-      .withArgs('beta/binary/3.3.0/darwin-x64', aws.bucket)
-      .resolves(darwinBuilds)
+        .stub(s3helpers, 'listS3Objects')
+        .withArgs('beta/binary/3.3.0/darwin-x64', aws.bucket)
+        .resolves(darwinBuilds)
 
       sinon
-      .stub(moveBinaries.s3helpers, 'verifyZipFileExists')
-      .withArgs(`${latestMacBuild}cypress.zip`, aws.bucket)
-      .resolves()
+        .stub(s3helpers, 'verifyZipFileExists')
+        .withArgs(`${latestMacBuild}cypress.zip`, aws.bucket)
+        .resolves()
 
       // our method will ask user to confirm copying
       sinon.stub(moveBinaries.prompts, 'shouldCopy').resolves()
 
       sinon
-      .stub(moveBinaries.s3helpers, 'copyS3')
-      .withArgs(
-        `${latestMacBuild}cypress.zip`,
-        'desktop/3.3.0/darwin-x64/cypress.zip',
-        aws.bucket
-      )
-      .resolves()
+        .stub(s3helpers, 'copyS3')
+        .withArgs(
+          `${latestMacBuild}cypress.zip`,
+          'desktop/3.3.0/darwin-x64/cypress.zip',
+          aws.bucket
+        )
+        .resolves()
 
       // first two arguments are sliced anyway
       const nodeName = null
       const scriptName = null
       const args = [nodeName, scriptName, '--sha', sha, '--version', version]
 
-      return move(args).then((result) => {
+      return move(args).then(result => {
         la(is.object(result), 'expected a result', result)
 
         snapshot('collected builds and copied desktop', result)

--- a/scripts/unit/binary/s3-api-spec.js
+++ b/scripts/unit/binary/s3-api-spec.js
@@ -1,0 +1,24 @@
+const la = require('lazy-ass')
+
+/* eslint-env mocha */
+describe('s3-api', () => {
+  context('hasOnlyStringValues', () => {
+    const { hasOnlyStringValues } = require('../../binary/s3-api')
+
+    it('returns true if object has only string values', () => {
+      const o = {
+        foo: 'bar',
+        baz: 'baz'
+      }
+      la(hasOnlyStringValues(o))
+    })
+
+    it('returns false if object has non-string value', () => {
+      const o = {
+        foo: 'bar',
+        baz: 42
+      }
+      la(!hasOnlyStringValues(o))
+    })
+  })
+})

--- a/scripts/unit/binary/s3-api-spec.js
+++ b/scripts/unit/binary/s3-api-spec.js
@@ -8,16 +8,18 @@ describe('s3-api', () => {
     it('returns true if object has only string values', () => {
       const o = {
         foo: 'bar',
-        baz: 'baz'
+        baz: 'baz',
       }
+
       la(hasOnlyStringValues(o))
     })
 
     it('returns false if object has non-string value', () => {
       const o = {
         foo: 'bar',
-        baz: 42
+        baz: 42,
       }
+
       la(!hasOnlyStringValues(o))
     })
   })


### PR DESCRIPTION
- closes #4083
- [x] fixed missing resolve in `copyS3` method
- [x] sha256 checksum (uses `hasha` module)
- [x] file size

You can see the extra headers on the ZIP file

```
x-amz-meta-checksum: e2d381523998efc81a50d9d04c18055a353664e65a26837756d036d4f23ed0def498fc206e03a428e4f4d3042d271e602cfd7e505bfe9918d68ac954f594c15e
x-amz-meta-size: 140304055
```

<img width="1317" alt="Screen Shot 2019-05-01 at 3 12 10 PM" src="https://user-images.githubusercontent.com/2212006/57037033-0630e180-6c24-11e9-83db-23d3eb4c9aa2.png">
