### PR TITLE
add --no-sandbox to spawn

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -797,12 +797,15 @@ linux-workflow: &linux-workflow
         requires:
           - build
     - driver-integration-tests-3x:
+        context: test-runner:integration-tests
         requires:
           - build
     - desktop-gui-integration-tests-2x:
+        context: test-runner:integration-tests
         requires:
           - build
     - reporter-integration-tests:
+        context: test-runner:integration-tests
         requires:
           - build
     - run-launcher:

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -9,6 +9,7 @@ const debugElectron = require('debug')('cypress:electron')
 const util = require('../util')
 const state = require('../tasks/state')
 const xvfb = require('./xvfb')
+const verify = require('../tasks/verify')
 const { throwFormErrorText, errors } = require('../errors')
 
 const isXlibOrLibudevRe = /^(?:Xlib|libudev)/
@@ -104,6 +105,10 @@ module.exports = {
         const envOverrides = util.getEnvOverrides()
         const electronArgs = _.clone(args)
         const node11WindowsFix = isPlatform('win32')
+
+        if (verify.needsSandbox()) {
+          electronArgs.push('--no-sandbox')
+        }
 
         // strip dev out of child process options
         let stdioOptions = _.pick(options, 'env', 'detached', 'stdio')

--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -11,6 +11,7 @@ const mockedEnv = require('mocked-env')
 const state = require(`${lib}/tasks/state`)
 const xvfb = require(`${lib}/exec/xvfb`)
 const spawn = require(`${lib}/exec/spawn`)
+const verify = require(`${lib}/tasks/verify`)
 const util = require(`${lib}/util.js`)
 const expect = require('chai').expect
 
@@ -76,8 +77,17 @@ describe('lib/exec/spawn', function () {
   })
 
   context('.start', function () {
+    // ️️⚠️ NOTE ⚠️
+    // when asserting the calls made to spawn the child Cypress process
+    // we have to be _very_ careful. Spawn uses process.env object, if an assertion
+    // fails, it will print the entire process.env object to the logs, which
+    // might contain sensitive environment variables. Think about what the
+    // failed assertion might print to the public CI logs and limit
+    // the environment variables when running tests on CI.
+
     it('passes args + options to spawn', function () {
       this.spawnedProcess.on.withArgs('close').yieldsAsync(0)
+      sinon.stub(verify, 'needsSandbox').returns(false)
 
       return spawn.start('--foo', { foo: 'bar' })
       .then(() => {
@@ -94,6 +104,7 @@ describe('lib/exec/spawn', function () {
 
     it('uses npm command when running in dev mode', function () {
       this.spawnedProcess.on.withArgs('close').yieldsAsync(0)
+      sinon.stub(verify, 'needsSandbox').returns(false)
 
       const p = path.resolve('..', 'scripts', 'start.js')
 

--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -102,6 +102,24 @@ describe('lib/exec/spawn', function () {
       })
     })
 
+    it('uses --no-sandbox when needed', function () {
+      this.spawnedProcess.on.withArgs('close').yieldsAsync(0)
+      sinon.stub(verify, 'needsSandbox').returns(true)
+
+      return spawn.start('--foo', { foo: 'bar' })
+      .then(() => {
+        const args = cp.spawn.firstCall.args.slice(0, 2)
+        const expectedCliArgs = [
+          '--foo',
+          '--cwd',
+          cwd,
+          '--no-sandbox',
+        ]
+
+        expect(args).deep.equal(['/path/to/cypress', expectedCliArgs])
+      })
+    })
+
     it('uses npm command when running in dev mode', function () {
       this.spawnedProcess.on.withArgs('close').yieldsAsync(0)
       sinon.stub(verify, 'needsSandbox').returns(false)

--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -108,6 +108,9 @@ describe('lib/exec/spawn', function () {
 
       return spawn.start('--foo', { foo: 'bar' })
       .then(() => {
+        // skip the options argument: we do not need anything about it
+        // and also less risk that a failed assertion would dump the
+        // entire ENV object with possible sensitive variables
         const args = cp.spawn.firstCall.args.slice(0, 2)
         const expectedCliArgs = [
           '--foo',
@@ -116,7 +119,7 @@ describe('lib/exec/spawn', function () {
           '--no-sandbox',
         ]
 
-        expect(args).deep.equal(['/path/to/cypress', expectedCliArgs])
+        expect(args).to.deep.equal(['/path/to/cypress', expectedCliArgs])
       })
     })
 


### PR DESCRIPTION
- closes #5208
- need to use `--no-sandbox` when spawning electron from CLI
- [x] update any existing tests
- [x] add a test that `--no-sandbox` is passed when needed