### PR TITLE
don't log multiple:true by default in dblclick

### DIFF
--- a/packages/driver/src/cy/commands/actions/click.js
+++ b/packages/driver/src/cy/commands/actions/click.js
@@ -64,13 +64,14 @@ const formatMouseEvents = (events) => {
 module.exports = (Commands, Cypress, cy, state, config) => {
   const { mouse } = cy.devices
 
-  const mouseAction = (eventName, { subject, positionOrX, y, options, onReady, onTable }) => {
+  const mouseAction = (eventName, { subject, positionOrX, y, options, onReady, onTable, defaultOptions }) => {
     let position
     let x
 
     ({ options, position, x, y } = $actionability.getPositionFromArguments(positionOrX, y, options))
 
     _.defaults(options, {
+      ...defaultOptions,
       $el: subject,
       log: true,
       verify: true,
@@ -98,7 +99,7 @@ module.exports = (Commands, Cypress, cy, state, config) => {
 
       if (options.log) {
         // figure out the options which actually change the behavior of clicks
-        deltaOptions = $utils.filterOutOptions(options)
+        deltaOptions = $utils.filterOutOptions(options, defaultOptions)
 
         options._log = Cypress.log({
           message: deltaOptions,
@@ -256,13 +257,12 @@ module.exports = (Commands, Cypress, cy, state, config) => {
     },
 
     dblclick (subject, positionOrX, y, options = {}) {
-      // TODO: 4.0 make this false by default
-      options.multiple = true
-
       return mouseAction('dblclick', {
         y,
         subject,
         options,
+        // TODO: 4.0 make this false by default
+        defaultOptions: { multiple: true },
         positionOrX,
         onReady (fromElViewport, forceEl) {
           const { clickEvents1, clickEvents2, dblclickProps } = mouse.dblclick(fromElViewport, forceEl)

--- a/packages/driver/src/cy/commands/actions/click.js
+++ b/packages/driver/src/cy/commands/actions/click.js
@@ -71,7 +71,6 @@ module.exports = (Commands, Cypress, cy, state, config) => {
     ({ options, position, x, y } = $actionability.getPositionFromArguments(positionOrX, y, options))
 
     _.defaults(options, {
-      ...defaultOptions,
       $el: subject,
       log: true,
       verify: true,
@@ -83,6 +82,7 @@ module.exports = (Commands, Cypress, cy, state, config) => {
       errorOnSelect: true,
       waitForAnimations: config('waitForAnimations'),
       animationDistanceThreshold: config('animationDistanceThreshold'),
+      ...defaultOptions,
     })
 
     // throw if we're trying to click multiple elements

--- a/packages/driver/test/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/click_spec.js
@@ -2826,6 +2826,20 @@ describe('src/cy/commands/actions/click', () => {
         })
       })
 
+      // TODO: remove this after 4.0 when {multiple:true} is no longer default
+      it('does not log default option {multiple:true}', () => {
+        const logs = []
+
+        cy.on('log:added', (attrs, log) => {
+          logs.push(log)
+        })
+
+        cy.get('button:first').dblclick().then(() => {
+          expect(logs[1].get('message')).to.eq('')
+          expect(logs[1].invoke('consoleProps').Options).not.ok
+        })
+      })
+
       it('returns only the $el for the element of the subject that was dblclicked', () => {
         const dblclicks = []
 

--- a/packages/driver/test/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/click_spec.js
@@ -2827,6 +2827,7 @@ describe('src/cy/commands/actions/click', () => {
       })
 
       // TODO: remove this after 4.0 when {multiple:true} is no longer default
+      // https://github.com/cypress-io/cypress/issues/5406
       it('does not log default option {multiple:true}', () => {
         const logs = []
 

--- a/packages/driver/test/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/click_spec.js
@@ -2900,9 +2900,6 @@ describe('src/cy/commands/actions/click', () => {
             'Command': 'dblclick',
             'Applied To': {},
             'Elements': 1,
-            'Options': {
-              'multiple': true,
-            },
             'table': {},
           })
 


### PR DESCRIPTION
- don't log default options during dblclick
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #5406 <!-- issue number here -->

### User facing changelog
- fix visual bug logging default options during `dblclick`
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

default option {multiple:true} no longer logged when no options provided to `dblclick`
- before:
![19-10-23_15:12::00](https://user-images.githubusercontent.com/14625260/67426752-c6cac880-f5a8-11e9-90e0-01a0cda2b22f.png)
![19-10-23_15:12::09](https://user-images.githubusercontent.com/14625260/67426782-d0543080-f5a8-11e9-89d9-874f828492f2.png)
- after:
![19-10-23_15:11::23](https://user-images.githubusercontent.com/14625260/67426766-ca5e4f80-f5a8-11e9-9441-ee750a11b24b.png)
![19-10-23_15:11::30](https://user-images.githubusercontent.com/14625260/67426791-d34f2100-f5a8-11e9-9305-1a38e2e3d931.png)



<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
