### PR TITLE
Provide strong types for 'invoke' command (#4022)

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -810,9 +810,15 @@ declare namespace Cypress {
     hash(options?: Partial<Loggable & Timeoutable>): Chainable<string>
 
     /**
-     * Invoke a function on the previously yielded subject.
+     * Invoke a function on the previously yielded subject, yielding the result.
      *
      * @see https://on.cypress.io/invoke
+     * @example
+     *    // Invoke the 'add' function, passing in parameters
+     *    cy.wrap({ add: (a, b) => a + b }).invoke('add', 1, 2).should('eq', 3)
+     *    // DOM elements are automatically wrapped with jQuery,
+     *    //   so jQuery functions (including 3rd party plugins) can be invoked
+     *    cy.get('.modal').invoke('show').should('be.visible') // jQuery's 'show' functions
      */
     invoke<
       TActualSubject extends (Subject extends Node | Node[] ? JQuery<Subject> : Subject),

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -815,9 +815,10 @@ declare namespace Cypress {
      * @see https://on.cypress.io/invoke
      */
     invoke<
-      TName extends { [K in keyof Subject]: Subject[K] extends (...args: any[]) => any ? K : never }[keyof Subject],
-      TArgs extends Subject[TName] extends (...args: infer A) => any ? A : never,
-      TReturn extends Subject[TName] extends (...args: any[]) => infer R ? R : never,
+      TActualSubject extends (Subject extends Node | Node[] ? JQuery<Subject> : Subject),
+      TName extends ({ [K in keyof TActualSubject]: TActualSubject[K] extends (...args: any[]) => any ? K : never }[keyof TActualSubject]),
+      TArgs extends (TActualSubject[TName] extends (...args: infer A) => any ? A : never),
+      TReturn extends (TActualSubject[TName] extends (...args: any[]) => infer R ? R : never),
     >(functionName: TName, ...args: TArgs): Chainable<TReturn>
 
     /**

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -814,7 +814,10 @@ declare namespace Cypress {
      *
      * @see https://on.cypress.io/invoke
      */
-    invoke<K extends { [K in keyof Subject]: Subject[K] extends (...args: any[]) => any ? K : never }[keyof Subject], R extends Subject[K] extends (...args: any[]) => infer R ? R : never>(functionName: K, ...args: any[]): Chainable<R>
+    invoke<
+      TName extends { [K in keyof Subject]: Subject[K] extends (...args: any[]) => any ? K : never }[keyof Subject],
+      TReturn extends Subject[TName] extends (...args: any[]) => infer R ? R : never,
+    >(functionName: TName, ...args: any[]): Chainable<TReturn>
 
     /**
      * Get a property’s value on the previously yielded subject.

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -811,14 +811,10 @@ declare namespace Cypress {
 
     /**
      * Invoke a function on the previously yielded subject.
-     * This isn't possible to strongly type without generic override yet.
-     * If called on an object you can do this instead: `.then(s => s.show())`.
-     * If called on an array you can do this instead: `.each(s => s.show())`.
-     * From there the subject will be properly typed.
      *
      * @see https://on.cypress.io/invoke
      */
-    invoke(functionName: keyof Subject, ...args: any[]): Chainable<Subject> // don't have a way to express return types yet
+    invoke<K extends { [K in keyof Subject]: Subject[K] extends (...args: any[]) => any ? K : never }[keyof Subject], R extends Subject[K] extends (...args: any[]) => infer R ? R : never>(functionName: K, ...args: any[]): Chainable<R>
 
     /**
      * Get a property’s value on the previously yielded subject.

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -4,7 +4,7 @@
 //                 Mike Woudenberg <https://github.com/mikewoudenberg>
 //                 Robbert van Markus <https://github.com/rvanmarkus>
 //                 Nicholas Boll <https://github.com/nicholasboll>
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 // Updated by the Cypress team: https://www.cypress.io/about/
 
 /// <reference path="./cy-blob-util.d.ts" />
@@ -816,8 +816,9 @@ declare namespace Cypress {
      */
     invoke<
       TName extends { [K in keyof Subject]: Subject[K] extends (...args: any[]) => any ? K : never }[keyof Subject],
+      TArgs extends Subject[TName] extends (...args: infer A) => any ? A : never,
       TReturn extends Subject[TName] extends (...args: any[]) => infer R ? R : never,
-    >(functionName: TName, ...args: any[]): Chainable<TReturn>
+    >(functionName: TName, ...args: TArgs): Chainable<TReturn>
 
     /**
      * Get a property’s value on the previously yielded subject.

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -301,8 +301,10 @@ cy.wrap('foobar').should('not.have.string', 'baz')
 
 cy.wrap('foobar').should('not.include', 'baz')
 
-cy.wrap({ foo: () => 1, bar: 2 }).invoke('foo').should('equal', 1)
-// cy.wrap({ foo: () => 1, bar: 2 }).invoke('bar') // compile ERROR
+const mrObj = { foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`, bar: 2 }
+cy.wrap(mrObj).invoke('foo', 1) // $ExpectType Chainable<string>
+cy.wrap(mrObj).invoke('foo', 5, 'b') // $ExpectType Chainable<string>
+cy.wrap(mrObj).invoke('bar') // $ExpectError
 
 ;
 () => {

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -301,12 +301,18 @@ cy.wrap('foobar').should('not.have.string', 'baz')
 
 cy.wrap('foobar').should('not.include', 'baz')
 
-const mrObj = { foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`, bar: 2 }
-cy.wrap(mrObj).invoke('foo', 1) // $ExpectType Chainable<string>
-cy.wrap(mrObj).invoke('foo', 5, 'b') // $ExpectType Chainable<string>
-cy.wrap(mrObj).invoke('bar') // $ExpectError
+const mrObj = {
+  foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`,
+  bar: { baz: (a: number) => a + 1 }
+}
+cy.wrap(mrObj).invoke('foo', 1).should('equal', 'n = 2') // $ExpectType Chainable<string>
+cy.wrap(mrObj).invoke('foo', 5, 'b').should('equal', 'b = 6') // $ExpectType Chainable<string>
+cy.wrap(mrObj).its('bar').invoke('baz', 2).should('equal', 3) // $ExpectType Chainable<number>
+cy.wrap(mrObj).invoke('bar', 2) // $ExpectError
+cy.wrap(mrObj).invoke('bar.baz', 2).should('equal', 3) // $ExpectError
 cy.wrap(mrObj).invoke('foo', 5, 1) // $ExpectError
 cy.wrap(mrObj).invoke('foo', 5, 'b', 1) // $ExpectError
+cy.get('input').then(it => it[0]).invoke('checkValidity') // $ExpectError
 
 ;
 () => {

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -301,19 +301,6 @@ cy.wrap('foobar').should('not.have.string', 'baz')
 
 cy.wrap('foobar').should('not.include', 'baz')
 
-const mrObj = {
-  foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`,
-  bar: { baz: (a: number) => a + 1 }
-}
-cy.wrap(mrObj).invoke('foo', 1).should('equal', 'n = 2') // $ExpectType Chainable<string>
-cy.wrap(mrObj).invoke('foo', 5, 'b').should('equal', 'b = 6') // $ExpectType Chainable<string>
-cy.wrap(mrObj).its('bar').invoke('baz', 2).should('equal', 3) // $ExpectType Chainable<number>
-cy.wrap(mrObj).invoke('bar', 2) // $ExpectError
-cy.wrap(mrObj).invoke('bar.baz', 2).should('equal', 3) // $ExpectError
-cy.wrap(mrObj).invoke('foo', 5, 1) // $ExpectError
-cy.wrap(mrObj).invoke('foo', 5, 'b', 1) // $ExpectError
-cy.get('input').then(it => it[0]).invoke('checkValidity') // $ExpectError
-
 ;
 () => {
   let val = 1

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -305,6 +305,8 @@ const mrObj = { foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`
 cy.wrap(mrObj).invoke('foo', 1) // $ExpectType Chainable<string>
 cy.wrap(mrObj).invoke('foo', 5, 'b') // $ExpectType Chainable<string>
 cy.wrap(mrObj).invoke('bar') // $ExpectError
+cy.wrap(mrObj).invoke('foo', 5, 1) // $ExpectError
+cy.wrap(mrObj).invoke('foo', 5, 'b', 1) // $ExpectError
 
 ;
 () => {

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -301,6 +301,9 @@ cy.wrap('foobar').should('not.have.string', 'baz')
 
 cy.wrap('foobar').should('not.include', 'baz')
 
+cy.wrap({ foo: () => 1, bar: 2 }).invoke('foo').should('equal', 1)
+// cy.wrap({ foo: () => 1, bar: 2 }).invoke('bar') // compile ERROR
+
 ;
 () => {
   let val = 1

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -317,3 +317,18 @@ namespace CypressContainsTests {
   cy.contains('#app', 'my text to find', {log: false, timeout: 100})
   cy.contains('my text to find', {log: false, timeout: 100})
 }
+
+namespace CypressInvokeTests {
+  const obj = {
+    foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`,
+    bar: { baz: (a: number) => a + 1 }
+  }
+  cy.wrap(obj).invoke('foo', 1).should('equal', 'n = 2') // $ExpectType Chainable<string>
+  cy.wrap(obj).invoke('foo', 5, 'b').should('equal', 'b = 6') // $ExpectType Chainable<string>
+  cy.wrap(obj).its('bar').invoke('baz', 2).should('equal', 3) // $ExpectType Chainable<number>
+  cy.wrap(obj).invoke('bar', 2) // $ExpectError
+  cy.wrap(obj).invoke('bar.baz', 2).should('equal', 3) // $ExpectError
+  cy.wrap(obj).invoke('foo', 5, 1) // $ExpectError
+  cy.wrap(obj).invoke('foo', 5, 'b', 1) // $ExpectError
+  cy.get('input').then(it => it[0]).invoke('checkValidity') // $ExpectError
+}


### PR DESCRIPTION
Closes #4022

Provides strong typing for arguments and return type of `invoke` command. Also ensures `functionName` is the key of a function on the `Subject`.

Since typing becomes more strict, this is technically a breaking change, but isn't considered a big deal (see https://github.com/cypress-io/cypress/pull/4907#issuecomment-517582651)

### Pre-merge Tasks

- [x] Have tests been added/updated for the changes in this PR?
- [x] Have the [type definitions](cli/types/index.d.ts) been updated with any user-facing API changes?
