### PR TITLE
WIP: Use Chrome 77 in CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ executors:
   # the Docker image with Cypress dependencies and Chrome browser
   cy-doc:
     docker:
-      - image: cypress/browsers:node12.0.0-chrome73
+      - image: cypress/browsers:node12.6.0-chrome77
     environment:
       PLATFORM: linux
 

--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ executors:
   # the Docker image with Cypress dependencies and Chrome browser
   cy-doc:
     docker:
-      - image: cypress/browsers:node12.6.0-chrome76
+      - image: cypress/browsers:node12.16.0-chrome76
     environment:
       PLATFORM: linux
 

--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ executors:
   # the Docker image with Cypress dependencies and Chrome browser
   cy-doc:
     docker:
-      - image: cypress/browsers:node12.6.0-chrome77
+      - image: cypress/browsers:node12.6.0-chrome76
     environment:
       PLATFORM: linux
 

--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ executors:
   # the Docker image with Cypress dependencies and Chrome browser
   cy-doc:
     docker:
-      - image: cypress/browsers:node12.16.0-chrome76
+      - image: cypress/browsers:node12.6.0-chrome77
     environment:
       PLATFORM: linux
 


### PR DESCRIPTION
<!-- Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md -->

- Closes #5236

### Description of change

Use Chrome 77 (or the current version) in the tests executes by CircleCI.

### How to use the feature

<!-- What code does the user write now versus before?
 (a GIF or screenshots of the feature in action is preferred!) 
 Fixing a bug? What test passes now that used to fail for the user? -->

Chrome 77 should be used automatically instead of Chrome 73 in the tests.

### How the design has changed

<!-- screenshots comparing the previous design(s) to new -->

### Notes

<!-- Have something else to add? Add it here :) -->

### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

- [ ] Have tests been added/updated for the changes in this PR?
- [ ] Has a PR to [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation) been submitted to document any user-facing changes? <!-- Link to PR here -->
- [ ] Have the [type definitions](cli/types/index.d.ts) been updated with any user-facing API changes?
- [ ] Has the [cypress.schema.json](cli/schema/cypress.schema.json) been updated with any new configuration options?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
