### PR TITLE
TypeScript: strict parameter type for `location`

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -867,7 +867,7 @@ declare namespace Cypress {
      *    // Assert on the href of the location
      *    cy.location('href').should('contain', '/tag/tutorials')
      */
-    location(key: string, options?: Partial<Loggable & Timeoutable>): Chainable<Location>
+    location(key: keyof Window['location'], options?: Partial<Loggable & Timeoutable>): Chainable<Location>
 
     /**
      * Print a message to the Cypress Command Log.

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -867,7 +867,7 @@ declare namespace Cypress {
      *    // Assert on the href of the location
      *    cy.location('href').should('contain', '/tag/tutorials')
      */
-    location(key: keyof Window['location'], options?: Partial<Loggable & Timeoutable>): Chainable<Location>
+    location<K extends keyof Location>(key: K, options?: Partial<Loggable & Timeoutable>): Chainable<Location[K]>
 
     /**
      * Print a message to the Cypress Command Log.

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -314,3 +314,9 @@ namespace CypressContainsTests {
   cy.contains('#app', 'my text to find', {log: false, timeout: 100})
   cy.contains('my text to find', {log: false, timeout: 100})
 }
+
+// https://github.com/cypress-io/cypress/pull/5574
+namespace CypressLocationTests {
+  cy.location('path') // $ExpectError
+  cy.location('pathname') // $ExpectType Chainable<string>
+}


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes <!-- issue number here -->

### User facing changelog

The type definitions for `cy.location()` have been improved.

### Additional details

```ts
cy.location('path') // type error
cy.location('pathname') // ✅
```

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
