### PR TITLE
fix: increase XVFB timeout from 5 seconds to 30 seconds

### DIFF
--- a/cli/lib/exec/xvfb.js
+++ b/cli/lib/exec/xvfb.js
@@ -8,7 +8,7 @@ const { throwFormErrorText, errors } = require('../errors')
 const util = require('../util')
 
 const xvfb = Promise.promisifyAll(new Xvfb({
-  timeout: 5000, // milliseconds
+  timeout: 30000, // milliseconds
   onStderrData (data) {
     if (debugXvfb.enabled) {
       debugXvfb(data.toString())


### PR DESCRIPTION
- Closes #5110
- XVFB start timeout 30 seconds

### Pre-merge Tasks

- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
