### PR TITLE
Use local webpack instance

### DIFF
--- a/packages/desktop-gui/package.json
+++ b/packages/desktop-gui/package.json
@@ -5,7 +5,7 @@
   "main": "lib/gui.js",
   "scripts": {
     "prebuild": "npm run check-deps-pre",
-    "build": "webpack",
+    "build": "npx webpack",
     "build-prod": "cross-env NODE_ENV=production npm run build",
     "check-deps": "node ../../scripts/check-deps.js --verbose",
     "check-deps-pre": "npm run check-deps -- --prescript",


### PR DESCRIPTION
When there is no global webpack installed, the build will fail.

<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #5443 

### User facing changelog

Use local webpack instead of global one.
