### PR TITLE
correct comments tagging fixed issues for cy.type

### DIFF
--- a/packages/driver/test/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/type_spec.js
@@ -2832,6 +2832,7 @@ describe('src/cy/commands/actions/type', () => {
           })
         })
 
+        // sends keyboard events for modifiers https://github.com/cypress-io/cypress/issues/3316
         it('sends keyup event for activated modifiers when typing is finished', (done) => {
           const $input = cy.$$('input:text:first')
           const events = []
@@ -4251,7 +4252,7 @@ describe('src/cy/commands/actions/type', () => {
         })
 
         // Updated not to input text when non-shift modifier is pressed
-        // https://github.com/cypress-io/cypress/issues/3316
+        // https://github.com/cypress-io/cypress/issues/5424
         it('has a table of keys', () => {
           cy.get(':text:first').type('{cmd}{option}foo{enter}b{leftarrow}{del}{enter}')
           .then(function () {


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

corrects comments that are linking incorrect issues as being fixed in type_spec

- #3316 was fixed prior to 3.4.1, but was open and missing comment on test
- #5424 was fixed by #4870 but not mentioned and missing comment on test

<!-- Example: "Closes #1234" -->

- address #3316
- address #5424 (was fixed in #4870)

- Closes NA<!-- issue number here -->

### User facing changelog
NA
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [NA] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
