### PR TITLE
Provide strong types for 'invoke' command (#4022)

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -4,7 +4,7 @@
 //                 Mike Woudenberg <https://github.com/mikewoudenberg>
 //                 Robbert van Markus <https://github.com/rvanmarkus>
 //                 Nicholas Boll <https://github.com/nicholasboll>
-// TypeScript Version: 3.0
+// TypeScript Version: 3.4
 // Updated by the Cypress team: https://www.cypress.io/about/
 
 /// <reference path="./cy-blob-util.d.ts" />
@@ -4496,48 +4496,90 @@ declare namespace Cypress {
    */
   type FunctionKeys<T> = ({ [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never }[keyof T])
 
+  type ExcludeUnknownArray<T> = unknown[] extends T ? never : T
+  type ExcludeUnknown<T> = unknown extends T ? never : T
+
   /**
-   * Obtain the union of all parameters of an overloaded function type in a tuple
-   * 
+   * Obtain the union of all overloaded parameters tuples of a function type
+   *
    * Accepts functions with up to 5 overloads
    */
   type OverloadedParameters<T> =
-    T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; (...args: infer A4): any; (...args: infer A5): any; } ? A1 | A2 | A3 | A4 | A5 :
-    T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; (...args: infer A4): any; } ? A1 | A2 | A3 | A4 :
-    T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; } ? A1 | A2 | A3 :
-    T extends { (...args: infer A1): any; (...args: infer A2): any; } ? A1 | A2 :
-    T extends { (...args: infer A1): any; } ? A1 :
-    // T extends (...args: infer A1) => any ? A1 :
+    T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; (...args: infer A4): any; (...args: infer A5): any; } ?
+      ExcludeUnknownArray<A1> | ExcludeUnknownArray<A2> | ExcludeUnknownArray<A3> | ExcludeUnknownArray<A4> | ExcludeUnknownArray<A5> :
+    T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; (...args: infer A4): any; } ?
+      ExcludeUnknownArray<A1> | ExcludeUnknownArray<A2> | ExcludeUnknownArray<A3> | ExcludeUnknownArray<A4> :
+    T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; } ?
+      ExcludeUnknownArray<A1> | ExcludeUnknownArray<A2> | ExcludeUnknownArray<A3> :
+    T extends { (...args: infer A1): any; (...args: infer A2): any; } ?
+      ExcludeUnknownArray<A1> | ExcludeUnknownArray<A2> :
+    T extends { (...args: infer A1): any; } ?
+      ExcludeUnknownArray<A1> :
     any[]
 
+  type ValidReturn<TArgs, TInferredArgs, TInferredReturn> =
+    [TArgs, TInferredReturn] extends [ExcludeUnknownArray<TInferredArgs>, ExcludeUnknown<TInferredReturn>]
+      ? TInferredReturn : never
+
   /**
-   * Obtain the return type of an overloaded function type corresponding to the provided arguments tuple type
-   * 
+   * Obtain the return type of a function type corresponding to the provided arguments tuple type
+   *
    * Accepts functions with up to 5 overloads
    */
   type OverloadedReturnType<T, TArgs extends unknown[]> =
     T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; (...args: infer A5): infer R5; }
-      ? unknown extends (TArgs extends A1 ? R1 : unknown)
-      ? unknown extends (TArgs extends A2 ? R2 : unknown)
-      ? unknown extends (TArgs extends A3 ? R3 : unknown)
-      ? unknown extends (TArgs extends A4 ? R4 : unknown)
-      ? unknown extends (TArgs extends A5 ? R5 : unknown) ? R5 : R5 : R4 : R3 : R2 : R1 :
+      ? ValidReturn<TArgs, A1, R1> | ValidReturn<TArgs, A2, R2> | ValidReturn<TArgs, A3, R3> | ValidReturn<TArgs, A4, R4> | ValidReturn<TArgs, A5, R5> :
     T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; }
-      ? unknown extends (TArgs extends A1 ? R1 : unknown)
-      ? unknown extends (TArgs extends A2 ? R2 : unknown)
-      ? unknown extends (TArgs extends A3 ? R3 : unknown)
-      ? unknown extends (TArgs extends A4 ? R4 : unknown) ? R4 : R4 : R3 : R2 : R1 :
+      ? ValidReturn<TArgs, A1, R1> | ValidReturn<TArgs, A2, R2> | ValidReturn<TArgs, A3, R3> | ValidReturn<TArgs, A4, R4> :
     T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; }
-      ? unknown extends (TArgs extends A1 ? R1 : unknown)
-      ? unknown extends (TArgs extends A2 ? R2 : unknown)
-      ? unknown extends (TArgs extends A3 ? R3 : unknown) ? R3 : R3 : R2 : R1 :
+      ? ValidReturn<TArgs, A1, R1> | ValidReturn<TArgs, A2, R2> | ValidReturn<TArgs, A3, R3> :
     T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; }
-      ? unknown extends (TArgs extends A1 ? R1 : unknown)
-      ? unknown extends (TArgs extends A2 ? R2 : unknown) ? R2 : R2 : R1 :
+      ? ValidReturn<TArgs, A1, R1> | ValidReturn<TArgs, A2, R2> :
     T extends { (...args: infer A1): infer R1; }
-      ? unknown extends (TArgs extends A1 ? R1 : unknown) ? R1 : R1 :
-    // T extends (...args: infer A1) => infer R1 ? R1 :
+      ? ValidReturn<TArgs, A1, R1> :
     any
+
+  interface Foo {
+    (s: string, b: number): string
+    (s: string): string
+    (n: number): number
+    (o: string | number): string | number
+  }
+  interface Bar {
+    (): number
+  }
+  interface Baz {
+    (a: number): number
+    (a: string): number
+  }
+  type jargs = OverloadedParameters<JQuery['val']>
+  type cargs = OverloadedParameters<JQuery['css']>
+  type FooP = OverloadedParameters<Foo>
+  type BarP = OverloadedParameters<Bar>
+  type BazP = OverloadedParameters<Baz>
+
+  type BarR1 = OverloadedReturnType<Bar, []>
+  type BarR2 = OverloadedReturnType<Bar, [string, number]>
+  type BazR1 = OverloadedReturnType<Bar, []>
+  type BazR2 = OverloadedReturnType<Bar, [string, number]>
+  type BazR3 = OverloadedReturnType<Bar, [number]>
+
+  type FooR1 = OverloadedReturnType<Foo, [string, number]>
+  type FooR2 = OverloadedReturnType<Foo, [string]>
+  type FooR3 = OverloadedReturnType<Foo, [number]>
+  type FooR4 = OverloadedReturnType<Foo, [number|string]>
+
+  type jr1 = OverloadedReturnType<JQuery['val'], [string]>
+  type jr2 = OverloadedReturnType<JQuery['val'], []>
+
+  type cr1 = OverloadedReturnType<JQuery['css'], [string, string]>
+  type cr2 = OverloadedReturnType<JQuery['css'], [JQuery.PlainObject<string>]>
+  type cr3 = OverloadedReturnType<JQuery['css'], [string]>
+  type cr4 = OverloadedReturnType<JQuery['css'], [string[]]>
+
+  type asdf = ExcludeUnknown<unknown>
+  type fjkds = never extends unknown ? 1 : 0
+  type fjdkds = never | 12
 
   /**
    * Public interface for the global "cy" object. If you want to add

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -4502,7 +4502,7 @@ declare namespace Cypress {
   /**
    * Obtain the union of all overloaded parameters tuples of a function type
    *
-   * Accepts functions with up to 5 overloads
+   * Handles functions with up to 5 overloads
    */
   type OverloadedParameters<T> =
     T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; (...args: infer A4): any; (...args: infer A5): any; } ?
