### PR TITLE
Prevent Appveyor build from failing when NextDevVersion is undefined

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -90,8 +90,8 @@ test_script:
   # make sure our snapshots are compared correctly
   # - npm run test-mocha-snapshot
   # the other larger tests
-  - echo Building Windows NPM package %NEXT_DEV_VERSION%
-  - npm --no-git-tag-version version %NEXT_DEV_VERSION%
+  - echo Building Windows NPM package ${NEXT_DEV_VERSION:-0.0.0-development}
+  - npm --no-git-tag-version version ${NEXT_DEV_VERSION:-0.0.0-development}
   - cd cli
   - npm install
   - npm run build


### PR DESCRIPTION
- Append  0.0.0-development to NextDevVersion so that it is not read as undefined in Windows