### PR TITLE
[WIP] Types: remove chainer interface fallback

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -2413,7 +2413,7 @@ declare namespace Cypress {
     encoding: Encodings
   }
 
-  // Kind of onerous, but has a nice auto-complete. Also fallbacks at the end for custom stuff
+  // Kind of onerous, but has a nice auto-complete.
   /**
    * @see https://on.cypress.io/should
    *
@@ -4089,15 +4089,6 @@ declare namespace Cypress {
      * @see https://on.cypress.io/assertions
      */
     (chainer: 'not.match', value: string): Chainable<Subject>
-
-    // fallback
-    /**
-     * Create an assertion. Assertions are automatically retried until they pass or time out.
-     * Ctrl+Space will invoke auto-complete in most editors.
-     * @see https://on.cypress.io/should
-     */
-    (chainers: string, value?: any): Chainable<Subject>
-    (chainers: string, value: any, match: any): Chainable<Subject>
 
     /**
      * Create an assertion. Assertions are automatically retried until they pass or time out.

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -2860,15 +2860,23 @@ declare namespace Cypress {
      * invoked after invoking the target function compared to when it’s invoked beforehand.
      * `.increase` also causes all `.by` assertions that follow in the chain to assert how much greater of a number is returned.
      * It’s often best to assert that the return value increased by the expected amount, rather than asserting it increased by any amount.
+     *
+     * When two arguments are provided, `.increase` asserts that the value of the given object `subject`’s `prop` property is greater after
+     * invoking the target function compared to beforehand.
+     * 
      * @example
      *    let val = 1
      *    function addTwo() { val += 2 }
      *    function getVal() { return val }
      *    cy.wrap(addTwo).should('increase', getVal)
+     * 
+     *    let myObj = { val: 1 }
+     *    function addTwo() { myObj.val += 2 }
+     *    cy.wrap(addTwo).should('increase', myObj, 'val')
      * @see http://chaijs.com/api/bdd/#method_increase
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'increase', value: object, property: string): Chainable<Subject>
+    (chainer: 'increase', value: object, property?: string): Chainable<Subject>
     /**
      * Asserts that the target matches the given regular expression `re`.
      * @example
@@ -3291,7 +3299,7 @@ declare namespace Cypress {
     /**
      * Asserts that the target’s `length` property is not less than or equal to the given number `n`.
      * @example
-     *    cy.wrap([1, 2, 3]).should('not.have.length.let', 2)
+     *    cy.wrap([1, 2, 3]).should('not.have.length.lte', 2)
      *    cy.wrap('foo').should('not.have.length.lte', 2)
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
@@ -3360,15 +3368,23 @@ declare namespace Cypress {
      * invoked after invoking the target function compared to when it’s invoked beforehand.
      * `.increase` also causes all `.by` assertions that follow in the chain to assert how much greater of a number is returned.
      * It’s often best to assert that the return value increased by the expected amount, rather than asserting it increased by any amount.
+     *
+     * When two arguments are provided, `.increase` asserts that the value of the given object `subject`’s `prop` property is greater after
+     * invoking the target function compared to beforehand.
+     * 
      * @example
      *    let val = 1
      *    function addTwo() { val += 2 }
      *    function getVal() { return val }
      *    cy.wrap(() => {}).should('not.increase', getVal)
+     * 
+     *    let myObj = { val: 1 }
+     *    function addTwo() { myObj.val += 2 }
+     *    cy.wrap(() => {}).should('not.increase', myObj, 'val')
      * @see http://chaijs.com/api/bdd/#method_increase
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.increase', value: object, property: string): Chainable<Subject>
+    (chainer: 'not.increase', value: object, property?: string): Chainable<Subject>
     /**
      * Asserts that the target does not match the given regular expression `re`.
      * @example
@@ -3407,7 +3423,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_throw
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'throw', value?: string | RegExp): Chainable<Subject>
+    (chainer: 'not.throw', value?: string | RegExp): Chainable<Subject>
     /**
      * When no arguments are provided, `.throw` invokes the target function and asserts that no error is thrown.
      * When one argument is provided, and it’s a string, `.throw` invokes the target function and asserts that no error is thrown with a message that contains that string.
@@ -3420,7 +3436,7 @@ declare namespace Cypress {
      * @see https://on.cypress.io/assertions
      */
     // tslint:disable-next-line ban-types
