### PR TITLE
Automatically retry verify and run commands on Linux if suspect DISPLAY problem

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,6 +266,14 @@ DEBUG=cypress:launcher
 We use [eslint](https://eslint.org/) to lint all JavaScript code and follow rules specified in
 [eslint-plugin-cypress-dev](https://github.com/cypress-io/eslint-plugin-cypress-dev) plugin.
 
+When you edit files, you can quickly fix all changed files before committing using
+
+```bash
+npm run lint-changed
+```
+
+When committing files, we run Git pre-commit hook to fix the staged JS files. See the `precommit-lint` script in [package.json](package.json). This might change JS files and you would need to commit the changes again.
+
 ### Tests
 
 For most packages there are typically unit and some integration tests.

--- a/cli/__snapshots__/errors_spec.js
+++ b/cli/__snapshots__/errors_spec.js
@@ -48,7 +48,7 @@ exports['invalid display error'] = `
 Cypress failed to start.
 
 First, we have tried to start Cypress using your DISPLAY settings
-but his the following problem:
+but encountered the following problem:
 
 ----------
 

--- a/cli/__snapshots__/errors_spec.js
+++ b/cli/__snapshots__/errors_spec.js
@@ -1,3 +1,14 @@
+exports['errors .errors.formErrorText calls solution if a function 1'] = `
+description
+
+a solution
+
+----------
+
+Platform: test platform (Foo-OsVersion)
+Cypress Version: 1.2.3
+`
+
 exports['errors .errors.formErrorText returns fully formed text message 1'] = `
 Your system is missing the dependency: XVFB
 
@@ -33,19 +44,26 @@ exports['errors individual has the following errors 1'] = [
   "versionMismatch"
 ]
 
-exports['errors .errors.formErrorText calls solution if a function 1'] = `
-description
+exports['invalid display error'] = `
+Cypress failed to start.
 
-a solution
+First, we have tried to start Cypress using your DISPLAY settings
+but his the following problem:
 
 ----------
 
-Platform: test platform (Foo-OsVersion)
-Cypress Version: 1.2.3
-`
+prev message
 
-exports['errors .errors.formErrorText custom solution returns specific solution if on Linux DISPLAY env is set 1'] = `
-Cypress failed to start.
+----------
+
+Then we started our own XVFB and tried to start Cypress again, but
+got the following error:
+
+----------
+
+current message
+
+----------
 
 This is usually caused by a missing library or dependency.
 
@@ -55,15 +73,8 @@ The error below should indicate which dependency is missing.
 
 If you are using Docker, we provide containers with all required dependencies installed.
 
-We have noticed that DISPLAY variable is set to "wrong-display-address"
-This might be a problem if X11 server is not responding.
-
-[34mhttps://github.com/cypress-io/cypress/issues/4034[39m
-
-Try deleting the DISPLAY variable and running the command again.
-
 ----------
 
-Platform: linux (Foo-OsVersion)
+Platform: test platform (Foo-OsVersion)
 Cypress Version: 1.2.3
 `

--- a/cli/__snapshots__/errors_spec.js
+++ b/cli/__snapshots__/errors_spec.js
@@ -31,3 +31,36 @@ exports['errors individual has the following errors 1'] = [
   "CYPRESS_RUN_BINARY",
   "smokeTestFailure"
 ]
+
+exports['errors .errors.formErrorText calls solution if a function 1'] = `
+description
+
+a solution
+
+----------
+
+Platform: test platform (Foo-OsVersion)
+Cypress Version: 1.2.3
+`
+
+exports['errors .errors.formErrorText custom solution returns specific solution if on Linux DISPLAY env is set 1'] = `
+Cypress failed to start.
+
+This is usually caused by a missing library or dependency.
+
+The error below should indicate which dependency is missing.
+
+[34mhttps://on.cypress.io/required-dependencies[39m
+
+If you are using Docker, we provide containers with all required dependencies installed.
+
+We have noticed that DISPLAY variable is set to "wrong-display-address"
+This might be a problem if X11 server is not responding.
+See [34mhttps://github.com/cypress-io/cypress/issues/4034[39m and try
+deleting the DISPLAY variable and running the command again.
+
+----------
+
+Platform: linux (Foo-OsVersion)
+Cypress Version: 1.2.3
+`

--- a/cli/__snapshots__/errors_spec.js
+++ b/cli/__snapshots__/errors_spec.js
@@ -56,8 +56,10 @@ If you are using Docker, we provide containers with all required dependencies in
 
 We have noticed that DISPLAY variable is set to "wrong-display-address"
 This might be a problem if X11 server is not responding.
-See [34mhttps://github.com/cypress-io/cypress/issues/4034[39m and try
-deleting the DISPLAY variable and running the command again.
+
+[34mhttps://github.com/cypress-io/cypress/issues/4034[39m
+
+Try deleting the DISPLAY variable and running the command again.
 
 ----------
 

--- a/cli/__snapshots__/errors_spec.js
+++ b/cli/__snapshots__/errors_spec.js
@@ -67,7 +67,7 @@ current message
 
 This is usually caused by a missing library or dependency.
 
-The error below should indicate which dependency is missing.
+The error above should indicate which dependency is missing.
 
 [34mhttps://on.cypress.io/required-dependencies[39m
 

--- a/cli/__snapshots__/errors_spec.js
+++ b/cli/__snapshots__/errors_spec.js
@@ -16,20 +16,21 @@ Cypress Version: 1.2.3
 `
 
 exports['errors individual has the following errors 1'] = [
-  "nonZeroExitCodeXvfb",
-  "missingXvfb",
-  "missingApp",
-  "notInstalledCI",
-  "missingDependency",
-  "versionMismatch",
+  "CYPRESS_RUN_BINARY",
   "binaryNotExecutable",
-  "unexpected",
   "failedDownload",
   "failedUnzip",
   "invalidCacheDirectory",
+  "invalidDisplayError",
+  "missingApp",
+  "missingDependency",
+  "missingXvfb",
+  "nonZeroExitCodeXvfb",
+  "notInstalledCI",
   "removed",
-  "CYPRESS_RUN_BINARY",
-  "smokeTestFailure"
+  "smokeTestFailure",
+  "unexpected",
+  "versionMismatch"
 ]
 
 exports['errors .errors.formErrorText calls solution if a function 1'] = `

--- a/cli/__snapshots__/install_spec.js
+++ b/cli/__snapshots__/install_spec.js
@@ -95,6 +95,9 @@ https://on.cypress.io/installing-cypress
 exports['invalid cache directory 1'] = `
 Error: Cypress cannot write to the cache directory due to file permissions
 
+See discussion and possible solutions at
+https://github.com/cypress-io/cypress/issues/1281
+
 ----------
 
 Failed to access /invalid/cache/dir:

--- a/cli/__snapshots__/verify_spec.js
+++ b/cli/__snapshots__/verify_spec.js
@@ -389,7 +389,7 @@ exports['tried to verify twice, on the first try got the DISPLAY error'] = `
 Cypress failed to start.
 
 First, we have tried to start Cypress using your DISPLAY settings
-but his the following problem:
+but encountered the following problem:
 
 ----------
 

--- a/cli/__snapshots__/verify_spec.js
+++ b/cli/__snapshots__/verify_spec.js
@@ -159,7 +159,7 @@ Error: Cypress verification timed out.
 
 This command failed with the following output:
 
-/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress --smoke-test --ping=222
+/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress --smoke-test --ping=222 --enable-logging
 
 ----------
 
@@ -181,7 +181,7 @@ Error: Cypress verification failed.
 
 This command failed with the following output:
 
-/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress --smoke-test --ping=222
+/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress --smoke-test --ping=222 --enable-logging
 
 ----------
 
@@ -203,7 +203,7 @@ Error: Cypress verification failed.
 
 This command failed with the following output:
 
-/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress --smoke-test --ping=222
+/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress --smoke-test --ping=222 --enable-logging
 
 ----------
 

--- a/cli/__snapshots__/verify_spec.js
+++ b/cli/__snapshots__/verify_spec.js
@@ -384,3 +384,38 @@ Platform: darwin (Foo-OsVersion)
 Cypress Version: 1.2.3
 
 `
+
+exports['tried to verify twice, on the first try got the DISPLAY error'] = `
+Cypress failed to start.
+
+First, we have tried to start Cypress using your DISPLAY settings
+but his the following problem:
+
+----------
+
+[some noise here] Gtk: cannot open display: 987
+
+----------
+
+Then we started our own XVFB and tried to start Cypress again, but
+got the following error:
+
+----------
+
+some other error
+
+----------
+
+This is usually caused by a missing library or dependency.
+
+The error above should indicate which dependency is missing.
+
+[34mhttps://on.cypress.io/required-dependencies[39m
+
+If you are using Docker, we provide containers with all required dependencies installed.
+
+----------
+
+Platform: linux (Foo-OsVersion)
+Cypress Version: 1.2.3
+`

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -12,6 +12,9 @@ const issuesUrl = 'https://github.com/cypress-io/cypress/issues'
 const docsUrl = 'https://on.cypress.io'
 const requiredDependenciesUrl = `${docsUrl}/required-dependencies`
 
+// TODO it would be nice if all error objects could be enforced via types
+// to only have description + solution properties
+
 // common errors Cypress application can encounter
 const failedDownload = {
   description: 'The Cypress App could not be downloaded.',

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -108,10 +108,6 @@ const smokeTestFailure = (smokeTestCommand, timedOut) => {
   }
 }
 
-const isDisplayOnLinuxSet = () => {
-  return os.platform() === 'linux' && Boolean(process.env.DISPLAY)
-}
-
 const invalidDisplayError = {
   description: 'Cypress failed to start.',
   solution  (msg, prevMessage) {
@@ -119,12 +115,16 @@ const invalidDisplayError = {
       First, we have tried to start Cypress using your DISPLAY settings
       but his the following problem:
 
+      ${hr}
+
       ${prevMessage}
 
       ${hr}
 
       Then we started our own XVFB and tried to start Cypress again, but
       got the following error:
+
+      ${hr}
 
       ${msg}
 
@@ -245,6 +245,9 @@ function formErrorText (info, msg, prevMessage) {
       )
     }
 
+    la(is.unemptyString(obj.description),
+      'expected error description to be text', obj.description)
+
     // assuming that if there the solution is a function it will handle
     // error message and (optional previous error message)
     if (is.fn(obj.solution)) {
@@ -259,6 +262,8 @@ function formErrorText (info, msg, prevMessage) {
 
       `)
     } else {
+      la(is.unemptyString(obj.solution),
+        'expected error solution to be text', obj.solution)
 
       add(`
         ${obj.description}

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -132,7 +132,7 @@ const invalidDisplayError = {
 
       This is usually caused by a missing library or dependency.
 
-      The error below should indicate which dependency is missing.
+      The error above should indicate which dependency is missing.
 
         ${chalk.blue(requiredDependenciesUrl)}
 

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -104,23 +104,44 @@ const smokeTestFailure = (smokeTestCommand, timedOut) => {
   }
 }
 
+const isDisplayOnLinuxSet = () => {
+  return os.platform() === 'linux' &&
+  Boolean(process.env.DISPLAY)
+}
+
 const missingDependency = {
   description: 'Cypress failed to start.',
   // this message is too Linux specific
-  solution: stripIndent`
-    This is usually caused by a missing library or dependency.
+  solution: () => {
+    let text = stripIndent`
+      This is usually caused by a missing library or dependency.
 
-    The error below should indicate which dependency is missing.
+      The error below should indicate which dependency is missing.
 
-      ${chalk.blue(requiredDependenciesUrl)}
+        ${chalk.blue(requiredDependenciesUrl)}
 
-    If you are using Docker, we provide containers with all required dependencies installed.
-  `,
+      If you are using Docker, we provide containers with all required dependencies installed.
+    `
+
+    if (isDisplayOnLinuxSet()) {
+      text += `\n\n${stripIndent`
+        We have noticed that DISPLAY variable is set to "${process.env.DISPLAY}"
+        This might be a problem if X11 server is not responding.
+        See ${chalk.blue('https://github.com/cypress-io/cypress/issues/4034')} and try
+        deleting the DISPLAY variable and running the command again.
+      `}`
+    }
+
+    return text
+  },
 }
 
 const invalidCacheDirectory = {
   description: 'Cypress cannot write to the cache directory due to file permissions',
-  solution: '',
+  solution: stripIndent`
+    See discussion and possible solutions at
+    ${chalk.blue('https://github.com/cypress-io/cypress/issues/1281')}
+  `,
 }
 
 const versionMismatch = {

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -8,7 +8,6 @@ const is = require('check-more-types')
 const util = require('./util')
 const state = require('./tasks/state')
 
-const issuesUrl = 'https://github.com/cypress-io/cypress/issues'
 const docsUrl = 'https://on.cypress.io'
 const requiredDependenciesUrl = `${docsUrl}/required-dependencies`
 
@@ -26,7 +25,7 @@ const failedUnzip = {
   solution: stripIndent`
     Search for an existing issue or open a GitHub issue at
 
-      ${chalk.blue(issuesUrl)}
+      ${chalk.blue(util.issuesUrl)}
   `,
 }
 
@@ -127,11 +126,15 @@ const missingDependency = {
     `
 
     if (isDisplayOnLinuxSet()) {
+      const issueUrl = util.getGitHubIssueUrl(4034)
+
       text += `\n\n${stripIndent`
         We have noticed that DISPLAY variable is set to "${process.env.DISPLAY}"
         This might be a problem if X11 server is not responding.
-        See ${chalk.blue('https://github.com/cypress-io/cypress/issues/4034')} and try
-        deleting the DISPLAY variable and running the command again.
+
+          ${chalk.blue(issueUrl)}
+
+        Try deleting the DISPLAY variable and running the command again.
       `}`
     }
 
@@ -143,7 +146,7 @@ const invalidCacheDirectory = {
   description: 'Cypress cannot write to the cache directory due to file permissions',
   solution: stripIndent`
     See discussion and possible solutions at
-    ${chalk.blue('https://github.com/cypress-io/cypress/issues/1281')}
+    ${chalk.blue(util.getGitHubIssueUrl(1281))}
   `,
 }
 
@@ -161,7 +164,7 @@ const unexpected = {
 
     Check if there is a GitHub issue describing this crash:
 
-      ${chalk.blue(issuesUrl)}
+      ${chalk.blue(util.issuesUrl)}
 
     Consider opening a new issue.
   `,

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -113,7 +113,7 @@ const invalidDisplayError = {
   solution  (msg, prevMessage) {
     return stripIndent`
       First, we have tried to start Cypress using your DISPLAY settings
-      but his the following problem:
+      but encountered the following problem:
 
       ${hr}
 

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -2,6 +2,8 @@ const os = require('os')
 const chalk = require('chalk')
 const { stripIndent, stripIndents } = require('common-tags')
 const { merge } = require('ramda')
+const la = require('lazy-ass')
+const is = require('check-more-types')
 
 const util = require('./util')
 const state = require('./tasks/state')
@@ -205,10 +207,14 @@ function formErrorText (info, msg) {
       )
     }
 
+    const solution = is.fn(obj.solution) ? obj.solution() : obj.solution
+
+    la(is.unemptyString(solution), 'expected solution to be text', solution)
+
     add(`
       ${obj.description}
 
-      ${obj.solution}
+      ${solution}
 
     `)
 

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -155,6 +155,8 @@ module.exports = {
         // call userFriendlySpawn ourselves
         // to prevent result of previous promise
         // from becoming a parameter to userFriendlySpawn
+        debug('spawning Cypress after starting XVFB')
+
         return userFriendlySpawn()
       })
       .finally(xvfb.stop)
@@ -171,7 +173,7 @@ module.exports = {
         const POTENTIAL_DISPLAY_PROBLEM_EXIT_CODE = 234
 
         if (shouldRetryOnDisplayProblem && code === POTENTIAL_DISPLAY_PROBLEM_EXIT_CODE) {
-          debug('Cypress thinks there is a display problem')
+          debug('Cypress thinks there is a potential display or OS problem')
           debug('retrying the command with our XVFB')
 
           // if we get this error, we are on Linux and DISPLAY is set
@@ -197,6 +199,10 @@ module.exports = {
       return spawnInXvfb()
     }
 
-    return userFriendlySpawn(os.platform() === 'linux')
+    // if we have problems spawning Cypress, maybe user DISPLAY setting is incorrect
+    // in that case retry with our own XVFB
+    const shouldRetryOnDisplayProblem = os.platform() === 'linux'
+
+    return userFriendlySpawn(shouldRetryOnDisplayProblem)
   },
 }

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -52,7 +52,7 @@ module.exports = {
       executable = path.resolve(util.getEnv('CYPRESS_RUN_BINARY'))
     }
 
-    debug('needs XVFB?', needsXvfb)
+    debug('needs to start own XVFB?', needsXvfb)
 
     // always push cwd into the args
     args = [].concat(args, '--cwd', process.cwd())

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -161,7 +161,7 @@ module.exports = {
     }
 
     const userFriendlySpawn = (shouldRetryOnDisplayProblem) => {
-      debug('spawning')
+      debug('spawning, should retry on display problem?', Boolean(shouldRetryOnDisplayProblem))
       if (os.platform() === 'linux') {
         debug('DISPLAY is %s', process.env.DISPLAY)
       }
@@ -174,10 +174,13 @@ module.exports = {
           debug('Cypress thinks there is a display problem')
           debug('retrying the command with our XVFB')
 
+          // if we get this error, we are on Linux and DISPLAY is set
           logger.warn(`${stripIndent`
 
             ${logSymbols.warning} Warning: Cypress process has finished very quickly with an error,
             which might be related to a potential problem with how the DISPLAY is configured.
+
+            DISPLAY was set to "${process.env.DISPLAY}"
 
             We will attempt to spin our XVFB server and run Cypress again.
           `}\n`)

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -4,10 +4,13 @@ const cp = require('child_process')
 const path = require('path')
 const Promise = require('bluebird')
 const debug = require('debug')('cypress:cli')
+const { stripIndent } = require('common-tags')
 
 const util = require('../util')
 const state = require('../tasks/state')
 const xvfb = require('./xvfb')
+const logger = require('../logger')
+const logSymbols = require('log-symbols')
 const { throwFormErrorText, errors } = require('../errors')
 
 const isXlibOrLibudevRe = /^(?:Xlib|libudev)/
@@ -170,6 +173,14 @@ module.exports = {
         if (shouldRetryOnDisplayProblem && code === POTENTIAL_DISPLAY_PROBLEM_EXIT_CODE) {
           debug('Cypress thinks there is a display problem')
           debug('retrying the command with our XVFB')
+
+          logger.warn(`${stripIndent`
+
+            ${logSymbols.warning} Warning: Cypress process has finished very quickly with an error,
+            which might be related to a potential problem with how the DISPLAY is configured.
+
+            We will attempt to spin our XVFB server and run Cypress again.
+          `}\n`)
 
           return spawnInXvfb()
         }

--- a/cli/lib/exec/xvfb.js
+++ b/cli/lib/exec/xvfb.js
@@ -2,7 +2,7 @@ const os = require('os')
 const Promise = require('bluebird')
 const Xvfb = require('@cypress/xvfb')
 const R = require('ramda')
-const {stripIndent} = require('common-tags')
+const { stripIndent } = require('common-tags')
 const debug = require('debug')('cypress:cli')
 const debugXvfb = require('debug')('cypress:xvfb')
 const { throwFormErrorText, errors } = require('../errors')
@@ -45,6 +45,7 @@ module.exports = {
     if (os.platform() !== 'linux') {
       return false
     }
+
     if (process.env.DISPLAY) {
       const message = stripIndent`
         DISPLAY environment variable is set to ${process.env.DISPLAY} on Linux
@@ -56,12 +57,15 @@ module.exports = {
         Solution: Unset the DISPLAY variable and try again:
           DISPLAY= npx cypress run ...
       `
+
       debug(message)
+
       return false
     }
 
     debug('undefined DISPLAY environment variable')
     debug('Cypress will spawn its own XVFB')
+
     return true
   },
 

--- a/cli/lib/exec/xvfb.js
+++ b/cli/lib/exec/xvfb.js
@@ -6,6 +6,7 @@ const { stripIndent } = require('common-tags')
 const debug = require('debug')('cypress:cli')
 const debugXvfb = require('debug')('cypress:xvfb')
 const { throwFormErrorText, errors } = require('../errors')
+const util = require('../util')
 
 const xvfb = Promise.promisifyAll(new Xvfb({
   timeout: 5000, // milliseconds
@@ -47,13 +48,15 @@ module.exports = {
     }
 
     if (process.env.DISPLAY) {
+      const issueUrl = util.getGitHubIssueUrl(4034)
+
       const message = stripIndent`
         DISPLAY environment variable is set to ${process.env.DISPLAY} on Linux
         Assuming this DISPLAY points at working X11 server,
         Cypress will not spawn own XVFB
 
         NOTE: if the X11 server is NOT working, Cypress will exit without explanation,
-          see https://github.com/cypress-io/cypress/issues/4034
+          see ${issueUrl}
         Solution: Unset the DISPLAY variable and try again:
           DISPLAY= npx cypress run ...
       `

--- a/cli/lib/exec/xvfb.js
+++ b/cli/lib/exec/xvfb.js
@@ -2,6 +2,7 @@ const os = require('os')
 const Promise = require('bluebird')
 const Xvfb = require('@cypress/xvfb')
 const R = require('ramda')
+const {stripIndent} = require('common-tags')
 const debug = require('debug')('cypress:cli')
 const debugXvfb = require('debug')('cypress:xvfb')
 const { throwFormErrorText, errors } = require('../errors')
@@ -41,7 +42,27 @@ module.exports = {
   },
 
   isNeeded () {
-    return os.platform() === 'linux' && !process.env.DISPLAY
+    if (os.platform() !== 'linux') {
+      return false
+    }
+    if (process.env.DISPLAY) {
+      const message = stripIndent`
+        DISPLAY environment variable is set to ${process.env.DISPLAY} on Linux
+        Assuming this DISPLAY points at working X11 server,
+        Cypress will not spawn own XVFB
+
+        NOTE: if the X11 server is NOT working, Cypress will exit without explanation,
+          see https://github.com/cypress-io/cypress/issues/4034
+        Solution: Unset the DISPLAY variable and try again:
+          DISPLAY= npx cypress run ...
+      `
+      debug(message)
+      return false
+    }
+
+    debug('undefined DISPLAY environment variable')
+    debug('Cypress will spawn its own XVFB')
+    return true
   },
 
   // async method, resolved with Boolean

--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -53,10 +53,12 @@ const runSmokeTest = (binaryDir, options) => {
       debug('Smoke test failed:', err)
 
       let errMessage = err.stderr || err.message
+
       debug('error message:', errMessage)
 
       if (err.timedOut) {
         debug('error timedOut is true')
+
         return throwFormErrorText(errors.smokeTestFailure(smokeTestCommand, true))(errMessage)
       }
 
@@ -65,6 +67,17 @@ const runSmokeTest = (binaryDir, options) => {
         // for the very first time
         // and we hit invalid display error
         debug('Smoke test hit Linux display problem: %s', errMessage)
+
+        logger.warn(stripIndent`
+
+          ${logSymbols.warning} Warning: we have caught a display problem:
+
+          ${errMessage}
+
+          We will attempt to spin our XVFB server and verify again.
+        `)
+        logger.log()
+
         const err = new Error(errMessage)
 
         err.displayError = true
@@ -83,6 +96,7 @@ const runSmokeTest = (binaryDir, options) => {
       }
 
       debug('throwing missing dependency error')
+
       return throwFormErrorText(errors.missingDependency)(errMessage)
     }
   }

--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -53,9 +53,10 @@ const runSmokeTest = (binaryDir, options) => {
       debug('Smoke test failed:', err)
 
       let errMessage = err.stderr || err.message
+      debug('error message:', errMessage)
 
       if (err.timedOut) {
-
+        debug('error timedOut is true')
         return throwFormErrorText(errors.smokeTestFailure(smokeTestCommand, true))(errMessage)
       }
 
@@ -63,7 +64,7 @@ const runSmokeTest = (binaryDir, options) => {
         // running without our XVFB
         // for the very first time
         // and we hit invalid display error
-        debug('Smoke test hit Linux display problem %s', errMessage)
+        debug('Smoke test hit Linux display problem: %s', errMessage)
         const err = new Error(errMessage)
 
         err.displayError = true
@@ -81,6 +82,7 @@ const runSmokeTest = (binaryDir, options) => {
         return throwFormErrorText(errors.invalidDisplayError)(errMessage, prevDisplayError.message)
       }
 
+      debug('throwing missing dependency error')
       return throwFormErrorText(errors.missingDependency)(errMessage)
     }
   }
@@ -115,7 +117,7 @@ const runSmokeTest = (binaryDir, options) => {
       debug('smoke test stdout "%s"', smokeTestReturned)
 
       if (!util.stdoutLineMatches(String(random), smokeTestReturned)) {
-        debug('Smoke test failed:', result)
+        debug('Smoke test failed because could not find %d in:', random, result)
 
         return throwFormErrorText(errors.smokeTestFailure(smokeTestCommand, false))(result.stderr || result.stdout)
       }

--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -68,15 +68,14 @@ const runSmokeTest = (binaryDir, options) => {
         // and we hit invalid display error
         debug('Smoke test hit Linux display problem: %s', errMessage)
 
-        logger.warn(stripIndent`
+        logger.warn(`${stripIndent`
 
           ${logSymbols.warning} Warning: we have caught a display problem:
 
           ${errMessage}
 
           We will attempt to spin our XVFB server and verify again.
-        `)
-        logger.log()
+        `}\n`)
 
         const err = new Error(errMessage)
 

--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -48,7 +48,7 @@ const runSmokeTest = (binaryDir, options) => {
     return throwFormErrorText(errors.missingXvfb)(`Caught error trying to run XVFB: "${err.message}"`)
   }
 
-  const onSmokeTestError = (smokeTestCommand) => {
+  const onSmokeTestError = (smokeTestCommand, runningWithOurXvfb, prevDisplayError) => {
     return (err) => {
       debug('Smoke test failed:', err)
 
@@ -59,6 +59,28 @@ const runSmokeTest = (binaryDir, options) => {
         return throwFormErrorText(errors.smokeTestFailure(smokeTestCommand, true))(errMessage)
       }
 
+      if (!runningWithOurXvfb && !prevDisplayError && util.isDisplayError(errMessage)) {
+        // running without our XVFB
+        // for the very first time
+        // and we hit invalid display error
+        debug('Smoke test hit Linux display problem %s', errMessage)
+        const err = new Error(errMessage)
+
+        err.displayError = true
+        err.platform = 'linux'
+        throw err
+      }
+
+      if (prevDisplayError) {
+        debug('this was our 2nd attempt at verifying')
+        debug('first we tried with user-given DISPLAY')
+        debug('now we have tried spinning our own XVFB')
+        debug('and yet it still has failed with')
+        debug(errMessage)
+
+        return throwFormErrorText(errors.invalidDisplayError)(errMessage, prevDisplayError.message)
+      }
+
       return throwFormErrorText(errors.missingDependency)(errMessage)
     }
   }
@@ -67,9 +89,13 @@ const runSmokeTest = (binaryDir, options) => {
 
   debug('needs XVFB?', needsXvfb)
 
-  const spawn = () => {
+  /**
+   * Spawn Cypress running smoke test to check if all operating system
+   * dependencies are good.
+   */
+  const spawn = (runningWithOurXvfb, prevDisplayError) => {
     const random = _.random(0, 1000)
-    const args = ['--smoke-test', `--ping=${random}`]
+    const args = ['--smoke-test', `--ping=${random}`, '--enable-logging']
     const smokeTestCommand = `${cypressExecPath} ${args.join(' ')}`
 
     debug('smoke test command:', smokeTestCommand)
@@ -79,7 +105,7 @@ const runSmokeTest = (binaryDir, options) => {
       args,
       { timeout: options.smokeTestTimeout }
     ))
-    .catch(onSmokeTestError(smokeTestCommand))
+    .catch(onSmokeTestError(smokeTestCommand, runningWithOurXvfb, prevDisplayError))
     .then((result) => {
 
       // TODO: when execa > 1.1 is released
@@ -96,18 +122,27 @@ const runSmokeTest = (binaryDir, options) => {
     })
   }
 
-  if (needsXvfb) {
+  const spinXvfbAndVerify = (prevDisplayError) => {
     return xvfb.start()
     .catch(onXvfbError)
-    .then(spawn)
+    .then(spawn.bind(null, true, prevDisplayError))
     .finally(() => {
       return xvfb.stop()
       .catch(onXvfbError)
     })
   }
 
-  return spawn()
+  if (needsXvfb) {
+    return spinXvfbAndVerify()
+  }
 
+  return spawn()
+  .catch({ displayError: true, platform: 'linux' }, (e) => {
+    debug('there was a display error')
+    debug('will try spinning our own XVFB and verify Cypress')
+
+    return spinXvfbAndVerify(e)
+  })
 }
 
 function testBinary (version, binaryDir, options) {

--- a/cli/lib/util.js
+++ b/cli/lib/util.js
@@ -255,7 +255,7 @@ const util = {
     la(_.isInteger(number), 'github issue should be an integer', number)
 
     return `${issuesUrl}/${number}`
-  }
+  },
 }
 
 module.exports = util

--- a/cli/lib/util.js
+++ b/cli/lib/util.js
@@ -1,6 +1,8 @@
 const _ = require('lodash')
 const R = require('ramda')
 const os = require('os')
+const la = require('lazy-ass')
+const is = require('check-more-types')
 const tty = require('tty')
 const path = require('path')
 const isCi = require('is-ci')
@@ -15,6 +17,8 @@ const isInstalledGlobally = require('is-installed-globally')
 const pkg = require(path.join(__dirname, '..', 'package.json'))
 const logger = require('./logger')
 const debug = require('debug')('cypress:cli')
+
+const issuesUrl = 'https://github.com/cypress-io/cypress/issues'
 
 const getosAsync = Promise.promisify(getos)
 
@@ -243,6 +247,15 @@ const util = {
   exec: execa,
 
   stdoutLineMatches,
+
+  issuesUrl,
+
+  getGitHubIssueUrl (number) {
+    la(is.positive(number), 'github issue should be a positive number', number)
+    la(_.isInteger(number), 'github issue should be an integer', number)
+
+    return `${issuesUrl}/${number}`
+  }
 }
 
 module.exports = util

--- a/cli/package.json
+++ b/cli/package.json
@@ -93,6 +93,7 @@
     "dtslint": "0.7.1",
     "execa-wrap": "1.4.0",
     "mock-fs": "4.9.0",
+    "mocked-env": "1.2.4",
     "nock": "9.6.1",
     "nyc": "13.3.0",
     "proxyquire": "2.1.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -87,6 +87,7 @@
     "babel-preset-es2015": "6.24.1",
     "bin-up": "1.2.0",
     "chai": "3.5.0",
+    "chai-as-promised": "7.1.1",
     "chai-string": "1.4.0",
     "dependency-check": "3.3.0",
     "dtslint": "0.7.1",

--- a/cli/test/lib/errors_spec.js
+++ b/cli/test/lib/errors_spec.js
@@ -4,9 +4,8 @@ const os = require('os')
 const snapshot = require('../support/snapshot')
 const { errors, formErrorText } = require(`${lib}/errors`)
 const util = require(`${lib}/util`)
-const mockedEnv = require('mocked-env')
 
-describe.only('errors', function () {
+describe('errors', function () {
   const { missingXvfb } = errors
 
   beforeEach(function () {
@@ -45,6 +44,20 @@ describe.only('errors', function () {
       })
     })
 
+    it('passes message and previous message', () => {
+      const solution = sinon.stub().returns('a solution')
+      const error = {
+        description: 'description',
+        solution,
+      }
+
+      return formErrorText(error, 'msg', 'prevMsg')
+      .then((text) => {
+        expect(solution).to.have.been.calledWithExactly('msg', 'prevMsg')
+        expect(text).to.equal('a solution')
+      })
+    })
+
     it('expects solution to be a string', () => {
       const error = {
         description: 'description',
@@ -54,26 +67,10 @@ describe.only('errors', function () {
       return expect(formErrorText(error)).to.be.rejected
     })
 
-    describe('custom solution', () => {
-      let restore
-
-      beforeEach(() => {
-        restore = mockedEnv({
-          DISPLAY: 'wrong-display-address',
-        })
-      })
-
-      afterEach(() => {
-        restore()
-      })
-
-      it('returns specific solution if on Linux DISPLAY env is set', () => {
-        os.platform.returns('linux')
-
-        return formErrorText(errors.missingDependency)
-        .then((text) => {
-          snapshot(text)
-        })
+    it('forms full text for invalid display error', () => {
+      return formErrorText(errors.invalidDisplayError, 'current message', 'prev message')
+      .then((text) => {
+        snapshot('invalid display error', text)
       })
     })
   })

--- a/cli/test/lib/errors_spec.js
+++ b/cli/test/lib/errors_spec.js
@@ -52,9 +52,8 @@ describe('errors', function () {
       }
 
       return formErrorText(error, 'msg', 'prevMsg')
-      .then((text) => {
+      .then(() => {
         expect(solution).to.have.been.calledWithExactly('msg', 'prevMsg')
-        expect(text).to.equal('a solution')
       })
     })
 

--- a/cli/test/lib/errors_spec.js
+++ b/cli/test/lib/errors_spec.js
@@ -19,7 +19,7 @@ describe('errors', function () {
     })
   })
 
-  context('.errors.formErrorText', function () {
+  context.only('.errors.formErrorText', function () {
     it('returns fully formed text message', () => {
       expect(missingXvfb).to.be.an('object')
 
@@ -28,6 +28,29 @@ describe('errors', function () {
         expect(text).to.be.a('string')
         snapshot(text)
       })
+    })
+
+    it('calls solution if a function', () => {
+      const solution = sinon.stub().returns('a solution')
+      const error = {
+        description: 'description',
+        solution,
+      }
+
+      return formErrorText(error)
+      .then((text) => {
+        console.log(text)
+        expect(solution).to.have.been.calledOnce
+      })
+    })
+
+    it('expects solution to be a string', () => {
+      const error = {
+        description: 'description',
+        solution: 42,
+      }
+
+      return expect(formErrorText(error)).to.be.rejected
     })
   })
 })

--- a/cli/test/lib/errors_spec.js
+++ b/cli/test/lib/errors_spec.js
@@ -4,6 +4,7 @@ const os = require('os')
 const snapshot = require('../support/snapshot')
 const { errors, formErrorText } = require(`${lib}/errors`)
 const util = require(`${lib}/util`)
+const mockedEnv = require('mocked-env')
 
 describe('errors', function () {
   const { missingXvfb } = errors
@@ -19,7 +20,7 @@ describe('errors', function () {
     })
   })
 
-  context.only('.errors.formErrorText', function () {
+  context('.errors.formErrorText', function () {
     it('returns fully formed text message', () => {
       expect(missingXvfb).to.be.an('object')
 
@@ -39,7 +40,7 @@ describe('errors', function () {
 
       return formErrorText(error)
       .then((text) => {
-        console.log(text)
+        snapshot(text)
         expect(solution).to.have.been.calledOnce
       })
     })
@@ -51,6 +52,29 @@ describe('errors', function () {
       }
 
       return expect(formErrorText(error)).to.be.rejected
+    })
+
+    describe('custom solution', () => {
+      let restore
+
+      beforeEach(() => {
+        restore = mockedEnv({
+          DISPLAY: 'wrong-display-address',
+        })
+      })
+
+      afterEach(() => {
+        restore()
+      })
+
+      it('returns specific solution if on Linux DISPLAY env is set', () => {
+        os.platform.returns('linux')
+
+        return formErrorText(errors.missingDependency)
+        .then((text) => {
+          snapshot(text)
+        })
+      })
     })
   })
 })

--- a/cli/test/lib/errors_spec.js
+++ b/cli/test/lib/errors_spec.js
@@ -6,7 +6,7 @@ const { errors, formErrorText } = require(`${lib}/errors`)
 const util = require(`${lib}/util`)
 const mockedEnv = require('mocked-env')
 
-describe('errors', function () {
+describe.only('errors', function () {
   const { missingXvfb } = errors
 
   beforeEach(function () {
@@ -16,7 +16,7 @@ describe('errors', function () {
 
   describe('individual', () => {
     it('has the following errors', () => {
-      return snapshot(Object.keys(errors))
+      return snapshot(Object.keys(errors).sort())
     })
   })
 

--- a/cli/test/lib/tasks/verify_spec.js
+++ b/cli/test/lib/tasks/verify_spec.js
@@ -56,7 +56,7 @@ context('lib/tasks/verify', () => {
     sinon.stub(_, 'random').returns('222')
 
     util.exec
-    .withArgs(executablePath, ['--smoke-test', '--ping=222'])
+    .withArgs(executablePath, ['--smoke-test', '--ping=222', '--enable-logging'])
     .resolves(spawnedProcess)
   })
 
@@ -500,7 +500,7 @@ context('lib/tasks/verify', () => {
         customDir: '/real/custom',
       })
       util.exec
-      .withArgs(realEnvBinaryPath, ['--smoke-test', '--ping=222'])
+      .withArgs(realEnvBinaryPath, ['--smoke-test', '--ping=222', '--enable-logging'])
       .resolves(spawnedProcess)
 
       return verify.start().then(() => {

--- a/cli/test/lib/tasks/verify_spec.js
+++ b/cli/test/lib/tasks/verify_spec.js
@@ -293,6 +293,7 @@ context('lib/tasks/verify', () => {
       })
 
       util.exec.restore()
+      sinon.spy(logger, 'warn')
     })
 
     it('successfully retries with our XVFB on Linux', () => {
@@ -304,6 +305,7 @@ context('lib/tasks/verify', () => {
         // to allow retry logic to work
         os.platform.returns('linux')
         const firstSpawnError = new Error('')
+
         // this message contains typical Gtk error shown if X11 is incorrect
         // like in the case of DISPLAY=987
         firstSpawnError.stderr = '[some noise here] Gtk: cannot open display: 987'
@@ -319,6 +321,8 @@ context('lib/tasks/verify', () => {
 
       return verify.start().then(() => {
         expect(util.exec).to.have.been.calledTwice
+        // user should have been warned
+        expect(logger.warn).to.have.been.calledOnce
       })
     })
 
@@ -331,6 +335,7 @@ context('lib/tasks/verify', () => {
 
         os.platform.returns('linux')
         const firstSpawnError = new Error('')
+
         // this message contains typical Gtk error shown if X11 is incorrect
         // like in the case of DISPLAY=987
         firstSpawnError.stderr = '[some noise here] Gtk: cannot open display: 987'
@@ -349,6 +354,9 @@ context('lib/tasks/verify', () => {
         // second time around we should have called XVFB
         expect(xvfb.start).to.have.been.calledOnce
         expect(xvfb.stop).to.have.been.calledOnce
+
+        // user should have been warned
+        expect(logger.warn).to.have.been.calledOnce
 
         snapshot('tried to verify twice, on the first try got the DISPLAY error', e.message)
       })

--- a/cli/test/lib/util_spec.js
+++ b/cli/test/lib/util_spec.js
@@ -15,6 +15,19 @@ describe('util', () => {
     sinon.stub(logger, 'error')
   })
 
+  context('.getGitHubIssueUrl', () => {
+    it('returls url for issue number', () => {
+      const url = util.getGitHubIssueUrl(4034)
+      expect(url).to.equal('https://github.com/cypress-io/cypress/issues/4034')
+    })
+
+    it('throws for anything but a positive integer', () => {
+      expect(() => util.getGitHubIssueUrl('4034')).to.throw
+      expect(() => util.getGitHubIssueUrl(-5)).to.throw
+      expect(() => util.getGitHubIssueUrl(5.19)).to.throw
+    })
+  })
+
   context('.stdoutLineMatches', () => {
     const { stdoutLineMatches } = util
 

--- a/cli/test/lib/util_spec.js
+++ b/cli/test/lib/util_spec.js
@@ -15,6 +15,16 @@ describe('util', () => {
     sinon.stub(logger, 'error')
   })
 
+  context('.isDisplayError', () => {
+    it('detects only GTK message', () => {
+      os.platform.returns('linux')
+      const text = '[some noise here] Gtk: cannot open display: 99'
+      expect(util.isDisplayError(text)).to.be.true
+      // and not for the other messages
+      expect(util.isDisplayError('display was set incorrectly')).to.be.false
+    })
+  })
+
   context('.getGitHubIssueUrl', () => {
     it('returls url for issue number', () => {
       const url = util.getGitHubIssueUrl(4034)

--- a/cli/test/lib/util_spec.js
+++ b/cli/test/lib/util_spec.js
@@ -18,13 +18,20 @@ describe('util', () => {
   context('.getGitHubIssueUrl', () => {
     it('returls url for issue number', () => {
       const url = util.getGitHubIssueUrl(4034)
+
       expect(url).to.equal('https://github.com/cypress-io/cypress/issues/4034')
     })
 
     it('throws for anything but a positive integer', () => {
-      expect(() => util.getGitHubIssueUrl('4034')).to.throw
-      expect(() => util.getGitHubIssueUrl(-5)).to.throw
-      expect(() => util.getGitHubIssueUrl(5.19)).to.throw
+      expect(() => {
+        return util.getGitHubIssueUrl('4034')
+      }).to.throw
+      expect(() => {
+        return util.getGitHubIssueUrl(-5)
+      }).to.throw
+      expect(() => {
+        return util.getGitHubIssueUrl(5.19)
+      }).to.throw
     })
   })
 

--- a/cli/test/spec_helper.js
+++ b/cli/test/spec_helper.js
@@ -27,6 +27,7 @@ global.lib = path.join(__dirname, '..', 'lib')
 require('chai')
 .use(require('@cypress/sinon-chai'))
 .use(require('chai-string'))
+.use(require('chai-as-promised'))
 
 sinon.usingPromise(Promise)
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "clean-deps": "npm run all clean-deps && rm -rf node_modules",
     "docker": "./scripts/run-docker-local.sh",
     "lint-js": "eslint --fix scripts/*.js packages/ts/*.js cli/*.js cli/**/*.js",
+    "lint-changed": "git diff --name-only | grep '\\.js$' | xargs npx eslint --fix",
     "lint-coffee": "coffeelint scripts/**/*.coffee",
     "lint": "npm run lint-js && npm run lint-coffee",
     "pretest": "npm run lint && npm run all lint && npm run test-scripts",

--- a/packages/electron/lib/electron.coffee
+++ b/packages/electron/lib/electron.coffee
@@ -72,6 +72,10 @@ module.exports = {
 
       debug("spawning %s with args", execPath, argv)
 
+      if debug.enabled
+        # let's see everything Electron spits back
+        argv.push("--enable-logging")
+
       cp.spawn(execPath, argv, {stdio: "inherit"})
       .on "close", (code) ->
         debug("electron closing with code", code)

--- a/packages/server/lib/cypress.coffee
+++ b/packages/server/lib/cypress.coffee
@@ -59,7 +59,9 @@ module.exports = {
             ## promise is expecting this object structure
             debug("electron finished with", code)
             resolve({totalFailed: code})
-          cypressElectron.open(".", require("./util/args").toArray(options), fn)
+          args = require("./util/args").toArray(options)
+          debug("electron open arguments %o", args)
+          cypressElectron.open(".", args, fn)
 
   openProject: (options) ->
     ## this code actually starts a project

--- a/packages/server/lib/cypress.coffee
+++ b/packages/server/lib/cypress.coffee
@@ -78,8 +78,10 @@ module.exports = {
                 ## ok, maybe the DISPLAY is set incorrectly
                 ## and Electron just failed to start with
                 ## an error "Could not open display"
+                ## or it could be some system library missing for Electron to start
                 debug("because Linux with DISPLAY set to %s", process.env.DISPLAY)
                 debug("and very short elapsed time, returning potentialDisplayProblem flag")
+                debug("could be DISPLAY configuration or OS dependency missing")
                 result.potentialDisplayProblem = true
 
             resolve(result)

--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -268,6 +268,7 @@ module.exports = {
     options = _.omit(options, configKeys)
 
     options = normalizeBackslashes(options)
+    debug('options %o', options)
 
     //# normalize project to projectRoot
     if (p = options.project || options.runProject) {


### PR DESCRIPTION
- closes #4034 
- if the first verify retry fails, reruns with our XVFB. If still fails, shows error message with first and second errors
- [x] should display a warning message if gets a display error on the first verify attempt
- [x] should retry `cypress run` if there is suspected display error (shows warning as well)

`cypress run` warning on Linux if DISPLAY is set before re-running with our XVFB

```
⚠ Warning: Cypress process has finished very quickly with an error,
which might be related to a potential problem with how the DISPLAY is configured.

DISPLAY was set to "test-display"

We will attempt to spin our XVFB server and run Cypress again.
```

Note: to see how it performs, spin a Docker container (instructions in a comment below) and 

- to see cypress verify use

```
node -e 'require("./cli/lib/tasks/verify").start({force: true})'
```

- to see spawn cypress run use 

```
node -e 'require("./cli/lib/exec/spawn").start(["--run-project", "."], {dev: true})
```