### PR TITLE
Close CLI when exit event fires

### DIFF
--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -138,6 +138,7 @@ module.exports = {
         const child = cp.spawn(executable, electronArgs, stdioOptions)
 
         child.on('close', resolve)
+        child.on('exit', resolve)
         child.on('error', reject)
 
         // if stdio options is set to 'pipe', then
@@ -234,7 +235,8 @@ module.exports = {
       }
 
       return spawn(overrides)
-      .then((code) => {
+      .then((code, signal) => {
+        debug('child exited %o', { code, signal })
         if (code !== 0 && brokenGtkDisplay) {
           util.logBrokenGtkDisplayWarning()
 

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -137,8 +137,15 @@ module.exports = {
 
         const child = cp.spawn(executable, electronArgs, stdioOptions)
 
-        child.on('close', resolve)
-        child.on('exit', resolve)
+        function resolver (event) {
+          return function (code, signal) {
+            debug('child event fired %o', { event, code, signal })
+            resolve(code)
+          }
+        }
+
+        child.on('close', resolver('close'))
+        child.on('exit', resolver('exit'))
         child.on('error', reject)
 
         // if stdio options is set to 'pipe', then
@@ -235,8 +242,7 @@ module.exports = {
       }
 
       return spawn(overrides)
-      .then((code, signal) => {
-        debug('child exited %o', { code, signal })
+      .then((code) => {
         if (code !== 0 && brokenGtkDisplay) {
           util.logBrokenGtkDisplayWarning()
 

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -137,15 +137,15 @@ module.exports = {
 
         const child = cp.spawn(executable, electronArgs, stdioOptions)
 
-        function resolver (event) {
+        function resolveOn (event) {
           return function (code, signal) {
             debug('child event fired %o', { event, code, signal })
             resolve(code)
           }
         }
 
-        child.on('close', resolver('close'))
-        child.on('exit', resolver('exit'))
+        child.on('close', resolveOn('close'))
+        child.on('exit', resolveOn('exit'))
         child.on('error', reject)
 
         // if stdio options is set to 'pipe', then

--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -163,7 +163,7 @@ describe('lib/exec/spawn', function () {
         })
       })
 
-      it(`if exit event fired and close event fired`, function () {
+      it('if exit event fired and close event fired', function () {
         this.spawnedProcess.on.withArgs('exit').yieldsAsync(0)
         this.spawnedProcess.on.withArgs('close').yieldsAsync(0)
 

--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -154,6 +154,16 @@ describe('lib/exec/spawn', function () {
       })
     })
 
+    context('closes', function () {
+      ['close', 'exit'].forEach((event) => {
+        it(`if '${event}' event fired`, function () {
+          this.spawnedProcess.on.withArgs(event).yieldsAsync(0)
+
+          return spawn.start('--foo')
+        })
+      })
+    })
+
     it('does not start xvfb when its not needed', function () {
       this.spawnedProcess.on.withArgs('close').yieldsAsync(0)
 

--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -162,6 +162,13 @@ describe('lib/exec/spawn', function () {
           return spawn.start('--foo')
         })
       })
+
+      it(`if exit event fired and close event fired`, function () {
+        this.spawnedProcess.on.withArgs('exit').yieldsAsync(0)
+        this.spawnedProcess.on.withArgs('close').yieldsAsync(0)
+
+        return spawn.start('--foo')
+      })
     })
 
     it('does not start xvfb when its not needed', function () {


### PR DESCRIPTION


### User facing changelog

Not user facing

### Additional details

Tests were failing with Node 6: https://circleci.com/gh/cypress-io/cypress-test-node-versions/8271

Before this PR, only the `close` event could resolve the child process in the CLI. The `close` event is only emitted once all underlying stdio streams from the child process end.

With this PR, either the `close` event or the `exit` event can resolve the child process. `exit` is typically fired before `close`, but other than that has the same `(code, signal) => {}` callback signature.

### How has the user experience changed?

N/A

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
