### PR TITLE
Fix auth after Electron upgrade

### DIFF
--- a/packages/server/lib/gui/auth.js
+++ b/packages/server/lib/gui/auth.js
@@ -127,9 +127,12 @@ const _launchServer = (baseLoginUrl, sendMessage) => {
         res.redirect(`${baseLoginUrl}?status=${status}`)
       }
 
-      if (_.get(req.query, 'status') === 'error') {
-        authCallback(new Error('There was an error authenticating to the Cypress dashboard.'))
-        redirectToStatus('error')
+      if (_.get(req.query, 'status') === 'error' || !authCallback) {
+        if (authCallback) {
+          authCallback(new Error('There was an error authenticating to the Cypress dashboard.'))
+        }
+
+        return redirectToStatus('error')
       }
 
       const { state, name, email, access_token } = req.query
@@ -190,10 +193,7 @@ const _launchNativeAuth = Promise.method((loginUrl, sendMessage) => {
 
   openExternalAttempted = true
 
-  // wrap openExternal here in case `electron.shell` is not available (during tests)
-  return Promise.fromCallback((cb) => {
-    shell.openExternal(loginUrl, {}, cb)
-  })
+  return shell.openExternal(loginUrl)
   .catch((err) => {
     debug('Error launching native auth: %o', { err })
     warnCouldNotLaunch()

--- a/packages/server/lib/gui/auth.js
+++ b/packages/server/lib/gui/auth.js
@@ -127,6 +127,11 @@ const _launchServer = (baseLoginUrl, sendMessage) => {
         res.redirect(`${baseLoginUrl}?status=${status}`)
       }
 
+      /**
+       * Cypress Dashboard can redirect to us with an error; or, if Electron's shell.openExternal
+       * is bugging out, `authCallback` can be undefined and reaching this point makes no sense.
+       * @see https://github.com/cypress-io/cypress/pull/5243
+       */
       if (_.get(req.query, 'status') === 'error' || !authCallback) {
         if (authCallback) {
           authCallback(new Error('There was an error authenticating to the Cypress dashboard.'))

--- a/packages/server/test/unit/gui/auth_spec.js
+++ b/packages/server/test/unit/gui/auth_spec.js
@@ -88,21 +88,21 @@ describe('lib/gui/auth', function () {
       })
 
       it('returns a promise that is fulfilled when openExternal succeeds', function () {
-        sinon.stub(electron.shell, 'openExternal').callsArg(2)
+        sinon.stub(electron.shell, 'openExternal').resolves()
 
         return auth._launchNativeAuth(REDIRECT_URL)
         .then(() => {
-          expect(electron.shell.openExternal).to.be.calledWithMatch(REDIRECT_URL, {}, sinon.match.func)
+          expect(electron.shell.openExternal).to.be.calledWithMatch(REDIRECT_URL)
         })
       })
 
       it('is still fulfilled when openExternal fails, but sendWarning is called', function () {
-        sinon.stub(electron.shell, 'openExternal').callsArgWith(2, new Error)
+        sinon.stub(electron.shell, 'openExternal').rejects()
         const sendWarning = sinon.stub()
 
         return auth._launchNativeAuth(REDIRECT_URL, sendWarning)
         .then(() => {
-          expect(electron.shell.openExternal).to.be.calledWithMatch(REDIRECT_URL, {}, sinon.match.func)
+          expect(electron.shell.openExternal).to.be.calledWithMatch(REDIRECT_URL)
           expect(sendWarning).to.be.calledWithMatch('warning', 'AUTH_COULD_NOT_LAUNCH_BROWSER', REDIRECT_URL)
         })
       })


### PR DESCRIPTION
shell.openExternal should've been converted to a Promise w/ Electron 5. Without this, Promise.fromCallback never resolves and `authCallback` is never set, leading to authentication failure.

### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

- [x] Have tests been added/updated for the changes in this PR?
