### PR TITLE
Catch stray reads/writes on destroyed stream_buffers

### DIFF
--- a/packages/server/lib/util/stream_buffer.js
+++ b/packages/server/lib/util/stream_buffer.js
@@ -10,6 +10,12 @@ function streamBuffer (initialSize = 2048) {
   const readers = []
 
   const onWrite = (chunk, enc, cb) => {
+    if (finished || !chunk || !buffer) {
+      debug('received write after deleting buffer, ignoring %o', { chunkLength: chunk && chunk.length, enc })
+
+      return cb()
+    }
+
     if (chunk.length + bytesWritten > buffer.length) {
       let newBufferLength = buffer.length
 
@@ -55,6 +61,12 @@ function streamBuffer (initialSize = 2048) {
     const readerId = _.uniqueId('reader')
 
     const onRead = function (size) {
+      if (!buffer) {
+        debug('read requested after unpipeAll, ignoring %o', { size })
+
+        return
+      }
+
       // if there are unread bytes in the buffer,
       // send up to bytesWritten back
       if (bytesRead < bytesWritten) {

--- a/packages/server/lib/util/stream_buffer.ts
+++ b/packages/server/lib/util/stream_buffer.ts
@@ -1,13 +1,15 @@
-const _ = require('lodash')
-const debug = require('debug')('cypress:server:stream_buffer')
-const stream = require('stream')
+import _ from 'lodash'
+import debugModule from 'debug'
+import stream from 'stream'
+
+const debug = debugModule('cypress:server:stream_buffer')
 
 function streamBuffer (initialSize = 2048) {
-  let buffer = Buffer.allocUnsafe(initialSize)
+  let buffer: Buffer | null = Buffer.allocUnsafe(initialSize)
   let bytesWritten = 0
   let finished = false
 
-  const readers = []
+  const readers: stream.Readable[] = []
 
   const onWrite = (chunk, enc, cb) => {
     if (finished || !chunk || !buffer) {
@@ -53,6 +55,7 @@ function streamBuffer (initialSize = 2048) {
   const writeable = new stream.Writable({
     write: onWrite,
     final: onFinal,
+    // @ts-ignore
     autoDestroy: true,
   })
 
@@ -112,6 +115,7 @@ function streamBuffer (initialSize = 2048) {
 
     const readable = new stream.Readable({
       read: onRead,
+      // @ts-ignore
       autoDestroy: true,
     })
 

--- a/packages/server/test/unit/stream_buffer_spec.js
+++ b/packages/server/test/unit/stream_buffer_spec.js
@@ -221,4 +221,23 @@ describe('lib/util/stream_buffer', () => {
 
     pt.end()
   })
+
+  it('silently discards writes after it has been destroyed, with no consumers', function (done) {
+    const sb = streamBuffer()
+
+    sb.write('foo')
+    sb.unpipeAll()
+    sb.write('bar', done)
+  })
+
+  it('silently discards writes after it has been destroyed, with a consumer', function (done) {
+    const sb = streamBuffer()
+    const pt = stream.PassThrough()
+
+    sb.createReadStream().pipe(pt)
+
+    sb.write('foo')
+    sb.unpipeAll()
+    sb.write('bar', done)
+  })
 })


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #5585

### User facing changelog

Fixed an issue where Cypress would crash with `TypeError: Cannot read property 'length' of null` on some network requests.

### Additional details

- It's possible for a stray read/write to occur after the buffer has been deleted from memory, causing the bug seen in #5585 This PR adds tests that the buffer is not null to catch these.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?