### PR TITLE
fix desktop gui specs not being watched for file changes

### DIFF
--- a/packages/server/lib/open_project.js
+++ b/packages/server/lib/open_project.js
@@ -205,9 +205,8 @@ const moduleFactory = () => {
     stopSpecsWatcher () {
       debug('stop spec watcher')
 
-      return Promise.try(() => {
-        return specsWatcher ? specsWatcher.close() : undefined
-      })
+      specsWatcher && specsWatcher.close()
+      specsWatcher = null
     },
 
     closeBrowser () {

--- a/packages/server/lib/open_project.js
+++ b/packages/server/lib/open_project.js
@@ -11,7 +11,6 @@ const preprocessor = require('./plugins/preprocessor')
 const moduleFactory = () => {
   let openProject = null
   let relaunchBrowser = null
-  let specsWatcher = null
 
   const reset = () => {
     openProject = null
@@ -29,6 +28,8 @@ const moduleFactory = () => {
   }
 
   return {
+    specsWatcher: null,
+
     reset: tryToCall('reset'),
 
     getConfig: tryToCall('getConfig'),
@@ -165,21 +166,21 @@ const moduleFactory = () => {
       250, { leading: true })
 
       const createSpecsWatcher = (cfg) => {
-        if (specsWatcher) {
+        if (this.specsWatcher) {
           return
         }
 
         debug('watch test files: %s in %s', cfg.testFiles, cfg.integrationFolder)
 
-        specsWatcher = chokidar.watch(cfg.testFiles, {
+        this.specsWatcher = chokidar.watch(cfg.testFiles, {
           cwd: cfg.integrationFolder,
           ignored: cfg.ignoreTestFiles,
           ignoreInitial: true,
         })
 
-        specsWatcher.on('add', checkForSpecUpdates)
+        this.specsWatcher.on('add', checkForSpecUpdates)
 
-        return specsWatcher.on('unlink', checkForSpecUpdates)
+        return this.specsWatcher.on('unlink', checkForSpecUpdates)
       }
 
       const get = () => {
@@ -205,8 +206,10 @@ const moduleFactory = () => {
     stopSpecsWatcher () {
       debug('stop spec watcher')
 
-      specsWatcher && specsWatcher.close()
-      specsWatcher = null
+      if (this.specsWatcher) {
+        this.specsWatcher.close()
+        this.specsWatcher = null
+      }
     },
 
     closeBrowser () {

--- a/packages/server/test/unit/open_project_spec.js
+++ b/packages/server/test/unit/open_project_spec.js
@@ -94,6 +94,7 @@ describe('lib/open_project', () => {
     beforeEach(function () {
       this.watcherStub = {
         on: sinon.stub(),
+        close: sinon.stub(),
       }
 
       sinon.stub(chokidar, 'watch').returns(this.watcherStub)
@@ -139,6 +140,16 @@ describe('lib/open_project', () => {
 
       return openProject.getSpecChanges({ onChange }).then(() => {
         expect(onChange).to.be.calledOnce
+      })
+    })
+
+    it('destroys and creates specsWatcher as expected', function () {
+      expect(openProject.specsWatcher).to.exist
+      openProject.stopSpecsWatcher()
+      expect(openProject.specsWatcher).to.be.null
+      openProject.getSpecChanges()
+      .then(() => {
+        expect(openProject.specsWatcher).to.exist
       })
     })
   })


### PR DESCRIPTION
- Fixes #5933 

### User facing changelog

- Fixed a bug where the specs list in interactive mode would not refresh when files are changed on disk.

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->