### PR TITLE
Always use --no-sandbox with Electron on non-Windows system

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ executors:
   # Docker image with non-root "node" user
   non-root-docker-user:
     docker:
-      - image: cypress/base:12.12.0
+      - image: cypress/base:12.0.0
         user: node
     environment:
       PLATFORM: linux

--- a/circle.yml
+++ b/circle.yml
@@ -27,6 +27,14 @@ executors:
     environment:
       PLATFORM: linux
 
+  # Docker image with non-root "node" user
+  non-root-docker-user:
+    docker:
+      - image: cypress/base:12.12.0
+        user: node
+    environment:
+      PLATFORM: linux
+
   # executor to run on Mac OS
   # https://circleci.com/docs/2.0/executor-types/#using-macos
   # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
@@ -885,6 +893,39 @@ jobs:
           command: npm run e2e
       - store-npm-logs
 
+  test-binary-as-non-root-user:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      # make sure the binary and NPM package files are present
+      - run: ls -l
+      - run: ls -l cypress.zip cypress.tgz
+      - run: mkdir test-binary
+      - run:
+          name: Create new NPM package
+          working_directory: test-binary
+          command: npm init -y
+      - run:
+          # install NPM from built NPM package folder
+          name: Install Cypress
+          working_directory: test-binary
+          # force installing the freshly built binary
+          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip npm i /root/cypress/cypress.tgz
+      - run:
+          name: Add Cypress demo
+          working_directory: test-binary
+          command: npx @bahmutov/cly init
+      - run:
+          name: Verify Cypress binary
+          working_directory: test-binary
+          command: $(npm bin)/cypress verify
+      - run:
+          name: Run Cypress binary
+          working_directory: test-binary
+          command: $(npm bin)/cypress run
+      - store-npm-logs
+
 linux-workflow: &linux-workflow
   jobs:
     - build
@@ -1014,7 +1055,6 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
-              - use-correct-folder
         requires:
           - build-binary
     - test-binary-and-npm-against-other-projects:
@@ -1023,7 +1063,6 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
-              - use-correct-folder
         requires:
           - upload-npm-package
           - upload-binary
@@ -1032,7 +1071,6 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
-              - use-correct-folder
         requires:
           - build-npm-package
           - build-binary
@@ -1042,7 +1080,6 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
-              - use-correct-folder
         requires:
           - build-npm-package
           - build-binary
@@ -1051,7 +1088,11 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
-              - use-correct-folder
+        requires:
+          - build-npm-package
+          - build-binary
+    - test-binary-as-non-root-user:
+        executor: non-root-docker-user
         requires:
           - build-npm-package
           - build-binary
@@ -1083,7 +1124,6 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
-              - use-correct-folder
         requires:
           - Mac NPM package
 
@@ -1095,7 +1135,6 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
-              - use-correct-folder
         requires:
           - Mac build
 
@@ -1107,7 +1146,6 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
-              - use-correct-folder
         requires:
           - Mac binary
 
@@ -1148,7 +1186,6 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
-              - use-correct-folder
         requires:
           - Mac NPM package upload
           - Mac binary upload

--- a/circle.yml
+++ b/circle.yml
@@ -901,6 +901,9 @@ jobs:
       # the user should be "node"
       - run: whoami
       - run: pwd
+      # prints the current user's effective user id
+      # for root it is 0
+      - run: node -e 'console.log(process.geteuid())'
       # make sure the binary and NPM package files are present
       - run: ls -l
       - run: ls -l cypress.zip cypress.tgz
@@ -922,11 +925,11 @@ jobs:
       - run:
           name: Verify Cypress binary
           working_directory: test-binary
-          command: $(npm bin)/cypress verify
+          command: DEBUG=cypress:cli $(npm bin)/cypress verify
       - run:
           name: Run Cypress binary
           working_directory: test-binary
-          command: $(npm bin)/cypress run
+          command: DEBUG=cypress:cli $(npm bin)/cypress run
       - store-npm-logs
 
 linux-workflow: &linux-workflow

--- a/circle.yml
+++ b/circle.yml
@@ -893,7 +893,7 @@ jobs:
           command: npm run e2e
       - store-npm-logs
 
-  test-binary-as-non-root-user:
+  test-binary-as-specific-user:
     <<: *defaults
     steps:
       - attach_workspace:
@@ -1097,13 +1097,14 @@ linux-workflow: &linux-workflow
         requires:
           - build-npm-package
           - build-binary
-    - test-binary-as-non-root-user:
+    - test-binary-as-specific-user:
+        name: "test binary as a non-root user"
         executor: non-root-docker-user
         requires:
           - build-npm-package
           - build-binary
