### PR TITLE
fix skipped test in screenshot_spec

### DIFF
--- a/packages/driver/test/cypress/integration/commands/screenshot_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/screenshot_spec.coffee
@@ -44,6 +44,7 @@ describe "src/cy/commands/screenshot", ->
       .then ->
         expect(Cypress.action).not.to.be.calledWith("cy:test:set:state")
         expect(Cypress.automation).not.to.be.called
+        Cypress.config("isTextTerminal", true)
 
     it "is noop when no test.err", ->
       Cypress.config("isInteractive", false)

--- a/packages/driver/test/cypress/integration/commands/screenshot_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/screenshot_spec.coffee
@@ -44,6 +44,7 @@ describe "src/cy/commands/screenshot", ->
       .then ->
         expect(Cypress.action).not.to.be.calledWith("cy:test:set:state")
         expect(Cypress.automation).not.to.be.called
+      .finally ->
         Cypress.config("isTextTerminal", true)
 
     it "is noop when no test.err", ->


### PR DESCRIPTION
this way we wont get the one "skipped due to hook failure" test in the report
![image](https://user-images.githubusercontent.com/14625260/62306913-b5ae6780-b450-11e9-9044-f53f16014470.png)
