### PR TITLE
Do not watch any files in run mode

### DIFF
--- a/packages/server/lib/project.coffee
+++ b/packages/server/lib/project.coffee
@@ -184,7 +184,7 @@ class Project extends EE
 
   watchPluginsFile: (cfg, options) ->
     debug("attempt watch plugins file: #{cfg.pluginsFile}")
-    if not cfg.pluginsFile
+    if not cfg.pluginsFile or options.isTextTerminal
       return Promise.resolve()
 
     fs.pathExists(cfg.pluginsFile)
@@ -206,7 +206,7 @@ class Project extends EE
 
   watchSettings: (onSettingsChanged) ->
     ## bail if we havent been told to
-    ## watch anything
+    ## watch anything (like in run mode)
     return if not onSettingsChanged
 
     debug("watch settings files")

--- a/packages/server/test/integration/cypress_spec.coffee
+++ b/packages/server/test/integration/cypress_spec.coffee
@@ -329,6 +329,16 @@ describe "lib/cypress", ->
         expect(browsers.open).to.be.calledWithMatch(ELECTRON_BROWSER, {url: "http://localhost:8888/__/#/tests/integration/test2.coffee"})
         @expectExitWith(0)
 
+    it "does not watch settings or plugins in run mode", ->
+      watch = sinon.spy(Watchers.prototype, "watch")
+      watchTree = sinon.spy(Watchers.prototype, "watchTree")
+
+      cypress.start(["--run-project=#{@pluginConfig}"])
+      .then =>
+        expect(watchTree).not.to.be.called
+        expect(watch).not.to.be.called
+        @expectExitWith(0)
+
     it "scaffolds out integration and example specs if they do not exist when not runMode", ->
       config.get(@pristinePath)
       .then (cfg) =>

--- a/packages/server/test/unit/project_spec.coffee
+++ b/packages/server/test/unit/project_spec.coffee
@@ -380,22 +380,28 @@ describe "lib/project", ->
 
     it "does nothing when {pluginsFile: false}", ->
       @config.pluginsFile = false
-      @project.watchPluginsFile(@config).then =>
+      @project.watchPluginsFile(@config, {}).then =>
         expect(@project.watchers.watchTree).not.to.be.called
 
     it "does nothing if pluginsFile does not exist", ->
       fs.pathExists.resolves(false)
-      @project.watchPluginsFile(@config).then =>
+      @project.watchPluginsFile(@config, {}).then =>
+        expect(@project.watchers.watchTree).not.to.be.called
+
+    it "does nothing if in run mode", ->
+      @project.watchPluginsFile(@config, {
+        isTextTerminal: true
+      }).then =>
         expect(@project.watchers.watchTree).not.to.be.called
 
     it "watches the pluginsFile", ->
-      @project.watchPluginsFile(@config).then =>
+      @project.watchPluginsFile(@config, {}).then =>
         expect(@project.watchers.watchTree).to.be.calledWith(@config.pluginsFile)
         expect(@project.watchers.watchTree.lastCall.args[1]).to.be.an("object")
         expect(@project.watchers.watchTree.lastCall.args[1].onChange).to.be.a("function")
 
     it "calls plugins.init when file changes", ->
-      @project.watchPluginsFile(@config).then =>
+      @project.watchPluginsFile(@config, {}).then =>
         @project.watchers.watchTree.firstCall.args[1].onChange()
         expect(plugins.init).to.be.calledWith(@config)
 


### PR DESCRIPTION
Fixes #4283 

Files are watched in 3 places:

- In `openProject`, `getSpecChanges` watches files to see if any are added or removed: https://github.com/cypress-io/cypress/blob/4bd3cf2c531bdbf1783493e8045c18f09dfc390b/packages/server/lib/open_project.coffee#L142-L153
    - This is only called from gui/events for desktop-gui, so it does not run in `run` mode: https://github.com/cypress-io/cypress/blob/4bd3cf2c531bdbf1783493e8045c18f09dfc390b/packages/server/lib/gui/events.coffee#L234-L234
- In `project`, `cypress.json`, `cypress.env.json`, and the `pluginsFile` are watched
    -  [x] `pluginsFile` is watched in run mode, so added a guard - normally watches all files in dependency tree outside of `node_modules`: https://github.com/cypress-io/cypress/blob/a389a51e45dc0bf708da304346079c3b6638caad/packages/server/lib/watchers.coffee#L40-L46
- by the bundler itself
	- `shouldWatch: false` is passed in run mode which tells the preprocessor not to use `watchify`
