### PR TITLE
add ci variables for GitHub Actions

### DIFF
--- a/packages/server/__snapshots__/cypress_spec.coffee.js
+++ b/packages/server/__snapshots__/cypress_spec.coffee.js
@@ -68,6 +68,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 - codeshipPro
 - concourse
 - drone
+- githubActions
 - gitlab
 - goCD
 - googleCloud
@@ -101,6 +102,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 - codeshipPro
 - concourse
 - drone
+- githubActions
 - gitlab
 - goCD
 - googleCloud
@@ -135,6 +137,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 - codeshipPro
 - concourse
 - drone
+- githubActions
 - gitlab
 - goCD
 - googleCloud

--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -86,6 +86,7 @@ const CI_PROVIDERS = {
   'codeshipPro': isCodeshipPro,
   'concourse': isConcourse,
   'drone': 'DRONE',
+  githubActions: 'GITHUB_ACTIONS',
   'gitlab': isGitlab,
   'goCD': 'GO_JOB_NAME',
   'googleCloud': isGoogleCloud,
@@ -197,6 +198,12 @@ const _providerCiParams = () => {
       'DRONE_BUILD_LINK',
       'DRONE_BUILD_NUMBER',
       'DRONE_PULL_REQUEST',
+    ]),
+    // https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables#default-environment-variables
+    githubActions: extract([
+      'GITHUB_WORKFLOW',
+      'GITHUB_ACTION',
+      'GITHUB_EVENT_NAME',
     ]),
     // see https://docs.gitlab.com/ee/ci/variables/
     gitlab: extract([
@@ -417,6 +424,12 @@ const _providerCommitParams = function () {
       authorEmail: env.DRONE_COMMIT_AUTHOR_EMAIL,
       // remoteOrigin: ???
       defaultBranch: env.DRONE_REPO_BRANCH,
+    },
+    githubActions: {
+      sha: env.GITHUB_SHA,
+      branch: env.GITHUB_REF,
+      defaultBranch: env.GITHUB_BASE_REF,
+      remoteBranch: env.GITHUB_HEAD_REF,
     },
     gitlab: {
       sha: env.CI_COMMIT_SHA,

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -374,6 +374,35 @@ describe "lib/util/ci_provider", ->
       defaultBranch: "droneRepoBranch"
     })
 
+  it "github actions", ->
+    resetEnv = mockedEnv({
+      GITHUB_ACTIONS: "true"
+
+      GITHUB_WORKFLOW: "ciGitHubWorkflowName"
+      GITHUB_ACTION: "ciGitHubActionId"
+      GITHUB_EVENT_NAME: "ciEventName"
+
+      GITHUB_SHA: "ciCommitSha"
+      GITHUB_REF: "ciCommitRef"
+
+      # only for forked repos
+      GITHUB_HEAD_REF: "ciHeadRef"
+      GITHUB_BASE_REF: "ciBaseRef"
+    }, {clear: true})
+
+    expectsName("githubActions")
+    expectsCiParams({
+      githubAction: "ciGitHubActionId"
+      githubEventName: "ciEventName"
+      githubWorkflow: "ciGitHubWorkflowName"
+    })
+    expectsCommitParams({
+      sha: "ciCommitSha"
+      defaultBranch: "ciBaseRef"
+      remoteBranch: "ciHeadRef"
+      branch: "ciCommitRef"
+    })
+
   it "gitlab", ->
     resetEnv = mockedEnv({
       GITLAB_CI: "true"
@@ -431,6 +460,7 @@ describe "lib/util/ci_provider", ->
     }, {clear: true})
 
     expectsName("gitlab")
+
   it "goCD", ->
     resetEnv = mockedEnv({
       GO_SERVER_URL: "https://127.0.0.1:8154/go",


### PR DESCRIPTION
- Closes #5609

### User facing changelog

If you use GitHub Actions to run Cypress with Dashboard recording, the env variables are detected and passed to the dashboard to be displayed in the run summary

### How has the user experience changed?

No more missing branch or undefined CI name in the Dashboard, see issue

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
