### PR TITLE
Catch & ignore ENOTCONN errors when piping Cypress subprocess

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -39,5 +39,5 @@ Delete tasks if they are not applicable.
 
 - [ ] Have tests been added/updated?
 - [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
-- [ ] Have API changes been updated in the [type definitions](cli/types/index.d.ts)?
-- [ ] Have new configuration options been added to the [cypress.schema.json](cli/schema/cypress.schema.json)?
+- [ ] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
+- [ ] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -179,13 +179,14 @@ module.exports = {
         }
 
         // https://github.com/cypress-io/cypress/issues/1841
+        // https://github.com/cypress-io/cypress/issues/5241
         // In some versions of node, it will throw on windows
         // when you close the parent process after piping
         // into the child process. unpiping does not seem
         // to have any effect. so we're just catching the
         // error here and not doing anything.
         process.stdin.on('error', (err) => {
-          if (err.code === 'EPIPE') {
+          if (['EPIPE', 'ENOTCONN'].includes(err.code)) {
             return
           }
 

--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -439,24 +439,28 @@ describe('lib/exec/spawn', function () {
       })
     })
 
-    it('catches process.stdin errors and returns when code=EPIPE', function () {
-      this.spawnedProcess.on.withArgs('close').yieldsAsync(0)
+    // https://github.com/cypress-io/cypress/issues/1841
+    // https://github.com/cypress-io/cypress/issues/5241
+    ;['EPIPE', 'ENOTCONN'].forEach((errCode) => {
+      it(`catches process.stdin errors and returns when code=${errCode}`, function () {
+        this.spawnedProcess.on.withArgs('close').yieldsAsync(0)
 
-      return spawn.start()
-      .then(() => {
-        let called = false
+        return spawn.start()
+        .then(() => {
+          let called = false
 
-        const fn = () => {
-          called = true
-          const err = new Error()
+          const fn = () => {
+            called = true
+            const err = new Error()
 
-          err.code = 'EPIPE'
+            err.code = errCode
 
-          return process.stdin.emit('error', err)
-        }
+            return process.stdin.emit('error', err)
+          }
 
-        expect(fn).not.to.throw()
-        expect(called).to.be.true
+          expect(fn).not.to.throw()
+          expect(called).to.be.true
+        })
       })
     })
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

- Closes #5241

### User facing changelog

Fixed a bug where Cypress would exit with an `ENOTCONN` error at the end of a test run if using Node 12.11.0 or greater on Windows.

### Additional details

~~Still trying to reproduce in my Windows VM, but a user in #5241 did say that this patch resolves the issue for them.~~

Was able to reproduce (only in `cypress run`) and confirmed that this patch does fix the issue for Node 12.11.0 and Windows 10.

### PR Tasks

- [x] Have tests been added/updated?