### PR TITLE
Added missing EventEmitter2 type to Cypress and cy + missing runUrl to Cypress.run() result.

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -37,6 +37,7 @@
     "commander": "2.15.1",
     "common-tags": "1.8.0",
     "debug": "3.2.6",
+    "eventemitter2": "4.1.2",
     "execa": "0.10.0",
     "executable": "4.1.1",
     "extract-zip": "1.6.7",

--- a/cli/types/cypress-npm-api.d.ts
+++ b/cli/types/cypress-npm-api.d.ts
@@ -461,6 +461,7 @@ declare module 'cypress' {
     totalPassed: number
     totalPending: number
     totalSkipped: number
+    runUrl: string
     runs: RunResult[]
     browserPath: string
     browserName: string

--- a/cli/types/cypress-npm-api.d.ts
+++ b/cli/types/cypress-npm-api.d.ts
@@ -462,7 +462,7 @@ declare module 'cypress' {
     totalPending: number
     totalSkipped: number
     /**
-     * If Cypress test run is being recorded, full rul will be provided.
+     * If Cypress test run is being recorded, full url will be provided.
      * @see https://on.cypress.io/dashboard-introduction
      */
     runUrl?: string

--- a/cli/types/cypress-npm-api.d.ts
+++ b/cli/types/cypress-npm-api.d.ts
@@ -461,7 +461,11 @@ declare module 'cypress' {
     totalPassed: number
     totalPending: number
     totalSkipped: number
-    runUrl: string
+    /**
+     * If Cypress test run is being recorded, full rul will be provided.
+     * @see https://on.cypress.io/dashboard-introduction
+     */
+    runUrl?: string
     runs: RunResult[]
     browserPath: string
     browserName: string

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -30,6 +30,15 @@
 // hmm, how to load it better?
 /// <reference path="./cypress-npm-api.d.ts" />
 
+// Cypress, cy, Log inherits EventEmitter.
+type EventEmitter2 = import("eventemitter2").EventEmitter2
+
+interface EventEmitter extends EventEmitter2 {
+  proxyTo: (cy: Cypress.cy) => null
+  emitMap: (eventName: string, args: any[]) => Array<(...args: any[]) => any>
+  emitThen: (eventName: string, args: any[]) => Bluebird.BluebirdStatic
+}
+
 // Cypress adds chai expect and assert to global
 declare const expect: Chai.ExpectStatic
 declare const assert: Chai.AssertStatic
@@ -4506,7 +4515,7 @@ cy.get('button').click()
 cy.get('.result').contains('Expected text')
 ```
  */
-declare const cy: Cypress.cy
+declare const cy: Cypress.cy & EventEmitter
 
 /**
  * Global variable `Cypress` holds common utilities and constants.
@@ -4518,4 +4527,4 @@ Cypress.version // => "1.4.0"
 Cypress._ // => Lodash _
 ```
  */
-declare const Cypress: Cypress.Cypress
+declare const Cypress: Cypress.Cypress & EventEmitter

--- a/cli/types/tests/cypress-npm-api-test.ts
+++ b/cli/types/tests/cypress-npm-api-test.ts
@@ -11,6 +11,7 @@ cypress.run().then(results => {
   results // $ExpectType CypressRunResult
   results.failures // $ExpectType number | undefined
   results.message // $ExpectType string | undefined
+  results.runUrl // $ExpectType string | undefined
 })
 cypress.open() // $ExpectType Promise<void>
 cypress.run() // $ExpectType Promise<CypressRunResult>

--- a/cli/types/tests/kitchen-sink.ts
+++ b/cli/types/tests/kitchen-sink.ts
@@ -63,18 +63,20 @@ stub()
 expect(stub).to.have.been.calledOnce
 cy.wrap(stub).should('have.been.calledOnce')
 
-// window:confirm stubbing
-Cypress.on('window:confirm', () => { })
-Cypress.on('window:confirm', cy.spy())
-Cypress.on('window:confirm', cy.stub())
-cy.on('window:confirm', () => { })
-cy.on('window:confirm', cy.spy())
-cy.on('window:confirm', cy.stub())
+namespace EventInterfaceTests {
+  // window:confirm stubbing
+  Cypress.on('window:confirm', () => { })
+  Cypress.on('window:confirm', cy.spy())
+  Cypress.on('window:confirm', cy.stub())
+  cy.on('window:confirm', () => { })
+  cy.on('window:confirm', cy.spy())
+  cy.on('window:confirm', cy.stub())
 
-Cypress.removeListener('fail', () => {})
-Cypress.removeAllListeners('fail')
-cy.removeListener('fail', () => {})
-cy.removeAllListeners('fail')
+  Cypress.removeListener('fail', () => {})
+  Cypress.removeAllListeners('fail')
+  cy.removeListener('fail', () => {})
+  cy.removeAllListeners('fail')
+}
 
 // specifying HTTP method directly in the options object
 cy.request({

--- a/cli/types/tests/kitchen-sink.ts
+++ b/cli/types/tests/kitchen-sink.ts
@@ -71,6 +71,11 @@ cy.on('window:confirm', () => { })
 cy.on('window:confirm', cy.spy())
 cy.on('window:confirm', cy.stub())
 
+Cypress.removeListener('fail', () => {})
+Cypress.removeAllListeners('fail')
+cy.removeListener('fail', () => {})
+cy.removeAllListeners('fail')
+
 // specifying HTTP method directly in the options object
 cy.request({
   url: "http://localhost:3000/myressource",


### PR DESCRIPTION
- Closes #5228
- Closes #6087

### User facing changelog

* EventEmitter2 types like `removeListener`, `removeAllListeners` are added to `Cypress` and `cy`.
* Missing `runUrl` is added to type.

### Additional details

#### Why was this change necessary?

* #5228: Unlike `on` or `once`, `removeListener` and `removeAllListeners` are [documented here](https://docs.cypress.io/api/events/catalog-of-events.html#Binding-to-Events). But their types didn't exist in `index.d.ts`. 
* #6087: [`runUrl` is documented](https://docs.cypress.io/guides/guides/module-api.html#cypress-run). But type is missing. 

#### What is affected by this change?

N/A

#### Any implementation details to explain?

* #5228: Added `eventemitter2` to `cli` and used `import()` in `index.d.ts`. 
* #6087: N/A

### How has the user experience changed?

#### #5228

**Before:**
![](https://user-images.githubusercontent.com/6719491/71596031-aa1db480-2b46-11ea-897f-5d1a887d8d0d.png)

**After:**
![Screenshot from 2019-12-31 11-18-26](https://user-images.githubusercontent.com/8130013/71607750-5c915e00-2bbf-11ea-9084-cc8858b82676.png)

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
