### PR TITLE
Expose `cy.isCy` as `Cypress.isCy`, add typedefs

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -246,6 +246,16 @@ declare namespace Cypress {
     env(object: ObjectLike): void
 
     /**
+     * Checks if a variable is a valid instance of `cy` or a `cy` chainable.
+     *
+     * @see https://on.cypress.io/iscy
+     * @example
+     *    Cypress.isCy(cy) // => true
+     */
+    isCy<TSubject = any>(obj: Chainable<TSubject>): obj is Chainable<TSubject>
+    isCy(obj: any): obj is Chainable
+
+    /**
      * Internal options for "cy.log" used in custom commands.
      *
      * @see https://on.cypress.io/cypress-log

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -40,6 +40,17 @@ namespace CypressEnvTests {
   })
 }
 
+namespace CypressIsCyTests {
+  Cypress.isCy(cy) // $ExpectType boolean
+  Cypress.isCy(undefined) // $ExpectType boolean
+
+  const chainer = cy.wrap("foo").then(function() {
+    if (Cypress.isCy(chainer)) {
+      chainer // $ExpectType Chainable<string>
+    }
+  })
+}
+
 namespace CypressCommandsTests {
   Cypress.Commands.add('newCommand', () => {
     return

--- a/packages/driver/src/cypress.coffee
+++ b/packages/driver/src/cypress.coffee
@@ -165,6 +165,7 @@ class $Cypress
 
     ## create cy and expose globally
     @cy = window.cy = $Cy.create(specWindow, @, @Cookies, @state, @config, logFn)
+    @isCy = @cy.isCy
     @log = $Log.create(@, @cy, @state, @config)
     @mocha = $Mocha.create(specWindow, @)
     @runner = $Runner.create(specWindow, @mocha, @, @cy)

--- a/packages/driver/test/cypress/integration/cypress/cypress_spec.coffee
+++ b/packages/driver/test/cypress/integration/cypress/cypress_spec.coffee
@@ -12,22 +12,6 @@ describe "driver/src/cypress/index", ->
       expect(window.$Cypress).to.be.undefined
       expect(window.top.$Cypress).to.be.undefined
 
-  context "$", ->
-    afterEach ->
-      delete Cypress.$.expr[":"].foo
-
-    ## https://github.com/cypress-io/cypress/issues/2830
-    it "exposes expr", ->
-      expect(Cypress.$).to.have.property("expr")
-
-      Cypress.$.expr[":"].foo = (elem) ->
-        Boolean(elem.getAttribute("foo"))
-
-      $foo = $("<div foo='bar'>foo element</div>").appendTo(cy.$$("body"))
-
-      cy.get(":foo").then ($el) ->
-        expect($el.get(0)).to.eq($foo.get(0))
-
   context "#backend", ->
     it "sets __stackCleaned__ on errors", (done) ->
       cy.stub(@Cypress, "emit")
@@ -47,7 +31,17 @@ describe "driver/src/cypress/index", ->
 
         done()
 
-  context "Log", ->
+  context ".isCy", ->
+    it "returns true on cy, cy chainable", ->
+      expect(Cypress.isCy(cy)).to.be.true
+      chainer = cy.wrap().then ->
+        expect(Cypress.isCy(chainer)).to.be.true
+
+    it "returns false on non-cy objects", ->
+      expect(Cypress.isCy(undefined)).to.be.false
+      expect(Cypress.isCy(() => {})).to.be.false
+
+  context ".Log", ->
     it "throws when using Cypress.Log.command()", ->
       fn = ->
         Cypress.Log.command({})

--- a/packages/driver/test/cypress/integration/cypress/cypress_spec.coffee
+++ b/packages/driver/test/cypress/integration/cypress/cypress_spec.coffee
@@ -12,6 +12,22 @@ describe "driver/src/cypress/index", ->
       expect(window.$Cypress).to.be.undefined
       expect(window.top.$Cypress).to.be.undefined
 
+  context "$", ->
+    afterEach ->
+      delete Cypress.$.expr[":"].foo
+
+    ## https://github.com/cypress-io/cypress/issues/2830
+    it "exposes expr", ->
+      expect(Cypress.$).to.have.property("expr")
+
+      Cypress.$.expr[":"].foo = (elem) ->
+        Boolean(elem.getAttribute("foo"))
+
+      $foo = $("<div foo='bar'>foo element</div>").appendTo(cy.$$("body"))
+
+      cy.get(":foo").then ($el) ->
+        expect($el.get(0)).to.eq($foo.get(0))
+
   context "#backend", ->
     it "sets __stackCleaned__ on errors", (done) ->
       cy.stub(@Cypress, "emit")


### PR DESCRIPTION
* Re-exposes `cy.isCy()` on `Cypress.isCy()`, since it doesn't return a chainer
* Adds types for `Cypress.isCy()`
* Documentation PR: cypress-io/cypress-documentation#1669

Closes #3822 
