### PR TITLE
Remove incorrect typing for Cypress.Commands.overwrite - does not accept options

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -292,7 +292,6 @@ declare namespace Cypress {
       add(name: string, fn: (...args: any[]) => void): void
       add(name: string, options: CommandOptions, fn: (...args: any[]) => void): void
       overwrite(name: string, fn: (...args: any[]) => void): void
-      overwrite(name: string, options: CommandOptions, fn: (...args: any[]) => void): void
     }
 
     /**

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -61,9 +61,6 @@ namespace CypressCommandsTests {
   Cypress.Commands.overwrite('newCommand', () => {
     return
   })
-  Cypress.Commands.overwrite('newCommand', { prevSubject: true }, () => {
-    return
-  })
 }
 
 namespace CypressLogsTest {


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #5341 

### User facing changelog

Updated typing for `Cypress.Commands.overwrite` to not allow an `options` object as an argument.

### Additional details

You can see in our `commands.coffee` file that the `overwrite` method is never passed the `option` object, it only accepts `name` and `callbackFn`.  

https://github.com/cypress-io/cypress/blob/a038e7f5d4c56d3efa844e745da40a3d917fefea/packages/driver/src/cypress/commands.coffee#L151-L152 

### How has the user experience changed?

Now when using typings, it will no longer suggest that `Cypress.Commands.overwrite` accepts `options` that it never did accept. 

**Wrong suggestion**

<img width="935" alt="Screen Shot 2019-10-10 at 5 19 02 PM" src="https://user-images.githubusercontent.com/1271364/66607379-16a99880-eb82-11e9-96ee-89d4a0a34b14.png">

**Now will only suggest**

<img width="891" alt="Screen Shot 2019-10-10 at 5 19 40 PM" src="https://user-images.githubusercontent.com/1271364/66607422-2d4fef80-eb82-11e9-9f89-f03805bd7d68.png">


### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/2148
- [x] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?