### PR TITLE
[WIP] Formats number strings in quotes.

### DIFF
--- a/packages/driver/src/cy/chai.coffee
+++ b/packages/driver/src/cy/chai.coffee
@@ -18,6 +18,7 @@ allPropertyWordsBetweenSingleQuotes = /('.*?')$/g
 allButLastWordsBetweenSingleQuotes = /('.*?')(.+)/g
 
 allBetweenFourStars = /\*\*.*\*\*/
+allNumberStrings = /'([0-9]+)'/g
 allSingleQuotes = /'/g
 allEscapedSingleQuotes = /\\'/g
 allQuoteMarkers = /__quote__/g
@@ -74,6 +75,7 @@ chai.use (chai, u) ->
     ## and if an empty string, put the quotes back
     message.replace allBetweenFourStars, (match) ->
       match
+        .replace(allNumberStrings, "__quote__$1__quote__")
         .replace(allEscapedSingleQuotes, "__quote__") # preserve escaped quotes
         .replace(allSingleQuotes, "")
         .replace(allQuoteMarkers, "'") ## put escaped quotes back

--- a/packages/driver/test/cypress/integration/commands/assertions_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/assertions_spec.coffee
@@ -742,6 +742,18 @@ describe "src/cy/commands/assertions", ->
       assert.isFalse(false, "is false")
       expect(@logs[0].get("message")).to.eq("is false: expected **false** to be false")
 
+  context "format", ->
+    it "format number strings", (done) -> 
+      cy.on "log:added", (attrs, log) ->
+        if attrs.name is "assert"
+          cy.removeAllListeners("log:added")
+
+          expect(log.get("message")).to.eq "expected **25** to equal **\'25\'**"
+          done()
+
+      cy.then ->
+        expect(25).to.eq('25')
+
   context "chai overrides", ->
     beforeEach ->
       @$body = cy.$$("body")


### PR DESCRIPTION
- Closes #25

### User facing changelog

Formats number strings in test results in quotes. In other words, 25 -> '25'.

### Additional details

#### Why was this change necessary:

> The ASSERT error (in red background) on the commands UI does not signify whether **my value is a string or not.**
>
> ![](https://cloud.githubusercontent.com/assets/1271364/7234411/edd38b90-e754-11e4-91ee-c9dda3f2b38c.png)

#### What is affected by this change?

Not much. I just added a test to show the case clearly. 

#### Any implementation details to explain?

Not much. 

As decaffeinated version(#5543) mysteriously breaks rerun_spec.coffee test, it is reimplemented in coffeescript. 

### How has the user experience changed?

Before: above.

After: 
![Screenshot from 2019-10-31 08-49-10](https://user-images.githubusercontent.com/8130013/67907505-6c8ac280-fbbb-11e9-96a3-146806a26f5e.png)

### PR Tasks

- [x] Have tests been added/updated?
- ~~Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->~~
- ~~Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?~~
- ~~Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?~~
