### PR TITLE
Do not take snapshots when numTestsKeptInMemory is 0

### DIFF
--- a/packages/driver/README.md
+++ b/packages/driver/README.md
@@ -26,6 +26,7 @@ If you're developing on the driver, you'll want to run in the normal Cypress GUI
 
 ```bash
 ## run in cypress GUI mode
+cd packages/driver
 npm run cypress:open
 ```
 
@@ -50,6 +51,7 @@ The driver uses a node server to test all of its edge cases, so first start that
 
 ```bash
 ## boot the driver's server
+cd packages/driver
 npm start
 ```
 

--- a/packages/driver/src/cypress/log.coffee
+++ b/packages/driver/src/cypress/log.coffee
@@ -263,7 +263,7 @@ Log = (state, config, obj) ->
       ## bail early and dont snapshot
       ## if we're in headless mode
       ## TODO: fix this
-      if not config("isInteractive")
+      if not config("isInteractive") || _.toString(config("numTestsKeptInMemory")) is '0'
         return @
 
       _.defaults options,

--- a/packages/driver/test/cypress/fixtures/issue-4104.html
+++ b/packages/driver/test/cypress/fixtures/issue-4104.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="/dynamically-sized-css-file/10000.css" />
+  </head>
+  <body>
+      <script>
+          // The .c# classname is tightly coupled to generated CSS file made in packages/driver/test/support/server.coffee
+          // Avoid 0 px, so should('be.visible') check does not randomly fail
+          var h1 = document.createElement('h1');
+          h1.id = 'test';
+          // Using 1000 here, so that the class name used will match one from the dynamic stylesheet
+          h1.className += "c" + (1 + Math.ceil((Math.random() * 1000)));
+          h1.innerText = 'h1 with "' + h1.className + '" class';
+          document.body.appendChild(h1);
+        </script>
+  </body>
+</html>

--- a/packages/driver/test/cypress/integration/issues/4104_spec.js
+++ b/packages/driver/test/cypress/integration/issues/4104_spec.js
@@ -1,0 +1,12 @@
+const _ = Cypress._
+
+describe('lots of assertions run against an HTML page with a large external stylesheet', () => {
+  beforeEach(() => {
+    cy.visit('/fixtures/issue-4104.html')
+  })
+  _.range(1, 51).forEach((n) => {
+    it(`assertion ${n}`, () => {
+      cy.get('#test').should('be.visible')
+    })
+  })
+})

--- a/packages/driver/test/support/server.coffee
+++ b/packages/driver/test/support/server.coffee
@@ -91,6 +91,19 @@ niv.install("react-dom@15.6.1")
     .status(500)
     .send("<html><body>server error</body></html>")
 
+  cachedCssRules = {}
+
+  ## <link href="/dynamically-sized-css-file/:ruleCount.css" /> will include a stylesheet with 1000 rules
+  app.get "/dynamically-sized-css-file/:ruleCount.css", (req, res) ->
+    ruleCount = parseInt(req.params.ruleCount, 10);
+
+    if !cachedCssRules[ruleCount]
+      ## cache dynamically generated css rules, so they don't slow down any tests
+      cachedCssRules[ruleCount] = _.range(1, ruleCount + 1).map((n) -> ".c#{n} { font-size: #{1 + Math.round n/10}px; }").join("\n");
+
+    res.setHeader('Content-Type', 'text/css')
+    res.status(200).send(cachedCssRules[ruleCount])
+
   app.use(express.static(path.join(__dirname, "..", "cypress")))
 
   app.use(require("errorhandler")())


### PR DESCRIPTION
closes #4104

Updated `log.coffee` to avoid snapshots when `numTestsKeptInMemory` is `0` in the same way that is done when `config("isInteractive")` is `true`. This resulted in a sample test with 50 assertions against an HTML document with a 10,000-rule CSS file, to run 40% faster. This also allows users running with `numTestsKeptInMemory` set to 0 to avoid the memory issues being addressed in #4068 

| | v3.20 | this branch |
| ---- | ---- | --- |
| 1 | 10.16s | 6.06s |
| 2 | 10.16s | 6.05s |
| 3 | 10.15s | 6.14s |
| 4 | 9.99s | 5.83s |
| 5 | 9.96s | 6.38s |
| avg | 10.08s | 6.09s |

In `packages/driver/test/support/server.coffee` I've also added a route that will generate a dynamically sized CSS file (per @brian-mann suggestion in #4068)

```coffeescript
  ## <link href="/dynamically-sized-css-file/:ruleCount.css" /> will include a stylesheet with 1000 rules
  app.get "/dynamically-sized-css-file/:ruleCount.css", (req, res) ->
```

----

## Screenshots

<img width="100%" style="margin: 0 auto;" alt="Screenshot of test run with numTestsKeptInMemory 0" src="https://user-images.githubusercontent.com/1461792/57168822-92ccd280-6dd1-11e9-90be-366ea00dbb8d.png">

In these 2 screenshots you can see that the most time spent is within different set of methods before and after these changes.
### Before
<img width="625" alt="Screen Shot 2019-05-03 at 6 48 38 PM" src="https://user-images.githubusercontent.com/1461792/57169397-66668580-6dd4-11e9-9602-255532740944.png">

### After
<img width="625" alt="Screen Shot 2019-05-03 at 6 50 19 PM" src="https://user-images.githubusercontent.com/1461792/57169399-66668580-6dd4-11e9-9251-dbd392c6e4dd.png">
