### PR TITLE
prevent .contains from finding `<style>` tags

### DIFF
--- a/packages/driver/src/dom/elements.js
+++ b/packages/driver/src/dom/elements.js
@@ -707,7 +707,7 @@ const getContainsSelector = (text, filter = '') => {
   const filters = filter.trim().split(',')
 
   const selectors = _.map(filters, (filter) => {
-    return `${filter}:not(script):contains('${escapedText}'), ${filter}[type='submit'][value~='${escapedText}']`
+    return `${filter}:not(script,style):contains('${escapedText}'), ${filter}[type='submit'][value~='${escapedText}']`
   })
 
   return selectors.join()

--- a/packages/driver/test/cypress/integration/commands/querying_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/querying_spec.coffee
@@ -1203,7 +1203,6 @@ describe "src/cy/commands/querying", ->
       cy.$$('<style> some-style-content {} </style>').appendTo(cy.$$('body'))
       cy.contains('some-style-content').should('not.match', 'style')
 
-
     it "finds the nearest element by :contains selector", ->
       cy.contains("li 0").then ($el) ->
         expect($el.length).to.eq(1)

--- a/packages/driver/test/cypress/integration/commands/querying_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/querying_spec.coffee
@@ -1195,6 +1195,15 @@ describe "src/cy/commands/querying", ->
       cy.contains("DOM Fixture").then ($el) ->
         expect($el).not.to.match("title")
 
+    it 'will not find script elements', ->
+      cy.$$('<script>// some-script-content </script>').appendTo(cy.$$('body'))
+      cy.contains('some-script-content').should('not.match', 'script')
+
+    it 'will not find style elements', ->
+      cy.$$('<style> some-style-content {} </style>').appendTo(cy.$$('body'))
+      cy.contains('some-style-content').should('not.match', 'style')
+
+
     it "finds the nearest element by :contains selector", ->
       cy.contains("li 0").then ($el) ->
         expect($el.length).to.eq(1)


### PR DESCRIPTION
<!-- Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md -->

this PR prevents `.contains` from yielding you a `<style>` element. 

Note however that if the style is inside the `body`, then the `body` will be yielded (same as `<script>`)

- Closes #2119
### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

- [x] Have tests been added/updated for the changes in this PR?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
