### PR TITLE
Config values that come from plugins are now colored properly (purple)

### DIFF
--- a/packages/desktop-gui/cypress/fixtures/config.json
+++ b/packages/desktop-gui/cypress/fixtures/config.json
@@ -196,7 +196,7 @@
       "value": "http://localhost:8080"
     },
     "browsers": {
-      "from": "plugins",
+      "from": "plugin",
       "value": [
         {
           "name": "chrome",

--- a/packages/desktop-gui/cypress/integration/settings_spec.js
+++ b/packages/desktop-gui/cypress/integration/settings_spec.js
@@ -109,16 +109,16 @@ describe('Settings', () => {
       it('applies the same color treatment to expanded key values as the root key', () => {
         cy.contains('span', 'browsers').parents('div').first().find('span').first().click()
         cy.get('.config-vars').as('config-vars')
-        .contains('span', 'Chrome').parent('span').should('have.class', 'plugins')
+        .contains('span', 'Chrome').parent('span').should('have.class', 'plugin')
 
         cy.get('@config-vars')
-        .contains('span', 'Chromium').parent('span').should('have.class', 'plugins')
+        .contains('span', 'Chromium').parent('span').should('have.class', 'plugin')
 
         cy.get('@config-vars')
-        .contains('span', 'Canary').parent('span').should('have.class', 'plugins')
+        .contains('span', 'Canary').parent('span').should('have.class', 'plugin')
 
         cy.get('@config-vars')
-        .contains('span', 'Electron').parent('span').should('have.class', 'plugins')
+        .contains('span', 'Electron').parent('span').should('have.class', 'plugin')
 
         cy.contains('span', 'blacklistHosts').parents('div').first().find('span').first().click()
         cy.get('@config-vars')
@@ -137,7 +137,7 @@ describe('Settings', () => {
         cy.get('@config-vars')
         .contains('span', 'Electron').parents('div').first().find('span').first().click()
 
-        cy.get('@config-vars').contains('span', 'electron').parents('li').eq(1).find('.line .plugins').should('have.length', 6)
+        cy.get('@config-vars').contains('span', 'electron').parents('li').eq(1).find('.line .plugin').should('have.length', 6)
       })
 
       it('displays string values as quoted strings', () => {

--- a/packages/desktop-gui/src/settings/configuration.jsx
+++ b/packages/desktop-gui/src/settings/configuration.jsx
@@ -174,7 +174,7 @@ const Configuration = observer(({ project }) => (
           <td>set from CLI arguments</td>
         </tr>
         <tr className='config-keys'>
-          <td><span className='plugins'>plugin</span></td>
+          <td><span className='plugin'>plugin</span></td>
           <td>set from plugin file</td>
         </tr>
       </tbody>

--- a/packages/desktop-gui/src/settings/settings.scss
+++ b/packages/desktop-gui/src/settings/settings.scss
@@ -100,7 +100,7 @@
     }
   }
 
-  .envFile, .env, .config, .cli, .plugins, .default {
+  .envFile, .env, .config, .cli, .plugin, .default {
     font-family: $font-mono;
     padding: 2px;
   }
@@ -125,7 +125,7 @@
     color: #A21313;
   }
 
-  .plugins {
+  .plugin {
     background-color: #f0e7fc;
     color: #134aa2;
   }


### PR DESCRIPTION
Closes #6024

### User facing changelog

Config values that come from plugins are now colored properly (purple) in the settings panel.

Before:
![image](https://user-images.githubusercontent.com/1578436/71379061-0e190980-2598-11ea-9e51-4aa6e0873754.png)

After:
![image](https://user-images.githubusercontent.com/1578436/71378976-c09c9c80-2597-11ea-8574-cbd3a6daa83d.png)

### Additional details

Tests were passing as they were using configuration data that was not completely representative of actual config data; i.e. the configuration's "from" value was set to "plugins" in the test, but actually has the value of "plugin."

Tests were altered to account for the above and SCSS styles were retargeted to the new className, `.plugin`.

### How has the user experience changed?

The UX will now highlight config values that come from a plugin in the correct shade of purple. This also extends to nested values.

![image](https://user-images.githubusercontent.com/1578436/71379209-7c5dcc00-2598-11ea-8620-012b344b4cda.png)

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
