### PR TITLE
retry CRI.List when connecting to the browser

### DIFF
--- a/packages/server/lib/browsers/protocol.js
+++ b/packages/server/lib/browsers/protocol.js
@@ -89,8 +89,7 @@ const getWsTargetFor = (port) => {
     port,
   }
 
-  // call via "module.exports" to enable easy stubbing from tests
-  return module.exports._connectAsync(connectOpts)
+  return _connectAsync(connectOpts)
   .tapCatch((err) => {
     debug('failed to connect to CDP %o', { connectOpts, err })
   })

--- a/packages/server/lib/browsers/protocol.js
+++ b/packages/server/lib/browsers/protocol.js
@@ -63,11 +63,12 @@ const findStartPage = (targets) => {
 }
 
 const findStartPageTarget = (connectOpts) => {
-  debug('CRI.List on port %d', connectOpts.port)
+  debug('CRI.List %o', connectOpts)
 
   // what happens if the next call throws an error?
   // it seems to leave the browser instance open
-  return CRI.List(connectOpts).then(findStartPage)
+  // need to clone connectOpts, CRI modifies it
+  return CRI.List(_.clone(connectOpts)).then(findStartPage)
 }
 
 /**
@@ -93,9 +94,6 @@ const getWsTargetFor = (port) => {
   }
 
   return _connectAsync(connectOpts)
-  .tapCatch((err) => {
-    debug('failed to connect to CDP %o', { connectOpts, err })
-  })
   .then(() => {
     const retry = () => {
       debug('attempting to find CRI target... %o', { retryIndex })
@@ -117,6 +115,9 @@ const getWsTargetFor = (port) => {
     }
 
     return retry()
+  })
+  .tapCatch((err) => {
+    debug('failed to connect to CDP %o', { connectOpts, err })
   })
 }
 

--- a/packages/server/lib/browsers/protocol.js
+++ b/packages/server/lib/browsers/protocol.js
@@ -89,7 +89,8 @@ const getWsTargetFor = (port) => {
     port,
   }
 
-  return _connectAsync(connectOpts)
+  // call via "module.exports" to enable easy stubbing from tests
+  return module.exports._connectAsync(connectOpts)
   .tapCatch((err) => {
     debug('failed to connect to CDP %o', { connectOpts, err })
   })
@@ -98,9 +99,11 @@ const getWsTargetFor = (port) => {
 
     // p-retry https://github.com/sindresorhus/p-retry uses options
     // from https://github.com/tim-kos/node-retry#retryoperationoptions
-    // and defaults (1 second first retry, exponential factor 2, 10 attempts)
+    // and defaults (1 second first retry, 10 attempts)
     // are reasonable
-    return pRetry(findPage)
+    return pRetry(findPage, {
+      factor: 1, // no need to increase timeouts exponentially
+    })
   })
 }
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -106,6 +106,7 @@
     "opn": "cypress-io/opn#2f4e9a216ca7bdb95dfae9d46d99ddf004b3cbb5",
     "ospath": "1.2.2",
     "p-queue": "6.1.0",
+    "p-retry": "4.2.0",
     "pluralize": "8.0.0",
     "ramda": "0.24.1",
     "randomstring": "1.1.5",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -106,7 +106,6 @@
     "opn": "cypress-io/opn#2f4e9a216ca7bdb95dfae9d46d99ddf004b3cbb5",
     "ospath": "1.2.2",
     "p-queue": "6.1.0",
-    "p-retry": "4.2.0",
     "pluralize": "8.0.0",
     "ramda": "0.24.1",
     "randomstring": "1.1.5",

--- a/packages/server/test/unit/browsers/protocol_spec.ts
+++ b/packages/server/test/unit/browsers/protocol_spec.ts
@@ -12,12 +12,12 @@ import snapshot from 'snap-shot-it'
 import stripAnsi from 'strip-ansi'
 import { stripIndents } from 'common-tags'
 
-describe('lib/browsers/protocol', function () {
+describe('lib/browsers/protocol', () => {
   // protocol connects explicitly to this host
   const host = '127.0.0.1'
 
-  context('._getDelayMsForRetry', function () {
-    it('retries as expected for up to 20 seconds', function () {
+  context('._getDelayMsForRetry', () => {
+    it('retries as expected for up to 20 seconds', () => {
       const log = sinon.spy(console, 'log')
 
       let delays = []
@@ -41,8 +41,8 @@ describe('lib/browsers/protocol', function () {
     })
   })
 
-  context('.getWsTargetFor', function () {
-    it('rejects if CDP connection fails', function () {
+  context('.getWsTargetFor', () => {
+    it('rejects if CDP connection fails', () => {
       const innerErr = new Error('cdp connection failure')
 
       sinon.stub(connect, 'createRetryingSocket').callsArgWith(1, innerErr)
@@ -58,12 +58,12 @@ describe('lib/browsers/protocol', function () {
         Error details:
       `
 
-      return expect(p).to.eventually.be.rejected
+      expect(p).to.eventually.be.rejected
       .and.property('message').include(expectedError)
       .and.include(innerErr.message)
     })
 
-    it('returns the debugger URL of the first about:blank tab', async function () {
+    it('returns the debugger URL of the first about:blank tab', async () => {
       const targets = [
         {
           type: 'page',
@@ -89,7 +89,7 @@ describe('lib/browsers/protocol', function () {
     })
   })
 
-  context('CRI.List', function () {
+  context('CRI.List', () => {
     it('retries several times if starting page cannot be found', async () => {
       const port = 1234
       const targets = [
@@ -105,7 +105,10 @@ describe('lib/browsers/protocol', function () {
         },
       ]
 
-      sinon.stub(protocol, '_connectAsync').resolves()
+      const end = sinon.stub()
+
+      sinon.stub(connect, 'createRetryingSocket').callsArgWith(1, null, { end })
+
       const criList = sinon.stub(CRI, 'List')
       .withArgs({ host, port })
       .onFirstCall().resolves([])

--- a/packages/server/test/unit/browsers/protocol_spec.ts
+++ b/packages/server/test/unit/browsers/protocol_spec.ts
@@ -79,7 +79,10 @@ describe('lib/browsers/protocol', () => {
 
       const end = sinon.stub()
 
-      sinon.stub(CRI, 'List').withArgs({ host, port: 12345 }).resolves(targets)
+      sinon.stub(CRI, 'List')
+      .withArgs({ host, port: 12345, getDelayMsForRetry: sinon.match.func })
+      .resolves(targets)
+
       sinon.stub(connect, 'createRetryingSocket').callsArgWith(1, null, { end })
 
       const p = protocol.getWsTargetFor(12345)
@@ -110,7 +113,7 @@ describe('lib/browsers/protocol', () => {
       sinon.stub(connect, 'createRetryingSocket').callsArgWith(1, null, { end })
 
       const criList = sinon.stub(CRI, 'List')
-      .withArgs({ host, port })
+      .withArgs({ host, port: 1234, getDelayMsForRetry: sinon.match.func }).resolves(targets)
       .onFirstCall().resolves([])
       .onSecondCall().resolves([])
       .onThirdCall().resolves(targets)


### PR DESCRIPTION
- Closes #6053 
- retries `CRI.List` if the `about:blank` page cannot be found, maybe the browser is starting

### User facing changelog

The CI runs should stop failing due to Cypress not being able to find the tab to control.

### Additional details

I did experiments with closing and opening Chrome Canary with lots of tabs and extensions and could get into situations where the initial `CRI.List` call returns no targets, but the next call returns full list of tabs. Adding retries seems like a solution we need to try.

### How has the user experience changed?

No changes, unless the user is running Cypress with debug logs `DEBUG=cypress:server:protocol`. In that case they should see several calls 

```
  cypress:server:protocol CRI.List on port 56428 +317ms
  cypress:server:protocol CRI List { numTargets: 1, targets: [ { description: '', devtoolsFrontendUrl: '/devtools/inspector.html?ws=localhost:56428/devtools/page/2FCCB2A0FA8B1DCD5E1CDC2849A6A326', id: '2FCCB2A0FA8B1DCD5E1CDC2849A6A326', title: 'Sortify', type: 'background_page', url: 'chrome-extension://aehmpfeibpcclkbjjkclhncmjncpebef/_generated_background_page.html', webSocketDebuggerUrl: 'ws://localhost:56428/devtools/page/2FCCB2A0FA8B1DCD5E1CDC2849A6A326' } ] } +88ms
  cypress:server:protocol CRI.List on port 56428 +1s
  cypress:server:protocol CRI List { numTargets: 10,
...
```

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->