### PR TITLE
fix: switch back to using jquery width/height on element dimensions

### DIFF
--- a/packages/driver/test/cypress/fixtures/dom.html
+++ b/packages/driver/test/cypress/fixtures/dom.html
@@ -49,6 +49,10 @@
           display: block
         }
 
+        .content-box {
+          box-sizing: content-box
+        }
+
       </style>
 
       DOM Fixture
@@ -434,6 +438,8 @@
       </div>
 
       <div id="invisible" style="display: none;">i am not visible</div>
+
+      <button class="content-box">content-box</button>
 
       <div id="svgs">
         <svg data-cy="line" width="300" height="200">

--- a/packages/driver/test/cypress/integration/e2e/domSnapshots.spec.js
+++ b/packages/driver/test/cypress/integration/e2e/domSnapshots.spec.js
@@ -2,16 +2,13 @@ const { withMutableReporterState, findReactInstance, getCommandLogWithText } = r
 const { $ } = Cypress
 
 describe('rect highlight', () => {
-
   it('content highlight does not include padding', () => {
     cy.visit('/fixtures/dom.html')
 
     cy.get('button:first')
 
     cy.wait(0)
-    // cy.wrap(null).should(() => {
-
-    cy.then(() => {
+    .then(() => {
       withMutableReporterState(() => {
 
         const commandLogEl = getCommandLogWithText('button:first')

--- a/packages/driver/test/cypress/integration/e2e/domSnapshots.spec.js
+++ b/packages/driver/test/cypress/integration/e2e/domSnapshots.spec.js
@@ -1,0 +1,42 @@
+const { withMutableReporterState, findReactInstance, getCommandLogWithText } = require('../../support/utils')
+const { $ } = Cypress
+
+describe('rect highlight', () => {
+
+  it('content highlight does not include padding', () => {
+    cy.visit('/fixtures/dom.html')
+
+    cy.get('button:first')
+
+    cy.wait(0)
+    // cy.wrap(null).should(() => {
+
+    cy.then(() => {
+      withMutableReporterState(() => {
+
+        const commandLogEl = getCommandLogWithText('button:first')
+
+        const reactCommandInstance = findReactInstance(commandLogEl)
+
+        reactCommandInstance.props.appState.isRunning = false
+
+        $(commandLogEl).find('.command-wrapper').click()
+      })
+    })
+
+    cy.get('div[data-layer=Content]').should(($el) => {
+      expectToBeInside($el[0].getBoundingClientRect(), cy.$$('div[data-layer=Border]')[0].getBoundingClientRect())
+    })
+  })
+})
+
+const expectToBeInside = (rectInner, rectOuter) => {
+  Cypress.log({ name: 'assert', message: `Expected to be inside rect` })
+  expect(rectInner.width, 'width').lte(rectOuter.width)
+  expect(rectInner.height, 'height').lte(rectOuter.height)
+  expect(rectInner.top, 'top').gte(rectOuter.top)
+  expect(rectInner.left, 'left').gte(rectOuter.left)
+  expect(rectInner.right, 'right').lte(rectOuter.right)
+  expect(rectInner.bottom, 'bottom').lte(rectOuter.bottom)
+
+}

--- a/packages/driver/test/cypress/integration/e2e/domSnapshots.spec.js
+++ b/packages/driver/test/cypress/integration/e2e/domSnapshots.spec.js
@@ -1,6 +1,24 @@
 const { withMutableReporterState, findReactInstance, getCommandLogWithText } = require('../../support/utils')
 const { $ } = Cypress
 
+describe('rect highlight', () => {
+  beforeEach(() => {
+    cy.visit('/fixtures/dom.html')
+  })
+
+  it('highlight elements are properly positioned', () => {
+    getAndPin('button:first')
+
+    expectCorrectHighlightPositions()
+  })
+
+  it('highlight elements properly positioned for content-box', () => {
+    getAndPin('button.content-box:first')
+
+    expectCorrectHighlightPositions()
+  })
+})
+
 const getAndPin = (sel) => {
   cy.get(sel)
 
@@ -19,41 +37,18 @@ const getAndPin = (sel) => {
   })
 }
 
-describe('rect highlight', () => {
-  it('highlight elements are properly positioned', () => {
-    cy.visit('/fixtures/dom.html')
+const expectCorrectHighlightPositions = () => {
+  return cy.wrap(null, { timeout: 400 }).should(() => {
+    const dims = {
+      content: cy.$$('div[data-layer=Content]')[0].getBoundingClientRect(),
+      padding: cy.$$('div[data-layer=Padding]')[0].getBoundingClientRect(),
+      border: cy.$$('div[data-layer=Border]')[0].getBoundingClientRect(),
+    }
 
-    getAndPin('button:first')
-
-    cy.wrap(null, { timeout: 400 }).should(() => {
-      const dims = {
-        content: cy.$$('div[data-layer=Content]')[0].getBoundingClientRect(),
-        padding: cy.$$('div[data-layer=Padding]')[0].getBoundingClientRect(),
-        border: cy.$$('div[data-layer=Border]')[0].getBoundingClientRect(),
-      }
-
-      expectToBeInside(dims.content, dims.padding, 'content to be inside padding')
-      expectToBeInside(dims.padding, dims.border, 'padding to be inside border')
-    })
+    expectToBeInside(dims.content, dims.padding, 'content to be inside padding')
+    expectToBeInside(dims.padding, dims.border, 'padding to be inside border')
   })
-
-  it('highlight elements properly positioned for content-box', () => {
-    cy.visit('/fixtures/dom.html')
-
-    getAndPin('button.content-box:first')
-
-    cy.wrap(null, { timeout: 400 }).should(() => {
-      const dims = {
-        content: cy.$$('div[data-layer=Content]')[0].getBoundingClientRect(),
-        padding: cy.$$('div[data-layer=Padding]')[0].getBoundingClientRect(),
-        border: cy.$$('div[data-layer=Border]')[0].getBoundingClientRect(),
-      }
-
-      expectToBeInside(dims.content, dims.padding, 'content to be inside padding')
-      expectToBeInside(dims.padding, dims.border, 'padding to be inside border')
-    })
-  })
-})
+}
 
 const expectToBeInside = (rectInner, rectOuter, mes = 'rect to be inside rect') => {
   try {

--- a/packages/driver/test/cypress/integration/e2e/domSnapshots.spec.js
+++ b/packages/driver/test/cypress/integration/e2e/domSnapshots.spec.js
@@ -9,13 +9,13 @@ describe('rect highlight', () => {
   it('highlight elements are properly positioned', () => {
     getAndPin('button:first')
 
-    expectCorrectHighlightPositions()
+    shouldHaveCorrectHighlightPositions()
   })
 
   it('highlight elements properly positioned for content-box', () => {
     getAndPin('button.content-box:first')
 
-    expectCorrectHighlightPositions()
+    shouldHaveCorrectHighlightPositions()
   })
 })
 
@@ -37,7 +37,7 @@ const getAndPin = (sel) => {
   })
 }
 
-const expectCorrectHighlightPositions = () => {
+const shouldHaveCorrectHighlightPositions = () => {
   return cy.wrap(null, { timeout: 400 }).should(() => {
     const dims = {
       content: cy.$$('div[data-layer=Content]')[0].getBoundingClientRect(),

--- a/packages/driver/test/cypress/integration/e2e/domSnapshots.spec.js
+++ b/packages/driver/test/cypress/integration/e2e/domSnapshots.spec.js
@@ -1,38 +1,71 @@
 const { withMutableReporterState, findReactInstance, getCommandLogWithText } = require('../../support/utils')
 const { $ } = Cypress
 
+const getAndPin = (sel) => {
+  cy.get(sel)
+
+  cy.wait(0)
+  .then(() => {
+    withMutableReporterState(() => {
+
+      const commandLogEl = getCommandLogWithText(sel)
+
+      const reactCommandInstance = findReactInstance(commandLogEl)
+
+      reactCommandInstance.props.appState.isRunning = false
+
+      $(commandLogEl).find('.command-wrapper').click()
+    })
+  })
+}
+
 describe('rect highlight', () => {
-  it('content highlight does not include padding', () => {
+  it('highlight elements are properly positioned', () => {
     cy.visit('/fixtures/dom.html')
 
-    cy.get('button:first')
+    getAndPin('button:first')
 
-    cy.wait(0)
-    .then(() => {
-      withMutableReporterState(() => {
+    cy.wrap(null, { timeout: 400 }).should(() => {
+      const dims = {
+        content: cy.$$('div[data-layer=Content]')[0].getBoundingClientRect(),
+        padding: cy.$$('div[data-layer=Padding]')[0].getBoundingClientRect(),
+        border: cy.$$('div[data-layer=Border]')[0].getBoundingClientRect(),
+      }
 
-        const commandLogEl = getCommandLogWithText('button:first')
-
-        const reactCommandInstance = findReactInstance(commandLogEl)
-
-        reactCommandInstance.props.appState.isRunning = false
-
-        $(commandLogEl).find('.command-wrapper').click()
-      })
+      expectToBeInside(dims.content, dims.padding, 'content to be inside padding')
+      expectToBeInside(dims.padding, dims.border, 'padding to be inside border')
     })
+  })
 
-    cy.get('div[data-layer=Content]').should(($el) => {
-      expectToBeInside($el[0].getBoundingClientRect(), cy.$$('div[data-layer=Border]')[0].getBoundingClientRect())
+  it('highlight elements properly positioned for content-box', () => {
+    cy.visit('/fixtures/dom.html')
+
+    getAndPin('button.content-box:first')
+
+    cy.wrap(null, { timeout: 400 }).should(() => {
+      const dims = {
+        content: cy.$$('div[data-layer=Content]')[0].getBoundingClientRect(),
+        padding: cy.$$('div[data-layer=Padding]')[0].getBoundingClientRect(),
+        border: cy.$$('div[data-layer=Border]')[0].getBoundingClientRect(),
+      }
+
+      expectToBeInside(dims.content, dims.padding, 'content to be inside padding')
+      expectToBeInside(dims.padding, dims.border, 'padding to be inside border')
     })
   })
 })
 
-const expectToBeInside = (rectInner, rectOuter) => {
-  expect(rectInner.width, 'width').lte(rectOuter.width)
-  expect(rectInner.height, 'height').lte(rectOuter.height)
-  expect(rectInner.top, 'top').gte(rectOuter.top)
-  expect(rectInner.left, 'left').gte(rectOuter.left)
-  expect(rectInner.right, 'right').lte(rectOuter.right)
-  expect(rectInner.bottom, 'bottom').lte(rectOuter.bottom)
+const expectToBeInside = (rectInner, rectOuter, mes = 'rect to be inside rect') => {
+  try {
+    expect(rectInner.width, 'width').lte(rectOuter.width)
+    expect(rectInner.height, 'height').lte(rectOuter.height)
+    expect(rectInner.top, 'top').gte(rectOuter.top)
+    expect(rectInner.left, 'left').gte(rectOuter.left)
+    expect(rectInner.right, 'right').lte(rectOuter.right)
+    expect(rectInner.bottom, 'bottom').lte(rectOuter.bottom)
+  } catch (e) {
+    e.message = `\nExpected ${mes}\n${e.message}`
+    throw e
+  }
 
 }

--- a/packages/driver/test/cypress/integration/e2e/domSnapshots.spec.js
+++ b/packages/driver/test/cypress/integration/e2e/domSnapshots.spec.js
@@ -31,7 +31,6 @@ describe('rect highlight', () => {
 })
 
 const expectToBeInside = (rectInner, rectOuter) => {
-  Cypress.log({ name: 'assert', message: `Expected to be inside rect` })
   expect(rectInner.width, 'width').lte(rectOuter.width)
   expect(rectInner.height, 'height').lte(rectOuter.height)
   expect(rectInner.top, 'top').gte(rectOuter.top)

--- a/packages/driver/test/cypress/support/utils.js
+++ b/packages/driver/test/cypress/support/utils.js
@@ -1,0 +1,28 @@
+export const getCommandLogWithText = (text) => cy.$$(`.runnable-active .command-wrapper:contains(${text}):visible`, top.document).parentsUntil('li').last().parent()[0]
+
+export const findReactInstance = function (dom) {
+  let key = Object.keys(dom).find((key) => key.startsWith('__reactInternalInstance$'))
+  let internalInstance = dom[key]
+
+  if (internalInstance == null) return null
+
+  return internalInstance._debugOwner
+    ? internalInstance._debugOwner.stateNode
+    : internalInstance.return.stateNode
+
+}
+
+export const withMutableReporterState = (fn) => {
+  top.Runner.configureMobx({ enforceActions: 'never' })
+
+  const currentTestLog = findReactInstance(cy.$$('.runnable-active', top.document)[0])
+
+  currentTestLog.props.model.isOpen = true
+
+  return Cypress.Promise.try(() => {
+    return fn()
+  }).then(() => {
+    top.Runner.configureMobx({ enforceActions: 'strict' })
+  })
+
+}

--- a/packages/runner/src/lib/dom.js
+++ b/packages/runner/src/lib/dom.js
@@ -233,15 +233,15 @@ function createLayer ($el, attr, color, container, dimensions) {
 function dimensionsMatchPreviousLayer (obj, container) {
   // since we're prepending to the container that
   // means the previous layer is actually the first child element
-  const previousLayer = container.children().first().get(0)
+  const previousLayer = container.children().first()
 
   // bail if there is no previous layer
   if (!previousLayer) {
     return
   }
 
-  return obj.width === previousLayer.offsetWidth &&
-  obj.height === previousLayer.offsetHeight
+  return obj.width === previousLayer.width() &&
+  obj.height === previousLayer.height()
 }
 
 function getDimensionsFor (dimensions, attr, dimension) {
@@ -254,15 +254,14 @@ function getZIndex (el) {
   }
 
   return _.toNumber(el.css('zIndex'))
+
 }
 
 function getElementDimensions ($el) {
-  const el = $el.get(0)
-
   const dimensions = {
     offset: $el.offset(), // offset disregards margin but takes into account border + padding
-    height: el.offsetHeight, // we want to use offsetHeight here (because that always returns just the content hight) instead of .css() because .css('height') is altered based on whether box-sizing: border-box is set
-    width: el.offsetWidth,
+    height: $el.height(), // we want to use height here (because that always returns just the content hight) instead of .css() because .css('height') is altered based on whether box-sizing: border-box is set
+    width: $el.width(),
     paddingTop: getPadding($el, 'top'),
     paddingRight: getPadding($el, 'right'),
     paddingBottom: getPadding($el, 'bottom'),
@@ -338,8 +337,8 @@ function isInViewport (win, el) {
   return (
     rect.top >= 0 &&
     rect.left >= 0 &&
-    rect.bottom <= win.innerHeight &&
-    rect.right <= win.innerWidth
+    rect.bottom <= $(win).height() &&
+    rect.right <= $(win).width()
   )
 }
 

--- a/packages/runner/src/lib/dom.js
+++ b/packages/runner/src/lib/dom.js
@@ -259,7 +259,6 @@ function getZIndex (el) {
   }
 
   return _.toNumber(el.css('zIndex'))
-
 }
 
 function getElementDimensions ($el) {
@@ -342,8 +341,8 @@ function isInViewport (win, el) {
   return (
     rect.top >= 0 &&
     rect.left >= 0 &&
-    rect.bottom <= $(win).height() &&
-    rect.right <= $(win).width()
+    rect.bottom <= win.innerHeight &&
+    rect.right <= win.innerWidth
   )
 }
 

--- a/packages/runner/src/lib/dom.js
+++ b/packages/runner/src/lib/dom.js
@@ -112,6 +112,11 @@ function addElementBoxModelLayers ($el, $body) {
       obj.left -= dimensions.marginLeft
     }
 
+    if (attr === 'Padding') {
+      obj.top += dimensions.borderTop
+      obj.left += dimensions.borderLeft
+    }
+
     // bail if the dimensions of this layer match the previous one
     // so we dont create unnecessary layers
     if (dimensionsMatchPreviousLayer(obj, $container)) return


### PR DESCRIPTION
<!-- Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md -->

- fix #5239
- partially revert #1229 
- address #1215
### Description of change
- use jquery .width() and height() methods to calculate dimensions of elements for dom highlights

<!-- How would you explain this change in our changelog 
for every user to read and understand -->

<!-- What code does the user write now versus before?
 (a GIF or screenshots of the feature in action is preferred!) 
 Fixing a bug? What test passes now that used to fail for the user? -->

### How the design has changed

<!-- screenshots comparing the previous design(s) to new -->

before:
![19-09-30_11:09::38](https://user-images.githubusercontent.com/14625260/65891701-ff450100-e372-11e9-8637-093c698f41e9.png)
after:
![image](https://user-images.githubusercontent.com/14625260/65895619-be041f80-e379-11e9-88fe-449b72f08538.png)
![19-09-30_11:58::20](https://user-images.githubusercontent.com/14625260/65895631-c2303d00-e379-11e9-9e67-97401ab824c9.png)


### Notes

<!-- Have something else to add? Add it here :) -->

### Pre-merge Tasks
- [x] fix padding box as well

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

- [x] Have tests been added/updated for the changes in this PR?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
