### PR TITLE
Remove packageRules from renovatebot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,13 @@
     "automerge": false
   },
   "rangeStrategy": "pin",
+  "packageRules": [
+    {
+      "packagePatterns": "^@types",
+      "groupName": "@types",
+      "schedule": "before 3am on Monday"
+    }
+  ],
   "separateMultipleMajor": true,
   "labels": [
     "type: dependencies",

--- a/renovate.json
+++ b/renovate.json
@@ -10,64 +10,6 @@
     "automerge": false
   },
   "rangeStrategy": "pin",
-  "packageRules": [
-    {
-      "packagePatterns": "^@cypress",
-      "groupName": "@cypress",
-      "schedule": "after 2am and before 4am"
-    },
-    {
-      "packageNames": [
-        "bin-up",
-        "check-dependencies",
-        "check-more-types",
-        "console-table",
-        "execa-wrap",
-        "is-fork-pr",
-        "lazy-ass",
-        "make-empty-github-commit",
-        "mocha-banner",
-        "prefixed-list",
-        "rebuild-node-sass",
-        "snap-shot-it",
-        "terminal-banner"
-      ],
-      "groupName": "team NPM packages",
-      "schedule": "after 2am and before 4am"
-    },
-    {
-      "packageNames": "node",
-      "enabled": false
-    },
-    {
-      "packagePatterns": "^@types",
-      "groupName": "@types",
-      "schedule": "before 3am on Monday"
-    },
-    {
-      "packagePatterns": "^sinon",
-      "groupName": "sinon",
-      "schedule": "before 3am on Sunday"
-    },
-    {
-      "packagePatterns": "^gulp",
-      "groupName": "gulp",
-      "schedule": "before 3am on Monday"
-    },
-    {
-      "packagePatterns": "^eslint",
-      "groupName": "eslint",
-      "schedule": "before 3am on Monday"
-    },
-    {
-      "packageNames": [
-        "typescript",
-        "ts-node",
-        "tslint-config-standard"
-      ],
-      "groupName": "typescript"
-    }
-  ],
   "separateMultipleMajor": true,
   "labels": [
     "type: dependencies",

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "rangeStrategy": "pin",
   "packageRules": [
     {
-      "packagePatterns": "^@types",
+      "packagePatterns": "^@types/",
       "groupName": "@types",
       "schedule": "before 3am on Monday"
     }


### PR DESCRIPTION
As much as I liked `packageRules` grouping in theory, in practice it is impractical for a few reasons: 

- We don't utilize the scheduling like we imagined and have sinse moved to the [giant renovatebot issue](https://github.com/cypress-io/cypress/issues/3777) - so everything is triggered manually. This means the grouping of 'important' packages over others in scheduling does not even matter. 
- Merging in our own packages is actually more difficult, so we end up not updating the most important packages. See the PR below, because it's trying to update 3 breaking change versions of 3 packages at once, it's more difficult to review which package broke the tests so we ignore it. https://github.com/cypress-io/cypress/pull/5396
	<img width="747" alt="Screen Shot 2019-12-17 at 2 16 40 PM" src="https://user-images.githubusercontent.com/1271364/70975498-71a6c100-20d8-11ea-934c-8db3e8aa1297.png">
- I did end up leaving the 'types' group cause...it is a lot of deps and arguably less important to upgrade urgently, but I updated the matching to be `@types/` since the previous matcher was also grabbing all PRs from `@typescript`
	<img width="658" alt="Screen Shot 2019-12-17 at 2 50 44 PM" src="https://user-images.githubusercontent.com/1271364/70977644-bc2a3c80-20dc-11ea-8b22-718058ac1acd.png">




