### PR TITLE
Allow video to be recorded till the end of the test

### DIFF
--- a/packages/server/lib/modes/run.coffee
+++ b/packages/server/lib/modes/run.coffee
@@ -4,9 +4,6 @@ path       = require("path")
 chalk      = require("chalk")
 human      = require("human-interval")
 debug      = require("debug")("cypress:server:run")
-# because this file also interacts with video recording
-# some debug logs should have ":video" namespace
-debugVideo = require("debug")("cypress:server:video")
 Promise    = require("bluebird")
 logSymbols = require("log-symbols")
 

--- a/packages/server/lib/modes/run.coffee
+++ b/packages/server/lib/modes/run.coffee
@@ -680,19 +680,28 @@ module.exports = {
       ## is the one that matches our id!
       project.on("socket:connected", fn)
 
-  waitForTestsToFinishRunning: (options = {}) ->
-    { project, screenshots, started, end, name, cname, videoCompression, videoUploadOnPasses, exit, spec, estimated } = options
-
-    @listenForProjectEnd(project, exit)
-    .tap ->
-      return unless end
-      # we are recording video of the test run
+  _delayToLetVideoFinish: ->
+    # we are recording video of the test run
       # and there still might be frames sent by the browser
       # in order to avoid chopping off the end of the video
       # delay closing the browser by N ms
       DELAY_TO_LET_VIDEO_FINISH_MS = 1000
       debugVideo('delaying closing the browser by %dms to let video finish', DELAY_TO_LET_VIDEO_FINISH_MS)
       Promise.delay(DELAY_TO_LET_VIDEO_FINISH_MS)
+
+  waitForTestsToFinishRunning: (options = {}) ->
+    { project, screenshots, started, end, name, cname, videoCompression, videoUploadOnPasses, exit, spec, estimated } = options
+
+    @listenForProjectEnd(project, exit)
+    .tap =>
+      # ? is this the best way to determine if we are recording a video?
+      # TODO rename "end" to something meaningful, like "videoCaptureEnd"
+      return unless end
+      # we are recording video of the test run
+      # and there still might be frames sent by the browser
+      # in order to avoid chopping off the end of the video
+      # delay closing the browser by N ms
+      @_delayToLetVideoFinish()
     .then (obj) =>
       _.defaults(obj, {
         error: null

--- a/packages/server/lib/modes/run.coffee
+++ b/packages/server/lib/modes/run.coffee
@@ -30,6 +30,8 @@ humanTime  = require("../util/human_time")
 electronApp = require("../util/electron_app")
 chromePolicyCheck = require("../util/chrome_policy_check")
 
+DELAY_TO_LET_VIDEO_FINISH_MS = 1000
+
 color = (val, c) ->
   chalk[c](val)
 
@@ -409,6 +411,70 @@ trashAssets = (config = {}) ->
     ## dont make trashing assets fail the build
     errors.warning("CANNOT_TRASH_ASSETS", err.stack)
 
+## if we've been told to record and we're not spawning a headed browser
+browserCanBeRecorded = (browser) ->
+  browser.name is "electron" and browser.isHeadless
+    
+createVideoRecording = (videoName) ->
+  outputDir = path.dirname(videoName)
+
+  fs
+  .ensureDirAsync(outputDir)
+  .then ->
+    videoCapture
+    .start(videoName, {
+      onError: (err) ->
+        ## catch video recording failures and log them out
+        ## but don't let this affect the run at all
+        errors.warning("VIDEO_RECORDING_FAILED", err.stack)
+    })
+
+getVideoRecordingDelay = (startedVideoCapture) ->
+  if startedVideoCapture
+    return DELAY_TO_LET_VIDEO_FINISH_MS
+
+  return 0
+    
+maybeStartVideoRecording = Promise.method (options = {}) ->
+  { spec, browser, video, videosFolder } = options
+
+  ## bail if we've been told not to capture
+  ## a video recording
+  if not video
+    return
+  
+  ## handle if this browser cannot actually
+  ## be recorded
+  if not browserCanBeRecorded(browser)
+    console.log("")
+
+    if browser.name is "electron" and browser.isHeaded
+      errors.warning("CANNOT_RECORD_VIDEO_HEADED")
+    else
+      errors.warning("CANNOT_RECORD_VIDEO_FOR_THIS_BROWSER", browser.name)
+
+    return
+
+  ## make sure we have a videsFolder
+  if not videosFolder
+    throw new Error("Missing videoFolder for recording")
+
+  videoPath = (suffix) ->
+    path.join(videosFolder, spec.name + suffix)
+
+  videoName  = videoPath(".mp4")
+  compressedVideoName = videoPath("-compressed.mp4")
+
+  @createVideoRecording(videoName)
+  .then (props = {}) ->
+    return {
+      videoName,
+      compressedVideoName,
+      endVideoCapture: props.endVideoCapture,
+      writeVideoFrame: props.writeVideoFrame,
+      startedVideoCapture: props.startedVideoCapture,
+    }
+    
 module.exports = {
   collectTestResults
 
@@ -418,18 +484,11 @@ module.exports = {
 
   openProjectCreate
 
-  createRecording: (name) ->
-    outputDir = path.dirname(name)
+  createVideoRecording
+  
+  getVideoRecordingDelay
 
-    fs
-    .ensureDirAsync(outputDir)
-    .then ->
-      videoCapture.start(name, {
-        onError: (err) ->
-          ## catch video recording failures and log them out
-          ## but don't let this affect the run at all
-          errors.warning("VIDEO_RECORDING_FAILED", err.stack)
-      })
+  maybeStartVideoRecording
 
   getElectronProps: (isHeaded, project, writeVideoFrame) ->
     electronProps = {
@@ -573,11 +632,11 @@ module.exports = {
       errors.warning("VIDEO_POST_PROCESSING_FAILED", err.stack)
 
   launchBrowser: (options = {}) ->
-    { browser, spec, write, project, screenshots, projectRoot } = options
+    { browser, spec, writeVideoFrame, project, screenshots, projectRoot } = options
 
     browserOpts = switch browser.name
       when "electron"
-        @getElectronProps(browser.isHeaded, project, write)
+        @getElectronProps(browser.isHeaded, project, writeVideoFrame)
       else
         {}
 
@@ -680,28 +739,17 @@ module.exports = {
       ## is the one that matches our id!
       project.on("socket:connected", fn)
 
-  _delayToLetVideoFinish: ->
-    # we are recording video of the test run
-      # and there still might be frames sent by the browser
-      # in order to avoid chopping off the end of the video
-      # delay closing the browser by N ms
-      DELAY_TO_LET_VIDEO_FINISH_MS = 1000
-      debugVideo('delaying closing the browser by %dms to let video finish', DELAY_TO_LET_VIDEO_FINISH_MS)
-      Promise.delay(DELAY_TO_LET_VIDEO_FINISH_MS)
-
   waitForTestsToFinishRunning: (options = {}) ->
-    { project, screenshots, started, end, name, cname, videoCompression, videoUploadOnPasses, exit, spec, estimated } = options
+    { project, screenshots, startedVideoCapture, endVideoCapture, videoName, compressedVideoName, videoCompression, videoUploadOnPasses, exit, spec, estimated } = options
+
+    ## https://github.com/cypress-io/cypress/issues/2370
+    ## delay 1 second if we're recording a video to give
+    ## the browser padding to render the final frames
+    ## to avoid chopping off the end of the video
+    delay = @getVideoRecordingDelay(startedVideoCapture)
 
     @listenForProjectEnd(project, exit)
-    .tap =>
-      # ? is this the best way to determine if we are recording a video?
-      # TODO rename "end" to something meaningful, like "videoCaptureEnd"
-      return unless end
-      # we are recording video of the test run
-      # and there still might be frames sent by the browser
-      # in order to avoid chopping off the end of the video
-      # delay closing the browser by N ms
-      @_delayToLetVideoFinish()
+    .delay(delay)
     .then (obj) =>
       _.defaults(obj, {
         error: null
@@ -712,9 +760,8 @@ module.exports = {
         reporterStats: null
       })
 
-      # TODO rename "end" to something meaningful, like "videoCaptureEnd"
-      if end
-        obj.video = name
+      if startedVideoCapture
+        obj.video = videoName
 
       if screenshots
         obj.screenshots = screenshots
@@ -736,13 +783,13 @@ module.exports = {
       hasFailingTests = _.get(stats, 'failures') > 0
 
       ## if we have a video recording
-      if started and tests and tests.length
+      if startedVideoCapture and tests and tests.length
         ## always set the video timestamp on tests
-        obj.tests = Reporter.setVideoTimestamp(started, tests)
+        obj.tests = Reporter.setVideoTimestamp(startedVideoCapture, tests)
 
       ## we should upload the video if we upload on passes (by default)
       ## or if we have any failures and have started the video
-      suv = Boolean(videoUploadOnPasses is true or (started and hasFailingTests))
+      suv = Boolean(videoUploadOnPasses is true or (startedVideoCapture and hasFailingTests))
 
       obj.shouldUploadVideo = suv
 
@@ -753,8 +800,8 @@ module.exports = {
       ## electron bug in windows
       openProject.closeBrowser()
       .then =>
-        if end
-          @postProcessRecording(end, name, cname, videoCompression, suv)
+        if endVideoCapture
+          @postProcessRecording(endVideoCapture, videoName, compressedVideoName, videoCompression, suv)
           .then(finish)
           ## TODO: add a catch here
         else
@@ -843,9 +890,9 @@ module.exports = {
       .return(results)
 
   runSpec: (spec = {}, options = {}, estimated) ->
-    { project, browser, video, videosFolder } = options
+    { project, browser } = options
 
-    { isHeadless, isHeaded } = browser
+    { isHeadless } = browser
 
     debug("about to run spec %o", {
       spec
@@ -861,62 +908,39 @@ module.exports = {
     ## we're using an event emitter interface
     ## to gracefully handle this in promise land
 
-    ## if we've been told to record and we're not spawning a headed browser
-    browserCanBeRecorded = (browser) ->
-      browser.name is "electron" and isHeadless
+    @maybeStartVideoRecording({
+      spec,
+      browser,
+      video: options.video,
+      videosFolder: options.videosFolder,
+    })
+    .then (videoRecordProps = {}) =>
+      Promise.props({
+        results: @waitForTestsToFinishRunning({
+          spec
+          project
+          estimated
+          screenshots
+          videoName:            videoRecordProps.videoName 
+          compressedVideoName:  videoRecordProps.compressedVideoName
+          endVideoCapture:      videoRecordProps.endVideoCapture
+          startedVideoCapture:  videoRecordProps.startedVideoCapture
+          exit:                 options.exit
+          videoCompression:     options.videoCompression
+          videoUploadOnPasses:  options.videoUploadOnPasses
+        }),
 
-    if video
-      if browserCanBeRecorded(browser)
-        if not videosFolder
-          throw new Error("Missing videoFolder for recording")
-
-        name  = path.join(videosFolder, spec.name + ".mp4")
-        cname = path.join(videosFolder, spec.name + "-compressed.mp4")
-
-        recording = @createRecording(name)
-      else
-        console.log("")
-
-        if browser.name is "electron" and isHeaded
-          errors.warning("CANNOT_RECORD_VIDEO_HEADED")
-        else
-          errors.warning("CANNOT_RECORD_VIDEO_FOR_THIS_BROWSER", browser.name)
-
-    Promise.resolve(recording)
-    .then (props = {}) =>
-      ## extract the started + ended promises from recording
-      {start, end, write} = props
-
-      ## make sure we start the recording first
-      ## before doing anything
-      Promise.resolve(start)
-      .then (started) =>
-        Promise.props({
-          results: @waitForTestsToFinishRunning({
-            end
-            name
-            spec
-            cname
-            started
-            project
-            estimated
-            screenshots
-            exit:                 options.exit
-            videoCompression:     options.videoCompression
-            videoUploadOnPasses:  options.videoUploadOnPasses
-          }),
-
-          connection: @waitForBrowserToConnect({
-            spec
-            write
-            project
-            browser
-            screenshots
-            socketId:    options.socketId
-            webSecurity: options.webSecurity
-            projectRoot: options.projectRoot
-          })
+        connection: @waitForBrowserToConnect({
+          spec
+          project
+          browser
+          screenshots
+          writeVideoFrame: videoRecordProps.writeVideoFrame
+          socketId:    options.socketId
+          webSecurity: options.webSecurity
+          projectRoot: options.projectRoot
         })
+      })
 
   findSpecs: (config, specPattern) ->
     specsUtil.find(config, specPattern)

--- a/packages/server/lib/video_capture.coffee
+++ b/packages/server/lib/video_capture.coffee
@@ -64,8 +64,6 @@ module.exports = {
 
       if wantsWrite
         if not wantsWrite = pt.write(data)
-          debugFrames("video stream wants to drain")
-      
           pt.once "drain", ->
             debugFrames("video stream drained")
       
@@ -73,7 +71,7 @@ module.exports = {
       else
         skipped += 1
 
-        debugFrames("skipping video frame. total is %d", skipped)
+        debugFrames("skipping video frame %o", { skipped })
 
     startCapturing = ->
       new Promise (resolve) ->

--- a/packages/server/lib/video_capture.coffee
+++ b/packages/server/lib/video_capture.coffee
@@ -1,6 +1,8 @@
 _          = require("lodash")
 utils      = require("fluent-ffmpeg/lib/utils")
 debug      = require("debug")("cypress:server:video")
+# extra verbose logs for logging individual frames
+debugFrames = require("debug")("cypress:server:video:frames")
 ffmpeg     = require("fluent-ffmpeg")
 stream     = require("stream")
 Promise    = require("bluebird")
@@ -59,13 +61,16 @@ module.exports = {
       ## we have written at least 1 byte
       written = true
 
+      debugFrames("video frame")
       if wantsWrite
         if not wantsWrite = pt.write(data)
+          debugFrames("video stream wants to drain")
           pt.once "drain", ->
+            debugFrames("video stream drained")
             wantsWrite = true
       else
         skipped += 1
-        # console.log("skipping frame. total is", skipped)
+        debugFrames("skipping frame. total is %d", skipped)
 
     cmd = ffmpeg({
       source: pt

--- a/packages/server/test/integration/cypress_spec.coffee
+++ b/packages/server/test/integration/cypress_spec.coffee
@@ -805,8 +805,8 @@ describe "lib/cypress", ->
             @expectExitWith(0)
 
         it "electron", ->
-          write = sinon.stub()
-          videoCapture.start.returns({ write })
+          writeVideoFrame = sinon.stub()
+          videoCapture.start.returns({ writeVideoFrame })
 
           cypress.start([
             "--run-project=#{@pluginBrowser}"

--- a/packages/server/test/unit/modes/run_spec.coffee
+++ b/packages/server/test/unit/modes/run_spec.coffee
@@ -371,7 +371,6 @@ describe "lib/modes/run", ->
       sinon.stub(runMode, "postProcessRecording").resolves()
       sinon.spy(runMode,  "displayResults")
       sinon.spy(runMode,  "displayScreenshots")
-      sinon.stub(runMode, "_delayToLetVideoFinish").resolves()
 
       process.nextTick =>
         expect(@projectInstance.listeners("exitEarlyWithErr")).to.have.length(1)

--- a/packages/server/test/unit/modes/run_spec.coffee
+++ b/packages/server/test/unit/modes/run_spec.coffee
@@ -288,6 +288,7 @@ describe "lib/modes/run", ->
   context ".waitForTestsToFinishRunning", ->
     beforeEach ->
       sinon.stub(@projectInstance, "getConfig").resolves({})
+      sinon.stub(runMode, "_delayToLetVideoFinish").resolves()
 
     it "end event resolves with obj, displays stats, displays screenshots, sets video timestamps", ->
       started = new Date
@@ -331,6 +332,8 @@ describe "lib/modes/run", ->
         }
       })
       .then (obj) ->
+        # since video was recording, there was a delay to let video finish
+        expect(runMode._delayToLetVideoFinish).to.be.calledOnce
         expect(runMode.postProcessRecording).to.be.calledWith(end, "foo.mp4", "foo-compressed.mp4", 32, true)
 
         expect(runMode.displayResults).to.be.calledWith(results)
@@ -368,6 +371,7 @@ describe "lib/modes/run", ->
       sinon.stub(runMode, "postProcessRecording").resolves()
       sinon.spy(runMode,  "displayResults")
       sinon.spy(runMode,  "displayScreenshots")
+      sinon.stub(runMode, "_delayToLetVideoFinish").resolves()
 
       process.nextTick =>
         expect(@projectInstance.listeners("exitEarlyWithErr")).to.have.length(1)
@@ -389,6 +393,8 @@ describe "lib/modes/run", ->
         }
       })
       .then (obj) ->
+        # since video was recording, there was a delay to let video finish
+        expect(runMode._delayToLetVideoFinish).to.be.calledOnce
         expect(runMode.postProcessRecording).to.be.calledWith(end, "foo.mp4", "foo-compressed.mp4", 32, true)
 
         expect(runMode.displayResults).to.be.calledWith(obj)


### PR DESCRIPTION
Adds hardcoded delay of 1 second after the end of the test run before closing the browser if there is video recording going on. This allows the last frames to be added, creating the complete video.

- Closes #2370
- added separate debug stream `DEBUG=cypress:server:video:frames` for Electron video frames, which should give more insight into video freezing in #4722  
- [x] fully records video in https://github.com/bahmutov/cypress-test-clock
- [x] fully records the repo from the original issue https://github.com/PinkyJie/cypress-auto-stub-example

## Reviews

Trying something new

- [x] initial review by @Bkucera 
- [x] final review by @brian-mann 

## Before

the last frame of the video

<img width="1277" alt="Screen Shot 2019-07-24 at 10 54 58 AM" src="https://user-images.githubusercontent.com/2212006/61804341-c2540f80-ae01-11e9-86fa-9c7a53db69d4.png">

## After

<img width="1280" alt="Screen Shot 2019-07-24 at 10 56 01 AM" src="https://user-images.githubusercontent.com/2212006/61804364-cc760e00-ae01-11e9-866c-c9384297ece4.png">

### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

- [x] Have tests been added/updated for the changes in this PR?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
