### PR TITLE
desktop-gui fixes: Fix scrolling after Electron upgrade, add auth fallback errors

### DIFF
--- a/packages/desktop-gui/cypress/integration/runs_list_spec.js
+++ b/packages/desktop-gui/cypress/integration/runs_list_spec.js
@@ -338,7 +338,7 @@ describe('Runs List', function () {
       })
 
       it('shows login message', () => {
-        cy.get('.login h1').should('contain', 'Log in')
+        cy.get('.login h1').should('contain', 'Log In')
       })
 
       it('clicking Log In to Dashboard opens login', () => {

--- a/packages/desktop-gui/src/app/nav.scss
+++ b/packages/desktop-gui/src/app/nav.scss
@@ -24,6 +24,7 @@
   background-color:#ececec;
   box-shadow: 0 0 3px 0 rgba(0,0,0,0.20);
   border-color: #c8c8c8;
+  z-index: 10;
 
   .nav {
     > .open {

--- a/packages/desktop-gui/src/auth/login-form.jsx
+++ b/packages/desktop-gui/src/auth/login-form.jsx
@@ -1,10 +1,13 @@
 import cs from 'classnames'
+import { observer } from 'mobx-react'
 import React, { Component } from 'react'
 
 import authApi from './auth-api'
+import authStore from './auth-store'
 import ipc from '../lib/ipc'
 import MarkdownRenderer from '../lib/markdown-renderer'
 
+@observer
 class LoginForm extends Component {
   static defaultProps = {
     onSuccess () {},
@@ -16,7 +19,7 @@ class LoginForm extends Component {
   }
 
   render () {
-    const { message } = this.props
+    const { message } = authStore
 
     return (
       <div className='login-content'>
@@ -54,7 +57,7 @@ class LoginForm extends Component {
   }
 
   _buttonContent () {
-    const message = this.props.message || {}
+    const message = authStore || {}
 
     if (this.state.isLoggingIn) {
       if (message.name === 'AUTH_COULD_NOT_LAUNCH_BROWSER') {

--- a/packages/desktop-gui/src/auth/login-form.jsx
+++ b/packages/desktop-gui/src/auth/login-form.jsx
@@ -31,7 +31,7 @@ class LoginForm extends Component {
           onClick={this._login}
           disabled={this.state.isLoggingIn}
         >
-          {this._buttonContent()}
+          {this._buttonContent(message)}
         </button>
         {
           message && <p className={`message ${message.type}`} onClick={this._selectUrl}>
@@ -56,11 +56,9 @@ class LoginForm extends Component {
     selection.addRange(range)
   }
 
-  _buttonContent () {
-    const message = authStore || {}
-
+  _buttonContent (message) {
     if (this.state.isLoggingIn) {
-      if (message.name === 'AUTH_COULD_NOT_LAUNCH_BROWSER') {
+      if (message && message.name === 'AUTH_COULD_NOT_LAUNCH_BROWSER') {
         return (
           <span>
             <i className='fa fa-exclamation-triangle'></i>{' '}
@@ -72,7 +70,7 @@ class LoginForm extends Component {
       return (
         <span>
           <i className='fa fa-spinner fa-spin'></i>{' '}
-          {message.browserOpened ? 'Waiting for browser login...' : 'Opening browser...'}
+          {message && message.browserOpened ? 'Waiting for browser login...' : 'Opening browser...'}
         </span>
       )
     }

--- a/packages/desktop-gui/src/auth/login-modal.jsx
+++ b/packages/desktop-gui/src/auth/login-modal.jsx
@@ -70,7 +70,7 @@ class LoginContent extends Component {
         <BootstrapModal.Dismiss className='btn btn-link close'>x</BootstrapModal.Dismiss>
         <h1><i className='fa fa-lock'></i> Log In</h1>
         <p>Logging in gives you access to the <a onClick={this._openDashboard}>Cypress Dashboard Service</a>. You can set up projects to be recorded and see test data from your project.</p>
-        <LoginForm message={authStore.message} onSuccess={() => this.setState({ succeeded: true })} />
+        <LoginForm onSuccess={() => this.setState({ succeeded: true })} />
       </div>
     )
   }

--- a/packages/desktop-gui/src/auth/login.scss
+++ b/packages/desktop-gui/src/auth/login.scss
@@ -63,7 +63,7 @@
       cursor: pointer;
     }
 
-    &.warning {
+    &.warning p {
       color: $red-primary;
     }
   }

--- a/packages/desktop-gui/src/project/project.scss
+++ b/packages/desktop-gui/src/project/project.scss
@@ -4,5 +4,8 @@
   flex-grow: 2;
   margin-bottom: 0;
   width: 100%;
-  min-height: 0;
+
+  & > * {
+    overflow: auto;
+  }
 }

--- a/packages/desktop-gui/src/project/project.scss
+++ b/packages/desktop-gui/src/project/project.scss
@@ -4,8 +4,5 @@
   flex-grow: 2;
   margin-bottom: 0;
   width: 100%;
-
-  & > * {
-    overflow: auto;
-  }
+  overflow: auto;
 }

--- a/packages/desktop-gui/src/runs/setup-project-modal.jsx
+++ b/packages/desktop-gui/src/runs/setup-project-modal.jsx
@@ -12,8 +12,6 @@ import { gravatarUrl } from '../lib/utils'
 import orgsStore from '../organizations/organizations-store'
 import orgsApi from '../organizations/organizations-api'
 
-import LoginForm from '../auth/login-form'
-
 @observer
 class SetupProject extends Component {
   static propTypes = {
@@ -72,7 +70,9 @@ class SetupProject extends Component {
 
   render () {
     if (!authStore.isAuthenticated) {
-      return this._loginMessage()
+      authStore.setShowingLogin(true)
+
+      return null
     }
 
     if (!orgsStore.isLoaded) {
@@ -106,17 +106,6 @@ class SetupProject extends Component {
             </div>
           </div>
         </form>
-      </div>
-    )
-  }
-
-  _loginMessage () {
-    return (
-      <div className='login modal-body'>
-        <BootstrapModal.Dismiss className='btn btn-link close'>x</BootstrapModal.Dismiss>
-        <h1><i className='fa fa-lock'></i> Log in</h1>
-        <p>Logging in gives you access to the <a onClick={this._openDashboard}>Cypress Dashboard Service</a>. You can set up projects to be recorded and see test data from your project.</p>
-        <LoginForm />
       </div>
     )
   }

--- a/packages/desktop-gui/src/specs/specs.scss
+++ b/packages/desktop-gui/src/specs/specs.scss
@@ -5,7 +5,6 @@ $max-nesting-level: 14;
   display: flex;
   flex-direction: column;
   width: 100%;
-  min-height: 0;
 
   .empty-well code {
     display: block;


### PR DESCRIPTION
Scrolling some panes in the desktop-gui was broken after the Electron update, since Chromium changed how sizing of children of `display:flex` elements are handled.

This PR also adds the fallback error messages (Open this URL in your browser to continue login: ...) to the Runs List login, and updates the New Project Modal to use the existing LoginModal which has fallback error messages.

## Before

Runs & Configuration view both have this scrolling bug:

![Peek 2019-09-30 09-19](https://user-images.githubusercontent.com/1151760/65883956-01549300-e366-11e9-8110-dc5fc73e097d.gif)

## After

- [x] Can someone validate that this is how the content should be scrolled?

![after2](https://user-images.githubusercontent.com/1151760/65885212-35c94e80-e368-11e9-82d7-d41357e26b1b.gif)
![after3](https://user-images.githubusercontent.com/1151760/65885213-35c94e80-e368-11e9-9f4c-468a345d2222.gif)
