### PR TITLE
fix .and chainer for chai-jquery assertions

### DIFF
--- a/cli/types/cy-chai.d.ts
+++ b/cli/types/cy-chai.d.ts
@@ -1,12 +1,14 @@
 // Shim definition to export a namespace. Cypress is actually a global module
 // so import/export isn't allowed there. We import here and define a global module
 /// <reference path="./chai/index.d.ts" />
-
-export = Chai
-export as namespace Chai
-
 declare namespace Chai {
-  type ChaiStatic = typeof chai
-  type ExpectStatic = typeof chai.expect
-  type AssertStatic = typeof chai.assert
+  interface Include {
+    html(html: string): Assertion
+    text(text: string): Assertion
+    value(text: string): Assertion
+  }
+
+  interface Match {
+      (selector: string): Assertion
+  }
 }

--- a/cli/types/cy-chai.d.ts
+++ b/cli/types/cy-chai.d.ts
@@ -7,8 +7,4 @@ declare namespace Chai {
     text(text: string): Assertion
     value(text: string): Assertion
   }
-
-  interface Match {
-      (selector: string): Assertion
-  }
 }

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -3743,6 +3743,14 @@ declare namespace Cypress {
      */
     (chainer: 'contain.html', value: string): Chainable<Subject>
     /**
+     * Assert that the html of the first element of the selection partially contains the given html, using `.html()`.
+     * @example
+     *    cy.get('#result').should('include.html', '<em>John Doe</em>')
+     * @see http://chaijs.com/plugins/chai-jquery/#htmlhtml
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'include.html', value: string): Chainable<Subject>
+    /**
      * Assert that the first element of the selection has the given id, using `.attr('id')`.
      * @example
      *    cy.get('#result').should('have.id', 'result')
@@ -3776,6 +3784,14 @@ declare namespace Cypress {
      */
     (chainer: 'contain.text', value: string): Chainable<Subject>
     /**
+     * Assert that the text of the first element of the selection partially contains the given text, using `.text()`.
+     * @example
+     *    cy.get('#result').should('include.text', 'John Doe')
+     * @see http://chaijs.com/plugins/chai-jquery/#texttext
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'include.text', value: string): Chainable<Subject>
+    /**
      * Assert that the first element of the selection has the given value, using `.val()`.
      * @example
      *    cy.get('textarea').should('have.value', 'foo bar baz')
@@ -3791,6 +3807,14 @@ declare namespace Cypress {
      * @see https://on.cypress.io/assertions
      */
     (chainer: 'contain.value', value: string): Chainable<Subject>
+    /**
+     * Assert that the first element of the selection partially contains the given value, using `.val()`.
+     * @example
+     *    cy.get('textarea').should('include.value', 'foo bar baz')
+     * @see http://chaijs.com/plugins/chai-jquery/#valuevalue
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'include.value', value: string): Chainable<Subject>
     /**
      * Assert that the selection matches a given selector, using `.is()`. Note that this overrides the built-in chai assertion. If the object asserted against is not a jQuery object, the original implementation will be called.
      * @example
@@ -3947,6 +3971,14 @@ declare namespace Cypress {
      */
     (chainer: 'not.contain.html', value: string): Chainable<Subject>
     /**
+     * Assert that the html of the first element of the selection does not contain the given html, using `.html()`.
+     * @example
+     *    cy.get('#result').should('not.include.html', '<em>John Doe</em>')
+     * @see http://chaijs.com/plugins/chai-jquery/#htmlhtml
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.include.html', value: string): Chainable<Subject>
+    /**
      * Assert that the first element of the selection does not have the given id, using `.attr('id')`.
      * @example
      *    cy.get('#result').should('not.have.id', 'result')
@@ -3980,6 +4012,14 @@ declare namespace Cypress {
      */
     (chainer: 'not.contain.text', value: string): Chainable<Subject>
     /**
+     * Assert that the text of the first element of the selection does not contain the given text, using `.text()`.
+     * @example
+     *    cy.get('#result').should('not.include.text', 'John Doe')
+     * @see http://chaijs.com/plugins/chai-jquery/#texttext
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.include.text', value: string): Chainable<Subject>
+    /**
      * Assert that the first element of the selection does not have the given value, using `.val()`.
      * @example
      *    cy.get('textarea').should('not.have.value', 'foo bar baz')
@@ -3995,6 +4035,14 @@ declare namespace Cypress {
      * @see https://on.cypress.io/assertions
      */
     (chainer: 'not.contain.value', value: string): Chainable<Subject>
+    /**
+     * Assert that the first element of the selection does not contain the given value, using `.val()`.
+     * @example
+     *    cy.get('textarea').should('not.include.value', 'foo bar baz')
+     * @see http://chaijs.com/plugins/chai-jquery/#valuevalue
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.include.value', value: string): Chainable<Subject>
     /**
      * Assert that the selection does not match a given selector, using `.is()`. Note that this overrides the built-in chai assertion. If the object asserted against is not a jQuery object, the original implementation will be called.
      * @example

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -131,6 +131,21 @@ cy.wrap('foo').should('not.contain.value')
 cy.wrap('foo').should('not.contain.text')
 cy.wrap('foo').should('not.contain.html')
 
+cy.wrap('foo').should('include.value')
+cy.wrap('foo').should('include.text')
+cy.wrap('foo').should('include.html')
+cy.wrap('foo').should('not.include.value')
+cy.wrap('foo').should('not.include.text')
+cy.wrap('foo').should('not.incldue.html')
+
+// Ensure we've extended chai.Includes correctly
+expect('foo').to.include.value('foo')
+expect('foo').to.contain.text('foo')
+expect('foo').to.include.html('foo')
+expect('foo').to.not.include.value('foo')
+expect('foo').to.not.include.text('foo')
+expect('foo').to.not.include.html('foo')
+
 cy.wrap([1, 2, 3]).should('include.members', [1, 2])
 ;
 () => {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@cypress/bumpercar": "2.0.9",
     "@cypress/commit-message-install": "2.7.0",
     "@cypress/env-or-json-file": "2.0.0",
-    "@cypress/eslint-plugin-dev": "3.7.0",
+    "@cypress/eslint-plugin-dev": "3.7.1",
     "@cypress/eslint-plugin-json": "3.2.1",
     "@cypress/github-commit-status-check": "1.5.0",
     "@cypress/npm-run-all": "4.0.5",

--- a/packages/driver/src/cypress/chai_jquery.coffee
+++ b/packages/driver/src/cypress/chai_jquery.coffee
@@ -50,9 +50,9 @@ $chaiJquery = (chai, chaiUtils, callbacks = {}) ->
         ctx._obj = ctx._obj.selector
 
       ## apply the assertion
-      ctx.assert(bool, args...)
+      ret = ctx.assert(bool, args...)
       ctx._obj = orig
-      return
+      return ret
     catch err
       ## send it up with the obj and whether it was negated
       callbacks.onError(err, method, ctx._obj, flag(ctx, "negate"))

--- a/packages/driver/src/cypress/chai_jquery.coffee
+++ b/packages/driver/src/cypress/chai_jquery.coffee
@@ -43,6 +43,7 @@ $chaiJquery = (chai, chaiUtils, callbacks = {}) ->
 
     try
       # ## reset obj to wrapped
+      orig = ctx._obj
       ctx._obj = wrap(ctx)
 
       if ctx._obj.length is 0
@@ -50,6 +51,8 @@ $chaiJquery = (chai, chaiUtils, callbacks = {}) ->
 
       ## apply the assertion
       ctx.assert(bool, args...)
+      ctx._obj = orig
+      return
     catch err
       ## send it up with the obj and whether it was negated
       callbacks.onError(err, method, ctx._obj, flag(ctx, "negate"))

--- a/packages/driver/src/cypress/chai_jquery.coffee
+++ b/packages/driver/src/cypress/chai_jquery.coffee
@@ -58,7 +58,7 @@ $chaiJquery = (chai, chaiUtils, callbacks = {}) ->
       callbacks.onError(err, method, ctx._obj, flag(ctx, "negate"))
 
   assertPartial = (ctx, method, actual, expected, message, notMessage, args...) ->
-    if ctx.__flags.contains
+    if ctx.__flags.contains or ctx.__flags.includes
       return assert(
         ctx
         method

--- a/packages/driver/src/cypress/chai_jquery.coffee
+++ b/packages/driver/src/cypress/chai_jquery.coffee
@@ -43,7 +43,6 @@ $chaiJquery = (chai, chaiUtils, callbacks = {}) ->
 
     try
       # ## reset obj to wrapped
-      orig = ctx._obj
       ctx._obj = wrap(ctx)
 
       if ctx._obj.length is 0
@@ -51,7 +50,6 @@ $chaiJquery = (chai, chaiUtils, callbacks = {}) ->
 
       ## apply the assertion
       ctx.assert(bool, args...)
-      ctx._obj = orig
     catch err
       ## send it up with the obj and whether it was negated
       callbacks.onError(err, method, ctx._obj, flag(ctx, "negate"))

--- a/packages/driver/test/cypress/integration/commands/assertions_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/assertions_spec.coffee
@@ -863,6 +863,9 @@ describe "src/cy/commands/assertions", ->
     beforeEach ->
       @logs = []
 
+      @clearLogs = =>
+        @logs = []
+
       cy.on "log:added", (attrs, log) =>
         @logs.push(log)
 
@@ -984,10 +987,9 @@ describe "src/cy/commands/assertions", ->
         @$div = $("<div><button>button</button></div>")
         @$div.html = -> throw new Error("html called")
 
-      it "html, not html", ->
+      it "html, not html, contain html", ->
         expect(@$div).to.have.html("<button>button</button>") ## 1
         expect(@$div).not.to.have.html("foo") ## 2
-
         expect(@logs.length).to.eq(2)
 
         l1 = @logs[0]
@@ -1001,13 +1003,32 @@ describe "src/cy/commands/assertions", ->
           "expected **<div>** not to have HTML **foo**"
         )
 
+        @clearLogs()
+        expect(@$div).to.contain.html("<button>")
+        expect(@logs[0].get('message')).to.eq(
+          "expected **<div>** to contain HTML **<button>**"
+        )
+
+        @clearLogs()
+        expect(@$div).to.not.contain.html("foo") ## 4
+        expect(@logs[0].get('message')).to.eq(
+          "expected **<div>** not to contain HTML **foo**"
+        )
+
+        @clearLogs()
         try
           expect(@$div).to.have.html("<span>span</span>")
         catch err
-          l6 = @logs[5]
-
-          expect(l6.get("message")).to.eq(
+          expect(@logs[0].get("message")).to.eq(
             "expected **<div>** to have HTML **<span>span</span>**, but the HTML was **<button>button</button>**"
+          )
+
+        @clearLogs()
+        try
+          expect(@$div).to.contain.html("<span>span</span>")
+        catch err
+          expect(@logs[0].get("message")).to.eq(
+            "expected **<div>** to contain HTML **<span>span</span>**, but the HTML was **<button>button</button>**"
           )
 
       it "throws when obj is not DOM", (done) ->
@@ -1034,7 +1055,7 @@ describe "src/cy/commands/assertions", ->
         @$div = $("<div>foo</div>")
         @$div.text = -> throw new Error("text called")
 
-      it "text, not text", ->
+      it "text, not text, contain text", ->
         expect(@$div).to.have.text("foo") ## 1
         expect(@$div).not.to.have.text("bar") ## 2
 
@@ -1051,13 +1072,32 @@ describe "src/cy/commands/assertions", ->
           "expected **<div>** not to have text **bar**"
         )
 
+        @clearLogs()
+        expect(@$div).to.contain.text("f")
+        expect(@logs[0].get("message")).to.eq(
+          "expected **<div>** to contain text **f**"
+        )
+
+        @clearLogs()
+        expect(@$div).to.not.contain.text("foob")
+        expect(@logs[0].get("message")).to.eq(
+          "expected **<div>** not to contain text **foob**"
+        )
+
+        @clearLogs()
         try
           expect(@$div).to.have.text("bar")
         catch err
-          l6 = @logs[5]
-
-          expect(l6.get("message")).to.eq(
+          expect(@logs[0].get("message")).to.eq(
             "expected **<div>** to have text **bar**, but the text was **foo**"
+          )
+
+        @clearLogs()
+        try
+          expect(@$div).to.contain.text("bar")
+        catch err
+          expect(@logs[0].get("message")).to.eq(
+            "expected **<div>** to contain text **bar**, but the text was **foo**"
           )
 
       it "partial match", ->
@@ -1085,7 +1125,7 @@ describe "src/cy/commands/assertions", ->
         @$input = $("<input value='foo' />")
         @$input.val = -> throw new Error("val called")
 
-      it "value, not value", ->
+      it "value, not value, contain value", ->
         expect(@$input).to.have.value("foo") ## 1
         expect(@$input).not.to.have.value("bar") ## 2
 
@@ -1102,13 +1142,32 @@ describe "src/cy/commands/assertions", ->
           "expected **<input>** not to have value **bar**"
         )
 
+        @clearLogs()
+        expect(@$input).to.contain.value("foo")
+        expect(@logs[0].get("message")).to.eq(
+          "expected **<input>** to contain value **foo**"
+        )
+        
+        @clearLogs()
+        expect(@$input).not.to.contain.value("bar")
+        expect(@logs[0].get("message")).to.eq(
+          "expected **<input>** not to contain value **bar**"
+        )
+
+        @clearLogs()
         try
           expect(@$input).to.have.value("bar")
         catch err
-          l6 = @logs[5]
-
-          expect(l6.get("message")).to.eq(
+          expect(@logs[0].get("message")).to.eq(
             "expected **<input>** to have value **bar**, but the value was **foo**"
+          )
+
+        @clearLogs()
+        try
+          expect(@$input).to.contain.value("bar")
+        catch err
+          expect(@logs[0].get("message")).to.eq(
+            "expected **<input>** to contain value **bar**, but the value was **foo**"
           )
 
       it "throws when obj is not DOM", (done) ->

--- a/packages/driver/test/cypress/integration/commands/assertions_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/assertions_spec.coffee
@@ -79,8 +79,8 @@ describe "src/cy/commands/assertions", ->
       obj = {requestJSON: {teamIds: [2]}}
       cy.noop(obj).its("requestJSON").should("have.property", "teamIds").should("deep.eq", [2])
 
-    ## TODO: make cy.then retry
-    ## https://github.com/cypress-io/cypress/issues/627
+    # TODO: make cy.then retry
+    # https://github.com/cypress-io/cypress/issues/627
     it.skip "outer assertions retry on cy.then", ->
       obj = {foo: "bar"}
 
@@ -668,6 +668,10 @@ describe "src/cy/commands/assertions", ->
           cy.$$("body").prepend $("<input value='' />")
           cy.get("input").eq(0).then ($input) ->
             expect($input).to.have.attr('value', '')
+
+        it "can chain off of chai-jquery assertions", ->
+          $el = cy.$$('ul#list')
+          expect($el).to.be.visible.and.have.id('list')
 
         describe "without selector", ->
           it "exists", (done) ->

--- a/packages/driver/test/cypress/integration/commands/assertions_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/assertions_spec.coffee
@@ -79,8 +79,8 @@ describe "src/cy/commands/assertions", ->
       obj = {requestJSON: {teamIds: [2]}}
       cy.noop(obj).its("requestJSON").should("have.property", "teamIds").should("deep.eq", [2])
 
-    # TODO: make cy.then retry
-    # https://github.com/cypress-io/cypress/issues/627
+    ## TODO: make cy.then retry
+    ## https://github.com/cypress-io/cypress/issues/627
     it.skip "outer assertions retry on cy.then", ->
       obj = {foo: "bar"}
 

--- a/packages/driver/test/cypress/integration/commands/assertions_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/assertions_spec.coffee
@@ -1025,6 +1025,7 @@ describe "src/cy/commands/assertions", ->
 
       it "partial match", ->
         expect(@$div).to.contain.html('button')
+        expect(@$div).to.include.html('button')
         expect(@$div).to.not.contain.html('span')
         cy.get('button').should('contain.html', 'button')
 
@@ -1062,6 +1063,7 @@ describe "src/cy/commands/assertions", ->
       it "partial match", ->
         expect(@$div).to.have.text('foo')
         expect(@$div).to.contain.text('o')
+        expect(@$div).to.include.text('o')
         cy.get('div').should('contain.text', 'iv').should('contain.text', 'd')
         cy.get('div').should('not.contain.text', 'fizzbuzz').should('contain.text', 'Nest')
 
@@ -1125,16 +1127,20 @@ describe "src/cy/commands/assertions", ->
       it "partial match", ->
         expect(@$input).to.contain.value('oo')
         expect(@$input).to.not.contain.value('oof')
+        ## make sure "includes" is an alias of "include"
+        expect(@$input).to.includes.value('oo')
         cy.get('input')
           .invoke('val','foobar')
           .should('contain.value', 'bar')
           .should('contain.value', 'foo')
+          .should('include.value', 'foo')
         cy.wrap(null).then ->
           cy.$$('<input value="foo1">').prependTo(cy.$$('body'))
           cy.$$('<input value="foo2">').prependTo(cy.$$('body'))
         cy.get('input').should ($els) ->
           expect($els).to.have.value('foo2')
           expect($els).to.contain.value('foo')
+          expect($els).to.include.value('foo')
         .should('contain.value', 'oo2')
 
     context "descendants", ->


### PR DESCRIPTION
<!-- Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md -->

- fixes #4833 
- fixes #4846
- [x] fix error thrown when chaining `.and` off of chai-jquery asserion
- [x] add `includes` as alias of `contains`
- [x] properly extend Chai typedefs + tests for `expect(foo).to.include.html`
- [x] add typedefs for `includes` in `should` style assertions
- [x] add tests for success/fail message in reporter + consoleProps

### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

- [x] Have tests been added/updated for the changes in this PR?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
