### PR TITLE
test kitchensink on all commits

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -745,6 +745,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - run: ls -l
       - run: ls -l /tmp/urls
       # NPM package file should have filename cypress-<version>.tgz
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -1006,7 +1006,6 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
-              - run-more-tests
         requires:
           - build-npm-package
     - build-binary:
@@ -1018,7 +1017,6 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
-              - run-more-tests
         requires:
           - build-binary
     - test-binary-and-npm-against-other-projects:
@@ -1083,7 +1081,6 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
-              - run-more-tests
         requires:
           - Mac NPM package
 
@@ -1095,7 +1092,6 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
-              - run-more-tests
         requires:
           - Mac build
 
@@ -1107,7 +1103,6 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
-              - run-more-tests
         requires:
           - Mac binary
 

--- a/circle.yml
+++ b/circle.yml
@@ -600,38 +600,32 @@ jobs:
             DEBUG: electron-builder,electron-osx-sign*
           command: npm run binary-build -- --platform $PLATFORM --version $NEXT_DEV_VERSION
       - run: npm run binary-zip -- --platform $PLATFORM
+      # Cypress binary file should be zipped to cypress.zip
       - run: ls -l *.zip
-      - run: mkdir /tmp/urls
-      - run: cp cypress.zip /tmp/urls
-      - run: ls -l /tmp/urls
       - store-npm-logs
       - persist_to_workspace:
-          root: /tmp/urls
+          root: ~/
           paths:
-            - cypress.zip
+            - cypress/cypress.zip
 
   upload-binary:
     <<: *defaults
     steps:
       - attach_workspace:
           at: ~/
-      - run: ls -l .
-      - run: ls -l /tmp/urls
+      - run: ls -l
       - run:
           name: upload unique binary
           command: |
             node scripts/binary.js upload-unique-binary \
-              --file /tmp/urls/cypress.zip \
+              --file cypress.zip \
               --version $NEXT_DEV_VERSION
       - run: cat binary-url.json
-      - run: cp binary-url.json /tmp/urls
-      - run: ls -l /tmp/urls
       - store-npm-logs
       - persist_to_workspace:
-          root: /tmp/urls
+          root: ~/
           paths:
-            - binary-url.json
-            - cypress.zip
+            - cypress/binary-url.json
 
   test-kitchensink:
     <<: *defaults
@@ -742,10 +736,6 @@ jobs:
           root: ~/
           paths:
             - cypress/cypress.tgz
-      # - persist_to_workspace:
-      #     root: /tmp/urls
-      #     paths:
-      #       - cypress.tgz
 
   upload-npm-package:
     <<: *defaults
@@ -753,9 +743,6 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: ls -l
-      # - run: ls -l cli/build
-      # - run: ls -l /tmp
-      # - run: ls -l /tmp/urls
       # NPM package file should have filename cypress-<version>.tgz
       - run:
           name: upload NPM package
@@ -763,15 +750,13 @@ jobs:
             node scripts/binary.js upload-npm-package \
               --file cypress.tgz \
               --version $NEXT_DEV_VERSION
-      - run: cat npm-package-url.json
-      - run: cp npm-package-url.json .
-      - run: ls -l
       - store-npm-logs
+      - run: ls -l
+      - run: cat npm-package-url.json
       - persist_to_workspace:
           root: ~/
           paths:
             - cypress/npm-package-url.json
-            # - cypress/cypress.tgz
 
   "test-binary-and-npm-against-other-projects":
     <<: *defaults
@@ -780,8 +765,8 @@ jobs:
           at: ~/
       - attach_workspace:
           at: /tmp/urls
