### PR TITLE
revert skipping text insert with modifier keys causing regression

### DIFF
--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -218,10 +218,6 @@ const getKeyDetails = (onKeyNotFound) => {
   }
 }
 
-const hasModifierBesidesShift = (modifiers: KeyboardModifiers) => {
-  return _.some(_.omit(modifiers, ['shift']))
-}
-
 /**
  * @example '{foo}' => 'foo'
  */
@@ -928,10 +924,11 @@ export class Keyboard {
       details.text = details.shiftText
     }
 
-    // If any modifier besides shift is pressed, no text.
-    if (hasModifierBesidesShift(modifiers)) {
-      details.text = ''
-    }
+    // TODO: Re-think skipping text insert if non-shift modifers
+    // @see https://github.com/cypress-io/cypress/issues/5622
+    // if (hasModifierBesidesShift(modifiers)) {
+    //   details.text = ''
+    // }
 
     return details
   }
@@ -1053,10 +1050,7 @@ export class Keyboard {
     debug('getSimulatedDefaultForKey', key.key)
     if (key.simulatedDefault) return key.simulatedDefault
 
-    let nonShiftModifierPressed = hasModifierBesidesShift(this.getActiveModifiers())
-
-    debug({ nonShiftModifierPressed, key })
-    if (!nonShiftModifierPressed && simulatedDefaultKeyMap[key.key]) {
+    if (simulatedDefaultKeyMap[key.key]) {
       return simulatedDefaultKeyMap[key.key]
     }
 

--- a/packages/driver/test/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/type_spec.js
@@ -1627,6 +1627,16 @@ describe('src/cy/commands/actions/type', () => {
           })
         })
 
+        // https://github.com/cypress-io/cypress/issues/5622
+        it('collapses selection to end on {rightarrow} with modifiers', () => {
+          cy.$$('[contenteditable]:first').get(0).innerHTML = '<div>bar</div>'
+
+          cy.get('[contenteditable]:first')
+          .type('{selectall}foo{selectall}{ctrl}Hello{selectall}{rightarrow} world').then(($div) => {
+            expect(trimInnerText($div)).to.eql('Hello world')
+          })
+        })
+
         it('can remove a placeholder <br>', () => {
           cy.$$('[contenteditable]:first').get(0).innerHTML = '<div><br></div>'
 
@@ -2819,6 +2829,12 @@ describe('src/cy/commands/actions/type', () => {
 
             done()
           })
+        })
+
+        // https://github.com/cypress-io/cypress/issues/5622
+        it('still inserts text with non-shift modifiers', () => {
+          cy.get('input:first').type('{ctrl}{meta}foobar')
+          .should('have.value', 'foobar')
         })
 
         it('does not maintain modifiers for subsequent click commands', (done) => {
@@ -4320,14 +4336,14 @@ describe('src/cy/commands/actions/type', () => {
             const expectedTable = {
               1: { 'Details': '{ code: MetaLeft, which: 91 }', Typed: '{cmd}', 'Events Fired': 'keydown', 'Active Modifiers': 'meta', 'Prevented Default': null, 'Target Element': $input[0] },
               2: { 'Details': '{ code: AltLeft, which: 18 }', Typed: '{option}', 'Events Fired': 'keydown', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
-              3: { 'Details': '{ code: KeyF, which: 70 }', Typed: 'f', 'Events Fired': 'keydown, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
-              4: { 'Details': '{ code: KeyO, which: 79 }', Typed: 'o', 'Events Fired': 'keydown, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
-              5: { 'Details': '{ code: KeyO, which: 79 }', Typed: 'o', 'Events Fired': 'keydown, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
-              6: { 'Details': '{ code: Enter, which: 13 }', Typed: '{enter}', 'Events Fired': 'keydown, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
-              7: { 'Details': '{ code: KeyB, which: 66 }', Typed: 'b', 'Events Fired': 'keydown, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
+              3: { 'Details': '{ code: KeyF, which: 70 }', Typed: 'f', 'Events Fired': 'keydown, keypress, textInput, input, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
+              4: { 'Details': '{ code: KeyO, which: 79 }', Typed: 'o', 'Events Fired': 'keydown, keypress, textInput, input, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
+              5: { 'Details': '{ code: KeyO, which: 79 }', Typed: 'o', 'Events Fired': 'keydown, keypress, textInput, input, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
+              6: { 'Details': '{ code: Enter, which: 13 }', Typed: '{enter}', 'Events Fired': 'keydown, keypress, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
+              7: { 'Details': '{ code: KeyB, which: 66 }', Typed: 'b', 'Events Fired': 'keydown, keypress, textInput, input, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
               8: { 'Details': '{ code: ArrowLeft, which: 37 }', Typed: '{leftarrow}', 'Events Fired': 'keydown, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
-              9: { 'Details': '{ code: Delete, which: 46 }', Typed: '{del}', 'Events Fired': 'keydown, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
-              10: { 'Details': '{ code: Enter, which: 13 }', Typed: '{enter}', 'Events Fired': 'keydown, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
+              9: { 'Details': '{ code: Delete, which: 46 }', Typed: '{del}', 'Events Fired': 'keydown, input, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
+              10: { 'Details': '{ code: Enter, which: 13 }', Typed: '{enter}', 'Events Fired': 'keydown, keypress, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
               11: { 'Details': '{ code: MetaLeft, which: 91 }', Typed: '{cmd}', 'Events Fired': 'keyup', 'Active Modifiers': 'alt', 'Prevented Default': null, 'Target Element': $input[0] },
               12: { 'Details': '{ code: AltLeft, which: 18 }', Typed: '{option}', 'Events Fired': 'keyup', 'Active Modifiers': null, 'Prevented Default': null, 'Target Element': $input[0] },
             }
@@ -4335,6 +4351,7 @@ describe('src/cy/commands/actions/type', () => {
             // uncomment for debugging
             // _.each(table.data, (v, i) => expect(v).containSubset(expectedTable[i]))
             expect(table.data).to.deep.eq(expectedTable)
+            expect($input.val()).eq('foo')
           })
         })
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

Breaking change introduced in `3.5.0` (#4870), where we would not insert text if non-shift modifier key was held down.

This broke quite a few people's tests because they wrote code unaware that the ctrl key is held down the entire rest of the sequence, e.g.:
```
cy.type('{ctrl}BHello')
```
people's app would capture the `ctrl+B` and bold the following text "hello"

the breaking change caused us to no longer insert the text "hello", thus the test was broken

- this PR reverts that behavior back to pre-3.5.0 and always inserts text regardless of modifiers

- Closes #5622

### User facing changelog
- fix regression introduced in 3.5.0 causing text after modifier keys not to be typed
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
