### PR TITLE
[WIP] Set values passed in as CYPRESS_CONFIG_FILE to Cypress env var

### DIFF
--- a/packages/server/lib/config.coffee
+++ b/packages/server/lib/config.coffee
@@ -91,55 +91,55 @@ systemConfigKeys = toWords """
 """
 
 CONFIG_DEFAULTS = {
-  port:                          null
-  hosts:                         null
-  morgan:                        true
+  animationDistanceThreshold:    5
+  autoOpen:                      false
   baseUrl:                       null
   # will be replaced by detected list of browsers
+  blacklistHosts:                null
   browsers:                      []
-  socketId:                      null
-  projectId:                     null
-  userAgent:                     null
+  chromeWebSecurity:             true
+  clientRoute:                   "/__/"
+  configFile:                    "cypress.json"
+  defaultCommandTimeout:         4000
+  execTimeout:                   60000
+  fileServerFolder:              ""
+  fixturesFolder:                "cypress/fixtures"
+  hosts:                         null
+  ignoreTestFiles:               "*.hot-update.js"
+  integrationFolder:             "cypress/integration"
   isTextTerminal:                false
+  modifyObstructiveCode:         true
+  morgan:                        true
+  namespace:                     "__cypress"
+  nodeVersion:                   "default"
+  numTestsKeptInMemory:          50
+  pageLoadTimeout:               60000
+  pluginsFile:                   "cypress/plugins"
+  port:                          null
+  projectId:                     null
   reporter:                      "spec"
   reporterOptions:               null
-  blacklistHosts:                null
-  clientRoute:                   "/__/"
-  xhrRoute:                      "/xhrs/"
-  socketIoRoute:                 "/__socket.io"
-  socketIoCookie:                "__socket.io"
   reporterRoute:                 "/__cypress/reporter"
-  ignoreTestFiles:               "*.hot-update.js"
-  testFiles:                     "**/*.*"
-  defaultCommandTimeout:         4000
   requestTimeout:                5000
   responseTimeout:               30000
-  pageLoadTimeout:               60000
-  execTimeout:                   60000
+  screenshotsFolder:             "cypress/screenshots"
+  socketId:                      null
+  socketIoRoute:                 "/__socket.io"
+  socketIoCookie:                "__socket.io"
+  supportFile:                   "cypress/support"
   taskTimeout:                   60000
+  testFiles:                     "**/*.*"
+  trashAssetsBeforeRuns:         true
+  userAgent:                     null
+  viewportHeight:                660
+  viewportWidth:                 1000
   video:                         true
   videoCompression:              32
-  videoUploadOnPasses:           true
-  modifyObstructiveCode:         true
-  chromeWebSecurity:             true
-  waitForAnimations:             true
-  animationDistanceThreshold:    5
-  numTestsKeptInMemory:          50
-  watchForFileChanges:           true
-  trashAssetsBeforeRuns:         true
-  autoOpen:                      false
-  viewportWidth:                 1000
-  viewportHeight:                660
-  fileServerFolder:              ""
   videosFolder:                  "cypress/videos"
-  supportFile:                   "cypress/support"
-  fixturesFolder:                "cypress/fixtures"
-  integrationFolder:             "cypress/integration"
-  screenshotsFolder:             "cypress/screenshots"
-  namespace:                     "__cypress"
-  pluginsFile:                   "cypress/plugins"
-  nodeVersion:                   "default"
-  configFile:                    "cypress.json"
+  videoUploadOnPasses:           true
+  waitForAnimations:             true
+  watchForFileChanges:           true
+  xhrRoute:                      "/xhrs/"
 
   ## deprecated
   javascripts:                   []

--- a/packages/server/lib/config.coffee
+++ b/packages/server/lib/config.coffee
@@ -88,7 +88,6 @@ breakingConfigKeys = toWords """
 # Internal configuration properties the user should be able to overwrite
 systemConfigKeys = toWords """
   browsers
-  configFile
 """
 
 CONFIG_DEFAULTS = {

--- a/packages/server/lib/config.coffee
+++ b/packages/server/lib/config.coffee
@@ -88,6 +88,7 @@ breakingConfigKeys = toWords """
 # Internal configuration properties the user should be able to overwrite
 systemConfigKeys = toWords """
   browsers
+  configFile
 """
 
 CONFIG_DEFAULTS = {

--- a/packages/server/test/unit/config_spec.coffee
+++ b/packages/server/test/unit/config_spec.coffee
@@ -763,6 +763,7 @@ describe "lib/config", ->
           expect(cfg.resolved).to.deep.eq({
             env:                        { }
             projectId:                  { value: null, from: "default" },
+            configFile:                 { value: "cypress.json", from: "default" },
             port:                       { value: 1234, from: "cli" },
             hosts:                      { value: null, from: "default" }
             blacklistHosts:             { value: null, from: "default" },
@@ -807,6 +808,7 @@ describe "lib/config", ->
           RECORD_KEY: "foobarbazquux",
           CI_KEY: "justanothercikey",
           PROJECT_ID: "projectId123"
+          CONFIG_FILE: "test.json"
         })
 
         obj = {
@@ -832,6 +834,7 @@ describe "lib/config", ->
           expect(cfg.resolved).to.deep.eq({
             projectId:                  { value: "projectId123", from: "env" },
             port:                       { value: 2020, from: "config" },
+            configFile:                 { value: "test.json", from: "env" },
             hosts:                      { value: null, from: "default" }
             blacklistHosts:             { value: null, from: "default" }
             browsers:                   { value: [], from: "default" }

--- a/packages/server/test/unit/config_spec.coffee
+++ b/packages/server/test/unit/config_spec.coffee
@@ -763,7 +763,6 @@ describe "lib/config", ->
           expect(cfg.resolved).to.deep.eq({
             env:                        { }
             projectId:                  { value: null, from: "default" },
-            configFile:                 { value: "cypress.json", from: "default" },
             port:                       { value: 1234, from: "cli" },
             hosts:                      { value: null, from: "default" }
             blacklistHosts:             { value: null, from: "default" },
@@ -804,11 +803,11 @@ describe "lib/config", ->
 
       it "sets config, envFile and env", ->
         sinon.stub(config, "getProcessEnvVars").returns({
-          quux: "quux"
+          quux: "quux",
+          CONFIG_FILE: "myOwnConfig.yml",
           RECORD_KEY: "foobarbazquux",
           CI_KEY: "justanothercikey",
           PROJECT_ID: "projectId123"
-          CONFIG_FILE: "test.json"
         })
 
         obj = {
@@ -834,7 +833,6 @@ describe "lib/config", ->
           expect(cfg.resolved).to.deep.eq({
             projectId:                  { value: "projectId123", from: "env" },
             port:                       { value: 2020, from: "config" },
-            configFile:                 { value: "test.json", from: "env" },
             hosts:                      { value: null, from: "default" }
             blacklistHosts:             { value: null, from: "default" }
             browsers:                   { value: [], from: "default" }
@@ -886,6 +884,10 @@ describe "lib/config", ->
               quux: {
                 value: "quux"
                 from: "env"
+              }
+              CONFIG_FILE: {
+                value: "myOwnConfig.yml",
+                from: "env",
               }
               RECORD_KEY: {
                 value: "fooba...zquux",


### PR DESCRIPTION
- Closes #5706

### User facing changelog

- Cypress environment variables are now properly read in when passed as `CYPRESS_CONFIG_FILE` in the command line.

### Additional details

Truthfully, this is likely a larger issue that has not been addressed, but basically when someone passes an env var with the `CYPRESS_` prefix that matches one of the configuration values that is *not* actually allowed in the configuration file, then it should read it in as a Cypress environment variable. 

They want to do:

```shell
CYPRESS_CONFIG_FILE=myOwnConfig.yml
```

Later in tests do the below, which has nothing to do with Cypress's configuration file.

```js
Cypress.env('CONFIG_FILE')
```

If we can not accommodate this, then we should somehow describe the behavior to the user.

### How has the user experience changed?

#### Before


#### After

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
