### PR TITLE
3.5.0 - Fix actionability for covered elements

### DIFF
--- a/packages/driver/src/cy/actionability.coffee
+++ b/packages/driver/src/cy/actionability.coffee
@@ -1,6 +1,7 @@
 _ = require("lodash")
 $ = require("jquery")
 Promise = require("bluebird")
+debug = require('debug')('cypress:driver:actionability')
 
 $dom = require("../dom")
 $utils = require("../cypress/utils")
@@ -49,8 +50,10 @@ ensureElIsNotCovered = (cy, win, $el, fromElViewport, options, log, onScroll) ->
     ## figure out the deepest element we are about to interact
     ## with at these coordinates
     $elAtCoords = getElementAtPointFromViewport(fromElViewport)
-
+    debug('elAtCoords', $elAtCoords)
+    debug('el has pointer-events none?')
     cy.ensureElDoesNotHaveCSS($el, 'pointer-events', 'none', log)
+    debug('is descendent of elAtCoords?')
     cy.ensureDescendents($el, $elAtCoords, log)
 
     return $elAtCoords
@@ -65,6 +68,8 @@ ensureElIsNotCovered = (cy, win, $el, fromElViewport, options, log, onScroll) ->
       ## from underneath this fixed position element until we can't
       ## anymore
       $fixed = getFixedOrStickyEl($elAtCoords)
+      
+      debug('elAtCoords is fixed', !!$fixed)
 
       ## if we dont have a fixed position
       ## then just bail, cuz we need to retry async
@@ -161,7 +166,9 @@ ensureElIsNotCovered = (cy, win, $el, fromElViewport, options, log, onScroll) ->
 
                 ## and possibly recursively scroll past it
                 ## if we haven't see it before
-                possiblyScrollMultipleTimes($fixed)
+                return possiblyScrollMultipleTimes($fixed)
+              
+              throw err
           else
             scrollContainers(scrollables)
 

--- a/packages/driver/src/cy/actionability.coffee
+++ b/packages/driver/src/cy/actionability.coffee
@@ -168,6 +168,7 @@ ensureElIsNotCovered = (cy, win, $el, fromElViewport, options, log, onScroll) ->
                 ## if we haven't see it before
                 return possiblyScrollMultipleTimes($fixed)
               
+              ## getElementAtPoint was falsey, so target element is no longer in the viewport
               throw err
           else
             scrollContainers(scrollables)

--- a/packages/driver/src/cy/retries.coffee
+++ b/packages/driver/src/cy/retries.coffee
@@ -35,7 +35,10 @@ create = (Cypress, state, timeout, clearTimeout, whenStable, finishAssertions) -
       ## correctly handles not rewrapping errors so that stack
       ## traces are correctly displayed
       if debug.enabled and error and not CypressErrorRe.test(error.name)
-        debug('retrying due to caught error...')
+        if debug.prevError && debug.prevError is error.message
+          debug('exiting due to catching same error twice...')
+          throw error
+        debug.prevError = error.message
         console.error(error)
 
       interval = options.interval ? options._interval

--- a/packages/driver/src/cy/retries.coffee
+++ b/packages/driver/src/cy/retries.coffee
@@ -35,10 +35,7 @@ create = (Cypress, state, timeout, clearTimeout, whenStable, finishAssertions) -
       ## correctly handles not rewrapping errors so that stack
       ## traces are correctly displayed
       if debug.enabled and error and not CypressErrorRe.test(error.name)
-        if debug.prevError && debug.prevError is error.message
-          debug('exiting due to catching same error twice...')
-          throw error
-        debug.prevError = error.message
+        debug('retrying due to caught error...')
         console.error(error)
 
       interval = options.interval ? options._interval

--- a/packages/driver/test/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/click_spec.js
@@ -306,6 +306,22 @@ describe('src/cy/commands/actions/click', () => {
       cy.getAll('el', 'focus focusin').each(shouldBeCalledOnce)
     })
 
+    it('does not attempt to click element outside viewport', (done) => {
+      cy.on('fail', (err) => {
+        expect(err.message).contain('id="email-with-value"')
+        expect(err.message).contain('hidden from view')
+        done()
+      })
+
+      cy.$$('#tabindex').css(overlayStyle)
+      cy.get('#email-with-value').click()
+    })
+
+    it('can click element outside viewport with force:true', () => {
+      cy.$$('#tabindex').css(overlayStyle)
+      cy.get('#email-with-value').click()
+    })
+
     it('does not fire a focus, mouseup, or click event when element has been removed on mousedown', () => {
       const $btn = cy.$$('button:first')
 

--- a/packages/driver/test/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/click_spec.js
@@ -61,6 +61,8 @@ const shouldBeCalledOnce = (stub) => wrapped(stub).should('be.calledOnce')
 const shouldBeCalledWithCount = (num) => (stub) => wrapped(stub).should('have.callCount', num)
 const shouldNotBeCalled = (stub) => wrapped(stub).should('not.be.called')
 
+const overlayStyle = { position: 'fixed', top: 0, width: '100%', height: '100%', opacity: 0.5 }
+
 describe('src/cy/commands/actions/click', () => {
   beforeEach(() => {
     cy.visit('/fixtures/dom.html')
@@ -306,7 +308,9 @@ describe('src/cy/commands/actions/click', () => {
       cy.getAll('el', 'focus focusin').each(shouldBeCalledOnce)
     })
 
+    // https://github.com/cypress-io/cypress/issues/5430
     it('does not attempt to click element outside viewport', (done) => {
+      cy.timeout(100)
       cy.on('fail', (err) => {
         expect(err.message).contain('id="email-with-value"')
         expect(err.message).contain('hidden from view')
@@ -319,7 +323,7 @@ describe('src/cy/commands/actions/click', () => {
 
     it('can click element outside viewport with force:true', () => {
       cy.$$('#tabindex').css(overlayStyle)
-      cy.get('#email-with-value').click()
+      cy.get('#email-with-value').click({ force: true })
     })
 
     it('does not fire a focus, mouseup, or click event when element has been removed on mousedown', () => {


### PR DESCRIPTION
fix bug that caused us to not error when the element is covered by a `position:fixed` element

- this in turn fixes issues that caused strange failures such as `cannot read property ownerDocument of null` during `cy.click` that would occur in Cypress `3.5.0`
fix #5430

<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

### User facing changelog
bugfix - fix issue causing obscure error message when an element cannot be interacted with due to being covered by an element with `position:fixed`.
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
**when trying to interact with an element that's covered by a `fixed` element**
- before (pre 3.5.0): user would receive no error that the element was covered, and the test would pass (incorrect)
- before (3.5.0): user would receive the error `cannot read property ownerDocument of null`
- after: user will receive failing test with an error message that the element is covered:
![image](https://user-images.githubusercontent.com/14625260/67803690-f293f580-fa63-11e9-8066-d36f71ff9971.png)


<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
