### PR TITLE
Fix DNS lookup for 'localhost' when offline on Windows

### DIFF
--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -1,6 +1,11 @@
 // override tty if we're being forced to
 require('./lib/util/tty').override()
 
+// fix for Node v8.9.3 not resolving localhost if system is offline
+// this can be removed as soon as we pass Node v8.10.0
+// https://github.com/cypress-io/cypress/issues/4763
+require('node-offline-localhost').ifOffline()
+
 if (process.env.CY_NET_PROFILE && process.env.CYPRESS_ENV) {
   const netProfiler = require('./lib/util/net_profiler')()
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -104,6 +104,7 @@
     "moment": "2.24.0",
     "morgan": "1.9.1",
     "node-machine-id": "1.1.10",
+    "node-offline-localhost": "0.9.0",
     "node-webkit-updater": "cypress-io/node-webkit-updater#e74623726f381487f543e373e71515177a32daeb",
     "opn": "cypress-io/opn#2f4e9a216ca7bdb95dfae9d46d99ddf004b3cbb5",
     "ospath": "1.2.2",


### PR DESCRIPTION
<!--
Thanks for contributing!

- Add tests! This is what we do afterall. 😉
- If you haven't already, complete the CLA.

Read more about contributing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md
-->

- Closes #4763 

Manually verified fix works in Windows 10:

![image](https://user-images.githubusercontent.com/1151760/61641759-b20b2b80-ac6d-11e9-90e8-95de6938dcfd.png)
