### PR TITLE
Fix bug where cy.request does not work with followRedirect: false and Set-Cookie

### DIFF
--- a/packages/server/__snapshots__/4_request_spec.coffee.js
+++ b/packages/server/__snapshots__/4_request_spec.coffee.js
@@ -21,6 +21,7 @@ exports['e2e requests / passes'] = `
     ✓ gets and sets cookies from cy.request
     ✓ visits idempotant
     ✓ automatically follows redirects
+    ✓ can turn off following redirects that set a cookie
     ✓ can turn off automatically following redirects
     ✓ follows all redirects even when they change methods
     ✓ can submit json body
@@ -32,14 +33,14 @@ exports['e2e requests / passes'] = `
     ✓ issue #375: does not duplicate request cookies on 302 redirect
 
 
-  12 passing
+  13 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        12                                                                               │
-  │ Passing:      12                                                                               │
+  │ Tests:        13                                                                               │
+  │ Passing:      13                                                                               │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -63,9 +64,9 @@ exports['e2e requests / passes'] = `
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  request_spec.coffee                      XX:XX       12       12        -        -        - │
+  │ ✔  request_spec.coffee                      XX:XX       13       13        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX       12       12        -        -        -  
+    ✔  All specs passed!                        XX:XX       13       13        -        -        -  
 
 
 `

--- a/packages/server/lib/request.coffee
+++ b/packages/server/lib/request.coffee
@@ -551,9 +551,9 @@ module.exports = (options = {}) ->
         push = (response) ->
           requestResponses.push(pick(response))
 
-        if options.followRedirect
-          currentUrl = options.url
+        currentUrl = options.url
 
+        if options.followRedirect
           options.followRedirect = (incomingRes) ->
             newUrl = url.resolve(currentUrl, incomingRes.headers.location)
 

--- a/packages/server/test/e2e/4_request_spec.coffee
+++ b/packages/server/test/e2e/4_request_spec.coffee
@@ -42,6 +42,10 @@ onServer2 = (app) ->
   app.get "/redirect", (req, res) ->
     res.redirect("/home")
 
+  app.get "/redirectWithCookie", (req, res) ->
+    res.cookie('foo', 'bar')
+    res.redirect("/home")
+
   app.get "/home", (req, res) ->
     res.send("<html>home</html>")
 

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/request_spec.coffee
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/request_spec.coffee
@@ -55,6 +55,18 @@ describe "redirects + requests", ->
         expect(resp.status).to.eq(200)
         expect(resp.body).to.eq("<html>home</html>")
 
+  ## https://github.com/cypress-io/cypress/issues/5654
+  it "can turn off following redirects that set a cookie", ->
+    Cypress.config('baseUrl', 'http://localhost:2294')
+
+    cy
+      .request({
+        url: "/redirectWithCookie"
+        followRedirect: false
+      })
+      .then (resp) ->
+        expect(resp.status).to.eq(302)
+
   it "can turn off automatically following redirects", ->
     cy
       .request({

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/request_spec.coffee
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/request_spec.coffee
@@ -57,11 +57,9 @@ describe "redirects + requests", ->
 
   ## https://github.com/cypress-io/cypress/issues/5654
   it "can turn off following redirects that set a cookie", ->
-    Cypress.config('baseUrl', 'http://localhost:2294')
-
     cy
       .request({
-        url: "/redirectWithCookie"
+        url: "http://localhost:2294/redirectWithCookie"
         followRedirect: false
       })
       .then (resp) ->


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #5654

### User facing changelog

- Fixed a regression introduced in v3.6.1 where `cy.request` with `followRedirect: false` would fail if a Set-Cookie header was present on the response. Fixes #5654 

### Additional details

* was a simple error, currentUrl was undefined but could still end up being used in this edge case

### How has the user experience changed?

N/A

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?