### PR TITLE
4429- Do not log 'counts' for aliases that are non-routes

### DIFF
--- a/packages/reporter/cypress/integration/aliases_spec.coffee
+++ b/packages/reporter/cypress/integration/aliases_spec.coffee
@@ -55,6 +55,12 @@ describe "aliases", ->
           }],
         })
 
+      it "has correct alias class", ->
+        cy.contains('.command-number', '1')
+          .parent()
+          .find('.command-alias')
+          .should('have.class', 'route')
+
       it "render without a count", ->
         cy.contains('.command-number', '1')
           .parent()
@@ -104,6 +110,9 @@ describe "aliases", ->
             ordinal: "2nd"
           }],
         })
+
+      it "renders all aliases ", ->
+        cy.get('.command-alias').should('have.length', 3)
 
       it "render with counts in non-event commands", ->
         cy.contains('.command-number', '1')
@@ -244,7 +253,7 @@ describe "aliases", ->
           state: "passed"
           name: "get"
           message: "body"
-          alias: "b"
+          alias: "barAlias"
           aliasType: "dom"
           event: true
           renderProps: {message: "", indicator: "passed"}
@@ -255,21 +264,27 @@ describe "aliases", ->
           name: "get"
           referencesAlias: [{
             cardinal: 1
-            name: "b"
+            name: "barAlias"
             ordinal: "1st"
           }],
         })
+
+      it "has correct alias class", ->
+        cy.contains('.command-number', '1')
+          .parent()
+          .find('.command-alias')
+          .should('have.class', 'dom')
 
       it "render without a count", ->
         cy.contains('.command-number', '1')
           .parent()
           .within ->
             cy.get('.command-alias-count').should('not.exist')
-            cy.contains('.command-alias', '@b')
+            cy.contains('.command-alias', '@barAlias')
               .trigger("mouseover")
 
         cy.get(".tooltip span").should ($tooltip) ->
-          expect($tooltip).to.contain("Found an alias for: 'b'")
+          expect($tooltip).to.contain("Found an alias for: 'barAlias'")
 
     describe "with consecutive duplicates", ->
       beforeEach ->
@@ -399,6 +414,9 @@ describe "aliases", ->
             ordinal: "2nd"
           }],
         })
+
+      it "renders all aliases ", ->
+        cy.get('.command-alias').should('have.length', 6)
 
       it "render without counts", ->
         cy.contains('.command-number', '1')

--- a/packages/reporter/cypress/integration/aliases_spec.coffee
+++ b/packages/reporter/cypress/integration/aliases_spec.coffee
@@ -17,206 +17,407 @@ addLog = (runner, log) ->
   runner.emit("reporter:log:add", _.extend(defaultLog, log))
 
 describe "aliases", ->
-  beforeEach ->
-    cy.fixture("aliases_runnables").as("runnables")
-
-    @runner = new EventEmitter()
-
-    cy.visit("cypress/support/index.html").then (win) =>
-      win.render({
-        runner: @runner
-        specPath: "/foo/bar"
-      })
-
-    cy.get(".reporter").then =>
-      @runner.emit("runnables:ready", @runnables)
-      @runner.emit("reporter:start", {})
-
-
-  describe "without duplicates", ->
+  context "route aliases", ->
     beforeEach ->
-      addLog(@runner, {
-        alias: "getUsers"
-        aliasType: "route"
-        displayName: "xhr stub"
-        event: true
-        name: "xhr"
-        renderProps: {message: "GET --- /users", indicator: "passed"}
-      })
-      addLog(@runner, {
-        aliasType: "route"
-        message: "@getUsers, function(){}"
-        name: "wait"
-        referencesAlias: [{
-          cardinal: 1
-          name: "getUsers"
-          ordinal: "1st"
-        }],
-      })
+      cy.fixture("aliases_runnables").as("runnables")
 
-    it "render without a count", ->
-      cy.contains('.command-number', '1')
-        .parent()
-        .within ->
-          cy.get('.command-alias-count').should('not.exist')
-          cy.contains('.command-alias', '@getUsers')
-            .trigger("mouseover")
+      @runner = new EventEmitter()
 
