### PR TITLE
Update issue template to be more specific about providing a failing test

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,18 +1,19 @@
-<!-- Is this a question? Don't open an issue. Ask in our chat https://on.cypress.io/chat  -->
+<!-- Is this a question? Questions WILL BE CLOSED. Ask in our chat https://on.cypress.io/chat  -->
 
 ### Current behavior:
 
-<!-- images, stack traces, etc -->
+<!-- A description including screenshots, stack traces, DEBUG logs, etc -->
 
 ### Desired behavior:
 
-<!-- A clear concise description of what you want to happen -->
+<!-- A clear description of what you want to happen -->
 
-### Steps to reproduce: (app code and test code)
+### Test code to reproduce
 
-<!-- Issues without reproducible steps WILL BE CLOSED -->
+<!-- If we cannot fully run the tests as provided the issue WILL BE CLOSED -->
+<!-- Issues without a reproducible example WILL BE CLOSED -->
 
-<!-- You can fork https://github.com/cypress-io/cypress-test-tiny repo, set up a failing test, then tell us the repo/branch to try. -->
+<!-- You can fork https://github.com/cypress-io/cypress-test-tiny repo, set up a failing test, then link to your fork -->
 
 ### Versions
 


### PR DESCRIPTION
Trying to get people to actually provide test code in the issue template instead of 'steps'. People are frequently writing things like:

>1. visit https:example.cypress.io
>2. get the input element
>3. type into the element with force true

When all I want is the test code

>```js
>cy.visit('https:example.cypress.io')
>cy.get('input').type({force: true})
>```