### PR TITLE
Fix `cypress run --headless`

### DIFF
--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -38,5 +38,5 @@
   "files": [
     "lib"
   ],
-  "types": "../ts/index.d.ts"
+  "types": "./lib/types.ts"
 }

--- a/packages/server/__snapshots__/2_headless_spec.ts.js
+++ b/packages/server/__snapshots__/2_headless_spec.ts.js
@@ -19,18 +19,19 @@ exports['e2e headless / tests in headless mode pass'] = `
 
   e2e headless spec
     ✓ has the expected values for Cypress.browser
+    ✓ has expected HeadlessChrome useragent
     ✓ has expected launch args
     ✓ has expected window bounds in CI
 
 
-  3 passing
+  4 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        3                                                                                │
-  │ Passing:      3                                                                                │
+  │ Tests:        4                                                                                │
+  │ Passing:      4                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -54,9 +55,9 @@ exports['e2e headless / tests in headless mode pass'] = `
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  headless_spec.js                         XX:XX        3        3        -        -        - │
+  │ ✔  headless_spec.js                         XX:XX        4        4        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        3        3        -        -        -  
+    ✔  All specs passed!                        XX:XX        4        4        -        -        -  
 
 
 `
@@ -82,18 +83,19 @@ exports['e2e headless / tests in headed mode pass [chrome]'] = `
 
   e2e headless spec
     ✓ has the expected values for Cypress.browser
+    ✓ has expected HeadlessChrome useragent
     ✓ has expected launch args
     ✓ has expected window bounds in CI
 
 
-  3 passing
+  4 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        3                                                                                │
-  │ Passing:      3                                                                                │
+  │ Tests:        4                                                                                │
+  │ Passing:      4                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -117,9 +119,9 @@ exports['e2e headless / tests in headed mode pass [chrome]'] = `
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  headless_spec.js                         XX:XX        3        3        -        -        - │
+  │ ✔  headless_spec.js                         XX:XX        4        4        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        3        3        -        -        -  
+    ✔  All specs passed!                        XX:XX        4        4        -        -        -  
 
 
 `
@@ -151,18 +153,19 @@ A video will not be recorded when using this mode.
 
   e2e headless spec
     ✓ has the expected values for Cypress.browser
+    ✓ has expected HeadlessChrome useragent
     ✓ has expected launch args
     ✓ has expected window bounds in CI
 
 
-  3 passing
+  4 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        3                                                                                │
-  │ Passing:      3                                                                                │
+  │ Tests:        4                                                                                │
+  │ Passing:      4                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -180,9 +183,9 @@ A video will not be recorded when using this mode.
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  headless_spec.js                         XX:XX        3        3        -        -        - │
+  │ ✔  headless_spec.js                         XX:XX        4        4        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        3        3        -        -        -  
+    ✔  All specs passed!                        XX:XX        4        4        -        -        -  
 
 
 `

--- a/packages/server/__snapshots__/2_headless_spec.ts.js
+++ b/packages/server/__snapshots__/2_headless_spec.ts.js
@@ -21,17 +21,16 @@ exports['e2e headless / tests in headless mode pass'] = `
     ✓ has the expected values for Cypress.browser
     ✓ has expected HeadlessChrome useragent
     ✓ has expected launch args
-    ✓ has expected window bounds in CI
 
 
-  4 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        4                                                                                │
-  │ Passing:      4                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -55,9 +54,9 @@ exports['e2e headless / tests in headless mode pass'] = `
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  headless_spec.js                         XX:XX        4        4        -        -        - │
+  │ ✔  headless_spec.js                         XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        4        4        -        -        -  
+    ✔  All specs passed!                        XX:XX        3        3        -        -        -  
 
 
 `
