### PR TITLE
store .npm/_logs in circleci artifacts in case there is a npm problem

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -37,6 +37,12 @@ executors:
       PLATFORM: mac
 
 commands:
+  store-npm-logs:
+    description: Saves any NPM debug logs as artifacts in case there is a problem
+    steps:
+      - store_artifacts:
+          path: ~/.npm/_logs
+
   # for caching node modules use project environment variable
   # like CACHE_VERSION=15
   save-cache:
@@ -226,10 +232,7 @@ jobs:
       - run: npm run all prune
 
       - save-caches
-
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:
@@ -244,9 +247,7 @@ jobs:
           at: ~/
       ## this will catch .only's in js/coffee as well
       - run: npm run lint-all
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   unit-tests:
     <<: *defaults
@@ -276,9 +277,7 @@ jobs:
       - run: npm run all test -- --package static
       - store_test_results:
           path: /tmp/cypress
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   lint-types:
     <<: *defaults
@@ -295,9 +294,7 @@ jobs:
       - run:
           command: npm run dtslint
           working_directory: cli
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "server-unit-tests":
     <<: *defaults
@@ -308,9 +305,7 @@ jobs:
       - run: npm run all test-unit -- --package server
       - store_test_results:
           path: /tmp/cypress
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "server-integration-tests":
     <<: *defaults
@@ -321,9 +316,7 @@ jobs:
       - run: npm run all test-integration -- --package server
       - store_test_results:
           path: /tmp/cypress
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "server-performance-tests":
       <<: *defaults
@@ -336,9 +329,7 @@ jobs:
           path: /tmp/cypress
       - store_artifacts:
           path: /tmp/artifacts
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "server-e2e-tests-1":
     <<: *defaults
@@ -350,9 +341,7 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "server-e2e-tests-2":
     <<: *defaults
@@ -364,9 +353,7 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "server-e2e-tests-3":
     <<: *defaults
@@ -378,9 +365,7 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+
 
   "server-e2e-tests-4":
     <<: *defaults
@@ -392,9 +377,7 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "server-e2e-tests-5":
     <<: *defaults
@@ -406,9 +389,7 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "server-e2e-tests-6":
     <<: *defaults
@@ -420,9 +401,7 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "server-e2e-tests-7":
     <<: *defaults
@@ -434,9 +413,7 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "server-e2e-tests-8":
       <<: *defaults
@@ -448,9 +425,7 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "driver-integration-tests-chrome":
     <<: *defaults
@@ -475,9 +450,7 @@ jobs:
           path: /tmp/cypress
       - store_artifacts:
           path: /tmp/artifacts
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "driver-integration-tests-electron":
     <<: *defaults
@@ -502,9 +475,7 @@ jobs:
           path: /tmp/cypress
       - store_artifacts:
           path: /tmp/artifacts
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "desktop-gui-integration-tests-2x":
     <<: *defaults
@@ -525,9 +496,7 @@ jobs:
           path: /tmp/cypress
       - store_artifacts:
           path: /tmp/artifacts
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "reporter-integration-tests":
     <<: *defaults
@@ -547,9 +516,7 @@ jobs:
           path: /tmp/cypress
       - store_artifacts:
           path: /tmp/artifacts
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "run-launcher":
     <<: *defaults
@@ -611,9 +578,7 @@ jobs:
       - run: cp binary-url.json /tmp/urls
       - run: cp cypress.zip /tmp/urls
       - run: ls /tmp/urls
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
       - persist_to_workspace:
           root: /tmp/urls
           paths:
@@ -645,9 +610,7 @@ jobs:
             CYPRESS_ENV=staging \
             CYPRESS_video=false \
             npm run cypress:run -- --project /tmp/repo --record
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "test-against-staging":
     <<: *defaults
@@ -664,9 +627,7 @@ jobs:
             CYPRESS_RECORD_KEY=$TEST_TINY_RECORD_KEY \
             CYPRESS_ENV=staging \
             npm run cypress:run -- --project /tmp/repo --record
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "build-npm-package":
     <<: *defaults
@@ -707,9 +668,7 @@ jobs:
       - run: cp cli/build/cypress-$NEXT_DEV_VERSION.tgz /tmp/urls/cypress.tgz
       - run: cp npm-package-url.json /tmp/urls
       - run: ls /tmp/urls
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
       - persist_to_workspace:
           root: /tmp/urls
           paths:
@@ -755,9 +714,7 @@ jobs:
               --npm /tmp/urls/npm-package-url.json \
               --binary /tmp/urls/binary-url.json \
               --provider circle
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "test-npm-module-and-verify-binary":
     <<: *defaults
@@ -787,9 +744,7 @@ jobs:
           name: Verify Cypress binary
           working_directory: test-binary
           command: $(npm bin)/cypress verify
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   # install NPM + binary zip and run against staging API
   "test-binary-against-staging":
@@ -819,9 +774,7 @@ jobs:
             CYPRESS_RECORD_KEY=$TEST_TINY_RECORD_KEY \
             CYPRESS_ENV=staging \
             $(npm bin)/cypress run --record
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
   "test-binary-against-kitchensink":
     <<: *defaults
@@ -851,9 +804,7 @@ jobs:
       - run:
           working_directory: /tmp/kitchensink
           command: npm run e2e
-      # store NPM logs in case there was a problem
-      - store_artifacts:
-          path: ~/.npm/_logs
+      - store-npm-logs
 
 linux-workflow: &linux-workflow
   jobs:

