### PR TITLE
WIP: Use Chrome 77 or later in the automated tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -405,6 +405,17 @@ jobs:
           at: ~/
       - install-google-chrome
       - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
+      - run:
           command: npm run all test-performance -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -415,6 +426,8 @@ jobs:
   "server-e2e-tests-chrome-1":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
       - run:
           name: Restore Google Chrome
           command: |
@@ -433,6 +446,8 @@ jobs:
   "server-e2e-tests-chrome-2":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
       - run:
           name: Restore Google Chrome
           command: |
@@ -451,6 +466,19 @@ jobs:
   "server-e2e-tests-chrome-3":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 3
@@ -458,6 +486,19 @@ jobs:
   "server-e2e-tests-chrome-4":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 4
@@ -465,6 +506,19 @@ jobs:
   "server-e2e-tests-chrome-5":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 5
@@ -472,6 +526,19 @@ jobs:
   "server-e2e-tests-chrome-6":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 6
@@ -479,6 +546,19 @@ jobs:
   "server-e2e-tests-chrome-7":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 7
@@ -486,6 +566,19 @@ jobs:
   "server-e2e-tests-chrome-8":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 8
@@ -554,6 +647,17 @@ jobs:
           at: ~/
       - install-google-chrome
       - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
+      - run:
           command: npm start
           background: true
           working_directory: packages/driver
@@ -604,6 +708,17 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
+      - run:
           command: npm run build-prod
           working_directory: packages/desktop-gui
       - run:
@@ -624,6 +739,17 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
+      - run:
           command: npm run build-prod
           working_directory: packages/reporter
       - run:
@@ -643,6 +769,17 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run:
           command: node index.js
           working_directory: packages/launcher
@@ -753,6 +890,17 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
+      - run:
           name: Cloning test project
           command: git clone https://github.com/cypress-io/cypress-example-kitchensink.git /tmp/repo
       - run:
@@ -779,6 +927,17 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run:
           name: Cloning test project
           command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/repo

--- a/circle.yml
+++ b/circle.yml
@@ -80,8 +80,8 @@ commands:
             fi
             if [[ "$OSTYPE" == "linux"* ]]; then
               apt update
-              apt install fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
-              dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb || true
+              apt install -y fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
+              dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb
               which google-chrome
               which google-chrome-stable
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -65,9 +65,7 @@ commands:
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
               dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb || true
-              apt-get update --fix-missing
-              dpkg --configure -a
-              apt-get install -f 
+              apt-get -f install 
             fi
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
@@ -111,6 +109,10 @@ commands:
           key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-root-{{ checksum "package.json" }}
           paths:
             - node_modules
+      - save_cache:
+          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome-{{ checksum "chrome_installers" }}
+          paths:
+            - chrome_installers
       - save-cache:
           packageName: coffee
       - save-cache:
@@ -175,6 +177,9 @@ commands:
       - restore-cache:
           packageName: root
           packagePath: package.json
+      - restore-cache:
+          packageName: chrome
+          packagePath: chrome_installers
       - restore-cache:
           packageName: coffee
           packagePath: packages/coffee/package.json
@@ -278,7 +283,7 @@ jobs:
             if [ ! -d "~/chrome_installers/google-chrome-stable.dmg" ] && [ "$OSTYPE" == "darwin"* ]; then
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/chrome_installers/google-chrome-stable.dmg
             fi
-            if [ ! -d "~/chrome_installers/google-chrome-stable_current_amd64.deb" ] && [ "$OSTYPE" != "darwin"* ]; then
+            if [ ! -d "~/chrome_installers/google-chrome-stable_current_amd64.deb" ] && [ "$OSTYPE" == "linux"* ]; then
               wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
               mv google-chrome-stable_current_amd64.deb ~/chrome_installers
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -278,9 +278,6 @@ jobs:
             set -e
             if [[ "$OSTYPE" == "darwin"* ]]; then
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/google-chrome-stable.dmg
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications
-              touch /usr/bin/google-chrome-stable # dummy
             else
               wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
               echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
