### PR TITLE
Suppress NODE_TLS_REJECT_UNAUTHORIZED warning

### DIFF
--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -22,17 +22,6 @@ require && require.extensions && delete require.extensions['.coffee.md']
 // https://github.com/electron/electron/blob/master/docs/api/process.md#processenablepromiseapis
 process.enablePromiseAPIs = process.env.CYPRESS_ENV !== 'production'
 
-// don't emit the NODE_TLS_REJECT_UNAUTHORIZED warning while
-// we work on proper SSL verification
-// https://github.com/cypress-io/cypress/issues/5248
-const originalEmitWarning = process.emitWarning
-
-process.emitWarning = (warning, options) => {
-  if (warning && warning.includes && warning.includes('NODE_TLS_REJECT_UNAUTHORIZED')) {
-    return
-  }
-
-  return originalEmitWarning.call(process, warning, options)
-}
+require('./lib/util/suppress_unauthorized_warning').suppress()
 
 module.exports = require('./lib/cypress').start(process.argv)

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -22,4 +22,17 @@ require && require.extensions && delete require.extensions['.coffee.md']
 // https://github.com/electron/electron/blob/master/docs/api/process.md#processenablepromiseapis
 process.enablePromiseAPIs = process.env.CYPRESS_ENV !== 'production'
 
+// don't emit the NODE_TLS_REJECT_UNAUTHORIZED warning while
+// we work on proper SSL verification
+// https://github.com/cypress-io/cypress/issues/5248
+const originalEmitWarning = process.emitWarning
+
+process.emitWarning = (warning, options) => {
+  if (warning && warning.includes && warning.includes('NODE_TLS_REJECT_UNAUTHORIZED')) {
+    return
+  }
+
+  return originalEmitWarning.call(process, warning, options)
+}
+
 module.exports = require('./lib/cypress').start(process.argv)

--- a/packages/server/lib/util/suppress_unauthorized_warning.ts
+++ b/packages/server/lib/util/suppress_unauthorized_warning.ts
@@ -1,5 +1,7 @@
 import _ from 'lodash'
 
+const originalEmitWarning = process.emitWarning
+
 let suppressed = false
 
 /**
@@ -13,8 +15,6 @@ export function suppress () {
   }
 
   suppressed = true
-
-  const originalEmitWarning = process.emitWarning
 
   process.emitWarning = (warning, ...args) => {
     if (_.isString(warning) && _.includes(warning, 'NODE_TLS_REJECT_UNAUTHORIZED')) {

--- a/packages/server/lib/util/suppress_unauthorized_warning.ts
+++ b/packages/server/lib/util/suppress_unauthorized_warning.ts
@@ -1,0 +1,30 @@
+import _ from 'lodash'
+
+let suppressed = false
+
+/**
+ * Don't emit the NODE_TLS_REJECT_UNAUTHORIZED warning while
+ * we work on proper SSL verification.
+ * https://github.com/cypress-io/cypress/issues/5248
+ */
+export function suppress () {
+  if (suppressed) {
+    return
+  }
+
+  suppressed = true
+
+  const originalEmitWarning = process.emitWarning
+
+  process.emitWarning = (warning, options) => {
+    if (_.isString(warning) && _.includes(warning, 'NODE_TLS_REJECT_UNAUTHORIZED')) {
+      // node will only emit the warning once
+      // https://github.com/nodejs/node/blob/82f89ec8c1554964f5029fab1cf0f4fad1fa55a8/lib/_tls_wrap.js#L1378-L1384
+      process.emitWarning = originalEmitWarning
+
+      return
+    }
+
+    return originalEmitWarning.call(process, warning, options)
+  }
+}

--- a/packages/server/lib/util/suppress_unauthorized_warning.ts
+++ b/packages/server/lib/util/suppress_unauthorized_warning.ts
@@ -16,7 +16,7 @@ export function suppress () {
 
   const originalEmitWarning = process.emitWarning
 
-  process.emitWarning = (warning, options) => {
+  process.emitWarning = (warning, ...args) => {
     if (_.isString(warning) && _.includes(warning, 'NODE_TLS_REJECT_UNAUTHORIZED')) {
       // node will only emit the warning once
       // https://github.com/nodejs/node/blob/82f89ec8c1554964f5029fab1cf0f4fad1fa55a8/lib/_tls_wrap.js#L1378-L1384
@@ -25,6 +25,6 @@ export function suppress () {
       return
     }
 
-    return originalEmitWarning.call(process, warning, options)
+    return originalEmitWarning.call(process, warning, ...args)
   }
 }

--- a/packages/server/test/unit/suppress_unauthorized_warning_spec.ts
+++ b/packages/server/test/unit/suppress_unauthorized_warning_spec.ts
@@ -1,0 +1,32 @@
+import execa from 'execa'
+import { expect } from 'chai'
+
+const ERROR_MESSAGE = 'Setting the NODE_TLS_REJECT_UNAUTHORIZED'
+
+const TLS_CONNECT = `require('tls').connect().on('error', ()=>{});`
+const SUPPRESS_WARNING = `require('@packages/ts/register'); require('${__dirname}/../../lib/util/suppress_unauthorized_warning').suppress();`
+
+describe('lib/util/suppress_unauthorized_warning', function () {
+  it('tls.connect emits warning if NODE_TLS_REJECT_UNAUTHORIZED=0 and not suppressed', function () {
+    return execa.shell(`node -e "${TLS_CONNECT}"`, {
+      env: {
+        'NODE_TLS_REJECT_UNAUTHORIZED': '0',
+      },
+    })
+    .then(({ stderr }) => {
+      expect(stderr).to.contain(ERROR_MESSAGE)
+    })
+  })
+
+  it('tls.connect does not emit warning if NODE_TLS_REJECT_UNAUTHORIZED=0 and suppressed', function () {
+    // test 2 sequential tls.connects
+    return execa.shell(`node -e "${SUPPRESS_WARNING} ${TLS_CONNECT} ${TLS_CONNECT}"`, {
+      env: {
+        'NODE_TLS_REJECT_UNAUTHORIZED': '0',
+      },
+    })
+    .then(({ stderr }) => {
+      expect(stderr).to.not.contain(ERROR_MESSAGE)
+    })
+  })
+})


### PR DESCRIPTION
<!-- Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md -->

- Closes #5248

### Description of change

Not user facing - suppresses a warning from Electron upgrade, which is unreleased

Manually verified that this technique works by doing the following:

```
➜ ~ NODE_TLS_REJECT_UNAUTHORIZED=0 node
Welcome to Node.js v12.4.0.
Type ".help" for more information.
> const originalEmitWarning = process.emitWarning
undefined
> 
> process.emitWarning = (warning, options) => {
...   if (warning && warning.includes && warning.includes('NODE_TLS_REJECT_UNAUTHORIZED')) {
.....     return
.....   }
... 
...   return originalEmitWarning.call(process, warning, options)
... }
[Function]
> tls.connect()
TLSSocket { ... }
> Thrown:
Error: connect ECONNREFUSED 127.0.0.1
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1054:14) { ... }

```

### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
