### PR TITLE
Allow platform specific environment variables

### DIFF
--- a/cli/lib/util.js
+++ b/cli/lib/util.js
@@ -136,6 +136,26 @@ function printNodeOptions (log = debug) {
 }
 
 /**
+ * Allow platform specific environment variables. A variable can be
+ * specified for Linux and Windows like:
+ *
+ * CYPRESS_INSTALL_BINARY___linux='https://this.is/the/linux/binary.zip'
+ * CYPRESS_INSTALL_BINARY___win32='https://this.is/the/win32/binary.zip'
+ *
+ * And if there is such a platform specific variable, it will be used,
+ * or else the CYPRESS_INSTALL_BINARY will be used.
+ */
+function getPlatformSpecificEnv (varName, platform = process.platform) {
+  const platformVariable = `${varName}___${platform}`
+
+  if (process.env[platformVariable]) {
+    return process.env[platformVariable]
+  }
+
+  return process.env[varName]
+}
+
+/**
  * Removes double quote characters
  * from the start and end of the given string IF they are both present
  *
@@ -323,10 +343,12 @@ const util = {
     return path.join(process.cwd(), '..', '..', filename)
   },
 
+  getPlatformSpecificEnv,
+
   getEnv (varName, trim) {
     la(is.unemptyString(varName), 'expected environment variable name, not', varName)
 
-    const envVar = process.env[varName]
+    const envVar = getPlatformSpecificEnv(varName)
     const configVar = process.env[`npm_config_${varName}`]
     const packageConfigVar = process.env[`npm_package_config_${varName}`]
 

--- a/cli/test/lib/util_spec.js
+++ b/cli/test/lib/util_spec.js
@@ -416,6 +416,15 @@ describe('util', () => {
     })
   })
 
+  describe('.getPlatformSpecificEnv', () => {
+    it('prefers platform specific env var', () => {
+      process.env.CYPRESS_INSTALL_BINARY___linux = 'Linux value'
+      process.env.CYPRESS_INSTALL_BINARY = 'Default value'
+      expect(util.getPlatformSpecificEnv('CYPRESS_INSTALL_BINARY', 'linux')).to.eql('Linux value')
+      expect(util.getPlatformSpecificEnv('CYPRESS_INSTALL_BINARY', 'win32')).to.eql('Default value')
+    })
+  })
+
   describe('.getEnv', () => {
     it('reads from package.json config', () => {
       process.env.npm_package_config_CYPRESS_FOO = 'bar'


### PR DESCRIPTION
The `.npmrc` can have:
```
CYPRESS_INSTALL_BINARY___linux = https://this.is/the/linux/binary.zip
CYPRESS_INSTALL_BINARY___win32 = https://this.is/the/win32/binary.zip
```

Where the suffix is taken from platform [names in Nodejs](https://nodejs.org/api/process.html#process_process_platform).

So that on Windows the effective value of `CYPRESS_INSTALL_BINARY` would be `https://this.is/the/win32/binary.zip`.

- Closes #5036

### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

- [x] Have tests been added/updated for the changes in this PR?
- [x] Has a PR to [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation) been submitted to document any user-facing changes? https://github.com/cypress-io/cypress-documentation/pull/2040