### PR TITLE
remove Node 4 support, bump packages that were previously approved but did not support Node 4

### DIFF
--- a/cli/__snapshots__/cli_spec.js
+++ b/cli/__snapshots__/cli_spec.js
@@ -37,12 +37,10 @@ exports['cli help command shows help 1'] = `
   Usage: cypress [options] [command]
 
   Options:
-
     -v, --version      prints Cypress version
     -h, --help         output usage information
 
   Commands:
-
     help               Shows CLI help and exits
     version            prints Cypress version
     run [options]      Runs Cypress tests from the CLI without the GUI
@@ -72,12 +70,10 @@ exports['cli help command shows help for --help 1'] = `
   Usage: cypress [options] [command]
 
   Options:
-
     -v, --version      prints Cypress version
     -h, --help         output usage information
 
   Commands:
-
     help               Shows CLI help and exits
     version            prints Cypress version
     run [options]      Runs Cypress tests from the CLI without the GUI
@@ -107,12 +103,10 @@ exports['cli help command shows help for -h 1'] = `
   Usage: cypress [options] [command]
 
   Options:
-
     -v, --version      prints Cypress version
     -h, --help         output usage information
 
   Commands:
-
     help               Shows CLI help and exits
     version            prints Cypress version
     run [options]      Runs Cypress tests from the CLI without the GUI
@@ -140,23 +134,20 @@ exports['cli unknown command shows usage and exits 1'] = `
   stdout:
   -------
   Unknown command "foo"
+  Usage: cypress [options] [command]
 
-    Usage: cypress [options] [command]
+  Options:
+    -v, --version      prints Cypress version
+    -h, --help         output usage information
 
-    Options:
-
-      -v, --version      prints Cypress version
-      -h, --help         output usage information
-
-    Commands:
-
-      help               Shows CLI help and exits
-      version            prints Cypress version
-      run [options]      Runs Cypress tests from the CLI without the GUI
-      open [options]     Opens Cypress in the interactive GUI.
-      install [options]  Installs the Cypress executable matching this package's version
-      verify             Verifies that Cypress is installed correctly and executable
-      cache [options]    Manages the Cypress binary cache
+  Commands:
+    help               Shows CLI help and exits
+    version            prints Cypress version
+    run [options]      Runs Cypress tests from the CLI without the GUI
+    open [options]     Opens Cypress in the interactive GUI.
+    install [options]  Installs the Cypress executable matching this package's version
+    verify             Verifies that Cypress is installed correctly and executable
+    cache [options]    Manages the Cypress binary cache
   -------
   stderr:
   -------
@@ -181,7 +172,6 @@ exports['cli unknown option shows help for cache command - no sub-command 1'] = 
   Manages the Cypress binary cache
 
   Options:
-
     list        list cached binary versions
     path        print the path to the binary cache
     clear       delete all cached binaries
@@ -207,13 +197,11 @@ exports['cli unknown option shows help for cache command - unknown option --foo 
   -------
   error: unknown option: --foo
 
-
   Usage: cache [command]
 
   Manages the Cypress binary cache
 
   Options:
-
     list        list cached binary versions
     path        print the path to the binary cache
     clear       delete all cached binaries
@@ -239,13 +227,11 @@ exports['cli unknown option shows help for cache command - unknown sub-command f
   -------
   error: unknown command: cache foo
 
-
   Usage: cache [command]
 
   Manages the Cypress binary cache
 
   Options:
-
     list        list cached binary versions
     path        print the path to the binary cache
     clear       delete all cached binaries
@@ -286,13 +272,11 @@ exports['shows help for open --foo 1'] = `
   -------
   error: unknown option: --foo
 
-
   Usage: open [options]
 
   Opens Cypress in the interactive GUI.
 
   Options:
-
     -p, --port <port>             runs Cypress on a specific port. overrides any value in cypress.json.
     -e, --env <env>               sets environment variables. separate multiple values with a comma. overrides any value in cypress.json or cypress.env.json
     -c, --config <config>         sets configuration values. separate multiple values with a comma. overrides any value in cypress.json.
@@ -323,13 +307,11 @@ exports['shows help for run --foo 1'] = `
   -------
   error: unknown option: --foo
 
-
   Usage: run [options]
 
   Runs Cypress tests from the CLI without the GUI
 
   Options:
-
     --record [bool]                            records the run. sends test results, screenshots and videos to your Cypress Dashboard.
     --headed                                   displays the Electron browser instead of running headlessly
     -k, --key <record-key>                     your secret Record Key. you can omit this if you set a CYPRESS_RECORD_KEY environment variable.

--- a/cli/package.json
+++ b/cli/package.json
@@ -66,7 +66,7 @@
     "ramda": "0.24.1",
     "request": "2.88.0",
     "request-progress": "0.4.0",
-    "supports-color": "5.5.0",
+    "supports-color": "6.1.0",
     "tmp": "0.1.0",
     "url": "0.11.0",
     "yauzl": "2.10.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -7,7 +7,7 @@
     "cypress": "bin/cypress"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "scripts": {
     "postinstall": "node ./scripts/post-install.js",
@@ -43,10 +43,10 @@
     "@cypress/xvfb": "1.2.4",
     "arch": "2.1.1",
     "bluebird": "3.5.0",
-    "cachedir": "1.3.0",
+    "cachedir": "2.2.0",
     "chalk": "2.4.2",
     "check-more-types": "2.24.0",
-    "commander": "2.15.1",
+    "commander": "2.20.0",
     "common-tags": "1.8.0",
     "debug": "3.2.6",
     "execa": "0.10.0",


### PR DESCRIPTION
- close #4200 

⚠️  **This update requires a major version release of Cypress.**