### PR TITLE
Workaround for cypress-docker-images issue 54 until detection for available XVFB ports can be implemented

### DIFF
--- a/cli/lib/exec/xvfb.js
+++ b/cli/lib/exec/xvfb.js
@@ -8,6 +8,7 @@ const { throwFormErrorText, errors } = require('../errors')
 const util = require('../util')
 
 const xvfb = Promise.promisifyAll(new Xvfb({
+  displayNum: util.getEnv('CYPRESS_xvfbPort'),
   timeout: 5000, // milliseconds
   onStderrData (data) {
     if (debugXvfb.enabled) {


### PR DESCRIPTION
- Provides a workaround for https://github.com/cypress-io/cypress-docker-images/issues/54
- Exposes an environment variable hook to allow users to control the XVFB port used, thereby allowing them to ensure that each of the containers participating in a parallel Cypress run does so using a different port number. While this doesn't address the underlying issue of port management, it may at least help others work around this problem by giving them control of the XVFB port used until such time as that underlying issue can be resolved.
- From what I've seen of Cypress so far, I would have liked to have made this property available as a configuration option also. However, I could not see a way to consume those options from xvfb.js.

### Pre-merge Tasks

- [ ] Have tests been added/updated for the changes in this PR?
I am very conscious that I've submitted this PR with no corresponding changes to tests. However, I struggled to find the correct place in which to add a test for this change. Any advice here would be much appreciated.
- [ ] Has a PR to [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation) been submitted to document any user-facing changes?
As per my comment above, I would have liked to have made the property introduced here available as a configuration option also (which would also have provided an obvious documentation precedent to follow). Given that this environment variable is outside of that pattern, advice would be welcomed on how you would like to see this documented.
- [ ] Have the [type definitions](cli/types/index.d.ts) been updated with any user-facing API changes?
N/A while the new property takes the form of an environment variable only. Have retained task in checklist in case PR feedback leads to making this property available as a configuration option also.
- [ ] Has the [cypress.schema.json](cli/schema/cypress.schema.json) been updated with any new configuration options?
N/A while the new property takes the form of an environment variable only. Have retained task in checklist in case PR feedback leads to making this property available as a configuration option also.
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
