### PR TITLE
fix flaky spec: server e2e snapshot spec 

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -90,7 +90,7 @@
     "chai-as-promised": "7.1.1",
     "chai-string": "1.4.0",
     "dependency-check": "3.3.0",
-    "dtslint": "0.7.1",
+    "dtslint": "0.7.6",
     "execa-wrap": "1.4.0",
     "mock-fs": "4.9.0",
     "mocked-env": "1.2.4",

--- a/packages/server/__snapshots__/7_record_spec.coffee.js
+++ b/packages/server/__snapshots__/7_record_spec.coffee.js
@@ -111,8 +111,8 @@ Because this error occurred during a 'before each' hook we are skipping the rema
 
   (Uploading Results)
 
-  - Done Uploading (1/2) /foo/bar/.projects/e2e/cypress/screenshots/record_fail_spec.coffee/record fails -- fails 1 -- before each hook (failed).png
-  - Done Uploading (2/2) /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
+  - Done Uploading (*/2) /foo/bar/.projects/e2e/cypress/screenshots/record_fail_spec.coffee/record fails -- fails 1 -- before each hook (failed).png
+  - Done Uploading (*/2) /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                     
@@ -212,8 +212,8 @@ We dynamically generated a new test to display this failure.
 
   (Uploading Results)
 
-  - Done Uploading (1/2) /foo/bar/.projects/e2e/cypress/screenshots/record_uncaught_spec.coffee/An uncaught error was detected outside of a test (failed).png
-  - Done Uploading (2/2) /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
+  - Done Uploading (*/2) /foo/bar/.projects/e2e/cypress/screenshots/record_uncaught_spec.coffee/An uncaught error was detected outside of a test (failed).png
+  - Done Uploading (*/2) /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
 
 ====================================================================================================
 
@@ -737,8 +737,8 @@ exports['e2e record api interaction errors uploading assets warns but proceeds 1
 
   (Uploading Results)
 
-  - Failed Uploading (1/2) /foo/bar/.projects/e2e/cypress/screenshots/record_pass_spec.coffee/yay it passes.png
-  - Failed Uploading (2/2) /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
+  - Failed Uploading (*/2) /foo/bar/.projects/e2e/cypress/screenshots/record_pass_spec.coffee/yay it passes.png
+  - Failed Uploading (*/2) /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
 
 ====================================================================================================
 
@@ -1034,8 +1034,8 @@ Because this error occurred during a 'before each' hook we are skipping the rema
 
   (Uploading Results)
 
-  - Done Uploading (1/2) /foo/bar/.projects/e2e/cypress/screenshots/record_fail_spec.coffee/record fails -- fails 1 -- before each hook (failed).png
-  - Done Uploading (2/2) /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
+  - Done Uploading (*/2) /foo/bar/.projects/e2e/cypress/screenshots/record_fail_spec.coffee/record fails -- fails 1 -- before each hook (failed).png
+  - Done Uploading (*/2) /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                     
@@ -1095,8 +1095,8 @@ We dynamically generated a new test to display this failure.
 
   (Uploading Results)
 
-  - Done Uploading (1/2) /foo/bar/.projects/e2e/cypress/screenshots/record_uncaught_spec.coffee/An uncaught error was detected outside of a test (failed).png
-  - Done Uploading (2/2) /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
+  - Done Uploading (*/2) /foo/bar/.projects/e2e/cypress/screenshots/record_uncaught_spec.coffee/An uncaught error was detected outside of a test (failed).png
+  - Done Uploading (*/2) /foo/bar/.projects/e2e/cypress/videos/abc123.mp4
 
 ====================================================================================================
 
@@ -1537,7 +1537,6 @@ StatusCodeError: 402
 
 `
 
-
 exports['e2e record api interaction errors create run 402 - free plan exceeds monthly tests errors and exits when on free plan and over recorded tests limit 1'] = `
 You've exceeded the limit of test recordings under your free plan this month. The limit is 500 test recordings.
 
@@ -1555,7 +1554,6 @@ To run your tests with groups, please visit your billing and upgrade to another 
 https://on.cypress.io/dashboard/organizations/org-id-1234/billing
 
 `
-
 
 exports['e2e record api interaction warnings create run warnings grace period - grouping feature warns when using parallel feature 1'] = `
 Grouping is not included under your free plan.

--- a/packages/server/test/support/helpers/e2e.coffee
+++ b/packages/server/test/support/helpers/e2e.coffee
@@ -58,6 +58,19 @@ replaceDurationInTables = (str, p1, p2) ->
   ## full length of the duration so it doesn't shift content
   _.padStart("XX:XX", p1.length + p2.length)
 
+replaceUploadingResults = (orig, match..., offset, string) ->
+  
+    results = match[1].split('\n').map((res) ->
+      res.replace(/\(\d+\/(\d+)\)/g, '(*/$1)')
+    )
+    .sort()
+    .join('\n')
+    ret =  match[0] + results + match[3]
+
+    return ret
+
+    
+
 normalizeStdout = (str) ->
   ## remove all of the dynamic parts of stdout
   ## to normalize against what we expected
@@ -74,6 +87,7 @@ normalizeStdout = (str) ->
   .replace(/(Duration\:\s+)(\d+\sminutes?,\s+)?(\d+\sseconds?)(\s+)/g, replaceDurationSeconds)
   .replace(/\((\d+ minutes?,\s+)?\d+ seconds?\)/g, "(X seconds)")
   .replace(/\r/g, "")
+  .replace(/(Uploading Results.*?\n\n)((.*-.*[\s\S\r]){2,}?)(\n\n)/g, replaceUploadingResults) ## replaces multiple lines of uploading results (since order not guaranteed)
   .replace("/\(\d{2,4}x\d{2,4}\)/g", "(YYYYxZZZZ)") ## screenshot dimensions
   .split("\n")
     .map(replaceStackTraceLines)

--- a/packages/server/test/support/helpers/e2e.coffee
+++ b/packages/server/test/support/helpers/e2e.coffee
@@ -59,7 +59,6 @@ replaceDurationInTables = (str, p1, p2) ->
   _.padStart("XX:XX", p1.length + p2.length)
 
 replaceUploadingResults = (orig, match..., offset, string) ->
-  
     results = match[1].split('\n').map((res) ->
       res.replace(/\(\d+\/(\d+)\)/g, '(*/$1)')
     )
@@ -68,8 +67,6 @@ replaceUploadingResults = (orig, match..., offset, string) ->
     ret =  match[0] + results + match[3]
 
     return ret
-
-    
 
 normalizeStdout = (str) ->
   ## remove all of the dynamic parts of stdout


### PR DESCRIPTION
the issue was that sometimes artifacts finish uploading in a different order than the saved snapshot test
the solution is to sort the stdout lines so the order doesn't affect the snapshot 
- cleanse stdout of uploading multi results




<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->
