### PR TITLE
fix failing kitchensink tests in develop

### DIFF
--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -329,6 +329,8 @@ const validateTyping = (
     return {}
   }
 
+  // throw error if element, which is normally typeable, is disabled for some reason
+  // don't throw if force: true
   if (!isFocusable && isTextLike && !force) {
     const node = $dom.stringify($el)
 
@@ -338,6 +340,7 @@ const validateTyping = (
     })
   }
 
+  // throw error if element cannot receive keyboard events under any conditions
   if (!isFocusable && !isTextLike) {
     const node = $dom.stringify($el)
 

--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -280,7 +280,8 @@ const validateTyping = (
   keys: KeyDetails[],
   currentIndex: number,
   onFail: Function,
-  skipCheckUntilIndex?: number,
+  skipCheckUntilIndex: number | undefined,
+  force: boolean
 ) => {
   const chars = joinKeyArrayToString(keys.slice(currentIndex))
   const allChars = joinKeyArrayToString(keys)
@@ -328,15 +329,17 @@ const validateTyping = (
     return {}
   }
 
-  if (!isFocusable) {
+  if (!isFocusable && isTextLike && !force) {
     const node = $dom.stringify($el)
 
-    if (isTextLike) {
-      $utils.throwErrByPath('type.not_actionable_textlike', {
-        onFail,
-        args: { node },
-      })
-    }
+    $utils.throwErrByPath('type.not_actionable_textlike', {
+      onFail,
+      args: { node },
+    })
+  }
+
+  if (!isFocusable && !isTextLike) {
+    const node = $dom.stringify($el)
 
     $utils.throwErrByPath('type.not_on_typeable_element', {
       onFail,
@@ -660,6 +663,7 @@ export class Keyboard {
               currentKeyIndex,
               options.onFail,
               _skipCheckUntilIndex,
+              options.force
             )
 
             _skipCheckUntilIndex = skipCheckUntilIndex

--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -211,7 +211,7 @@ const getKeyDetails = (onKeyNotFound) => {
 
     onKeyNotFound(key, _.keys(getKeymap()).join(', '))
 
-    throw Error(`Not a valid key: ${key}`)
+    throw new Error('this can never happen')
   }
 }
 

--- a/packages/driver/src/dom/selection.ts
+++ b/packages/driver/src/dom/selection.ts
@@ -154,6 +154,9 @@ const setSelectionRange = function (el, start, end) {
   $elements.callNativeMethod(el, 'setSelectionRange', start, end)
 }
 
+// Whether or not the selection contains any text
+// since Selection.isCollapsed will be true when selection
+// is inside non-selectionRange input (e.g. input[type=email])
 const isSelectionCollapsed = function (selection: Selection) {
   return !selection.toString()
 }

--- a/packages/driver/src/dom/selection.ts
+++ b/packages/driver/src/dom/selection.ts
@@ -154,6 +154,10 @@ const setSelectionRange = function (el, start, end) {
   $elements.callNativeMethod(el, 'setSelectionRange', start, end)
 }
 
+const isSelectionCollapsed = function (selection: Selection) {
+  return !selection.toString()
+}
+
 const deleteRightOfCursor = function (el) {
   if ($elements.canSetSelectionRangeElement(el)) {
     const { start, end } = getSelectionBounds(el)
@@ -167,7 +171,7 @@ const deleteRightOfCursor = function (el) {
 
   const selection = _getSelectionByEl(el)
 
-  if (selection.isCollapsed) {
+  if (isSelectionCollapsed(selection)) {
     $elements.callNativeMethod(
       selection,
       'modify',
@@ -195,7 +199,7 @@ const deleteLeftOfCursor = function (el) {
 
   const selection = _getSelectionByEl(el)
 
-  if (selection.isCollapsed) {
+  if (isSelectionCollapsed(selection)) {
     $elements.callNativeMethod(
       selection,
       'modify',

--- a/packages/driver/test/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/type_spec.js
@@ -199,6 +199,12 @@ describe('src/cy/commands/actions/type', () => {
         })
       })
 
+      it('can force click when element is disabled', function () {
+        cy.$$('input:text:first').prop('disabled', true)
+        cy.get('input:text:first').type('foo', { force: true })
+        .should('have.value', 'foo')
+      })
+
       it('can forcibly click even when being covered by another element', () => {
         const $input = $('<input />')
         .attr('id', 'input-covered-in-span')
@@ -1808,6 +1814,13 @@ describe('src/cy/commands/actions/type', () => {
           cy.get(':text:first').invoke('val', 'bar').type('{leftarrow}{backspace}u').then(($input) => {
             expect($input).to.have.value('bur')
           })
+        })
+
+        it('can delete all with {selectall}{backspace} in non-selectionrange element', () => {
+          cy.get('input[type=email]:first')
+          .should(($el) => $el.val('sdfsdf'))
+          .type('{selectall}{backspace}')
+          .should('have.value', '')
         })
 
         it('can backspace a selection range of characters', () => {
@@ -4415,22 +4428,6 @@ describe('src/cy/commands/actions/type', () => {
         cy.get('input:text:first').type('foo')
       })
 
-      it('throws when subject is disabled and force:true', function (done) {
-        cy.timeout(200)
-
-        cy.$$('input:text:first').prop('disabled', true)
-
-        cy.on('fail', (err) => {
-          // get + type logs
-          expect(this.logs.length).eq(2)
-          expect(err.message).to.include('cy.type() failed because it targeted a disabled element.')
-
-          done()
-        })
-
-        cy.get('input:text:first').type('foo', { force: true })
-      })
-
       it('throws when submitting within nested forms')
 
       it('logs once when not dom subject', function (done) {
@@ -4532,11 +4529,11 @@ https://on.cypress.io/type`)
         })
       })
 
-      describe('naughtly strings', () => {
+      describe('naughty strings', () => {
         _.each(['Ω≈ç√∫˜µ≤≥÷', '2.2250738585072011e-308', '田中さんにあげて下さい',
           '<foo val=`bar\' />', '⁰⁴⁵₀₁₂', '🐵 🙈 🙉 🙊',
           '<script>alert(123)</script>', '$USER'], (val) => {
-          it(`allows typing some naughtly strings (${val})`, () => {
+          it(`allows typing some naughty strings (${val})`, () => {
             cy
             .get(':text:first').type(val)
             .should('have.value', val)

--- a/packages/driver/test/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/type_spec.js
@@ -183,7 +183,7 @@ describe('src/cy/commands/actions/type', () => {
     })
 
     describe('actionability', () => {
-      it('can forcibly click even when element is invisible', () => {
+      it('can forcibly type + click even when element is invisible', () => {
         const $txt = cy.$$(':text:first').hide()
 
         expect($txt).not.to.have.value('foo')
@@ -199,13 +199,13 @@ describe('src/cy/commands/actions/type', () => {
         })
       })
 
-      it('can force click when element is disabled', function () {
+      it('can force type when element is disabled', function () {
         cy.$$('input:text:first').prop('disabled', true)
         cy.get('input:text:first').type('foo', { force: true })
         .should('have.value', 'foo')
       })
 
-      it('can forcibly click even when being covered by another element', () => {
+      it('can forcibly type + click even when being covered by another element', () => {
         const $input = $('<input />')
         .attr('id', 'input-covered-in-span')
         .css({


### PR DESCRIPTION
so, there were test cases covered in the kitchen sink that were not covered in type_spec, and they were failing. This PR adds them to type_spec and fixes them.
- [x] fix force typing in disabled input
- [x] fix selection ranges on non-selectionrange inputs
- cleanup from #4870
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes NA

### User facing changelog
NA
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
NA
<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [NA] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
