### PR TITLE
replace abandoned cli-table2 dep for currently maintained cli-table3 dep

### DIFF
--- a/packages/server/lib/util/terminal.js
+++ b/packages/server/lib/util/terminal.js
@@ -14,8 +14,8 @@
  */
 const _ = require('lodash')
 const chalk = require('chalk')
-const Table = require('cli-table2')
-const utils = require('cli-table2/src/utils')
+const Table = require('cli-table3')
+const utils = require('cli-table3/src/utils')
 const widestLine = require('widest-line')
 const terminalSize = require('./terminal-size')
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -54,7 +54,7 @@
     "check-more-types": "2.24.0",
     "chokidar": "3.0.1",
     "cjsxify": "0.3.0",
-    "cli-table2": "0.2.0",
+    "cli-table3": "0.5.1",
     "color-string": "1.5.3",
     "common-tags": "1.8.0",
     "compression": "1.7.4",


### PR DESCRIPTION
- Requires Node 6+
- Includes type defs
- Fixes a few bugs
- Reduces dep size

cli-table2: 62.3 kB MINIFIED & 22.6 kB MINIFIED + GZIPPED
cli-table3: 13 kB MINIFIED & 4.9 kB MINIFIED + GZIPPED