### PR TITLE
[WIP] Replaced the deprecated dep @types/blob-util

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@cypress/sinon-chai": "1.1.0",
-    "@types/blob-util": "1.3.3",
     "@types/bluebird": "3.5.29",
     "@types/chai": "4.2.7",
     "@types/chai-jquery": "1.1.40",


### PR DESCRIPTION
- Closes <#6001>

<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details
Replaced @types/blob-util dependency. This is a stub types definition. blob-util provides its own type definitions, so you do not need this included.


### PR Tasks
- [ ] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
