### PR TITLE
Do not crash on invalid HTTP CONNECT

### DIFF
--- a/packages/https-proxy/lib/server.coffee
+++ b/packages/https-proxy/lib/server.coffee
@@ -139,6 +139,8 @@ class Server
 
       browserSocket.resume()
 
+    port or= "443"
+
     if upstreamProxy = @_getProxyForUrl("https://#{hostname}:#{port}")
       # todo: as soon as all requests are intercepted, this can go away since this is just for pass-through
       debug("making proxied connection %o", {

--- a/packages/https-proxy/test/unit/server_spec.coffee
+++ b/packages/https-proxy/test/unit/server_spec.coffee
@@ -43,11 +43,11 @@ describe "lib/server", ->
       socket.destroy = @sandbox.stub()
       head = {}
 
-      onError = (err, socket, head, port) ->
+      onError = (err, socket2, head2, port) ->
         expect(err.message).to.eq("connect ECONNREFUSED 127.0.0.1:8444")
 
-        expect(socket).to.eq(socket)
-        expect(head).to.eq(head)
+        expect(socket).to.eq(socket2)
+        expect(head).to.eq(head2)
         expect(port).to.eq("8444")
 
         expect(socket.destroy).to.be.calledOnce
@@ -66,11 +66,11 @@ describe "lib/server", ->
       socket.destroy = @sandbox.stub()
       head = {}
 
-      onError = (err, socket, head, port) ->
+      onError = (err, socket2, head2, port) ->
         expect(err.message).to.eq("connect ECONNREFUSED 127.0.0.1:443")
 
-        expect(socket).to.eq(socket)
-        expect(head).to.eq(head)
+        expect(socket).to.eq(socket2)
+        expect(head).to.eq(head2)
         expect(port).to.eq("443")
 
         expect(socket.destroy).to.be.calledOnce
@@ -88,11 +88,11 @@ describe "lib/server", ->
       socket.destroy = @sandbox.stub()
       head = {}
 
-      onError = (err, socket, head, port) ->
+      onError = (err, socket2, head2, port) ->
         expect(err.message).to.eq("A connection to the upstream proxy could not be established: connect ECONNREFUSED 127.0.0.1:8444")
 
-        expect(socket).to.eq(socket)
-        expect(head).to.eq(head)
+        expect(socket).to.eq(socket2)
+        expect(head).to.eq(head2)
         expect(port).to.eq("11111")
 
         expect(socket.destroy).to.be.calledOnce


### PR DESCRIPTION
<!-- Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md -->

Previously if Cypress received an erroneous HTTP CONNECT (for example, `CONNECT %7Balgolia_application_id%7D-dsn.algolia.net:443`), it would try to decode it via url.parse, receive an empty port, pass that empty port to `net.connect`, and then crash because `net.connect` requires a port and the rejection is unhandled.

This ensures that `net.connect` is always called with a port so that the request can cleanly error out in an expected way.

- Closes #3250 

### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

- [x] Have tests been added/updated for the changes in this PR?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
