### PR TITLE
Remove support for Node 6

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -47,7 +47,7 @@
     "lazy-ass": "1.6.0",
     "listr": "0.14.3",
     "lodash": "4.17.15",
-    "log-symbols": "2.2.0",
+    "log-symbols": "3.0.0",
     "minimist": "1.2.0",
     "moment": "2.24.0",
     "ramda": "0.24.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -50,7 +50,7 @@
     "log-symbols": "3.0.0",
     "minimist": "1.2.0",
     "moment": "2.24.0",
-    "ramda": "0.24.1",
+    "ramda": "0.26.1",
     "request": "2.88.0",
     "request-progress": "3.0.0",
     "supports-color": "7.1.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -37,7 +37,7 @@
     "commander": "4.0.1",
     "common-tags": "1.8.0",
     "debug": "4.1.1",
-    "execa": "0.10.0",
+    "execa": "3.3.0",
     "executable": "4.1.1",
     "extract-zip": "1.6.7",
     "fs-extra": "5.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -30,7 +30,7 @@
     "@cypress/xvfb": "1.2.4",
     "@types/sizzle": "2.3.2",
     "arch": "2.1.1",
-    "bluebird": "3.5.0",
+    "bluebird": "3.7.1",
     "cachedir": "2.3.0",
     "chalk": "3.0.0",
     "check-more-types": "2.24.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -40,7 +40,7 @@
     "execa": "3.3.0",
     "executable": "4.1.1",
     "extract-zip": "1.6.7",
-    "fs-extra": "5.0.0",
+    "fs-extra": "8.1.0",
     "getos": "3.1.1",
     "is-ci": "2.0.0",
     "is-installed-globally": "0.3.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -55,7 +55,7 @@
     "request-progress": "3.0.0",
     "supports-color": "7.1.0",
     "tmp": "0.1.0",
-    "untildify": "3.0.3",
+    "untildify": "4.0.0",
     "url": "0.11.0",
     "yauzl": "2.10.0"
   },

--- a/cli/package.json
+++ b/cli/package.json
@@ -36,7 +36,7 @@
     "check-more-types": "2.24.0",
     "commander": "2.20.0",
     "common-tags": "1.8.0",
-    "debug": "3.2.6",
+    "debug": "4.1.1",
     "execa": "0.10.0",
     "executable": "4.1.1",
     "extract-zip": "1.6.7",

--- a/cli/package.json
+++ b/cli/package.json
@@ -43,7 +43,7 @@
     "fs-extra": "5.0.0",
     "getos": "3.1.1",
     "is-ci": "2.0.0",
-    "is-installed-globally": "0.1.0",
+    "is-installed-globally": "0.3.1",
     "lazy-ass": "1.6.0",
     "listr": "0.14.3",
     "lodash": "4.17.15",

--- a/cli/package.json
+++ b/cli/package.json
@@ -32,7 +32,7 @@
     "arch": "2.1.1",
     "bluebird": "3.5.0",
     "cachedir": "2.2.0",
-    "chalk": "2.4.2",
+    "chalk": "3.0.0",
     "check-more-types": "2.24.0",
     "commander": "2.20.0",
     "common-tags": "1.8.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -42,7 +42,7 @@
     "extract-zip": "1.6.7",
     "fs-extra": "5.0.0",
     "getos": "3.1.1",
-    "is-ci": "1.2.1",
+    "is-ci": "2.0.0",
     "is-installed-globally": "0.1.0",
     "lazy-ass": "1.6.0",
     "listr": "0.14.3",

--- a/cli/package.json
+++ b/cli/package.json
@@ -31,7 +31,7 @@
     "@types/sizzle": "2.3.2",
     "arch": "2.1.1",
     "bluebird": "3.5.0",
-    "cachedir": "2.2.0",
+    "cachedir": "2.3.0",
     "chalk": "3.0.0",
     "check-more-types": "2.24.0",
     "commander": "4.0.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -101,7 +101,7 @@
     "cypress": "bin/cypress"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "types": "types"
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -34,7 +34,7 @@
     "cachedir": "2.2.0",
     "chalk": "3.0.0",
     "check-more-types": "2.24.0",
-    "commander": "2.20.0",
+    "commander": "4.0.1",
     "common-tags": "1.8.0",
     "debug": "4.1.1",
     "execa": "0.10.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -53,7 +53,7 @@
     "ramda": "0.24.1",
     "request": "2.88.0",
     "request-progress": "3.0.0",
-    "supports-color": "6.1.0",
+    "supports-color": "7.1.0",
     "tmp": "0.1.0",
     "untildify": "3.0.3",
     "url": "0.11.0",

--- a/cli/test/lib/tasks/install_spec.js
+++ b/cli/test/lib/tasks/install_spec.js
@@ -30,13 +30,13 @@ describe('/lib/tasks/install', function () {
 
     // allow simpler log message comparison without
     // chalk's terminal control strings
-    chalk.enabled = false
+    chalk.level = 0
   })
 
   afterEach(() => {
     stdout.restore()
 
-    chalk.enabled = true
+    chalk.level = 3
   })
 
   context('.start', function () {


### PR DESCRIPTION
- close #4200

### User facing changelog

- Node 6 reached its end of life on April 30, 2019. This Node version will no longer be supported. The minimum Node version supported by Cypress is Node 8.
- Upgraded `bluebird` from `3.5.0` to `3.7.1`.
- Upgraded `cachedir` from `2.2.0` to `2.3.0`.
- Upgraded `chalk` from `2.4.2` to `3.0.0`.
- Upgraded `commander` from `2.20.0` to `4.0.1`.
- Upgraded `debug` from `3.2.6` to `4.1.1`.
- Upgraded `execa` from `0.10.0` to `3.3.0`.
- Upgraded `fs-extra` from `5.0.0` to `8.1.0`.
- Upgraded `is-ci` from `1.2.1` to `2.0.0`.
- Upgraded `is-installed-globally` from `0.1.0` to `0.3.1`.
- Upgraded `log-symbols` from `2.2.0` to `3.0.0`.
- Upgraded `supports-color` from `6.1.0` to `7.1.0`.
- Upgraded `untildify` from `3.0.3` to `4.0.0`.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [NA] Have tests been added/updated?
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? Is part of 4.0 docs https://github.com/cypress-io/cypress-documentation/pull/1710
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?


