### PR TITLE
do not inject context, closes #5312

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -854,20 +854,16 @@ linux-workflow: &linux-workflow
         requires:
           - build
     - driver-integration-tests-chrome:
-        context: test-runner:integration-tests
         requires:
           - build
     ## TODO: add these back in when flaky tests are fixed
     # - driver-integration-tests-electron:
-    #     context: test-runner:integration-tests
     #     requires:
     #       - build
     - desktop-gui-integration-tests-2x:
-        context: test-runner:integration-tests
         requires:
           - build
     - reporter-integration-tests:
-        context: test-runner:integration-tests
         requires:
           - build
     - run-launcher:


### PR DESCRIPTION
- closes #5312

uses a global environment variable `PACKAGES_RECORD_KEY` on CircleCI to record cypress integration test results. This variable is only available for internal branches. It is UNAVAILABLE to external pull requests