### PR TITLE
Revert "Fix incorrect `performance.getEntries.*` return types (#4108)"

### DIFF
--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -44,7 +44,7 @@
     "js-cookie": "2.2.0",
     "jsdom": "13.2.0",
     "lodash": "4.17.11",
-    "lolex": "4.1.0",
+    "lolex": "3.1.0",
     "methods": "1.1.2",
     "method-override": "3.0.0",
     "minimatch": "3.0.4",

--- a/packages/driver/test/cypress/integration/commands/clock_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/clock_spec.coffee
@@ -72,20 +72,6 @@ describe "src/cy/commands/clock", ->
         expect(new win.Date()).to.be.an.instanceof(win.Date)
         expect(new win.Date() instanceof win.Date).to.be.true
 
-    it "doesn't override window.performance members", ->
-      cy.clock()
-      .then (clock) ->
-        cy.window().then (win) ->
-          expect(win.performance.getEntriesByType("paint")).to.deep.eq([])
-          expect(win.performance.getEntriesByName("first-paint")).to.deep.eq([])
-          expect(win.performance.getEntries()).to.deep.eq([])
-
-          clock.restore()
-
-          expect(win.performance.getEntriesByType("paint").length).to.be.at.least(1)
-          expect(win.performance.getEntriesByName("first-paint").length).to.be.at.least(1)
-          expect(win.performance.getEntries().length).to.be.at.least(1)
-
     context "errors", ->
       it "throws if now is not a number (or options object)", (done) ->
         cy.on "fail", (err) ->


### PR DESCRIPTION
Caused binary smoke tests to fail (hanging forever) 
https://circleci.com/gh/cypress-io/cypress/118395
https://ci.appveyor.com/project/cypress-io/cypress/builds/25044614
This reverts commit 209063940121a2cda26ea0d673fc51f1274974fb.

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->

Edit: NVM, develop has been failing for a long time