### PR TITLE
Avoid warning when URL in CYPRESS_INSTALL_BINARY

### DIFF
--- a/cli/lib/tasks/install.js
+++ b/cli/lib/tasks/install.js
@@ -250,7 +250,7 @@ const start = (options = {}) => {
       return
     }
 
-    if (needVersion !== pkgVersion) {
+    if (needVersion !== pkgVersion && util.isSemver(needVersion)) {
       logger.log(
         chalk.yellow(stripIndent`
           ${logSymbols.warning} Warning: Forcing a binary version different than the default.


### PR DESCRIPTION
When having `CYPRESS_INSTALL_BINARY` set to a URL, like `https://cdn.cypress.io/desktop/3.4.1/darwin-x64/cypress.zip`, I get a warning about forcing binary version.

Because `needVersion`, which now is a URL, is compared to `pkgVersion`, which is a semantic version.

<!-- Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md -->

- Closes #5062
