### PR TITLE
cli: add sizzle types needed by jQuery types

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@cypress/listr-verbose-renderer": "0.4.1",
     "@cypress/xvfb": "1.2.4",
+    "@types/sizzle": "2.3.2",
     "arch": "2.1.1",
     "bluebird": "3.5.0",
     "cachedir": "1.3.0",

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -19,6 +19,10 @@
 /// <reference path="./jquery/index.d.ts" />
 /// <reference path="./chai-jquery/index.d.ts" />
 
+// jQuery includes dependency "sizzle" that provides types
+// so we include it too in "node_modules/sizzle".
+// This way jQuery can load it using 'reference types="sizzle"' directive
+
 // "moment" types are with "node_modules/moment"
 /// <reference types="moment" />
 


### PR DESCRIPTION
- closes #5245

Since jQuery v3 types need sizzle types, include sizzle types as production CLI dependency