### PR TITLE
Update logic of actionability to check for "writability" only if the action is "typing"

### DIFF
--- a/packages/driver/src/cy/actionability.coffee
+++ b/packages/driver/src/cy/actionability.coffee
@@ -208,7 +208,7 @@ ensureNotAnimating = (cy, $el, coordsHistory, animationDistanceThreshold) ->
   ## 5 pixels of x/y
   cy.ensureElementIsNotAnimating($el, coordsHistory, animationDistanceThreshold)
 
-verify = (cy, $el, options, callbacks) ->
+verify = (cy, $el, options, actionType, callbacks) ->
   win = $dom.getWindowByElement($el.get(0))
 
   { _log, force, position } = options
@@ -241,8 +241,12 @@ verify = (cy, $el, options, callbacks) ->
         ## ensure its visible
         cy.ensureVisibility($el, _log)
 
-        ## ensure its 'receivable' (not disabled, readonly)
+        ## ensure its 'receivable' (not disabled)
         cy.ensureReceivability($el, _log)
+
+        ## ensure its 'writable' only when typing (not readonly)
+        if actionType is 'type'
+          cy.ensureWriteability($el, _log)
 
       ## now go get all the coords for this element
       coords = getCoordinatesForEl(cy, $el, options)

--- a/packages/driver/src/cy/commands/actions/click.js
+++ b/packages/driver/src/cy/commands/actions/click.js
@@ -153,7 +153,7 @@ module.exports = (Commands, Cypress, cy, state, config) => {
         //# because we're issuing the clicks synchonrously
         //# once we establish the coordinates and the element
         //# passes all of the internal checks
-        return $actionability.verify(cy, $el, options, {
+        return $actionability.verify(cy, $el, options, 'click', {
           onScroll ($el, type) {
             return Cypress.action('cy:scrolled', $el, type)
           },

--- a/packages/driver/src/cy/commands/actions/trigger.coffee
+++ b/packages/driver/src/cy/commands/actions/trigger.coffee
@@ -77,7 +77,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
         if dispatchEarly
           return dispatch(subject, eventName, eventOptions)
 
-        $actionability.verify(cy, subject, options, {
+        $actionability.verify(cy, subject, options, 'trigger', {
           onScroll: ($el, type) ->
             Cypress.action("cy:scrolled", $el, type)
 

--- a/packages/driver/src/cy/commands/actions/type.coffee
+++ b/packages/driver/src/cy/commands/actions/type.coffee
@@ -354,7 +354,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
           ## TODO: not scrolling here, but revisit when scroll algorithm changes
           return type()
 
-        $actionability.verify(cy, options.$el, options, {
+        $actionability.verify(cy, options.$el, options, 'type', {
           onScroll: ($el, type) ->
             Cypress.action("cy:scrolled", $el, type)
 

--- a/packages/driver/src/cy/ensures.coffee
+++ b/packages/driver/src/cy/ensures.coffee
@@ -112,6 +112,8 @@ create = (state, expect) ->
         args: { cmd, node }
       })
 
+  ensureWriteability = (subject, onFail) -> 
+    cmd = state("current").get("name")
     # readonly can only be applied to input/textarea
     # not on checkboxes, radios, etc..
     if $dom.isTextLike(subject) and subject.prop("readonly")
@@ -326,6 +328,8 @@ create = (state, expect) ->
     ensureElementIsNotAnimating
 
     ensureReceivability
+
+    ensureWriteability
 
     ensureVisibility
 

--- a/packages/driver/src/cypress/cy.coffee
+++ b/packages/driver/src/cypress/cy.coffee
@@ -672,6 +672,7 @@ create = (specWindow, Cypress, Cookies, state, config, log) ->
     ensureVisibility: ensures.ensureVisibility
     ensureDescendents: ensures.ensureDescendents
     ensureReceivability: ensures.ensureReceivability
+    ensureWriteability: ensures.ensureWriteability
     ensureValidPosition: ensures.ensureValidPosition
     ensureScrollability: ensures.ensureScrollability
     ensureElementIsNotAnimating: ensures.ensureElementIsNotAnimating

--- a/packages/driver/test/cypress/fixtures/dom.html
+++ b/packages/driver/test/cypress/fixtures/dom.html
@@ -289,7 +289,7 @@
           <input type="submit" value ="submit me2" />
         </form>
 
-        <form>
+        <form id="readonly">
           <!-- All values are valid readonly -->
           <input id="readonly-attr" readonly />
           <input id="readonly-readonly" readonly="readonly" />
@@ -297,6 +297,13 @@
 
           <!-- Although not strictly part of spec, Chrome respects any string -->
           <input id="readonly-str" readonly="abc" />
+
+          <!-- readonly doesn't enforce on non typeable inputs -->
+          <input type="checkbox" id="readonly-checkbox" readonly />
+          <input type="submit" id="readonly-submit" value="readonly click" readonly />
+          <select name="hunter" readonly>
+            <option value="gon-val" readonly>gon</option>
+          </select>
         </form>
       </div>
 

--- a/packages/driver/test/cypress/fixtures/dom.html
+++ b/packages/driver/test/cypress/fixtures/dom.html
@@ -363,7 +363,7 @@
         <a href="#">5</a>
       </div>
 
-      <select name="maps">
+      <select id="select-maps" name="maps">
         <option value="de_dust2">dust2</option>
         <option value="de_aztec">inferno</option>
         <option value="de_nuke">nuke</option>

--- a/packages/driver/test/cypress/integration/commands/actions/check_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/check_spec.coffee
@@ -75,6 +75,11 @@ describe "src/cy/commands/actions/check", ->
         done("should not fire change event")
 
       cy.get(checkbox).check()
+    
+    ## readonly should only be limited to inputs, not checkboxes
+    it "can check readonly checkboxes", ->
+      cy.get('#readonly-checkbox').check().then ($checkbox) ->
+        expect($checkbox).to.be.checked
 
     it "does not require visibility with force: true", ->
       checkbox = ":checkbox[name='birds']"

--- a/packages/driver/test/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/click_spec.js
@@ -613,9 +613,17 @@ describe('src/cy/commands/actions/click', () => {
     })
 
     describe('actionability', () => {
-
       it('can click on inline elements that wrap lines', () => {
         cy.get('#overflow-link').find('.wrapped').click()
+      })
+
+      // readonly should only limit typing, not clicking
+      it('can click on readonly inputs', () => {
+        cy.get('#readonly-attr').click()
+      })
+
+      it('can click on readonly submit inputs', () => {
+        cy.get('#readonly-submit').click()
       })
 
       it('can click elements which are hidden until scrolled within parent container', () => {

--- a/packages/driver/test/cypress/integration/commands/actions/focus_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/focus_spec.coffee
@@ -153,6 +153,14 @@ describe "src/cy/commands/actions/focus", ->
       cy.get("[data-cy=rect]").focus().then ->
         expect(onFocus).to.be.calledOnce
 
+    it "can focus on readonly inputs", ->
+      onFocus = cy.stub()
+
+      cy.$$("#readonly-attr").focus(onFocus)
+
+      cy.get("#readonly-attr").focus().then ->
+        expect(onFocus).to.be.calledOnce
+
     describe "assertion verification", ->
       beforeEach ->
         cy.on "log:added", (attrs, log) =>

--- a/packages/driver/test/cypress/integration/commands/actions/select_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/select_spec.coffee
@@ -66,6 +66,11 @@ describe "src/cy/commands/actions/select", ->
       cy.get("select[name=movies]").select(["The Human Condition", "There Will Be Blood"]).then ($select) ->
         expect($select.val()).to.deep.eq ["thc", "twbb"]
 
+    ## readonly should only be limited to inputs, not checkboxes
+    it "can select a readonly select", ->
+      cy.get("select[name=hunter]").select("gon").then ($select) ->
+        expect($select.val()).to.eq("gon-val")
+
     it "clears previous values when providing an array", ->
       ## make sure we have a previous value
       select = cy.$$("select[name=movies]").val(["2001"])

--- a/packages/driver/test/cypress/integration/commands/actions/select_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/select_spec.coffee
@@ -80,17 +80,16 @@ describe "src/cy/commands/actions/select", ->
         expect($select.val()).to.deep.eq ["apoc", "br"]
 
     it "lists the select as the focused element", ->
-      select = cy.$$("select:first")
+      select = cy.$$("#select-maps")
 
-      cy.get("select:first").select("de_train").focused().then ($focused) ->
+      cy.get("#select-maps").select("de_train").focused().then ($focused) ->
         expect($focused.get(0)).to.eq select.get(0)
 
     it "causes previous input to receive blur", (done) ->
       cy.$$("input:text:first").blur -> done()
 
-      cy
-        .get("input:text:first").type("foo")
-        .get("select:first").select("de_train")
+      cy.get("input:text:first").type("foo")
+      cy.get("#select-maps").select("de_train")
 
     it "can forcibly click even when being covered by another element", (done) ->
       select  = $("<select><option>foo</option></select>").attr("id", "select-covered-in-span").prependTo(cy.$$("body"))
@@ -112,19 +111,19 @@ describe "src/cy/commands/actions/select", ->
       cy.get("#select-covered-in-span").select("foobar", {timeout: 1000, interval: 60})
 
     it "can forcibly click even when element is invisible", (done) ->
-      select = cy.$$("select:first").hide()
+      select = cy.$$("#select-maps").hide()
 
       select.click -> done()
 
-      cy.get("select:first").select("de_dust2", {force: true})
+      cy.get("#select-maps").select("de_dust2", {force: true})
 
     it "retries until <option> can be selected", ->
       option = cy.$$("<option>foo</option>")
 
       cy.on "command:retry", _.once =>
-        cy.$$("select:first").append option
+        cy.$$("#select-maps").append option
 
-      cy.get("select:first").select("foo")
+      cy.get("#select-maps").select("foo")
 
     it "retries until <select> is no longer disabled", ->
       select = cy.$$("select[name=disabled]")
@@ -151,12 +150,12 @@ describe "src/cy/commands/actions/select", ->
         return null
 
       it "eventually passes the assertion", ->
-        cy.$$("select:first").change ->
+        cy.$$("#select-maps").change ->
           _.delay =>
             $(@).addClass("selected")
           , 100
 
-        cy.get("select:first").select("de_nuke").should("have.class", "selected").then ->
+        cy.get("#select-maps").select("de_nuke").should("have.class", "selected").then ->
           lastLog = @lastLog
 
           expect(lastLog.get("name")).to.eq("assert")
@@ -215,7 +214,7 @@ describe "src/cy/commands/actions/select", ->
       it "throws when subject is not in the document", (done) ->
         selected = 0
 
-        $select = cy.$$("select:first").change (e) ->
+        $select = cy.$$("#select-maps").change (e) ->
           selected += 1
           $select.remove()
 
@@ -224,7 +223,7 @@ describe "src/cy/commands/actions/select", ->
           expect(err.message).to.include "cy.select() failed because this element"
           done()
 
-        cy.get("select:first").select("de_dust2").select("de_aztec")
+        cy.get("#select-maps").select("de_dust2").select("de_aztec")
 
       it "throws when more than 1 element in the collection", (done) ->
         num = cy.$$("select").length
@@ -259,13 +258,13 @@ describe "src/cy/commands/actions/select", ->
         cy.get("select[name=names]").select(["bm", "ss"])
 
       it "throws when the subject isnt visible", (done) ->
-        select = cy.$$("select:first").show().hide()
+        select = cy.$$("#select-maps").show().hide()
 
         cy.on "fail", (err) ->
           expect(err.message).to.include "cy.select() failed because this element is not visible"
           done()
 
-        cy.get("select:first").select("de_dust2")
+        cy.get("#select-maps").select("de_dust2")
 
       it "throws when value or text does not exist", (done) ->
         cy.on "fail", (err) ->
@@ -300,14 +299,14 @@ describe "src/cy/commands/actions/select", ->
 
           done()
 
-        cy.get("select:first").select("de_nuke").should("have.class", "selected")
+        cy.get("#select-maps").select("de_nuke").should("have.class", "selected")
 
       it "does not log an additional log on failure", (done) ->
         cy.on "fail", =>
           expect(@logs.length).to.eq(3)
           done()
 
-        cy.get("select:first").select("de_nuke").should("have.class", "selected")
+        cy.get("#select-maps").select("de_nuke").should("have.class", "selected")
 
       it "only logs once on failure", (done) ->
         cy.on "fail", (err) =>
@@ -315,7 +314,7 @@ describe "src/cy/commands/actions/select", ->
           expect(@logs.length).to.eq(2)
           done()
 
-        cy.get("select:first").select("does_not_exist")
+        cy.get("#select-maps").select("does_not_exist")
 
     describe ".log", ->
       beforeEach ->
@@ -328,19 +327,19 @@ describe "src/cy/commands/actions/select", ->
         return null
 
       it "logs out select", ->
-        cy.get("select:first").select("de_dust2").then ->
+        cy.get("#select-maps").select("de_dust2").then ->
           lastLog = @lastLog
 
           expect(lastLog.get("name")).to.eq "select"
 
       it "passes in $el", ->
-        cy.get("select:first").select("de_dust2").then ($select) ->
+        cy.get("#select-maps").select("de_dust2").then ($select) ->
           lastLog = @lastLog
 
           expect(lastLog.get("$el")).to.eq $select
 
       it "snapshots before clicking", (done) ->
-        cy.$$("select:first").change =>
+        cy.$$("#select-maps").change =>
           lastLog = @lastLog
 
           expect(lastLog.get("snapshots").length).to.eq(1)
@@ -348,10 +347,10 @@ describe "src/cy/commands/actions/select", ->
           expect(lastLog.get("snapshots")[0].body).to.be.an("object")
           done()
 
-        cy.get("select:first").select("de_dust2").then ($select) ->
+        cy.get("#select-maps").select("de_dust2").then ($select) ->
 
       it "snapshots after clicking", ->
-        cy.get("select:first").select("de_dust2").then ($select) ->
+        cy.get("#select-maps").select("de_dust2").then ($select) ->
           lastLog = @lastLog
 
           expect(lastLog.get("snapshots").length).to.eq(2)
@@ -359,22 +358,22 @@ describe "src/cy/commands/actions/select", ->
           expect(lastLog.get("snapshots")[1].body).to.be.an("object")
 
       it "is not immediately ended", (done) ->
-        cy.$$("select:first").click =>
+        cy.$$("#select-maps").click =>
           lastLog = @lastLog
 
           expect(lastLog.get("state")).to.eq("pending")
           done()
 
-        cy.get("select:first").select("de_dust2")
+        cy.get("#select-maps").select("de_dust2")
 
       it "ends", ->
-        cy.get("select:first").select("de_dust2").then ->
+        cy.get("#select-maps").select("de_dust2").then ->
           lastLog = @lastLog
 
           expect(lastLog.get("state")).to.eq("passed")
 
       it "#consoleProps", ->
-        cy.get("select:first").select("de_dust2").then ($select) ->
+        cy.get("#select-maps").select("de_dust2").then ($select) ->
           { fromWindow } = Cypress.dom.getElementCoordinatesByPosition($select)
           console = @lastLog.invoke("consoleProps")
           expect(console.Command).to.eq("select")
@@ -390,12 +389,12 @@ describe "src/cy/commands/actions/select", ->
           if log.get("name") is "select"
             types.push(log)
 
-        cy.get("select:first").select("de_dust2").then ->
+        cy.get("#select-maps").select("de_dust2").then ->
           expect(@logs.length).to.eq(2)
           expect(types.length).to.eq(1)
 
       it "logs deltaOptions", ->
-        cy.get("select:first").select("de_dust2", {force: true, timeout: 1000}).then ->
+        cy.get("#select-maps").select("de_dust2", {force: true, timeout: 1000}).then ->
           lastLog = @lastLog
 
           expect(lastLog.get("message")).to.eq "{force: true, timeout: 1000}"

--- a/packages/driver/test/cypress/integration/commands/actions/trigger_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/actions/trigger_spec.coffee
@@ -166,6 +166,9 @@ describe "src/cy/commands/actions/trigger", ->
       it "can trigger on elements which are hidden until scrolled within parent container", ->
         cy.get("#overflow-auto-container").contains("quux").trigger("mousedown")
 
+      it "can trigger on readonly inputs", ->
+        cy.get("#readonly-attr").trigger("mousedown")
+
       it "does not scroll when being forced", ->
         scrolled = []
 


### PR DESCRIPTION
- close #4874
- Write tests to ensure other actions happen appropriately on readonly elements