### PR TITLE
set --headed false when passing --headless

### DIFF
--- a/packages/server/lib/cypress.js
+++ b/packages/server/lib/cypress.js
@@ -157,6 +157,10 @@ module.exports = {
 
     if (options.headless) {
       // --headless is same as --headed false
+      if (options.headed) {
+        throw new Error('Impossible options: both headless and headed are true')
+      }
+
       options.headed = false
     }
 

--- a/packages/server/lib/cypress.js
+++ b/packages/server/lib/cypress.js
@@ -153,7 +153,15 @@ module.exports = {
 
     const options = argsUtils.toObject(argv)
 
+    debug('from argv %o got options %o', argv, options)
+
+    if (options.headless) {
+      // --headless is same as --headed false
+      options.headed = false
+    }
+
     if (options.runProject && !options.headed) {
+      debug('scaling electron app in headless mode')
       // scale the electron browser window
       // to force retina screens to not
       // upsample their images when offscreen
@@ -196,7 +204,7 @@ module.exports = {
   },
 
   startInMode (mode, options) {
-    debug('starting in mode %s', mode)
+    debug('starting in mode %s with options %o', mode, options)
 
     switch (mode) {
       case 'version':

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -348,6 +348,26 @@ describe('lib/cypress', () => {
       })
     })
 
+    it('sets --headed false if --headless', function () {
+      sinon.spy(cypress, 'startInMode')
+
+      return cypress.start([`--run-project=${this.todosPath}`, '--headless'])
+      .then(() => {
+        expect(browsers.open).to.be.calledWithMatch(ELECTRON_BROWSER)
+        this.expectExitWith(0)
+
+        // check how --headless option sets --headed
+        expect(cypress.startInMode).to.be.calledOnce
+        expect(cypress.startInMode).to.be.calledWith('run')
+        const startInModeOptions = cypress.startInMode.firstCall.args[1]
+
+        expect(startInModeOptions).to.include({
+          headless: true,
+          headed: false,
+        })
+      })
+    })
+
     describe('strips --', () => {
       beforeEach(() => {
         sinon.spy(argsUtil, 'toObject')

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -368,6 +368,12 @@ describe('lib/cypress', () => {
       })
     })
 
+    it('throws an error if both --headed and --headless are true', function () {
+      // error is thrown synchronously
+      expect(() => cypress.start([`--run-project=${this.todosPath}`, '--headless', '--headed']))
+      .to.throw('Impossible options: both headless and headed are true')
+    })
+
     describe('strips --', () => {
       beforeEach(() => {
         sinon.spy(argsUtil, 'toObject')


### PR DESCRIPTION
- Closes #6151

### User facing changelog

No changes for the user, same `cypress run --headless` behavior

### Additional details

When we run Cypress directly from `npm run dev` we should respect `--headless` CLI option, otherwise, the behavior is different from `cypress run`

### How has the user experience changed?

Now running from the monorepo

```
npm run dev -- --run-project ... --headless
```

Is the same as

```
npm run dev -- --run-project ... --headed false
```

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
