### PR TITLE
Font awesome 5 icon improvements

### DIFF
--- a/packages/desktop-gui/cypress/integration/project_nav_spec.js
+++ b/packages/desktop-gui/cypress/integration/project_nav_spec.js
@@ -167,7 +167,7 @@ describe('Project Nav', function () {
 
         it('displays browser icon as spinner', () => {
           cy.get('.browsers-list>a').first().find('i')
-          .should('have.class', 'fas fa-sync fa-spin')
+          .should('have.class', 'fas fa-sync-alt fa-spin')
         })
 
         it('disables browser dropdown', () => {

--- a/packages/desktop-gui/src/app/nav.scss
+++ b/packages/desktop-gui/src/app/nav.scss
@@ -26,8 +26,6 @@
   border-color: #c8c8c8;
   z-index: 10;
 
-
-
   .nav {
     > .open {
       > a, > a:hover {
@@ -36,9 +34,11 @@
       }
     }
 
-    i {
-      font-size: 11px;
-      color: #555;
+    &.left-nav {
+      i {
+        font-size: 11px;
+        color: #555;
+      }
     }
 
     > li {

--- a/packages/desktop-gui/src/app/nav.scss
+++ b/packages/desktop-gui/src/app/nav.scss
@@ -26,12 +26,19 @@
   border-color: #c8c8c8;
   z-index: 10;
 
+
+
   .nav {
     > .open {
       > a, > a:hover {
         background-color: #dedede;
         color: #262626;
       }
+    }
+
+    i {
+      font-size: 11px;
+      color: #555;
     }
 
     > li {
@@ -41,6 +48,8 @@
         color: #444;
         padding: 1px 20px 0 20px;
         line-height: 35px;
+
+
       }
 
       > a  {
@@ -67,6 +76,12 @@
         padding-left: 15px;
         padding-right: 15px;
       }
+    }
+  }
+
+  .browsers.nav {
+    i {
+      font-size: 13px;
     }
   }
 }
@@ -119,6 +134,10 @@
         background-color: #111;
         color: #fff;
       }
+    }
+
+    i {
+      font-size: 12px;
     }
 
     > li > div,

--- a/packages/desktop-gui/src/auth/login-modal.jsx
+++ b/packages/desktop-gui/src/auth/login-modal.jsx
@@ -104,7 +104,7 @@ class LoginContent extends Component {
             className='btn btn-default btn-sm'
             onClick={this._pingApiServer}
           >
-            <i className='fas fa-sync'></i>{' '}
+            <i className='fas fa-sync-alt'></i>{' '}
             Try again
           </button>
         </p>

--- a/packages/desktop-gui/src/lib/utils.js
+++ b/packages/desktop-gui/src/lib/utils.js
@@ -65,7 +65,7 @@ export const getStatusIcon = (status) => {
     case 'passed':
       return 'check-circle'
     case 'running':
-      return 'sync fa-spin'
+      return 'sync-alt fa-spin'
     case 'overLimit':
       return 'exclamation-triangle'
     case 'timedOut':

--- a/packages/desktop-gui/src/project-nav/browsers.jsx
+++ b/packages/desktop-gui/src/project-nav/browsers.jsx
@@ -58,7 +58,7 @@ export default class Browsers extends Component {
     let prefixText
 
     if (project.browserState === 'opening') {
-      icon = 'fas fa-sync fa-spin'
+      icon = 'fas fa-sync-alt fa-spin'
       prefixText = 'Opening'
     } else if (project.browserState === 'opened') {
       icon = 'fas fa-check-circle green far'

--- a/packages/desktop-gui/src/project-nav/project-nav.jsx
+++ b/packages/desktop-gui/src/project-nav/project-nav.jsx
@@ -9,7 +9,7 @@ export default class ProjectNav extends Component {
 
     return (
       <nav className='project-nav navbar navbar-default'>
-        <ul className='nav'>
+        <ul className='nav left-nav'>
           <li>
             <Link to={routes.specs(project)}>
               <i className='fas fa-code'></i>{' '}

--- a/packages/desktop-gui/src/project/error-message.jsx
+++ b/packages/desktop-gui/src/project/error-message.jsx
@@ -81,7 +81,7 @@ class ErrorMessage extends Component {
             className='btn btn-default btn-sm'
             onClick={this.props.onTryAgain}
           >
-            <i className='fas fa-sync'></i>{' '}
+            <i className='fas fa-sync-alt'></i>{' '}
             Try Again
           </button>
         </div>

--- a/packages/desktop-gui/src/runs/runs-list.jsx
+++ b/packages/desktop-gui/src/runs/runs-list.jsx
@@ -215,7 +215,7 @@ class RunsList extends Component {
               disabled={this.runsStore.isLoading}
               onClick={this._getRuns}
             >
-              <i aria-hidden="true" className={`fas fa-sync ${this.runsStore.isLoading ? 'fa-spin' : ''}`}></i>
+              <i aria-hidden="true" className={`fas fa-sync-alt ${this.runsStore.isLoading ? 'fa-spin' : ''}`}></i>
             </button>
           </h5>
           <div>
@@ -258,7 +258,7 @@ class RunsList extends Component {
             className='btn btn-default btn-sm'
             onClick={this._pingApiServer}
           >
-            <i className='fas fa-sync'></i>{' '}
+            <i className='fas fa-sync-alt'></i>{' '}
             Try again
           </button>
         </p>

--- a/packages/desktop-gui/src/runs/setup-project-modal.jsx
+++ b/packages/desktop-gui/src/runs/setup-project-modal.jsx
@@ -98,7 +98,7 @@ class SetupProject extends Component {
               >
                 {
                   this.state.isSubmitting ?
-                    <span><i className='fas fa-spin fa-sync'></i>{' '}</span> :
+                    <span><i className='fas fa-spin fa-sync-alt'></i>{' '}</span> :
                     null
                 }
                 <span>Set up project</span>

--- a/packages/desktop-gui/src/specs/specs-list.jsx
+++ b/packages/desktop-gui/src/specs/specs-list.jsx
@@ -88,7 +88,7 @@ class SpecsList extends Component {
   }
 
   _specIcon (isChosen) {
-    return isChosen ? 'fa-dot-circle green' : 'fa-file-code'
+    return isChosen ? 'far fa-dot-circle green' : 'far fa-file'
   }
 
   _clearFilter = () => {
@@ -154,7 +154,7 @@ class SpecsList extends Component {
         <a href='#' onClick={this._selectSpec.bind(this, spec)} className={cs({ active: specsStore.isChosen(spec) })}>
           <div>
             <div className="file-name">
-              <i className={`far fa-fw ${this._specIcon(specsStore.isChosen(spec))}`}></i>
+              <i className={`fa-fw ${this._specIcon(specsStore.isChosen(spec))}`}></i>
               {spec.displayName}
             </div>
           </div>

--- a/packages/desktop-gui/src/specs/specs.scss
+++ b/packages/desktop-gui/src/specs/specs.scss
@@ -95,7 +95,7 @@ $max-nesting-level: 14;
     }
 
     i {
-      font-size: 10px;
+      font-size: 8px;
       position: relative;
       top: -1px;
     }
@@ -118,7 +118,7 @@ $max-nesting-level: 14;
       align-items: center;
 
       i {
-        font-size: 13px;
+        font-size: 12px;
         margin-right: 5px;
         flex-shrink: 0;
       }

--- a/packages/reporter/src/header/header.scss
+++ b/packages/reporter/src/header/header.scss
@@ -121,7 +121,7 @@
       margin: 5px;
 
       &.fa-redo {
-        font-size: 112%;
+        font-size: 100%;
         position: relative;
         top: 1px;
       }

--- a/packages/reporter/src/runnables/runnables.scss
+++ b/packages/reporter/src/runnables/runnables.scss
@@ -81,6 +81,7 @@
       min-width: 12px;
       height: 18px;
       text-align: center;
+      font-size: 11px;
     }
 
     &.suite .collapsible-indicator  {

--- a/packages/reporter/src/runnables/runnables.scss
+++ b/packages/reporter/src/runnables/runnables.scss
@@ -69,7 +69,7 @@
 
     &.runnable-active {
       .runnable-state {
-        @extend .#{$fa-css-prefix}-sync;
+        @extend .#{$fa-css-prefix}-sync-alt;
         @extend .#{$fa-css-prefix}-spin;
       }
     }

--- a/packages/runner/src/errors/automation-disconnected.jsx
+++ b/packages/runner/src/errors/automation-disconnected.jsx
@@ -6,7 +6,7 @@ export default ({ onReload }) => (
       <p>Whoops, the Cypress Chrome extension has disconnected.</p>
       <p className='muted'>Cypress cannot run tests without this extension.</p>
       <button onClick={onReload}>
-        <i className='fas fa-sync'></i> Reload the Browser
+        <i className='fas fa-sync-alt'></i> Reload the Browser
       </button>
       <div className='helper-line'>
         <a href='https://on.cypress.io/launching-browsers' target='_blank'>

--- a/packages/runner/src/header/header.scss
+++ b/packages/runner/src/header/header.scss
@@ -29,14 +29,13 @@
     cursor: pointer;
     border-radius: 0;
     display: block;
-    font-size: 17px;
+    font-size: 15px;
     font-weight: 500;
     line-height: 1.4;
     outline: 0;
     padding: 10px 16px;
     text-align: center;
     touch-action: manipulation;
-    vertical-align: middle;
     white-space: nowrap;
     user-select: none;
 


### PR DESCRIPTION
- Close #5863
- Close #5866 
 
### User facing changelog

N/A, this is fixing prerelease changes

### Additional details

- Ideally we need to purchase a [Font-Awesome Pro license](https://fontawesome.com/plans) so that we can have more fine grained control over the icons (including font-weight) + 1,000s of more icons, but this will require getting more people involved and I wanted to get the heavy lifting out of the way first before involving that decision.
- I changed the `file-code` icons in the desktop-gui to just `fa-file`, they looked worse in fa 5, and arguably never looked very good in the first place.


### How has the user experience changed?

#### Font awesome 4 reporter/runner header

![Screen Shot 2019-12-04 at 2 01 11 PM](https://user-images.githubusercontent.com/1271364/70122319-cd1b8c80-169e-11ea-8f50-a7aab81abc09.png)


#### Font awesome 5 reporter/runner header with this PR

<img width="1374" alt="Screen Shot 2019-12-04 at 2 01 35 PM" src="https://user-images.githubusercontent.com/1271364/70122328-d3116d80-169e-11ea-889c-2a24a58b2e96.png">


#### Font awesome 4 spinner

![](http://g.recordit.co/OlSmFp8jTD.gif)

#### Font awesome 5 spinner w/ this PR

![](http://g.recordit.co/WlVU5sVyb7.gif)

#### Font awesome 4 desktop-gui

![Screen Shot 2019-12-04 at 2 19 42 PM](https://user-images.githubusercontent.com/1271364/70123477-297fab80-16a1-11ea-8176-c9ea05c4a1e5.png)


#### Font awesome 5 desktop-gui

![Screen Shot 2019-12-06 at 12 17 31 AM](https://user-images.githubusercontent.com/1271364/70260075-ea934800-17bd-11ea-90b9-28ade3ef6fb6.png)


### PR Tasks

- [x] Have tests been added/updated?
- [NA] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?


