### PR TITLE
should() chaining

### DIFF
--- a/packages/driver/src/cy/assertions.js
+++ b/packages/driver/src/cy/assertions.js
@@ -284,7 +284,18 @@ const create = function (state, queue, retryFn) {
         // assertions
         if (cmdHasFunctionArg(cmd)) {
           let index = cmd.get('assertionIndex')
-          const assertions = cmd.get('assertions')
+          let assertions = cmd.get('assertions')
+
+          // https://github.com/cypress-io/cypress/issues/4981
+          // `assertions` is undefined because assertions added by
+          // `should` command are not handled yet.
+          // So, don't increase i and go back to the last command.
+          if (!assertions) {
+            i -= 1
+            cmd = cmds[i - 1]
+            index = cmd.get('assertionIndex')
+            assertions = cmd.get('assertions')
+          }
 
           // always increase the assertionIndex
           // so our next assertion matches up

--- a/packages/driver/test/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/test/cypress/integration/commands/assertions_spec.js
@@ -211,6 +211,29 @@ describe('src/cy/commands/assertions', () => {
         })
       })
 
+      it('can be chained', () => {
+        cy.wrap('ab')
+        .should((subject) => {
+          expect(subject).to.be.a('string')
+          expect(subject).to.contain('a')
+        })
+        .should((subject) => {
+          expect(subject).to.contain('b')
+          expect(subject).to.have.length(2)
+        })
+        .and((subject) => {
+          expect(subject).to.eq('ab')
+          expect(subject).not.to.contain('c')
+        })
+        .then(function () {
+          expect(this.logs.length).to.eq(8)
+
+          this.logs.slice(1).forEach((log) => {
+            expect(log.get('name')).to.eq('assert')
+          })
+        })
+      })
+
       context('remote jQuery instances', () => {
         beforeEach(function () {
           this.remoteWindow = cy.state('window')


### PR DESCRIPTION
- Closes #4981

### User facing changelog

Now, `should()` and `and()` with function argument can be chained. 

### Additional details

#### Why was this change necessary?

Sometimes, we want to organize our assertions by chaining `should()`s but we couldn't. 

#### What is affected by this change?

N/A

#### Any implementation details to explain?

N/A

### How has the user experience changed?

Now code like below works.

```js
cy.wrap('ab')
.should((subject) => {
  expect(subject).to.be.a('string')
  expect(subject).to.contain('a')
})
.should((subject) => {
  expect(subject).to.contain('b')
  expect(subject).to.have.length(2)
})
.and((subject) => {
  expect(subject).to.eq('ab')
  expect(subject).not.to.contain('c')
})
```


### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
