### PR TITLE
Fix the cy.stub type signature

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -1785,7 +1785,7 @@ declare namespace Cypress {
     writeFile<C extends FileContents>(filePath: string, contents: C, encoding: Encodings, options?: Partial<Loggable>): Chainable<C>
   }
 
-  interface Agent<A extends sinon.SinonSpy> {
+  interface SinonSpyAgent<A extends sinon.SinonSpy> {
     log(shouldOutput?: boolean): Omit<A, 'withArgs'> & Agent<A>
 
     /**
@@ -1808,6 +1808,8 @@ declare namespace Cypress {
      */
     withArgs(...args: any[]): Omit<A, 'withArgs'> & Agent<A>
   }
+         
+  type Agent<T> = SinonSpyAgent<T> & T
 
   interface CookieDefaults {
     whitelist: string | string[] | RegExp | ((cookie: any) => boolean)

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -1808,8 +1808,8 @@ declare namespace Cypress {
      */
     withArgs(...args: any[]): Omit<A, 'withArgs'> & Agent<A>
   }
-         
-  type Agent<T> = SinonSpyAgent<T> & T
+
+  type Agent<T extends sinon.SinonSpy> = SinonSpyAgent<T> & T
 
   interface CookieDefaults {
     whitelist: string | string[] | RegExp | ((cookie: any) => boolean)
@@ -3980,7 +3980,7 @@ declare namespace Cypress {
     })
     ```
      */
-    (action: 'window:confirm', fn: ((text: string) => false | void) | Agent<sinon.SinonSpy> | Agent<sinon.SinonStub>): void
+    (action: 'window:confirm', fn: ((text: string) => false | void) | SinonSpyAgent<sinon.SinonSpy> | SinonSpyAgent<sinon.SinonStub>): void
     /**
      * Fires when your app calls the global `window.alert()` method.
      * Cypress will auto accept alerts. You cannot change this behavior.
@@ -3997,7 +3997,7 @@ declare namespace Cypress {
     ```
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'window:alert', fn: ((text: string) => void) | Agent<sinon.SinonSpy> | Agent<sinon.SinonStub>): void
+    (action: 'window:alert', fn: ((text: string) => void) | SinonSpyAgent<sinon.SinonSpy> | SinonSpyAgent<sinon.SinonStub>): void
     /**
      * Fires as the page begins to load, but before any of your applications JavaScript has executed. This fires at the exact same time as `cy.visit()` `onBeforeLoad` callback. Useful to modify the window on a page transition.
      * @see https://on.cypress.io/catalog-of-events#App-Events


### PR DESCRIPTION
Hi
The `cy.stub` TypeScript signature is wrong. I started from your [Add example to cy.stub() for stubbing window.prompt behavior](https://github.com/cypress-io/cypress-documentation/issues/193) but, with the same code, I get an error form TypeSctypt
```
Property 'returns' does not exist on type 'Agent<SinonStub<any[], any>>'.
```
see the screenshot of the code
![ts-stub](https://user-images.githubusercontent.com/173663/58313415-ce295280-7e0d-11e9-8618-a95a47b3e27b.jpg)
In the above screenshot, I show you how everything works fine with the `log`, `as` and `withArgs` functions added by the `Agent` type.

The problem is that the `cy.stub` function returns a `Agent<sinon.SinonStub>` but the `Agent` itself doesn't extend the `sinon.SinonStub` type.

Since the code
```javascript
cy.stub(win, "prompt").returns("yes");
```
works perfectly in a standard JavaScript spec file, the error is in the TypeScript definitions only.

The easiest solution I found is to rename the `Agent` type to `SinonSpyAgent` and declare a new type `Agent` with the following signature
```typescript
type Agent<T> = SinonSpyAgent<T> & T
```
I made it because both the `cy.stub` and `cy.spy` functions return the `Agent` type.

Doing so:
- the `cy.stub` and `cy.spy` signatures don't change
- TypeScript no more throws an error

Let me know if I missed something and thank you for all, Cypress is simply amazing 😉