### PR TITLE
Adding presets for following viewports: 1) iPhone-XR, 2) iPhone-X, 3)…

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -4364,7 +4364,7 @@ declare namespace Cypress {
 
   type Encodings = 'ascii' | 'base64' | 'binary' | 'hex' | 'latin1' | 'utf8' | 'utf-8' | 'ucs2' | 'ucs-2' | 'utf16le' | 'utf-16le'
   type PositionType = "topLeft" | "top" | "topRight" | "left" | "center" | "right" | "bottomLeft" | "bottom" | "bottomRight"
-  type ViewportPreset = 'macbook-15' | 'macbook-13' | 'macbook-11' | 'ipad-2' | 'ipad-mini' | 'iphone-6+' | 'iphone-6' | 'iphone-5' | 'iphone-4' | 'iphone-3'
+  type ViewportPreset = 'macbook-15' | 'macbook-13' | 'macbook-11' | 'ipad-2' | 'ipad-mini' | 'iphone-xr' | 'iphone-x' | 'iphone-6+' | 'iphone-6' | 'iphone-5' | 'iphone-4' | 'iphone-3' | 'samsung-s10' | 'samsung-note9'
   interface Offset {
     top: number,
     left: number

--- a/packages/driver/src/cy/commands/window.coffee
+++ b/packages/driver/src/cy/commands/window.coffee
@@ -14,6 +14,8 @@ viewports = {
   "iphone-5"   : "320x568"
   "iphone-4"   : "320x480"
   "iphone-3"   : "320x480"
+  "samsung-s10"   : "360x760"
+  "samsung-note9"   : "414x846"
 }
 
 validOrientations = ["landscape", "portrait"]

--- a/packages/driver/test/cypress/integration/commands/window_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/window_spec.coffee
@@ -546,6 +546,20 @@ describe "src/cy/commands/window", ->
 
         cy.viewport("ipad-mini")
 
+      it "iphone-xr", (done) ->
+        cy.on "viewport:changed", (viewport) ->
+          expect(viewport).to.deep.eq {viewportWidth: 414, viewportHeight: 896}
+          done()
+
+        cy.viewport("iphone-xr")
+      
+      it "iphone-x", (done) ->
+        cy.on "viewport:changed", (viewport) ->
+          expect(viewport).to.deep.eq {viewportWidth: 375, viewportHeight: 812}
+          done()
+
+        cy.viewport("iphone-x")
+
       it "iphone-6+", (done) ->
         cy.on "viewport:changed", (viewport) ->
           expect(viewport).to.deep.eq {viewportWidth: 414, viewportHeight: 736}
@@ -580,6 +594,20 @@ describe "src/cy/commands/window", ->
           done()
 
         cy.viewport("iphone-5", "portrait")
+
+      it "samsung-s10", (done) ->
+        cy.on "viewport:changed", (viewport) ->
+          expect(viewport).to.deep.eq {viewportWidth: 360, viewportHeight: 760}
+          done()
+
+        cy.viewport("samsung-s10")
+
+      it "samsung-note9", (done) ->
+        cy.on "viewport:changed", (viewport) ->
+          expect(viewport).to.deep.eq {viewportWidth: 414, viewportHeight: 846}
+          done()
+
+        cy.viewport("samsung-note9")
 
     context "errors", ->
       beforeEach ->


### PR DESCRIPTION
… Samsung-S10, 4) Samsung-Note9

<!-- Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md -->

Adds support to more preset viewports

### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

- [x] Have tests been added/updated for the changes in this PR?
- [ ] Has a PR to [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation) been submitted to document any user-facing changes? <!-- Link to PR here -->
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
