### PR TITLE
fix(driver): type() can target activeElement

### DIFF
--- a/packages/driver/src/cy/commands/actions/type.js
+++ b/packages/driver/src/cy/commands/actions/type.js
@@ -112,12 +112,13 @@ module.exports = function (Commands, Cypress, cy, state, config) {
       const isMonth = $dom.isType(options.$el, 'month')
       const isWeek = $dom.isType(options.$el, 'week')
       const hasTabIndex = $dom.isSelector(options.$el, '[tabindex]')
+      const isCurrentlyFocused = $dom.isFocused($dom.getElements(options.$el))
 
       // TODO: tabindex can't be -1
 
       const isTypeableButNotAnInput = isBody || (hasTabIndex && !isTextLike)
 
-      if (!isBody && !isTextLike && !hasTabIndex) {
+      if (!isBody && !isTextLike && !hasTabIndex && !isCurrentlyFocused) {
         const node = $dom.stringify(options.$el)
 
         $utils.throwErrByPath('type.not_on_typeable_element', {

--- a/packages/driver/src/cypress/error_messages.coffee
+++ b/packages/driver/src/cypress/error_messages.coffee
@@ -923,7 +923,7 @@ module.exports = {
 
         > {{node}}
 
-      Cypress considers the 'body', 'textarea', any 'element' with a 'tabindex' or 'contenteditable' attribute, or any 'input' with a 'type' attribute of 'text', 'password', 'email', 'number', 'date', 'week', 'month', 'time', 'datetime', 'datetime-local', 'search', 'url', or 'tel' to be valid typeable elements.
+      Cypress considers the currently focused element, 'body', 'textarea', any 'element' with a 'tabindex' or 'contenteditable' attribute, or any 'input' with a 'type' attribute of 'text', 'password', 'email', 'number', 'date', 'week', 'month', 'time', 'datetime', 'datetime-local', 'search', 'url', or 'tel' to be valid typeable elements.
     """
     tab: "{tab} isn't a supported character sequence. You'll want to use the command #{cmd('tab')}, which is not ready yet, but when it is done that's what you'll use."
     wrong_type: "#{cmd('type')} can only accept a String or Number. You passed in: '{{chars}}'"

--- a/packages/driver/test/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/type_spec.js
@@ -167,6 +167,11 @@ describe('src/cy/commands/actions/type', () => {
       })
     })
 
+    it('can type into the focused element', () => {
+      cy.get('button:first').focus()
+      cy.focused().type('{downarrow}')
+    })
+
     describe('actionability', () => {
       it('can forcibly click even when element is invisible', () => {
         const $txt = cy.$$(':text:first').hide()
@@ -4237,7 +4242,7 @@ describe('src/cy/commands/actions/type', () => {
           expect(err.message).to.include('cy.type() failed because it requires a valid typeable element.')
           expect(err.message).to.include('The element typed into was:')
           expect(err.message).to.include('<form id="by-id">...</form>')
-          expect(err.message).to.include('Cypress considers the \'body\', \'textarea\', any \'element\' with a \'tabindex\' or \'contenteditable\' attribute, or any \'input\' with a \'type\' attribute of \'text\', \'password\', \'email\', \'number\', \'date\', \'week\', \'month\', \'time\', \'datetime\', \'datetime-local\', \'search\', \'url\', or \'tel\' to be valid typeable elements.')
+          expect(err.message).to.include('Cypress considers the currently focused element, \'body\', \'textarea\', any \'element\' with a \'tabindex\' or \'contenteditable\' attribute, or any \'input\' with a \'type\' attribute of \'text\', \'password\', \'email\', \'number\', \'date\', \'week\', \'month\', \'time\', \'datetime\', \'datetime-local\', \'search\', \'url\', or \'tel\' to be valid typeable elements.')
 
           done()
         })


### PR DESCRIPTION
- Closes #2166 (vaguely related)

The following fails right now:

```js
cy.get('button').focus();
cy.focused().type('{downarrow}');
```
`force: true` does not help. Only adding `tabIndex="-1"` to the button which shouldn't be required since a button is already focusable and even in tab-order.

This would also follow the current UI-Events spec draft:

> The event target of a key event is the currently focused element which is processing the keyboard activity.

-- https://w3c.github.io/uievents/#event-type-keydown

### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

- [x] Have tests been added/updated for the changes in this PR?
- [ ] Has a PR to [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation) been submitted to document any user-facing changes? <!-- Link to PR here -->
- ~[ ] Have the [type definitions](cli/types/index.d.ts) been updated with any user-facing API changes?~
- ~[ ] Has the [cypress.schema.json](cli/schema/cypress.schema.json) been updated with any new configuration options?~
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
