### PR TITLE
Properly close login modal during project setup

### DIFF
--- a/packages/desktop-gui/cypress/integration/setup_project_modal_spec.js
+++ b/packages/desktop-gui/cypress/integration/setup_project_modal_spec.js
@@ -447,6 +447,12 @@ describe('Set Up Project', function () {
       cy.get('.modal').contains('Log In to Dashboard')
     })
 
+    it('closes login modal', () => {
+      cy.get('.modal').contains('Log In to Dashboard')
+      cy.get('.close').click()
+      cy.get('.btn').contains('Set up project').click()
+    })
+
     describe('when login succeeds', function () {
       beforeEach(function () {
         cy.stub(this.ipc, 'beginAuth').resolves(this.user)

--- a/packages/desktop-gui/cypress/integration/setup_project_modal_spec.js
+++ b/packages/desktop-gui/cypress/integration/setup_project_modal_spec.js
@@ -460,6 +460,7 @@ describe('Set Up Project', function () {
       })
 
       it('shows setup', () => {
+        cy.get('.login-content > .btn').click()
         cy.contains('h4', 'Set up project')
       })
     })

--- a/packages/desktop-gui/src/app/nav.jsx
+++ b/packages/desktop-gui/src/app/nav.jsx
@@ -127,7 +127,7 @@ export default class Nav extends Component {
   }
 
   _showLogin () {
-    authStore.setShowingLogin(true)
+    authStore.openLogin()
   }
 
   _openDocs (e) {

--- a/packages/desktop-gui/src/auth/auth-store.js
+++ b/packages/desktop-gui/src/auth/auth-store.js
@@ -19,9 +19,20 @@ class AuthStore {
     this.message = message
   }
 
-  @action setShowingLogin (isShowing) {
+  @action openLogin (onCloseCb) {
+    this.onCloseCb = onCloseCb
+
     this.setMessage(null)
-    this.isShowingLogin = isShowing
+    this.isShowingLogin = true
+  }
+
+  @action closeLogin () {
+    if (this.onCloseCb) {
+      this.onCloseCb(this.isAuthenticated)
+    }
+
+    this.setMessage(null)
+    this.isShowingLogin = false
   }
 
   @action setUser (user) {

--- a/packages/desktop-gui/src/auth/login-modal.jsx
+++ b/packages/desktop-gui/src/auth/login-modal.jsx
@@ -8,7 +8,7 @@ import authStore from './auth-store'
 import ipc from '../lib/ipc'
 
 const close = () => {
-  authStore.setShowingLogin(false)
+  authStore.closeLogin()
 }
 
 // LoginContent is a separate component so that it pings the api

--- a/packages/desktop-gui/src/runs/project-not-setup.jsx
+++ b/packages/desktop-gui/src/runs/project-not-setup.jsx
@@ -6,6 +6,7 @@ import BootstrapModal from 'react-bootstrap-modal'
 import ipc from '../lib/ipc'
 import { configFileFormatted } from '../lib/config-file-formatted'
 import SetupProject from './setup-project-modal'
+import authStore from '../auth/auth-store'
 
 @observer
 export default class ProjectNotSetup extends Component {
@@ -91,6 +92,22 @@ export default class ProjectNotSetup extends Component {
 
   _projectSetup () {
     if (!this.state.setupProjectModalOpen) return null
+
+    if (!this.props.isAuthenticated) {
+      authStore.openLogin((isAuthenticated) => {
+        if (!isAuthenticated) {
+          // auth was canceled, cancel project setup too
+          this.setState({ setupProjectModalOpen: false })
+        }
+      })
+
+      return null
+    }
+
+    if (this.props.isShowingLogin) {
+      // login dialog still open, wait for it to close before proceeding
+      return null
+    }
 
     return (
       <SetupProject

--- a/packages/desktop-gui/src/runs/runs-list.jsx
+++ b/packages/desktop-gui/src/runs/runs-list.jsx
@@ -290,6 +290,8 @@ class RunsList extends Component {
   _projectNotSetup (isValid = true) {
     return (
       <ProjectNotSetup
+        isAuthenticated={authStore.isAuthenticated}
+        isShowingLogin={authStore.isShowingLogin}
         project={this.props.project}
         isValid={isValid}
         onSetup={this._setProjectDetails}

--- a/packages/desktop-gui/src/runs/setup-project-modal.jsx
+++ b/packages/desktop-gui/src/runs/setup-project-modal.jsx
@@ -70,7 +70,7 @@ class SetupProject extends Component {
 
   render () {
     if (!authStore.isAuthenticated) {
-      authStore.setShowingLogin(true)
+      authStore.openLogin()
 
       return null
     }

--- a/packages/desktop-gui/src/settings/record-key.jsx
+++ b/packages/desktop-gui/src/settings/record-key.jsx
@@ -22,7 +22,7 @@ const openRecordKeyGuide = (e) => {
 }
 
 const showLogin = () => {
-  authStore.setShowingLogin(true)
+  authStore.openLogin()
 }
 
 @observer


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #5631 

### User facing changelog

Fixed a bug where Cypress would appear frozen after cancelling user login while in the "Runs" tab.

### Additional details

- Previously, there were 2 overlapping modals, even once the auth closed, the "setup project" was still open
- This PR makes it so that if the auth is closed without the user logging in, the "setup project" modal will never open

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?

