### PR TITLE
use default next-dev-version if not set during Linux binary bui…

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -607,7 +607,10 @@ jobs:
       - run:
           environment:
             DEBUG: electron-builder,electron-osx-sign*
-          command: npm run binary-build -- --platform $PLATFORM --version $NEXT_DEV_VERSION
+          # if this is a forked pull request, the NEXT_DEV_VERSION environment variable
+          # won't be set and we will use default version, since we are not going to
+          # upload the dev binary build anywhere
+          command: npm run binary-build -- --platform $PLATFORM --version ${NEXT_DEV_VERSION:-0.0.0-development}
       - run: npm run binary-zip -- --platform $PLATFORM
       # Cypress binary file should be zipped to cypress.zip
       - run: ls -l *.zip

--- a/scripts/binary/index.coffee
+++ b/scripts/binary/index.coffee
@@ -139,9 +139,11 @@ deploy = {
   build: (options) ->
     console.log('#build')
     options ?= @parseOptions(process.argv)
+    debug("parsed build options %o", options)
 
     askMissingOptions(['version', 'platform'])(options)
     .then ->
+      debug("building binary: platform %s version %s", options.platform, options.version)
       build(options.platform, options.version, options)
 
   zip: (options) ->


### PR DESCRIPTION
- Closes #5509

### Additional details

During forked pull requests when we try to build the binary and we need `NEXT_DEV_VERSION` environment variable, it is undefined - because the environment variables are not passed to the forks. With this change, we will use default value `0.0.0-development` instead in such cases.