@@ -4518,68 +4518,25 @@ declare namespace Cypress {
     any[]
 
   type ValidReturn<TArgs, TInferredArgs, TInferredReturn> =
-    [TArgs, TInferredReturn] extends [ExcludeUnknownArray<TInferredArgs>, ExcludeUnknown<TInferredReturn>]
-      ? TInferredReturn : never
+    [TArgs, TInferredReturn] extends [ExcludeUnknownArray<TInferredArgs>, ExcludeUnknown<TInferredReturn>] ? TInferredReturn : never
 
   /**
    * Obtain the return type of a function type corresponding to the provided arguments tuple type
    *
-   * Accepts functions with up to 5 overloads
+   * Handles functions with up to 5 overloads
    */
   type OverloadedReturnType<T, TArgs extends unknown[]> =
-    T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; (...args: infer A5): infer R5; }
-      ? ValidReturn<TArgs, A1, R1> | ValidReturn<TArgs, A2, R2> | ValidReturn<TArgs, A3, R3> | ValidReturn<TArgs, A4, R4> | ValidReturn<TArgs, A5, R5> :
-    T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; }
-      ? ValidReturn<TArgs, A1, R1> | ValidReturn<TArgs, A2, R2> | ValidReturn<TArgs, A3, R3> | ValidReturn<TArgs, A4, R4> :
-    T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; }
-      ? ValidReturn<TArgs, A1, R1> | ValidReturn<TArgs, A2, R2> | ValidReturn<TArgs, A3, R3> :
-    T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; }
-      ? ValidReturn<TArgs, A1, R1> | ValidReturn<TArgs, A2, R2> :
-    T extends { (...args: infer A1): infer R1; }
-      ? ValidReturn<TArgs, A1, R1> :
+    T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; (...args: infer A5): infer R5; } ?
+      ValidReturn<TArgs, A1, R1> | ValidReturn<TArgs, A2, R2> | ValidReturn<TArgs, A3, R3> | ValidReturn<TArgs, A4, R4> | ValidReturn<TArgs, A5, R5> :
+    T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; } ?
+      ValidReturn<TArgs, A1, R1> | ValidReturn<TArgs, A2, R2> | ValidReturn<TArgs, A3, R3> | ValidReturn<TArgs, A4, R4> :
+    T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; } ?
+      ValidReturn<TArgs, A1, R1> | ValidReturn<TArgs, A2, R2> | ValidReturn<TArgs, A3, R3> :
+    T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; } ?
+      ValidReturn<TArgs, A1, R1> | ValidReturn<TArgs, A2, R2> :
+    T extends { (...args: infer A1): infer R1; } ?
+      ValidReturn<TArgs, A1, R1> :
     any
-
-  interface Foo {
-    (s: string, b: number): string
-    (s: string): string
-    (n: number): number
-    (o: string | number): string | number
-  }
-  interface Bar {
-    (): number
-  }
-  interface Baz {
-    (a: number): number
-    (a: string): number
-  }
-  type jargs = OverloadedParameters<JQuery['val']>
-  type cargs = OverloadedParameters<JQuery['css']>
-  type FooP = OverloadedParameters<Foo>
-  type BarP = OverloadedParameters<Bar>
-  type BazP = OverloadedParameters<Baz>
-
-  type BarR1 = OverloadedReturnType<Bar, []>
-  type BarR2 = OverloadedReturnType<Bar, [string, number]>
-  type BazR1 = OverloadedReturnType<Bar, []>
-  type BazR2 = OverloadedReturnType<Bar, [string, number]>
-  type BazR3 = OverloadedReturnType<Bar, [number]>
-
-  type FooR1 = OverloadedReturnType<Foo, [string, number]>
-  type FooR2 = OverloadedReturnType<Foo, [string]>
-  type FooR3 = OverloadedReturnType<Foo, [number]>
-  type FooR4 = OverloadedReturnType<Foo, [number|string]>
-
-  type jr1 = OverloadedReturnType<JQuery['val'], [string]>
-  type jr2 = OverloadedReturnType<JQuery['val'], []>
-
-  type cr1 = OverloadedReturnType<JQuery['css'], [string, string]>
-  type cr2 = OverloadedReturnType<JQuery['css'], [JQuery.PlainObject<string>]>
-  type cr3 = OverloadedReturnType<JQuery['css'], [string]>
-  type cr4 = OverloadedReturnType<JQuery['css'], [string[]]>
-
-  type asdf = ExcludeUnknown<unknown>
-  type fjkds = never extends unknown ? 1 : 0
-  type fjdkds = never | 12
 
   /**
    * Public interface for the global "cy" object. If you want to add

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -895,80 +895,12 @@ declare namespace Cypress {
      */
     invoke<
       TActualSubject extends (Subject extends Node | Node[] ? JQuery<Subject> : Subject),
-      TName extends ({ [K in keyof TActualSubject]: TActualSubject[K] extends (...args: any[]) => any ? K : never }[keyof TActualSubject]),
-      TArgs extends OverloadedArgumentsType<TActualSubject[TName]>,
+      TName extends FunctionKeys<TActualSubject>,
+      TArgs extends OverloadedParameters<TActualSubject[TName]>,
       TReturn extends OverloadedReturnType<TActualSubject[TName], TArgs>,
     >(functionName: TName, ...args: TArgs): Chainable<TReturn>
     invoke(options: Loggable, functionName: keyof Subject, ...args: any[]): Chainable<Subject>
 