-    (chainer: 'throw', error: Error | Function, expected?: string | RegExp): Chainable<Subject>
+    (chainer: 'not.throw', error: Error | Function, expected?: string | RegExp): Chainable<Subject>
 
     // sinon-chai
     /**

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -93,7 +93,7 @@ cy.wrap({ x: {a: 1 }}).should('have.deep.property', 'x', { a: 1 })
 cy.wrap([1, 2, 3]).should('have.length', 3)
 cy.wrap('foo').should('have.length', 3)
 
-cy.wrap([1, 2, 3]).should('have.length.greaterThan')
+cy.wrap([1, 2, 3]).should('have.length.greaterThan', 2)
 cy.wrap('foo').should('have.length.greaterThan', 2)
 
 cy.wrap([1, 2, 3]).should('have.length.gt', 2)
@@ -124,19 +124,19 @@ cy.wrap('foobar').should('have.string', 'bar')
 
 cy.wrap('foobar').should('include', 'foo')
 
-cy.wrap('foo').should('contain.value')
-cy.wrap('foo').should('contain.text')
-cy.wrap('foo').should('contain.html')
-cy.wrap('foo').should('not.contain.value')
-cy.wrap('foo').should('not.contain.text')
-cy.wrap('foo').should('not.contain.html')
+cy.wrap('foo').should('contain.value', 'foo')
+cy.wrap('foo').should('contain.text', 'foo')
+cy.wrap('foo').should('contain.html', 'foo')
+cy.wrap('foo').should('not.contain.value', 'foo')
+cy.wrap('foo').should('not.contain.text', 'foo')
+cy.wrap('foo').should('not.contain.html', 'foo')
 
-cy.wrap('foo').should('include.value')
-cy.wrap('foo').should('include.text')
-cy.wrap('foo').should('include.html')
-cy.wrap('foo').should('not.include.value')
-cy.wrap('foo').should('not.include.text')
-cy.wrap('foo').should('not.incldue.html')
+cy.wrap('foo').should('include.value', 'foo')
+cy.wrap('foo').should('include.text', 'foo')
+cy.wrap('foo').should('include.html', 'foo')
+cy.wrap('foo').should('not.include.value', 'foo')
+cy.wrap('foo').should('not.include.text', 'foo')
+cy.wrap('foo').should('not.include.html', 'foo')
 
 // Ensure we've extended chai.Includes correctly
 expect('foo').to.include.value('foo')
@@ -252,7 +252,7 @@ cy.wrap('tester').should('not.contain', 'foo')
   cy.wrap(() => {}).should('not.decrease', myObj, 'val')
 }
 
-cy.wrap({ a: 1 }).should('not.deep.equal', { b: 1 })
+cy.wrap<{a?: number, b?: number }>({ a: 1 }).should('not.deep.equal', { b: 1 })
 
 cy.wrap(null).should('not.exist')
 
@@ -283,12 +283,12 @@ cy.wrap('foo').should('have.length.lessThan', 2)
 cy.wrap([1, 2, 3]).should('not.have.length.lt', 2)
 cy.wrap('foo').should('not.have.length.lt', 2)
 
-cy.wrap([1, 2, 3]).should('not.have.length.let', 2)
+cy.wrap([1, 2, 3]).should('not.have.length.lte', 2)
 cy.wrap('foo').should('not.have.length.lte', 2)
 
 cy.wrap([1, 2, 3]).should('not.have.members', [4, 5, 6])
 
-cy.wrap([1, 2, 3]).should('not. have.ordered.members', [4, 5, 6])
+cy.wrap([1, 2, 3]).should('not.have.ordered.members', [4, 5, 6])
 
 ;
 (Object as any).prototype.b = 2
@@ -356,8 +356,6 @@ cy.get('#result').should('not.be.focused')
 
 cy.get('#result').should('have.focus')
 cy.get('#result').should('not.have.focus')
-
-cy.get('#result').should('be.contain', 'text')
 
 cy.get('#result').should('have.attr', 'role')
 cy.get('#result').should('have.attr', 'role', 'menu')


### PR DESCRIPTION
Closes #5573

### User facing changelog

- Removes fallback types for `.should()`, which were accepting any parameters. This means that bad input will now show an error


### How has the user experience changed?

Better dev UX:


![image](https://user-images.githubusercontent.com/1393142/68139969-0e324c80-fef9-11e9-88cf-c2dcc2a64bf3.png)
