### PR TITLE
[WIP] Use Chrome 78 or later in the automated tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,17 +20,17 @@ defaults: &defaults
     LINES: 24
 
 executors:
-  # the Docker image with Cypress dependencies and Chrome browser
+  # the Docker image with Cypress dependencies
   cy-doc:
     docker:
-      - image: cypress/browsers:node12.0.0-chrome73
+      - image: cypress/base:12.12.0
     environment:
       PLATFORM: linux
 
   # Docker image with non-root "node" user
   non-root-docker-user:
     docker:
-      - image: cypress/base:12.0.0
+      - image: cypress/base:12.12.0
         user: node
     environment:
       PLATFORM: linux
@@ -45,6 +45,16 @@ executors:
       PLATFORM: mac
 
 commands:
+  install-google-chrome:
+    description: Download and install Google Chrome (stable) and its dependencies
+    steps:
+      - run:
+          command: |
+            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+            echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
+            apt update
+            apt install -y google-chrome-stable
+            google-chrome -version
   run-e2e-tests:
     parameters:
       browser:
@@ -56,6 +66,7 @@ commands:
     steps:
       - attach_workspace:
           at: ~/
+      - install-google-chrome
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
           working_directory: packages/server
@@ -249,8 +260,7 @@ jobs:
       # Install the root packages
       # Link sup packages in ./node_modules/@packages/*
       # Install sub packages dependencies and build all sub packages via postinstall script
-      # try several times, because flaky NPM installs ...
-      - run: npm install || npm install
+      - run: npm install
       - run:
           name: Top level packages
           command: npm ls --depth=0 || true
@@ -329,6 +339,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - install-google-chrome
       - run: npm run all test-unit -- --package server
       - store_test_results:
           path: /tmp/cypress
@@ -350,6 +361,7 @@ jobs:
       steps:
       - attach_workspace:
           at: ~/
+      - install-google-chrome
       - run:
           command: npm run all test-performance -- --package server
       - store_test_results:
@@ -476,6 +488,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - install-google-chrome
       - run:
           command: npm start
           background: true
@@ -604,6 +617,11 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: $(npm bin)/print-arch
+      - run: 
+          name: Install zip
+          command: |
+            apt update
+            apt install zip -y
       - run:
           environment:
             DEBUG: electron-builder,electron-osx-sign*
@@ -1227,3 +1245,4 @@ workflows:
     <<: *linux-workflow
   mac:
     <<: *mac-workflow
