### PR TITLE
Simply state that the element is not visible.

### DIFF
--- a/packages/driver/src/dom/visibility.js
+++ b/packages/driver/src/dom/visibility.js
@@ -521,7 +521,7 @@ ${covered}\
     }
   }
 
-  return `Cypress could not determine why this element '${node}' is not visible.`
+  return `This element '${node}' is not visible.`
 }
 /* eslint-enable no-cond-assign */
 

--- a/packages/driver/test/cypress/integration/dom/visibility_spec.js
+++ b/packages/driver/test/cypress/integration/dom/visibility_spec.js
@@ -1051,7 +1051,7 @@ This element '<div#coveredUpPosFixed>' is not visible because it has CSS propert
       })
 
       it('cannot determine why element is not visible', function () {
-        this.reasonIs(this.$btnOpacity, 'Cypress could not determine why this element \'<button>\' is not visible.')
+        this.reasonIs(this.$btnOpacity, 'This element \'<button>\' is not visible.')
       })
     })
   })


### PR DESCRIPTION
- Partially addresses #5974

### User facing changelog

We updated the fallback error message for visibility checks to be less confusing.

### Additional details

- This error message is pretty awful. It should just state that the element is not visible if it can't find the reason.

### How has the user experience changed?

#### Before

Test would fail visibility assertion and print:

```
Cypress could not determine why this element '<button>' is not visible.
```

#### After

Test will fail visibility assertion and print:

```
This element '<button>' is not visible.
```

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [NA] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)--> DOESN'T REALLY CLOSE ISSUE
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
