### PR TITLE
[driver] Fix xhr ballooning callback stack depth.

### DIFF
--- a/packages/driver/src/cypress/server.coffee
+++ b/packages/driver/src/cypress/server.coffee
@@ -496,8 +496,7 @@ create = (options = {}) ->
               bak = fns[prop]
 
               if _.isFunction(bak)
-                fns[prop] = ->
-                  bak.apply(xhr, arguments)
+                -> bak.apply(xhr, arguments)
               else
                 overrides[prop]
             set: (fn) ->

--- a/packages/driver/test/cypress/integration/commands/xhr_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/xhr_spec.coffee
@@ -94,6 +94,7 @@ describe "src/cy/commands/xhr", ->
           expect(responseStatuses).to.be.gt(1)
           expect(xhr.status).to.eq(200)
 
+    ## https://github.com/cypress-io/cypress/issues/5864
     it "does not exceed max call stack", ->
       cy
         .server()

--- a/packages/driver/test/cypress/integration/commands/xhr_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/xhr_spec.coffee
@@ -94,6 +94,25 @@ describe "src/cy/commands/xhr", ->
           expect(responseStatuses).to.be.gt(1)
           expect(xhr.status).to.eq(200)
 
+    it "does not exceed max call stack", ->
+      cy
+        .server()
+        .route({url: /foo/}).as("getFoo")
+        .window().then (win) ->
+          xhr = new win.XMLHttpRequest()
+          xhr.open("GET", "/foo")
+
+          # This tests an old bug where calling onreadystatechange's getter would
+          # create nested wrapper functions and exceed the max stack depth when called.
+          # 20000 nested calls should be enough to break the stack in most implementations
+          xhr.onreadystatechange = -> {}
+          [xhr.onreadystatechange() for i in [1...20000]]
+
+          xhr.send()
+          null
+        .wait("@getFoo").then (xhr) ->
+          expect(xhr.status).to.eq(404)
+
     it "works with jquery too", ->
       failed = false
       onloaded = false


### PR DESCRIPTION
<!-- Example: "Closes #1234" -->

- Closes https://github.com/cypress-io/cypress/issues/5864

### User facing changelog

Fix deep call stacks for XHRs

### Additional details

Cypress wraps xhr callbacks with an override.  However, in the current code, every time a callback getter is called, we replace the original memoized callback with the wrapper. Every time the getter is called, another wrapper is added, which in extreme cases (e.g. iterating over chunks of a long request body and calling `onreadystatechange` for each chunk) can cause "Maximum call stack size exceeded" errors.

This change resolves the issue by not overwriting the memoized callback in the getter. The setter will still correctly memoize the new callback.
<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
N/A
<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks
N/A
<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