+    

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Cypress.io end to end testing tool",
   "private": true,
   "scripts": {

--- a/packages/server/__snapshots__/2_cdp_spec.ts.js
+++ b/packages/server/__snapshots__/2_cdp_spec.ts.js
@@ -15,7 +15,22 @@ exports['e2e cdp / fails when remote debugging port cannot be connected to'] = `
 ────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                     
   Running:  spec.ts                                                                         (1 of 1)
-Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 5 seconds.
+Failed to connect to Chrome, retrying in 1 second (attempt 18/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 19/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 20/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 21/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 22/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 23/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 24/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 25/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 26/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 27/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 28/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 29/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 30/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 31/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 32/32)
+Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 20 seconds.
 
 This usually indicates there was a problem opening the Chrome browser.
 

--- a/packages/server/__snapshots__/protocol_spec.ts.js
+++ b/packages/server/__snapshots__/protocol_spec.ts.js
@@ -1,4 +1,4 @@
-exports['lib/browsers/protocol ._getDelayMsForRetry retries as expected for up to 5 seconds 1'] = [
+exports['lib/browsers/protocol ._getDelayMsForRetry retries as expected for up to 20 seconds 1'] = [
   100,
   100,
   100,
@@ -16,5 +16,20 @@ exports['lib/browsers/protocol ._getDelayMsForRetry retries as expected for up t
   500,
   500,
   500,
-  500
+  500,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000
 ]

--- a/packages/server/lib/browsers/protocol.js
+++ b/packages/server/lib/browsers/protocol.js
@@ -15,6 +15,12 @@ function _getDelayMsForRetry (i) {
   if (i < 18) {
     return 500
   }
+
+  if (i < 33) { // after 5 seconds, begin logging and retrying
+    errors.warning('CDP_RETRYING_CONNECTION', i)
+
+    return 1000
+  }
 }
 
 function _connectAsync (opts) {

--- a/packages/server/lib/errors.coffee
+++ b/packages/server/lib/errors.coffee
@@ -848,7 +848,7 @@ getMsgByType = (type, arg1 = {}, arg2) ->
       """
     when "CDP_COULD_NOT_CONNECT"
       """
-      Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 5 seconds.
+      Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 20 seconds.
 
       This usually indicates there was a problem opening the Chrome browser.
 
@@ -857,6 +857,10 @@ getMsgByType = (type, arg1 = {}, arg2) ->
       Error details:
 
       #{arg2.stack}
+      """
+    when "CDP_RETRYING_CONNECTION"
+      """
+      Failed to connect to Chrome, retrying in 1 second (attempt #{chalk.yellow(arg1)}/32)
       """
 
 get = (type, arg1, arg2) ->

--- a/packages/server/test/unit/browsers/protocol_spec.ts
+++ b/packages/server/test/unit/browsers/protocol_spec.ts
@@ -9,11 +9,14 @@ import humanInterval from 'human-interval'
 import protocol from '../../../lib/browsers/protocol'
 import sinon from 'sinon'
 import snapshot from 'snap-shot-it'
+import stripAnsi from 'strip-ansi'
 import { stripIndents } from 'common-tags'
 
 describe('lib/browsers/protocol', function () {
   context('._getDelayMsForRetry', function () {
-    it('retries as expected for up to 5 seconds', function () {
+    it('retries as expected for up to 20 seconds', function () {
+      const log = sinon.spy(console, 'log')
+
       let delays = []
       let delay: number
       let i = 0
@@ -23,7 +26,13 @@ describe('lib/browsers/protocol', function () {
         i++
       }
 
-      expect(_.sum(delays)).to.eq(humanInterval('5 seconds'))
+      expect(_.sum(delays)).to.eq(humanInterval('20 seconds'))
+
+      log.getCalls().forEach((log, i) => {
+        const line = stripAnsi(log.args[0])
+
+        expect(line).to.include(`Failed to connect to Chrome, retrying in 1 second (attempt ${i + 18}/32)`)
+      })
 
       snapshot(delays)
     })
@@ -37,7 +46,7 @@ describe('lib/browsers/protocol', function () {
       const p = protocol.getWsTargetFor(12345)
 
       const expectedError = stripIndents`
-        Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 5 seconds.
+        Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 20 seconds.
 
         This usually indicates there was a problem opening the Chrome browser.
 


### PR DESCRIPTION
<!-- Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md -->

- Closes #5236 

### Description of change

<!-- How would you explain this change in our changelog 
for every user to read and understand -->
The automated regression tests done by CircleCI was using Chrome 73.  The latest Chrome version is 78. Let's use the latest version in the testing.

### How to use the feature

<!-- What code does the user write now versus before?
 (a GIF or screenshots of the feature in action is preferred!) 
 Fixing a bug? What test passes now that used to fail for the user? -->
The contributors to this repository should not see any changes. Those who are interested can see the Chrome version (in a docker file) used in the tests for a PR from a CircleCI log.

### How the design has changed

<!-- screenshots comparing the previous design(s) to new -->
No design has been changed.

### Notes

<!-- Have something else to add? Add it here :) -->
N/A

### Pre-merge Tasks

<!-- The following tasks must be completed before a PR can be merged.
You can delete tasks if they are not applicable to the PR changes. -->

This is a change used by the developers only.  The contributors, maintainers and Cypress users should not see any differences.  We may be able to catch Chrome 78+ specific issues in the PRs.