@@ -289,18 +286,8 @@ jobs:
               rm -rf /var/lib/apt/lists/*
               which google-chrome-stable
               google-chrome-stable -version
-              touch /Applications/Google\ Chrome.app # dummy
+              cp -r `which google-chrome-stable` ~
             fi
-
-      - persist_to_workspace:
-          root: /usr/bin/
-          paths:
-            - google-chrome-stable
-      
-      - persist_to_workspace:
-          root: /Applications/
-          paths:
-            - Google\ Chrome.app
 
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:
@@ -323,6 +310,16 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r google-chrome-stable /usr/bin/
+            fi
       # make sure mocha runs
       - run: npm run test-mocha
       # test binary build code
@@ -382,6 +379,16 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r google-chrome-stable /usr/bin/
+            fi
       - run: npm run all test-integration -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -404,6 +411,16 @@ jobs:
   "server-e2e-tests-chrome-1":
     <<: *defaults
     steps:
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 1
@@ -411,6 +428,16 @@ jobs:
   "server-e2e-tests-chrome-2":
     <<: *defaults
     steps:
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 2

--- a/circle.yml
+++ b/circle.yml
@@ -403,6 +403,17 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
+      - run:
           command: npm run all test-performance -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -413,6 +424,8 @@ jobs:
   "server-e2e-tests-chrome-1":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
       - run:
           name: Restore Google Chrome
           command: |
@@ -431,6 +444,8 @@ jobs:
   "server-e2e-tests-chrome-2":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
       - run:
           name: Restore Google Chrome
           command: |
@@ -449,6 +464,19 @@ jobs:
   "server-e2e-tests-chrome-3":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 3
@@ -456,6 +484,19 @@ jobs:
   "server-e2e-tests-chrome-4":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 4
@@ -463,6 +504,19 @@ jobs:
   "server-e2e-tests-chrome-5":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 5
@@ -470,6 +524,19 @@ jobs:
   "server-e2e-tests-chrome-6":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 6
@@ -477,6 +544,19 @@ jobs:
   "server-e2e-tests-chrome-7":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 7
@@ -484,6 +564,19 @@ jobs:
   "server-e2e-tests-chrome-8":
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 8
@@ -551,6 +644,17 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
+      - run:
           command: npm start
           background: true
           working_directory: packages/driver
@@ -601,6 +705,17 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
+      - run:
           command: npm run build-prod
           working_directory: packages/desktop-gui
       - run:
@@ -621,6 +736,17 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
+      - run:
           command: npm run build-prod
           working_directory: packages/reporter
       - run:
@@ -640,6 +766,17 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run:
           command: node index.js
           working_directory: packages/launcher
@@ -719,6 +856,17 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
+      - run:
           name: Cloning test project
           command: git clone https://github.com/cypress-io/cypress-example-kitchensink.git /tmp/repo
       - run:
@@ -771,6 +919,17 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r ~/google-chrome-stable /usr/bin/
+            fi
       - run:
           name: Cloning test project
           command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/repo

--- a/circle.yml
+++ b/circle.yml
@@ -264,7 +264,8 @@ jobs:
             set -e
             if [[ "$OSTYPE" == "darwin"* ]]; then
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/google-chrome-stable.dmg
-              open ~/google-chrome-stable.dmg
+              hdiutil attach  ~/google-chrome-stable.dmg
+              ls /Volumnes/
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications
             else
               wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ defaults: &defaults
     LINES: 24
 
 executors:
-  # the Docker image with Cypress dependencies and Chrome browser
+  # the Docker image with Cypress dependencies
   cy-doc:
     docker:
       - image: cypress/base:12.12.0
@@ -65,8 +65,9 @@ commands:
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             fi
             if [[ "$OSTYPE" == "linux"* ]]; then
+              apt update
+              apt install fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
               dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb || true
-              apt-get -f install
               which google-chrome
               which google-chrome-stable
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -74,13 +74,14 @@ commands:
           name: Install Google Chrome
           command: |
             set -e
-            ls ~/installers
             if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/installers/google-chrome-stable.dmg
+              hdiutil attach  ~/chrome_installers/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
-              dpkg -i ~/installers/google-chrome-stable_current_amd64.deb
-              sudo apt-get install -f
+              dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb || true
+              apt-get update --fix-missing
+              dpkg --configure -a
+              apt-get install -f 
             fi
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
@@ -283,20 +284,20 @@ jobs:
       # Prune so we do not save removed dependencies to cache
       - run: npm run all prune
 
-      - save-caches
-      - store-npm-logs
-
       - run:
           name: "Download Google Chrome (stable) intaller"
           command: |
-            set -e
-            mkdir ~/installers
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/installers/google-chrome-stable.dmg
-            else
-              wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-              mv google-chrome-stable_current_amd64.deb ~/installers
+            mkdir -p ~/chrome_installers
+            if [ ! -d "~/installers/google-chrome-stable.dmg" ]; then
+              curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/chrome_installers/google-chrome-stable.dmg
             fi
+            if [ ! -d "~/installers/google-chrome-stable_current_amd64.deb" ]; then
+              wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+              mv google-chrome-stable_current_amd64.deb ~/chrome_installers
+            fi
+
+      - save-caches
+      - store-npm-logs
 
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:

--- a/circle.yml
+++ b/circle.yml
@@ -283,6 +283,7 @@ jobs:
           root: ~/
           paths:
             - cypress
+            - google-chrome-stable*
 
   lint:
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -66,6 +66,7 @@ commands:
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
               dpkg -i ~/installers/google-chrome-stable_current_amd64.deb
+              sudo apt-get install -f
             fi
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
@@ -623,6 +624,7 @@ jobs:
             else
               echo "Not Mac platform, skipping code sign setup"
             fi
+
       - attach_workspace:
           at: ~/
       - run: $(npm bin)/print-arch

--- a/circle.yml
+++ b/circle.yml
@@ -65,9 +65,11 @@ commands:
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             fi
             if [[ "$OSTYPE" == "linux"* ]]; then
+              ls ~
               apt update
               apt install -y fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
-              dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb
+              apt install -y google-chrome-stable
+              #dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb
               which google-chrome
               which google-chrome-stable
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -77,7 +77,8 @@ commands:
             if [[ "$OSTYPE" == "darwin"* ]]; then
               hdiutil attach  ~/chrome_installers/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
+            fi
+            if [[ "$OSTYPE" == "linux"* ]]; then
               dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb || true
               apt-get -f install
               which google-chrome
@@ -126,7 +127,7 @@ commands:
           paths:
             - node_modules
       - save_cache:
-          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome-{{ checksum "~/chrome_installers" }}
+          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome
           paths:
             - ~/chrome_installers
       - save-cache:
@@ -193,9 +194,9 @@ commands:
       - restore-cache:
           packageName: root
           packagePath: package.json
-      - restore-cache:
-          packageName: chrome
-          packagePath: ~/chrome_installers
+      - restore_cache:
+          name: Restoring cache for chrome
+          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome
       - restore-cache:
           packageName: coffee
           packagePath: packages/coffee/package.json

--- a/circle.yml
+++ b/circle.yml
@@ -254,7 +254,6 @@ jobs:
             if [[ "$OSTYPE" == "darwin"* ]]; then
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/google-chrome-stable.dmg
               hdiutil attach  ~/google-chrome-stable.dmg
-              ls /Volumnes/
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications
             else
               wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \

--- a/circle.yml
+++ b/circle.yml
@@ -286,8 +286,9 @@ jobs:
               rm -rf /var/lib/apt/lists/*
               which google-chrome-stable
               google-chrome-stable -version
-              cp -r `which google-chrome-stable` ~/google-chrome-stable
+              cp -r `which google-chrome-stable` ~/
             fi
+            ls ~/
 
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:
@@ -423,7 +424,7 @@ jobs:
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
-              cp -r google-chrome-stable /usr/bin/
+              cp -r ~/google-chrome-stable /usr/bin/
             fi
       - run-e2e-tests:
           browser: chrome
@@ -441,7 +442,7 @@ jobs:
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
-              cp -r google-chrome-stable /usr/bin/
+              cp -r ~/google-chrome-stable /usr/bin/
             fi
       - run-e2e-tests:
           browser: chrome

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,6 @@ executors:
   cy-doc:
     docker:
       - image: cypress/base:12.12.0
-<<<<<<< HEAD
     environment:
       PLATFORM: linux
 
@@ -33,8 +32,6 @@ executors:
     docker:
       - image: cypress/base:12.12.0
         user: node
-=======
->>>>>>> Download installer in build step. Install browser in run-e2e-tests
     environment:
       PLATFORM: linux
 
@@ -307,6 +304,8 @@ jobs:
               wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
               mv google-chrome-stable_current_amd64.deb ~/chrome_installers
             fi
+            ls -lath .
+            ls -lath ~/chrome_installers
 
       - save-caches
       - store-npm-logs

--- a/circle.yml
+++ b/circle.yml
@@ -47,14 +47,24 @@ executors:
 commands:
   install-google-chrome:
     description: Download and install Google Chrome (stable) and its dependencies
+    parameters:
+      browser:
+        description: browser shortname (chrome or electron)
+        type: string
+        default: chrome
     steps:
       - run:
           command: |
-            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-            echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
-            apt update
-            apt install -y google-chrome-stable
-            google-chrome -version
+            if [ << parameters.browser >> == "chrome" ];
+            then
+              wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - ;
+              echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list;
+              apt update;
+              apt install -y google-chrome-stable;
+              google-chrome -version;
+            else
+              echo "Chrome is not installed because the browser is set to "<< parameters.browser >>;
+            fi
   run-e2e-tests:
     parameters:
       browser:
@@ -66,7 +76,8 @@ commands:
     steps:
       - attach_workspace:
           at: ~/
-      - install-google-chrome
+      - install-google-chrome:
+          browser: << parameters.browser >>
       - run:
           name: Install Google Chrome
           command: |
@@ -356,7 +367,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - install-google-chrome
       - run: npm run all test-unit -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -378,7 +388,8 @@ jobs:
       steps:
       - attach_workspace:
           at: ~/
-      - install-google-chrome
+      - install-google-chrome:
+          browser: chrome
       - run:
           command: npm run all test-performance -- --package server
       - store_test_results:
@@ -505,7 +516,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - install-google-chrome
+      - install-google-chrome:
+          browser: chrome
       - run:
           command: npm start
           background: true

--- a/circle.yml
+++ b/circle.yml
@@ -47,24 +47,14 @@ executors:
 commands:
   install-google-chrome:
     description: Download and install Google Chrome (stable) and its dependencies
-    parameters:
-      browser:
-        description: browser shortname (chrome or electron)
-        type: string
-        default: chrome
     steps:
       - run:
           command: |
-            if [ << parameters.browser >> == "chrome" ];
-            then
-              wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - ;
-              echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list;
-              apt update;
-              apt install -y google-chrome-stable;
-              google-chrome -version;
-            else
-              echo "Chrome is not installed because the browser is set to "<< parameters.browser >>;
-            fi
+            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+            echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
+            apt update
+            apt install -y google-chrome-stable
+            google-chrome -version
   run-e2e-tests:
     parameters:
       browser:
@@ -76,8 +66,7 @@ commands:
     steps:
       - attach_workspace:
           at: ~/
-      - install-google-chrome:
-          browser: << parameters.browser >>
+      - install-google-chrome
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
           working_directory: packages/server
@@ -350,6 +339,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - install-google-chrome
       - run: npm run all test-unit -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -371,8 +361,7 @@ jobs:
       steps:
       - attach_workspace:
           at: ~/
-      - install-google-chrome:
-          browser: chrome
+      - install-google-chrome
       - run:
           command: npm run all test-performance -- --package server
       - store_test_results:
@@ -499,8 +488,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - install-google-chrome:
-          browser: chrome
+      - install-google-chrome
       - run:
           command: npm start
           background: true

--- a/circle.yml
+++ b/circle.yml
@@ -60,13 +60,14 @@ commands:
           name: Install Google Chrome
           command: |
             set -e
-            ls ~/installers
             if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/installers/google-chrome-stable.dmg
+              hdiutil attach  ~/chrome_installers/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
-              dpkg -i ~/installers/google-chrome-stable_current_amd64.deb
-              sudo apt-get install -f
+              dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb || true
+              apt-get update --fix-missing
+              dpkg --configure -a
+              apt-get install -f 
             fi
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
@@ -269,20 +270,20 @@ jobs:
       # Prune so we do not save removed dependencies to cache
       - run: npm run all prune
 
-      - save-caches
-      - store-npm-logs
-
       - run:
           name: "Download Google Chrome (stable) intaller"
           command: |
-            set -e
-            mkdir ~/installers
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/installers/google-chrome-stable.dmg
-            else
-              wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-              mv google-chrome-stable_current_amd64.deb ~/installers
+            mkdir -p ~/chrome_installers
+            if [ ! -d "~/installers/google-chrome-stable.dmg" ]; then
+              curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/chrome_installers/google-chrome-stable.dmg
             fi
+            if [ ! -d "~/installers/google-chrome-stable_current_amd64.deb" ]; then
+              wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+              mv google-chrome-stable_current_amd64.deb ~/chrome_installers
+            fi
+
+      - save-caches
+      - store-npm-logs
 
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:

--- a/circle.yml
+++ b/circle.yml
@@ -73,13 +73,15 @@ commands:
       - run:
           name: Install Google Chrome
           command: |
-            set -e
+            ls ~/chrome_installers
             if [[ "$OSTYPE" == "darwin"* ]]; then
               hdiutil attach  ~/chrome_installers/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
               dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb || true
-              apt-get -f install 
+              apt-get -f install
+              which google-chrome
+              which google-chrome-stable
             fi
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
@@ -124,9 +126,9 @@ commands:
           paths:
             - node_modules
       - save_cache:
-          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome-{{ checksum "chrome_installers" }}
+          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome-{{ checksum "~/chrome_installers" }}
           paths:
-            - chrome_installers
+            - ~/chrome_installers
       - save-cache:
           packageName: coffee
       - save-cache:
@@ -193,7 +195,7 @@ commands:
           packagePath: package.json
       - restore-cache:
           packageName: chrome
-          packagePath: chrome_installers
+          packagePath: ~/chrome_installers
       - restore-cache:
           packageName: coffee
           packagePath: packages/coffee/package.json

--- a/circle.yml
+++ b/circle.yml
@@ -63,7 +63,8 @@ commands:
             if [[ "$OSTYPE" == "darwin"* ]]; then
               hdiutil attach  ~/chrome_installers/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
+            fi
+            if [[ "$OSTYPE" == "linux"* ]]; then
               dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb || true
               apt-get -f install
               which google-chrome
@@ -112,7 +113,7 @@ commands:
           paths:
             - node_modules
       - save_cache:
-          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome-{{ checksum "~/chrome_installers" }}
+          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome
           paths:
             - ~/chrome_installers
       - save-cache:
@@ -179,9 +180,9 @@ commands:
       - restore-cache:
           packageName: root
           packagePath: package.json
-      - restore-cache:
-          packageName: chrome
-          packagePath: ~/chrome_installers
+      - restore_cache:
+          name: Restoring cache for chrome
+          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome
       - restore-cache:
           packageName: coffee
           packagePath: packages/coffee/package.json

--- a/circle.yml
+++ b/circle.yml
@@ -65,7 +65,7 @@ commands:
               hdiutil attach  ~/installers/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
-              dpkg -i installers/google-chrome-stable_current_amd64.deb
+              dpkg -i ~/installers/google-chrome-stable_current_amd64.deb
             fi
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>

--- a/circle.yml
+++ b/circle.yml
@@ -261,11 +261,18 @@ jobs:
       - run:
           name: "Install Google Chrome (stable)"
           command: |
-            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-            echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
-            apt-get update
-            apt-get install -y google-chrome-stable
-            rm -rf /var/lib/apt/lists/*
+            set -e
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/google-chrome-stable.dmg
+              open ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications
+            else
+              wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+              echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+              apt-get update
+              apt-get install -y google-chrome-stable
+              rm -rf /var/lib/apt/lists/*
+            fi
 
       # Install the root packages
       # Link sup packages in ./node_modules/@packages/*

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ defaults: &defaults
     LINES: 24
 
 executors:
-  # the Docker image with Cypress dependencies and Chrome browser
+  # the Docker image with Cypress dependencies
   cy-doc:
     docker:
       - image: cypress/base:12.12.0
@@ -79,8 +79,9 @@ commands:
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             fi
             if [[ "$OSTYPE" == "linux"* ]]; then
+              apt update
+              apt install fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
               dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb || true
-              apt-get -f install
               which google-chrome
               which google-chrome-stable
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -73,17 +73,16 @@ commands:
       - run:
           name: Install Google Chrome
           command: |
-            ls ~/chrome_installers
+            ls -lah ~/chrome_installers
+            find ~/ -name *.deb
             if [[ "$OSTYPE" == "darwin"* ]]; then
               hdiutil attach  ~/chrome_installers/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             fi
             if [[ "$OSTYPE" == "linux"* ]]; then
-              ls ~
               apt update
               apt install -y fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
-              apt install -y google-chrome-stable
-              #dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb
+              dpkg -i `find ~/ -name *.deb`
               which google-chrome
               which google-chrome-stable
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -261,7 +261,7 @@ jobs:
       - run:
           name: "Install Google Chrome (stable)"
           command: |
-            deb http://dl.google.com/linux/chrome/deb/ stable main
+            sudo add-apt-repository "deb http://dl.google.com/linux/chrome/deb/ stable main" 
             wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
             sudo apt-get update 
             sudo apt-get install google-chrome-stable

--- a/circle.yml
+++ b/circle.yml
@@ -45,6 +45,18 @@ executors:
       PLATFORM: mac
 
 commands:
+  install-google-chrome:
+    steps:
+      - run:
+          command: |
+            ls ~/
+            ls ~/chrome_installer
+            apt update
+            apt install -y fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
+            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            dpkg -i google-chrome-stable_current_amd64.deb
+            which google-chrome
+            google-chrome -version
   run-e2e-tests:
     parameters:
       browser:
@@ -56,23 +68,7 @@ commands:
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: Install Google Chrome
-          command: |
-            ls -lah ~/chrome_installers
-            find ~/ -name *.deb
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/chrome_installers/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            fi
-            if [[ "$OSTYPE" == "linux"* ]]; then
-              apt update
-              apt install -y fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
-              wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-              dpkg -i google-chrome-stable_current_amd64.deb
-              which google-chrome
-              which google-chrome-stable
-            fi
+      - install-google-chrome
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
           working_directory: packages/server
@@ -293,6 +289,8 @@ jobs:
               wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
               mv google-chrome-stable_current_amd64.deb ~/chrome_installers
             fi
+            ls -lath .
+            ls -lath ~/chrome_installers
 
       - save-caches
       - store-npm-logs
@@ -366,6 +364,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - install-google-chrome
       - run: npm run all test-unit -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -387,6 +386,7 @@ jobs:
       steps:
       - attach_workspace:
           at: ~/
+      - install-google-chrome
       - run:
           command: npm run all test-performance -- --package server
       - store_test_results:
@@ -513,6 +513,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - install-google-chrome
       - run:
           command: npm start
           background: true
@@ -641,6 +642,9 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: $(npm bin)/print-arch
+      - run: 
+          name: Install zip
+          command: apt install zip -y
       - run:
           environment:
             DEBUG: electron-builder,electron-osx-sign*

--- a/circle.yml
+++ b/circle.yml
@@ -257,6 +257,20 @@ jobs:
       - run: ls $(npm -g bin)
       - run: ls $(npm -g bin)/../lib/node_modules
 
+      # Install the root packages
+      # Link sup packages in ./node_modules/@packages/*
+      # Install sub packages dependencies and build all sub packages via postinstall script
+      - run: npm install
+      - run:
+          name: Top level packages
+          command: npm ls --depth=0 || true
+
+      # Prune so we do not save removed dependencies to cache
+      - run: npm run all prune
+
+      - save-caches
+      - store-npm-logs
+
       # Install current versions of Chrome
       - run:
           name: "Install Google Chrome (stable)"
@@ -272,21 +286,14 @@ jobs:
               apt-get update
               apt-get install -y google-chrome-stable
               rm -rf /var/lib/apt/lists/*
+              which google-chrome-stable
+              google-chrome-stable -version
             fi
 
-      # Install the root packages
-      # Link sup packages in ./node_modules/@packages/*
-      # Install sub packages dependencies and build all sub packages via postinstall script
-      - run: npm install
-      - run:
-          name: Top level packages
-          command: npm ls --depth=0 || true
-
-      # Prune so we do not save removed dependencies to cache
-      - run: npm run all prune
-
-      - save-caches
-      - store-npm-logs
+      - persist_to_workspace:
+          root: /usr/bin/
+          paths:
+            - google-chrome-stable
 
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:

--- a/circle.yml
+++ b/circle.yml
@@ -126,10 +126,6 @@ commands:
           key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-root-{{ checksum "package.json" }}
           paths:
             - node_modules
-      - save_cache:
-          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome
-          paths:
-            - google-chrome-stable_current_amd64.deb
       - save-cache:
           packageName: coffee
       - save-cache:
@@ -194,9 +190,6 @@ commands:
       - restore-cache:
           packageName: root
           packagePath: package.json
-      - restore_cache:
-          name: Restoring cache for chrome
-          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome
       - restore-cache:
           packageName: coffee
           packagePath: packages/coffee/package.json
@@ -291,14 +284,6 @@ jobs:
 
       # Prune so we do not save removed dependencies to cache
       - run: npm run all prune
-
-      - run:
-          name: "Download Google Chrome (stable) intaller"
-          command: |
-            cd ~/
-            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-            cp *.deb cypress
-            ls -lath .
 
       - save-caches
       - store-npm-logs

--- a/circle.yml
+++ b/circle.yml
@@ -318,7 +318,7 @@ jobs:
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
-              cp -r google-chrome-stable /usr/bin/
+              cp -r ~/google-chrome-stable /usr/bin/
             fi
       # make sure mocha runs
       - run: npm run test-mocha
@@ -387,7 +387,7 @@ jobs:
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
-              cp -r google-chrome-stable /usr/bin/
+              cp -r ~/google-chrome-stable /usr/bin/
             fi
       - run: npm run all test-integration -- --package server
       - store_test_results:

--- a/circle.yml
+++ b/circle.yml
@@ -20,10 +20,11 @@ defaults: &defaults
     LINES: 24
 
 executors:
-  # the Docker image with Cypress dependencies
+  # the Docker image with Cypress dependencies and Chrome browser
   cy-doc:
     docker:
       - image: cypress/base:12.12.0
+<<<<<<< HEAD
     environment:
       PLATFORM: linux
 
@@ -32,6 +33,8 @@ executors:
     docker:
       - image: cypress/base:12.12.0
         user: node
+=======
+>>>>>>> Download installer in build step. Install browser in run-e2e-tests
     environment:
       PLATFORM: linux
 
@@ -67,6 +70,17 @@ commands:
       - attach_workspace:
           at: ~/
       - install-google-chrome
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              dpkg -i google-chrome-stable_current_amd64.deb
+            fi
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
           working_directory: packages/server
@@ -271,31 +285,23 @@ jobs:
       - save-caches
       - store-npm-logs
 
-      # Install current versions of Chrome
       - run:
-          name: "Install Google Chrome (stable)"
+          name: "Download Google Chrome (stable) intaller"
           command: |
             set -e
             if [[ "$OSTYPE" == "darwin"* ]]; then
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/google-chrome-stable.dmg
             else
-              wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-              echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
-              apt-get update
-              apt-get install -y google-chrome-stable
-              rm -rf /var/lib/apt/lists/*
-              which google-chrome-stable
-              google-chrome-stable -version
-              cp -r `which google-chrome-stable` ~/
+              wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
             fi
-            ls ~/
 
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:
           root: ~/
           paths:
             - cypress
-            - google-chrome-stable*
+            - *.dmg
+            - *.deb
 
   lint:
     <<: *defaults
@@ -312,17 +318,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       # make sure mocha runs
       - run: npm run test-mocha
       # test binary build code
@@ -382,17 +377,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run: npm run all test-integration -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -405,17 +389,6 @@ jobs:
           at: ~/
       - install-google-chrome
       - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
-      - run:
           command: npm run all test-performance -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -426,19 +399,6 @@ jobs:
   "server-e2e-tests-chrome-1":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 1
@@ -446,19 +406,6 @@ jobs:
   "server-e2e-tests-chrome-2":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 2
@@ -466,19 +413,6 @@ jobs:
   "server-e2e-tests-chrome-3":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 3
@@ -486,19 +420,6 @@ jobs:
   "server-e2e-tests-chrome-4":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 4
@@ -506,19 +427,6 @@ jobs:
   "server-e2e-tests-chrome-5":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 5
@@ -526,19 +434,6 @@ jobs:
   "server-e2e-tests-chrome-6":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 6
@@ -546,19 +441,6 @@ jobs:
   "server-e2e-tests-chrome-7":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 7
@@ -566,19 +448,6 @@ jobs:
   "server-e2e-tests-chrome-8":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 8
@@ -647,17 +516,6 @@ jobs:
           at: ~/
       - install-google-chrome
       - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
-      - run:
           command: npm start
           background: true
           working_directory: packages/driver
@@ -708,17 +566,6 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
-      - run:
           command: npm run build-prod
           working_directory: packages/desktop-gui
       - run:
@@ -739,17 +586,6 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
-      - run:
           command: npm run build-prod
           working_directory: packages/reporter
       - run:
@@ -769,17 +605,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run:
           command: node index.js
           working_directory: packages/launcher
@@ -814,7 +639,6 @@ jobs:
             else
               echo "Not Mac platform, skipping code sign setup"
             fi
-
       - attach_workspace:
           at: ~/
       - run: $(npm bin)/print-arch
@@ -890,17 +714,6 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
-      - run:
           name: Cloning test project
           command: git clone https://github.com/cypress-io/cypress-example-kitchensink.git /tmp/repo
       - run:
@@ -927,17 +740,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run:
           name: Cloning test project
           command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/repo

--- a/circle.yml
+++ b/circle.yml
@@ -267,9 +267,6 @@ jobs:
             set -e
             if [[ "$OSTYPE" == "darwin"* ]]; then
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/google-chrome-stable.dmg
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications
-              touch /usr/bin/google-chrome-stable # dummy
             else
               wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
               echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
@@ -278,18 +275,8 @@ jobs:
               rm -rf /var/lib/apt/lists/*
               which google-chrome-stable
               google-chrome-stable -version
-              touch /Applications/Google\ Chrome.app # dummy
+              cp -r `which google-chrome-stable` ~
             fi
-
-      - persist_to_workspace:
-          root: /usr/bin/
-          paths:
-            - google-chrome-stable
-      
-      - persist_to_workspace:
-          root: /Applications/
-          paths:
-            - Google\ Chrome.app
 
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:
@@ -312,6 +299,16 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r google-chrome-stable /usr/bin/
+            fi
       # make sure mocha runs
       - run: npm run test-mocha
       # test binary build code
@@ -359,6 +356,16 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r google-chrome-stable /usr/bin/
+            fi
       - run: npm run all test-unit -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -370,6 +377,16 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r google-chrome-stable /usr/bin/
+            fi
       - run: npm run all test-integration -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -391,6 +408,16 @@ jobs:
   "server-e2e-tests-chrome-1":
     <<: *defaults
     steps:
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 1
@@ -398,6 +425,16 @@ jobs:
   "server-e2e-tests-chrome-2":
     <<: *defaults
     steps:
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              cp -r google-chrome-stable /usr/bin/
+            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 2

--- a/circle.yml
+++ b/circle.yml
@@ -257,6 +257,15 @@ jobs:
       - run: ls $(npm -g bin)
       - run: ls $(npm -g bin)/../lib/node_modules
 
+      # Install current versions of Chrome
+      - run:
+          name: "Install Google Chrome (stable)"
+          command: |
+            deb http://dl.google.com/linux/chrome/deb/ stable main
+            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+            sudo apt-get update 
+            sudo apt-get install google-chrome-stable
+
       # Install the root packages
       # Link sup packages in ./node_modules/@packages/*
       # Install sub packages dependencies and build all sub packages via postinstall script

--- a/circle.yml
+++ b/circle.yml
@@ -66,8 +66,8 @@ commands:
             fi
             if [[ "$OSTYPE" == "linux"* ]]; then
               apt update
-              apt install fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
-              dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb || true
+              apt install -y fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
+              dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb
               which google-chrome
               which google-chrome-stable
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -307,7 +307,7 @@ jobs:
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
-              cp -r google-chrome-stable /usr/bin/
+              cp -r ~/google-chrome-stable /usr/bin/
             fi
       # make sure mocha runs
       - run: npm run test-mocha
@@ -364,7 +364,7 @@ jobs:
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
-              cp -r google-chrome-stable /usr/bin/
+              cp -r ~/google-chrome-stable /usr/bin/
             fi
       - run: npm run all test-unit -- --package server
       - store_test_results:
@@ -385,7 +385,7 @@ jobs:
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
-              cp -r google-chrome-stable /usr/bin/
+              cp -r ~/google-chrome-stable /usr/bin/
             fi
       - run: npm run all test-integration -- --package server
       - store_test_results:

--- a/circle.yml
+++ b/circle.yml
@@ -57,15 +57,15 @@ commands:
       - attach_workspace:
           at: ~/
       - run:
-          name: Restore Google Chrome
+          name: Install Google Chrome
           command: |
             set -e
-            ls ~
+            ls ~/installers
             if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
+              hdiutil attach  ~/installers/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
-              dpkg -i google-chrome-stable_current_amd64.deb
+              dpkg -i installers/google-chrome-stable_current_amd64.deb
             fi
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
@@ -275,10 +275,12 @@ jobs:
           name: "Download Google Chrome (stable) intaller"
           command: |
             set -e
+            mkdir ~/installers
             if [[ "$OSTYPE" == "darwin"* ]]; then
-              curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/google-chrome-stable.dmg
+              curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/installers/google-chrome-stable.dmg
             else
               wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+              mv google-chrome-stable_current_amd64.deb ~/installers
             fi
 
       ## save entire folder as artifact for other jobs to run without reinstalling
@@ -286,8 +288,7 @@ jobs:
           root: ~/
           paths:
             - cypress
-            - *.dmg
-            - *.deb
+            - installers
 
   lint:
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -47,14 +47,24 @@ executors:
 commands:
   install-google-chrome:
     description: Download and install Google Chrome (stable) and its dependencies
+    parameters:
+      browser:
+        description: browser shortname (chrome or electron)
+        type: string
+        default: chrome
     steps:
       - run:
           command: |
-            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-            echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
-            apt update
-            apt install -y google-chrome-stable
-            google-chrome -version
+            if [ << parameters.browser >> == "chrome" ];
+            then
+              wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - ;
+              echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list;
+              apt update;
+              apt install -y google-chrome-stable;
+              google-chrome -version;
+            else
+              echo "Chrome is not installed because the browser is set to "<< parameters.browser >>;
+            fi
   run-e2e-tests:
     parameters:
       browser:
@@ -66,7 +76,8 @@ commands:
     steps:
       - attach_workspace:
           at: ~/
-      - install-google-chrome
+      - install-google-chrome:
+          browser: << parameters.browser >>
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
           working_directory: packages/server
@@ -339,7 +350,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - install-google-chrome
       - run: npm run all test-unit -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -361,7 +371,8 @@ jobs:
       steps:
       - attach_workspace:
           at: ~/
-      - install-google-chrome
+      - install-google-chrome:
+          browser: chrome
       - run:
           command: npm run all test-performance -- --package server
       - store_test_results:
@@ -488,7 +499,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - install-google-chrome
+      - install-google-chrome:
+          browser: chrome
       - run:
           command: npm start
           background: true

--- a/circle.yml
+++ b/circle.yml
@@ -68,7 +68,8 @@ commands:
             if [[ "$OSTYPE" == "linux"* ]]; then
               apt update
               apt install -y fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
-              dpkg -i `find ~/ -name *.deb`
+              wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+              dpkg -i google-chrome-stable_current_amd64.deb
               which google-chrome
               which google-chrome-stable
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -275,7 +275,7 @@ jobs:
               rm -rf /var/lib/apt/lists/*
               which google-chrome-stable
               google-chrome-stable -version
-              cp -r `which google-chrome-stable` ~
+              cp -r `which google-chrome-stable` ~/google-chrome-stable
             fi
 
       ## save entire folder as artifact for other jobs to run without reinstalling
@@ -303,6 +303,7 @@ jobs:
           name: Restore Google Chrome
           command: |
             set -e
+            ls ~
             if [[ "$OSTYPE" == "darwin"* ]]; then
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
@@ -360,6 +361,7 @@ jobs:
           name: Restore Google Chrome
           command: |
             set -e
+            ls ~
             if [[ "$OSTYPE" == "darwin"* ]]; then
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
@@ -381,6 +383,7 @@ jobs:
           name: Restore Google Chrome
           command: |
             set -e
+            ls ~
             if [[ "$OSTYPE" == "darwin"* ]]; then
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
@@ -412,6 +415,7 @@ jobs:
           name: Restore Google Chrome
           command: |
             set -e
+            ls ~
             if [[ "$OSTYPE" == "darwin"* ]]; then
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/

--- a/circle.yml
+++ b/circle.yml
@@ -79,9 +79,7 @@ commands:
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
               dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb || true
-              apt-get update --fix-missing
-              dpkg --configure -a
-              apt-get install -f 
+              apt-get -f install 
             fi
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
@@ -125,6 +123,10 @@ commands:
           key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-root-{{ checksum "package.json" }}
           paths:
             - node_modules
+      - save_cache:
+          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome-{{ checksum "chrome_installers" }}
+          paths:
+            - chrome_installers
       - save-cache:
           packageName: coffee
       - save-cache:
@@ -189,6 +191,9 @@ commands:
       - restore-cache:
           packageName: root
           packagePath: package.json
+      - restore-cache:
+          packageName: chrome
+          packagePath: chrome_installers
       - restore-cache:
           packageName: coffee
           packagePath: packages/coffee/package.json
@@ -292,7 +297,7 @@ jobs:
             if [ ! -d "~/chrome_installers/google-chrome-stable.dmg" ] && [ "$OSTYPE" == "darwin"* ]; then
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/chrome_installers/google-chrome-stable.dmg
             fi
-            if [ ! -d "~/chrome_installers/google-chrome-stable_current_amd64.deb" ] && [ "$OSTYPE" != "darwin"* ]; then
+            if [ ! -d "~/chrome_installers/google-chrome-stable_current_amd64.deb" ] && [ "$OSTYPE" == "linux"* ]; then
               wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
               mv google-chrome-stable_current_amd64.deb ~/chrome_installers
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -80,6 +80,7 @@ commands:
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
               dpkg -i ~/installers/google-chrome-stable_current_amd64.deb
+              sudo apt-get install -f
             fi
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
@@ -640,6 +641,7 @@ jobs:
             else
               echo "Not Mac platform, skipping code sign setup"
             fi
+
       - attach_workspace:
           at: ~/
       - run: $(npm bin)/print-arch

--- a/circle.yml
+++ b/circle.yml
@@ -288,10 +288,11 @@ jobs:
           name: "Download Google Chrome (stable) intaller"
           command: |
             mkdir -p ~/chrome_installers
+            echo $OSTYPE
             if [ ! -d "~/chrome_installers/google-chrome-stable.dmg" ] && [ "$OSTYPE" == "darwin"* ]; then
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/chrome_installers/google-chrome-stable.dmg
             fi
-            if [ ! -d "~/chrome_installers/google-chrome-stable_current_amd64.deb" ] && [ ! "$OSTYPE" == "darwin"* ]; then
+            if [ ! -d "~/chrome_installers/google-chrome-stable_current_amd64.deb" ] && [ "$OSTYPE" != "darwin"* ]; then
               wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
               mv google-chrome-stable_current_amd64.deb ~/chrome_installers
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -261,10 +261,11 @@ jobs:
       - run:
           name: "Install Google Chrome (stable)"
           command: |
-            sudo add-apt-repository "deb http://dl.google.com/linux/chrome/deb/ stable main" 
-            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-            sudo apt-get update 
-            sudo apt-get install google-chrome-stable
+            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+            echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+            apt-get update
+            apt-get install -y google-chrome-stable
+            rm -rf /var/lib/apt/lists/*
 
       # Install the root packages
       # Link sup packages in ./node_modules/@packages/*

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ executors:
   # Docker image with non-root "node" user
   non-root-docker-user:
     docker:
-      - image: cypress/base:12.0.0
+      - image: cypress/base:12.12.0
         user: node
     environment:
       PLATFORM: linux
@@ -46,11 +46,12 @@ executors:
 
 commands:
   install-google-chrome:
+    description: Download and install Google Chrome (stable) and its dependencies
     steps:
       - run:
           command: |
             ls ~/
-            ls ~/chrome_installer
+            ls ~/cypress
             apt update
             apt install -y fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
             wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
@@ -114,7 +115,7 @@ commands:
       - save_cache:
           key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome
           paths:
-            - ~/chrome_installers
+            - google-chrome-stable_current_amd64.deb
       - save-cache:
           packageName: coffee
       - save-cache:
@@ -280,17 +281,10 @@ jobs:
       - run:
           name: "Download Google Chrome (stable) intaller"
           command: |
-            mkdir -p ~/chrome_installers
-            echo $OSTYPE
-            if [ ! -d "~/chrome_installers/google-chrome-stable.dmg" ] && [ "$OSTYPE" == "darwin"* ]; then
-              curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/chrome_installers/google-chrome-stable.dmg
-            fi
-            if [ ! -d "~/chrome_installers/google-chrome-stable_current_amd64.deb" ] && [ "$OSTYPE" == "linux"* ]; then
-              wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-              mv google-chrome-stable_current_amd64.deb ~/chrome_installers
-            fi
+            cd ~/
+            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            cp *.deb cypress
             ls -lath .
-            ls -lath ~/chrome_installers
 
       - save-caches
       - store-npm-logs
@@ -300,7 +294,6 @@ jobs:
           root: ~/
           paths:
             - cypress
-            - chrome_installers
 
   lint:
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -47,24 +47,14 @@ executors:
 commands:
   install-google-chrome:
     description: Download and install Google Chrome (stable) and its dependencies
-    parameters:
-      browser:
-        description: browser shortname (chrome or electron)
-        type: string
-        default: chrome
     steps:
       - run:
           command: |
-            if [ << parameters.browser >> == "chrome" ];
-            then
-              wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - ;
-              echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list;
-              apt update;
-              apt install -y google-chrome-stable;
-              google-chrome -version;
-            else
-              echo "Chrome is not installed because the browser is set to "<< parameters.browser >>;
-            fi
+            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+            echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
+            apt update
+            apt install -y google-chrome-stable
+            google-chrome -version
   run-e2e-tests:
     parameters:
       browser:
@@ -76,8 +66,7 @@ commands:
     steps:
       - attach_workspace:
           at: ~/
-      - install-google-chrome:
-          browser: << parameters.browser >>
+      - install-google-chrome
       - run:
           name: Install Google Chrome
           command: |
@@ -367,6 +356,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - install-google-chrome
       - run: npm run all test-unit -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -388,8 +378,7 @@ jobs:
       steps:
       - attach_workspace:
           at: ~/
-      - install-google-chrome:
-          browser: chrome
+      - install-google-chrome
       - run:
           command: npm run all test-performance -- --package server
       - store_test_results:
@@ -516,8 +505,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - install-google-chrome:
-          browser: chrome
+      - install-google-chrome
       - run:
           command: npm start
           background: true

--- a/circle.yml
+++ b/circle.yml
@@ -253,7 +253,8 @@ jobs:
             set -e
             if [[ "$OSTYPE" == "darwin"* ]]; then
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/google-chrome-stable.dmg
-              open ~/google-chrome-stable.dmg
+              hdiutil attach  ~/google-chrome-stable.dmg
+              ls /Volumnes/
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications
             else
               wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \

--- a/circle.yml
+++ b/circle.yml
@@ -59,13 +59,15 @@ commands:
       - run:
           name: Install Google Chrome
           command: |
-            set -e
+            ls ~/chrome_installers
             if [[ "$OSTYPE" == "darwin"* ]]; then
               hdiutil attach  ~/chrome_installers/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
               dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb || true
-              apt-get -f install 
+              apt-get -f install
+              which google-chrome
+              which google-chrome-stable
             fi
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
@@ -110,9 +112,9 @@ commands:
           paths:
             - node_modules
       - save_cache:
-          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome-{{ checksum "chrome_installers" }}
+          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome-{{ checksum "~/chrome_installers" }}
           paths:
-            - chrome_installers
+            - ~/chrome_installers
       - save-cache:
           packageName: coffee
       - save-cache:
@@ -179,7 +181,7 @@ commands:
           packagePath: package.json
       - restore-cache:
           packageName: chrome
-          packagePath: chrome_installers
+          packagePath: ~/chrome_installers
       - restore-cache:
           packageName: coffee
           packagePath: packages/coffee/package.json

--- a/circle.yml
+++ b/circle.yml
@@ -129,7 +129,7 @@ commands:
       - save_cache:
           key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome
           paths:
-            - ~/chrome_installers
+            - google-chrome-stable_current_amd64.deb
       - save-cache:
           packageName: coffee
       - save-cache:
@@ -295,17 +295,10 @@ jobs:
       - run:
           name: "Download Google Chrome (stable) intaller"
           command: |
-            mkdir -p ~/chrome_installers
-            echo $OSTYPE
-            if [ ! -d "~/chrome_installers/google-chrome-stable.dmg" ] && [ "$OSTYPE" == "darwin"* ]; then
-              curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/chrome_installers/google-chrome-stable.dmg
-            fi
-            if [ ! -d "~/chrome_installers/google-chrome-stable_current_amd64.deb" ] && [ "$OSTYPE" == "linux"* ]; then
-              wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-              mv google-chrome-stable_current_amd64.deb ~/chrome_installers
-            fi
+            cd ~/
+            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            cp *.deb cypress
             ls -lath .
-            ls -lath ~/chrome_installers
 
       - save-caches
       - store-npm-logs
@@ -315,7 +308,6 @@ jobs:
           root: ~/
           paths:
             - cypress
-            - chrome_installers
 
   lint:
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -274,10 +274,10 @@ jobs:
           name: "Download Google Chrome (stable) intaller"
           command: |
             mkdir -p ~/chrome_installers
-            if [ ! -d "~/installers/google-chrome-stable.dmg" ]; then
+            if [ ! -d "~/chrome_installers/google-chrome-stable.dmg" ] && [ "$OSTYPE" == "darwin"* ]; then
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/chrome_installers/google-chrome-stable.dmg
             fi
-            if [ ! -d "~/installers/google-chrome-stable_current_amd64.deb" ]; then
+            if [ ! -d "~/chrome_installers/google-chrome-stable_current_amd64.deb" ] && [ ! "$OSTYPE" == "darwin"* ]; then
               wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
               mv google-chrome-stable_current_amd64.deb ~/chrome_installers
             fi
@@ -290,7 +290,7 @@ jobs:
           root: ~/
           paths:
             - cypress
-            - installers
+            - chrome_installers
 
   lint:
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -50,13 +50,10 @@ commands:
     steps:
       - run:
           command: |
-            ls ~/
-            ls ~/cypress
+            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+            echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
             apt update
-            apt install -y fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
-            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-            dpkg -i google-chrome-stable_current_amd64.deb
-            which google-chrome
+            apt install -y google-chrome-stable
             google-chrome -version
   run-e2e-tests:
     parameters:
@@ -112,10 +109,6 @@ commands:
           key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-root-{{ checksum "package.json" }}
           paths:
             - node_modules
-      - save_cache:
-          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome
-          paths:
-            - google-chrome-stable_current_amd64.deb
       - save-cache:
           packageName: coffee
       - save-cache:
@@ -180,9 +173,6 @@ commands:
       - restore-cache:
           packageName: root
           packagePath: package.json
-      - restore_cache:
-          name: Restoring cache for chrome
-          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-chrome
       - restore-cache:
           packageName: coffee
           packagePath: packages/coffee/package.json
@@ -277,14 +267,6 @@ jobs:
 
       # Prune so we do not save removed dependencies to cache
       - run: npm run all prune
-
-      - run:
-          name: "Download Google Chrome (stable) intaller"
-          command: |
-            cd ~/
-            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-            cp *.deb cypress
-            ls -lath .
 
       - save-caches
       - store-npm-logs
@@ -637,7 +619,9 @@ jobs:
       - run: $(npm bin)/print-arch
       - run: 
           name: Install zip
-          command: apt install zip -y
+          command: |
+            apt update
+            apt install zip -y
       - run:
           environment:
             DEBUG: electron-builder,electron-osx-sign*

--- a/circle.yml
+++ b/circle.yml
@@ -288,10 +288,10 @@ jobs:
           name: "Download Google Chrome (stable) intaller"
           command: |
             mkdir -p ~/chrome_installers
-            if [ ! -d "~/installers/google-chrome-stable.dmg" ]; then
+            if [ ! -d "~/chrome_installers/google-chrome-stable.dmg" ] && [ "$OSTYPE" == "darwin"* ]; then
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/chrome_installers/google-chrome-stable.dmg
             fi
-            if [ ! -d "~/installers/google-chrome-stable_current_amd64.deb" ]; then
+            if [ ! -d "~/chrome_installers/google-chrome-stable_current_amd64.deb" ] && [ ! "$OSTYPE" == "darwin"* ]; then
               wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
               mv google-chrome-stable_current_amd64.deb ~/chrome_installers
             fi
@@ -304,7 +304,7 @@ jobs:
           root: ~/
           paths:
             - cypress
-            - installers
+            - chrome_installers
 
   lint:
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -286,7 +286,7 @@ jobs:
               rm -rf /var/lib/apt/lists/*
               which google-chrome-stable
               google-chrome-stable -version
-              cp -r `which google-chrome-stable` ~
+              cp -r `which google-chrome-stable` ~/google-chrome-stable
             fi
 
       ## save entire folder as artifact for other jobs to run without reinstalling
@@ -314,6 +314,7 @@ jobs:
           name: Restore Google Chrome
           command: |
             set -e
+            ls ~
             if [[ "$OSTYPE" == "darwin"* ]]; then
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
@@ -383,6 +384,7 @@ jobs:
           name: Restore Google Chrome
           command: |
             set -e
+            ls ~
             if [[ "$OSTYPE" == "darwin"* ]]; then
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
@@ -415,6 +417,7 @@ jobs:
           name: Restore Google Chrome
           command: |
             set -e
+            ls ~
             if [[ "$OSTYPE" == "darwin"* ]]; then
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
@@ -432,6 +435,7 @@ jobs:
           name: Restore Google Chrome
           command: |
             set -e
+            ls ~
             if [[ "$OSTYPE" == "darwin"* ]]; then
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/

--- a/circle.yml
+++ b/circle.yml
@@ -79,9 +79,11 @@ commands:
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             fi
             if [[ "$OSTYPE" == "linux"* ]]; then
+              ls ~
               apt update
               apt install -y fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
-              dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb
+              apt install -y google-chrome-stable
+              #dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb
               which google-chrome
               which google-chrome-stable
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -79,7 +79,7 @@ commands:
               hdiutil attach  ~/installers/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
-              dpkg -i installers/google-chrome-stable_current_amd64.deb
+              dpkg -i ~/installers/google-chrome-stable_current_amd64.deb
             fi
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>

--- a/circle.yml
+++ b/circle.yml
@@ -82,7 +82,8 @@ commands:
             if [[ "$OSTYPE" == "linux"* ]]; then
               apt update
               apt install -y fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
-              dpkg -i `find ~/ -name *.deb`
+              wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+              dpkg -i google-chrome-stable_current_amd64.deb
               which google-chrome
               which google-chrome-stable
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -265,7 +265,6 @@ jobs:
             if [[ "$OSTYPE" == "darwin"* ]]; then
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/google-chrome-stable.dmg
               hdiutil attach  ~/google-chrome-stable.dmg
-              ls /Volumnes/
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications
             else
               wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \

--- a/circle.yml
+++ b/circle.yml
@@ -294,6 +294,7 @@ jobs:
           root: ~/
           paths:
             - cypress
+            - google-chrome-stable*
 
   lint:
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -71,15 +71,15 @@ commands:
           at: ~/
       - install-google-chrome
       - run:
-          name: Restore Google Chrome
+          name: Install Google Chrome
           command: |
             set -e
-            ls ~
+            ls ~/installers
             if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
+              hdiutil attach  ~/installers/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
-              dpkg -i google-chrome-stable_current_amd64.deb
+              dpkg -i installers/google-chrome-stable_current_amd64.deb
             fi
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
@@ -289,10 +289,12 @@ jobs:
           name: "Download Google Chrome (stable) intaller"
           command: |
             set -e
+            mkdir ~/installers
             if [[ "$OSTYPE" == "darwin"* ]]; then
-              curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/google-chrome-stable.dmg
+              curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/installers/google-chrome-stable.dmg
             else
               wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+              mv google-chrome-stable_current_amd64.deb ~/installers
             fi
 
       ## save entire folder as artifact for other jobs to run without reinstalling
@@ -300,8 +302,7 @@ jobs:
           root: ~/
           paths:
             - cypress
-            - *.dmg
-            - *.deb
+            - installers
 
   lint:
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -274,10 +274,11 @@ jobs:
           name: "Download Google Chrome (stable) intaller"
           command: |
             mkdir -p ~/chrome_installers
+            echo $OSTYPE
             if [ ! -d "~/chrome_installers/google-chrome-stable.dmg" ] && [ "$OSTYPE" == "darwin"* ]; then
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/chrome_installers/google-chrome-stable.dmg
             fi
-            if [ ! -d "~/chrome_installers/google-chrome-stable_current_amd64.deb" ] && [ ! "$OSTYPE" == "darwin"* ]; then
+            if [ ! -d "~/chrome_installers/google-chrome-stable_current_amd64.deb" ] && [ "$OSTYPE" != "darwin"* ]; then
               wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
               mv google-chrome-stable_current_amd64.deb ~/chrome_installers
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -269,6 +269,7 @@ jobs:
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/google-chrome-stable.dmg
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications
+              touch /usr/bin/google-chrome-stable # dummy
             else
               wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
               echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
@@ -277,12 +278,18 @@ jobs:
               rm -rf /var/lib/apt/lists/*
               which google-chrome-stable
               google-chrome-stable -version
+              touch /Applications/Google\ Chrome.app # dummy
             fi
 
       - persist_to_workspace:
           root: /usr/bin/
           paths:
             - google-chrome-stable
+      
+      - persist_to_workspace:
+          root: /Applications/
+          paths:
+            - Google\ Chrome.app
 
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:

--- a/circle.yml
+++ b/circle.yml
@@ -59,17 +59,16 @@ commands:
       - run:
           name: Install Google Chrome
           command: |
-            ls ~/chrome_installers
+            ls -lah ~/chrome_installers
+            find ~/ -name *.deb
             if [[ "$OSTYPE" == "darwin"* ]]; then
               hdiutil attach  ~/chrome_installers/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             fi
             if [[ "$OSTYPE" == "linux"* ]]; then
-              ls ~
               apt update
               apt install -y fonts-liberation libappindicator3-1  lsb-release xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 distro-info-data libindicator3-7
-              apt install -y google-chrome-stable
-              #dpkg -i ~/chrome_installers/google-chrome-stable_current_amd64.deb
+              dpkg -i `find ~/ -name *.deb`
               which google-chrome
               which google-chrome-stable
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -275,8 +275,9 @@ jobs:
               rm -rf /var/lib/apt/lists/*
               which google-chrome-stable
               google-chrome-stable -version
-              cp -r `which google-chrome-stable` ~/google-chrome-stable
+              cp -r `which google-chrome-stable` ~/
             fi
+            ls ~/
 
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:
@@ -421,7 +422,7 @@ jobs:
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
-              cp -r google-chrome-stable /usr/bin/
+              cp -r ~/google-chrome-stable /usr/bin/
             fi
       - run-e2e-tests:
           browser: chrome
@@ -434,11 +435,12 @@ jobs:
           name: Restore Google Chrome
           command: |
             set -e
+            ls ~
             if [[ "$OSTYPE" == "darwin"* ]]; then
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
             else
-              cp -r google-chrome-stable /usr/bin/
+              cp -r ~/google-chrome-stable /usr/bin/
             fi
       - run-e2e-tests:
           browser: chrome

--- a/circle.yml
+++ b/circle.yml
@@ -246,6 +246,20 @@ jobs:
       - run: ls $(npm -g bin)
       - run: ls $(npm -g bin)/../lib/node_modules
 
+      # Install the root packages
+      # Link sup packages in ./node_modules/@packages/*
+      # Install sub packages dependencies and build all sub packages via postinstall script
+      - run: npm install
+      - run:
+          name: Top level packages
+          command: npm ls --depth=0 || true
+
+      # Prune so we do not save removed dependencies to cache
+      - run: npm run all prune
+
+      - save-caches
+      - store-npm-logs
+
       # Install current versions of Chrome
       - run:
           name: "Install Google Chrome (stable)"
@@ -261,22 +275,14 @@ jobs:
               apt-get update
               apt-get install -y google-chrome-stable
               rm -rf /var/lib/apt/lists/*
+              which google-chrome-stable
+              google-chrome-stable -version
             fi
 
-      # Install the root packages
-      # Link sup packages in ./node_modules/@packages/*
-      # Install sub packages dependencies and build all sub packages via postinstall script
-      # try several times, because flaky NPM installs ...
-      - run: npm install || npm install
-      - run:
-          name: Top level packages
-          command: npm ls --depth=0 || true
-
-      # Prune so we do not save removed dependencies to cache
-      - run: npm run all prune
-
-      - save-caches
-      - store-npm-logs
+      - persist_to_workspace:
+          root: /usr/bin/
+          paths:
+            - google-chrome-stable
 
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:

--- a/circle.yml
+++ b/circle.yml
@@ -20,10 +20,10 @@ defaults: &defaults
     LINES: 24
 
 executors:
-  # the Docker image with Cypress dependencies
+  # the Docker image with Cypress dependencies and Chrome browser
   cy-doc:
     docker:
-      - image: cypress/base:12.6.0
+      - image: cypress/base:12.12.0
     environment:
       PLATFORM: linux
 
@@ -56,6 +56,17 @@ commands:
     steps:
       - attach_workspace:
           at: ~/
+      - run:
+          name: Restore Google Chrome
+          command: |
+            set -e
+            ls ~
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+              hdiutil attach  ~/google-chrome-stable.dmg
+              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
+            else
+              dpkg -i google-chrome-stable_current_amd64.deb
+            fi
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
           working_directory: packages/server
@@ -260,31 +271,23 @@ jobs:
       - save-caches
       - store-npm-logs
 
-      # Install current versions of Chrome
       - run:
-          name: "Install Google Chrome (stable)"
+          name: "Download Google Chrome (stable) intaller"
           command: |
             set -e
             if [[ "$OSTYPE" == "darwin"* ]]; then
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/google-chrome-stable.dmg
             else
-              wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-              echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
-              apt-get update
-              apt-get install -y google-chrome-stable
-              rm -rf /var/lib/apt/lists/*
-              which google-chrome-stable
-              google-chrome-stable -version
-              cp -r `which google-chrome-stable` ~/
+              wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
             fi
-            ls ~/
 
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:
           root: ~/
           paths:
             - cypress
-            - google-chrome-stable*
+            - *.dmg
+            - *.deb
 
   lint:
     <<: *defaults
@@ -301,17 +304,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       # make sure mocha runs
       - run: npm run test-mocha
       # test binary build code
@@ -359,17 +351,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run: npm run all test-unit -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -381,17 +362,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run: npm run all test-integration -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -403,17 +373,6 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
-      - run:
           command: npm run all test-performance -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -424,19 +383,6 @@ jobs:
   "server-e2e-tests-chrome-1":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 1
@@ -444,19 +390,6 @@ jobs:
   "server-e2e-tests-chrome-2":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 2
@@ -464,19 +397,6 @@ jobs:
   "server-e2e-tests-chrome-3":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 3
@@ -484,19 +404,6 @@ jobs:
   "server-e2e-tests-chrome-4":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 4
@@ -504,19 +411,6 @@ jobs:
   "server-e2e-tests-chrome-5":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 5
@@ -524,19 +418,6 @@ jobs:
   "server-e2e-tests-chrome-6":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 6
@@ -544,19 +425,6 @@ jobs:
   "server-e2e-tests-chrome-7":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 7
@@ -564,19 +432,6 @@ jobs:
   "server-e2e-tests-chrome-8":
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run-e2e-tests:
           browser: chrome
           chunk: 8
@@ -644,17 +499,6 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
-      - run:
           command: npm start
           background: true
           working_directory: packages/driver
@@ -705,17 +549,6 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
-      - run:
           command: npm run build-prod
           working_directory: packages/desktop-gui
       - run:
@@ -736,17 +569,6 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
-      - run:
           command: npm run build-prod
           working_directory: packages/reporter
       - run:
@@ -766,17 +588,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run:
           command: node index.js
           working_directory: packages/launcher
@@ -811,7 +622,6 @@ jobs:
             else
               echo "Not Mac platform, skipping code sign setup"
             fi
-
       - attach_workspace:
           at: ~/
       - run: $(npm bin)/print-arch
@@ -855,17 +665,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run:
           name: Cloning test project
           command: git clone https://github.com/cypress-io/cypress-example-kitchensink.git /tmp/repo
@@ -919,17 +718,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: Restore Google Chrome
-          command: |
-            set -e
-            ls ~
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              hdiutil attach  ~/google-chrome-stable.dmg
-              cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/
-            else
-              cp -r ~/google-chrome-stable /usr/bin/
-            fi
       - run:
           name: Cloning test project
           command: git clone https://github.com/cypress-io/cypress-test-tiny.git /tmp/repo

--- a/circle.yml
+++ b/circle.yml
@@ -280,6 +280,7 @@ jobs:
               curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg > ~/google-chrome-stable.dmg
               hdiutil attach  ~/google-chrome-stable.dmg
               cp -r /Volumes/Google\ Chrome/Google\ Chrome.app /Applications
+              touch /usr/bin/google-chrome-stable # dummy
             else
               wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
               echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
@@ -288,12 +289,18 @@ jobs:
               rm -rf /var/lib/apt/lists/*
               which google-chrome-stable
               google-chrome-stable -version
+              touch /Applications/Google\ Chrome.app # dummy
             fi
 
       - persist_to_workspace:
           root: /usr/bin/
           paths:
             - google-chrome-stable
+      
+      - persist_to_workspace:
+          root: /Applications/
+          paths:
+            - Google\ Chrome.app
 
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:


### PR DESCRIPTION
<!-- Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md -->

- Closes #5236 

### Description of change

<!-- How would you explain this change in our changelog 
for every user to read and understand -->
The automated regression tests done by CircleCI was using Chrome 73.  The latest Chrome version is 77. Let's use the latest version in the testing.

### How to use the feature

<!-- What code does the user write now versus before?
 (a GIF or screenshots of the feature in action is preferred!) 
 Fixing a bug? What test passes now that used to fail for the user? -->
The contributors to this repository should not see any changes. Those who are interested can see the Chrome version (in a docker file) used in the tests for a PR from a CircleCI log.

### How the design has changed

<!-- screenshots comparing the previous design(s) to new -->
No design has been changed.

### Notes

<!-- Have something else to add? Add it here :) -->
N/A

### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

This is an internal change.  The contributors, maintainers and Cypress users should not see any differences.  We may be able to catch Chrome 77 specific issues in the PRs.


