### PR TITLE
Fix the cy.once typings

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -331,6 +331,12 @@ declare namespace Cypress {
      * These events come from Cypress as it issues commands and reacts to their state. These are all useful to listen to for debugging purposes.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
+    once: Actions
+
+    /**
+     * These events come from Cypress as it issues commands and reacts to their state. These are all useful to listen to for debugging purposes.
+     * @see https://on.cypress.io/catalog-of-events#App-Events
+     */
     off: Actions
   }
 
@@ -933,6 +939,12 @@ declare namespace Cypress {
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
     on: Actions
+
+    /**
+     * These events come from Cypress as it issues commands and reacts to their state. These are all useful to listen to for debugging purposes.
+     * @see https://on.cypress.io/catalog-of-events#App-Events
+     */
+    once: Actions
 
     /**
      * These events come from Cypress as it issues commands and reacts to their state. These are all useful to listen to for debugging purposes.

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -246,7 +246,7 @@ namespace CypressOnTests {
   })
 }
 
-namespace CypressOnCeTests {
+namespace CypressOnceTests {
   Cypress.once('uncaught:exception', (error, runnable) => {
     error // $ExpectType Error
     runnable // $ExpectType IRunnable

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -246,6 +246,18 @@ namespace CypressOnTests {
   })
 }
 
+namespace CypressOnCeTests {
+  Cypress.once('uncaught:exception', (error, runnable) => {
+    error // $ExpectType Error
+    runnable // $ExpectType IRunnable
+  })
+
+  cy.once('uncaught:exception', (error, runnable) => {
+    error // $ExpectType Error
+    runnable // $ExpectType IRunnable
+  })
+}
+
 namespace CypressOffTests {
   Cypress.off('uncaught:exception', (error, runnable) => {
     error // $ExpectType Error


### PR DESCRIPTION
The `cy.once` function has not the corresponding types, I get the

> Property 'once' does not exist on type 'Chainable<undefined>'.ts(2339)

error while using it in a TS file (see the screenshot below).

I duplicated the `cy.on` signature an added the tests, let me know if I need to do something more 😊

![Screen Shot 2019-07-23 at 13 54 10](https://user-images.githubusercontent.com/173663/61712078-d17d8380-ad55-11e9-9d5e-d3928f888127.png)

### Pre-merge Tasks
- [x] Have the [type definitions](cli/types/index.d.ts) been updated with any user-facing API changes?
- [x] Have tests been added/updated for the changes in this PR?

Thank you guys 👋