-      cy.get(".tooltip span").should ($tooltip) ->
-        expect($tooltip).to.contain("Found an alias for: 'getUsers'")
+      cy.visit("cypress/support/index.html").then (win) =>
+        win.render({
+          runner: @runner
+          specPath: "/foo/bar"
+        })
 
-  describe "with consecutive duplicates", ->
+      cy.get(".reporter").then =>
+        @runner.emit("runnables:ready", @runnables)
+        @runner.emit("reporter:start", {})
+
+
+    describe "without duplicates", ->
+      beforeEach ->
+        addLog(@runner, {
+          alias: "getUsers"
+          aliasType: "route"
+          displayName: "xhr stub"
+          event: true
+          name: "xhr"
+          renderProps: {message: "GET --- /users", indicator: "passed"}
+        })
+        addLog(@runner, {
+          aliasType: "route"
+          message: "@getUsers, function(){}"
+          name: "wait"
+          referencesAlias: [{
+            cardinal: 1
+            name: "getUsers"
+            ordinal: "1st"
+          }],
+        })
+
+      it "render without a count", ->
+        cy.contains('.command-number', '1')
+          .parent()
+          .within ->
+            cy.get('.command-alias-count').should('not.exist')
+            cy.contains('.command-alias', '@getUsers')
+              .trigger("mouseover")
+
+        cy.get(".tooltip span").should ($tooltip) ->
+          expect($tooltip).to.contain("Found an alias for: 'getUsers'")
+
+    describe "with consecutive duplicates", ->
+      beforeEach ->
+        addLog(@runner, {
+          alias: "getPosts"
+          aliasType: "route"
+          displayName: "xhr stub"
+          event: true
+          name: "xhr"
+          renderProps: {message: "GET --- /posts", indicator: "passed"}
+        })
+        addLog(@runner, {
+          alias: "getPosts"
+          aliasType: "route"
+          displayName: "xhr stub"
+          event: true
+          name: "xhr"
+          renderProps: {message: "GET --- /posts", indicator: "passed"}
+        })
+        addLog(@runner, {
+          aliasType: "route"
+          message: "@getPosts, function(){}"
+          name: "wait"
+          referencesAlias: [{
+            cardinal: 1
+            name: "getPosts"
+            ordinal: "1st"
+          }],
+        })
+        addLog(@runner, {
+          aliasType: "route"
+          message: "@getPosts, function(){}"
+          name: "wait"
+          referencesAlias: [{
+            cardinal: 2
+            name: "getPosts"
+            ordinal: "2nd"
+          }],
+        })
+
+      it "render with counts in non-event commands", ->
+        cy.contains('.command-number', '1')
+          .parent()
+          .within ->
+            cy.contains('.command-alias-count', '1')
+            cy.contains('.command-alias', '@getPosts')
+              .trigger("mouseover")
+
+        cy.get(".tooltip span").should ($tooltip) ->
+          expect($tooltip).to.contain("Found 1st alias for: 'getPosts'")
+
+        cy.contains('.command-number', '2')
+          .parent()
+          .within ->
+            cy.contains('.command-alias-count', '2')
+            cy.contains('.command-alias', '@getPosts')
+              .trigger("mouseover")
+
+        cy.get(".tooltip span").should ($tooltip) ->
+          expect($tooltip).to.contain("Found 2nd alias for: 'getPosts'")
+
+      it "render with counts in event commands when collapsed", ->
+        cy.get(".command-wrapper")
+          .first()
+          .within ->
+            cy.contains('.num-duplicates', '2')
+            cy.contains('.command-alias', 'getPosts')
+
+      it "render without counts in event commands when expanded", ->
+        cy.get(".command-expander")
+          .first()
+          .click()
+
+        cy.get(".command-wrapper")
+          .first()
+          .within ($commandWrapper) ->
+            cy.get('.num-duplicates').should('not.be.visible')
+            cy.contains('.command-alias', 'getPosts')
+
+    describe "with non-consecutive duplicates", ->
+      beforeEach ->
+        addLog(@runner, {
+          alias: "getPosts"
+          aliasType: "route"
+          displayName: "xhr stub"
+          event: true
+          name: "xhr"
+          renderProps: {message: "GET --- /posts", indicator: "passed"}
+        })
+        addLog(@runner, {
+          alias: "getUsers"
+          aliasType: "route"
+          displayName: "xhr stub"
+          event: true
+          name: "xhr"
+          renderProps: {message: "GET --- /users", indicator: "passed"}
+        })
+        addLog(@runner, {
+          alias: "getPosts"
+          aliasType: "route"
+          displayName: "xhr stub"
+          event: true
+          name: "xhr"
+          renderProps: {message: "GET --- /posts", indicator: "passed"}
+        })
+        addLog(@runner, {
+          aliasType: "route"
+          message: "@getPosts, function(){}"
+          name: "wait"
+          referencesAlias: [{
+            cardinal: 1
+            name: "getPosts"
+            ordinal: "1st"
+          }],
+        })
+        addLog(@runner, {
+          aliasType: "route"
+          message: "@getUsers, function(){}"
+          name: "wait"
+          referencesAlias: [{
+            cardinal: 1
+            name: "getUsers"
+            ordinal: "1st"
+          }],
+        })
+        addLog(@runner, {
+          aliasType: "route"
+          message: "@getPosts, function(){}"
+          name: "wait"
+          referencesAlias: [{
+            cardinal: 2
+            name: "getPosts"
+            ordinal: "2nd"
+          }],
+        })
+
+      it "render with counts", ->
+        cy.contains('.command-number', '1')
+          .parent()
+          .within ->
+            cy.contains('.command-alias-count', '1')
+            cy.contains('.command-alias', '@getPosts')
+              .trigger("mouseover")
+
+        cy.get(".tooltip span").should ($tooltip) ->
+          expect($tooltip).to.contain("Found 1st alias for: 'getPosts'")
+
+        cy.contains('.command-number', '3')
+          .parent()
+          .within ->
+            cy.contains('.command-alias-count', '2')
+            cy.contains('.command-alias', '@getPosts')
+              .trigger("mouseover")
+
+        cy.get(".tooltip span").should ($tooltip) ->
+          expect($tooltip).to.contain("Found 2nd alias for: 'getPosts'")
+
+  context "element aliases", ->
     beforeEach ->
