### PR TITLE
fix selector-playground css

### DIFF
--- a/packages/driver/test/cypress/integration/e2e/selector_playground.spec.js
+++ b/packages/driver/test/cypress/integration/e2e/selector_playground.spec.js
@@ -3,6 +3,8 @@ describe('selector_playground', () => {
   it('draws rect over currently hovered element', () => {
     cy.visit('/fixtures/dom.html')
     .then(() => {
+
+      // We trick the selector-playground into rendering while the test is running
       top.Runner.configureMobx({ enforceActions: 'never' })
       top.Runner.state.isRunning = false
 

--- a/packages/driver/test/cypress/integration/e2e/selector_playground.spec.js
+++ b/packages/driver/test/cypress/integration/e2e/selector_playground.spec.js
@@ -1,0 +1,40 @@
+describe('selector_playground', () => {
+
+  it('draws rect over currently hovered element', () => {
+    cy.visit('/fixtures/dom.html')
+    .then(() => {
+      top.Runner.configureMobx({ enforceActions: 'never' })
+      top.Runner.state.isRunning = false
+
+      const $highlightBtn = cy.$$('button.highlight-toggle:visible', top.document)
+
+      if (!$highlightBtn.length) {
+        const $btn = cy.$$('button.selector-playground-toggle', top.document)
+
+        $btn.click()
+      } else {
+        if (!$highlightBtn.hasClass('active')) {
+          $highlightBtn.click()
+        }
+      }
+
+      cy.get('input:first')
+      .trigger('mousemove', { force: true })
+      .should(expectToBeCovered)
+
+    })
+  })
+})
+
+/**
+ *
+ * @param {JQuery<HTMLElement>} $el
+ */
+const expectToBeCovered = ($el) => {
+  const el = $el[0]
+  const rect = el.getBoundingClientRect()
+
+  const elAtPoint = el.ownerDocument.elementFromPoint(rect.left, rect.top)
+
+  expect(el).not.eq(elAtPoint)
+}

--- a/packages/runner/src/lib/dom.js
+++ b/packages/runner/src/lib/dom.js
@@ -2,6 +2,8 @@ import _ from 'lodash'
 
 import { $ } from '@packages/driver'
 import selectorPlaygroundHighlight from '../selector-playground/highlight'
+// The '!' tells webpack to disable normal loaders, and keep loaders with `enforce: 'pre'` and `enforce: 'post'`
+// This disables the CSSExtractWebpackPlugin and allows us to get the CSS as a raw string instead of saving it to a separate file.
 import selectorPlaygroundCSS from '!../selector-playground/selector-playground.scss'
 
 const styles = (styleString) => {

--- a/packages/runner/src/main.jsx
+++ b/packages/runner/src/main.jsx
@@ -7,10 +7,13 @@ import Container from './app/container'
 
 configure({ enforceActions: 'strict' })
 
-window.Runner = {
+const Runner = {
   start (el, config) {
     action('started', () => {
       const state = new State((config.state || {}).reporterWidth)
+
+      Runner.state = state
+      Runner.configureMobx = configure
 
       state.updateDimensions(config.viewportWidth, config.viewportHeight)
 
@@ -18,3 +21,5 @@ window.Runner = {
     })()
   },
 }
+
+window.Runner = Runner

--- a/packages/web-config/package.json
+++ b/packages/web-config/package.json
@@ -12,6 +12,7 @@
     "@types/copy-webpack-plugin": "5.0.0",
     "@types/html-webpack-plugin": "3.2.0",
     "@types/webpack": "4.4.25",
+    "ansi-escapes": "4.2.1",
     "autoprefixer": "9.6.1",
     "babel-loader": "8.0.5",
     "browser-resolve": "1.11.3",

--- a/packages/web-config/webpack.config.base.ts
+++ b/packages/web-config/webpack.config.base.ts
@@ -82,6 +82,13 @@ const config: webpack.Configuration = {
         exclude: /node_modules/,
         use: [
           { loader: MiniCSSExtractWebpackPlugin.loader },
+        ],
+      },
+      {
+        test: /\.s?css$/,
+        exclude: /node_modules/,
+        enforce: 'pre',
+        use: [
           {
             loader: require.resolve('css-loader'),
             options: {


### PR DESCRIPTION
- fixes regression introduced in 3.4.0 by webpack changes
- also remove some async code since we no longer fetch the css at runtime
- [x] add a test to ensure the box gets drawn properly over the element

fix #4872 