@@ -85,17 +84,16 @@ exports['e2e headless / tests in headed mode pass [chrome]'] = `
     ✓ has the expected values for Cypress.browser
     ✓ has expected HeadlessChrome useragent
     ✓ has expected launch args
-    ✓ has expected window bounds in CI
 
 
-  4 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        4                                                                                │
-  │ Passing:      4                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -119,9 +117,9 @@ exports['e2e headless / tests in headed mode pass [chrome]'] = `
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  headless_spec.js                         XX:XX        4        4        -        -        - │
+  │ ✔  headless_spec.js                         XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        4        4        -        -        -  
+    ✔  All specs passed!                        XX:XX        3        3        -        -        -  
 
 
 `
@@ -155,17 +153,16 @@ A video will not be recorded when using this mode.
     ✓ has the expected values for Cypress.browser
     ✓ has expected HeadlessChrome useragent
     ✓ has expected launch args
-    ✓ has expected window bounds in CI
 
 
-  4 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        4                                                                                │
-  │ Passing:      4                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -183,9 +180,9 @@ A video will not be recorded when using this mode.
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  headless_spec.js                         XX:XX        4        4        -        -        - │
+  │ ✔  headless_spec.js                         XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        4        4        -        -        -  
+    ✔  All specs passed!                        XX:XX        3        3        -        -        -  
 
 
 `

--- a/packages/server/__snapshots__/2_headless_spec.ts.js
+++ b/packages/server/__snapshots__/2_headless_spec.ts.js
@@ -34,16 +34,11 @@ exports['e2e headless / tests in headless mode pass'] = `
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        true                                                                             │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     headless_spec.js                                                                 │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/headless_spec.js/window-size.png                    (1280x720)
 
 
   (Video)
@@ -102,16 +97,11 @@ exports['e2e headless / tests in headed mode pass [chrome]'] = `
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        true                                                                             │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     headless_spec.js                                                                 │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/headless_spec.js/window-size.png                    (1280x720)
 
 
   (Video)
@@ -176,16 +166,11 @@ A video will not be recorded when using this mode.
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     headless_spec.js                                                                 │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/headless_spec.js/window-size.png                    (1280x695)
 
 
 ====================================================================================================

--- a/packages/server/__snapshots__/2_headless_spec.ts.js
+++ b/packages/server/__snapshots__/2_headless_spec.ts.js
@@ -19,24 +19,31 @@ exports['e2e headless / tests in headless mode pass'] = `
 
   e2e headless spec
     ✓ has the expected values for Cypress.browser
+    ✓ has expected launch args
+    ✓ has expected window bounds in CI
 
 
-  1 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        1                                                                                │
-  │ Passing:      1                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  0                                                                                │
+  │ Screenshots:  1                                                                                │
   │ Video:        true                                                                             │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     headless_spec.js                                                                 │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Screenshots)
+
+  -  /XXX/XXX/XXX/cypress/screenshots/headless_spec.js/window-size.png                    (1280x720)
 
 
   (Video)
@@ -52,9 +59,9 @@ exports['e2e headless / tests in headless mode pass'] = `
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  headless_spec.js                         XX:XX        1        1        -        -        - │
+  │ ✔  headless_spec.js                         XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        1        1        -        -        -  
+    ✔  All specs passed!                        XX:XX        3        3        -        -        -  
 
 
 `
@@ -80,24 +87,31 @@ exports['e2e headless / tests in headed mode pass [chrome]'] = `
 
   e2e headless spec
     ✓ has the expected values for Cypress.browser
+    ✓ has expected launch args
+    ✓ has expected window bounds in CI
 
 
-  1 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        1                                                                                │
-  │ Passing:      1                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  0                                                                                │
+  │ Screenshots:  1                                                                                │
   │ Video:        true                                                                             │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     headless_spec.js                                                                 │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Screenshots)
+
+  -  /XXX/XXX/XXX/cypress/screenshots/headless_spec.js/window-size.png                    (1280x720)
 
 
   (Video)
@@ -113,9 +127,9 @@ exports['e2e headless / tests in headed mode pass [chrome]'] = `
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  headless_spec.js                         XX:XX        1        1        -        -        - │
+  │ ✔  headless_spec.js                         XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        1        1        -        -        -  
+    ✔  All specs passed!                        XX:XX        3        3        -        -        -  
 
 
 `
@@ -147,24 +161,31 @@ A video will not be recorded when using this mode.
 
   e2e headless spec
     ✓ has the expected values for Cypress.browser
