### PR TITLE
actually require newly renamed coffeescript module

### DIFF
--- a/packages/coffee/index.js
+++ b/packages/coffee/index.js
@@ -1,1 +1,1 @@
-module.exports = require("coffee-script")
+module.exports = require('coffeescript')

--- a/packages/coffee/register.js
+++ b/packages/coffee/register.js
@@ -1,10 +1,11 @@
 if (process.env.CYPRESS_ENV !== 'production') {
-  require('coffee-script/register')
+  require('coffeescript/register')
 
   // using hack found here to prevent problems with
   // cypress coffee script being replaced by modules which
-  // use coffee-script/register
+  // use coffeescript/register
   // https://github.com/abresas/register-coffee-coverage/blob/master/index.js
+  // remove when https://github.com/benbria/coffee-coverage/issues/69 is resolved
   const loader = require.extensions['.coffee']
 
   Object.defineProperty(require.extensions, '.coffee', {

--- a/packages/server/test/support/helpers/coverage.coffee
+++ b/packages/server/test/support/helpers/coverage.coffee
@@ -20,7 +20,7 @@ coffeeCoverage.register({
 
 ## using hack found here to prevent problems with
 ## coffee-coverage being replaced by modules which
-## use coffee-script/register
+## use coffeescript/register
 ## https://github.com/abresas/register-coffee-coverage/blob/master/index.js
 loader = require.extensions[".coffee"]
 

--- a/scripts/win-appveyor-build.js
+++ b/scripts/win-appveyor-build.js
@@ -20,8 +20,9 @@ shell.set('-e') // any error is fatal
 
 const isRightBranch = () => {
   const branch = process.env.APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH || process.env.APPVEYOR_REPO_BRANCH
+  const shouldForceBinaryBuild = (process.env.APPVEYOR_REPO_COMMIT_MESSAGE || '').includes('[build binary]')
 
-  return branch === 'develop'
+  return branch === 'develop' || shouldForceBinaryBuild
 }
 
 const isForkedPullRequest = () => {


### PR DESCRIPTION
- closes #4388 

Honestly, I don’t know how the tests ever passed when we were not requiring coffeescript correctly