### PR TITLE
cli: remove any leftover double quotes from group and ci build id

### DIFF
--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -70,47 +70,7 @@ const parseVariableOpts = (fnArgs, args) => {
     }
   }
 
-  return parseOpts(opts)
-}
-
-const parseOpts = (opts) => {
-  opts = _.pick(
-    opts,
-    'project',
-    'spec',
-    'reporter',
-    'reporterOptions',
-    'path',
-    'destination',
-    'port',
-    'env',
-    'cypressVersion',
-    'config',
-    'record',
-    'key',
-    'configFile',
-    'browser',
-    'detached',
-    'headed',
-    'global',
-    'dev',
-    'force',
-    'exit',
-    'cachePath',
-    'cacheList',
-    'cacheClear',
-    'parallel',
-    'group',
-    'ciBuildId'
-  )
-
-  if (opts.exit) {
-    opts = _.omit(opts, 'exit')
-  }
-
-  debug('parsed cli options', opts)
-
-  return opts
+  return util.parseOpts(opts)
 }
 
 const descriptions = {
@@ -272,7 +232,7 @@ module.exports = {
     .action((opts) => {
       debug('opening Cypress')
       require('./exec/open')
-      .start(parseOpts(opts))
+      .start(util.parseOpts(opts))
       .catch(util.logErrorExit1)
     })
 
@@ -285,7 +245,7 @@ module.exports = {
     .option('-f, --force', text('forceInstall'))
     .action((opts) => {
       require('./tasks/install')
-      .start(parseOpts(opts))
+      .start(util.parseOpts(opts))
       .catch(util.logErrorExit1)
     })
 
@@ -298,7 +258,7 @@ module.exports = {
     .option('--dev', text('dev'), coerceFalse)
     .action((opts) => {
       const defaultOpts = { force: true, welcomeMessage: false }
-      const parsedOpts = parseOpts(opts)
+      const parsedOpts = util.parseOpts(opts)
       const options = _.extend(parsedOpts, defaultOpts)
 
       require('./tasks/verify')

--- a/cli/lib/util.js
+++ b/cli/lib/util.js
@@ -158,6 +158,8 @@ function printNodeOptions (log = debug) {
  * Removes double quote characters
  * from the start and end of the given string IF they are both present
  *
+ * @param {string} str Input string
+ * @returns {string} Trimmed string or the original string if there are no double quotes around it.
  * @example
   ```
   dequote('"foo"')
@@ -213,8 +215,8 @@ const parseOpts = (opts) => {
   // some options might be quoted - which leads to unexpected results
   // remove double quotes from certain options
   const removeQuotes = {
-    group: util.dequote,
-    ciBuildId: util.dequote,
+    group: dequote,
+    ciBuildId: dequote,
   }
   const cleanOpts = R.evolve(removeQuotes, opts)
 

--- a/cli/lib/util.js
+++ b/cli/lib/util.js
@@ -175,8 +175,57 @@ const dequote = (str) => {
   return str
 }
 
+const parseOpts = (opts) => {
+  opts = _.pick(
+    opts,
+    'project',
+    'spec',
+    'reporter',
+    'reporterOptions',
+    'path',
+    'destination',
+    'port',
+    'env',
+    'cypressVersion',
+    'config',
+    'record',
+    'key',
+    'configFile',
+    'browser',
+    'detached',
+    'headed',
+    'global',
+    'dev',
+    'force',
+    'exit',
+    'cachePath',
+    'cacheList',
+    'cacheClear',
+    'parallel',
+    'group',
+    'ciBuildId'
+  )
+
+  if (opts.exit) {
+    opts = _.omit(opts, 'exit')
+  }
+
+  // some options might be quoted - which leads to unexpected results
+  // remove double quotes from certain options
+  const removeQuotes = {
+    group: util.dequote,
+    ciBuildId: util.dequote,
+  }
+  const cleanOpts = R.evolve(removeQuotes, opts)
+
+  debug('parsed cli options %o', cleanOpts)
+
+  return cleanOpts
+}
+
 const util = {
   normalizeModuleOptions,
+  parseOpts,
   isValidCypressEnvValue,
   printNodeOptions,
 

--- a/cli/test/lib/cli_spec.js
+++ b/cli/test/lib/cli_spec.js
@@ -313,6 +313,11 @@ describe('cli', () => {
       snapshot(logger.warn.getCall(0).args[0])
       done()
     })
+
+    it('removes stray double quotes', () => {
+      this.exec('run --ci-build-id "123" --group "staging"')
+      expect(run.start).to.be.calledWith({ ciBuildId: '123', group: 'staging' })
+    })
   })
 
   context('cypress open', () => {

--- a/cli/test/lib/util_spec.js
+++ b/cli/test/lib/util_spec.js
@@ -497,4 +497,54 @@ describe('util', () => {
       })
     })
   })
+
+  context('parseOpts', () => {
+    it('passes normal options and strips unknown ones', () => {
+      const result = util.parseOpts({
+        unknownOptions: true,
+        group: 'my group name',
+        ciBuildId: 'my ci build id',
+      })
+
+      expect(result).to.deep.equal({
+        group: 'my group name',
+        ciBuildId: 'my ci build id',
+      })
+    })
+
+    it('removes leftover double quotes', () => {
+      const result = util.parseOpts({
+        group: '"my group name"',
+        ciBuildId: '"my ci build id"',
+      })
+
+      expect(result).to.deep.equal({
+        group: 'my group name',
+        ciBuildId: 'my ci build id',
+      })
+    })
+
+    it('leaves unbalanced double quotes', () => {
+      const result = util.parseOpts({
+        group: 'my group name"',
+        ciBuildId: '"my ci build id',
+      })
+
+      expect(result).to.deep.equal({
+        group: 'my group name"',
+        ciBuildId: '"my ci build id',
+      })
+    })
+
+    it('works with unspecified options', () => {
+      const result = util.parseOpts({
+        // notice that "group" option is missing
+        ciBuildId: '"my ci build id"',
+      })
+
+      expect(result).to.deep.equal({
+        ciBuildId: 'my ci build id',
+      })
+    })
+  })
 })


### PR DESCRIPTION
- Closes #5686

### User facing changelog

You can run `cypress run --ci-build-id "123" --group "staging"` and it will automatically strip double quotes from `ciBuildId` and `group` parameters

### Additional details

I have noticed unexpected ci build id and group names which moved Windows runs into separate Dashboard runs in https://github.com/cypress-io/github-action/issues/5

### How has the user experience changed?

One more less thing to worry about due to OS differences

### PR Tasks

- [x] Have tests been added/updated?
