### PR TITLE
fix eslint for fixture specs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,7 +7,12 @@
 **/dist
 **/dist-test
 **/node_modules
-**/support/fixtures
+**/support/fixtures/*
+!**/support/fixtures/projects
+**/support/fixtures/projects/**/_fixtures/*
+**/support/fixtures/projects/**/*.jsx
+**/support/fixtures/projects/**/jquery.js
+**/support/fixtures/projects/**/fail.js
 **/test/fixtures
 **/vendor
 

--- a/packages/server/test/support/fixtures/projects/busted-support-file/cypress/support/index.js
+++ b/packages/server/test/support/fixtures/projects/busted-support-file/cypress/support/index.js
@@ -1,1 +1,1 @@
-import "./does/not/exist"
+import './does/not/exist'

--- a/packages/server/test/support/fixtures/projects/default-layout/cypress/integration/default_layout_spec.js
+++ b/packages/server/test/support/fixtures/projects/default-layout/cypress/integration/default_layout_spec.js
@@ -1,1 +1,2 @@
+/* eslint-disable mocha/no-global-tests */
 it('works', () => {})

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/browserify_babel_es2015_failing_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/browserify_babel_es2015_failing_spec.js
@@ -1,1 +1,1 @@
-import "../../lib/fail"
+import '../../lib/fail'

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/https_passthru_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/https_passthru_spec.js
@@ -23,6 +23,7 @@ describe('https passthru retries', () => {
       img.onload = () => {
         reject(new Error('onload event fired, but should not have. expected onerror to fire.'))
       }
+
       img.onerror = resolve
     })
   })

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/network_error_handling_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/network_error_handling_spec.js
@@ -27,8 +27,10 @@ describe('network error handling', function () {
       })
       .get('input[type=text]')
       .type('bar')
+
       cy.get('input[type=submit]')
       .click()
+
       cy.contains('{"foo":"bar"}')
     })
   })

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/plugins/index.js
@@ -101,6 +101,7 @@ module.exports = (on) => {
 
     'record:fast_visit_spec' ({ percentiles, url, browser, currentRetry }) {
       percentiles.forEach(([percent, percentile]) => {
+        // eslint-disable-next-line no-console
         console.log(`${percent}%\t of visits to ${url} finished in less than ${percentile}ms`)
       })
 
@@ -110,8 +111,9 @@ module.exports = (on) => {
         currentRetry,
         ...percentiles.reduce((acc, pair) => {
           acc[pair[0]] = pair[1]
+
           return acc
-        }, {})
+        }, {}),
       }
 
       return performance.track('fast_visit_spec percentiles', data)

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/support/foo/bar.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/support/foo/bar.js
@@ -1,1 +1,2 @@
-console.log("bar")
+/* eslint-disable no-console */
+console.log('bar')

--- a/packages/server/test/support/fixtures/projects/e2e/lib/bar.js
+++ b/packages/server/test/support/fixtures/projects/e2e/lib/bar.js
@@ -1,3 +1,3 @@
-import baz from "./baz"
+import baz from './baz'
 
 export default baz

--- a/packages/server/test/support/fixtures/projects/e2e/lib/baz.js
+++ b/packages/server/test/support/fixtures/projects/e2e/lib/baz.js
@@ -1,3 +1,3 @@
 export default () => {
-  return "baz"
+  return 'baz'
 }

--- a/packages/server/test/support/fixtures/projects/e2e/reporters/custom.js
+++ b/packages/server/test/support/fixtures/projects/e2e/reporters/custom.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 module.exports = function Reporter (runner) {
   runner.on('test end', function (test) {
     console.log(test.title)

--- a/packages/server/test/support/fixtures/projects/ids/cypress/integration/bar.js
+++ b/packages/server/test/support/fixtures/projects/ids/cypress/integration/bar.js
@@ -1,3 +1,3 @@
-context("some context[i9w]", function(){
+context('some context[i9w]', function () {
   it('tests[abc]')
 })

--- a/packages/server/test/support/fixtures/projects/ids/cypress/integration/baz.js
+++ b/packages/server/test/support/fixtures/projects/ids/cypress/integration/baz.js
@@ -1,1 +1,1 @@
-import "./dom.jsx"
+import './dom.jsx'

--- a/packages/server/test/support/fixtures/projects/multiple-task-registrations/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/multiple-task-registrations/cypress/plugins/index.js
@@ -1,11 +1,19 @@
 module.exports = (on) => {
   on('task', {
-    'one' () { return 'one' },
-    'two' () { return 'two' },
+    'one' () {
+      return 'one'
+    },
+    'two' () {
+      return 'two'
+    },
   })
 
   on('task', {
-    'two' () { return 'two again' },
-    'three' () { return 'three' },
+    'two' () {
+      return 'two again'
+    },
+    'three' () {
+      return 'three'
+    },
   })
 }

--- a/packages/server/test/support/fixtures/projects/no-server/helpers/includes.js
+++ b/packages/server/test/support/fixtures/projects/no-server/helpers/includes.js
@@ -1,3 +1,3 @@
-beforeEach(function(){
+beforeEach(function () {
 
-});
+})

--- a/packages/server/test/support/fixtures/projects/no-server/my-tests/test1.js
+++ b/packages/server/test/support/fixtures/projects/no-server/my-tests/test1.js
@@ -1,3 +1,4 @@
-it("tests without a server", function(){
+/* eslint-disable mocha/no-global-tests */
+it('tests without a server', function () {
 
-});
+})

--- a/packages/server/test/support/fixtures/projects/plugin-extension/ext/background.js
+++ b/packages/server/test/support/fixtures/projects/plugin-extension/ext/background.js
@@ -1,5 +1,3 @@
-/* global document */
-
 const el = document.getElementById('extension')
 
 if (el) {

--- a/packages/server/test/support/fixtures/projects/plugin-extension/ext/manifest.json
+++ b/packages/server/test/support/fixtures/projects/plugin-extension/ext/manifest.json
@@ -3,16 +3,22 @@
   "version": "0",
   "description": "tests adding user extension into Cypress",
   "permissions": [
-    "tabs", "webNavigation", "<all_urls>"
+    "tabs",
+    "webNavigation",
+    "<all_urls>"
   ],
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": [
+        "<all_urls>"
+      ],
       "exclude_matches": [
         "*://*/__cypress/*",
         "*://*/__/*"
       ],
-      "js": ["background.js"],
+      "js": [
+        "background.js"
+      ],
       "run_at": "document_end",
       "all_frames": true
     }

--- a/packages/server/test/support/fixtures/projects/plugins-async-error/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/plugins-async-error/cypress/plugins/index.js
@@ -1,5 +1,3 @@
-/* global Promise */
-
 module.exports = (on) => {
   on('file:preprocessor', () => {
     return new Promise(() => {

--- a/packages/server/test/support/fixtures/projects/todos/tests/test1.js
+++ b/packages/server/test/support/fixtures/projects/todos/tests/test1.js
@@ -1,3 +1,4 @@
-it("is truthy", function(){
+/* eslint-disable mocha/no-global-tests */
+it('is truthy', function () {
   expect(true).to.be.true
 })

--- a/packages/server/test/support/fixtures/projects/working-preprocessor/cypress/integration/another_spec.js
+++ b/packages/server/test/support/fixtures/projects/working-preprocessor/cypress/integration/another_spec.js
@@ -1,5 +1,4 @@
-/* global it, expect */
-
+/* eslint-disable mocha/no-global-tests */
 it('is another spec', () => {
   expect(false).to.be.false
 })


### PR DESCRIPTION
- Add eslint to `support/fixtures` files, since there are a lot of specs written in there.