### PR TITLE
Allow users modify scroll behaviour

### DIFF
--- a/packages/driver/src/cy/actionability.coffee
+++ b/packages/driver/src/cy/actionability.coffee
@@ -207,7 +207,7 @@ ensureNotAnimating = (cy, $el, coordsHistory, animationDistanceThreshold) ->
 verify = (cy, $el, options, callbacks) ->
   win = $dom.getWindowByElement($el.get(0))
 
-  { _log, force, position } = options
+  { _log, force, position, scrollOptions } = options
 
   { onReady, onScroll } = callbacks
 
@@ -229,7 +229,7 @@ verify = (cy, $el, options, callbacks) ->
     runAllChecks = ->
       if force isnt true
         ## scroll the element into view
-        $el.get(0).scrollIntoView()
+        $el.get(0).scrollIntoView(scrollOptions)
 
         if onScroll
           onScroll($el, "element")


### PR DESCRIPTION
#871
Cypress automatically calls `scrollIntoView` function when `click()`, `type()` or something similar is called. This causes problems if there are elements with `position: fixed`
This can be fixed by allowing users to send parameters to `scrollIntoView` function. With parameters we can set where do we want element to be positioned after element is scrolled into view. Both horizontally and vertically

Example:
```js
const scrollOptions = {
    block: "center", // Vertical aligment, ["start", "center", "end", "nearest"]
    inline: "center", // Horizontal aligment, ["start", "center", "end", "nearest"]
}
cy.get('#my-element').click({ scrollOptions: scrollOptions});
```
This way element would be scrolled into center of the page instead of current behaviour: top-left.

https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->
