### PR TITLE
logger warn from CLI should strip all indent from nested message

### DIFF
--- a/cli/__snapshots__/logger_spec.js
+++ b/cli/__snapshots__/logger_spec.js
@@ -1,0 +1,15 @@
+exports['stripIndent removes indent from literal string 1'] = `
+first line
+  second line
+    third line
+last line
+`
+
+exports['stripIndent can be used with nested message 1'] = `
+first line
+
+foo
+bar
+
+last line
+`

--- a/cli/__snapshots__/verify_spec.js
+++ b/cli/__snapshots__/verify_spec.js
@@ -394,6 +394,7 @@ but encountered the following problem:
 ----------
 
 [some noise here] Gtk: cannot open display: 987
+and maybe a few other lines here with weird indent
 
 ----------
 
@@ -403,6 +404,8 @@ got the following error:
 ----------
 
 some other error
+again with
+some weird indent
 
 ----------
 

--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -3,7 +3,7 @@ const chalk = require('chalk')
 const Listr = require('listr')
 const debug = require('debug')('cypress:cli')
 const verbose = require('@cypress/listr-verbose-renderer')
-const { stripIndent } = require('common-tags')
+const { stripIndent, stripIndents } = require('common-tags')
 const Promise = require('bluebird')
 const logSymbols = require('log-symbols')
 
@@ -68,11 +68,11 @@ const runSmokeTest = (binaryDir, options) => {
         // and we hit invalid display error
         debug('Smoke test hit Linux display problem: %s', errMessage)
 
-        logger.warn(`${stripIndent`
+        logger.warn(`${stripIndents`
 
           ${logSymbols.warning} Warning: we have caught a display problem:
 
-          ${errMessage}
+          ${stripIndents(errMessage)}
 
           We will attempt to spin our XVFB server and verify again.
         `}\n`)

--- a/cli/test/lib/logger_spec.js
+++ b/cli/test/lib/logger_spec.js
@@ -1,0 +1,45 @@
+require('../spec_helper')
+
+const la = require('lazy-ass')
+const {stripIndent, stripIndents} = require('common-tags')
+const snapshot = require('../support/snapshot')
+
+describe('stripIndent', () => {
+  it('removes indent from literal string', () => {
+    const removed = stripIndent`
+      first line
+        second line
+          third line
+      last line
+    `
+    // should preserve the structure of the text
+    snapshot(removed)
+  })
+
+  it('can be called as a function', () => {
+    const text = '  foo\n    bar\n'
+    const removed = stripIndent(text)
+    // removed 1 level of indentation and trimmed the string
+    const expected = 'foo\n  bar'
+    la(removed === expected, 'removed indent is\n' + removed)
+  })
+
+  it('can be used with nested message', () => {
+    const nested = stripIndents('    foo\n    bar\n')
+    const str = stripIndents`
+      first line
+
+      ${nested}
+
+      last line
+    `
+    // should have NO indents
+    // first line
+    //
+    // foo
+    // bar
+    //
+    // last line
+    snapshot(str)
+  })
+})

--- a/cli/test/lib/tasks/verify_spec.js
+++ b/cli/test/lib/tasks/verify_spec.js
@@ -308,7 +308,10 @@ context('lib/tasks/verify', () => {
 
         // this message contains typical Gtk error shown if X11 is incorrect
         // like in the case of DISPLAY=987
-        firstSpawnError.stderr = '[some noise here] Gtk: cannot open display: 987'
+        firstSpawnError.stderr = stripIndent`
+          [some noise here] Gtk: cannot open display: 987
+            and maybe a few other lines here with weird indent
+        `
         firstSpawnError.stdout = ''
 
         // the second time the binary returns expected ping
@@ -338,11 +341,19 @@ context('lib/tasks/verify', () => {
 
         // this message contains typical Gtk error shown if X11 is incorrect
         // like in the case of DISPLAY=987
-        firstSpawnError.stderr = '[some noise here] Gtk: cannot open display: 987'
+        firstSpawnError.stderr = stripIndent`
+          [some noise here] Gtk: cannot open display: 987
+            and maybe a few other lines here with weird indent
+        `
         firstSpawnError.stdout = ''
 
         // the second time it runs, it fails for some other reason
-        util.exec.withArgs(executablePath).rejects(new Error('some other error'))
+        const secondMessage = stripIndent`
+          some other error
+            again with
+              some weird indent
+        `
+        util.exec.withArgs(executablePath).rejects(new Error(secondMessage))
 
         return Promise.reject(firstSpawnError)
       })


### PR DESCRIPTION
- closes #4187

## CLI error message before

```
It looks like this is your first time using Cypress: 1.2.3

⚠ Warning: we have caught a display problem:

        [some noise here] Gtk: cannot open display: 987
and maybe a few other lines here with weird indent

        We will attempt to spin our XVFB server and verify again.

 ✔  Verified Cypress! /cache/Cypress/1.2.3/Cypress.app
```

## CLI error message after

```
It looks like this is your first time using Cypress: 1.2.3

⚠ Warning: we have caught a display problem:

[some noise here] Gtk: cannot open display: 987
and maybe a few other lines here with weird indent

We will attempt to spin our XVFB server and verify again.

 ✔  Verified Cypress! /cache/Cypress/1.2.3/Cypress.app
```