### PR TITLE
Fix selector playground triggering keyboard shortcut

### DIFF
--- a/packages/driver/src/cypress.coffee
+++ b/packages/driver/src/cypress.coffee
@@ -498,5 +498,6 @@ class $Cypress
 ## attaching these so they are accessible
 ## via the runner + integration spec helper
 $Cypress.$ = $
+$Cypress.dom = $dom
 
 module.exports = $Cypress

--- a/packages/reporter/cypress/integration/shortcuts_spec.js
+++ b/packages/reporter/cypress/integration/shortcuts_spec.js
@@ -59,6 +59,19 @@ describe('controls', function () {
       })
     })
 
+    it('does not run shortcut if typed into an input', () => {
+      cy.get('body')
+      .then(($body) => {
+        // this realistically happens with the selector playground, but
+        // need to add an input since this environment is isolated
+        $body.append('<input id="temp-input" />')
+      })
+      .get('#temp-input').type('r')
+      .then(() => {
+        expect(runner.emit).not.to.have.been.calledWith('runner:restart')
+      })
+    })
+
     it('has shortcut in tooltips', () => {
       cy.get('.focus-tests > button').trigger('mouseover')
       cy.get('.tooltip').should('have.text', 'View All Tests F')

--- a/packages/reporter/cypress/integration/shortcuts_spec.js
+++ b/packages/reporter/cypress/integration/shortcuts_spec.js
@@ -28,10 +28,10 @@ describe('controls', function () {
     })
   })
 
-  describe('shortcuts', function () {
-    it('stops tests', function () {
+  describe('shortcuts', () => {
+    it('stops tests', () => {
       cy.get('body').then(() => {
-        expect(runner.emit).to.not.have.been.calledWith('runner:stop')
+        expect(runner.emit).not.to.have.been.calledWith('runner:stop')
       })
 
       cy.get('body').type('s').then(() => {
@@ -39,9 +39,9 @@ describe('controls', function () {
       })
     })
 
-    it('resumes tests', function () {
+    it('resumes tests', () => {
       cy.get('body').then(() => {
-        expect(runner.emit).to.not.have.been.calledWith('runner:restart')
+        expect(runner.emit).not.to.have.been.calledWith('runner:restart')
       })
 
       cy.get('body').type('r').then(() => {
@@ -49,9 +49,9 @@ describe('controls', function () {
       })
     })
 
-    it('focuses on specs', function () {
+    it('focuses on specs', () => {
       cy.get('body').then(() => {
-        expect(runner.emit).to.not.have.been.calledWith('focus:tests')
+        expect(runner.emit).not.to.have.been.calledWith('focus:tests')
       })
 
       cy.get('body').type('f').then(() => {

--- a/packages/reporter/src/lib/shortcuts.js
+++ b/packages/reporter/src/lib/shortcuts.js
@@ -1,3 +1,4 @@
+import { $, dom } from '@packages/driver'
 import events from './events'
 
 class Shortcuts {
@@ -9,6 +10,9 @@ class Shortcuts {
     document.removeEventListener('keydown', this._handleKeyDownEvent)
   }
   _handleKeyDownEvent (event) {
+    // if typing into an input, textarea, etc, don't trigger any shortcuts
+    if (dom.isTextLike($(event.target))) return
+
     switch (event.key) {
       case 'r': events.emit('restart')
         break

--- a/packages/reporter/src/lib/shortcuts.js
+++ b/packages/reporter/src/lib/shortcuts.js
@@ -2,13 +2,14 @@ import { $, dom } from '@packages/driver'
 import events from './events'
 
 class Shortcuts {
-  start (appState) {
-    this._appState = appState
+  start () {
     document.addEventListener('keydown', this._handleKeyDownEvent)
   }
+
   stop () {
     document.removeEventListener('keydown', this._handleKeyDownEvent)
   }
+
   _handleKeyDownEvent (event) {
     // if typing into an input, textarea, etc, don't trigger any shortcuts
     if (dom.isTextLike($(event.target))) return

--- a/packages/reporter/src/main.jsx
+++ b/packages/reporter/src/main.jsx
@@ -76,7 +76,7 @@ class Reporter extends Component {
   }
 
   componentDidMount () {
-    shortcuts.start(this.props.appState)
+    shortcuts.start()
     EQ.init()
   }
   componentWillUnmount () {


### PR DESCRIPTION
<!-- Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md -->

- Closes #5283

### Description of change

Fixes an issue where typing into the selector playground input could trigger keyboard shortcuts.

This does not need to be added to the changelog because the keyboard shortcut feature has not yet been released.

### How to use the feature

N/A

### How the design has changed

N/A

### Notes

N/A

### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

- [x] Have tests been added/updated for the changes in this PR?
- N/A Has a PR to [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation) been submitted to document any user-facing changes? <!-- Link to PR here -->
- N/A Have the [type definitions](cli/types/index.d.ts) been updated with any user-facing API changes?
- N/A Has the [cypress.schema.json](cli/schema/cypress.schema.json) been updated with any new configuration options?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
