### PR TITLE
fix not sending click event to proper element

### DIFF
--- a/packages/driver/src/cy/commands/actions/click.js
+++ b/packages/driver/src/cy/commands/actions/click.js
@@ -43,7 +43,7 @@ const formatMouseEvents = (events) => {
       const reason = val.skipped
 
       return {
-        'Event Name': key.slice(0, -5),
+        'Event Name': key,
         'Target Element': reason,
         'Prevented Default?': null,
         'Stopped Propagation?': null,
@@ -52,7 +52,7 @@ const formatMouseEvents = (events) => {
     }
 
     return {
-      'Event Name': key.slice(0, -5),
+      'Event Name': key,
       'Target Element': val.el,
       'Prevented Default?': val.preventedDefault,
       'Stopped Propagation?': val.stoppedPropagation,
@@ -265,10 +265,10 @@ module.exports = (Commands, Cypress, cy, state, config) => {
         defaultOptions: { multiple: true },
         positionOrX,
         onReady (fromElViewport, forceEl) {
-          const { clickEvents1, clickEvents2, dblclickProps } = mouse.dblclick(fromElViewport, forceEl)
+          const { clickEvents1, clickEvents2, dblclick } = mouse.dblclick(fromElViewport, forceEl)
 
           return {
-            dblclickProps,
+            dblclick,
             clickEvents: [clickEvents1, clickEvents2],
           }
         },
@@ -281,8 +281,8 @@ module.exports = (Commands, Cypress, cy, state, config) => {
               return {
                 name: 'Mouse Click Events',
                 data: _.concat(
-                  formatMouseEvents(domEvents.clickEvents[0], formatMouseEvents),
-                  formatMouseEvents(domEvents.clickEvents[1], formatMouseEvents)
+                  formatMouseEvents(domEvents.clickEvents[0]),
+                  formatMouseEvents(domEvents.clickEvents[1])
                 ),
               }
             },
@@ -290,7 +290,7 @@ module.exports = (Commands, Cypress, cy, state, config) => {
               return {
                 name: 'Mouse Double Click Event',
                 data: formatMouseEvents({
-                  dblclickProps: domEvents.dblclickProps,
+                  dblclick: domEvents.dblclick,
                 }),
               }
             },

--- a/packages/driver/src/cy/mouse.js
+++ b/packages/driver/src/cy/mouse.js
@@ -310,12 +310,12 @@ const create = (state, keyboard, focused) => {
       }, mouseEvtOptionsExtend)
 
       // TODO: pointer events should have fractional coordinates, not rounded
-      let pointerdownProps = sendPointerdown(
+      let pointerdown = sendPointerdown(
         el,
         pointerEvtOptions
       )
 
-      const pointerdownPrevented = pointerdownProps.preventedDefault
+      const pointerdownPrevented = pointerdown.preventedDefault
       const elIsDetached = $elements.isDetachedEl(el)
 
       if (pointerdownPrevented || elIsDetached) {
@@ -326,31 +326,37 @@ const create = (state, keyboard, focused) => {
         }
 
         return {
-          pointerdownProps,
-          mousedownProps: {
-            skipped: formatReasonNotFired(reason),
+          targetEl: el,
+          events: {
+            pointerdown,
+            mousedown: {
+              skipped: formatReasonNotFired(reason),
+            },
           },
         }
       }
 
-      let mousedownProps = sendMousedown(el, mouseEvtOptions)
+      let mousedown = sendMousedown(el, mouseEvtOptions)
 
       return {
-        pointerdownProps,
-        mousedownProps,
+        targetEl: el,
+        events: {
+          pointerdown,
+          mousedown,
+        },
       }
     },
 
     down (fromElViewport, forceEl, pointerEvtOptionsExtend = {}, mouseEvtOptionsExtend = {}) {
       const $previouslyFocused = focused.getFocused()
 
-      const mouseDownEvents = mouse._downEvents(fromElViewport, forceEl, pointerEvtOptionsExtend, mouseEvtOptionsExtend)
+      const mouseDownPhase = mouse._downEvents(fromElViewport, forceEl, pointerEvtOptionsExtend, mouseEvtOptionsExtend)
 
       // el we just send pointerdown
-      const el = mouseDownEvents.pointerdownProps.el
+      const el = mouseDownPhase.targetEl
 
-      if (mouseDownEvents.pointerdownProps.preventedDefault || mouseDownEvents.mousedownProps.preventedDefault || !$elements.isAttachedEl(el)) {
-        return mouseDownEvents
+      if (mouseDownPhase.events.pointerdown.preventedDefault || mouseDownPhase.events.mousedown.preventedDefault || !$elements.isAttachedEl(el)) {
+        return mouseDownPhase
       }
 
       //# retrieve the first focusable $el in our parent chain
@@ -377,7 +383,7 @@ const create = (state, keyboard, focused) => {
         $selection.moveSelectionToEnd($dom.getDocumentFromElement($elToFocus[0]), { onlyIfEmptySelection: true })
       }
 
-      return mouseDownEvents
+      return mouseDownPhase
     },
 
     /**
@@ -416,11 +422,11 @@ const create = (state, keyboard, focused) => {
     click (fromElViewport, forceEl, pointerEvtOptionsExtend = {}, mouseEvtOptionsExtend = {}) {
       debug('mouse.click', { fromElViewport, forceEl })
 
-      const mouseDownEvents = mouse.down(fromElViewport, forceEl, pointerEvtOptionsExtend, mouseEvtOptionsExtend)
+      const mouseDownPhase = mouse.down(fromElViewport, forceEl, pointerEvtOptionsExtend, mouseEvtOptionsExtend)
 
-      const skipMouseupEvent = mouseDownEvents.pointerdownProps.skipped || mouseDownEvents.pointerdownProps.preventedDefault
+      const skipMouseupEvent = mouseDownPhase.events.pointerdown.skipped || mouseDownPhase.events.pointerdown.preventedDefault
 
-      const mouseUpEvents = mouse.up(fromElViewport, forceEl, skipMouseupEvent, pointerEvtOptionsExtend, mouseEvtOptionsExtend)
+      const mouseUpPhase = mouse.up(fromElViewport, forceEl, skipMouseupEvent, pointerEvtOptionsExtend, mouseEvtOptionsExtend)
 
       const getElementToClick = () => {
         // Never skip the click event when force:true
@@ -429,13 +435,13 @@ const create = (state, keyboard, focused) => {
         }
 
         // Only send click event if mousedown element is not detached.
-        if ($elements.isDetachedEl(mouseDownEvents.pointerdownProps.el)) {
+        if ($elements.isDetachedEl(mouseDownPhase.targetEl)) {
           return { skipClickEventReason: 'element was detached' }
         }
 
-        const commonAncestor = mouseUpEvents.pointerupProps.el &&
-        mouseDownEvents.pointerdownProps.el &&
-        $elements.getFirstCommonAncestor(mouseUpEvents.pointerupProps.el, mouseDownEvents.pointerdownProps.el)
+        const commonAncestor = mouseUpPhase.targetEl &&
+        mouseDownPhase.targetEl &&
+        $elements.getFirstCommonAncestor(mouseUpPhase.targetEl, mouseDownPhase.targetEl)
 
         return { elToClick: commonAncestor }
       }
@@ -444,7 +450,7 @@ const create = (state, keyboard, focused) => {
 
       const mouseClickEvents = mouse._mouseClickEvents(fromElViewport, elToClick, forceEl, skipClickEventReason, mouseEvtOptionsExtend)
 
-      return _.extend({}, mouseDownEvents, mouseUpEvents, mouseClickEvents)
+      return _.extend({}, mouseDownPhase.events, mouseUpPhase.events, mouseClickEvents)
     },
 
     /**
@@ -470,29 +476,35 @@ const create = (state, keyboard, focused) => {
 
       const el = forceEl || mouse.moveToCoords(fromElViewport)
 
-      let pointerupProps = sendPointerup(el, pointerEvtOptions)
+      let pointerup = sendPointerup(el, pointerEvtOptions)
 
       if (skipMouseEvent || $elements.isDetachedEl($(el))) {
         return {
-          pointerupProps,
-          mouseupProps: {
-            skipped: formatReasonNotFired('Previous event cancelled'),
+          targetEl: el,
+          events: {
+            pointerup,
+            mouseup: {
+              skipped: formatReasonNotFired('Previous event cancelled'),
+            },
           },
         }
       }
 
-      let mouseupProps = sendMouseup(el, mouseEvtOptions)
+      let mouseup = sendMouseup(el, mouseEvtOptions)
 
       return {
-        pointerupProps,
-        mouseupProps,
+        targetEl: el,
+        events: {
+          pointerup,
+          mouseup,
+        },
       }
     },
 
     _mouseClickEvents (fromElViewport, el, forceEl, skipClickEvent, mouseEvtOptionsExtend = {}) {
       if (skipClickEvent) {
         return {
-          clickProps: {
+          click: {
             skipped: formatReasonNotFired(skipClickEvent),
           },
         }
@@ -511,9 +523,9 @@ const create = (state, keyboard, focused) => {
         detail: 1,
       }, mouseEvtOptionsExtend)
 
-      let clickProps = sendClick(el, clickEventOptions)
+      let click = sendClick(el, clickEventOptions)
 
-      return { clickProps }
+      return { click }
     },
 
     _contextmenuEvent (fromElViewport, forceEl, mouseEvtOptionsExtend) {
@@ -529,9 +541,9 @@ const create = (state, keyboard, focused) => {
         which: 3,
       }, mouseEvtOptionsExtend)
 
-      let contextmenuProps = sendContextmenu(el, mouseEvtOptions)
+      let contextmenu = sendContextmenu(el, mouseEvtOptions)
 
-      return { contextmenuProps }
+      return { contextmenu }
     },
 
     dblclick (fromElViewport, forceEl, mouseEvtOptionsExtend = {}) {
@@ -552,9 +564,9 @@ const create = (state, keyboard, focused) => {
         detail: 2,
       }, mouseEvtOptionsExtend)
 
-      let dblclickProps = sendDblclick(el, dblclickEvtProps)
+      let dblclick = sendDblclick(el, dblclickEvtProps)
 
-      return { clickEvents1, clickEvents2, dblclickProps }
+      return { clickEvents1, clickEvents2, dblclick }
     },
 
     rightclick (fromElViewport, forceEl) {
@@ -569,15 +581,14 @@ const create = (state, keyboard, focused) => {
         which: 3,
       }
 
-      const mouseDownEvents = mouse.down(fromElViewport, forceEl, pointerEvtOptionsExtend, mouseEvtOptionsExtend)
+      const mouseDownPhase = mouse.down(fromElViewport, forceEl, pointerEvtOptionsExtend, mouseEvtOptionsExtend)
 
       const contextmenuEvent = mouse._contextmenuEvent(fromElViewport, forceEl)
 
-      const skipMouseupEvent = mouseDownEvents.pointerdownProps.skipped || mouseDownEvents.pointerdownProps.preventedDefault
+      const skipMouseupEvent = mouseDownPhase.events.pointerdown.skipped || mouseDownPhase.events.pointerdown.preventedDefault
+      const mouseUpPhase = mouse.up(fromElViewport, forceEl, skipMouseupEvent, pointerEvtOptionsExtend, mouseEvtOptionsExtend)
 
-      const mouseUpEvents = mouse.up(fromElViewport, forceEl, skipMouseupEvent, pointerEvtOptionsExtend, mouseEvtOptionsExtend)
-
-      const clickEvents = _.extend({}, mouseDownEvents, mouseUpEvents)
+      const clickEvents = _.extend({}, mouseDownPhase.events, mouseUpPhase.events)
 
       return _.extend({}, { clickEvents, contextmenuEvent })
     },

--- a/packages/driver/src/cy/mouse.js
+++ b/packages/driver/src/cy/mouse.js
@@ -410,8 +410,8 @@ const create = (state, keyboard, focused) => {
     * el2 = moveToCoordsOrNoop(coords)
     * sendMouseup(el2)
     * el3 = moveToCoordsOrNoop(coords)
-    * if (notDetached(el1) && el1 === el2)
-    *   sendClick(el3)
+    * if (notDetached(el1))
+    *   sendClick(ancestorOf(el1, el2))
     */
     click (fromElViewport, forceEl, pointerEvtOptionsExtend = {}, mouseEvtOptionsExtend = {}) {
       debug('mouse.click', { fromElViewport, forceEl })
@@ -438,17 +438,10 @@ const create = (state, keyboard, focused) => {
         $elements.getFirstCommonAncestor(mouseUpEvents.pointerupProps.el, mouseDownEvents.pointerdownProps.el)
 
         return { elToClick: commonAncestor }
-        // if (!mouseUpEvents.pointerupProps.el || mouseDownEvents.pointerdownProps.el !== mouseUpEvents.pointerupProps.el) {
-        //   return {skipClickEvent: 'mouseup and mousedown not in the same tree'}
-        // }
-
-        // No reason to skip the click event
-        // return false
       }
 
       const { skipClickEventReason, elToClick } = getElementToClick()
 
-      debug('sending click to', elToClick)
       const mouseClickEvents = mouse._mouseClickEvents(fromElViewport, elToClick, forceEl, skipClickEventReason, mouseEvtOptionsExtend)
 
       return _.extend({}, mouseDownEvents, mouseUpEvents, mouseClickEvents)

--- a/packages/driver/test/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/click_spec.js
@@ -242,19 +242,18 @@ describe('src/cy/commands/actions/click', () => {
     it('will not send mouseEvents/focus if pointerdown is defaultPrevented', () => {
       const $btn = cy.$$('#button')
 
-      // let clicked = false
-
-      $btn.get(0).addEventListener('pointerdown', (e) => {
-        // clicked = true
+      const onEvent = cy.stub().callsFake((e) => {
         e.preventDefault()
-
         expect(e.defaultPrevented).to.be.true
       })
 
+      $btn.get(0).addEventListener('pointerdown', onEvent)
+
       attachMouseClickListeners({ $btn })
 
+      // uncomment to manually test
+      // cy.wrap(onEvent).should('be.called')
       cy.get('#button').click().should('not.have.focus')
-      // cy.wrap(null).should(() => expect(clicked).ok)
 
       cy.getAll('$btn', 'pointerdown pointerup click').each(shouldBeCalledOnce)
       cy.getAll('$btn', 'mousedown mouseup').each(shouldNotBeCalled)
@@ -386,15 +385,15 @@ describe('src/cy/commands/actions/click', () => {
       attachMouseClickListeners({ btn, div, root })
       attachMouseHoverListeners({ btn, div })
 
-      // let clicked = false
-
-      btn.on('mousedown', () => {
-        // clicked = true
+      const onEvent = cy.stub().callsFake(() => {
         div.css(overlayStyle)
       })
 
+      btn.on('mousedown', onEvent)
+
+      // uncomment to manually test
+      // cy.wrap(onEvent).should('be.called')
       cy.contains('button').click()
-      // cy.wrap(null).should(() => expect(clicked).ok)
 
       cy.getAll('btn', 'mouseover mouseenter mousedown focus').each(shouldBeCalled)
       cy.getAll('btn', 'click mouseup').each(shouldNotBeCalled)
@@ -411,15 +410,15 @@ describe('src/cy/commands/actions/click', () => {
       attachMouseClickListeners({ btn, div })
       attachMouseHoverListeners({ btn, div })
 
-      // let clicked = false
-
-      btn.on('mouseup', () => {
-        // clicked = true
+      const onEvent = cy.stub().callsFake(() => {
         div.css(overlayStyle)
       })
 
+      btn.on('mouseup', onEvent)
+
+      // uncomment to manually test
+      // cy.wrap(onEvent).should('be.called')
       cy.contains('button').click()
-      // cy.wrap(null).should(() => expect(clicked).ok)
 
       cy.getAll('btn', 'mouseover mouseenter mousedown focus click mouseup').each(shouldBeCalled)
       cy.getAll('div', 'mouseover mouseenter').each(shouldBeCalled)
@@ -434,15 +433,15 @@ describe('src/cy/commands/actions/click', () => {
       attachMouseClickListeners({ btn, div })
       attachMouseHoverListeners({ btn, div })
 
-      // let clicked = false
-
-      btn.on('click', () => {
-        // clicked = true
+      const onEvent = cy.stub().callsFake(() => {
         div.css(overlayStyle)
       })
 
+      btn.on('click', onEvent)
+
+      // uncomment to manually test
+      // cy.wrap(onEvent).should('be.called')
       cy.contains('button').click()
-      // cy.wrap(null).should(() => expect(clicked).ok)
 
       cy.getAll('btn', 'mouseover mouseenter mousedown focus click mouseup').each(shouldBeCalled)
       cy.getAll('div', 'focus click mouseup mousedown').each(shouldNotBeCalled)
@@ -457,16 +456,17 @@ describe('src/cy/commands/actions/click', () => {
       attachMouseClickListeners({ btn, span })
       attachMouseHoverListeners({ btn, span })
 
-      // let clicked = false
-
-      btn.on('mousedown', () => {
+      const onEvent = cy.stub().callsFake(() => {
         // clicked = true
         btn.html('')
         btn.append(span)
       })
 
+      btn.on('mousedown', onEvent)
+
+      // uncomment to manually test
+      // cy.wrap(onEvent).should('be.called')
       cy.contains('button').click()
-      // cy.wrap(null).should(() => expect(clicked).ok)
 
       cy.getAll('btn', 'mousedown focus click mouseup').each(shouldBeCalled)
       cy.getAll('span', 'mouseup').each(shouldBeCalled)
@@ -484,15 +484,13 @@ describe('src/cy/commands/actions/click', () => {
       btn.html('')
       btn.append(span)
 
-      // let clicked = false
-
-      btn.on('mousedown', () => {
-        // clicked = true
+      const onEvent = cy.stub().callsFake(() => {
         span.css({ marginLeft: 50 })
       })
 
+      btn.on('mousedown', onEvent)
+
       cy.get('button:first').click()
-      // cy.wrap(null).should(() => expect(clicked).ok)
 
       cy.getAll('btn', 'mousedown focus click mouseup').each(shouldBeCalled)
       cy.getAll('span', 'mousedown').each(shouldBeCalled)
@@ -508,19 +506,19 @@ describe('src/cy/commands/actions/click', () => {
       attachMouseClickListeners({ btn, span1, span2 })
       attachMouseHoverListeners({ btn, span1, span2 })
 
-      // let clicked = false
-
       btn.html('')
       btn.append(span1)
 
-      btn.on('mousedown', () => {
-        // clicked = true
+      const onEvent = cy.stub().callsFake(() => {
         btn.html('')
         btn.append(span2)
       })
 
+      btn.on('mousedown', onEvent)
+
+      // uncomment to manually test
+      // cy.wrap(onEvent).should('be.called')
       cy.get('button:first').click()
-      // cy.wrap(null).should(() => expect(clicked).ok)
 
       cy.getAll('btn', 'mouseenter mousedown mouseup').each(shouldBeCalled)
       cy.getAll('btn', 'click focus').each(shouldNotBeCalled)
@@ -4331,12 +4329,11 @@ describe('mouse state', () => {
       })
       .appendTo(btn.parent())
 
-      // let clicked = false
-
-      cover.on('mouseup', () => {
+      const onEvent = cy.stub().callsFake(() => {
         cover.hide()
-        // clicked = true
       })
+
+      cover.on('mouseup', onEvent)
 
       attachFocusListeners({ btn, cover })
       attachMouseHoverListeners({ btn, cover })
@@ -4346,8 +4343,9 @@ describe('mouse state', () => {
         btn.attr('disabled', true)
       })
 
+      // uncomment to manually test
+      // cy.wrap(onEvent).should('be.called')
       cy.get('#cover').click()
-      // cy.wrap(null).should(() => expect(clicked).ok)
 
       cy.getAll('cover', 'mousedown mouseup click mouseout mouseleave').each(shouldBeCalledOnce)
       cy.getAll('cover', 'focus').each(shouldNotBeCalled)
@@ -4372,12 +4370,13 @@ describe('mouse state', () => {
       })
       .appendTo(btn.parent())
 
-      // let clicked = false
-
-      cover.on('mouseover', () => {
+      const onEvent = cy.stub().callsFake(() => {
         cover.hide()
-        // clicked = true
       })
+
+      // uncomment to manually test
+      // cy.wrap(onEvent).should('be.called')
+      cover.on('mouseover', onEvent)
 
       attachFocusListeners({ btn, cover })
       attachMouseHoverListeners({ btn, cover })

--- a/packages/driver/test/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/click_spec.js
@@ -380,9 +380,10 @@ describe('src/cy/commands/actions/click', () => {
     it('events when element moved on mousedown', () => {
       const btn = cy.$$('button:first')
       const div = cy.$$('div#tabindex')
+      const root = cy.$$('#dom')
 
       attachFocusListeners({ btn, div })
-      attachMouseClickListeners({ btn, div })
+      attachMouseClickListeners({ btn, div, root })
       attachMouseHoverListeners({ btn, div })
 
       // let clicked = false
@@ -399,6 +400,7 @@ describe('src/cy/commands/actions/click', () => {
       cy.getAll('btn', 'click mouseup').each(shouldNotBeCalled)
       cy.getAll('div', 'mouseover mouseenter mouseup').each(shouldBeCalled)
       cy.getAll('div', 'click focus').each(shouldNotBeCalled)
+      cy.getAll('root', 'click').each(shouldBeCalled)
     })
 
     it('events when element moved on mouseup', () => {
@@ -538,6 +540,10 @@ describe('src/cy/commands/actions/click', () => {
 
       $btn.on('click', () => {
         fail('should not have gotten click')
+      })
+
+      cy.$$('body').on('click', (e) => {
+        throw new Error('should not have happened')
       })
 
       cy.contains('button').click()

--- a/packages/driver/test/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/click_spec.js
@@ -446,6 +446,7 @@ describe('src/cy/commands/actions/click', () => {
       cy.getAll('div', 'focus click mouseup mousedown').each(shouldNotBeCalled)
     })
 
+    // https://github.com/cypress-io/cypress/issues/5578
     it('click when mouseup el is child of mousedown el', () => {
       const btn = cy.$$('button:first')
       const span = $('<span>foooo</span>')

--- a/packages/driver/test/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/click_spec.js
@@ -446,6 +446,87 @@ describe('src/cy/commands/actions/click', () => {
       cy.getAll('div', 'focus click mouseup mousedown').each(shouldNotBeCalled)
     })
 
+    it('click when mouseup el is child of mousedown el', () => {
+      const btn = cy.$$('button:first')
+      const span = $('<span>foooo</span>')
+
+      attachFocusListeners({ btn, span })
+      attachMouseClickListeners({ btn, span })
+      attachMouseHoverListeners({ btn, span })
+
+      // let clicked = false
+
+      btn.on('mousedown', () => {
+        // clicked = true
+        btn.html('')
+        btn.append(span)
+      })
+
+      cy.contains('button').click()
+      // cy.wrap(null).should(() => expect(clicked).ok)
+
+      cy.getAll('btn', 'mousedown focus click mouseup').each(shouldBeCalled)
+      cy.getAll('span', 'mouseup').each(shouldBeCalled)
+      cy.getAll('span', 'focus click mousedown').each(shouldNotBeCalled)
+    })
+
+    it('click when mousedown el is child of mouseup el', () => {
+      const btn = cy.$$('button:first')
+      const span = $('<span>foooo</span>')
+
+      attachFocusListeners({ btn, span })
+      attachMouseClickListeners({ btn, span })
+      attachMouseHoverListeners({ btn, span })
+
+      btn.html('')
+      btn.append(span)
+
+      // let clicked = false
+
+      btn.on('mousedown', () => {
+        // clicked = true
+        span.css({ marginLeft: 50 })
+      })
+
+      cy.get('button:first').click()
+      // cy.wrap(null).should(() => expect(clicked).ok)
+
+      cy.getAll('btn', 'mousedown focus click mouseup').each(shouldBeCalled)
+      cy.getAll('span', 'mousedown').each(shouldBeCalled)
+      cy.getAll('span', 'focus click mouseup').each(shouldNotBeCalled)
+    })
+
+    it('no click when new element at coords is not ancestor', () => {
+      const btn = cy.$$('button:first')
+      const span1 = $('<span>foooo</span>')
+      const span2 = $('<span>baaaar</span>')
+
+      attachFocusListeners({ btn, span1, span2 })
+      attachMouseClickListeners({ btn, span1, span2 })
+      attachMouseHoverListeners({ btn, span1, span2 })
+
+      // let clicked = false
+
+      btn.html('')
+      btn.append(span1)
+
+      btn.on('mousedown', () => {
+        // clicked = true
+        btn.html('')
+        btn.append(span2)
+      })
+
+      cy.get('button:first').click()
+      // cy.wrap(null).should(() => expect(clicked).ok)
+
+      cy.getAll('btn', 'mouseenter mousedown mouseup').each(shouldBeCalled)
+      cy.getAll('btn', 'click focus').each(shouldNotBeCalled)
+      cy.getAll('span1', 'mouseover mouseenter mousedown').each(shouldBeCalled)
+      cy.getAll('span1', 'focus click mouseup').each(shouldNotBeCalled)
+      cy.getAll('span2', 'mouseup mouseover mouseenter').each(shouldBeCalled)
+      cy.getAll('span2', 'focus click mousedown').each(shouldNotBeCalled)
+    })
+
     it('does not fire a click when element has been removed on mouseup', () => {
       const $btn = cy.$$('button:first')
 
@@ -2594,9 +2675,9 @@ describe('src/cy/commands/actions/click', () => {
             },
             {
               'Event Name': 'click',
-              'Target Element': '⚠️ not fired (mouseup and mousedown not received by same element)',
-              'Prevented Default?': null,
-              'Stopped Propagation?': null,
+              'Target Element': { id: 'dom' },
+              'Prevented Default?': false,
+              'Stopped Propagation?': false,
               'Modifiers': null,
             },
           ])


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #5578

### User facing changelog
- fixed regression introduced in `3.6.0` causing an incorrect element to receive the `click` event during action commands.
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
if the an element moves or does not receive both mouseup and mousedown during cy.click():
- <3.5.0: same element will always receive both events and therefore the click event (incorrect algorithm)
- 3.5.0: the element at the mouse coords will always receive the click event (incorrect algorithm)
- 3.6.0: the element at that received both mouseup and mousedown will receive the click event. otherwise it's not fired (incorrect algorithm)
- 3.6.1: the commonAncestor of mouseup and mousedown elements will receive the click event. (correct algorithm)

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks
- [x] refactor manual testing code
<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
