### PR TITLE
upgrade jQuery types to 3.3.31 to pass TS 3.6.2 check

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -63,7 +63,7 @@
     "@types/bluebird": "3.5.18",
     "@types/chai": "4.0.8",
     "@types/chai-jquery": "1.1.38",
-    "@types/jquery": "3.3.6",
+    "@types/jquery": "3.3.31",
     "@types/lodash": "4.14.122",
     "@types/minimatch": "3.0.3",
     "@types/mocha": "5.2.7",

--- a/cli/scripts/post-install.js
+++ b/cli/scripts/post-install.js
@@ -20,6 +20,12 @@ includeTypes.forEach((folder) => {
   shell.cp('-R', source, 'types')
 })
 
+// jQuery v3.3.x includes "dist" folder that just references back to itself
+// causing dtslint to think there are double definitions. Remove that folder.
+const typesJqueryDistFolder = join('types', 'jquery', 'dist')
+
+shell.rm('-rf', typesJqueryDistFolder)
+
 // fix paths to Chai, jQuery and other types to be relative
 shell.sed(
   '-i',


### PR DESCRIPTION
- closes #5065 
- [x] issue has release set
