### PR TITLE
WIP: #4452 Add message specify_file_by_relative_path

### DIFF
--- a/packages/desktop-gui/src/styles/components/_alerts.scss
+++ b/packages/desktop-gui/src/styles/components/_alerts.scss
@@ -42,12 +42,17 @@
   display: flex;
   flex-grow: 2;
   justify-content: center;
+  overflow: auto;
+  padding: 30px 60px;
 }
 
 .full-alert {
+  // `margin: auto` fixes issue with flexbox vertically-centered element + oveflow
+  // https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container
+  margin: auto;
   overflow: auto;
-  text-align: center;
   padding: 20px;
+  text-align: center;
 
   .alert-content {
     text-align: left;
@@ -61,6 +66,11 @@
 
   code {
     padding: 1px 4px;
+  }
+
+  pre {
+    max-height: 200px;
+    overflow: auto;
   }
 
   summary {

--- a/packages/driver/src/cy/commands/navigation.coffee
+++ b/packages/driver/src/cy/commands/navigation.coffee
@@ -71,6 +71,14 @@ cannotVisit2ndDomain = (origin, previousDomainVisited, log) ->
     }
   })
 
+specifyFileByRelativePath = (url, log) ->
+  $utils.throwErrByPath("visit.specify_file_by_relative_path", {
+    onFail: log
+    args: {
+      attemptedUrl: url
+    }
+  })
+
 aboutBlank = (win) ->
   new Promise (resolve) ->
     cy.once("window:load", resolve)
@@ -602,6 +610,9 @@ module.exports = (Commands, Cypress, cy, state, config) ->
         existing = $utils.locExisting()
 
         ## TODO: $Location.resolve(existing.origin, url)
+
+        if $Location.isLocalFileUrl(url)
+          return specifyFileByRelativePath(url, options._log)
 
         ## in the case we are visiting a relative url
         ## then prepend the existing origin to it

--- a/packages/driver/src/cypress/error_messages.coffee
+++ b/packages/driver/src/cypress/error_messages.coffee
@@ -1090,6 +1090,13 @@ module.exports = {
 
         #{cmd('request')} will automatically get and set cookies and enable you to parse responses.
       """
+    specify_file_by_relative_path: """
+      #{cmd('visit')} failed because the 'file://...' protocol is not supported by Cypress.
+
+      However, you can pass in the relative path to the file from your projectRoot.
+
+      https://docs.cypress.io/api/commands/visit.html
+    """
 
   wait:
     alias_invalid: "'{{prop}}' is not a valid alias property. Are you trying to ask for the first request? If so write @{{str}}.request"

--- a/packages/driver/src/cypress/location.coffee
+++ b/packages/driver/src/cypress/location.coffee
@@ -19,6 +19,7 @@ ipAddressRe = /^[\d\.]+$/
 
 reHttp = /^https?:\/\//
 reWww = /^www/
+reFile = /^file:\/\//
 
 reLocalHost = /^(localhost|0\.0\.0\.0|127\.0\.0\.1)/
 
@@ -129,6 +130,9 @@ class $Location
       superDomain: @getSuperDomain()
       toString: _.bind(@getToString, @)
     }
+
+  @isLocalFileUrl = (url) ->
+    reFile.test(url)
 
   @isFullyQualifiedUrl = (url) ->
     reHttp.test(url)


### PR DESCRIPTION
<!-- Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md -->

- Closes #4452

### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

- [ ] Have tests been added/updated for the changes in this PR? (TODO)
- [x] Has a PR to [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation) been submitted to document any user-facing changes https://github.com/cypress-io/cypress-documentation/issues/1989


I've added an error message notifying the user that the "file:///" protocol isn't supported by Cypress.  I'm marking this PR as a WIP because
* The error message can be improved.
* The documentation to cy.visit() does not specify that the "file:///" protocol isn't supported. I need to add a note to this page.
* Where should I add the test?  I cannot add it to navigation_spec.coffee because of the same origin policy.  In other words, I cannot just have a test with a single cy.visit('file:///....') command.  The cypress.json file has the baseUrl specified.