-      addLog(@runner, {
-        alias: "getPosts"
-        aliasType: "route"
-        displayName: "xhr stub"
-        event: true
-        name: "xhr"
-        renderProps: {message: "GET --- /posts", indicator: "passed"}
-      })
-      addLog(@runner, {
-        alias: "getPosts"
-        aliasType: "route"
-        displayName: "xhr stub"
-        event: true
-        name: "xhr"
-        renderProps: {message: "GET --- /posts", indicator: "passed"}
-      })
-      addLog(@runner, {
-        aliasType: "route"
-        message: "@getPosts, function(){}"
-        name: "wait"
-        referencesAlias: [{
-          cardinal: 1
-          name: "getPosts"
-          ordinal: "1st"
-        }],
-      })
-      addLog(@runner, {
-        aliasType: "route"
-        message: "@getPosts, function(){}"
-        name: "wait"
-        referencesAlias: [{
-          cardinal: 2
-          name: "getPosts"
-          ordinal: "2nd"
-        }],
-      })
+      cy.fixture("aliases_runnables").as("runnables")
 
-    it "render with counts in non-event commands", ->
-      cy.contains('.command-number', '1')
-        .parent()
-        .within ->
-          cy.contains('.command-alias-count', '1')
-          cy.contains('.command-alias', '@getPosts')
-            .trigger("mouseover")
+      @runner = new EventEmitter()
 
-      cy.get(".tooltip span").should ($tooltip) ->
-        expect($tooltip).to.contain("Found 1st alias for: 'getPosts'")
+      cy.visit("cypress/support/index.html").then (win) =>
+        win.render({
+          runner: @runner
+          specPath: "/foo/bar"
+        })
 
