### PR TITLE
Informative error when invalid CYPRESS_INSTALL_BINARY

### DIFF
--- a/cli/__snapshots__/errors_spec.js
+++ b/cli/__snapshots__/errors_spec.js
@@ -29,6 +29,7 @@ Cypress Version: 1.2.3
 exports['errors individual has the following errors 1'] = [
   "CYPRESS_RUN_BINARY",
   "binaryNotExecutable",
+  "cypressInstallBinaryInvalid",
   "failedDownload",
   "failedUnzip",
   "invalidCacheDirectory",

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -159,6 +159,16 @@ const invalidCacheDirectory = {
   `,
 }
 
+const cypressInstallBinaryInvalid = {
+  description: 'Was not able to identify CYPRESS_INSTALL_BINARY as a semantic version, filesystem path or URL.',
+  solution: stripIndent`
+    The value can be one of:
+    - Semantic version of Cypress, numbers like x.y.z
+    - A path on the filesystem to an existing binary distribution
+    - A URL pointing at the binary distribtion
+  `,
+}
+
 const versionMismatch = {
   description: 'Installed version does not match package version.',
   solution: 'Install Cypress and verify app again',
@@ -338,5 +348,6 @@ module.exports = {
     removed,
     CYPRESS_RUN_BINARY,
     smokeTestFailure,
+    cypressInstallBinaryInvalid,
   },
 }


### PR DESCRIPTION
I had `CYPRESS_INSTALL_BINARY` set to `'http://serrver.com/'` (including single quotes). And I did not get an informative error stating that this was the case.

<!-- Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md -->

- Closes #5059 

### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

- [x] Have tests been added/updated for the changes in this PR?
