### PR TITLE
Truncate cy.log() in Command Log to 50 lines instead of 1

### DIFF
--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -378,7 +378,7 @@
   }
 
   .command-name-log {
-    .command-message {
+    .command-message-text {
       white-space: initial;
       word-wrap: break-word;
       line-height: 1.5;

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -377,6 +377,13 @@
     }
   }
 
+  .command-name-log {
+    .command-message {
+      white-space: initial;
+      word-wrap: break-word;
+    }
+  }
+
   .command-controls {
     i {
       padding: 2px;
@@ -389,7 +396,7 @@
       line-height: 1.75;
       margin-left: 5px;
 
-      
+
     }
 
     i:hover {

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -381,6 +381,10 @@
     .command-message {
       white-space: initial;
       word-wrap: break-word;
+      line-height: 1.5;
+      display: -webkit-box;
+      -webkit-line-clamp: 50;
+      -webkit-box-orient: vertical;
     }
   }
 


### PR DESCRIPTION
- Closes #5625 

### User facing changelog

Messages from `cy.log()` are now truncated at 50 lines the Command Log instead of the 1 line.

### How has the user experience changed?

Before:
![screenshot_174](https://user-images.githubusercontent.com/227391/71263699-b766c200-2342-11ea-85bb-419df78ca0a6.png)

After:

Truncates the log to 50 lines and shows ellipsis to indicate truncation.

Clicking to log to console will log full `cy.log()` content. 

<img width="517" alt="Screen Shot 2020-01-09 at 12 40 53 PM" src="https://user-images.githubusercontent.com/1271364/72042581-55fc9800-32dd-11ea-908e-6f4a29dce5ea.png">



### PR Tasks

none.
