### PR TITLE
Revert "update coffee-script to non-deprecated npm package coffeescri…

### DIFF
--- a/packages/coffee/package.json
+++ b/packages/coffee/package.json
@@ -3,7 +3,7 @@
   "main": "index.js",
   "private": true,
   "dependencies": {
-    "coffeescript": "1.12.7"
+    "coffee-script": "1.12.7"
   },
   "files": [
     "register.js"


### PR DESCRIPTION
…pt (#4147)"

This reverts commit ce29366ad793de608dd5eda9a46bf18b882aa019.

Was causing build binary smoke tests to hang forever:
https://circleci.com/gh/cypress-io/cypress/118063
https://ci.appveyor.com/project/cypress-io/cypress/builds/25022675

Likely just needs a tweak to get working, but it's best to get this out of develop since it's failing every build
<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->
