### PR TITLE
Always pass NODE_OPTIONS with max-http-header-size

### DIFF
--- a/cli/__snapshots__/spawn_spec.js
+++ b/cli/__snapshots__/spawn_spec.js
@@ -1,0 +1,18 @@
+exports['lib/exec/spawn .start forces colors and streams when supported 1'] = {
+  "FORCE_COLOR": "1",
+  "DEBUG_COLORS": "1",
+  "MOCHA_COLORS": "1",
+  "FORCE_STDIN_TTY": "1",
+  "FORCE_STDOUT_TTY": "1",
+  "FORCE_STDERR_TTY": "1",
+  "NODE_OPTIONS": "--max-http-header-size=1048576"
+}
+
+exports['lib/exec/spawn .start does not force colors and streams when not supported 1'] = {
+  "FORCE_COLOR": "0",
+  "DEBUG_COLORS": "0",
+  "FORCE_STDIN_TTY": "0",
+  "FORCE_STDOUT_TTY": "0",
+  "FORCE_STDERR_TTY": "0",
+  "NODE_OPTIONS": "--max-http-header-size=1048576"
+}

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -102,7 +102,7 @@ module.exports = {
         }
 
         const { onStderrData, electronLogging } = overrides
-        const envOverrides = util.getEnvOverrides()
+        const envOverrides = util.getEnvOverrides(options)
         const electronArgs = _.clone(args)
         const node11WindowsFix = isPlatform('win32')
 

