### PR TITLE
re-add post-decaffeinate-bulk npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "cypress:verify": "node ./cli/bin/cypress verify --dev",
     "predecaffeinate-bulk": "shx cp .eslintrc.decaffeinate.js .eslintrc.js",
     "decaffeinate-bulk": "bulk-decaffeinate",
+    "postdecaffeinate-bulk": "shx rm .eslintrc.js",
     "dev": "node ./scripts/start.js",
     "dev-debug": "node ./scripts/debug.js dev",
     "docker": "./scripts/run-docker-local.sh",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cypress:verify": "node ./cli/bin/cypress verify --dev",
     "predecaffeinate-bulk": "shx cp .eslintrc.decaffeinate.js .eslintrc.js",
     "decaffeinate-bulk": "bulk-decaffeinate",
-    "postdecaffeinate-bulk": "shx rm .eslintrc.js",
+    "postdecaffeinate-bulk": "shx rm .eslintrc.js || true",
     "dev": "node ./scripts/start.js",
     "dev-debug": "node ./scripts/debug.js dev",
     "docker": "./scripts/run-docker-local.sh",


### PR DESCRIPTION
this way the `eslintrc.js` override file will be deleted after decaffeinate

not sure how it got removed