### PR TITLE
call setTimeout with the right global scope to prevent 'this' from being undefined

### DIFF
--- a/packages/driver/src/cy/timers.js
+++ b/packages/driver/src/cy/timers.js
@@ -19,7 +19,7 @@ const create = () => {
 
   const invoke = (contentWindow, fnOrCode, params = []) => {
     if (_.isFunction(fnOrCode)) {
-      return fnOrCode(...params)
+      return fnOrCode.apply(contentWindow, params)
     }
 
     return contentWindow.eval(fnOrCode)

--- a/packages/driver/test/cypress/fixtures/issue-5707.html
+++ b/packages/driver/test/cypress/fixtures/issue-5707.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<body>
+  <script>
+    'use strict';
+    window.setTimeout(function () {
+      this.foo = 'bar'
+    }, 50)
+  </script>
+</body>
+</html>

--- a/packages/driver/test/cypress/integration/issues/5707_spec.js
+++ b/packages/driver/test/cypress/integration/issues/5707_spec.js
@@ -1,0 +1,7 @@
+// https://github.com/cypress-io/cypress/issues/5707
+describe('issue 5707', () => {
+  it('calls setTimeout with the correct context', () => {
+    cy.visit('/fixtures/issue-5707.html')
+    cy.window().its('foo').should('eq', 'bar')
+  })
+})


### PR DESCRIPTION
closes #5707 
addresses #5698 

### User facing changelog

- The context of `window` is no longer `undefined` within the application under test when called within a `setTimeout` during strict mode. 

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

The test below would previously fail - having `window` evaluate to undefined. Now it passes. 

```html
<!doctype html>
<html lang="en">
<body>
  <script>
    'use strict';
    window.setTimeout(function () {
      this.foo = 'bar'
    }, 50)
  </script>
</body>
</html>
```

```js
it('asserts', () => {
  cy.visit('index.html')
  cy.window().its('foo').should('eq', 'bar')
})
```

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?