### PR TITLE
parse ~ in CYPRESS_CACHE_FOLDER env variable

### DIFF
--- a/cli/lib/tasks/state.js
+++ b/cli/lib/tasks/state.js
@@ -1,6 +1,7 @@
 const _ = require('lodash')
 const os = require('os')
 const path = require('path')
+const untildify = require('untildify')
 const debug = require('debug')('cypress:cli')
 
 const fs = require('../fs')
@@ -57,7 +58,7 @@ const getCacheDir = () => {
   let cache_directory = util.getCacheDir()
 
   if (util.getEnv('CYPRESS_CACHE_FOLDER')) {
-    const envVarCacheDir = util.getEnv('CYPRESS_CACHE_FOLDER')
+    const envVarCacheDir = untildify(util.getEnv('CYPRESS_CACHE_FOLDER'))
 
     debug('using environment variable CYPRESS_CACHE_FOLDER %s', envVarCacheDir)
     cache_directory = path.resolve(envVarCacheDir)

--- a/cli/package.json
+++ b/cli/package.json
@@ -55,6 +55,7 @@
     "request-progress": "3.0.0",
     "supports-color": "5.5.0",
     "tmp": "0.1.0",
+    "untildify": "3.0.3",
     "url": "0.11.0",
     "yauzl": "2.10.0"
   },

--- a/cli/test/lib/tasks/state_spec.js
+++ b/cli/test/lib/tasks/state_spec.js
@@ -5,6 +5,7 @@ const path = require('path')
 const Promise = require('bluebird')
 const proxyquire = require('proxyquire')
 const mockfs = require('mock-fs')
+const debug = require('debug')('test')
 
 const fs = require(`${lib}/fs`)
 const logger = require(`${lib}/logger`)
@@ -257,6 +258,16 @@ describe('lib/tasks/state', function () {
       const ret = state.getCacheDir()
 
       expect(ret).to.eql(path.resolve('local-cache/folder'))
+    })
+
+    it('resolves ~ with user home folder', () => {
+      process.env.CYPRESS_CACHE_FOLDER = '~/.cache/Cypress'
+
+      const ret = state.getCacheDir()
+
+      debug('cache dir is "%s"', ret)
+      expect(path.isAbsolute(ret), ret).to.be.true
+      expect(ret, '~ has been resolved').to.not.contain('~')
     })
   })
 

--- a/cli/test/lib/tasks/state_spec.js
+++ b/cli/test/lib/tasks/state_spec.js
@@ -261,6 +261,8 @@ describe('lib/tasks/state', function () {
     })
 
     it('resolves ~ with user home folder', () => {
+      const homeDir = os.homedir()
+
       process.env.CYPRESS_CACHE_FOLDER = '~/.cache/Cypress'
 
       const ret = state.getCacheDir()
@@ -268,6 +270,7 @@ describe('lib/tasks/state', function () {
       debug('cache dir is "%s"', ret)
       expect(path.isAbsolute(ret), ret).to.be.true
       expect(ret, '~ has been resolved').to.not.contain('~')
+      expect(ret, 'replaced ~ with home directory').to.equal(`${homeDir}/.cache/Cypress`)
     })
   })
 


### PR DESCRIPTION
- Closes #5386

### User facing changelog

You can use `~` when overwriting Cypress cache folder likes this

```
CYPRESS_CACHE_FOLDER='~/.cache/Cypress'
```

The `~` will be resolved to the user's home directory by Cypress (not by the terminal shell)

### Additional details

Often CIs allow you to set the environment variable but do not automatically expand `~` when passing it to Cypress. This change lets Cypress behave the way a user would expect it to behave as if running in the terminal shell, for example 

```
CYPRESS_CACHE_FOLDER=~/.cache/Cypress npm cypress cache path
```

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/2167