-      cy.contains('.command-number', '2')
-        .parent()
-        .within ->
-          cy.contains('.command-alias-count', '2')
-          cy.contains('.command-alias', '@getPosts')
-            .trigger("mouseover")
+      cy.get(".reporter").then =>
+        @runner.emit("runnables:ready", @runnables)
+        @runner.emit("reporter:start", {})
 
-      cy.get(".tooltip span").should ($tooltip) ->
-        expect($tooltip).to.contain("Found 2nd alias for: 'getPosts'")
+    describe "without duplicates", ->
+      beforeEach ->
+        addLog(@runner, {
+          state: "passed"
+          name: "get"
+          message: "body"
+          alias: "b"
+          aliasType: "dom"
+          event: true
+          renderProps: {message: "", indicator: "passed"}
+        })
+        addLog(@runner, {
+          aliasType: "dom"
+          message: ""
+          name: "get"
+          referencesAlias: [{
+            cardinal: 1
+            name: "b"
+            ordinal: "1st"
+          }],
+        })
 
-    it "render with counts in event commands when collapsed", ->
-      cy.get(".command-wrapper")
-        .first()
-        .within ->
-          cy.contains('.num-duplicates', '2')
-          cy.contains('.command-alias', 'getPosts')
+      it "render without a count", ->
+        cy.contains('.command-number', '1')
+          .parent()
+          .within ->
+            cy.get('.command-alias-count').should('not.exist')
+            cy.contains('.command-alias', '@b')
+              .trigger("mouseover")
 
-    it "render without counts in event commands when expanded", ->
-      cy.get(".command-expander")
-        .first()
-        .click()
+        cy.get(".tooltip span").should ($tooltip) ->
+          expect($tooltip).to.contain("Found an alias for: 'b'")
 
-      cy.get(".command-wrapper")
-        .first()
-        .within ($commandWrapper) ->
-          cy.get('.num-duplicates').should('not.be.visible')
-          cy.contains('.command-alias', 'getPosts')
+    describe "with consecutive duplicates", ->
+      beforeEach ->
+        addLog(@runner, {
+          state: "passed"
+          name: "get"
+          message: "[attr='dropdown']"
+          alias: "dropdown"
+          aliasType: "dom"
+          event: true
+          renderProps: {message: "", indicator: "passed"}
+        })
+        addLog(@runner, {
+          state: "passed"
+          name: "get"
+          message: "select"
+          alias: "dropdown"
+          aliasType: "dom"
+          event: true
+          renderProps: {message: "", indicator: "passed"}
+        })
+        addLog(@runner, {
+          aliasType: "dom"
+          message: ""
+          name: "get"
+          referencesAlias: [{
+            cardinal: 1
+            name: "dropdown"
+            ordinal: "1st"
+          }],
+        })
+        addLog(@runner, {
+          aliasType: "dom"
+          message: ""
+          name: "get"
+          referencesAlias: [{
+            cardinal: 2
+            name: "dropdown"
+            ordinal: "2nd"
+          }],
+        })
 
-  describe "with non-consecutive duplicates", ->
-    beforeEach ->
-      addLog(@runner, {
-        alias: "getPosts"
-        aliasType: "route"
-        displayName: "xhr stub"
-        event: true
-        name: "xhr"
-        renderProps: {message: "GET --- /posts", indicator: "passed"}
-      })
-      addLog(@runner, {
-        alias: "getUsers"
-        aliasType: "route"
-        displayName: "xhr stub"
-        event: true
-        name: "xhr"
-        renderProps: {message: "GET --- /users", indicator: "passed"}
-      })
-      addLog(@runner, {
-        alias: "getPosts"
-        aliasType: "route"
-        displayName: "xhr stub"
-        event: true
-        name: "xhr"
-        renderProps: {message: "GET --- /posts", indicator: "passed"}
-      })
-      addLog(@runner, {
-        aliasType: "route"
-        message: "@getPosts, function(){}"
-        name: "wait"
-        referencesAlias: [{
-          cardinal: 1
-          name: "getPosts"
-          ordinal: "1st"
-        }],
-      })
-      addLog(@runner, {
-        aliasType: "route"
-        message: "@getUsers, function(){}"
-        name: "wait"
-        referencesAlias: [{
-          cardinal: 1
-          name: "getUsers"
-          ordinal: "1st"
-        }],
-      })
-      addLog(@runner, {
-        aliasType: "route"
-        message: "@getPosts, function(){}"
-        name: "wait"
-        referencesAlias: [{
-          cardinal: 2
-          name: "getPosts"
-          ordinal: "2nd"
-        }],
-      })
+      it "render without a count in non-event commands", ->
+        cy.contains('.command-number', '1')
+          .parent()
+          .within ->
+            cy.get('.command-alias-count').should('not.exist')
+            cy.contains('.command-alias', '@dropdown')
+              .trigger("mouseover")
 
