### PR TITLE
set node_env for production and add static asset tests

### DIFF
--- a/packages/web-config/webpack.config.base.ts
+++ b/packages/web-config/webpack.config.base.ts
@@ -169,14 +169,17 @@ const config: webpack.Configuration = {
     // })] :
 
     ...(env === 'production' ?
-      [] :
-      // @ts-ignore
-      [new webpack.EvalDevToolModulePlugin({
-        moduleFilenameTemplate: 'cypress://[namespace]/[resource-path]',
-        fallbackModuleFilenameTemplate: 'cypress://[namespace]/[resourcePath]?[hash]',
-      })]
+      [
+        new webpack.DefinePlugin({ 'process.env.NODE_ENV': JSON.stringify('production') }),
+      ] :
+      [
+        // @ts-ignore
+        new webpack.EvalDevToolModulePlugin({
+          moduleFilenameTemplate: 'cypress://[namespace]/[resource-path]',
+          fallbackModuleFilenameTemplate: 'cypress://[namespace]/[resourcePath]?[hash]',
+        }),
+      ]
     ),
-
     ...(liveReloadEnabled ? [new LiveReloadPlugin({ appendScriptTag: 'true', port: 0, hostname: 'localhost' })] : []),
   ],
 

--- a/scripts/binary/util/testStaticAssets.js
+++ b/scripts/binary/util/testStaticAssets.js
@@ -47,6 +47,12 @@ const testStaticAssets = async (buildResourcePath) => {
       goodStrings: [
         // make sure webpack is run with NODE_ENV=production
         `window.env = 'production'`,
+      ],
+    }),
+    testPackageStaticAssets({
+      assetGlob: `${buildResourcePath}/packages/desktop-gui/dist/app.js`,
+      goodStrings: [
+        // make sure webpack is run with NODE_ENV=production
         'react.production.min.js',
       ],
     }),

--- a/scripts/binary/util/testStaticAssets.js
+++ b/scripts/binary/util/testStaticAssets.js
@@ -17,11 +17,14 @@ const testStaticAssets = async (buildResourcePath) => {
       badStrings: [
         // should only exist during development
         'webpack-livereload-plugin',
-        // indicates eval source maps were included, which cause crossorigin errors
+        // indicates eval source maps were included, which cause cross-origin errors
         '//# sourceURL=cypress://',
+        // make sure webpack is not run with NODE_ENV=development
+        'react.development.js',
       ],
       goodStrings: [
-        // indicates inline source maps were included
+        // make sure webpack is run with NODE_ENV=production
+        'react.production.min.js',
       ],
       testAssetStrings: [
         [
@@ -42,7 +45,9 @@ const testStaticAssets = async (buildResourcePath) => {
     testPackageStaticAssets({
       assetGlob: `${buildResourcePath}/packages/desktop-gui/dist/index.html`,
       goodStrings: [
+        // make sure webpack is run with NODE_ENV=production
         `window.env = 'production'`,
+        'react.production.min.js',
       ],
     }),
   ])


### PR DESCRIPTION
<!-- Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md -->
- fix #4844
- [x] Ensure we are bundling the production versions of dependencies for the final binary
### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

- [x] Have tests been added/updated for the changes in this PR?

- [x] ensure bluebird longStackTraces can be set in prod mode
	- verified building binary and in open mode, `Cypress.Promise.hasLongStackTraces()` was `true`
- [x] verify testStaticAssets will fail when NODE_ENV isn't `production`
- [x] open + tag issue for this PR