### PR TITLE
Fix not keeping track of correct URL when setting cookies durin…

### DIFF
--- a/packages/server/__snapshots__/request_spec.coffee.js
+++ b/packages/server/__snapshots__/request_spec.coffee.js
@@ -1,0 +1,65 @@
+exports['lib/request #sendPromise followRedirect gets + attaches the cookies at each redirect 1'] = {
+  "setCalls": [
+    {
+      "currentUrl": "http://localhost:1234/",
+      "setCookie": "foo=bar"
+    },
+    {
+      "currentUrl": "http://localhost:1234/B",
+      "setCookie": "bar=baz"
+    },
+    {
+      "currentUrl": "http://localhost:1234/B",
+      "setCookie": "foo=bar"
+    },
+    {
+      "currentUrl": "http://localhost:1234/",
+      "setCookie": "quuz=quux"
+    }
+  ],
+  "getCalls": [
+    {
+      "newUrl": "http://localhost:1234/"
+    },
+    {
+      "newUrl": "http://localhost:1234/B"
+    },
+    {
+      "newUrl": "http://localhost:1234/B"
+    },
+    {
+      "newUrl": "http://localhost:1234/B"
+    }
+  ]
+}
+
+exports['lib/request #sendStream gets + attaches the cookies at each redirect 1'] = {
+  "setCalls": [
+    {
+      "currentUrl": "http://localhost:1234/",
+      "setCookie": "foo=bar"
+    },
+    {
+      "currentUrl": "http://localhost:1234/B",
+      "setCookie": "bar=baz"
+    },
+    {
+      "currentUrl": "http://localhost:1234/B",
+      "setCookie": "foo=bar"
+    }
+  ],
+  "getCalls": [
+    {
+      "newUrl": "http://localhost:1234/"
+    },
+    {
+      "newUrl": "http://localhost:1234/B"
+    },
+    {
+      "newUrl": "http://localhost:1234/B"
+    },
+    {
+      "newUrl": "http://localhost:1234/B"
+    }
+  ]
+}

--- a/packages/server/test/unit/request_spec.coffee
+++ b/packages/server/test/unit/request_spec.coffee
@@ -3,8 +3,43 @@ require("../spec_helper")
 _       = require("lodash")
 http    = require("http")
 Request = require("#{root}lib/request")
+snapshot = require("snap-shot-it")
 
 request = Request({timeout: 100})
+
+testAttachingCookiesWith = (fn) ->
+  set = sinon.spy(request, 'setCookiesOnBrowser')
+  get = sinon.spy(request, 'setRequestCookieHeader')
+
+  nock("http://localhost:1234")
+  .get("/")
+  .reply(302, "", {
+    'set-cookie': 'foo=bar'
+    location: "/B"
+  })
+  .get("/B")
+  .reply(302, "", {
+    'set-cookie': 'bar=baz'
+    location: "/B"
+  })
+  .get("/B")
+  .reply(200, "", {
+    'set-cookie': 'quuz=quux'
+  })
+
+  fn()
+  .then ->
+    snapshot({
+      setCalls: set.getCalls().map (call) ->
+        {
+          currentUrl: call.args[1],
+          setCookie: call.args[0].headers['set-cookie']
+        }
+      getCalls: get.getCalls().map (call) ->
+        {
+          newUrl: _.get(call, 'args.1')
+        }
+    })
 
 describe "lib/request", ->
   beforeEach ->
@@ -722,6 +757,12 @@ describe "lib/request", ->
           expect(resp.status).to.eq(200)
           expect(resp).not.to.have.property("redirectedToUrl")
 
+      it "gets + attaches the cookies at each redirect", ->
+        testAttachingCookiesWith =>
+          request.sendPromise({}, @fn, {
+            url: "http://localhost:1234/"
+          })
+
     context "form=true", ->
       beforeEach ->
         nock("http://localhost:8080")
@@ -843,3 +884,16 @@ describe "lib/request", ->
         beginFn()
         expect(request.create).to.be.calledOnce
         expect(request.create).to.be.calledWith(options)
+
+    it "gets + attaches the cookies at each redirect", ->
+      testAttachingCookiesWith =>
+        request.sendStream({}, @fn, {
+          url: "http://localhost:1234/"
+          followRedirect: _.stubTrue
+        })
+        .then (fn) =>
+          req = fn()
+
+          new Promise (resolve, reject) =>
+            req.on('response', resolve)
+            req.on('error', reject)


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #5432

### User facing changelog

Fixed a regression in 3.5.0 where cookies may not be set on the correct URL during a redirect inside of a `cy.visit()` or `cy.request()`.

### Additional details

- The code in `request.coffee` never actually kept track of the correct URL
- This was fine before, because the cookies were just stored in a JAR which had other ways of tracking the URL
- After Electron upgrade PR #4720, `newUrl` started to be used to set the cookies via CDP, which was a problem since `newUrl` would always be equal to the original `options.url`
- This fixes the failing SSO test in `cypress-example-recipes`

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?