### PR TITLE
Fix CDP cookie matching algorithm

### DIFF
--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -20,16 +20,16 @@ interface CyCookie {
 
 type SendDebuggerCommand = (message: string, data?: any) => Bluebird<any>
 
-const cookieMatches = (cookie: CyCookie, data) => {
-  if (data.domain && !tough.domainMatch(cookie.domain, data.domain)) {
+const cookieMatches = (cookie: CyCookie, filter) => {
+  if (filter.domain && !tough.domainMatch(filter.domain, cookie.domain)) {
     return false
   }
 
-  if (data.path && !tough.pathMatch(cookie.path, data.path)) {
+  if (filter.path && !tough.pathMatch(filter.path, cookie.path)) {
     return false
   }
 
-  if (data.name && data.name !== cookie.name) {
+  if (filter.name && filter.name !== cookie.name) {
     return false
   }
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -143,6 +143,7 @@
     "@cypress/json-schemas": "5.33.0",
     "@cypress/sinon-chai": "1.1.0",
     "@types/chai-as-promised": "7.1.2",
+    "@types/chrome": "0.0.91",
     "babel-plugin-add-module-exports": "1.0.2",
     "babelify": "10.0.0",
     "bin-up": "1.2.2",

--- a/packages/server/test/unit/browsers/cdp_automation_spec.coffee
+++ b/packages/server/test/unit/browsers/cdp_automation_spec.coffee
@@ -1,7 +1,63 @@
 require("../../spec_helper")
-{ CdpAutomation } = require("#{root}../lib/browsers/cdp_automation")
+{
+  CdpAutomation,
+  _cookieMatches,
+  _domainIsWithinSuperdomain
+} = require("#{root}../lib/browsers/cdp_automation")
 
 context "lib/browsers/cdp_automation", ->
+  context "._domainIsWithinSuperdomain", ->
+    it "matches as expected", ->
+      [
+        {
+          domain: 'a.com'
+          suffix: 'a.com'
+          expected: true
+        }
+        {
+          domain: 'a.com'
+          suffix: 'b.com'
+          expected: false
+        }
+        {
+          domain: 'c.a.com'
+          suffix: 'a.com'
+          expected: true
+        }
+        {
+          domain: 'localhost'
+          suffix: 'localhost'
+          expected: true
+        }
+        {
+          domain: '.localhost'
+          suffix: '.localhost'
+          expected: true
+        }
+        {
+          domain: '.localhost'
+          suffix: 'reddit.com'
+          expected: false
+        }
+      ].forEach ({ domain, suffix, expected }, i) =>
+        expect(_domainIsWithinSuperdomain(domain, suffix)).to.eq(expected)
+
+  context "._cookieMatches", ->
+    it "matches as expected", ->
+      [
+        {
+          cookie: { domain: 'example.com' }
+          filter: { domain: 'example.com' }
+          expected: true
+        }
+        {
+          cookie: { domain: 'example.com' }
+          filter: { domain: '.example.com' }
+          expected: true
+        }
+      ].forEach ({ cookie, filter, expected }) =>
+        expect(_cookieMatches(cookie, filter)).to.eq(expected)
+
   context ".CdpAutomation", ->
     beforeEach ->
       @sendDebuggerCommand = sinon.stub()

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -6,5 +6,8 @@
   ],
   "files": [
     "./../ts/index.d.ts"
-  ]
+  ],
+  "compilerOptions": {
+    "types": ["mocha", "node", "chrome"]
+  }
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #5656

### User facing changelog

<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

- previously, we were using `tough.cookieMatch` to filter cookies: https://github.com/cypress-io/cypress/blob/d56c551b0bb77a838da8de15bff137f1d96f9d47/packages/server/lib/browsers/cdp_automation.ts#L23-L37
- however, this is *incorrect*
	- Cypress was designed around the internal 'cookie filter' having the same structure as the filter for WebExtensions cookies.getAll: https://developer.chrome.com/extensions/cookies#method-getAll
	- the WebExtensions filter uses `domain` like this: "Restricts the retrieved cookies to those whose domains match or are subdomains of this one."
	- we were using tough.domainMatch, which matches like an actual browser, instead

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->