-    - test-binary-as-non-root-user:
-        name: "test binary as root user"
+    - test-binary-as-specific-user:
+        name: "test binary as a root user"
         requires:
           - build-npm-package
           - build-binary

--- a/circle.yml
+++ b/circle.yml
@@ -898,6 +898,9 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      # the user should be "node"
+      - run: whoami
+      - run: pwd
       # make sure the binary and NPM package files are present
       - run: ls -l
       - run: ls -l cypress.zip cypress.tgz
@@ -911,7 +914,7 @@ jobs:
           name: Install Cypress
           working_directory: test-binary
           # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip npm i /root/cypress/cypress.tgz
+          command: CYPRESS_INSTALL_BINARY=/home/node/cypress/cypress.zip npm i /home/node/cypress/cypress.tgz
       - run:
           name: Add Cypress demo
           working_directory: test-binary

--- a/circle.yml
+++ b/circle.yml
@@ -903,6 +903,7 @@ jobs:
       - run: pwd
       # prints the current user's effective user id
       # for root it is 0
+      # for other users it is a positive integer
       - run: node -e 'console.log(process.geteuid())'
       # make sure the binary and NPM package files are present
       - run: ls -l
@@ -1098,6 +1099,11 @@ linux-workflow: &linux-workflow
           - build-binary
     - test-binary-as-non-root-user:
         executor: non-root-docker-user
+        requires:
+          - build-npm-package
+          - build-binary
+    - test-binary-as-non-root-user:
+        name: "test binary as root user"
         requires:
           - build-npm-package
           - build-binary

--- a/circle.yml
+++ b/circle.yml
@@ -918,7 +918,7 @@ jobs:
           name: Install Cypress
           working_directory: test-binary
           # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=/home/node/cypress/cypress.zip npm i /home/node/cypress/cypress.tgz
+          command: CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip npm i ~/cypress/cypress.tgz
       - run:
           name: Add Cypress demo
           working_directory: test-binary

--- a/cli/__snapshots__/verify_spec.js
+++ b/cli/__snapshots__/verify_spec.js
@@ -159,7 +159,7 @@ Error: Cypress verification timed out.
 
 This command failed with the following output:
 
-/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress --smoke-test --ping=222
+/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress --no-sandbox --smoke-test --ping=222
 
 ----------
 
@@ -181,7 +181,7 @@ Error: Cypress verification failed.
 
 This command failed with the following output:
 
-/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress --smoke-test --ping=222
+/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress --no-sandbox --smoke-test --ping=222
 
 ----------
 
@@ -203,7 +203,7 @@ Error: Cypress verification failed.
 
 This command failed with the following output:
 
-/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress --smoke-test --ping=222
+/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress --no-sandbox --smoke-test --ping=222
 
 ----------
 

--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -7,6 +7,7 @@ const { stripIndent } = require('common-tags')
 const Promise = require('bluebird')
 const logSymbols = require('log-symbols')
 const path = require('path')
+const os = require('os')
 
 const { throwFormErrorText, errors } = require('../errors')
 const util = require('../util')
@@ -82,6 +83,7 @@ const runSmokeTest = (binaryDir, options) => {
 
     if (needsSandbox()) {
       // electron requires --no-sandbox to run as root
+      debug('disabling Electron sandbox')
       args.unshift('--no-sandbox')
     }
 
@@ -354,15 +356,18 @@ const start = (options = {}) => {
   })
 }
 
-const isLinuxLike = () => process.platform !== 'win32'
-
-const isRootUser = () => process.geteuid() === 0
+const isLinuxLike = () => os.platform() !== 'win32'
 
 /**
  * Returns true if running on a system where Electron needs "--no-sandbox" flag.
  * @see https://crbug.com/638180
+ *
+ * On Debian we had problems running in sandbox even for non-root users.
+ * @see https://github.com/cypress-io/cypress/issues/5434
+ * Seems there is a lot of discussion around this issue among Electron users
+ * @see https://github.com/electron/electron/issues/17972
 */
-const needsSandbox = () => isLinuxLike() && isRootUser()
+const needsSandbox = () => isLinuxLike()
 
 module.exports = {
   start,


### PR DESCRIPTION
- Closes #5434 

### User facing changelog

Users have reported that the new Electron v5 seems to require `--no-sandbox` flag even when running as a regular non-root user. This PR always sets this flag when verifying or starting Cypress Electron app.

### Additional details

Seems Electron tries to use a sandboxed feature even if running as a non-root and I could not figure out how to change / update permissions on the installed files, see the discussion in https://github.com/electron/electron/issues/17972

### How has the user experience changed?

Should not change user behavior at all

### PR Tasks

- [x] Have tests been added/updated?
