### PR TITLE
Update https-proxy-agent to point back to original repo

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -161,7 +161,7 @@
     "express-session": "1.16.1",
     "express-useragent": "1.0.12",
     "http-mitm-proxy": "0.7.0",
-    "https-proxy-agent": "lpinca/node-https-proxy-agent#967f0115bddedbce0e4591c2a2250f988809dec8",
+    "https-proxy-agent": "TooTallNate/node-https-proxy-agent#6c804a2c919b53d29030340da8b02fd8225fd258",
     "istanbul": "0.4.5",
     "mocked-env": "1.2.4",
     "mockery": "2.1.0",


### PR DESCRIPTION
We were previously using this PR as the source for our `node-https-proxy-agent`: TooTallNate/node-https-proxy-agent#73 

But it got merged, and the author deleted his branch. So now we need to update this ref to point back to TooTallNate's repo (since he hasn't cut a release with these changes yet)