### PR TITLE
catch child process killed with a signal

### DIFF
--- a/cli/__snapshots__/errors_spec.js
+++ b/cli/__snapshots__/errors_spec.js
@@ -72,3 +72,28 @@ If you are using Docker, we provide containers with all required dependencies in
 Platform: test platform (Foo-OsVersion)
 Cypress Version: 1.2.3
 `
+
+exports['child kill error object'] = {
+  "description": "The Test Runner received event [36mexit[39m with signal [36mSIGKILL[39m",
+  "solution": "Please search Cypress documentation for possible solutions:\n\n  [34mhttps://on.cypress.io[39m\n\nCheck if there is a GitHub issue describing this crash:\n\n  [34mhttps://github.com/cypress-io/cypress/issues[39m\n\nConsider opening a new issue.",
+  "exitCode": 12
+}
+
+exports['Error message'] = `
+The Test Runner received event [36mexit[39m with signal [36mSIGKILL[39m
+
+Please search Cypress documentation for possible solutions:
+
+[34mhttps://on.cypress.io[39m
+
+Check if there is a GitHub issue describing this crash:
+
+[34mhttps://github.com/cypress-io/cypress/issues[39m
+
+Consider opening a new issue.
+
+----------
+
+Platform: test platform (Foo-OsVersion)
+Cypress Version: 1.2.3
+`

--- a/cli/__snapshots__/errors_spec.js
+++ b/cli/__snapshots__/errors_spec.js
@@ -29,6 +29,7 @@ Cypress Version: 1.2.3
 exports['errors individual has the following errors 1'] = [
   "CYPRESS_RUN_BINARY",
   "binaryNotExecutable",
+  "childProcessKilled",
   "failedDownload",
   "failedUnzip",
   "invalidCacheDirectory",

--- a/cli/__snapshots__/errors_spec.js
+++ b/cli/__snapshots__/errors_spec.js
@@ -74,12 +74,12 @@ Cypress Version: 1.2.3
 `
 
 exports['child kill error object'] = {
-  "description": "The Test Runner received event [36mexit[39m with signal [36mSIGKILL[39m",
+  "description": "The Test Runner unexpectedly exited via a [36mexit[39m event with signal [36mSIGKILL[39m",
   "solution": "Please search Cypress documentation for possible solutions:\n\n  [34mhttps://on.cypress.io[39m\n\nCheck if there is a GitHub issue describing this crash:\n\n  [34mhttps://github.com/cypress-io/cypress/issues[39m\n\nConsider opening a new issue."
 }
 
 exports['Error message'] = `
-The Test Runner received event [36mexit[39m with signal [36mSIGKILL[39m
+The Test Runner unexpectedly exited via a [36mexit[39m event with signal [36mSIGKILL[39m
 
 Please search Cypress documentation for possible solutions:
 

--- a/cli/__snapshots__/errors_spec.js
+++ b/cli/__snapshots__/errors_spec.js
@@ -75,8 +75,7 @@ Cypress Version: 1.2.3
 
 exports['child kill error object'] = {
   "description": "The Test Runner received event [36mexit[39m with signal [36mSIGKILL[39m",
-  "solution": "Please search Cypress documentation for possible solutions:\n\n  [34mhttps://on.cypress.io[39m\n\nCheck if there is a GitHub issue describing this crash:\n\n  [34mhttps://github.com/cypress-io/cypress/issues[39m\n\nConsider opening a new issue.",
-  "exitCode": 12
+  "solution": "Please search Cypress documentation for possible solutions:\n\n  [34mhttps://on.cypress.io[39m\n\nCheck if there is a GitHub issue describing this crash:\n\n  [34mhttps://github.com/cypress-io/cypress/issues[39m\n\nConsider opening a new issue."
 }
 
 exports['Error message'] = `

--- a/cli/__snapshots__/spawn_spec.js
+++ b/cli/__snapshots__/spawn_spec.js
@@ -1,5 +1,5 @@
 exports['lib/exec/spawn .start detects kill signal exits with error on SIGKILL 1'] = `
-The Test Runner received event [36mexit[39m with signal [36mSIGKILL[39m
+The Test Runner unexpectedly exited via a [36mexit[39m event with signal [36mSIGKILL[39m
 
 Please search Cypress documentation for possible solutions:
 

--- a/cli/__snapshots__/spawn_spec.js
+++ b/cli/__snapshots__/spawn_spec.js
@@ -1,0 +1,18 @@
+exports['lib/exec/spawn .start detects kill signal exits with error on SIGKILL 1'] = `
+The Test Runner received event [36mexit[39m with signal [36mSIGKILL[39m
+
+Please search Cypress documentation for possible solutions:
+
+[34mhttps://on.cypress.io[39m
+
+Check if there is a GitHub issue describing this crash:
+
+[34mhttps://github.com/cypress-io/cypress/issues[39m
+
+Consider opening a new issue.
+
+----------
+
+Platform: darwin (Foo-OsVersion)
+Cypress Version: 0.0.0
+`

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -201,7 +201,7 @@ const invalidCypressEnv = {
 */
 const childProcessKilled = (eventName, signal) => {
   return {
-    description: `The Test Runner received event ${chalk.cyan(eventName)} with signal ${chalk.cyan(signal)}`,
+    description: `The Test Runner unexpectedly exited via a ${chalk.cyan(eventName)} event with signal ${chalk.cyan(signal)}`,
     solution: solutionUnknown,
   }
 }

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -203,7 +203,6 @@ const childProcessKilled = (eventName, signal) => {
   return {
     description: `The Test Runner received event ${chalk.cyan(eventName)} with signal ${chalk.cyan(signal)}`,
     solution: solutionUnknown,
-    exitCode: 12,
   }
 }
 

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -256,6 +256,18 @@ function addPlatformInformation (info) {
   })
 }
 
+/**
+ * Given an error object (see the errors above), forms error message text with details,
+ * then resolves with Error instance you can throw or reject with.
+ * @param {object} errorObject
+ * @returns {Promise<Error>} resolves with an Error
+ * @example
+  ```js
+  // inside a Promise with "resolve" and "reject"
+  const errorObject = childProcessKilled('exit', 'SIGKILL')
+  return getError(errorObject).then(reject)
+  ```
+ */
 function getError (errorObject) {
   return formErrorText(errorObject).then((errorMessage) => {
     const err = new Error(errorMessage)

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -141,7 +141,7 @@ module.exports = {
           return function (code, signal) {
             debug('child event fired %o', { event, code, signal })
 
-            if (code === null && signal) {
+            if (code === null) {
               const errorObject = errors.errors.childProcessKilled(event, signal)
 
               return errors.getError(errorObject).then(reject)

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -145,7 +145,6 @@ module.exports = {
               const errorObject = errors.errors.childProcessKilled(event, signal)
 
               return errors.getError(errorObject).then(reject)
-              // return reject(new Error('nope'))
             }
 
             resolve(code)

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -10,7 +10,7 @@ const util = require('../util')
 const state = require('../tasks/state')
 const xvfb = require('./xvfb')
 const verify = require('../tasks/verify')
-const { throwFormErrorText, errors } = require('../errors')
+const errors = require('../errors')
 
 const isXlibOrLibudevRe = /^(?:Xlib|libudev)/
 const isHighSierraWarningRe = /\*\*\* WARNING/
@@ -140,6 +140,14 @@ module.exports = {
         function resolveOn (event) {
           return function (code, signal) {
             debug('child event fired %o', { event, code, signal })
+
+            if (code === null && signal) {
+              const errorObject = errors.errors.childProcessKilled(event, signal)
+
+              return errors.getError(errorObject).then(reject)
+              // return reject(new Error('nope'))
+            }
+
             resolve(code)
           }
         }
@@ -251,7 +259,9 @@ module.exports = {
 
         return code
       })
-      .catch(throwFormErrorText(errors.unexpected))
+      // we can format and handle an error message from the code above
+      // prevent wrapping error again by using "known: undefined" filter
+      .catch({ known: undefined }, errors.throwFormErrorText(errors.errors.unexpected))
     }
 
     if (needsXvfb) {

--- a/cli/test/lib/errors_spec.js
+++ b/cli/test/lib/errors_spec.js
@@ -2,7 +2,7 @@ require('../spec_helper')
 
 const os = require('os')
 const snapshot = require('../support/snapshot')
-const { errors, formErrorText } = require(`${lib}/errors`)
+const { errors, getError, formErrorText } = require(`${lib}/errors`)
 const util = require(`${lib}/util`)
 
 describe('errors', function () {
@@ -16,6 +16,20 @@ describe('errors', function () {
   describe('individual', () => {
     it('has the following errors', () => {
       return snapshot(Object.keys(errors).sort())
+    })
+  })
+
+  context('getError', () => {
+    it('forms full message and creates Error object', () => {
+      const errObject = errors.childProcessKilled('exit', 'SIGKILL')
+
+      snapshot('child kill error object', errObject)
+
+      return getError(errObject).then((e) => {
+        expect(e).to.be.an('Error')
+        expect(e).to.have.property('known', true)
+        snapshot('Error message', e.message)
+      })
     })
   })
 


### PR DESCRIPTION
- Closes #5808

### User facing changelog

If the Test Runner child process is killed with a signal like `SIGKILL` or `SIGBUS`, the NPM CLI process shows an error and exits with non-zero code, no longer swallowing the error.

### Additional details

Child Electron process could crash for some reason (like running out of memory) while running tests, and close. In that case the CLI parent process would receive `code: null, signal: <name>` which is different from successful exit `code: 0, signal: null` or a failded test exit `code: 1, signal: null`. But the CLI parent process would just do truthy check `if (code) { reject ... }` thus swallowing the crash.

### How has the user experience changed?

The users should get better CI information, that no longer shows passing green build while the tests crashed in Electron browser.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->

## Local testing

- run Cypress with `npm start`. This will start the GUI in global mode
- find the PID of the process id with `ps` like this
```
68518 ttys000    0:00.26 npm  
68521 ttys000    0:00.35 node ./cli/bin/cypress open --dev --global
68522 ttys000    0:01.19 node /Users/gleb/git/cypress/scripts/start.js --cwd /Users/gleb/git/cypress 
68523 ttys000    0:04.56 /Users/gleb/git/cypress/packages/electron/dist/Cypress/Cypress.app/Contents/
68524 ttys000    0:00.31 /Users/gleb/git/cypress/packages/electron/dist/Cypress/Cypress.app/Contents/
68526 ttys000    0:00.62 /Users/gleb/git/cypress/packages/electron/dist/Cypress/Cypress.app/Contents/
```

- kill the `node /Users/gleb/git/cypress/scripts/start.js` process like `kill -9 68522`
- CLI should show the following error
```
The Test Runner received event exit with signal SIGKILL

Please search Cypress documentation for possible solutions:

https://on.cypress.io

Check if there is a GitHub issue describing this crash:

https://github.com/cypress-io/cypress/issues

Consider opening a new issue.

----------

Platform: darwin (16.7.0)
Cypress Version: 0.0.0
```
and the exit code should be non-zero
```
$ echo $?
1
```
