### PR TITLE
fix coords when specified x,y during click

### DIFF
--- a/packages/driver/src/dom/coordinates.js
+++ b/packages/driver/src/dom/coordinates.js
@@ -203,7 +203,7 @@ const getBottomRightCoordinates = (rect) => {
 const getElementCoordinatesByPositionRelativeToXY = ($el, x, y) => {
   const positionProps = getElementPositioning($el)
 
-  const { fromElViewport, fromElWindow } = positionProps
+  const { fromElViewport, fromElWindow, fromAutWindow } = positionProps
 
   fromElViewport.left += x
   fromElViewport.top += y
@@ -211,14 +211,21 @@ const getElementCoordinatesByPositionRelativeToXY = ($el, x, y) => {
   fromElWindow.left += x
   fromElWindow.top += y
 
+  fromAutWindow.left += x
+  fromAutWindow.top += y
+
   const viewportTargetCoords = getTopLeftCoordinates(fromElViewport)
   const windowTargetCoords = getTopLeftCoordinates(fromElWindow)
+  const AUTwindowTargetCoords = getTopLeftCoordinates(fromAutWindow)
 
   fromElViewport.x = viewportTargetCoords.x
   fromElViewport.y = viewportTargetCoords.y
 
   fromElWindow.x = windowTargetCoords.x
   fromElWindow.y = windowTargetCoords.y
+
+  fromAutWindow.x = AUTwindowTargetCoords.x
+  fromAutWindow.y = AUTwindowTargetCoords.y
 
   return positionProps
 }

--- a/packages/driver/test/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/click_spec.js
@@ -1675,7 +1675,7 @@ describe('src/cy/commands/actions/click', () => {
     })
 
     describe('relative coordinate arguments', () => {
-      it('can specify x and y', (done) => {
+      it('can specify x and y', () => {
         const $btn = $('<button>button covered</button>')
         .attr('id', 'button-covered-in-span')
         .css({ height: 100, width: 100 })
@@ -1685,14 +1685,20 @@ describe('src/cy/commands/actions/click', () => {
         .css({ position: 'absolute', left: $btn.offset().left + 50, top: $btn.offset().top + 65, padding: 5, display: 'inline-block', backgroundColor: 'yellow' })
         .appendTo($btn)
 
-        const clicked = _.after(2, () => {
-          done()
+        cy.on('log:changed', (log, attr) => {
+          if (log.name === 'click' && attr._emittedAttrs.coords) {
+            expect(attr._emittedAttrs.coords).property('x')
+            expect(attr._emittedAttrs.coords).property('y')
+          }
         })
+
+        const clicked = cy.stub()
 
         $span.on('click', clicked)
         $btn.on('click', clicked)
 
         cy.get('#button-covered-in-span').click(75, 78)
+        .then(() => expect(clicked).calledTwice)
       })
 
       it('can pass options along with x, y', (done) => {

--- a/packages/driver/test/cypress/integration/e2e/dom_hitbox.spec.js
+++ b/packages/driver/test/cypress/integration/e2e/dom_hitbox.spec.js
@@ -49,7 +49,36 @@ describe('rect highlight', () => {
     // TODO: assert covers element bounding-box
     ensureCorrectHighlightPositions(null)
   })
+
+  it('correct target position during click', () => {
+    clickAndPin('#button')
+    ensureCorrectHighlightPositions('#button')
+    ensureCorrectTargetPosition('#button')
+  })
+
+  it('correct target position during click with offset coords', () => {
+    clickAndPin('#button', 5, 10)
+    ensureCorrectHighlightPositions('#button')
+    ensureCorrectTargetPosition('#button')
+  })
 })
+
+const ensureCorrectTargetPosition = (sel) => {
+  return cy.wrap(null, { timeout: 400 }).should(() => {
+    const target = cy.$$('div[data-highlight-hitbox]')[0].getBoundingClientRect()
+
+    const dims = {
+      left: target.left + target.width / 2,
+      right: target.left + target.width / 2,
+      top: target.top + target.height / 2,
+      bottom: target.top + target.height / 2,
+      width: 1,
+      height: 1,
+    }
+
+    expectToBeInside(dims, cy.$$(sel)[0].getBoundingClientRect(), 'border-box to match selector bounding-box')
+  })
+}
 
 const ensureCorrectHighlightPositions = (sel) => {
   return cy.wrap(null, { timeout: 400 }).should(() => {
@@ -72,6 +101,12 @@ const getAndPin = (sel) => {
   cy.get(sel)
 
   clickCommandLog(sel)
+}
+
+const clickAndPin = (sel, ...args) => {
+  cy.get(sel).click(...args)
+
+  clickCommandLog('click')
 }
 
 const expectToBeEqual = (rect1, rect2, mes = 'rect to be equal to rect') => {


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

- there was an edge case in `coordinates.js` that did not attach x,y property to `fromAUTWindow` as of `3.5.0`
- we now attach x,y to fromAUTWindow when given offset coords

- Closes #5624 

### User facing changelog
- fixed regression(3.5.0) causing click coordinate target to be rendered incorrectly when specifying offset coordinates to `cy.click()` #5624 
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
during `cy.click(x, y)`
- before (target out of sight, appended at bottom of document)
![19-11-07_13:04::52](https://user-images.githubusercontent.com/14625260/68415025-679bb500-015f-11ea-8d6d-ea94bfd7d2d1.png)
- after (target correctly placed)
![19-11-07_13:04::13](https://user-images.githubusercontent.com/14625260/68415028-69fe0f00-015f-11ea-9ede-e026e67bf49b.png)

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
