### PR TITLE
reduce test flake in electron-driver-tests

### DIFF
--- a/packages/driver/test/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/click_spec.js
@@ -1487,7 +1487,10 @@ describe('src/cy/commands/actions/click', () => {
 
         cy.get('input:first')
         .then(($el) => {
-          $el[0].ownerDocument.addEventListener('scroll', () => {
+          // This represents an asynchronous re-render
+          // since we fire the 'scrolled' event during actionability
+          // if we use el.on('scroll'), headless electron is flaky
+          cy.on('scrolled', () => {
             $el.remove()
           })
         })

--- a/packages/driver/test/cypress/integration/e2e/domSnapshots.spec.js
+++ b/packages/driver/test/cypress/integration/e2e/domSnapshots.spec.js
@@ -22,8 +22,10 @@ describe('rect highlight', () => {
 const getAndPin = (sel) => {
   cy.get(sel)
 
-  cy.wait(0)
-  .then(() => {
+  // arbitrary wait to allow clicking and pinning command
+  // if reduced, test is flakey
+  cy.wait(10)
+  .should(() => {
     withMutableReporterState(() => {
 
       const commandLogEl = getCommandLogWithText(sel)
@@ -33,6 +35,9 @@ const getAndPin = (sel) => {
       reactCommandInstance.props.appState.isRunning = false
 
       $(commandLogEl).find('.command-wrapper').click()
+
+      // make sure command was pinned, otherwise throw a better error message
+      expect(cy.$$('.command-pin:visible', top.document).length, 'command should be pinned').ok
     })
   })
 }


### PR DESCRIPTION
- [x] increase wait on domSnapshot.spec to reduce test 
example failure here: https://dashboard.cypress.io/#/projects/ypt4pf/runs/7261/failures

- [x] fix flakey click_spec > element detached during actionability
example failure here: https://dashboard.cypress.io/#/projects/ypt4pf/runs/7264/failures
*only fails in headless electron

<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->


### User facing changelog
n/a

<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
n/a
<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
