### PR TITLE
remove string-to-stream dep (getStream isn't called anywhere)

### DIFF
--- a/packages/server/lib/controllers/xhrs.coffee
+++ b/packages/server/lib/controllers/xhrs.coffee
@@ -1,6 +1,5 @@
 _           = require("lodash")
 mime        = require("mime")
-str         = require("string-to-stream")
 Promise     = require("bluebird")
 fixture     = require("../fixture")
 
@@ -78,13 +77,6 @@ module.exports = {
     fixture.get(config.fixturesFolder, filePath, options)
     .then (bytes) ->
       {data: bytes, encoding: encoding}
-
-  getStream: (resp) ->
-    if fixturesRe.test(resp)
-      @_get(resp).then (contents) ->
-        str(contents)
-    else
-      str(resp)
 
   getResponse: (resp, config) ->
     if fixturesRe.test(resp)

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -179,7 +179,6 @@
     "shell-env": "3.0.0",
     "signal-exit": "3.0.2",
     "sinon": "5.1.1",
-    "string-to-stream": "1.1.1",
     "strip-ansi": "3.0.1",
     "supports-color": "6.1.0",
     "syntax-error": "1.4.0",


### PR DESCRIPTION
I don’t see `getStream` being called anywhere in the code, this is the
only method that uses string-to-stream

Removes 33.2kB MINIFIED, 9.6kB MINIFIED + GZIPPED