### PR TITLE
Extend cy.its and cy.invoke to accept a number as 1st arg

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -4,7 +4,7 @@
 //                 Mike Woudenberg <https://github.com/mikewoudenberg>
 //                 Robbert van Markus <https://github.com/rvanmarkus>
 //                 Nicholas Boll <https://github.com/nicholasboll>
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 // Updated by the Cypress team: https://www.cypress.io/about/
 
 /// <reference path="./cy-blob-util.d.ts" />
@@ -867,6 +867,12 @@ declare namespace Cypress {
     hash(options?: Partial<Loggable & Timeoutable>): Chainable<string>
 
     /**
+     * Invoke a function in an array of functions.
+     * @see https://on.cypress.io/invoke
+     */
+    invoke<T extends (...args: any[]) => any, Subject extends T[]>(index: number): Chainable<ReturnType<T>>
+
+    /**
      * Invoke a function on the previously yielded subject.
      * This isn't possible to strongly type without generic override yet.
      * If called on an object you can do this instead: `.then(s => s.show())`.
@@ -888,6 +894,13 @@ declare namespace Cypress {
      *    cy.wrap({foo: {bar: {baz: 1}}}).its('foo.bar.baz')
      */
     its<K extends keyof Subject>(propertyName: K): Chainable<Subject[K]>
+    /**
+     * Get a value by index from an array yielded from the previous command.
+     * @see https://on.cypress.io/its
+     * @example
+     *    cy.wrap(['a', 'b']).its(1).should('equal', 'b')
+     */
+    its<T, Subject extends T[]>(index: number): Chainable<T>
 
     /**
      * Get the last DOM element within a set of DOM elements.

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -98,6 +98,10 @@ cy.wrap({ foo: [1, 2, 3] })
     s
   })
 
+cy.wrap(['foo', 'bar']).its(1)
+
+cy.wrap([()=>{}, ()=>{}]).invoke(1)
+
 cy.wrap({ foo: ['bar', 'baz'] })
   .its('foo')
   .then(([first, second]) => {

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -98,7 +98,7 @@ cy.wrap({ foo: [1, 2, 3] })
     s
   })
 
-cy.wrap(['foo', 'bar']).its(1)
+cy.wrap(['foo', 'bar']).its(1) // $ExpectType string
 
 cy.wrap([()=>{}, ()=>{}]).invoke(1)
 

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -92,15 +92,29 @@ namespace CypressLocalStorageTest {
   }
 }
 
-cy.wrap({ foo: [1, 2, 3] })
-  .its('foo')
-  .each((s: number) => {
+namespace CypressItsTests {
+  cy.wrap({ foo: [1, 2, 3] })
+    .its('foo')
+    .each((s: number) => {
+      s
+    })
+
+  cy.wrap({foo: 'bar'}).its('foo') // $ExpectType Chainable<string>
+  cy.wrap([1, 2]).its(1) // $ExpectType Chainable<number>
+  cy.wrap(['foo', 'bar']).its(1) // $ExpectType Chainable<string>
+  .then((s: string) => {
     s
   })
+}
 
-cy.wrap(['foo', 'bar']).its(1) // $ExpectType string
+namespace CypressInvokeTests {
+  const returnsString = () => 'foo'
+  const returnsNumber = () => 42
 
-cy.wrap([()=>{}, ()=>{}]).invoke(1)
+  // unfortunately could not define more precise type
+  // in this case it should have been "number", but so far no luck
+  cy.wrap([returnsString, returnsNumber]).invoke(1) // $ExpectType Chainable<any>
+}
 
 cy.wrap({ foo: ['bar', 'baz'] })
   .its('foo')

--- a/packages/driver/src/cy/commands/connectors.coffee
+++ b/packages/driver/src/cy/commands/connectors.coffee
@@ -160,7 +160,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
       consoleProps: ->
         Subject: subject
 
-    if not _.isString(str)
+    if not _.isString(str) and not _.isNumber(str)
       $utils.throwErrByPath("invoke_its.invalid_1st_arg", {
         onFail: options._log
         args: { cmd: name }
@@ -295,7 +295,10 @@ module.exports = (Commands, Cypress, cy, state, config) ->
 
       actualSubject = remoteSubject or subject
 
-      paths = str.split(".")
+      if _.isString(str)
+        paths = str.split(".")
+      else
+        paths = [str]
 
       prop = traverseObjectAtPath(actualSubject, paths)
 

--- a/packages/driver/src/cypress/error_messages.coffee
+++ b/packages/driver/src/cypress/error_messages.coffee
@@ -409,7 +409,7 @@ module.exports = {
 
       cy.wrap({ foo: {{value}} }).its('foo.baz').should('not.exist')
       """
-    invalid_1st_arg: "#{cmd('{{cmd}}')} only accepts a string as the first argument."
+    invalid_1st_arg: "#{cmd('{{cmd}}')} only accepts a string or a number as the first argument."
     invalid_num_of_args:
       """
       #{cmd('{{cmd}}')} only accepts a single argument.

--- a/packages/driver/test/cypress/integration/commands/connectors_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/connectors_spec.coffee
@@ -337,6 +337,14 @@ describe "src/cy/commands/connectors", ->
           cy.noop(@obj).invoke("foo").then (str) ->
             expect(str).to.eq "foo"
 
+        it "works with numerical indexes", ->
+          i = 0
+          fn = ->
+            i++
+            return i == 5
+
+          cy.noop([_.noop, fn]).invoke(1).should('be.true')
+
         it "forwards any additional arguments", ->
           cy.noop(@obj).invoke("bar", 1, 2).then (num) ->
             expect(num).to.eq 3
@@ -604,11 +612,11 @@ describe "src/cy/commands/connectors", ->
 
           cy.invoke("queue")
 
-        it "throws when first argument isnt a string", (done) ->
+        it "throws when first argument isnt a string or a number", (done) ->
           cy.on "fail", (err) =>
             lastLog = @lastLog
 
-            expect(err.message).to.eq "cy.invoke() only accepts a string as the first argument."
+            expect(err.message).to.eq "cy.invoke() only accepts a string or a number as the first argument."
             expect(lastLog.get("error")).to.eq err
             done()
 
@@ -697,6 +705,9 @@ describe "src/cy/commands/connectors", ->
       it "proxies to #invokeFn", ->
         fn = -> "bar"
         cy.wrap({foo: fn}).its("foo").should("eq", fn)
+
+      it "works with numerical indexes", ->
+        cy.wrap(['foo', 'bar']).its(1).should('eq', 'bar')
 
       it "reduces into dot separated values", ->
         obj = {


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #5754 

### User facing changelog

- `cy.its()` and `cy.invoke()` now support a number for the first argument.

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/2264
- [x] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