-  }
-
-    type OverloadedReturnType<T, TArgs> = 
-      T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; }
-        ? unknown extends (TArgs extends A1 ? R1 : unknown)
-        ? unknown extends (TArgs extends A2 ? R2 : unknown)
-        ? unknown extends (TArgs extends A3 ? R3 : unknown)
-        ? unknown extends (TArgs extends A4 ? R4 : unknown) ? 0 : R4 : R3 : R2 : R1 :
-      T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; }
-        ? unknown extends (TArgs extends A1 ? R1 : unknown)
-        ? unknown extends (TArgs extends A2 ? R2 : unknown)
-        ? unknown extends (TArgs extends A3 ? R3 : unknown) ? 1 : R3 : R2 : R1 :
-      T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; }
-        ? unknown extends (TArgs extends A1 ? R1 : unknown)
-        ? unknown extends (TArgs extends A2 ? R2 : unknown) ? 2 : R2 : R1 :
-      T extends { (...args: infer A1): infer R1; }
-        ? unknown extends (TArgs extends A1 ? R1 : unknown) ? 3 : R1 :
-      4
-        // [[A1, R1],[A2, R2],[A3, R3],[A4, R4]]:never
-    // type OverloadedReturnType<T, TArgs> = 
-    //   T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; }
-    //     ? (A1 extends TArgs ? R1 : A2 extends TArgs ? R2 : A3 extends TArgs ? R3 : A4 extends TArgs ? R4 : never) : 1
-    // type OverloadedReturnType<T, TArgs> = 
-    //   T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; (...args: infer A4): any; }
-    //     ? A1 | A2 | A3 | A4 :
-    //   T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; } ? A1 | A2 | A3 :
-    //   T extends { (...args: infer A1): any; (...args: infer A2): any; } ? A1 | A2 :
-    //   T extends { (...args: infer A1): any; } ? A1 :
-    //   never
-    type OverloadedArgumentsType<T> = 
-      T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; (...args: infer A4): any; } ? A1 | A2 | A3 | A4 :
-      T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; } ? A1 | A2 | A3 :
-      T extends { (...args: infer A1): any; (...args: infer A2): any; } ? A1 | A2 :
-      T extends { (...args: infer A1): any; } ? A1 :
-      never
-    type TActualSubject = JQuery<HTMLInputElement>
-    type TFunctionNames = { [K in keyof TActualSubject]: TActualSubject[K] extends (...args: any[]) => any ? K : never }[keyof TActualSubject]
-    type TFunctions = TActualSubject['css']
-    type TFunc = TFunctions extends (arg: infer A) => any ? A : 
-      TFunctions extends (arg1: infer A, arg2: infer B) => any ? [A, B] : never
-    type Css = TActualSubject['css']
-    type CssA = OverloadedArgumentsType<Css>
-    type CssR = OverloadedReturnType<Css, [string]>
-    type Val = TActualSubject['val']
-    type ValA = OverloadedArgumentsType<Val>
-    type ValR1 = OverloadedReturnType<Val, [number]>
-    type ValR2 = OverloadedReturnType<Val, []>
-    type Foo = {
-      (s: string, b: number): string;
-      (s: string): string;
-      (n: number): number;
-      (o: string | number): string | number
-    }
-    type FooA = OverloadedArgumentsType<Foo>
-    type FooR1 = OverloadedReturnType<Foo, [string, number]>
-    type FooR2 = OverloadedReturnType<Foo, [string]>
-    type FooR3 = OverloadedReturnType<Foo, [number]>
-    type FooR4 = OverloadedReturnType<Foo, [number|string]>
-    // type asdf = [number] extends unknown[] ? R1 : unknown[]) extends unknown[] ? 1 : 0
-    type assdf = unknown[] extends [number] ? 1 : 0
-    type dsijfog = number extends unknown ? 1 : 0
-    type dsdijfog = unknown extends number ? 1 : 0
-    type basdf = [number] extends [number|string] ? 1 : 0
-    type bassdf = [number|string] extends [number] ? 1 : 0
-    // type ValC = (...args: )
-    // type TReturn = TActualSubject[TFunctionNames] extends (...args: TArgs) => infer R ? R : never
-
-    interface Chainable<Subject = any> {
     /**
      * Get a property’s value on the previously yielded subject.
      *
@@ -4558,6 +4490,54 @@ declare namespace Cypress {
   // Diff taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
   type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T]
   type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+
+  /**
+   * Obtain the keys of T whose values are functions
+   */
+  type FunctionKeys<T> = ({ [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never }[keyof T])
+
+  /**
+   * Obtain the union of all parameters of an overloaded function type in a tuple
+   * 
+   * Accepts functions with up to 5 overloads
+   */
+  type OverloadedParameters<T> =
+    T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; (...args: infer A4): any; (...args: infer A5): any; } ? A1 | A2 | A3 | A4 | A5 :
+    T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; (...args: infer A4): any; } ? A1 | A2 | A3 | A4 :
+    T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; } ? A1 | A2 | A3 :
+    T extends { (...args: infer A1): any; (...args: infer A2): any; } ? A1 | A2 :
+    T extends { (...args: infer A1): any; } ? A1 :
+    // T extends (...args: infer A1) => any ? A1 :
+    any[]
+
+  /**
+   * Obtain the return type of an overloaded function type corresponding to the provided arguments tuple type
+   * 
+   * Accepts functions with up to 5 overloads
+   */
+  type OverloadedReturnType<T, TArgs extends unknown[]> =
+    T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; (...args: infer A5): infer R5; }
+      ? unknown extends (TArgs extends A1 ? R1 : unknown)
+      ? unknown extends (TArgs extends A2 ? R2 : unknown)
+      ? unknown extends (TArgs extends A3 ? R3 : unknown)
+      ? unknown extends (TArgs extends A4 ? R4 : unknown)
+      ? unknown extends (TArgs extends A5 ? R5 : unknown) ? R5 : R5 : R4 : R3 : R2 : R1 :
+    T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; }
+      ? unknown extends (TArgs extends A1 ? R1 : unknown)
+      ? unknown extends (TArgs extends A2 ? R2 : unknown)
+      ? unknown extends (TArgs extends A3 ? R3 : unknown)
+      ? unknown extends (TArgs extends A4 ? R4 : unknown) ? R4 : R4 : R3 : R2 : R1 :
+    T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; }
+      ? unknown extends (TArgs extends A1 ? R1 : unknown)
+      ? unknown extends (TArgs extends A2 ? R2 : unknown)
+      ? unknown extends (TArgs extends A3 ? R3 : unknown) ? R3 : R3 : R2 : R1 :
+    T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; }
+      ? unknown extends (TArgs extends A1 ? R1 : unknown)
+      ? unknown extends (TArgs extends A2 ? R2 : unknown) ? R2 : R2 : R1 :
+    T extends { (...args: infer A1): infer R1; }
+      ? unknown extends (TArgs extends A1 ? R1 : unknown) ? R1 : R1 :
+    // T extends (...args: infer A1) => infer R1 ? R1 :
+    any
 
   /**
    * Public interface for the global "cy" object. If you want to add

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -888,9 +888,10 @@ declare namespace Cypress {
      * @see https://on.cypress.io/invoke
      */
     invoke<
