### PR TITLE
Fix desktop-gui layout issues when there's a plugins file error

### DIFF
--- a/packages/desktop-gui/src/styles/components/_alerts.scss
+++ b/packages/desktop-gui/src/styles/components/_alerts.scss
@@ -42,12 +42,17 @@
   display: flex;
   flex-grow: 2;
   justify-content: center;
+  overflow: auto;
+  padding: 30px 60px;
 }
 
 .full-alert {
+  // `margin: auto` fixes issue with flexbox vertically-centered element + oveflow
+  // https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container
+  margin: auto;
   overflow: auto;
-  text-align: center;
   padding: 20px;
+  text-align: center;
 
   .alert-content {
     text-align: left;
@@ -61,6 +66,11 @@
 
   code {
     padding: 1px 4px;
+  }
+
+  pre {
+    max-height: 200px;
+    overflow: auto;
   }
 
   summary {


### PR DESCRIPTION
- Closes #4959 

No longer covers nav and footer when the error details are expanded:

![Screen Shot 2019-08-09 at 10 16 52 AM](https://user-images.githubusercontent.com/1157043/62785811-5d4e1a00-ba8f-11e9-90ad-0075b17d1fde.png)

Bonus: caps the height of the error details and scrolls them instead of the entire error message so 'Try Again' button stays visible (as long as desktop gui height is at a reasonable size):

![desktop-gui-error-scrolling](https://user-images.githubusercontent.com/1157043/62785852-7060ea00-ba8f-11e9-8fb7-56cb9e379ce5.gif)


### Pre-merge Tasks
- [x] Have tests been added/updated for the changes in this PR?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
