### PR TITLE
[internal] use localhost for webpack livereload plugin

### DIFF
--- a/packages/web-config/webpack.config.base.ts
+++ b/packages/web-config/webpack.config.base.ts
@@ -177,7 +177,7 @@ const config: webpack.Configuration = {
       })]
     ),
 
-    ...(liveReloadEnabled ? [new LiveReloadPlugin({ appendScriptTag: 'true', port: 0 })] : []),
+    ...(liveReloadEnabled ? [new LiveReloadPlugin({ appendScriptTag: 'true', port: 0, hostname: 'localhost' })] : []),
   ],
 
   cache: true,


### PR DESCRIPTION
this fixes development mode of cypress visiting non-localhost domains, since `livereload` script was not hard-coding localhost

- [x] no tests needed