### PR TITLE
NPM install up to 3 times on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,7 +70,8 @@ install:
   # everything from "postinstall" script as commands
   - npm run link
   # install every package one by one
-  - npm run all install -- --serial || npm run all install -- --serial
+  # try to do several attempts, because on AppVeyor random install errors happen
+  - npm run all install -- --serial || npm run all install -- --serial || npm run all install -- --serial
   # - npm prune
   # - npm run all prune -- --serial
   - npm run all build -- --serial


### PR DESCRIPTION
failed on second npm install for example here: https://ci.appveyor.com/project/cypress-io/cypress/builds/26026722/job/6k0c7uip7v2707pu

Maybe 3 times is the charm