+    ✓ has expected launch args
+    ✓ has expected window bounds in CI
 
 
-  1 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        1                                                                                │
-  │ Passing:      1                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  0                                                                                │
+  │ Screenshots:  1                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     headless_spec.js                                                                 │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Screenshots)
+
+  -  /XXX/XXX/XXX/cypress/screenshots/headless_spec.js/window-size.png                    (1280x695)
 
 
 ====================================================================================================
@@ -174,9 +195,9 @@ A video will not be recorded when using this mode.
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  headless_spec.js                         XX:XX        1        1        -        -        - │
+  │ ✔  headless_spec.js                         XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        1        1        -        -        -  
+    ✔  All specs passed!                        XX:XX        3        3        -        -        -  
 
 
 `

--- a/packages/server/lib/browsers/chrome.js
+++ b/packages/server/lib/browsers/chrome.js
@@ -316,10 +316,6 @@ module.exports = {
       args.push('--proxy-bypass-list=<-loopback>')
     }
 
-    if (options.isHeadless) {
-      args.push('--headless')
-    }
-
     return args
   },
 
@@ -331,6 +327,10 @@ module.exports = {
     return Promise
     .try(() => {
       const args = this._getArgs(options)
+
+      if (browser.isHeadless) {
+        args.push('--headless')
+      }
 
       return getRemoteDebuggingPort()
       .then((port) => {

--- a/packages/server/lib/browsers/chrome.js
+++ b/packages/server/lib/browsers/chrome.js
@@ -118,7 +118,11 @@ const pluginsBeforeBrowserLaunch = function (browser, args) {
   })
 }
 
-const _normalizeArgExtensions = function (dest, args) {
+const _normalizeArgExtensions = function (dest, args, browser) {
+  if (browser.isHeadless) {
+    return args
+  }
+
   let userExtensions
   const loadExtension = _.find(args, (arg) => {
     return arg.includes(LOAD_EXTENSION)
@@ -356,7 +360,7 @@ module.exports = {
       .spread((extDest) => {
         // normalize the --load-extensions argument by
         // massaging what the user passed into our own
-        args = _normalizeArgExtensions(extDest, args)
+        args = _normalizeArgExtensions(extDest, args, browser)
 
         // this overrides any previous user-data-dir args
         // by being the last one

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -1,4 +1,3 @@
-import '../../../../cli'
 import _ from 'lodash'
 import os from 'os'
 import path from 'path'

--- a/packages/server/lib/browsers/electron.coffee
+++ b/packages/server/lib/browsers/electron.coffee
@@ -157,7 +157,7 @@ module.exports = {
         debug('debugger: received response to %s: %o', message, res)
         res
       .catch (err) ->
-        debug('debugger: received error on %s: %o', messsage, err)
+        debug('debugger: received error on %s: %o', message, err)
         throw err
 
     webContents.debugger.sendCommand('Browser.getVersion')

--- a/packages/server/test/e2e/2_headless_spec.ts
+++ b/packages/server/test/e2e/2_headless_spec.ts
@@ -8,6 +8,7 @@ describe('e2e headless', function () {
     spec: 'headless_spec.js',
     config: {
       env: {
+        'CI': process.env.CI,
         'EXPECT_HEADLESS': '1',
       },
     },
@@ -19,6 +20,11 @@ describe('e2e headless', function () {
   // cypress run --headed
   e2e.it('tests in headed mode pass', {
     spec: 'headless_spec.js',
+    config: {
+      env: {
+        'CI': process.env.CI,
+      },
+    },
     expectedExitCode: 0,
     headed: true,
     snapshot: true,

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
@@ -5,4 +5,15 @@ describe('e2e headless spec', function () {
     expect(Cypress.browser.isHeadless).to.eq(expectedHeadless)
     expect(Cypress.browser.isHeaded).to.eq(!expectedHeadless)
   })
+
+  it('has expected launch args', function () {
+    if (Cypress.browser.family !== 'chrome') {
+      return
+    }
+
+    cy.exec(`ps aux`)
+    .its('stdout')
+    .should('contain', 'chrome')
+    .and(expectedHeadless ? 'match' : 'not.match', /chrome[^\n]+--headless/)
+  })
 })

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
@@ -1,4 +1,3 @@
-const { _ } = Cypress
 const expectedHeadless = !!Cypress.env('EXPECT_HEADLESS')
 
 describe('e2e headless spec', function () {
@@ -23,40 +22,5 @@ describe('e2e headless spec', function () {
 
     cy.task('get:browser:args')
     .should(expectedHeadless ? 'contain' : 'not.contain', '--headless')
-  })
-
-  it('has expected window bounds in CI', function () {
-    if (!Cypress.env('CI')) {
-      // will only work in the CI docker container, so skip it if we're not in CI
-      return this.skip()
-    }
-
-    if (Cypress.browser.family !== 'chrome') {
-      // Browser.getWindowForTarget does not exist in Electron
-      return
-    }
-
-    // in CI with Xvfb, Cypress will fill the entire screen, this test is to explicitly
-    // assert on the expected dimensions
-
-    const cdp = _.bind(Cypress.automation, Cypress, 'remote:debugger:protocol')
-
-    return cdp({
-      command: 'Browser.getWindowForTarget',
-    })
-    .then(({ windowId }) => {
-      return cdp({
-        command: 'Browser.getWindowBounds',
-        params: {
-          windowId,
-        },
-      })
-    })
-    .then(({ bounds }) => {
-      expect(bounds).to.include({
-        width: expectedHeadless ? 800 : 1050,
-        height: expectedHeadless ? 600 : 1004,
-      })
-    })
   })
 })

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
@@ -26,12 +26,17 @@ describe('e2e headless spec', function () {
   })
 
   it('has expected window bounds in CI', function () {
+    if (!Cypress.env('CI')) {
+      // will only work in the CI docker container, so skip it if we're not in CI
+      return this.skip()
+    }
+
     if (Cypress.browser.family !== 'chrome') {
       // Browser.getWindowForTarget does not exist in Electron
       return
     }
 
-    // in CI, Cypress will fill the entire screen, this test is to explicitly
+    // in CI with Xvfb, Cypress will fill the entire screen, this test is to explicitly
     // assert on the expected dimensions
 
     const cdp = _.bind(Cypress.automation, Cypress, 'remote:debugger:protocol')

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
@@ -7,6 +7,15 @@ describe('e2e headless spec', function () {
     expect(Cypress.browser.isHeaded).to.eq(!expectedHeadless)
   })
 
+  it('has expected HeadlessChrome useragent', function () {
+    if (Cypress.browser.family !== 'chrome') {
+      return
+    }
+
+    cy.wrap(navigator.userAgent)
+    .should(expectedHeadless ? 'contain' : 'not.contain', 'HeadlessChrome')
+  })
+
   it('has expected launch args', function () {
     if (Cypress.browser.family !== 'chrome') {
       return

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
@@ -12,23 +12,32 @@ describe('e2e headless spec', function () {
       return
     }
 
-    cy.exec(`ps aux`)
-    .its('stdout')
-    .should('contain', 'chrome')
-    .and(expectedHeadless ? 'match' : 'not.match', /chrome[^\n]+--headless/)
+    cy.task('get:browser:args')
+    .should(expectedHeadless ? 'contain' : 'not.contain', '--headless')
   })
 
   it('has expected window bounds in CI', function () {
+    // in CI, Cypress will fill the entire screen, this test is to explicitly
+    // assert on the expected dimensions
+
     cy.screenshot('window-size', {
       capture: 'runner',
     })
     .task('get:screenshots:taken')
     .then((screenshotsTaken) => {
+      let expectedHeight = 695
+
+      const noTopBar = expectedHeadless || Cypress.browser.family === 'chrome'
+
+      if (noTopBar) {
+        expectedHeight += 25
+      }
+
       const ss = _.find(screenshotsTaken, { name: 'window-size' })
 
       expect(ss.dimensions).to.deep.eq({
         width: 1280,
-        height: 720,
+        height: expectedHeight,
       })
     })
   })

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
@@ -1,3 +1,4 @@
+const { _ } = Cypress
 const expectedHeadless = !!Cypress.env('EXPECT_HEADLESS')
 
 describe('e2e headless spec', function () {
@@ -15,5 +16,20 @@ describe('e2e headless spec', function () {
     .its('stdout')
     .should('contain', 'chrome')
     .and(expectedHeadless ? 'match' : 'not.match', /chrome[^\n]+--headless/)
+  })
+
+  it('has expected window bounds in CI', function () {
+    cy.screenshot('window-size', {
+      capture: 'runner',
+    })
+    .task('get:screenshots:taken')
+    .then((screenshotsTaken) => {
+      const ss = _.find(screenshotsTaken, { name: 'window-size' })
+
+      expect(ss.dimensions).to.deep.eq({
+        width: 1280,
+        height: 720,
+      })
+    })
   })
 })

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/plugins/index.js
@@ -6,6 +6,8 @@ const path = require('path')
 const Promise = require('bluebird')
 const performance = require('../../../../test/support/helpers/performance')
 
+const screenshotsTaken = []
+
 module.exports = (on) => {
   // save some time by only reading the originals once
   let cache = {}
@@ -23,6 +25,10 @@ module.exports = (on) => {
       return image
     })
   }
+
+  on('after:screenshot', (details) => {
+    screenshotsTaken.push(details)
+  })
 
   on('task', {
     'returns:undefined' () {},
@@ -121,6 +127,10 @@ module.exports = (on) => {
 
       return performance.track('fast_visit_spec percentiles', data)
       .return(null)
+    },
+
+    'get:screenshots:taken' () {
+      return screenshotsTaken
     },
   })
 }

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/plugins/index.js
@@ -6,11 +6,12 @@ const path = require('path')
 const Promise = require('bluebird')
 const performance = require('../../../../test/support/helpers/performance')
 
-const screenshotsTaken = []
-
 module.exports = (on) => {
   // save some time by only reading the originals once
   let cache = {}
+
+  const screenshotsTaken = []
+  let browserArgs = null
 
   function getCachedImage (name) {
     const cachedImage = cache[name]
@@ -28,6 +29,12 @@ module.exports = (on) => {
 
   on('after:screenshot', (details) => {
     screenshotsTaken.push(details)
+  })
+
+  on('before:browser:launch', (browser, args) => {
+    browserArgs = args
+
+    return args
   })
 
   on('task', {
@@ -131,6 +138,10 @@ module.exports = (on) => {
 
     'get:screenshots:taken' () {
       return screenshotsTaken
+    },
+
+    'get:browser:args' () {
+      return browserArgs
     },
   })
 }

--- a/packages/server/test/unit/browsers/chrome_spec.coffee
+++ b/packages/server/test/unit/browsers/chrome_spec.coffee
@@ -70,16 +70,17 @@ describe "lib/browsers/chrome", ->
 
     it "does not load extension in headless mode", ->
       plugins.has.returns(false)
+      chrome._writeExtension.restore()
 
       pathToTheme = extension.getPathToTheme()
 
-      chrome.open("chrome", "http://", { isHeadless: true, isHeaded: false }, @automation)
+      chrome.open({ isHeadless: true, isHeaded: false }, "http://", {}, @automation)
       .then =>
         args = utils.launch.firstCall.args[2]
 
         expect(args).to.deep.eq([
+          "--headless"
           "--remote-debugging-port=50505"
-          "--load-extension=/path/to/ext,#{pathToTheme}"
           "--user-data-dir=/profile/dir"
           "--disk-cache-dir=/profile/dir/CypressCache"
         ])


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #5949

### User facing changelog

- Fixed a bug where `cypress run --headless` would not run Chrome-family browsers headlessly.

### Additional details

- mis-merged a decaffeinated version of `chrome.js` and tests didn't catch it :/


#### Results of Browser.getWindowBounds:  

|    | chrome |
| --- | --- |
| headless | 800x600 |
| headed | 1050x1004 |

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->