### PR TITLE
move close too quickly check into CLI (DISPLAY re-try)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,6 +317,24 @@ cd packages/desktop-gui
 npm rebuild node-sass
 ```
 
+#### Docker for built binary
+
+You can also use Docker to simulate and debug built binary. In a temp folder (for example from the folder `/tmp/test-folder/`) start a Docker image
+
+```shell
+$ docker run -it -w /app -v $PWD:/app cypress/base:8 /bin/bash
+```
+
+Point installation at a specific binary and NPM (if needed) and _set local cache folder_ to unzip downloaded binary into a subfolder.
+
+```shell
+$ export CYPRESS_INSTALL_BINARY=https://cdn.cypress.io/beta/.../cypress.zip
+$ export CYPRESS_CACHE_FOLDER=./cypress-cache
+$ npm i https://cdn.cypress.io/beta/npm/.../cypress.tgz
+```
+
+Note that unzipping Linux binary inside Docker container onto a mapped volume drive is slow. But once this is done you can modify application resource folder in local folder `/tmp/test-folder/node_modules/cypress/cypress-cache/3.3.0/Cypress/resources/app` to debug issues.
+
 ### Packages
 
 Generally when making contributions, you are typically making them to a small number of packages. Most of your local development work will be inside a single package at a time.

--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -135,9 +135,7 @@ describe('lib/exec/spawn', function () {
       })
 
       it('retries with xvfb if fails with display exit code', function () {
-        const POTENTIAL_DISPLAY_PROBLEM_EXIT_CODE = 234
-
-        this.spawnedProcess.on.withArgs('close').onFirstCall().yieldsAsync(POTENTIAL_DISPLAY_PROBLEM_EXIT_CODE)
+        this.spawnedProcess.on.withArgs('close').onFirstCall().yieldsAsync(1)
         this.spawnedProcess.on.withArgs('close').onSecondCall().yieldsAsync(0)
 
         os.platform.returns('linux')


### PR DESCRIPTION
- revert the changes to cypress.coffee from https://github.com/cypress-io/cypress/pull/4165/files#diff-fbc9f64a5652c9142e1ab0a9d54272a0
- instead measure how long it takes to spawn the process in the CLI