### PR TITLE
[#4461] Change typescript declaration for .writeFile()

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -1776,13 +1776,13 @@ declare namespace Cypress {
       })
     ```
      */
-    writeFile<C extends FileContents>(filePath: string, contents: C, options?: Partial<Loggable>): Chainable<C>
+    writeFile<C extends FileContents>(filePath: string, contents: C, encoding: Encodings): Chainable<C>
     /**
      * Write to a file with the specified encoding and contents.
      *
      * @see https://on.cypress.io/writefile
      */
-    writeFile<C extends FileContents>(filePath: string, contents: C, encoding: Encodings, options?: Partial<Loggable>): Chainable<C>
+    writeFile<C extends FileContents>(filePath: string, contents: C, options?: Partial<WriteFileOptions>): Chainable<C>
 
     /**
      * jQuery library bound to the AUT
@@ -2316,6 +2316,12 @@ declare namespace Cypress {
      * @default true
      */
     cancelable: boolean
+  }
+
+  /** Options to change the default behavior of .writeFile */
+  interface WriteFileOptions extends Loggable { 
+    flag: string
+    encoding: Encodings
   }
 
   // Kind of onerous, but has a nice auto-complete. Also fallbacks at the end for custom stuff


### PR DESCRIPTION
<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->

Closes #4461

Changing typescript definition signature for `.writeFile` method according to [the docs](https://docs.cypress.io/api/commands/writefile.html#Syntax). 