### PR TITLE
Remove strict cookie validation from cookie commands

### DIFF
--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -55,7 +55,6 @@
     "parse-domain": "2.3.4",
     "setimmediate": "1.0.5",
     "sinon": "3.3.0",
-    "strict-cookie-parser": "3.1.0",
     "text-mask-addons": "3.8.0",
     "underscore": "1.9.1",
     "underscore.string": "3.3.5",

--- a/packages/driver/src/cy/commands/cookies.js
+++ b/packages/driver/src/cy/commands/cookies.js
@@ -89,6 +89,7 @@ module.exports = function (Commands, Cypress, cy, state, config) {
           action,
           command,
           browserDisplayName: Cypress.browser.displayName,
+          errMessage: err.message,
           errStack: err.stack,
         },
         onFail,

--- a/packages/driver/src/cy/commands/cookies.js
+++ b/packages/driver/src/cy/commands/cookies.js
@@ -1,8 +1,5 @@
-/* global Cypress */
-
 const _ = require('lodash')
 const Promise = require('bluebird')
-const cookieParser = require('strict-cookie-parser')
 
 const $utils = require('../../cypress/utils')
 const $Location = require('../../cypress/location')
@@ -33,12 +30,6 @@ const mergeDefaults = function (obj) {
   }
 
   return merge(obj)
