### PR TITLE
Update https-proxy-agent to 3.0.0

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -161,7 +161,7 @@
     "express-session": "1.16.1",
     "express-useragent": "1.0.12",
     "http-mitm-proxy": "0.7.0",
-    "https-proxy-agent": "TooTallNate/node-https-proxy-agent#6c804a2c919b53d29030340da8b02fd8225fd258",
+    "https-proxy-agent": "3.0.0",
     "istanbul": "0.4.5",
     "mocked-env": "1.2.4",
     "mockery": "2.1.0",


### PR DESCRIPTION
### User facing changelog

Not user facing

### Additional details

The fixes we need for our tests to run have been merged:

https://github.com/TooTallNate/node-https-proxy-agent/releases/tag/3.0.0

This dependency doesn't need to rely on a git hash now that the changes have been published to NPM.
