### PR TITLE
fix flaky navigation_spec test

### DIFF
--- a/packages/driver/test/cypress/integration/commands/navigation_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/navigation_spec.coffee
@@ -195,7 +195,7 @@ describe "src/cy/commands/navigation", ->
       it "does not log 'Page Load' events", ->
         cy.reload().then ->
           @logs.slice(0).forEach (log) ->
-            expect(log.get("event")).to.be.false
+            expect(log.get("name")).not.eq('page load')
 
       it "logs before + after", ->
         beforeunload = false
@@ -393,7 +393,7 @@ describe "src/cy/commands/navigation", ->
           .visit("/fixtures/jquery.html")
           .go("back").then ->
             @logs.slice(0).forEach (log) ->
-              expect(log.get("event")).to.be.false
+              expect(log.get("name")).not.eq('page load')
 
       it "logs before + after", ->
         beforeunload = false
@@ -782,7 +782,7 @@ describe "src/cy/commands/navigation", ->
           .visit("/fixtures/jquery.html")
           .then ->
             @logs.slice(0).forEach (log) ->
-              expect(log.get("event")).to.be.false
+              expect(log.get("name")).not.eq('page load')
 
       it "logs immediately before resolving", ->
         expected = false
@@ -1872,6 +1872,7 @@ describe "src/cy/commands/navigation", ->
       cy.on "log:added", (attrs, log) =>
         if attrs.name is "new url"
           @lastLog = log
+          attrs.event = false
 
           @logs.push(log)
 

--- a/packages/driver/test/cypress/integration/commands/navigation_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/navigation_spec.coffee
@@ -1872,7 +1872,6 @@ describe "src/cy/commands/navigation", ->
       cy.on "log:added", (attrs, log) =>
         if attrs.name is "new url"
           @lastLog = log
-          attrs.event = false
 
           @logs.push(log)
 


### PR DESCRIPTION
fix #6030 

fix flaky test which was incorrectly failing due to the 'new url' event