### PR TITLE
fix: edge cases during cy.type in number input

### DIFF
--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -62,7 +62,7 @@ const monthRe = /^\d{4}-(0\d|1[0-2])/
 const weekRe = /^\d{4}-W(0[1-9]|[1-4]\d|5[0-3])/
 const timeRe = /^([0-1]\d|2[0-3]):[0-5]\d(:[0-5]\d)?(\.[0-9]{1,3})?/
 const dateTimeRe = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}/
-const numberRe = /^-?(0|[1-9]\d*)(\.\d+)?(e-?(0|[1-9]\d*))?$/i
+const numberRe = /^-?(\d+|\d+\.\d+|\.\d+)([eE][-+]?\d+)?$/i
 const charsBetweenCurlyBracesRe = /({.+?})/
 
 const INITIAL_MODIFIERS = {
@@ -260,7 +260,11 @@ const shouldUpdateValue = (el: HTMLElement, key: KeyDetails, options) => {
 
       if (!(numberRe.test(potentialValue))) {
         debug('skipping inserting value since number input would be invalid', key.text, potentialValue)
-        options.prevVal = needsValue + key.text
+        if (key.text.match(/[-+eE\d\.]/)) {
+          options.prevVal = needsValue + key.text
+        } else {
+          options.prevVal = ''
+        }
 
         return
       }
@@ -477,7 +481,9 @@ function _getEndIndex (str, substr) {
 // Simulated default actions for select few keys.
 const simulatedDefaultKeyMap: { [key: string]: SimulatedDefault } = {
   Enter: (el, key, options) => {
-    $selection.replaceSelectionContents(el, '\n')
+    if (!$elements.isInput(el)) {
+      $selection.replaceSelectionContents(el, '\n')
+    }
 
     options.onEnterPressed()
   },

--- a/packages/driver/test/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/type_spec.js
@@ -1302,6 +1302,20 @@ describe('src/cy/commands/actions/type', () => {
             expect(blurred).to.be.calledOnce
           })
         })
+
+        // https://github.com/cypress-io/cypress/issues/5997
+        it('type=number can accept values with commas (,)', () => {
+          cy.get('#number-without-value')
+          .type('1,000')
+          .should('have.value', '1000')
+        })
+
+        // https://github.com/cypress-io/cypress/issues/5968
+        it('type=number can include {enter}', () => {
+          cy.get('#number-without-value')
+          .type('100{enter}')
+          .should('have.value', '100')
+        })
       })
 
       describe('input[type=email]', () => {


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- fix #5968
{enter} in input type=number
- fix #5997
allow non-number chars in number input


### User facing changelog
- bug fix: fixed regression in 3.8.0 during cy.type with non-number characters and {enter} special character.
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