-      - run: ls -la /tmp/urls
-      - run: cat /tmp/urls/*.json
+      - run: ls -la
+      - run: cat *.json
       - run: mkdir /tmp/testing
       - run:
           name: create dummy package
@@ -792,8 +777,8 @@ jobs:
           name: Install Cypress
           command: |
             node scripts/test-unique-npm-and-binary.js \
-              --npm /tmp/urls/npm-package-url.json \
-              --binary /tmp/urls/binary-url.json \
+              --npm npm-package-url.json \
+              --binary binary-url.json \
               --cwd /tmp/testing
       - run:
           name: Verify Cypress binary

--- a/circle.yml
+++ b/circle.yml
@@ -601,22 +601,13 @@ jobs:
           command: npm run binary-build -- --platform $PLATFORM --version $NEXT_DEV_VERSION
       - run: npm run binary-zip -- --platform $PLATFORM
       - run: ls -l *.zip
-      # - run:
-      #     name: upload unique binary
-      #     command: |
-      #       node scripts/binary.js upload-unique-binary \
-      #         --file cypress.zip \
-      #         --version $NEXT_DEV_VERSION
-      # - run: cat binary-url.json
       - run: mkdir /tmp/urls
-      # - run: cp binary-url.json /tmp/urls
       - run: cp cypress.zip /tmp/urls
-      - run: ls /tmp/urls
+      - run: ls -l /tmp/urls
       - store-npm-logs
       - persist_to_workspace:
           root: /tmp/urls
           paths:
-            # - binary-url.json
             - cypress.zip
 
   upload-binary:
@@ -624,24 +615,22 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run: ls -l
-      # - run:
-      #     name: upload unique binary
-      #     command: |
-      #       node scripts/binary.js upload-unique-binary \
-      #         --file cypress.zip \
-      #         --version $NEXT_DEV_VERSION
+      - run: ls -l /tmp/urls
+      - run:
+          name: upload unique binary
+          command: |
+            node scripts/binary.js upload-unique-binary \
+              --file /tmp/urls/cypress.zip \
+              --version $NEXT_DEV_VERSION
       - run: cat binary-url.json
-      # - run: mkdir /tmp/urls
       - run: cp binary-url.json /tmp/urls
-      # - run: cp cypress.zip /tmp/urls
-      - run: ls /tmp/urls
+      - run: ls -l /tmp/urls
       - store-npm-logs
       - persist_to_workspace:
           root: /tmp/urls
           paths:
             - binary-url.json
-            # - cypress.zip
+            - cypress.zip
 
   test-kitchensink:
     <<: *defaults
@@ -1073,22 +1062,25 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
-              - test-example-repos-on-mac-4526
         requires:
           - Mac build
 
     - build-binary:
         name: Mac binary
         executor: mac
+        requires:
+          - Mac build
+
+    - upload-binary:
+        name: Mac binary upload
+        executor: mac
         context: org-global
         filters:
           branches:
             only:
               - develop
-              - binary-metadata
-              - test-example-repos-on-mac-4526
         requires:
-          - Mac build
+          - Mac binary
 
     - test-kitchensink:
         name: Test Mac Kitchensink

--- a/circle.yml
+++ b/circle.yml
@@ -739,7 +739,7 @@ jobs:
       - run: pwd
       - run: ls -l
       - persist_to_workspace:
-          root: ~
+          root: ~/cypress
           paths:
             - cypress.tgz
       # - persist_to_workspace:

--- a/circle.yml
+++ b/circle.yml
@@ -702,7 +702,7 @@ jobs:
             npm run cypress:run -- --project /tmp/repo --record
       - store-npm-logs
 
-  "build-npm-package":
+  build-npm-package:
     <<: *defaults
     steps:
       - attach_workspace:
@@ -730,17 +730,31 @@ jobs:
           working_directory: cli/build
           command: ls -l
       # created file should have filename cypress-<version>.tgz
+      - run: mkdir /tmp/urls
+      - run: cp cli/build/cypress-$NEXT_DEV_VERSION.tgz /tmp/urls/cypress.tgz
+      - run: ls -l /tmp/urls
+      - store-npm-logs
+      - persist_to_workspace:
+          root: /tmp/urls
+          paths:
+            - cypress.tgz
+
+  upload-npm-package:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+          command: ls -l /tmp/urls
+      # created file should have filename cypress-<version>.tgz
       - run:
           name: upload NPM package
           command: |
             node scripts/binary.js upload-npm-package \
-              --file cli/build/cypress-$NEXT_DEV_VERSION.tgz \
+              --file /tmp/urls/cypress-$NEXT_DEV_VERSION.tgz \
               --version $NEXT_DEV_VERSION
       - run: cat npm-package-url.json
-      - run: mkdir /tmp/urls
-      - run: cp cli/build/cypress-$NEXT_DEV_VERSION.tgz /tmp/urls/cypress.tgz
       - run: cp npm-package-url.json /tmp/urls
-      - run: ls /tmp/urls
+      - run: ls -l /tmp/urls
       - store-npm-logs
       - persist_to_workspace:
           root: /tmp/urls
@@ -988,13 +1002,16 @@ linux-workflow: &linux-workflow
         requires:
           - build
     - build-npm-package:
+        requires:
+          - build
+    - upload-npm-package:
         context: test-runner:upload
         filters:
           branches:
             only:
               - develop
         requires:
-          - build
+          - build-npm-package
     - build-binary:
         requires:
           - build
@@ -1056,6 +1073,12 @@ mac-workflow: &mac-workflow
 
     - build-npm-package:
         name: Mac NPM package
+        executor: mac
+        requires:
+          - Mac build
+
+    - upload-npm-package:
+        name: Mac NPM package upload
         context: test-runner:upload
         executor: mac
         filters:
@@ -1063,7 +1086,7 @@ mac-workflow: &mac-workflow
             only:
               - develop
         requires:
-          - Mac build
+          - Mac NPM package
 
     - build-binary:
         name: Mac binary

--- a/circle.yml
+++ b/circle.yml
@@ -746,6 +746,8 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: ls -l
+      - run: ls -l cli/build
+      - run: ls -l /tmp
       - run: ls -l /tmp/urls
       # NPM package file should have filename cypress-<version>.tgz
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -732,9 +732,15 @@ jobs:
           command: ls -l
       # created file should have filename cypress-<version>.tgz
       - run: mkdir /tmp/urls
+      - run: cp cli/build/cypress-$NEXT_DEV_VERSION.tgz cypress.tgz
       - run: cp cli/build/cypress-$NEXT_DEV_VERSION.tgz /tmp/urls/cypress.tgz
       - run: ls -l /tmp/urls
       - store-npm-logs
+      - run: pwd
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - cypress.tgz
       - persist_to_workspace:
           root: /tmp/urls
           paths:

--- a/circle.yml
+++ b/circle.yml
@@ -619,6 +619,32 @@ jobs:
             - binary-url.json
             - cypress.zip
 
+  test-kitchensink:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Cloning test project
+          command: git clone https://github.com/cypress-io/cypress-example-kitchensink.git /tmp/repo
+      - run:
+          name: Install prod dependencies
+          command: npm install --production
+          working_directory: /tmp/repo
+      - run:
+          name: Example server
+          command: npm start
+          working_directory: /tmp/repo
+          background: true
+      - run:
+          name: Run Kitchensink example project
+          command: npm run cypress:run -- --project /tmp/repo
+      - store_artifacts:
+          path: /tmp/repo/cypress/screenshots
+      - store_artifacts:
+          path: /tmp/repo/cypress/videos
+      - store-npm-logs
+
   "test-kitchensink-against-staging":
     <<: *defaults
     steps:
@@ -937,6 +963,9 @@ linux-workflow: &linux-workflow
               - develop
         requires:
           - build
+    - test-kitchensink:
+        requires:
+          - build
     - test-kitchensink-against-staging:
         context: test-runner:record-tests
         filters:
@@ -1031,6 +1060,12 @@ mac-workflow: &mac-workflow
               - develop
               - binary-metadata
               - test-example-repos-on-mac-4526
+        requires:
+          - Mac build
+
+    - test-kitchensink:
+        name: Test Mac Kitchensink
+        executor: mac
         requires:
           - Mac build
 

--- a/circle.yml
+++ b/circle.yml
@@ -1089,14 +1089,20 @@ mac-workflow: &mac-workflow
 
     - build-binary:
         name: Mac binary
+        context: org-global
         executor: mac
+        filters:
+          branches:
+            only:
+              - develop
+              - run-more-tests
         requires:
           - Mac build
 
     - upload-binary:
         name: Mac binary upload
         executor: mac
-        context: org-global
+        context: test-runner:upload
         filters:
           branches:
             only:

--- a/circle.yml
+++ b/circle.yml
@@ -737,8 +737,9 @@ jobs:
       - run: ls -l /tmp/urls
       - store-npm-logs
       - run: pwd
+      - run: ls -l
       - persist_to_workspace:
-          root: ~/
+          root: .
           paths:
             - cypress.tgz
       - persist_to_workspace:

--- a/circle.yml
+++ b/circle.yml
@@ -739,13 +739,13 @@ jobs:
       - run: pwd
       - run: ls -l
       - persist_to_workspace:
-          root: .
+          root: ~/
           paths:
             - cypress.tgz
-      - persist_to_workspace:
-          root: /tmp/urls
-          paths:
-            - cypress.tgz
+      # - persist_to_workspace:
+      #     root: /tmp/urls
+      #     paths:
+      #       - cypress.tgz
 
   upload-npm-package:
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -1010,6 +1010,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
+              - run-more-tests
         requires:
           - build-npm-package
     - build-binary:
@@ -1021,6 +1022,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
+              - run-more-tests
         requires:
           - build-binary
     - test-binary-and-npm-against-other-projects:
@@ -1085,6 +1087,7 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
+              - run-more-tests
         requires:
           - Mac NPM package
 
@@ -1102,6 +1105,7 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
+              - run-more-tests
         requires:
           - Mac binary
 

--- a/circle.yml
+++ b/circle.yml
@@ -739,9 +739,9 @@ jobs:
       - run: pwd
       - run: ls -l
       - persist_to_workspace:
-          root: ~/cypress
+          root: ~/
           paths:
-            - cypress.tgz
+            - cypress/cypress.tgz
       # - persist_to_workspace:
       #     root: /tmp/urls
       #     paths:
@@ -753,25 +753,25 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: ls -l
-      - run: ls -l cli/build
-      - run: ls -l /tmp
-      - run: ls -l /tmp/urls
+      # - run: ls -l cli/build
+      # - run: ls -l /tmp
+      # - run: ls -l /tmp/urls
       # NPM package file should have filename cypress-<version>.tgz
       - run:
           name: upload NPM package
           command: |
             node scripts/binary.js upload-npm-package \
-              --file /tmp/urls/cypress-$NEXT_DEV_VERSION.tgz \
+              --file cypress.tgz \
               --version $NEXT_DEV_VERSION
       - run: cat npm-package-url.json
-      - run: cp npm-package-url.json /tmp/urls
-      - run: ls -l /tmp/urls
+      - run: cp npm-package-url.json .
+      - run: ls -l
       - store-npm-logs
       - persist_to_workspace:
-          root: /tmp/urls
+          root: ~/
           paths:
-            - npm-package-url.json
-            - cypress.tgz
+            - cypress/npm-package-url.json
+            # - cypress/cypress.tgz
 
   "test-binary-and-npm-against-other-projects":
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -601,23 +601,47 @@ jobs:
           command: npm run binary-build -- --platform $PLATFORM --version $NEXT_DEV_VERSION
       - run: npm run binary-zip -- --platform $PLATFORM
       - run: ls -l *.zip
-      - run:
-          name: upload unique binary
-          command: |
-            node scripts/binary.js upload-unique-binary \
-              --file cypress.zip \
-              --version $NEXT_DEV_VERSION
-      - run: cat binary-url.json
+      # - run:
+      #     name: upload unique binary
+      #     command: |
+      #       node scripts/binary.js upload-unique-binary \
+      #         --file cypress.zip \
+      #         --version $NEXT_DEV_VERSION
+      # - run: cat binary-url.json
       - run: mkdir /tmp/urls
-      - run: cp binary-url.json /tmp/urls
+      # - run: cp binary-url.json /tmp/urls
       - run: cp cypress.zip /tmp/urls
       - run: ls /tmp/urls
       - store-npm-logs
       - persist_to_workspace:
           root: /tmp/urls
           paths:
-            - binary-url.json
+            # - binary-url.json
             - cypress.zip
+
+  upload-binary:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: ls -l
+      # - run:
+      #     name: upload unique binary
+      #     command: |
+      #       node scripts/binary.js upload-unique-binary \
+      #         --file cypress.zip \
+      #         --version $NEXT_DEV_VERSION
+      - run: cat binary-url.json
+      # - run: mkdir /tmp/urls
+      - run: cp binary-url.json /tmp/urls
+      # - run: cp cypress.zip /tmp/urls
+      - run: ls /tmp/urls
+      - store-npm-logs
+      - persist_to_workspace:
+          root: /tmp/urls
+          paths:
+            - binary-url.json
+            # - cypress.zip
 
   test-kitchensink:
     <<: *defaults
@@ -983,13 +1007,16 @@ linux-workflow: &linux-workflow
         requires:
           - build
     - build-binary:
+        requires:
+          - build
+    - upload-binary:
         context: test-runner:upload
         filters:
           branches:
             only:
               - develop
         requires:
-          - build
+          - build-binary
     - test-binary-and-npm-against-other-projects:
         context: test-runner:trigger-test-jobs
         filters:

--- a/circle.yml
+++ b/circle.yml
@@ -615,6 +615,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - run: ls -l .
       - run: ls -l /tmp/urls
       - run:
           name: upload unique binary
@@ -744,8 +745,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-          command: ls -l /tmp/urls
-      # created file should have filename cypress-<version>.tgz
+      - run: ls -l /tmp/urls
+      # NPM package file should have filename cypress-<version>.tgz
       - run:
           name: upload NPM package
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -739,7 +739,7 @@ jobs:
       - run: pwd
       - run: ls -l
       - persist_to_workspace:
-          root: ~/
+          root: ~
           paths:
             - cypress.tgz
       # - persist_to_workspace:


### PR DESCRIPTION
- Closes #5421 

### Additional details

- [x] runs Kitchensink tests on Linux and Mac for all commits, not just on `develop`
- [x] builds binary and NPM package for all commits (upload is a separate job)
