### PR TITLE
cli: unnzip Cypress using `unzip` utility on Linux

### DIFF
--- a/cli/lib/tasks/unzip.js
+++ b/cli/lib/tasks/unzip.js
@@ -12,6 +12,10 @@ const { throwFormErrorText, errors } = require('../errors')
 const fs = require('../fs')
 const util = require('../util')
 
+const unzipTools = {
+  extract,
+}
+
 // expose this function for simple testing
 const unzip = ({ zipFilePath, installDir, progress }) => {
   debug('unzipping from %s', zipFilePath)
@@ -32,9 +36,6 @@ const unzip = ({ zipFilePath, installDir, progress }) => {
 
         if (err) return reject(err)
 
-        // debug('zipfile.paths:', zipFile)
-        // zipFile.on('entry', debug)
-        // debug(zipFile.readEntry())
         const total = zipFile.entryCount
 
         debug('zipFile entries count', total)
@@ -77,7 +78,7 @@ const unzip = ({ zipFilePath, installDir, progress }) => {
             onEntry: tick,
           }
 
-          return extract(zipFilePath, opts, endFn)
+          return unzipTools.extract(zipFilePath, opts, endFn)
         }
 
         const unzipWithUnzipTool = () => {
@@ -198,4 +199,8 @@ const start = ({ zipFilePath, installDir, progress }) => {
 
 module.exports = {
   start,
+  utils: {
+    unzip,
+    unzipTools,
+  },
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Fixes #3803 on Linux

### User facing changelog

- Cypress will attempt to use the `unzip` binary during `cypress install` before trying the slower, Node.js-based unzipping method.

### Additional details

- time spent unzipping (unzipMs):
	- with node.js unzipping: 25667ms
	- with `unzip`: 5320ms
	- will definitely help people with slow CI
- technically, `unzip` could work on macOS or windows, but it's probably not going to exist on either so I'm not sure we should even attempt it

### How has the user experience changed?

`cypress install` is much faster

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
	- not sure how to test - existing `ditto` stuff doesn't have a test
    - I have written a test for a situation when `unzip` is unavailable, but had to skip it - it was causing weird `verify_spec` failures
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
