### PR TITLE
Fix `run_plugins_spec` test leaking into other tests, other flake in `request_spec`

### DIFF
--- a/packages/server/test/unit/plugins/child/run_plugins_spec.coffee
+++ b/packages/server/test/unit/plugins/child/run_plugins_spec.coffee
@@ -96,7 +96,7 @@ describe "lib/plugins/child/run_plugins", ->
       runPlugins(@ipc, "plugins-file")
       @ipc.on.withArgs("load").yield()
 
-      @ipc.send = (event, errorType, pluginsFile, stack) ->
+      @ipc.send = _.once (event, errorType, pluginsFile, stack) ->
         expect(event).to.eq("load:error")
         expect(errorType).to.eq("PLUGINS_FUNCTION_ERROR")
         expect(pluginsFile).to.eq("plugins-file")

--- a/packages/server/test/unit/plugins/child/run_plugins_spec.coffee
+++ b/packages/server/test/unit/plugins/child/run_plugins_spec.coffee
@@ -72,7 +72,7 @@ describe "lib/plugins/child/run_plugins", ->
       @ipc.on.withArgs("load").yields({})
       runPlugins(@ipc, "plugins-file")
 
-      @ipc.send = (event, errorType, pluginsFile, stack) ->
+      @ipc.send = _.once (event, errorType, pluginsFile, stack) ->
         expect(event).to.eq("load:error")
         expect(errorType).to.eq("PLUGINS_FUNCTION_ERROR")
         expect(pluginsFile).to.eq("plugins-file")

--- a/packages/server/test/unit/request_spec.coffee
+++ b/packages/server/test/unit/request_spec.coffee
@@ -200,6 +200,7 @@ describe "lib/request", ->
         opts = {
           url: "http://localhost:9988/econnreset"
           retryIntervals: [0, 1, 2, 3]
+          timeout: 250
         }
 
         stream = request.create(opts)
@@ -252,6 +253,7 @@ describe "lib/request", ->
         opts = {
           url: "http://localhost:9988/econnreset"
           retryIntervals: [0, 1, 2, 3]
+          timeout: 250
         }
 
         request.create(opts, true)


### PR DESCRIPTION
Fixes #4481

Also increases the timeout on the 4x retry test for ECONNRESET, I could never get it to flake locally, only in CI, assuming it's just random slowdown. Bumping timeout from 100 to 250ms should fix this.