### PR TITLE
Use 'path' for key in browsers dropdown, fix desktop-gui duplicate key warning

### DIFF
--- a/packages/desktop-gui/src/project-nav/browsers.jsx
+++ b/packages/desktop-gui/src/project-nav/browsers.jsx
@@ -22,7 +22,7 @@ export default class Browsers extends Component {
           others={project.otherBrowsers}
           onSelect={this._onSelect}
           renderItem={this._browser}
-          keyProperty='name'
+          keyProperty='path'
           browserState={project.browserState}
         />
       </ul>


### PR DESCRIPTION
Noticed this error when multiple copies of the same browser exist:

![image](https://user-images.githubusercontent.com/1151760/60122019-5626b300-9752-11e9-853e-ac192d211fc7.png)

This PR changes the key to use `path` instead of `name` since `path` is always unique.