### PR TITLE
cli: detect installing from postinstall hook

### DIFF
--- a/cli/test/lib/tasks/state_spec.js
+++ b/cli/test/lib/tasks/state_spec.js
@@ -260,6 +260,26 @@ describe('lib/tasks/state', function () {
       expect(ret).to.eql(path.resolve('local-cache/folder'))
     })
 
+    it('CYPRESS_CACHE_FOLDER resolves from relative path during postinstall', () => {
+      process.env.CYPRESS_CACHE_FOLDER = './local-cache/folder'
+      // simulates current folder when running "npm postinstall" hook
+      sinon.stub(process, 'cwd').returns('/my/project/folder/node_modules/cypress')
+      const ret = state.getCacheDir()
+
+      debug('returned cache dir %s', ret)
+      expect(ret).to.eql(path.resolve('/my/project/folder/local-cache/folder'))
+    })
+
+    it('CYPRESS_CACHE_FOLDER resolves from absolute path during postinstall', () => {
+      process.env.CYPRESS_CACHE_FOLDER = '/cache/folder/Cypress'
+      // simulates current folder when running "npm postinstall" hook
+      sinon.stub(process, 'cwd').returns('/my/project/folder/node_modules/cypress')
+      const ret = state.getCacheDir()
+
+      debug('returned cache dir %s', ret)
+      expect(ret).to.eql(path.resolve('/cache/folder/Cypress'))
+    })
+
     it('resolves ~ with user home folder', () => {
       const homeDir = os.homedir()
 


### PR DESCRIPTION
- Closes #2634

### User facing changelog

"Normalizes" installation when running with custom relative Cypress cache folder. For example if you want to install Cypress and cache it in the _current_ folder, rather than in `~/.cache`

```shell
export CYPRESS_CACHE_FOLDER=cache/Cypress
npm i cypress
npx cypress run
```

### Additional details

Before this change, during `npm i cypress`, the installation was executed in `./node_modules/cypress` folder, which is a normal NPM behavior in `postinstall` hook. But this of course is very surprising to the user who expected the relative path `CYPRESS_CACHE_FOLDER=cache/Cypress` to resolve in the _current_ folder, and not with respect to `node_modules/cypress`.

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
