### PR TITLE
Add environment variable CYPRESS_FORCE_INSTALL #2074

### DIFF
--- a/cli/lib/tasks/install.js
+++ b/cli/lib/tasks/install.js
@@ -127,6 +127,11 @@ const downloadAndUnzip = ({ version, installDir, downloadDir }) => {
 }
 
 const start = (options = {}) => {
+  // if CYPRESS_FORCE_INSTALL is set set options force to true
+  if (util.getEnv('CYPRESS_FORCE_INSTALL')) {
+    options.force = true
+  }
+
   // handle deprecated / removed
   if (util.getEnv('CYPRESS_BINARY_VERSION')) {
     return throwFormErrorText(errors.removed.CYPRESS_BINARY_VERSION)()


### PR DESCRIPTION
- Closes #2074 

### User facing changelog

Having CYPRESS_FORCE_INSTALL=1 would act as if the --force flag is always set during npm install and cypress install

### Additional details

Change necessary to not edit CI scripts, but just set CYPRESS_FORCE_INSTALL=1 to env.

### How has the user experience changed?

There is no need to update CI scripts to force install Cypress, just set CYPRESS_FORCE_INSTALL=1 and it will be installed like with 

