### PR TITLE
fix flaky navigation_spec in electron

### DIFF
--- a/packages/driver/src/cy/commands/navigation.coffee
+++ b/packages/driver/src/cy/commands/navigation.coffee
@@ -449,6 +449,8 @@ module.exports = (Commands, Cypress, cy, state, config) ->
             win.history.go(num)
 
             retWin = ->
+              knownCommandCausedInstability = false
+
               ## need to set the attributes of 'go'
               ## consoleProps here with win
 
@@ -459,8 +461,6 @@ module.exports = (Commands, Cypress, cy, state, config) ->
             Promise
             .delay(100)
             .then ->
-              knownCommandCausedInstability = false
-
               ## if we've didUnload then we know we're
               ## doing a full page refresh and we need
               ## to wait until


### PR DESCRIPTION
- fix race-condition in navigation_spec (fixes flaky electron test in na…vigation_spec)
example of failure: https://circleci.com/gh/cypress-io/cypress/162196#tests/containers/2
- tests in electron were flaky since a page-load event was being emitted during a navigation command (go) in 1/50 test runs 
- @brian-mann please make sure this one line change makes sense

<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->


### User facing changelog

<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [N] Have tests been added/updated?
- [N] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [N] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
