### PR TITLE
Fix flaky `fast_visit_spec`

### DIFF
--- a/packages/server/__snapshots__/6_visit_spec.coffee.js
+++ b/packages/server/__snapshots__/6_visit_spec.coffee.js
@@ -845,8 +845,40 @@ You have set the browser to: 'chrome'
 A video will not be recorded when using this browser.
 
 
-  ✓ always finishes in less than XX:XX on localhost with connection: close
-  ✓ always finishes in less than XX:XX on localhost with connection: keep-alive
+  on localhost 100% of visits are faster than XX:XX, 90% are faster than XX:XX
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+    ✓ with connection: close
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+    ✓ with connection: keep-alive
+
 
   2 passing
 
@@ -899,8 +931,40 @@ exports['e2e visit resolves visits quickly in electron (headless) 1'] = `
   Running: fast_visit_spec.coffee...                                                       (1 of 1) 
 
 
-  ✓ always finishes in less than XX:XX on localhost with connection: close
-  ✓ always finishes in less than XX:XX on localhost with connection: keep-alive
+  on localhost 100% of visits are faster than XX:XX, 90% are faster than XX:XX
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+    ✓ with connection: close
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+histogram line
+    ✓ with connection: keep-alive
+
 
   2 passing
 

--- a/packages/server/test/e2e/6_visit_spec.coffee
+++ b/packages/server/test/e2e/6_visit_spec.coffee
@@ -171,12 +171,17 @@ describe "e2e visit", ->
       }
     })
 
+    onStdout = (stdout) ->
+      stdout
+      .replace(/^\d+%\s+of visits to [^\s]+ finished in less than.*$/gm, 'histogram line')
+
     it "in chrome (headed)", ->
       e2e.exec(@, {
         spec: "fast_visit_spec.coffee"
         snapshot: true
         expectedExitCode: 0
         browser: 'chrome'
+        onStdout
       })
 
     it "in electron (headless)", ->
@@ -185,4 +190,5 @@ describe "e2e visit", ->
         snapshot: true
         expectedExitCode: 0
         browser: 'electron'
+        onStdout
       })

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/plugins/index.js
@@ -6,13 +6,17 @@ const Promise = require('bluebird')
 module.exports = (on) => {
   // save some time by only reading the originals once
   let cache = {}
+
   function getCachedImage (name) {
     const cachedImage = cache[name]
+
     if (cachedImage) return Promise.resolve(cachedImage)
 
     const imagePath = path.join(__dirname, '..', 'screenshots', `${name}.png`)
+
     return Jimp.read(imagePath).then((image) => {
       cache[name] = image
+
       return image
     })
   }
@@ -52,6 +56,7 @@ module.exports = (on) => {
       }
 
       const comparePath = path.join(__dirname, '..', 'screenshots', `${b}.png`)
+
       return Promise.all([
         getCachedImage(a),
         Jimp.read(comparePath),

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/plugins/index.js
@@ -96,5 +96,11 @@ module.exports = (on) => {
         return null
       })
     },
+
+    'console:log' (obj) {
+      console.log(obj) // eslint-disable-line no-console
+
+      return null
+    },
   })
 }


### PR DESCRIPTION
Now asserts that 90% of visits complete in less than 100ms, and 100% of visits complete in less than 250ms.

Also logs out a nice histogram to understand if a failure is just flake or if it represents a real speed change.