### PR TITLE
Prefer American spelling 'canceled'

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -3996,7 +3996,7 @@ declare namespace Cypress {
     (action: 'uncaught:exception', fn: (error: Error, runnable: Mocha.IRunnable) => false | void): void
     /**
      * Fires when your app calls the global `window.confirm()` method.
-     * Cypress will auto accept confirmations. Return `false` from this event and the confirmation will be cancelled.
+     * Cypress will auto accept confirmations. Return `false` from this event and the confirmation will be canceled.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      * @example
     ```

--- a/packages/desktop-gui/src/app/intro.jsx
+++ b/packages/desktop-gui/src/app/intro.jsx
@@ -74,7 +74,7 @@ class Default extends Component {
   _selectProject = (e) => {
     e.preventDefault()
     ipc.showDirectoryDialog().then((path) => {
-      if (!path) return // user cancelled
+      if (!path) return // user canceled
 
       return this._addProject(path)
     })

--- a/packages/driver/src/cy/commands/actions/click.js
+++ b/packages/driver/src/cy/commands/actions/click.js
@@ -169,7 +169,7 @@ module.exports = (Commands, Cypress, cy, state, config) => {
 
             domEvents.mouseDown = $Mouse.mouseDown($elToClick, coords.fromViewport)
 
-            //# if mousedown was cancelled then or caused
+            //# if mousedown was canceled then or caused
             //# our element to be removed from the DOM
             //# just resolve after mouse down and dont
             //# send a focus event
@@ -291,7 +291,7 @@ module.exports = (Commands, Cypress, cy, state, config) => {
       }
 
       //# create a new promise and chain off of it using reduce to insert
-      //# the artificial delays.  we have to set this as cancellable for it
+      //# the artificial delays.  we have to set this as cancelable for it
       //# to propogate since this is an "inner" promise
 
       //# return our original subject when our promise resolves

--- a/packages/driver/src/cy/commands/actions/select.coffee
+++ b/packages/driver/src/cy/commands/actions/select.coffee
@@ -153,7 +153,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
         }).then( ->
 
           ## TODO:
-          ## 1. test cancellation
+          ## 1. test cancelation
           ## 2. test passing optionEls to each directly
           ## 3. update other tests using this Promise.each pattern
           ## 4. test that force is always true

--- a/packages/driver/src/cy/commands/actions/submit.coffee
+++ b/packages/driver/src/cy/commands/actions/submit.coffee
@@ -50,7 +50,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
 
       ## now we need to check to see if we should actually submit
       ## the form!
-      ## dont submit the form if our dispatched event was cancelled (false)
+      ## dont submit the form if our dispatched event was canceled (false)
       form.submit() if dispatched
 
       cy.timeout($actionability.delay, true)

--- a/packages/driver/src/cy/listeners.coffee
+++ b/packages/driver/src/cy/listeners.coffee
@@ -46,7 +46,7 @@ module.exports = {
     contentWindow.onerror = callbacks.onError
 
     addListener contentWindow, "beforeunload", (e) ->
-      ## bail if we've cancelled this event (from another source)
+      ## bail if we've canceled this event (from another source)
       ## or we've set a returnValue on the original event
       return if e.defaultPrevented or eventHasReturnValue(e)
 

--- a/packages/driver/src/cy/timers.js
+++ b/packages/driver/src/cy/timers.js
@@ -4,13 +4,13 @@ const create = () => {
   let paused
   let flushing
   let timerQueue
-  let cancelledTimerIds
+  let canceledTimerIds
 
   const reset = () => {
     paused = false
     flushing = false
     timerQueue = []
-    cancelledTimerIds = {}
+    canceledTimerIds = {}
   }
 
   const isPaused = () => {
@@ -31,11 +31,11 @@ const create = () => {
     _.each(timerQueue, (timer) => {
       const { timerId, type, fnOrCode, params, contentWindow } = timer
 
-      // if we are a setInterval and we're been cancelled
+      // if we are a setInterval and we're been canceled
       // then just return. this can happen when a setInterval
       // queues many callbacks, and from within that callback
-      // we would have cancelled the original setInterval
-      if (type === 'setInterval' && cancelledTimerIds[timerId]) {
+      // we would have canceled the original setInterval
+      if (type === 'setInterval' && canceledTimerIds[timerId]) {
         return
       }
 
@@ -70,7 +70,7 @@ const create = () => {
     const wrapCancel = (fnName) => {
       return (timerId) => {
         if (flushing) {
-          cancelledTimerIds[timerId] = true
+          canceledTimerIds[timerId] = true
         }
 
         return callThrough(fnName, [timerId])

--- a/packages/driver/src/cypress/cy.coffee
+++ b/packages/driver/src/cypress/cy.coffee
@@ -956,7 +956,7 @@ create = (specWindow, Cypress, Cookies, state, config, log) ->
       ## listeners returned false
       return if _.some(results, returnedFalse)
 
-      ## do all the normal fail stuff and promise cancellation
+      ## do all the normal fail stuff and promise cancelation
       ## but dont re-throw the error
       if r = state("reject")
         r(err)

--- a/packages/driver/src/cypress/mouse.js
+++ b/packages/driver/src/cypress/mouse.js
@@ -32,10 +32,10 @@ module.exports = {
       return stopPropagation.apply(this, args)
     }
 
-    const cancelled = !el.dispatchEvent(mdownEvt)
+    const canceled = !el.dispatchEvent(mdownEvt)
 
     const props = {
-      preventedDefault: cancelled,
+      preventedDefault: canceled,
       stoppedPropagation: !!mdownEvt._hasStoppedPropagation,
     }
 
@@ -76,10 +76,10 @@ module.exports = {
       return stopPropagation.apply(this, args)
     }
 
-    const cancelled = !el.dispatchEvent(mupEvt)
+    const canceled = !el.dispatchEvent(mupEvt)
 
     const props = {
-      preventedDefault: cancelled,
+      preventedDefault: canceled,
       stoppedPropagation: !!mupEvt._hasStoppedPropagation,
     }
 
@@ -120,10 +120,10 @@ module.exports = {
       return stopPropagation.apply(this, args)
     }
 
-    const cancelled = !el.dispatchEvent(clickEvt)
+    const canceled = !el.dispatchEvent(clickEvt)
 
     const props = {
-      preventedDefault: cancelled,
+      preventedDefault: canceled,
       stoppedPropagation: !!clickEvt._hasStoppedPropagation,
     }
 

--- a/packages/driver/test/cypress/integration/commands/actions/focus_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/focus_spec.coffee
@@ -192,7 +192,7 @@ describe "src/cy/commands/actions/focus", ->
 
         ## we can't end early here because our focus()
         ## command will still be in flight and the promise
-        ## chain will get cancelled before it gets attached
+        ## chain will get canceled before it gets attached
         ## (besides the code will continue to run and create
         ## side effects)
         cy.on "log:added", (attrs, log) ->

--- a/packages/driver/test/cypress/integration/commands/actions/type_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/type_spec.coffee
@@ -3191,7 +3191,7 @@ describe "src/cy/commands/actions/type", ->
 
           cy.get(":text:first").type(val)
 
-      it "throws when type is cancelled by preventingDefault mousedown"
+      it "throws when type is canceled by preventingDefault mousedown"
 
       it "throws when element animation exceeds timeout", (done) ->
         ## force the animation calculation to think we moving at a huge distance ;-)

--- a/packages/driver/test/cypress/integration/commands/xhr_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/xhr_spec.coffee
@@ -1541,7 +1541,7 @@ describe "src/cy/commands/xhr", ->
 
         cy.on "command:retry", =>
           if cy.state("error")
-            done("should have cancelled and not retried after failing")
+            done("should have canceled and not retried after failing")
 
         cy.on "fail", (err) =>
           p = cy.state("promise")

--- a/packages/driver/test/cypress/integration/cy/timers_spec.js
+++ b/packages/driver/test/cypress/integration/cy/timers_spec.js
@@ -281,7 +281,7 @@ describe('driver/src/cy/timers', () => {
 
         expect(win.bar).to.eq('bar')
       })
-      .log('cancelling the timeout after timers are paused still cancels')
+      .log('canceling the timeout after timers are paused still cancels')
       .then(() => {
         win.bar = null
 

--- a/packages/driver/test/cypress/integration/e2e/cancelation_spec.coffee
+++ b/packages/driver/test/cypress/integration/e2e/cancelation_spec.coffee
@@ -3,7 +3,7 @@ Promise = Cypress.Promise
 previousTestWasCanceled = false
 calledAfterDoneEarly = false
 
-describe "cancelling command queues", ->
+describe "canceling command queues", ->
   it "Cypress.stop()", (done) ->
     cy.stub(Cypress.runner, "stop")
 

--- a/packages/server/test/integration/server_spec.coffee
+++ b/packages/server/test/integration/server_spec.coffee
@@ -320,7 +320,7 @@ describe "Server", ->
 
             Promise.delay(100)
             .then =>
-              ## the p1 should not have a current promise phase or reqStream until it's cancelled
+              ## the p1 should not have a current promise phase or reqStream until it's canceled
               expect(p1).not.to.have.property('currentPromisePhase')
               expect(p1).not.to.have.property('reqStream')
 

--- a/packages/server/test/unit/socket_spec.coffee
+++ b/packages/server/test/unit/socket_spec.coffee
@@ -251,11 +251,11 @@ describe "lib/socket", ->
 
             _.delay ->
               ## wait another 100ms and make sure
-              ## that it was cancelled and not continuously
+              ## that it was canceled and not continuously
               ## retried!
               ## if we remove Promise.config({cancellation: true})
               ## then this will fail. bluebird has changed its
-              ## cancellation logic before and so we want to use
+              ## cancelation logic before and so we want to use
               ## an integration test to ensure this works as expected
               expect(callCount).to.eq(iSC.callCount)
               done()

--- a/scripts/binary/move-binaries.ts
+++ b/scripts/binary/move-binaries.ts
@@ -185,7 +185,7 @@ export const moveBinaries = async (args = []) => {
   try {
     await prompts.shouldCopy()
   } catch (e) {
-    console.log('Copying has been cancelled')
+    console.log('Copying has been canceled')
     return
   }
 


### PR DESCRIPTION
- Convert uses of 'cancelled' to 'canceled', etc
- Make searching for ‘canceled’ easier within codebase.