### PR TITLE
fix mouse events and adjust tests

### DIFF
--- a/packages/driver/src/cypress/mouse.coffee
+++ b/packages/driver/src/cypress/mouse.coffee
@@ -22,7 +22,7 @@ module.exports = {
       detail: 1
     })
 
-    mdownEvt = new window.MouseEvent "mousedown", mdownEvtProps
+    mdownEvt = new win.MouseEvent "mousedown", mdownEvtProps
 
     ## ensure this property exists on older chromium versions
     mdownEvt.buttons ?= 1
@@ -57,7 +57,7 @@ module.exports = {
       detail: 1
     })
 
-    mupEvt = new MouseEvent "mouseup", mupEvtProps
+    mupEvt = new win.MouseEvent "mouseup", mupEvtProps
 
     ## ensure this property exists on older chromium versions
     mupEvt.buttons ?= 0
@@ -92,7 +92,7 @@ module.exports = {
       detail: 1
     })
 
-    clickEvt = new MouseEvent "click", clickEvtProps
+    clickEvt = new win.MouseEvent "click", clickEvtProps
 
     ## ensure this property exists on older chromium versions
     clickEvt.buttons ?= 0

--- a/packages/driver/test/cypress/integration/commands/actions/click_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/click_spec.coffee
@@ -21,6 +21,8 @@ describe "src/cy/commands/actions/click", ->
     it "receives native click event", (done) ->
       $btn = cy.$$("#button")
 
+      win = cy.state('window')
+
       $btn.on "click", (e) =>
         { fromViewport } = Cypress.dom.getElementCoordinatesByPosition($btn)
 
@@ -28,7 +30,7 @@ describe "src/cy/commands/actions/click", ->
         expect(obj).to.deep.eq {
           bubbles: true
           cancelable: true
-          view: cy.state("window")
+          view: win
           button: 0
           buttons: 0
           which: 1
@@ -41,6 +43,7 @@ describe "src/cy/commands/actions/click", ->
           type: "click"
         }
 
+        expect(e.originalEvent instanceof win.Event).to.be.true
         expect(e.clientX).to.be.closeTo(fromViewport.x, 1)
         expect(e.clientY).to.be.closeTo(fromViewport.y, 1)
         done()
@@ -82,6 +85,7 @@ describe "src/cy/commands/actions/click", ->
           type: "mousedown"
         }
 
+        expect(e instanceof win.Event).to.be.true
         expect(e.clientX).to.be.closeTo(fromViewport.x, 1)
         expect(e.clientY).to.be.closeTo(fromViewport.y, 1)
         done()
@@ -113,6 +117,7 @@ describe "src/cy/commands/actions/click", ->
           type: "mouseup"
         }
 
+        expect(e instanceof win.Event).to.be.true
         expect(e.clientX).to.be.closeTo(fromViewport.x, 1)
         expect(e.clientY).to.be.closeTo(fromViewport.y, 1)
         done()


### PR DESCRIPTION
Hi, our team is developing web UI components and recently we faced an issue with cypress clicking on our widgets. While debugging the issue I found out that mouse events don't pass the "instanceof Event" check because the mouse event originated from the cypress window but not from the app window. You can check out example of our [rich text editor](https://dhtmlx.com/docs/products/dhtmlxRichText/). Right now clicking on any button on toolbar will not affect anything.