-    it "render with counts", ->
-      cy.contains('.command-number', '1')
-        .parent()
-        .within ->
-          cy.contains('.command-alias-count', '1')
-          cy.contains('.command-alias', '@getPosts')
-            .trigger("mouseover")
+        cy.get(".tooltip span").should ($tooltip) ->
+          expect($tooltip).to.contain("Found an alias for: 'dropdown'")
 
-      cy.get(".tooltip span").should ($tooltip) ->
-        expect($tooltip).to.contain("Found 1st alias for: 'getPosts'")
+        cy.contains('.command-number', '2')
+          .parent()
+          .within ->
+            cy.get('.command-alias-count').should('not.exist')
+            cy.contains('.command-alias', '@dropdown')
+              .trigger("mouseover")
 
-      cy.contains('.command-number', '3')
-        .parent()
-        .within ->
-          cy.contains('.command-alias-count', '2')
-          cy.contains('.command-alias', '@getPosts')
-            .trigger("mouseover")
+        cy.get(".tooltip span").should ($tooltip) ->
+          expect($tooltip).to.contain("Found an alias for: 'dropdown'")
 
-      cy.get(".tooltip span").should ($tooltip) ->
-        expect($tooltip).to.contain("Found 2nd alias for: 'getPosts'")
+      it "render without counts in event commands when collapsed", ->
+        cy.get(".command-wrapper")
+          .first()
+          .within ->
+            cy.get('.num-duplicates').should('not.be.visible')
+            cy.contains('.command-alias', 'dropdown')
+
+    describe "with non-consecutive duplicates", ->
+      beforeEach ->
+        addLog(@runner, {
+          state: "passed"
+          name: "get"
+          message: "[attr='dropdown']"
+          alias: "dropdown"
+          aliasType: "dom"
+          event: true
+          renderProps: {message: "", indicator: "passed"}
+        })
+        addLog(@runner, {
+          state: "passed"
+          name: "get"
+          message: "[attr='modal']"
+          alias: "modal"
+          aliasType: "dom"
+          event: true
+          renderProps: {message: "", indicator: "passed"}
+        })
+        addLog(@runner, {
+          state: "passed"
+          name: "get"
+          message: "[attr='dropdown']"
+          alias: "dropdown"
+          aliasType: "dom"
+          event: true
+          renderProps: {message: "", indicator: "passed"}
+        })
+        addLog(@runner, {
+          aliasType: "dom"
+          message: ""
+          name: "get"
+          referencesAlias: [{
+            cardinal: 1
+            name: "dropdown"
+            ordinal: "1st"
+          }],
+        })
+        addLog(@runner, {
+          aliasType: "dom"
+          message: ""
+          name: "get"
+          referencesAlias: [{
+            cardinal: 1
+            name: "modal"
+            ordinal: "1st"
+          }],
+        })
+        addLog(@runner, {
+          aliasType: "dom"
+          message: ""
+          name: "get"
+          referencesAlias: [{
+            cardinal: 2
+            name: "dropdown"
+            ordinal: "2nd"
+          }],
+        })
+
+      it "render without counts", ->
+        cy.contains('.command-number', '1')
+          .parent()
+          .within ->
+            cy.get('.command-alias-count').should('not.exist')
+            cy.contains('.command-alias', '@dropdown')
+              .trigger("mouseover")
+
+        cy.get(".tooltip span").should ($tooltip) ->
+          expect($tooltip).to.contain("Found an alias for: 'dropdown'")
+
+        cy.contains('.command-number', '3')
+          .parent()
+          .within ->
+            cy.get('.command-alias-count').should('not.exist')
+            cy.contains('.command-alias', '@dropdown')
+              .trigger("mouseover")
+
+        cy.get(".tooltip span").should ($tooltip) ->
+          expect($tooltip).to.contain("Found an alias for: 'dropdown'")
+

