### PR TITLE
Remove unused dep "tar-fs"

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -184,7 +184,6 @@
     "strip-ansi": "3.0.1",
     "supports-color": "5.5.0",
     "syntax-error": "1.4.0",
-    "tar-fs": "1.16.3",
     "term-size": "1.2.0",
     "through": "2.3.8",
     "tough-cookie": "3.0.1",


### PR DESCRIPTION
- Remove ‘tar-fs’ dependency, it is not being used anywhere
- saves 50.9kB minified size / 15.3 kB minified + gzipped size https://bundlephobia.com/result?p=tar-fs@1.16.3
