### PR TITLE
allow same version when building npm package on Circle

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,6 +53,7 @@ install:
   - node --version
   - node --print process.arch
   - npm --version
+  - npm run check-next-dev-version
   # prints all public variables relevant to the build
   - print-env Platform
   - npm run check-node-version

--- a/circle.yml
+++ b/circle.yml
@@ -714,19 +714,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: show current NPM package version
-          command: grep \"version\" package.json
-      - run:
-          name: show next NPM package version to build
-          command: |
-            set -e
-            if [ -z "$NEXT_DEV_VERSION" ]; then
-              echo "env variable NEXT_DEV_VERSION is not set";
-            else
-              echo "env variable NEXT_DEV_VERSION is set to '$NEXT_DEV_VERSION'";
-            fi
-            echo "Generally next dev version should be different from the current version"
+      - run: npm run check-next-dev-version
       - run:
           name: bump NPM version
           command: npm --no-git-tag-version --allow-same-version version ${NEXT_DEV_VERSION:-0.0.0-development}

--- a/circle.yml
+++ b/circle.yml
@@ -715,8 +715,21 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
+          name: show current NPM package version
+          command: grep \"version\" package.json
+      - run:
+          name: show next NPM package version to build
+          command: |
+            set -e
+            if [ -z "$NEXT_DEV_VERSION" ]; then
+              echo "env variable NEXT_DEV_VERSION is not set";
+            else
+              echo "env variable NEXT_DEV_VERSION is set to '$NEXT_DEV_VERSION'";
+            fi
+            echo "Generally next dev version should be different from the current version"
+      - run:
           name: bump NPM version
-          command: npm --no-git-tag-version version ${NEXT_DEV_VERSION:-0.0.0-development}
+          command: npm --no-git-tag-version --allow-same-version version ${NEXT_DEV_VERSION:-0.0.0-development}
       - run:
           name: build NPM package
           working_directory: cli
@@ -1121,7 +1134,7 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
-        
+
     - lint:
         name: Mac lint
         executor: mac

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bump": "node ./scripts/binary.js bump",
     "check-deps": "node ./scripts/check-deps.js --verbose",
     "check-deps-pre": "node ./scripts/check-deps.js --verbose --prescript",
+    "check-next-dev-version": "node scripts/check-next-dev-version.js",
     "check-node-version": "node scripts/check-node-version.js",
     "check-terminal": "node scripts/check-terminal.js",
     "clean-deps": "npm run all clean-deps && rm -rf node_modules",

--- a/scripts/check-next-dev-version.js
+++ b/scripts/check-next-dev-version.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-console */
+if (!process.env.NEXT_DEV_VERSION) {
+  console.log('NEXT_DEV_VERSION is not set')
+  process.exit(0)
+}
+
+const currentVersion = require('../package.json').version
+
+if (currentVersion === process.env.NEXT_DEV_VERSION) {
+  console.warn('⚠️ NEXT_DEV_VERSION is set to the same value as current package.json version')
+  process.exit(0)
+}
+
+console.log('NEXT_DEV_VERSION is different from the current package version "%s"', currentVersion)

--- a/scripts/check-next-dev-version.js
+++ b/scripts/check-next-dev-version.js
@@ -7,7 +7,7 @@ if (!process.env.NEXT_DEV_VERSION) {
 const currentVersion = require('../package.json').version
 
 if (currentVersion === process.env.NEXT_DEV_VERSION) {
-  console.warn('⚠️ NEXT_DEV_VERSION is set to the same value as current package.json version')
+  console.warn('⚠️ NEXT_DEV_VERSION is set to the same value as current package.json version "%s"', currentVersion)
   process.exit(0)
 }
 


### PR DESCRIPTION
- solves https://circleci.com/gh/cypress-io/cypress/182772 when we have not upgraded `NEXT_DEV_VERSION` on CircleCI after publishing new cypress NPM version

```
#!/bin/bash -eo pipefail
npm --no-git-tag-version version ${NEXT_DEV_VERSION:-0.0.0-development}
npm ERR! Version not changed, might want --allow-same-version

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2019-11-04T19_15_45_338Z-debug.log
Exited with code 1
```

Building a duplicate version is not a problem, since we control when we upload and release the official version.