### PR TITLE
Increase CDP timeout to 20 seconds; add logs after 5 seconds

### DIFF
--- a/packages/server/__snapshots__/2_cdp_spec.ts.js
+++ b/packages/server/__snapshots__/2_cdp_spec.ts.js
@@ -15,7 +15,22 @@ exports['e2e cdp / fails when remote debugging port cannot be connected to'] = `
 ────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                     
   Running:  spec.ts                                                                         (1 of 1)
-Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 5 seconds.
+Failed to connect to Chrome, retrying in 1 second (attempt 18/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 19/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 20/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 21/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 22/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 23/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 24/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 25/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 26/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 27/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 28/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 29/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 30/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 31/32)
+Failed to connect to Chrome, retrying in 1 second (attempt 32/32)
+Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 20 seconds.
 
 This usually indicates there was a problem opening the Chrome browser.
 

--- a/packages/server/__snapshots__/protocol_spec.ts.js
+++ b/packages/server/__snapshots__/protocol_spec.ts.js
@@ -1,4 +1,4 @@
-exports['lib/browsers/protocol ._getDelayMsForRetry retries as expected for up to 5 seconds 1'] = [
+exports['lib/browsers/protocol ._getDelayMsForRetry retries as expected for up to 20 seconds 1'] = [
   100,
   100,
   100,
@@ -16,5 +16,20 @@ exports['lib/browsers/protocol ._getDelayMsForRetry retries as expected for up t
   500,
   500,
   500,
-  500
+  500,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000,
+  1000
 ]

--- a/packages/server/lib/browsers/protocol.js
+++ b/packages/server/lib/browsers/protocol.js
@@ -15,6 +15,12 @@ function _getDelayMsForRetry (i) {
   if (i < 18) {
     return 500
   }
+
+  if (i < 33) { // after 5 seconds, begin logging and retrying
+    errors.warning('CDP_RETRYING_CONNECTION', i)
+
+    return 1000
+  }
 }
 
 function _connectAsync (opts) {

--- a/packages/server/lib/errors.coffee
+++ b/packages/server/lib/errors.coffee
@@ -858,6 +858,10 @@ getMsgByType = (type, arg1 = {}, arg2) ->
 
       #{arg2.stack}
       """
+    when "CDP_RETRYING_CONNECTION"
+      """
+      Failed to connect to Chrome, retrying in 1 second (attempt #{chalk.yellow(arg1)}/32)
+      """
 
 get = (type, arg1, arg2) ->
   msg = getMsgByType(type, arg1, arg2)

--- a/packages/server/lib/errors.coffee
+++ b/packages/server/lib/errors.coffee
@@ -848,7 +848,7 @@ getMsgByType = (type, arg1 = {}, arg2) ->
       """
     when "CDP_COULD_NOT_CONNECT"
       """
-      Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 5 seconds.
+      Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 20 seconds.
 
       This usually indicates there was a problem opening the Chrome browser.
 

--- a/packages/server/test/unit/browsers/protocol_spec.ts
+++ b/packages/server/test/unit/browsers/protocol_spec.ts
@@ -9,11 +9,14 @@ import humanInterval from 'human-interval'
 import protocol from '../../../lib/browsers/protocol'
 import sinon from 'sinon'
 import snapshot from 'snap-shot-it'
+import stripAnsi from 'strip-ansi'
 import { stripIndents } from 'common-tags'
 
 describe('lib/browsers/protocol', function () {
   context('._getDelayMsForRetry', function () {
-    it('retries as expected for up to 5 seconds', function () {
+    it('retries as expected for up to 20 seconds', function () {
+      const log = sinon.spy(console, 'log')
+
       let delays = []
       let delay: number
       let i = 0
@@ -23,7 +26,13 @@ describe('lib/browsers/protocol', function () {
         i++
       }
 
-      expect(_.sum(delays)).to.eq(humanInterval('5 seconds'))
+      expect(_.sum(delays)).to.eq(humanInterval('20 seconds'))
+
+      log.getCalls().forEach((log, i) => {
+        const line = stripAnsi(log.args[0])
+
+        expect(line).to.include(`Failed to connect to Chrome, retrying in 1 second (attempt ${i + 18}/32)`)
+      })
 
       snapshot(delays)
     })

--- a/packages/server/test/unit/browsers/protocol_spec.ts
+++ b/packages/server/test/unit/browsers/protocol_spec.ts
@@ -46,7 +46,7 @@ describe('lib/browsers/protocol', function () {
       const p = protocol.getWsTargetFor(12345)
 
       const expectedError = stripIndents`
-        Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 5 seconds.
+        Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 20 seconds.
 
         This usually indicates there was a problem opening the Chrome browser.
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Partially addresses #5445

### User facing changelog

Increased the timeout when connecting to the Chrome DevTools Protocol from 5 seconds to 20 seconds. Added logging for when the connection is taking longer than 5 seconds to help with debugging.

### Additional details

- see https://github.com/cypress-io/cypress/issues/5445#issuecomment-547310305
- increasing this timeout is reasonable, if their CPU/memory is seriously constrained, Chrome could take a long time to launch

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
