### PR TITLE
Fix flaky request retrying unit tests

### DIFF
--- a/packages/server/test/unit/request_spec.coffee
+++ b/packages/server/test/unit/request_spec.coffee
@@ -2,6 +2,7 @@ require("../spec_helper")
 
 _       = require("lodash")
 http    = require("http")
+Bluebird = require("bluebird")
 Request = require("#{root}lib/request")
 snapshot = require("snap-shot-it")
 
@@ -200,10 +201,10 @@ describe "lib/request", ->
       @srv.close()
 
     context "retries for streams", ->
-      it "does not retry on a timeout", (done) ->
+      it "does not retry on a timeout", ->
         opts = request.setDefaults({
           url: "http://localhost:9988/never-ends"
-          timeout: 100
+          timeout: 1000
         })
 
         stream = request.create(opts)
@@ -213,16 +214,19 @@ describe "lib/request", ->
         stream.on "retry", ->
           retries++
 
-        stream.on "error", (err) ->
+        p = Bluebird.fromCallback (cb) ->
+          stream.on "error", cb
+
+        expect(p).to.be.rejected
+        .then (err) ->
           expect(err.code).to.eq('ESOCKETTIMEDOUT')
           expect(retries).to.eq(0)
-          done()
 
-      it "retries 4x on a connection reset", (done) ->
+      it "retries 4x on a connection reset", ->
         opts = {
           url: "http://localhost:9988/econnreset"
           retryIntervals: [0, 1, 2, 3]
-          timeout: 250
+          timeout: 1000
         }
 
         stream = request.create(opts)
@@ -232,17 +236,21 @@ describe "lib/request", ->
         stream.on "retry", ->
           retries++
 
-        stream.on "error", (err) ->
+        p = Bluebird.fromCallback (cb) ->
+          stream.on "error", cb
+
+        expect(p).to.be.rejected
+        .then (err) ->
           expect(err.code).to.eq('ECONNRESET')
           expect(retries).to.eq(4)
-          done()
 
-      it "retries 4x on a NXDOMAIN (ENOTFOUND)", (done) ->
+      it "retries 4x on a NXDOMAIN (ENOTFOUND)", ->
         nock.enableNetConnect()
 
         opts = {
           url: "http://will-never-exist.invalid.example.com"
           retryIntervals: [0, 1, 2, 3]
+          timeout: 1000
         }
 
         stream = request.create(opts)
@@ -252,10 +260,13 @@ describe "lib/request", ->
         stream.on "retry", ->
           retries++
 
-        stream.on "error", (err) ->
+        p = Bluebird.fromCallback (cb) ->
+          stream.on "error", cb
+
+        expect(p).to.be.rejected
+        .then (err) ->
           expect(err.code).to.eq('ENOTFOUND')
           expect(retries).to.eq(4)
-          done()
 
     context "retries for promises", ->
       it "does not retry on a timeout", ->


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes <!-- issue number here -->

### User facing changelog
N/A

### Additional details

* this fixes those annoying server-unit-tests that fail occasionally
* makes it so that a failure in these 3 tests will only fail the test, not crash the process
* increased timeout to reduce flake
* [x] ran for 40 minutes straight locally without crashing or failing

### How has the user experience changed?
N/A

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?