### PR TITLE
filter out duplicate modifiers from cy.type

### DIFF
--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -712,30 +712,13 @@ export class Keyboard {
           }
 
           this.typeSimulatedKey(activeEl, key, options)
-          debug('returning null')
 
           return null
         }
       }
     )
 
-    const modifierKeys = _.filter(keyDetailsArr, isModifier)
-
-    if (options.simulated && !options.delay) {
-      _.each(typeKeyFns, (fn) => {
-        return fn()
-      })
-
-      if (options.release !== false) {
-        _.each(modifierKeys, (key) => {
-          return this.simulatedKeyup(getActiveEl(doc), key, options)
-        })
-      }
-
-      options.onAfterType()
-
-      return
-    }
+    const modifierKeys = _.uniqBy(_.filter(keyDetailsArr, isModifier), (v) => v.key)
 
     return Promise
     .each(typeKeyFns, (fn) => {
@@ -745,7 +728,7 @@ export class Keyboard {
     })
     .then(() => {
       if (options.release !== false) {
-        return Promise.map(modifierKeys, (key) => {
+        return Promise.map(modifierKeys.reverse(), (key) => {
           options.id = _.uniqueId('char')
 
           return this.simulatedKeyup(getActiveEl(doc), key, options)
@@ -898,7 +881,6 @@ export class Keyboard {
     debug(`dispatched [${eventType}] on ${el}`)
     const formattedKeyString = getFormattedKeyString(keyDetails)
 
-    debug('format string', formattedKeyString)
     options.onEvent(options.id, formattedKeyString, event, dispatched)
 
     return dispatched
@@ -956,7 +938,7 @@ export class Keyboard {
       const didFlag = this.flagModifier(_key)
 
       if (!didFlag) {
-        return null
+        _key.events.keydown = false
       }
 
       _key.events.keyup = false

--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -729,8 +729,7 @@ export class Keyboard {
     })
     .then(() => {
       if (options.release !== false) {
-        // reverse the modifiers so we keyup in LIFO order
-        return Promise.map(modifierKeys.reverse(), (key) => {
+        return Promise.map(modifierKeys, (key) => {
           options.id = _.uniqueId('char')
 
           return this.simulatedKeyup(getActiveEl(doc), key, options)

--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -719,7 +719,11 @@ export class Keyboard {
     )
 
     // we will only press each modifier once, so only find unique modifiers
-    const modifierKeys = _.uniqBy(_.filter(keyDetailsArr, isModifier), (v) => v.key)
+    const modifierKeys = _
+    .chain(keyDetailsArr)
+    .filter(isModifier)
+    .uniqBy('key')
+    .value()
 
     return Promise
     .each(typeKeyFns, (fn) => {

--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -718,6 +718,7 @@ export class Keyboard {
       }
     )
 
+    // we will only press each modifier once, so only find unique modifiers
     const modifierKeys = _.uniqBy(_.filter(keyDetailsArr, isModifier), (v) => v.key)
 
     return Promise
@@ -728,6 +729,7 @@ export class Keyboard {
     })
     .then(() => {
       if (options.release !== false) {
+        // reverse the modifiers so we keyup in LIFO order
         return Promise.map(modifierKeys.reverse(), (key) => {
           options.id = _.uniqueId('char')
 
@@ -938,9 +940,11 @@ export class Keyboard {
       const didFlag = this.flagModifier(_key)
 
       if (!didFlag) {
+        // we've already pressed this modifier, so ignore it and don't fire keydown or keyup
         _key.events.keydown = false
       }
 
+      // don't fire keyup for modifier keys, this will happen after all other keys are typed
       _key.events.keyup = false
     }
 

--- a/packages/driver/test/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/type_spec.js
@@ -2837,6 +2837,33 @@ describe('src/cy/commands/actions/type', () => {
           .should('have.value', 'foobar')
         })
 
+        // https://github.com/cypress-io/cypress/issues/5622
+        it('ignores duplicate modifiers in one command', () => {
+          const events = []
+
+          cy.$$('input:first').on('keydown', (e) => {
+            events.push(['keydown', e.key])
+          }).on('keyup', (e) => {
+            events.push(['keyup', e.key])
+          })
+
+          cy.get('input:first')
+          .type('{ctrl}{meta}a{control}b')
+          .should('have.value', 'ab')
+          .then(() => {
+            expect(events).deep.eq([
+              ['keydown', 'Control'],
+              ['keydown', 'Meta'],
+              ['keydown', 'a'],
+              ['keyup', 'a'],
+              ['keydown', 'b'],
+              ['keyup', 'b'],
+              ['keyup', 'Meta'],
+              ['keyup', 'Control'],
+            ])
+          })
+        })
+
         it('does not maintain modifiers for subsequent click commands', (done) => {
           const $button = cy.$$('button:first')
           let mouseDownEvent = null

--- a/packages/driver/test/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/type_spec.js
@@ -2858,8 +2858,8 @@ describe('src/cy/commands/actions/type', () => {
               ['keyup', 'a'],
               ['keydown', 'b'],
               ['keyup', 'b'],
-              ['keyup', 'Meta'],
               ['keyup', 'Control'],
+              ['keyup', 'Meta'],
             ])
           })
         })


### PR DESCRIPTION
- this restores behavior in Cypress <3.5.0 where duplicate modifiers in strings passed to `cy.type` are ignored.

- this is an edge case affecting uses of `.type` that mistakenly use duplicate modifiers in one command. This is common when a user does not realize modifiers are active and pressed down during the entire command.

 
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #5622<!-- issue number here -->

### User facing changelog
- fix regression introduced in 3.5.0 causing `.type` command to send duplicate modifier keys
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
during cy.type, if a user tries to type multiple of the same modifier:
![image](https://user-images.githubusercontent.com/14625260/68807724-560e4d80-0636-11ea-8aaa-02bd4f25488a.png)

- before (3.5.0+): keydown is sent for each modifier
![19-11-13_16:53::12](https://user-images.githubusercontent.com/14625260/68807754-632b3c80-0636-11ea-8576-ae284e00548b.png)


- after: the modifier is only typed one time, subsequent are ignored (same as <3.5.0)
![19-11-13_16:54::32](https://user-images.githubusercontent.com/14625260/68807762-658d9680-0636-11ea-8688-458a929bcd6c.png)


### PR Tasks


- [x] Have tests been added/updated?