### PR TITLE
Move binary state file to be in the version folder of the cache

### DIFF
--- a/cli/lib/tasks/state.js
+++ b/cli/lib/tasks/state.js
@@ -108,6 +108,10 @@ const getDistDir = () => {
   return path.join(__dirname, '..', '..', 'dist')
 }
 
+/**
+ * Returns full filename to the file that keeps the Test Runner verification state as JSON text.
+ * @param {string} binaryDir - full path to the folder holding the binary
+ */
 const getBinaryStatePath = (binaryDir) => {
   return path.join(binaryDir, 'binary_state.json')
 }
@@ -132,7 +136,10 @@ const clearBinaryStateAsync = (binaryDir) => {
 }
 
 /**
- * @param {boolean} verified
+ * Writes the new binary status.
+ * @param {boolean} verified The new test runner state after smoke test
+ * @param {string} binaryDir Folder holding the binary
+ * @returns {Promise<void>} returns a promise
  */
 const writeBinaryVerifiedAsync = (verified, binaryDir) => {
   return getBinaryStateContentsAsync(binaryDir)

--- a/cli/lib/tasks/state.js
+++ b/cli/lib/tasks/state.js
@@ -110,16 +110,19 @@ const getDistDir = () => {
 
 /**
  * Returns full filename to the file that keeps the Test Runner verification state as JSON text.
- * @param {string} binaryDir - full path to the folder holding the binary
+ * Note: the binary state file will be stored one level up from the given binary folder.
+ * @param {string} binaryDir - full path to the folder holding the binary.
  */
 const getBinaryStatePath = (binaryDir) => {
-  return path.join(binaryDir, 'binary_state.json')
+  return path.join(binaryDir, '..', 'binary_state.json')
 }
 
 const getBinaryStateContentsAsync = (binaryDir) => {
-  return fs.readJsonAsync(getBinaryStatePath(binaryDir))
+  const fullPath = getBinaryStatePath(binaryDir)
+
+  return fs.readJsonAsync(fullPath)
   .catch({ code: 'ENOENT' }, SyntaxError, () => {
-    debug('could not read binary_state.json file')
+    debug('could not read binary_state.json file at "%s"', fullPath)
 
     return {}
   })

--- a/cli/test/lib/tasks/state_spec.js
+++ b/cli/test/lib/tasks/state_spec.js
@@ -179,16 +179,18 @@ describe('lib/tasks/state', function () {
     })
 
     it('can accept custom binaryDir', function () {
-      const customBinaryDir = '/custom/binary/dir'
+      // note how the binary state file is in the runner's parent folder
+      const customBinaryDir = '/custom/binary/1.2.3/runner'
+      const binaryStatePath = '/custom/binary/1.2.3/binary_state.json'
 
       sinon
       .stub(fs, 'pathExistsAsync')
-      .withArgs('/custom/binary/dir/binary_state.json')
-      .resolves({ verified: true })
+      .withArgs(binaryStatePath)
+      .resolves(true)
 
       sinon
       .stub(fs, 'readJsonAsync')
-      .withArgs('/custom/binary/dir/binary_state.json')
+      .withArgs(binaryStatePath)
       .resolves({ verified: true })
 
       return state
@@ -200,6 +202,8 @@ describe('lib/tasks/state', function () {
   })
 
   context('.writeBinaryVerified', function () {
+    const binaryStateFilename = path.join(versionDir, 'binary_state.json')
+
     beforeEach(() => {
       mockfs({})
     })
@@ -216,7 +220,7 @@ describe('lib/tasks/state', function () {
       .then(
         () => {
           return expect(fs.outputJsonAsync).to.be.calledWith(
-            path.join(binaryDir, 'binary_state.json'),
+            binaryStateFilename,
             { verified: true }
           )
         },
@@ -231,7 +235,7 @@ describe('lib/tasks/state', function () {
       .writeBinaryVerifiedAsync(false, binaryDir)
       .then(() => {
         return expect(fs.outputJsonAsync).to.be.calledWith(
-          path.join(binaryDir, 'binary_state.json'),
+          binaryStateFilename,
           { verified: false },
           { spaces: 2 }
         )

--- a/cli/test/lib/tasks/verify_spec.js
+++ b/cli/test/lib/tasks/verify_spec.js
@@ -1,5 +1,6 @@
 require('../../spec_helper')
 
+const path = require('path')
 const _ = require('lodash')
 const os = require('os')
 const cp = require('child_process')
@@ -23,7 +24,7 @@ const snapshot = require('../../support/snapshot')
 const packageVersion = '1.2.3'
 const cacheDir = '/cache/Cypress'
 const executablePath = '/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress'
-const binaryStatePath = '/cache/Cypress/1.2.3/Cypress.app/binary_state.json'
+const binaryStatePath = '/cache/Cypress/1.2.3/binary_state.json'
 
 let stdout
 let spawnedProcess
@@ -751,14 +752,19 @@ function createfs ({ alreadyVerified, executable, packageVersion, customDir }) {
     customDir = '/cache/Cypress/1.2.3/Cypress.app'
   }
 
+  // binary state is stored one folder higher than the runner itself
+  const binaryStateFolder = path.join(customDir, '..')
+
   const binaryState = {
     verified: alreadyVerified,
   }
   const binaryStateText = JSON.stringify(binaryState)
 
   let mockFiles = {
-    [customDir]: {
+    [binaryStateFolder]: {
       'binary_state.json': binaryStateText,
+    },
+    [customDir]: {
       Contents: {
         MacOS: executable
           ? {

--- a/cli/test/lib/tasks/verify_spec.js
+++ b/cli/test/lib/tasks/verify_spec.js
@@ -753,6 +753,7 @@ function createfs ({ alreadyVerified, executable, packageVersion, customDir }) {
   }
 
   // binary state is stored one folder higher than the runner itself
+  // see https://github.com/cypress-io/cypress/issues/6089
   const binaryStateFolder = path.join(customDir, '..')
 
   const binaryState = {

--- a/cli/test/lib/tasks/verify_spec.js
+++ b/cli/test/lib/tasks/verify_spec.js
@@ -747,9 +747,18 @@ context('lib/tasks/verify', () => {
 
 // TODO this needs documentation with examples badly.
 function createfs ({ alreadyVerified, executable, packageVersion, customDir }) {
+  if (!customDir) {
+    customDir = '/cache/Cypress/1.2.3/Cypress.app'
+  }
+
+  const binaryState = {
+    verified: alreadyVerified,
+  }
+  const binaryStateText = JSON.stringify(binaryState)
+
   let mockFiles = {
-    [customDir ? customDir : '/cache/Cypress/1.2.3/Cypress.app']: {
-      'binary_state.json': `{"verified": ${alreadyVerified}}`,
+    [customDir]: {
+      'binary_state.json': binaryStateText,
       Contents: {
         MacOS: executable
           ? {


### PR DESCRIPTION
- Closes #6089

### User facing changelog

To the user, the changes will be invisible

### Additional details

This will preserve the new Mac notarization from https://github.com/cypress-io/cypress/pull/6013 to work because we no longer will be writing the file `binary_state.json` in the binary folder. Instead the `cypress verify` status will be written in `~/.cache/Cypress/<version>/binary_state.json` file (the actual path depends on the platform).

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->