--- a/circle.yml
+++ b/circle.yml
@@ -227,6 +227,10 @@ jobs:
 
       - save-caches
 
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
+
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:
           root: ~/
@@ -240,6 +244,9 @@ jobs:
           at: ~/
       ## this will catch .only's in js/coffee as well
       - run: npm run lint-all
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   unit-tests:
     <<: *defaults
@@ -269,6 +276,9 @@ jobs:
       - run: npm run all test -- --package static
       - store_test_results:
           path: /tmp/cypress
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   lint-types:
     <<: *defaults
@@ -285,6 +295,9 @@ jobs:
       - run:
           command: npm run dtslint
           working_directory: cli
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "server-unit-tests":
     <<: *defaults
@@ -295,6 +308,9 @@ jobs:
       - run: npm run all test-unit -- --package server
       - store_test_results:
           path: /tmp/cypress
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "server-integration-tests":
     <<: *defaults
@@ -305,6 +321,9 @@ jobs:
       - run: npm run all test-integration -- --package server
       - store_test_results:
           path: /tmp/cypress
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "server-performance-tests":
       <<: *defaults
@@ -317,6 +336,9 @@ jobs:
           path: /tmp/cypress
       - store_artifacts:
           path: /tmp/artifacts
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "server-e2e-tests-1":
     <<: *defaults
@@ -328,6 +350,9 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "server-e2e-tests-2":
     <<: *defaults
@@ -339,6 +364,9 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "server-e2e-tests-3":
     <<: *defaults
@@ -350,6 +378,9 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "server-e2e-tests-4":
     <<: *defaults
@@ -361,6 +392,9 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "server-e2e-tests-5":
     <<: *defaults
@@ -372,6 +406,9 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "server-e2e-tests-6":
     <<: *defaults
@@ -383,6 +420,9 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "server-e2e-tests-7":
     <<: *defaults
@@ -394,6 +434,9 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "server-e2e-tests-8":
       <<: *defaults
@@ -405,6 +448,9 @@ jobs:
           working_directory: packages/server
       - store_test_results:
           path: /tmp/cypress
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "driver-integration-tests-chrome":
     <<: *defaults
@@ -429,6 +475,9 @@ jobs:
           path: /tmp/cypress
       - store_artifacts:
           path: /tmp/artifacts
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "driver-integration-tests-electron":
     <<: *defaults
@@ -453,6 +502,9 @@ jobs:
           path: /tmp/cypress
       - store_artifacts:
           path: /tmp/artifacts
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "desktop-gui-integration-tests-2x":
     <<: *defaults
@@ -473,6 +525,9 @@ jobs:
           path: /tmp/cypress
       - store_artifacts:
           path: /tmp/artifacts
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "reporter-integration-tests":
     <<: *defaults
@@ -492,6 +547,9 @@ jobs:
           path: /tmp/cypress
       - store_artifacts:
           path: /tmp/artifacts
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "run-launcher":
     <<: *defaults
@@ -553,6 +611,9 @@ jobs:
       - run: cp binary-url.json /tmp/urls
       - run: cp cypress.zip /tmp/urls
       - run: ls /tmp/urls
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
       - persist_to_workspace:
           root: /tmp/urls
           paths:
@@ -584,6 +645,9 @@ jobs:
             CYPRESS_ENV=staging \
             CYPRESS_video=false \
             npm run cypress:run -- --project /tmp/repo --record
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "test-against-staging":
     <<: *defaults
@@ -600,6 +664,9 @@ jobs:
             CYPRESS_RECORD_KEY=$TEST_TINY_RECORD_KEY \
             CYPRESS_ENV=staging \
             npm run cypress:run -- --project /tmp/repo --record
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "build-npm-package":
     <<: *defaults
@@ -640,6 +707,9 @@ jobs:
       - run: cp cli/build/cypress-$NEXT_DEV_VERSION.tgz /tmp/urls/cypress.tgz
       - run: cp npm-package-url.json /tmp/urls
       - run: ls /tmp/urls
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
       - persist_to_workspace:
           root: /tmp/urls
           paths:
@@ -685,6 +755,9 @@ jobs:
               --npm /tmp/urls/npm-package-url.json \
               --binary /tmp/urls/binary-url.json \
               --provider circle
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "test-npm-module-and-verify-binary":
     <<: *defaults
@@ -714,6 +787,9 @@ jobs:
           name: Verify Cypress binary
           working_directory: test-binary
           command: $(npm bin)/cypress verify
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   # install NPM + binary zip and run against staging API
   "test-binary-against-staging":
@@ -743,6 +819,9 @@ jobs:
             CYPRESS_RECORD_KEY=$TEST_TINY_RECORD_KEY \
             CYPRESS_ENV=staging \
             $(npm bin)/cypress run --record
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
   "test-binary-against-kitchensink":
     <<: *defaults
@@ -772,6 +851,9 @@ jobs:
       - run:
           working_directory: /tmp/kitchensink
           command: npm run e2e
+      # store NPM logs in case there was a problem
+      - store_artifacts:
+          path: ~/.npm/_logs
 
 linux-workflow: &linux-workflow
   jobs:


### PR DESCRIPTION
### User facing changelog

N/A

### Additional details

Sometimes there are failures in `npm` commands when run in CircleCI. The logs indicated that we can see more information by looking at the `.npm/_logs` file, but currently we don't save these files anywhere in Circle.ci, so they cannot be reviewed.

This change saves the `.npm/_log` files in the CircleCI artifacts to review if there was a failure during any of our CircleCI jobs that returns an npm debug log.
 
### How has the user experience changed?

N/A

### PR Tasks

N/A