-}
-
-const validateCookieName = function (cmd, name, onFail) {
-  if (cookieParser.isCookieName(name) !== true) {
-    return Cypress.utils.throwErrByPath('cookies.invalid_name', { args: { cmd, name }, onFail })
-  }
 }
 
 module.exports = function (Commands, Cypress, cy, state, config) {
@@ -129,8 +120,6 @@ module.exports = function (Commands, Cypress, cy, state, config) {
         $utils.throwErrByPath('getCookie.invalid_argument', { onFail })
       }
 
-      validateCookieName('getCookie', name, onFail)
-
       return automateCookies('get:cookie', { name }, options._log, options.timeout)
       .then((resp) => {
         options.cookie = resp
@@ -214,12 +203,6 @@ module.exports = function (Commands, Cypress, cy, state, config) {
         Cypress.utils.throwErrByPath('setCookie.invalid_arguments', { onFail })
       }
 
-      validateCookieName('setCookie', name, onFail)
-
-      if (cookieParser.parseCookieValue(value) === null) {
-        Cypress.utils.throwErrByPath('setCookie.invalid_value', { args: { value }, onFail })
-      }
-
       return automateCookies('set:cookie', cookie, options._log, options.timeout)
       .then((resp) => {
         options.cookie = resp
@@ -270,8 +253,6 @@ module.exports = function (Commands, Cypress, cy, state, config) {
       if (!_.isString(name)) {
         $utils.throwErrByPath('clearCookie.invalid_argument', { onFail })
       }
-
-      validateCookieName('clearCookie', name, onFail)
 
       // TODO: prevent clearing a cypress namespace
       return automateCookies('clear:cookie', { name }, options._log, options.timeout)

--- a/packages/driver/src/cypress/error_messages.coffee
+++ b/packages/driver/src/cypress/error_messages.coffee
@@ -153,6 +153,7 @@ module.exports = {
     backend_error: """
     #{cmd('{{command}}')} had an unexpected error {{action}} {{browserDisplayName}}.
 
+    {{errMessage}}
     {{errStack}}
     """
     removed_method: """

--- a/packages/driver/src/cypress/error_messages.coffee
+++ b/packages/driver/src/cypress/error_messages.coffee
@@ -150,7 +150,6 @@ module.exports = {
     length_option: "#{cmd('contains')} cannot be passed a length option because it will only ever return 1 element."
 
   cookies:
-    invalid_name: "#{cmd('{{cmd}}')} must be passed an RFC-6265-compliant cookie name. You passed:\n\n`{{name}}`"
     removed_method: """
       The Cypress.Cookies.{{method}}() method has been removed.
 
@@ -412,10 +411,10 @@ module.exports = {
     invalid_prop_name_arg: "#{cmd('{{cmd}}')} only accepts a string or a number as the {{identifier}}Name argument."
     null_or_undefined_property_name: "#{cmd('{{cmd}}')} expects the {{identifier}}Name argument to have a value."
     invalid_options_arg: "#{cmd('{{cmd}}')} only accepts an object as the options argument."
-    invalid_num_of_args:	
-      """	
-      #{cmd('{{cmd}}')} does not accept additional arguments.	
-      If you want to invoke a function with arguments, use cy.invoke().	
+    invalid_num_of_args:
+      """
+      #{cmd('{{cmd}}')} does not accept additional arguments.
+      If you want to invoke a function with arguments, use cy.invoke().
       """
     timed_out:
       """
@@ -829,7 +828,6 @@ module.exports = {
     {{errStack}}
     """
     invalid_arguments: "#{cmd('setCookie')} must be passed two string arguments for name and value."
-    invalid_value: "#{cmd('setCookie')} must be passed an RFC-6265-compliant cookie value. You passed:\n\n`{{value}}`"
 
   spread:
     invalid_type: "#{cmd('spread')} requires the existing subject be array-like."

--- a/packages/driver/src/cypress/error_messages.coffee
+++ b/packages/driver/src/cypress/error_messages.coffee
@@ -150,6 +150,11 @@ module.exports = {
     length_option: "#{cmd('contains')} cannot be passed a length option because it will only ever return 1 element."
 
   cookies:
+    backend_error: """
+    #{cmd('{{command}}')} had an unexpected error {{action}} {{browserDisplayName}}.
+
+    {{errStack}}
+    """
     removed_method: """
       The Cypress.Cookies.{{method}}() method has been removed.
 
@@ -822,11 +827,6 @@ module.exports = {
     unavailable: "The XHR server is unavailable or missing. This should never happen and likely is a bug. Open an issue if you see this message."
 
   setCookie:
-    backend_error: """
-    #{cmd('setCookie')} had an unexpected error setting the requested cookie in {{browserDisplayName}}.
-
-    {{errStack}}
-    """
     invalid_arguments: "#{cmd('setCookie')} must be passed two string arguments for name and value."
 
   spread:

--- a/packages/driver/test/cypress/integration/commands/cookies_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/cookies_spec.coffee
@@ -292,15 +292,6 @@ describe "src/cy/commands/cookies", ->
 
         cy.getCookie(123)
 
-      it "throws an error if the cookie name is invalid", (done) ->
-        cy.on "fail", (err) =>
-          expect(err.message).to.include("cy.getCookie() must be passed an RFC-6265-compliant cookie name.")
-          expect(err.message).to.include('You passed:\n\n`m=m`')
-
-          done()
-
-        cy.getCookie("m=m")
-
     describe ".log", ->
       beforeEach ->
         cy.on "log:added", (attrs, log) =>
@@ -498,27 +489,6 @@ describe "src/cy/commands/cookies", ->
         cy.setCookie("foo", 123)
 
       context "when setting an invalid cookie", ->
-        it "throws an error if the cookie name is invalid", (done) ->
-          cy.on "fail", (err) =>
-            expect(err.message).to.include("cy.setCookie() must be passed an RFC-6265-compliant cookie name.")
-            expect(err.message).to.include('You passed:\n\n`m=m`')
-
-            done()
-
-          ## cookie names may not contain =
-          ## https://stackoverflow.com/a/6109881/3474615
-          cy.setCookie("m=m", "foo")
-
-        it "throws an error if the cookie value is invalid", (done) ->
-          cy.on "fail", (err) =>
-            expect(err.message).to.include('must be passed an RFC-6265-compliant cookie value.')
-            expect(err.message).to.include('You passed:\n\n` bar`')
-
-            done()
-
-          ## cookies may not contain unquoted whitespace
-          cy.setCookie("foo", " bar")
-
         it "throws an error if the backend responds with an error", (done) ->
           cy.on "fail", (err) =>
             expect(skipErrStub).to.be.calledOnce
@@ -680,15 +650,6 @@ describe "src/cy/commands/cookies", ->
           done()
 
         cy.clearCookie(123)
-
-      it "throws an error if the cookie name is invalid", (done) ->
-        cy.on "fail", (err) =>
-          expect(err.message).to.include("cy.clearCookie() must be passed an RFC-6265-compliant cookie name.")
-          expect(err.message).to.include('You passed:\n\n`m=m`')
-
-          done()
-
-        cy.clearCookie("m=m")
 
     describe ".log", ->
       beforeEach ->

--- a/packages/driver/test/cypress/integration/commands/cookies_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/cookies_spec.coffee
@@ -117,7 +117,7 @@ describe "src/cy/commands/cookies", ->
           expect(@logs.length).to.eq(1)
 
           expect(lastLog.get("error").message).to.contain "cy.getCookies() had an unexpected error reading cookies from #{Cypress.browser.displayName}."
-          expect(lastLog.get("error").message).to.contain "foo: some err message"
+          expect(lastLog.get("error").message).to.contain "some err message"
           expect(lastLog.get("error").message).to.contain error.stack
           done()
 
@@ -259,7 +259,7 @@ describe "src/cy/commands/cookies", ->
           expect(@logs.length).to.eq(1)
 
           expect(lastLog.get("error").message).to.contain "cy.getCookie() had an unexpected error reading the requested cookie from #{Cypress.browser.displayName}."
-          expect(lastLog.get("error").message).to.contain "foo: some err message"
+          expect(lastLog.get("error").message).to.contain "some err message"
           expect(lastLog.get("error").message).to.contain error.stack
           done()
 
@@ -612,7 +612,7 @@ describe "src/cy/commands/cookies", ->
 
           expect(@logs.length).to.eq(1)
           expect(lastLog.get("error").message).to.contain "cy.clearCookie() had an unexpected error clearing the requested cookie in #{Cypress.browser.displayName}."
-          expect(lastLog.get("error").message).to.contain "foo: some err message"
+          expect(lastLog.get("error").message).to.contain "some err message"
           expect(lastLog.get("error").message).to.contain error.stack
           done()
 
@@ -838,7 +838,7 @@ describe "src/cy/commands/cookies", ->
 
           expect(@logs.length).to.eq(1)
           expect(lastLog.get("error").message).to.contain "cy.clearCookies() had an unexpected error clearing cookies in #{Cypress.browser.displayName}."
-          expect(lastLog.get("error").message).to.contain "foo: some err message"
+          expect(lastLog.get("error").message).to.contain "some err message"
           expect(lastLog.get("error").message).to.contain error.stack
           expect(lastLog.get("error")).to.eq(err)
           done()
@@ -877,7 +877,7 @@ describe "src/cy/commands/cookies", ->
 
           expect(@logs.length).to.eq(1)
           expect(lastLog.get("error").message).to.contain "cy.clearCookies() had an unexpected error clearing cookies in #{Cypress.browser.displayName}."
-          expect(lastLog.get("error").message).to.contain "foo: some err message"
+          expect(lastLog.get("error").message).to.contain "some err message"
           expect(lastLog.get("error").message).to.contain error.stack
           expect(lastLog.get("error")).to.eq(err)
           done()

--- a/packages/driver/test/cypress/integration/commands/cookies_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/cookies_spec.coffee
@@ -116,9 +116,9 @@ describe "src/cy/commands/cookies", ->
 
           expect(@logs.length).to.eq(1)
 
-          expect(lastLog.get("error").message).to.eq "some err message"
-          expect(lastLog.get("error").name).to.eq "foo"
-          expect(lastLog.get("error").stack).to.eq error.stack
+          expect(lastLog.get("error").message).to.contain "cy.getCookies() had an unexpected error reading cookies from #{Cypress.browser.displayName}."
+          expect(lastLog.get("error").message).to.contain "foo: some err message"
+          expect(lastLog.get("error").message).to.contain error.stack
           done()
 
         cy.getCookies()
@@ -258,9 +258,9 @@ describe "src/cy/commands/cookies", ->
 
           expect(@logs.length).to.eq(1)
 
-          expect(lastLog.get("error").message).to.eq "some err message"
-          expect(lastLog.get("error").name).to.eq "foo"
-          expect(lastLog.get("error").stack).to.eq error.stack
+          expect(lastLog.get("error").message).to.contain "cy.getCookie() had an unexpected error reading the requested cookie from #{Cypress.browser.displayName}."
+          expect(lastLog.get("error").message).to.contain "foo: some err message"
+          expect(lastLog.get("error").message).to.contain error.stack
           done()
 
         cy.getCookie("foo")
@@ -611,9 +611,9 @@ describe "src/cy/commands/cookies", ->
           lastLog = @lastLog
 
           expect(@logs.length).to.eq(1)
-          expect(lastLog.get("error").message).to.eq "some err message"
-          expect(lastLog.get("error").name).to.eq "foo"
-          expect(lastLog.get("error").stack).to.eq error.stack
+          expect(lastLog.get("error").message).to.contain "cy.clearCookie() had an unexpected error clearing the requested cookie in #{Cypress.browser.displayName}."
+          expect(lastLog.get("error").message).to.contain "foo: some err message"
+          expect(lastLog.get("error").message).to.contain error.stack
           done()
 
         cy.clearCookie("foo")
@@ -837,9 +837,9 @@ describe "src/cy/commands/cookies", ->
           lastLog = @lastLog
 
           expect(@logs.length).to.eq(1)
-          expect(lastLog.get("error").message).to.eq "some err message"
-          expect(lastLog.get("error").name).to.eq "foo"
-          expect(lastLog.get("error").stack).to.eq err.stack
+          expect(lastLog.get("error").message).to.contain "cy.clearCookies() had an unexpected error clearing cookies in #{Cypress.browser.displayName}."
+          expect(lastLog.get("error").message).to.contain "foo: some err message"
+          expect(lastLog.get("error").message).to.contain error.stack
           expect(lastLog.get("error")).to.eq(err)
           done()
 
@@ -876,9 +876,9 @@ describe "src/cy/commands/cookies", ->
           lastLog = @lastLog
 
           expect(@logs.length).to.eq(1)
-          expect(lastLog.get("error").message).to.eq "some err message"
-          expect(lastLog.get("error").name).to.eq "foo"
-          expect(lastLog.get("error").stack).to.eq error.stack
+          expect(lastLog.get("error").message).to.contain "cy.clearCookies() had an unexpected error clearing cookies in #{Cypress.browser.displayName}."
+          expect(lastLog.get("error").message).to.contain "foo: some err message"
+          expect(lastLog.get("error").message).to.contain error.stack
           expect(lastLog.get("error")).to.eq(err)
           done()
 

--- a/packages/driver/test/cypress/integration/commands/cookies_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/cookies_spec.coffee
@@ -491,18 +491,12 @@ describe "src/cy/commands/cookies", ->
       context "when setting an invalid cookie", ->
         it "throws an error if the backend responds with an error", (done) ->
           cy.on "fail", (err) =>
-            expect(skipErrStub).to.be.calledOnce
-            expect(errStub).to.be.calledTwice
+            expect(errStub).to.be.calledOnce
             expect(err.message).to.contain('unexpected error setting the requested cookie')
             done()
 
           errStub = cy.stub(Cypress.utils, "throwErrByPath")
           errStub.callThrough()
-
-          ## stub cookie validation so this invalid cookie can make it to the backend
-          skipErrStub = errStub
-          .withArgs("setCookie.invalid_value")
-          .returns()
 
           ## browser backend should yell since this is invalid
           cy.setCookie("foo", " bar")


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #5642

### User facing changelog

- The strict cookie validation added in 3.5.0 for `cy.setCookie`, `cy.clearCookie`, and `cy.getCookie` has been removed. 

### Additional details

- added error wrapping for the automation errors, since they are more likely now

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

Users will now get the browser's error message and won't be subject to the overly strict strict-cookie-parser rules

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->