--- a/cli/lib/util.js
+++ b/cli/lib/util.js
@@ -193,7 +193,21 @@ const util = {
     .mapValues((value) => { // stringify to 1 or 0
       return value ? '1' : '0'
     })
+    .extend(util.getNodeOptions())
     .value()
+  },
+
+  getNodeOptions () {
+    // https://github.com/cypress-io/cypress/issues/5431
+    const NODE_OPTIONS = `--max-http-header-size=${1024 * 1024}`
+
+    if (_.isString(process.env.NODE_OPTIONS)) {
+      return {
+        NODE_OPTIONS: `${process.env.NODE_OPTIONS} ${NODE_OPTIONS}`,
+      }
+    }
+
+    return { NODE_OPTIONS }
   },
 
   getForceTty () {

--- a/cli/lib/util.js
+++ b/cli/lib/util.js
@@ -184,7 +184,7 @@ const util = {
     return isCi
   },
 
-  getEnvOverrides () {
+  getEnvOverrides (options = {}) {
     return _
     .chain({})
     .extend(util.getEnvColors())
@@ -193,11 +193,18 @@ const util = {
     .mapValues((value) => { // stringify to 1 or 0
       return value ? '1' : '0'
     })
-    .extend(util.getNodeOptions())
+    .extend(util.getNodeOptions(options))
     .value()
   },
 
-  getNodeOptions () {
+  getNodeOptions (options) {
+    if (options.dev && Number(process.versions.node.split('.', 2).join('.')) < 11.10) {
+      // `node` is used when --dev is passed, so this won't work if Node is too old
+      logger.warn('(dev-mode warning only) NODE_OPTIONS=--max-http-header-size could not be set. See https://github.com/cypress-io/cypress/pull/5452')
+
+      return
+    }
+
     // https://github.com/cypress-io/cypress/issues/5431
     const NODE_OPTIONS = `--max-http-header-size=${1024 * 1024}`
 

--- a/cli/lib/util.js
+++ b/cli/lib/util.js
@@ -197,8 +197,12 @@ const util = {
     .value()
   },
 
-  getNodeOptions (options) {
-    if (options.dev && Number(process.versions.node.split('.', 2).join('.')) < 11.10) {
+  getNodeOptions (options, nodeVersion) {
+    if (!nodeVersion) {
+      nodeVersion = Number(process.versions.node.split('.')[0])
+    }
+
+    if (options.dev && nodeVersion < 12) {
       // `node` is used when --dev is passed, so this won't work if Node is too old
       logger.warn('(dev-mode warning only) NODE_OPTIONS=--max-http-header-size could not be set. See https://github.com/cypress-io/cypress/pull/5452')
 
@@ -210,7 +214,8 @@ const util = {
 
     if (_.isString(process.env.NODE_OPTIONS)) {
       return {
-        NODE_OPTIONS: `${process.env.NODE_OPTIONS} ${NODE_OPTIONS}`,
+        NODE_OPTIONS: `${NODE_OPTIONS} ${process.env.NODE_OPTIONS}`,
+        ORIGINAL_NODE_OPTIONS: process.env.NODE_OPTIONS || '',
       }
     }
 

--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -3,6 +3,7 @@ require('../../spec_helper')
 const _ = require('lodash')
 const cp = require('child_process')
 const os = require('os')
+const snapshot = require('snap-shot-it')
 const tty = require('tty')
 const path = require('path')
 const EE = require('events')
@@ -287,14 +288,7 @@ describe('lib/exec/spawn', function () {
 
       return spawn.start([], { env: {} })
       .then(() => {
-        expect(cp.spawn.firstCall.args[2].env).to.deep.eq({
-          FORCE_COLOR: '1',
-          DEBUG_COLORS: '1',
-          MOCHA_COLORS: '1',
-          FORCE_STDERR_TTY: '1',
-          FORCE_STDIN_TTY: '1',
-          FORCE_STDOUT_TTY: '1',
-        })
+        snapshot(cp.spawn.firstCall.args[2].env)
       })
     })
 
@@ -326,13 +320,7 @@ describe('lib/exec/spawn', function () {
 
       return spawn.start([], { env: {} })
       .then(() => {
-        expect(cp.spawn.firstCall.args[2].env).to.deep.eq({
-          FORCE_COLOR: '0',
-          DEBUG_COLORS: '0',
-          FORCE_STDERR_TTY: '0',
-          FORCE_STDIN_TTY: '0',
-          FORCE_STDOUT_TTY: '0',
-        })
+        snapshot(cp.spawn.firstCall.args[2].env)
       })
     })
 

--- a/cli/test/lib/util_spec.js
+++ b/cli/test/lib/util_spec.js
@@ -3,6 +3,7 @@ require('../spec_helper')
 const os = require('os')
 const tty = require('tty')
 const snapshot = require('../support/snapshot')
+const mockedEnv = require('mocked-env')
 const supportsColor = require('supports-color')
 const proxyquire = require('proxyquire')
 const hasha = require('hasha')
@@ -10,6 +11,9 @@ const la = require('lazy-ass')
 
 const util = require(`${lib}/util`)
 const logger = require(`${lib}/logger`)
+
+// https://github.com/cypress-io/cypress/issues/5431
+const expectedNodeOptions = `--max-http-header-size=${1024 * 1024}`
 
 describe('util', () => {
   beforeEach(() => {
@@ -213,6 +217,7 @@ describe('util', () => {
         FORCE_COLOR: '1',
         DEBUG_COLORS: '1',
         MOCHA_COLORS: '1',
+        NODE_OPTIONS: expectedNodeOptions,
       })
 
       util.supportsColor.returns(false)
@@ -224,6 +229,38 @@ describe('util', () => {
         FORCE_STDERR_TTY: '0',
         FORCE_COLOR: '0',
         DEBUG_COLORS: '0',
+        NODE_OPTIONS: expectedNodeOptions,
+      })
+    })
+  })
+
+  context('.getNodeOptions', () => {
+    let restoreEnv
+
+    afterEach(() => {
+      if (restoreEnv) {
+        restoreEnv()
+        restoreEnv = null
+      }
+    })
+
+    it('adds required NODE_OPTIONS', () => {
+      restoreEnv = mockedEnv({
+        NODE_OPTIONS: undefined,
+      })
+
+      expect(util.getNodeOptions()).to.deep.eq({
+        NODE_OPTIONS: expectedNodeOptions,
+      })
+    })
+
+    it('includes existing NODE_OPTIONS', () => {
+      restoreEnv = mockedEnv({
+        NODE_OPTIONS: '--foo --bar',
+      })
+
+      expect(util.getNodeOptions()).to.deep.eq({
+        NODE_OPTIONS: `--foo --bar ${expectedNodeOptions}`,
       })
     })
   })

--- a/cli/test/lib/util_spec.js
+++ b/cli/test/lib/util_spec.js
@@ -260,14 +260,15 @@ describe('util', () => {
       })
 
       expect(util.getNodeOptions({})).to.deep.eq({
-        NODE_OPTIONS: `--foo --bar ${expectedNodeOptions}`,
+        NODE_OPTIONS: `${expectedNodeOptions} --foo --bar`,
+        ORIGINAL_NODE_OPTIONS: '--foo --bar',
       })
     })
 
-    it('does not return if dev is set', () => {
+    it('does not return if dev is set and version < 12', () => {
       expect(util.getNodeOptions({
         dev: true,
-      })).to.be.undefined
+      }, 11)).to.be.undefined
     })
   })
 

--- a/cli/test/lib/util_spec.js
+++ b/cli/test/lib/util_spec.js
@@ -249,7 +249,7 @@ describe('util', () => {
         NODE_OPTIONS: undefined,
       })
 
-      expect(util.getNodeOptions()).to.deep.eq({
+      expect(util.getNodeOptions({})).to.deep.eq({
         NODE_OPTIONS: expectedNodeOptions,
       })
     })
@@ -259,9 +259,15 @@ describe('util', () => {
         NODE_OPTIONS: '--foo --bar',
       })
 
-      expect(util.getNodeOptions()).to.deep.eq({
+      expect(util.getNodeOptions({})).to.deep.eq({
         NODE_OPTIONS: `--foo --bar ${expectedNodeOptions}`,
       })
+    })
+
+    it('does not return if dev is set', () => {
+      expect(util.getNodeOptions({
+        dev: true,
+      })).to.be.undefined
     })
   })
 

--- a/packages/electron/lib/electron.coffee
+++ b/packages/electron/lib/electron.coffee
@@ -75,10 +75,6 @@ module.exports = {
         if opts.inspectBrk
           argv.unshift("--inspect-brk=5566")
 
-      ## max HTTP header size 8kb -> 1mb
-      ## https://github.com/cypress-io/cypress/issues/76
-      argv.unshift("--max-http-header-size=#{1024*1024}")
-
       debug("spawning %s with args", execPath, argv)
 
       if debug.enabled

--- a/packages/server/__snapshots__/4_xhr_spec.coffee.js
+++ b/packages/server/__snapshots__/4_xhr_spec.coffee.js
@@ -23,20 +23,21 @@ exports['e2e xhr / passes'] = `
     ✓ does not inject into json's contents from http server even requesting text/html
     ✓ does not inject into json's contents from file server even requesting text/html
     ✓ works prior to visit
+    ✓ can stub a 100kb response
     server with 1 visit
       ✓ response body
       ✓ request body
       ✓ aborts
 
 
-  8 passing
+  9 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        8                                                                                │
-  │ Passing:      8                                                                                │
+  │ Tests:        9                                                                                │
+  │ Passing:      9                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -60,9 +61,9 @@ exports['e2e xhr / passes'] = `
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  xhr_spec.coffee                          XX:XX        8        8        -        -        - │
+  │ ✔  xhr_spec.coffee                          XX:XX        9        9        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        8        8        -        -        -  
+    ✔  All specs passed!                        XX:XX        9        9        -        -        -  
 
 
 `

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -1,3 +1,11 @@
+// if running in production mode (CYPRESS_ENV)
+// all transpile should have been done already
+// and these calls should do nothing
+require('@packages/ts/register')
+require('@packages/coffee/register')
+
+require('./lib/util/reset_node_options').reset()
+
 // override tty if we're being forced to
 require('./lib/util/tty').override()
 
@@ -9,11 +17,6 @@ if (process.env.CY_NET_PROFILE && process.env.CYPRESS_ENV) {
 
 process.env.UV_THREADPOOL_SIZE = 128
 require('graceful-fs').gracefulify(require('fs'))
-// if running in production mode (CYPRESS_ENV)
-// all transpile should have been done already
-// and these calls should do nothing
-require('@packages/ts/register')
-require('@packages/coffee/register')
 
 require && require.extensions && delete require.extensions['.litcoffee']
 require && require.extensions && delete require.extensions['.coffee.md']

--- a/packages/server/lib/util/reset_node_options.ts
+++ b/packages/server/lib/util/reset_node_options.ts
@@ -1,0 +1,17 @@
+/**
+ * Once the Electron process is launched, restore the user's original NODE_OPTIONS
+ * environment variables from before the CLI added extra NODE_OPTIONS.
+ *
+ * This way, any `node` processes launched by Cypress will retain the user's
+ * `NODE_OPTIONS` without unexpected modificiations that could cause issues with
+ * user code.
+ */
+
+export function reset () {
+  // @ts-ignore
+  if (process.versions.electron && typeof process.env.ORIGINAL_NODE_OPTIONS === 'string') {
+    process.env.NODE_OPTIONS = process.env.ORIGINAL_NODE_OPTIONS
+
+    delete process.env.ORIGINAL_NODE_OPTIONS
+  }
+}

--- a/packages/server/test/e2e/4_xhr_spec.coffee
+++ b/packages/server/test/e2e/4_xhr_spec.coffee
@@ -30,4 +30,5 @@ describe "e2e xhr", ->
     spec: "xhr_spec.coffee"
     snapshot: true
     expectedExitCode: 0
+    useCli: true
   }

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/xhr_spec.coffee
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/xhr_spec.coffee
@@ -76,6 +76,33 @@ describe "xhrs", ->
   it "works prior to visit", ->
     cy.server()
 
+  ## https://github.com/cypress-io/cypress/issues/5431
+  it "can stub a 100kb response", (done) ->
+    body = 'X'.repeat(100 * 1024)
+
+    cy.server()
+    cy.route({
+      method: 'POST'
+      url: '/foo'
+      response: {
+        'bar': body
+      }
+    })
+
+    cy.visit("/index.html")
+    .then (win) ->
+      xhr = new win.XMLHttpRequest
+      xhr.open("POST", "/foo")
+      xhr.send()
+
+      finish = ->
+        expect(xhr.status).to.eq(200)
+        expect(xhr.responseText).to.include(body)
+        done()
+
+      xhr.onload = finish
+      xhr.onerror = finish
+
   describe "server with 1 visit", ->
     before ->
       cy.visit("/xhr.html")

--- a/packages/server/test/support/helpers/e2e.coffee
+++ b/packages/server/test/support/helpers/e2e.coffee
@@ -73,7 +73,7 @@ replaceParenTime = (str, p1) ->
   return _.padStart("(X second)", p1.length)
 
 replaceScreenshotDims = (str, p1) ->
-  return _.padStart("(YxX)", p1.length) 
+  return _.padStart("(YxX)", p1.length)
 
 replaceUploadingResults = (orig, match..., offset, string) ->
   results = match[1].split('\n').map((res) ->
@@ -89,35 +89,35 @@ normalizeStdout = (str, options = {}) ->
   ## remove all of the dynamic parts of stdout
   ## to normalize against what we expected
   str = str
-  ## /Users/jane/........../ -> //foo/bar/.projects/  
+  ## /Users/jane/........../ -> //foo/bar/.projects/
   ## (Required when paths are printed outside of our own formatting)
   .split(pathUpToProjectName).join("/foo/bar/.projects")
   .replace(availableBrowsersRe, "$1browser1, browser2, browser3")
   .replace(browserNameVersionRe, replaceBrowserName)
   ## numbers in parenths
-  .replace(/\s\(\d+([ms]|ms)\)/g, "") 
+  .replace(/\s\(\d+([ms]|ms)\)/g, "")
    ## 12:35 -> XX:XX
   .replace(/(\s+?)(\d+ms|\d+:\d+:?\d+)/g, replaceDurationInTables)
   .replace(/(coffee|js)-\d{3}/g, "$1-456")
   ## Cypress: 2.1.0 -> Cypress: 1.2.3
-  .replace(/(Cypress\:\s+)(\d\.\d\.\d)/g, "$1" + "1.2.3") 
+  .replace(/(Cypress\:\s+)(\d\.\d\.\d)/g, "$1" + "1.2.3")
   ## Node Version: 10.2.3 (Users/jane/node) -> Node Version: X (foo/bar/node)
-  .replace(/(Node Version\:\s+v)(\d+\.\d+\.\d+)( \(.*\)\s+)/g, replaceNodeVersion) 
+  .replace(/(Node Version\:\s+v)(\d+\.\d+\.\d+)( \(.*\)\s+)/g, replaceNodeVersion)
   ## 15 seconds -> X second
   .replace(/(Duration\:\s+)(\d+\sminutes?,\s+)?(\d+\sseconds?)(\s+)/g, replaceDurationSeconds)
   ## duration='1589' -> duration='XXXX'
-  .replace(/(duration\=\')(\d+)(\')/g, replaceDurationFromReporter) 
+  .replace(/(duration\=\')(\d+)(\')/g, replaceDurationFromReporter)
   ## (15 seconds) -> (XX seconds)
   .replace(/(\((\d+ minutes?,\s+)?\d+ seconds?\))/g, replaceParenTime)
   .replace(/\r/g, "")
   ## replaces multiple lines of uploading results (since order not guaranteed)
-  .replace(/(Uploading Results.*?\n\n)((.*-.*[\s\S\r]){2,}?)(\n\n)/g, replaceUploadingResults) 
+  .replace(/(Uploading Results.*?\n\n)((.*-.*[\s\S\r]){2,}?)(\n\n)/g, replaceUploadingResults)
   ## fix "Require stacks" for CI
-  .replace(/^(\- )(\/.*\/packages\/server\/)(.*)$/gm, "$1$3") 
+  .replace(/^(\- )(\/.*\/packages\/server\/)(.*)$/gm, "$1$3")
 
   if options.sanitizeScreenshotDimensions
     ## screenshot dimensions
-    str = str.replace(/(\(\d+x\d+\))/g, replaceScreenshotDims) 
+    str = str.replace(/(\(\d+x\d+\))/g, replaceScreenshotDims)
 
   return str.split("\n")
     .map(replaceStackTraceLines)
@@ -126,7 +126,7 @@ normalizeStdout = (str, options = {}) ->
 ensurePort = (port) ->
   if port is 5566
     throw new Error('Specified port cannot be on 5566 because it conflicts with --inspect-brk=5566')
-    
+
 startServer = (obj) ->
   { onServer, port, https } = obj
 
@@ -182,7 +182,7 @@ copy = ->
     )
 
 getMochaItFn = (only, skip, browser, specifiedBrowser) ->
-  ## if we've been told to skip this test 
+  ## if we've been told to skip this test
   ## or if we specified a particular browser and this
   ## doesn't match the one we're currently trying to run...
   if skip or (specifiedBrowser and specifiedBrowser isnt browser)
@@ -193,13 +193,13 @@ getMochaItFn = (only, skip, browser, specifiedBrowser) ->
     return it.only
 
   return it
-  
+
 getBrowsers = (generateTestsForDefaultBrowsers, browser, defaultBrowsers) ->
   ## if we're generating tests for default browsers
   if generateTestsForDefaultBrowsers
     ## then return an array of default browsers
     return defaultBrowsers
-  
+
   ## but if we haven't been told to generate tests for default browsers
   ## and weren't provided a specified browser then throw
   if not browser
@@ -226,7 +226,7 @@ localItFn = (title, options = {}) ->
 
   if not title
     throw new Error('e2e.it(...) must be passed a title as the first argument')
-  
+
   ## LOGIC FOR AUTOGENERATING DYNAMIC TESTS
   ## - if generateTestsForDefaultBrowsers
   ##   - create multiple tests for each default browser
@@ -234,7 +234,7 @@ localItFn = (title, options = {}) ->
   ##     ...skip the tests for each default browser if that browser
   ##     ...does not match the specified one (used in CI)
   ## - else only generate a single test with the specified browser
-  
+
   ## run the tests for all the default browsers, or if a browser
   ## has been specified, only run it for that
   specifiedBrowser = browser
@@ -242,7 +242,7 @@ localItFn = (title, options = {}) ->
 
   browserToTest = (browser) ->
     mochaItFn = getMochaItFn(only, skip, browser, specifiedBrowser)
-    
+
     testTitle = "#{title} [#{browser}]"
 
     mochaItFn testTitle, ->
@@ -373,10 +373,19 @@ module.exports = e2e = {
 
   args: (options = {}) ->
     args = [
+      "index.js",
       ## hides a user warning to go through NPM module
       "--cwd=#{process.cwd()}",
       "--run-project=#{options.project}"
     ]
+
+    if options.useCli
+      args = [
+        "#{path.join(__dirname, '../../../../../cli/bin/cypress')}",
+        "run",
+        "--dev",
+        "--project=#{options.project}"
+      ]
 
     if options.spec
       args.push("--spec=#{options.spec}")
@@ -421,7 +430,9 @@ module.exports = e2e = {
     if options.outputPath
       args.push("--output-path", options.outputPath)
 
-    if options.exit?
+    if options.useCli and options.exit is false
+      args.push("--no-exit")
+    else if options.exit?
       args.push("--exit", options.exit)
 
     if options.inspectBrk
@@ -441,8 +452,6 @@ module.exports = e2e = {
   exec: (ctx, options = {}) ->
     options = @options(ctx, options)
     args    = @args(options)
-
-    args = ["index.js"].concat(args)
 
     stdout = ""
     stderr = ""

--- a/packages/server/test/support/helpers/e2e.coffee
+++ b/packages/server/test/support/helpers/e2e.coffee
@@ -432,7 +432,8 @@ module.exports = e2e = {
 
     if options.useCli and options.exit is false
       args.push("--no-exit")
-    else if options.exit?
+
+    if not options.useCli and options.exit?
       args.push("--exit", options.exit)
 
     if options.inspectBrk

--- a/packages/server/test/support/helpers/e2e.coffee
+++ b/packages/server/test/support/helpers/e2e.coffee
@@ -504,8 +504,7 @@ module.exports = e2e = {
         env: _.chain(process.env)
         .omit("CYPRESS_DEBUG")
         .extend({
-          ## FYI: color will be disabled
-          ## because we are piping the child process
+          NO_COLOR: 1
           COLUMNS: 100
           LINES: 24
         })


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #5431 

### User facing changelog

Fixes a regression in 3.5.0 where the maximum size of an HTTP header or `cy.route()` stub body was limited to 8kb and requests would fail with HTTP error 431.

### Additional details

- Passes `--max-http-header-size=${1024 * 1024}` in `NODE_OPTIONS` environment var from CLI
	- Passing it as a CLI arg (the way we thought it worked) does not seem to work with vanilla Electron binary or with built Cypress binary, so this is the only way
	- By ordering it before the user-supplied NODE_OPTIONS, the user can still override this via NODE_OPTIONS if they choose
- Makes 4_xhr_spec e2e test go through CLI so it can run a test with this max http header size set
- User's original NODE_OPTIONS are backed up and restored once Electron successfully launches so that `node` processes launched by Cypress on behalf of the user have desired NODE_OPTIONS

### How has the user experience changed?

N/A

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
