### PR TITLE
Use a default NEXT_DEV_VERSION to build NPM package; only run Mac in dev

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -716,7 +716,7 @@ jobs:
           at: ~/
       - run:
           name: bump NPM version
-          command: npm --no-git-tag-version version $NEXT_DEV_VERSION
+          command: npm --no-git-tag-version version ${NEXT_DEV_VERSION:-0.0.0-development}
       - run:
           name: build NPM package
           working_directory: cli
@@ -738,8 +738,8 @@ jobs:
           command: ls -l
       # created file should have filename cypress-<version>.tgz
       - run: mkdir /tmp/urls
-      - run: cp cli/build/cypress-$NEXT_DEV_VERSION.tgz cypress.tgz
-      - run: cp cli/build/cypress-$NEXT_DEV_VERSION.tgz /tmp/urls/cypress.tgz
+      - run: cp cli/build/cypress-${NEXT_DEV_VERSION:-0.0.0-development}.tgz cypress.tgz
+      - run: cp cli/build/cypress-${NEXT_DEV_VERSION:-0.0.0-development}.tgz /tmp/urls/cypress.tgz
       - run: ls -l /tmp/urls
       - store-npm-logs
       - run: pwd
@@ -1117,11 +1117,20 @@ mac-workflow: &mac-workflow
     - build:
         name: Mac build
         executor: mac
+        filters:
+          branches:
+            only:
+              - develop
+        
     - lint:
         name: Mac lint
         executor: mac
         requires:
           - Mac build
+        filters:
+          branches:
+            only:
+              - develop
 
     # maybe run unit tests?
 
@@ -1130,6 +1139,10 @@ mac-workflow: &mac-workflow
         executor: mac
         requires:
           - Mac build
+        filters:
+          branches:
+            only:
+              - develop
 
     - upload-npm-package:
         name: Mac NPM package upload
@@ -1167,6 +1180,10 @@ mac-workflow: &mac-workflow
     - test-kitchensink:
         name: Test Mac Kitchensink
         executor: mac
+        filters:
+          branches:
+            only:
+              - develop
         requires:
           - Mac build
 


### PR DESCRIPTION
Part 2 of #5512 

### User facing changelog

N/A

### Additional details

- Adds default NEXT_DEV_VERSION to build-npm-package so external PRs can build
- Only run Mac jobs in develop
	- They are really slow due to Circle's limited macOS executor pool, oftentimes way longer than the Linux jobs
	- Doesn't offer any additional benefit to build binary + package on mac on each commit, since we already do the same on Linux on each commit

### How has the user experience changed?

N/A

### PR Tasks