### PR TITLE
upgrade kitchensink to get rid of http-server dependency

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -29,7 +29,7 @@
     "bin-up": "1.2.0",
     "chai": "3.5.0",
     "cross-env": "5.2.0",
-    "cypress-example-kitchensink": "1.5.2",
+    "cypress-example-kitchensink": "1.5.3",
     "gulp": "3.9.1",
     "gulp-clean": "0.4.0",
     "gulp-gh-pages-will": "0.5.5",


### PR DESCRIPTION
to get around unpublished `ecstatic`