### PR TITLE
Include workspace recommendations for extensions in VS code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,25 @@
+{
+    "recommendations": [
+        "alefragnani.bookmarks",
+        "msjsdiag.debugger-for-chrome",
+        "kisstkondoros.vscode-codemetrics",
+        "yorkxin.coffeescript-support",
+        "drknoxy.eslint-disable-snippets",
+        "eamodio.gitlens",
+        "ms-vsliveshare.vsliveshare",
+        "karigari.chat",
+        "lostintangent.vsls-pomodoro",
+        "lostintangent.vsls-whiteboard",
+        "yzhang.markdown-all-in-one",
+        "bierner.markdown-emoji",
+        "eg2.vscode-npm-script",
+        "christian-kohler.npm-intellisense",
+        "buenon.scratchpads",
+        "jasonnutter.search-node-modules",
+        "asvetliakov.snapshot-tools",
+        "fabiospampinato.vscode-terminals",
+        "chrisbreiding.test-utils",
+        "britesnow.vscode-toggle-quotes",
+        "pflannery.vscode-versionlens"
+    ]
+}


### PR DESCRIPTION
Closes #5689 

This will enable showing/sharing recommended VS Code extensions for developers working on Cypress. Several have been added as a starting place. This is accessed in VS Code via searching for `@recommended` extensions under the `Workspace Recommended Extensions` section.

![image](https://user-images.githubusercontent.com/1578436/68787067-d91bad80-060e-11ea-8b10-577320c0d4bf.png)
