### PR TITLE
Get TRAVIS_PULL_REQUEST_SHA or the commit sha

### DIFF
--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -486,7 +486,7 @@ const _providerCommitParams = function () {
       authorName: env.BUILD_SOURCEVERSIONAUTHOR,
     },
     travis: {
-      sha: env.TRAVIS_COMMIT,
+      sha: env.TRAVIS_PULL_REQUEST_SHA || env.TRAVIS_COMMIT,
       // for PRs, TRAVIS_BRANCH is the base branch being merged into
       branch: env.TRAVIS_PULL_REQUEST_BRANCH || env.TRAVIS_BRANCH,
       // authorName: ???

--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -330,6 +330,7 @@ const _providerCiParams = () => {
       'TRAVIS_BUILD_NUMBER',
       'TRAVIS_PULL_REQUEST',
       'TRAVIS_PULL_REQUEST_BRANCH',
+      'TRAVIS_PULL_REQUEST_SHA',
     ]),
     wercker: null,
   }

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -789,6 +789,7 @@ describe "lib/util/ci_provider", ->
     })
 
   it "travis", ->
+    ## normal non-PR build
     resetEnv = mockedEnv({
       TRAVIS: "true"
 
@@ -799,8 +800,9 @@ describe "lib/util/ci_provider", ->
       TRAVIS_EVENT_TYPE: "travisEventType"
       TRAVIS_COMMIT_RANGE: "travisCommitRange"
       TRAVIS_BUILD_NUMBER: "travisBuildNumber"
-      TRAVIS_PULL_REQUEST: "travisPullRequest"
-      TRAVIS_PULL_REQUEST_BRANCH: "travisPullRequestBranch"
+      TRAVIS_PULL_REQUEST: ""
+      TRAVIS_PULL_REQUEST_BRANCH: ""
+      TRAVIS_PULL_REQUEST_SHA: ""
 
       TRAVIS_COMMIT: "travisCommit"
       TRAVIS_BRANCH: "travisBranch"
@@ -816,12 +818,13 @@ describe "lib/util/ci_provider", ->
       travisEventType: "travisEventType"
       travisCommitRange: "travisCommitRange"
       travisBuildNumber: "travisBuildNumber"
-      travisPullRequest: "travisPullRequest"
-      travisPullRequestBranch: "travisPullRequestBranch"
+      travisPullRequest: ""
+      travisPullRequestBranch: ""
+      travisPullRequestSha: ""
     })
     expectsCommitParams({
       sha: "travisCommit"
-      branch: "travisPullRequestBranch"
+      branch: "travisBranch"
       message: "travisCommitMessage"
     })
 
@@ -832,6 +835,24 @@ describe "lib/util/ci_provider", ->
 
     expectsCommitParams({
       branch: "travisBranch"
+    })
+
+    ## Pull Request build
+    resetEnv = mockedEnv({
+      TRAVIS: "true"
+      TRAVIS_PULL_REQUEST: "travisPullRequest"
+      TRAVIS_PULL_REQUEST_BRANCH: "travisPullRequestBranch"
+      TRAVIS_PULL_REQUEST_SHA: "travisPullRequestSha" 
+
+      TRAVIS_COMMIT: "travisCommit"
+      TRAVIS_BRANCH: "travisBranch"
+      TRAVIS_COMMIT_MESSAGE: "travisCommitMessage"
+    }, {clear: true})
+
+    expectsCommitParams({
+      sha: "travisPullRequestSha"
+      branch: "travisPullRequestBranch"
+      message: "travisCommitMessage"
     })
 
   it "wercker", ->


### PR DESCRIPTION
- close #5728 

### User facing changelog

Cypress now captures the SHA of the build generated through Travis CI during pull requests. This should resolve issues with Cypress status checks sometimes not running with our GitHub Integration.

### Additional Details

I experimented [here](https://github.com/cypress-io/cypress-example-kitchensink/pull/328) and verified a few things:

- The `TRAVIS_PULL_REQUEST_SHA` and `TRAVIS_COMMIT` are different when initiated by the Travis PR build
- The `TRAVIS_PULL_REQUEST_SHA` is empty when initiated by a Travis commit build (this means we can write an `||` statement and always get the correct one)
- Passing the `TRAVIS_PULL_REQUEST_SHA` to the `COMMIT_SHA` for Cypress use initiates the status check during a PR build (previously did not run any status check on PR initiated builds)

### How has the user experience changed?

N/A

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?