--- a/packages/reporter/src/commands/command.jsx
+++ b/packages/reporter/src/commands/command.jsx
@@ -24,12 +24,16 @@ const visibleMessage = (model) => {
     'This element is not visible.'
 }
 
-const shouldShowCount = (aliasesWithDuplicates, aliasName) => {
+const shouldShowCount = (aliasesWithDuplicates, aliasName, model) => {
+  if (model.aliasType !== 'route') {
+    return false
+  }
+
   return _.includes(aliasesWithDuplicates, aliasName)
 }
 
-const AliasReference = observer(({ model, aliasObj, aliasesWithDuplicates }) => {
-  if (shouldShowCount(aliasesWithDuplicates, aliasObj.name)) {
+const AliasReference = observer(({ aliasObj, model, aliasesWithDuplicates }) => {
+  if (shouldShowCount(aliasesWithDuplicates, aliasObj.name, model)) {
     return (
       <Tooltip placement='top' title={`Found ${aliasObj.ordinal} alias for: '${aliasObj.name}'`}>
         <span>
@@ -64,7 +68,9 @@ const Aliases = observer(({ model, aliasesWithDuplicates }) => {
     <span>
       {_.map([].concat(model.alias), (alias) => (
         <Tooltip key={alias} placement='top' title={`${model.displayMessage} aliased as: '${alias}'`}>
-          <span className={cs('command-alias', `${model.aliasType}`, { 'show-count': (model.aliasType === 'route' && model.numDuplicates > 1) ? shouldShowCount(aliasesWithDuplicates, alias) : false })}>{alias}</span>
+          <span className={cs('command-alias', `${model.aliasType}`, { 'show-count': shouldShowCount(aliasesWithDuplicates, alias, model) })}>
+            {alias}
+          </span>
         </Tooltip>
       ))}
     </span>

--- a/packages/reporter/src/commands/command.spec.jsx
+++ b/packages/reporter/src/commands/command.spec.jsx
@@ -1,9 +1,9 @@
-import { shallow, mount } from 'enzyme'
+import { shallow } from 'enzyme'
 import _ from 'lodash'
 import React from 'react'
 import sinon from 'sinon'
 
-import Command, { Aliases, AliasesReferences, Message } from './command'
+import Command, { Message } from './command'
 
 const longText = Array(110).join('-')
 const withMarkdown = '**this** is _markdown_'
@@ -172,85 +172,6 @@ describe('<Command />', () => {
       const component = shallow(<Command model={model({ renderProps: { indicator: 'bad' } })} />)
 
       expect(component.find(Message).first().shallow().find('.bad')).to.exist
-    })
-  })
-
-  context('aliases', () => {
-    context('message', () => {
-      let aliases
-
-      beforeEach(() => {
-        aliases = mount(<Command model={model({ referencesAlias: [{ name: 'barAlias' }, { name: 'bazAlias', ordinal: '1st', cardinal: '1' }, { name: 'bazAlias', ordinal: '2nd', cardinal: '2' }], aliasType: 'dom' })} aliasesWithDuplicates={['bazAlias']}/>).find(AliasesReferences)
-      })
-
-      it('renders the aliases for each one it references', () => {
-        expect(aliases.find('.command-alias').length).to.equal(3)
-      })
-
-      it('renders the aliases with the right class', () => {
-        expect(aliases.find('.command-alias').first()).to.have.className('dom')
-      })
-
-      it('renders the aliases in the right format', () => {
-        expect(aliases.find('.command-alias').first()).to.have.text('@barAlias')
-        expect(aliases.find('.command-alias').last()).to.have.text('@bazAlias')
-      })
-
-      it('renders tooltip for each alias it references', () => {
-        expect(aliases.find('Tooltip').length).to.equal(3)
-      })
-
-      it('renders the right tooltip title for each alias it references', () => {
-        const tooltips = aliases.find('Tooltip')
-
-        expect(tooltips.first()).to.have.prop('title', 'Found an alias for: \'barAlias\'')
-        expect(tooltips.last()).to.have.prop('title', 'Found 2nd alias for: \'bazAlias\'')
-      })
-
-      it('only renders the count for aliases with duplicates', () => {
-        const commandAliasContainers = aliases.find('.command-alias-container')
-
-        expect(commandAliasContainers.first().find('.command-alias-count')).to.not.exist
-        expect(commandAliasContainers.last().find('.command-alias-count')).to.have.text('2')
-      })
-    })
-
-    context('controls', () => {
-      let aliases
-
-      describe('any case / when there is a single alias', () => {
-        beforeEach(() => {
-          aliases = shallow(<Command model={model({ alias: 'fooAlias', aliasType: 'dom' })} />).find(Aliases).shallow()
-        })
-
-        it('renders the alias', () => {
-          expect(aliases.find('.command-alias').first()).to.have.text('fooAlias')
-        })
-
-        it('renders the alias with the alias type as a class', () => {
-          expect(aliases.find('.command-alias')).to.have.className('dom')
-        })
-
-        it('renders a tooltip for the alias', () => {
-          expect(aliases.find('Tooltip').first().find('.command-alias')).to.exist
-        })
-
-        it('renders the alias tooltip with the right title', () => {
-          expect(aliases.find('Tooltip').first()).to.have.prop('title', 'The message aliased as: \'fooAlias\'')
-        })
-      })
-
-      describe('when there are multiple aliases', () => {
-        beforeEach(() => {
-          aliases = shallow(<Command model={model({ alias: ['fooAlias', 'barAlias'], aliasType: 'dom' })} />).find(Aliases).shallow()
-        })
-
-        it('renders all the aliases', () => {
-          expect(aliases.find('.command-alias').length).to.equal(2)
-          expect(aliases.find('.command-alias').first()).to.have.text('fooAlias')
-          expect(aliases.find('.command-alias').last()).to.have.text('barAlias')
-        })
-      })
     })
   })
 

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -116,8 +116,12 @@
     .command-alias {
       border-radius: 10px;
       color: #777888;
-      padding: 0px 5px;
+      padding: 0 5px;
       display: inline-block;
+
+      &.show-count {
+        padding-right: 2px;
+      }
 
       &.route {
         background-color: lighten(#FFB61C, 25%);
@@ -157,20 +161,20 @@
       margin-left: 0;
     }
 
-    .num-duplicates.has-alias,
+    .num-duplicates.has-alias {
+      border-radius: 0 10px 10px 0;
+      line-height: 2;
+      padding: 4px 6px 2px 4px;
+    }
+
     .command-alias-count {
       border-radius: 0 10px 10px 0;
-      padding: 0px 6px 1px 4px;
+      padding: 5px 6px 3px 4px;
     }
 
     .num-duplicates,
     .command-alias-count {
-      background-color: lighten(#ffdf9c, 8%);
-    }
-
-    .command-alias-count {
-      display: inline;
-      padding: 2px 6px 2px 4px;
+      background-color: darken(#ffdf9c, 8%) !important;
     }
   }
 
@@ -382,8 +386,10 @@
     .command-alias {
       font-family: $open-sans;
       font-size: 10px;
-      line-height: 1.5;
+      line-height: 1.75;
       margin-left: 5px;
+
+      
     }
 
     i:hover {


### PR DESCRIPTION
- Update styling of alias counts to be more centered
- Write tests for non-route aliases to display in runner
- I also manually tested that the situation in issue #4429 is fixed
- close #4429 