-      TName extends { [K in keyof Subject]: Subject[K] extends (...args: any[]) => any ? K : never }[keyof Subject],
-      TArgs extends Subject[TName] extends (...args: infer A) => any ? A : never,
-      TReturn extends Subject[TName] extends (...args: any[]) => infer R ? R : never,
+      TActualSubject extends (Subject extends Node | Node[] ? JQuery<Subject> : Subject),
+      TName extends ({ [K in keyof TActualSubject]: TActualSubject[K] extends (...args: any[]) => any ? K : never }[keyof TActualSubject]),
+      TArgs extends (TActualSubject[TName] extends (...args: infer A) => any ? A : never),
+      TReturn extends (TActualSubject[TName] extends (...args: any[]) => infer R ? R : never),
     >(functionName: TName, ...args: TArgs): Chainable<TReturn>
     invoke(options: Loggable, functionName: keyof Subject, ...args: any[]): Chainable<Subject>
 

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -884,14 +884,10 @@ declare namespace Cypress {
 
     /**
      * Invoke a function on the previously yielded subject.
-     * This isn't possible to strongly type without generic override yet.
-     * If called on an object you can do this instead: `.then(s => s.show())`.
-     * If called on an array you can do this instead: `.each(s => s.show())`.
-     * From there the subject will be properly typed.
      *
      * @see https://on.cypress.io/invoke
      */
-    invoke(functionName: keyof Subject, ...args: any[]): Chainable<Subject> // don't have a way to express return types yet
+    invoke<K extends { [K in keyof Subject]: Subject[K] extends (...args: any[]) => any ? K : never }[keyof Subject], R extends Subject[K] extends (...args: any[]) => infer R ? R : never>(functionName: K, ...args: any[]): Chainable<R>
     invoke(options: Loggable, functionName: keyof Subject, ...args: any[]): Chainable<Subject>
 
     /**

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -887,7 +887,10 @@ declare namespace Cypress {
      *
      * @see https://on.cypress.io/invoke
      */
-    invoke<K extends { [K in keyof Subject]: Subject[K] extends (...args: any[]) => any ? K : never }[keyof Subject], R extends Subject[K] extends (...args: any[]) => infer R ? R : never>(functionName: K, ...args: any[]): Chainable<R>
+    invoke<
+      TName extends { [K in keyof Subject]: Subject[K] extends (...args: any[]) => any ? K : never }[keyof Subject],
+      TReturn extends Subject[TName] extends (...args: any[]) => infer R ? R : never,
+    >(functionName: TName, ...args: any[]): Chainable<TReturn>
     invoke(options: Loggable, functionName: keyof Subject, ...args: any[]): Chainable<Subject>
 
     /**

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -883,9 +883,15 @@ declare namespace Cypress {
     invoke<T extends (...args: any[]) => any, Subject extends T[]>(options: Loggable, index: number): Chainable<ReturnType<T>>
 
     /**
-     * Invoke a function on the previously yielded subject.
+     * Invoke a function on the previously yielded subject, yielding the result.
      *
      * @see https://on.cypress.io/invoke
+     * @example
+     *    // Invoke the 'add' function, passing in parameters
+     *    cy.wrap({ add: (a, b) => a + b }).invoke('add', 1, 2).should('eq', 3)
+     *    // DOM elements are automatically wrapped with jQuery,
+     *    //   so jQuery functions (including 3rd party plugins) can be invoked
+     *    cy.get('.modal').invoke('show').should('be.visible') // jQuery's 'show' functions
      */
     invoke<
       TActualSubject extends (Subject extends Node | Node[] ? JQuery<Subject> : Subject),

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -896,11 +896,79 @@ declare namespace Cypress {
     invoke<
       TActualSubject extends (Subject extends Node | Node[] ? JQuery<Subject> : Subject),
       TName extends ({ [K in keyof TActualSubject]: TActualSubject[K] extends (...args: any[]) => any ? K : never }[keyof TActualSubject]),
-      TArgs extends (TActualSubject[TName] extends (...args: infer A) => any ? A : never),
-      TReturn extends (TActualSubject[TName] extends (...args: any[]) => infer R ? R : never),
+      TArgs extends OverloadedArgumentsType<TActualSubject[TName]>,
+      TReturn extends OverloadedReturnType<TActualSubject[TName], TArgs>,
     >(functionName: TName, ...args: TArgs): Chainable<TReturn>
     invoke(options: Loggable, functionName: keyof Subject, ...args: any[]): Chainable<Subject>
 
+  }
+
+    type OverloadedReturnType<T, TArgs> = 
+      T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; }
+        ? unknown extends (TArgs extends A1 ? R1 : unknown)
+        ? unknown extends (TArgs extends A2 ? R2 : unknown)
+        ? unknown extends (TArgs extends A3 ? R3 : unknown)
+        ? unknown extends (TArgs extends A4 ? R4 : unknown) ? 0 : R4 : R3 : R2 : R1 :
+      T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; }
+        ? unknown extends (TArgs extends A1 ? R1 : unknown)
+        ? unknown extends (TArgs extends A2 ? R2 : unknown)
+        ? unknown extends (TArgs extends A3 ? R3 : unknown) ? 1 : R3 : R2 : R1 :
+      T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; }
+        ? unknown extends (TArgs extends A1 ? R1 : unknown)
+        ? unknown extends (TArgs extends A2 ? R2 : unknown) ? 2 : R2 : R1 :
+      T extends { (...args: infer A1): infer R1; }
+        ? unknown extends (TArgs extends A1 ? R1 : unknown) ? 3 : R1 :
+      4
+        // [[A1, R1],[A2, R2],[A3, R3],[A4, R4]]:never
+    // type OverloadedReturnType<T, TArgs> = 
+    //   T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; }
+    //     ? (A1 extends TArgs ? R1 : A2 extends TArgs ? R2 : A3 extends TArgs ? R3 : A4 extends TArgs ? R4 : never) : 1
+    // type OverloadedReturnType<T, TArgs> = 
+    //   T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; (...args: infer A4): any; }
+    //     ? A1 | A2 | A3 | A4 :
+    //   T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; } ? A1 | A2 | A3 :
+    //   T extends { (...args: infer A1): any; (...args: infer A2): any; } ? A1 | A2 :
+    //   T extends { (...args: infer A1): any; } ? A1 :
+    //   never
+    type OverloadedArgumentsType<T> = 
+      T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; (...args: infer A4): any; } ? A1 | A2 | A3 | A4 :
+      T extends { (...args: infer A1): any; (...args: infer A2): any; (...args: infer A3): any; } ? A1 | A2 | A3 :
+      T extends { (...args: infer A1): any; (...args: infer A2): any; } ? A1 | A2 :
+      T extends { (...args: infer A1): any; } ? A1 :
+      never
+    type TActualSubject = JQuery<HTMLInputElement>
+    type TFunctionNames = { [K in keyof TActualSubject]: TActualSubject[K] extends (...args: any[]) => any ? K : never }[keyof TActualSubject]
+    type TFunctions = TActualSubject['css']
+    type TFunc = TFunctions extends (arg: infer A) => any ? A : 
+      TFunctions extends (arg1: infer A, arg2: infer B) => any ? [A, B] : never
+    type Css = TActualSubject['css']
+    type CssA = OverloadedArgumentsType<Css>
+    type CssR = OverloadedReturnType<Css, [string]>
+    type Val = TActualSubject['val']
+    type ValA = OverloadedArgumentsType<Val>
+    type ValR1 = OverloadedReturnType<Val, [number]>
+    type ValR2 = OverloadedReturnType<Val, []>
+    type Foo = {
+      (s: string, b: number): string;
+      (s: string): string;
+      (n: number): number;
+      (o: string | number): string | number
+    }
+    type FooA = OverloadedArgumentsType<Foo>
+    type FooR1 = OverloadedReturnType<Foo, [string, number]>
+    type FooR2 = OverloadedReturnType<Foo, [string]>
+    type FooR3 = OverloadedReturnType<Foo, [number]>
+    type FooR4 = OverloadedReturnType<Foo, [number|string]>
+    // type asdf = [number] extends unknown[] ? R1 : unknown[]) extends unknown[] ? 1 : 0
+    type assdf = unknown[] extends [number] ? 1 : 0
+    type dsijfog = number extends unknown ? 1 : 0
+    type dsdijfog = unknown extends number ? 1 : 0
+    type basdf = [number] extends [number|string] ? 1 : 0
+    type bassdf = [number|string] extends [number] ? 1 : 0
+    // type ValC = (...args: )
+    // type TReturn = TActualSubject[TFunctionNames] extends (...args: TArgs) => infer R ? R : never
+
+    interface Chainable<Subject = any> {
     /**
      * Get a property’s value on the previously yielded subject.
      *

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -878,9 +878,21 @@ declare namespace Cypress {
     /**
      * Invoke a function in an array of functions.
      * @see https://on.cypress.io/invoke
-     */
-    invoke<T extends (...args: any[]) => any, Subject extends T[]>(index: number): Chainable<ReturnType<T>>
-    invoke<T extends (...args: any[]) => any, Subject extends T[]>(options: Loggable, index: number): Chainable<ReturnType<T>>
+     */ 
+    invoke<
+      TIndex extends keyof Exclude<keyof Subject, keyof any[]>,
+      // @ts-ignore compiler can't figure out that TIndex can index Subject
+      TFunc extends Subject[TIndex],
+      TArgs extends OverloadedParameters<TFunc>,
+      TReturn extends OverloadedReturnType<TFunc, TArgs>,
+    >(index: TIndex, ...args: TArgs): Chainable<TReturn>
+    invoke<
+      TIndex extends keyof Exclude<keyof Subject, keyof any[]>,
+      // @ts-ignore compiler can't figure out that TIndex can index Subject
+      TFunc extends Subject[TIndex],
+      TArgs extends OverloadedParameters<TFunc>,
+      TReturn extends OverloadedReturnType<TFunc, TArgs>,
+    >(options: Loggable, index: TIndex, ...args: TArgs): Chainable<TReturn>
 
     /**
      * Invoke a function on the previously yielded subject, yielding the result.

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -894,12 +894,17 @@ declare namespace Cypress {
      *    cy.get('.modal').invoke('show').should('be.visible') // jQuery's 'show' functions
      */
     invoke<
-      TActualSubject extends (Subject extends Node | Node[] ? JQuery<Subject> : Subject),
+      TActualSubject extends WrapJQuery<Subject>,
       TName extends FunctionKeys<TActualSubject>,
       TArgs extends OverloadedParameters<TActualSubject[TName]>,
       TReturn extends OverloadedReturnType<TActualSubject[TName], TArgs>,
     >(functionName: TName, ...args: TArgs): Chainable<TReturn>
-    invoke(options: Loggable, functionName: keyof Subject, ...args: any[]): Chainable<Subject>
+    invoke<
+      TActualSubject extends WrapJQuery<Subject>,
+      TName extends FunctionKeys<TActualSubject>,
+      TArgs extends OverloadedParameters<TActualSubject[TName]>,
+      TReturn extends OverloadedReturnType<TActualSubject[TName], TArgs>,
+    >(options: Loggable, functionName: TName, ...args: TArgs): Chainable<TReturn>
 
     /**
      * Get a property’s value on the previously yielded subject.
@@ -4495,6 +4500,8 @@ declare namespace Cypress {
    * Obtain the keys of T whose values are functions
    */
   type FunctionKeys<T> = ({ [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never }[keyof T])
+
+  type WrapJQuery<T> = T extends Node | Node[] ? JQuery<T> : T
 
   type ExcludeUnknownArray<T> = unknown[] extends T ? never : T
   type ExcludeUnknown<T> = unknown extends T ? never : T

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -880,15 +880,19 @@ declare namespace Cypress {
      * @see https://on.cypress.io/invoke
      */ 
     invoke<
-      TIndex extends keyof Exclude<keyof Subject, keyof any[]>,
-      // @ts-ignore compiler can't figure out that TIndex can index Subject
+      TIndex extends
+        & (keyof Exclude<keyof Subject, keyof any[]>)
+        // needed because compiler can't figure out that the type above is a valid index for Subject
+        & (keyof Subject),
       TFunc extends Subject[TIndex],
       TArgs extends OverloadedParameters<TFunc>,
       TReturn extends OverloadedReturnType<TFunc, TArgs>,
     >(index: TIndex, ...args: TArgs): Chainable<TReturn>
     invoke<
-      TIndex extends keyof Exclude<keyof Subject, keyof any[]>,
-      // @ts-ignore compiler can't figure out that TIndex can index Subject
+      TIndex extends
+        & (keyof Exclude<keyof Subject, keyof any[]>)
+        // needed because compiler can't figure out that the type above is a valid index for Subject
+        & (keyof Subject),
       TFunc extends Subject[TIndex],
       TArgs extends OverloadedParameters<TFunc>,
       TReturn extends OverloadedReturnType<TFunc, TArgs>,

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -878,7 +878,7 @@ declare namespace Cypress {
     /**
      * Invoke a function in an array of functions.
      * @see https://on.cypress.io/invoke
-     */ 
+     */
     invoke<
       TIndex extends
         & (keyof Exclude<keyof Subject, keyof any[]>)

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -4,7 +4,7 @@
 //                 Mike Woudenberg <https://github.com/mikewoudenberg>
 //                 Robbert van Markus <https://github.com/rvanmarkus>
 //                 Nicholas Boll <https://github.com/nicholasboll>
-// TypeScript Version: 2.9
+// TypeScript Version: 3.0
 // Updated by the Cypress team: https://www.cypress.io/about/
 
 /// <reference path="./cy-blob-util.d.ts" />
@@ -889,8 +889,9 @@ declare namespace Cypress {
      */
     invoke<
       TName extends { [K in keyof Subject]: Subject[K] extends (...args: any[]) => any ? K : never }[keyof Subject],
+      TArgs extends Subject[TName] extends (...args: infer A) => any ? A : never,
       TReturn extends Subject[TName] extends (...args: any[]) => infer R ? R : never,
-    >(functionName: TName, ...args: any[]): Chainable<TReturn>
+    >(functionName: TName, ...args: TArgs): Chainable<TReturn>
     invoke(options: Loggable, functionName: keyof Subject, ...args: any[]): Chainable<Subject>
 
     /**

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -301,8 +301,10 @@ cy.wrap('foobar').should('not.have.string', 'baz')
 
 cy.wrap('foobar').should('not.include', 'baz')
 
-cy.wrap({ foo: () => 1, bar: 2 }).invoke('foo').should('equal', 1)
-// cy.wrap({ foo: () => 1, bar: 2 }).invoke('bar') // compile ERROR
+const mrObj = { foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`, bar: 2 }
+cy.wrap(mrObj).invoke('foo', 1) // $ExpectType Chainable<string>
+cy.wrap(mrObj).invoke('foo', 5, 'b') // $ExpectType Chainable<string>
+cy.wrap(mrObj).invoke('bar') // $ExpectError
 
 ;
 () => {

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -301,12 +301,18 @@ cy.wrap('foobar').should('not.have.string', 'baz')
 
 cy.wrap('foobar').should('not.include', 'baz')
 
-const mrObj = { foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`, bar: 2 }
-cy.wrap(mrObj).invoke('foo', 1) // $ExpectType Chainable<string>
-cy.wrap(mrObj).invoke('foo', 5, 'b') // $ExpectType Chainable<string>
-cy.wrap(mrObj).invoke('bar') // $ExpectError
+const mrObj = {
+  foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`,
+  bar: { baz: (a: number) => a + 1 }
+}
+cy.wrap(mrObj).invoke('foo', 1).should('equal', 'n = 2') // $ExpectType Chainable<string>
+cy.wrap(mrObj).invoke('foo', 5, 'b').should('equal', 'b = 6') // $ExpectType Chainable<string>
+cy.wrap(mrObj).its('bar').invoke('baz', 2).should('equal', 3) // $ExpectType Chainable<number>
+cy.wrap(mrObj).invoke('bar', 2) // $ExpectError
+cy.wrap(mrObj).invoke('bar.baz', 2).should('equal', 3) // $ExpectError
 cy.wrap(mrObj).invoke('foo', 5, 1) // $ExpectError
 cy.wrap(mrObj).invoke('foo', 5, 'b', 1) // $ExpectError
+cy.get('input').then(it => it[0]).invoke('checkValidity') // $ExpectError
 
 ;
 () => {

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -301,19 +301,6 @@ cy.wrap('foobar').should('not.have.string', 'baz')
 
 cy.wrap('foobar').should('not.include', 'baz')
 
-const mrObj = {
-  foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`,
-  bar: { baz: (a: number) => a + 1 }
-}
-cy.wrap(mrObj).invoke('foo', 1).should('equal', 'n = 2') // $ExpectType Chainable<string>
-cy.wrap(mrObj).invoke('foo', 5, 'b').should('equal', 'b = 6') // $ExpectType Chainable<string>
-cy.wrap(mrObj).its('bar').invoke('baz', 2).should('equal', 3) // $ExpectType Chainable<number>
-cy.wrap(mrObj).invoke('bar', 2) // $ExpectError
-cy.wrap(mrObj).invoke('bar.baz', 2).should('equal', 3) // $ExpectError
-cy.wrap(mrObj).invoke('foo', 5, 1) // $ExpectError
-cy.wrap(mrObj).invoke('foo', 5, 'b', 1) // $ExpectError
-cy.get('input').then(it => it[0]).invoke('checkValidity') // $ExpectError
-
 ;
 () => {
   let val = 1

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -305,6 +305,8 @@ const mrObj = { foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`
 cy.wrap(mrObj).invoke('foo', 1) // $ExpectType Chainable<string>
 cy.wrap(mrObj).invoke('foo', 5, 'b') // $ExpectType Chainable<string>
 cy.wrap(mrObj).invoke('bar') // $ExpectError
+cy.wrap(mrObj).invoke('foo', 5, 1) // $ExpectError
+cy.wrap(mrObj).invoke('foo', 5, 'b', 1) // $ExpectError
 
 ;
 () => {

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -301,6 +301,9 @@ cy.wrap('foobar').should('not.have.string', 'baz')
 
 cy.wrap('foobar').should('not.include', 'baz')
 
+cy.wrap({ foo: () => 1, bar: 2 }).invoke('foo').should('equal', 1)
+// cy.wrap({ foo: () => 1, bar: 2 }).invoke('bar') // compile ERROR
+
 ;
 () => {
   let val = 1

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -334,6 +334,26 @@ namespace CypressContainsTests {
 }
 
 namespace CypressInvokeTests {
+  class TestClass {
+    foo(s: string, b: number): string | number
+    foo(s: string): string
+    foo(n: number): number
+    foo(o: string | number): string | number {
+      return typeof(o) === 'string' ? o + '1' : o + 1
+    }
+    bar(): number{
+      return 1
+    }
+  }
+
+  const instance = new TestClass()
+  cy.wrap(instance).invoke('foo', 'a', 1) // $ExpectType Chainable<string | number>
+  cy.wrap(instance).invoke('foo', 'a') // $ExpectType Chainable<string>
+  cy.wrap(instance).invoke('foo', 1) // $ExpectType Chainable<number>
+  cy.wrap(instance).invoke('foo') // $ExpectError
+  cy.wrap(instance).invoke('bar') // $ExpectType Chainable<number>
+  cy.wrap(instance).invoke('foo', 1, 1) // $ExpectError
+
   const obj = {
     foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`,
     bar: { baz: (a: number) => a + 1 }
@@ -346,6 +366,9 @@ namespace CypressInvokeTests {
   cy.wrap(obj).invoke('foo', 5, 1) // $ExpectError
   cy.wrap(obj).invoke('foo', 5, 'b', 1) // $ExpectError
   cy.get('input').then(it => it[0]).invoke('checkValidity') // $ExpectError
+  cy.get('input').invoke('val', 25) // $ExpectType Chainable<JQuery<HTMLInputElement>>
+  cy.get('input').invoke('css', '') // $ExpectType Chainable<string>
+  cy.get('input').invoke('css') // $ExpectError
 }
 
 // https://github.com/cypress-io/cypress/pull/5574

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -108,12 +108,35 @@ namespace CypressItsTests {
 }
 
 namespace CypressInvokeTests {
+  const options = { log: false }
   const returnsString = () => 'foo'
   const returnsNumber = () => 42
+  const returnsStringWithSuffix = (it: string) => it + 'foo'
+  const returnsNumberPlusOne = (it: number) => it + 1
+  const returnsSum = (a: number, b: number) => a + b
 
-  // unfortunately could not define more precise type
-  // in this case it should have been "number", but so far no luck
-  cy.wrap([returnsString, returnsNumber]).invoke(1) // $ExpectType Chainable<any>
+  const a: [() => string, () => number] = [returnsString, returnsNumber]
+  cy.wrap(a).invoke(0) // $ExpectType Chainable<string>
+  cy.wrap(a).invoke(1) // $ExpectType Chainable<number>
+  cy.wrap(a).invoke(1, 2) // $ExpectError
+  cy.wrap(a).invoke(options, 1) // $ExpectType Chainable<number>
+
+  const b: [() => string, (it: number) => number] = [returnsString, returnsNumberPlusOne]
+  cy.wrap(b).invoke(1, 82) // $ExpectType Chainable<number>
+  cy.wrap(b).invoke(1, 82, 4) // $ExpectError
+  cy.wrap(b).invoke(options, 1, 82) // $ExpectType Chainable<number>
+
+  const c: [() => string, (a: number, b: number) => number] = [returnsString, returnsSum]
+  cy.wrap(c).invoke(1, 82, 3) // $ExpectType Chainable<number>
+  cy.wrap(c).invoke(0, 82, 3) // $ExpectError
+  cy.wrap(c).invoke(options, 1, 82, 3) // $ExpectType Chainable<number>
+
+  const d: [(it: string) => string, (it: number) => number] = [returnsStringWithSuffix, returnsNumberPlusOne]
+  cy.wrap(d).invoke(0, 'a') // $ExpectType Chainable<string>
+  cy.wrap(d).invoke(1, 'a') // $ExpectError
+  cy.wrap(d).invoke(0, 23) // $ExpectError
+  cy.wrap(d).invoke(1, 23) // $ExpectType Chainable<number>
+  cy.wrap(d).invoke(options, 1, 23) // $ExpectType Chainable<number>
 
   class TestClass {
     foo(s: string, b: number): string | number

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -114,6 +114,48 @@ namespace CypressInvokeTests {
   // unfortunately could not define more precise type
   // in this case it should have been "number", but so far no luck
   cy.wrap([returnsString, returnsNumber]).invoke(1) // $ExpectType Chainable<any>
+
+  class TestClass {
+    foo(s: string, b: number): string | number
+    foo(s: string): string
+    foo(n: number): number
+    foo(o: string | number): string | number {
+      return typeof(o) === 'string' ? o + '1' : o + 1
+    }
+    bar(): number {
+      return 1
+    }
+  }
+
+  const instance = new TestClass()
+  cy.wrap(instance).invoke('foo', 'a', 1) // $ExpectType Chainable<string | number>
+  cy.wrap(instance).invoke('foo', 'a') // $ExpectType Chainable<string>
+  cy.wrap(instance).invoke('foo', 1) // $ExpectType Chainable<number>
+  cy.wrap(instance).invoke('foo') // $ExpectError
+  cy.wrap(instance).invoke('bar') // $ExpectType Chainable<number>
+  cy.wrap(instance).invoke('bar', 1) // $ExpectError
+  cy.wrap(instance).invoke('foo', 1, 1) // $ExpectError
+
+  const obj = {
+    foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`,
+    bar: { baz: (a: number) => a + 1 },
+    bam: () => 1
+  }
+  cy.wrap(obj).invoke('foo', 1).should('equal', 'n = 2') // $ExpectType Chainable<string>
+  cy.wrap(obj).invoke('foo', 5, 'b').should('equal', 'b = 6') // $ExpectType Chainable<string>
+  cy.wrap(obj).its('bar').invoke('baz', 2).should('equal', 3) // $ExpectType Chainable<number>
+  cy.wrap(obj).invoke('bam') // $ExpectType Chainable<number>
+  cy.wrap(obj).invoke('bam', 1) // $ExpectError
+  cy.wrap(obj).invoke('bar', 2) // $ExpectError
+  cy.wrap(obj).invoke('bar.baz', 2).should('equal', 3) // $ExpectError
+  cy.wrap(obj).invoke('foo', 5, 1) // $ExpectError
+  cy.wrap(obj).invoke('foo', 5, 'b', 1) // $ExpectError
+  cy.get('input').then(it => it[0]).invoke('checkValidity') // $ExpectError
+  cy.get('input').invoke('val', 25, 12) // $ExpectError
+  cy.get('input').invoke('val', 25) // $ExpectType Chainable<JQuery<HTMLInputElement>>
+  cy.get('input').invoke('val') // $ExpectType Chainable<string | number | string[] | undefined>
+  cy.get('input').invoke('css', '') // $ExpectType Chainable<string>
+  cy.get('input').invoke('css') // $ExpectError
 }
 
 cy.wrap({ foo: ['bar', 'baz'] })
@@ -331,50 +373,6 @@ namespace CypressContainsTests {
   cy.contains('#app', 'my text to find')
   cy.contains('#app', 'my text to find', {log: false, timeout: 100})
   cy.contains('my text to find', {log: false, timeout: 100})
-}
-
-namespace CypressInvokeTests {
-  class TestClass {
-    foo(s: string, b: number): string | number
-    foo(s: string): string
-    foo(n: number): number
-    foo(o: string | number): string | number {
-      return typeof(o) === 'string' ? o + '1' : o + 1
-    }
-    bar(): number {
-      return 1
-    }
-  }
-
-  const instance = new TestClass()
-  cy.wrap(instance).invoke('foo', 'a', 1) // $ExpectType Chainable<string | number>
-  cy.wrap(instance).invoke('foo', 'a') // $ExpectType Chainable<string>
-  cy.wrap(instance).invoke('foo', 1) // $ExpectType Chainable<number>
-  cy.wrap(instance).invoke('foo') // $ExpectError
-  cy.wrap(instance).invoke('bar') // $ExpectType Chainable<number>
-  cy.wrap(instance).invoke('bar', 1) // $ExpectError
-  cy.wrap(instance).invoke('foo', 1, 1) // $ExpectError
-
-  const obj = {
-    foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`,
-    bar: { baz: (a: number) => a + 1 },
-    bam: () => 1
-  }
-  cy.wrap(obj).invoke('foo', 1).should('equal', 'n = 2') // $ExpectType Chainable<string>
-  cy.wrap(obj).invoke('foo', 5, 'b').should('equal', 'b = 6') // $ExpectType Chainable<string>
-  cy.wrap(obj).its('bar').invoke('baz', 2).should('equal', 3) // $ExpectType Chainable<number>
-  cy.wrap(obj).invoke('bam') // $ExpectType Chainable<number>
-  cy.wrap(obj).invoke('bam', 1) // $ExpectError
-  cy.wrap(obj).invoke('bar', 2) // $ExpectError
-  cy.wrap(obj).invoke('bar.baz', 2).should('equal', 3) // $ExpectError
-  cy.wrap(obj).invoke('foo', 5, 1) // $ExpectError
-  cy.wrap(obj).invoke('foo', 5, 'b', 1) // $ExpectError
-  cy.get('input').then(it => it[0]).invoke('checkValidity') // $ExpectError
-  cy.get('input').invoke('val', 25, 12) // $ExpectError
-  cy.get('input').invoke('val', 25) // $ExpectType Chainable<JQuery<HTMLInputElement>>
-  cy.get('input').invoke('val') // $ExpectType Chainable<string | number | string[] | undefined>
-  cy.get('input').invoke('css', '') // $ExpectType Chainable<string>
-  cy.get('input').invoke('css') // $ExpectError
 }
 
 // https://github.com/cypress-io/cypress/pull/5574

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -341,7 +341,7 @@ namespace CypressInvokeTests {
     foo(o: string | number): string | number {
       return typeof(o) === 'string' ? o + '1' : o + 1
     }
-    bar(): number{
+    bar(): number {
       return 1
     }
   }
@@ -352,21 +352,27 @@ namespace CypressInvokeTests {
   cy.wrap(instance).invoke('foo', 1) // $ExpectType Chainable<number>
   cy.wrap(instance).invoke('foo') // $ExpectError
   cy.wrap(instance).invoke('bar') // $ExpectType Chainable<number>
+  cy.wrap(instance).invoke('bar', 1) // $ExpectError
   cy.wrap(instance).invoke('foo', 1, 1) // $ExpectError
 
   const obj = {
     foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`,
-    bar: { baz: (a: number) => a + 1 }
+    bar: { baz: (a: number) => a + 1 },
+    bam: () => 1
   }
   cy.wrap(obj).invoke('foo', 1).should('equal', 'n = 2') // $ExpectType Chainable<string>
   cy.wrap(obj).invoke('foo', 5, 'b').should('equal', 'b = 6') // $ExpectType Chainable<string>
   cy.wrap(obj).its('bar').invoke('baz', 2).should('equal', 3) // $ExpectType Chainable<number>
+  cy.wrap(obj).invoke('bam') // $ExpectType Chainable<number>
+  cy.wrap(obj).invoke('bam', 1) // $ExpectError
   cy.wrap(obj).invoke('bar', 2) // $ExpectError
   cy.wrap(obj).invoke('bar.baz', 2).should('equal', 3) // $ExpectError
   cy.wrap(obj).invoke('foo', 5, 1) // $ExpectError
   cy.wrap(obj).invoke('foo', 5, 'b', 1) // $ExpectError
   cy.get('input').then(it => it[0]).invoke('checkValidity') // $ExpectError
+  cy.get('input').invoke('val', 25, 12) // $ExpectError
   cy.get('input').invoke('val', 25) // $ExpectType Chainable<JQuery<HTMLInputElement>>
+  cy.get('input').invoke('val') // $ExpectType Chainable<string | number | string[] | undefined>
   cy.get('input').invoke('css', '') // $ExpectType Chainable<string>
   cy.get('input').invoke('css') // $ExpectError
 }

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -333,6 +333,21 @@ namespace CypressContainsTests {
   cy.contains('my text to find', {log: false, timeout: 100})
 }
 
+namespace CypressInvokeTests {
+  const obj = {
+    foo: (value: number, name = 'n') => `${ name } = ${ value + 1 }`,
+    bar: { baz: (a: number) => a + 1 }
+  }
+  cy.wrap(obj).invoke('foo', 1).should('equal', 'n = 2') // $ExpectType Chainable<string>
+  cy.wrap(obj).invoke('foo', 5, 'b').should('equal', 'b = 6') // $ExpectType Chainable<string>
+  cy.wrap(obj).its('bar').invoke('baz', 2).should('equal', 3) // $ExpectType Chainable<number>
+  cy.wrap(obj).invoke('bar', 2) // $ExpectError
+  cy.wrap(obj).invoke('bar.baz', 2).should('equal', 3) // $ExpectError
+  cy.wrap(obj).invoke('foo', 5, 1) // $ExpectError
+  cy.wrap(obj).invoke('foo', 5, 'b', 1) // $ExpectError
+  cy.get('input').then(it => it[0]).invoke('checkValidity') // $ExpectError
+}
+
 // https://github.com/cypress-io/cypress/pull/5574
 namespace CypressLocationTests {
   cy.location('path') // $ExpectError

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -141,6 +141,7 @@ namespace CypressInvokeTests {
     bar: { baz: (a: number) => a + 1 },
     bam: () => 1
   }
+  cy.wrap(obj).invoke({ log: false }, 'foo', 1).should('equal', 'n = 2') // $ExpectType Chainable<string>
   cy.wrap(obj).invoke('foo', 1).should('equal', 'n = 2') // $ExpectType Chainable<string>
   cy.wrap(obj).invoke('foo', 5, 'b').should('equal', 'b = 6') // $ExpectType Chainable<string>
   cy.wrap(obj).its('bar').invoke('baz', 2).should('equal', 3) // $ExpectType Chainable<number>
@@ -153,6 +154,7 @@ namespace CypressInvokeTests {
   cy.get('input').then(it => it[0]).invoke('checkValidity') // $ExpectError
   cy.get('input').invoke('val', 25, 12) // $ExpectError
   cy.get('input').invoke('val', 25) // $ExpectType Chainable<JQuery<HTMLInputElement>>
+  cy.get('input').invoke({ log: false }, 'val', 25) // $ExpectType Chainable<JQuery<HTMLInputElement>>
   cy.get('input').invoke('val') // $ExpectType Chainable<string | number | string[] | undefined>
   cy.get('input').invoke('css', '') // $ExpectType Chainable<string>
   cy.get('input').invoke('css') // $ExpectError


### PR DESCRIPTION
Closes #4022 (1st attempt -> https://github.com/cypress-io/cypress/pull/4907)

Provides strong typing for arguments and return type of `invoke` command. Also ensures `functionName` is the key of a function on the `Subject`.

This PR is much crazier than the first in order to address the issue detailed in https://github.com/cypress-io/cypress/issues/4022#issuecomment-519197525, as well as other issues that came up, e.g. functions with no parameters.

I expanded the test cases to cover several more scenarios; not all of those tests pass under TypeScript 3.3, but work with 3.4+.

BTW, I totally understand if there's too much craziness in here to merge; I'm just glad this was a nice problem for playing with complex types.

### Pre-merge Tasks

- [x] Have tests been added/updated for the changes in this PR?
- [x] Have the [type definitions](cli/types/index.d.ts) been updated with any user-facing API changes?
