### PR TITLE
Update Bamboo variables for CI

### DIFF
--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -142,9 +142,7 @@ const _providerCiParams = () => {
       'bamboo_buildNumber',
       'bamboo_buildResultsUrl',
       'bamboo_planRepository_repositoryUrl',
-      'bamboo_planKey',
       'bamboo_buildKey',
-      'bamboo_agentId',
     ]),
     bitbucket: extract([
       'BITBUCKET_REPO_SLUG',

--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -108,16 +108,15 @@ const _detectProviderName = () => {
   // return the key of the first provider
   // which is truthy
 
-    return _.findKey(CI_PROVIDERS, (value) => {
-      if (_.isString(value)) {
-        return env[value]
-      }
+  return _.findKey(CI_PROVIDERS, (value) => {
+    if (_.isString(value)) {
+      return env[value]
+    }
 
-      if (_.isFunction(value)) {
-
-          return value()
-      }
-    })
+    if (_.isFunction(value)) {
+      return value()
+    }
+  })
 }
 
 // TODO: dont forget about buildNumber!

--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -30,8 +30,8 @@ const isAzureCi = () => {
   return process.env.TF_BUILD && process.env.AZURE_HTTP_USER_AGENT
 }
 
-const isBamboo =() => {
-    return process.env.bamboo_buildNumber
+const isBamboo = () => {
+  return process.env.bamboo_buildNumber
 }
 
 const isCodeshipBasic = () => {
@@ -107,15 +107,16 @@ const _detectProviderName = () => {
   const { env } = process
   // return the key of the first provider
   // which is truthy
+
     return _.findKey(CI_PROVIDERS, (value) => {
-        if (_.isString(value)) {
-            return env[value]
-        }
+      if (_.isString(value)) {
+        return env[value]
+      }
 
-        if (_.isFunction(value)) {
+      if (_.isFunction(value)) {
 
-            return value()
-        }
+          return value()
+      }
     })
 }
 
@@ -144,7 +145,7 @@ const _providerCiParams = () => {
       'bamboo_planRepository_repositoryUrl',
       'bamboo_planKey',
       'bamboo_buildKey',
-      'bamboo_agentId'
+      'bamboo_agentId',
     ]),
     bitbucket: extract([
       'BITBUCKET_REPO_SLUG',
@@ -376,7 +377,7 @@ const _providerCommitParams = () => {
       // message: ???
       authorName: env.bamboo_planRepository_username,
       // authorEmail: ???
-      remoteOrigin: env.bamboo_planRepository_repositoryURL
+      remoteOrigin: env.bamboo_planRepository_repositoryURL,
       // defaultBranch: ???
     },
     bitbucket: {

--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -30,6 +30,10 @@ const isAzureCi = () => {
   return process.env.TF_BUILD && process.env.AZURE_HTTP_USER_AGENT
 }
 
+const isBamboo =() => {
+    return process.env.bamboo_buildNumber
+}
+
 const isCodeshipBasic = () => {
   return process.env.CI_NAME && (process.env.CI_NAME === 'codeship') && process.env.CODESHIP
 }
@@ -78,7 +82,7 @@ const isWercker = () => {
 const CI_PROVIDERS = {
   'appveyor': 'APPVEYOR',
   'azure': isAzureCi,
-  'bamboo': 'bamboo.buildNumber',
+  'bamboo': isBamboo,
   'bitbucket': 'BITBUCKET_BUILD_NUMBER',
   'buildkite': 'BUILDKITE',
   'circle': 'CIRCLECI',
@@ -101,18 +105,18 @@ const CI_PROVIDERS = {
 
 const _detectProviderName = () => {
   const { env } = process
-
   // return the key of the first provider
   // which is truthy
-  return _.findKey(CI_PROVIDERS, (value) => {
-    if (_.isString(value)) {
-      return env[value]
-    }
+    return _.findKey(CI_PROVIDERS, (value) => {
+        if (_.isString(value)) {
+            return env[value]
+        }
 
-    if (_.isFunction(value)) {
-      return value()
-    }
-  })
+        if (_.isFunction(value)) {
+
+            return value()
+        }
+    })
 }
 
 // TODO: dont forget about buildNumber!
@@ -135,10 +139,12 @@ const _providerCiParams = () => {
       'BUILD_REPOSITORY_URI',
     ]),
     bamboo: extract([
-      'bamboo.resultsUrl',
-      'bamboo.buildNumber',
-      'bamboo.buildResultsUrl',
-      'bamboo.planRepository.repositoryUrl',
+      'bamboo_buildNumber',
+      'bamboo_buildResultsUrl',
+      'bamboo_planRepository_repositoryUrl',
+      'bamboo_planKey',
+      'bamboo_buildKey',
+      'bamboo_agentId'
     ]),
     bitbucket: extract([
       'BITBUCKET_REPO_SLUG',
@@ -365,12 +371,12 @@ const _providerCommitParams = () => {
       authorEmail: env.BUILD_REQUESTEDFOREMAIL,
     },
     bamboo: {
-      // sha: ???
-      branch: env['bamboo.planRepository.branch'],
+      sha: env.bamboo_planRepository_revision,
+      branch: env.bamboo_planRepository_branch,
       // message: ???
-      // authorName: ???
+      authorName: env.bamboo_planRepository_username,
       // authorEmail: ???
-      // remoteOrigin: ???
+      remoteOrigin: env.bamboo_planRepository_repositoryURL
       // defaultBranch: ???
     },
     bitbucket: {

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -106,9 +106,7 @@ describe "lib/util/ci_provider", ->
       "bamboo_buildNumber": "bambooBuildNumber"
       "bamboo_buildResultsUrl": "bambooBuildResultsUrl"
       "bamboo_planRepository_repositoryUrl": "bambooPlanRepositoryRepositoryUrl"
-      "bamboo_planKey": "bambooPlanKey"
       "bamboo_buildKey": "bambooBuildKey"
-      "bamboo_agentId": "bambooAgentId"
       "bamboo_planRepository_revision": "gitSha"
       "bamboo_planRepository_branch": "gitBranch"
       "bamboo_planRepository_username": "gitAuthor"
@@ -120,9 +118,7 @@ describe "lib/util/ci_provider", ->
       bambooBuildNumber: "bambooBuildNumber"
       bambooBuildResultsUrl: "bambooBuildResultsUrl"
       bambooPlanRepositoryRepositoryUrl: "bambooPlanRepositoryRepositoryUrl"
-      bambooPlanKey: "bambooPlanKey"
       bambooBuildKey: "bambooBuildKey"
-      bambooAgentId: "bambooAgentId"
     })
     expectsCommitParams({
       sha: "gitSha"

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -103,24 +103,32 @@ describe "lib/util/ci_provider", ->
 
   it "bamboo", ->
     resetEnv = mockedEnv({
-      "bamboo.buildNumber": "123"
-
-      "bamboo.resultsUrl": "bamboo.resultsUrl"
-      "bamboo.buildResultsUrl": "bamboo.buildResultsUrl"
-      "bamboo.planRepository.repositoryUrl": "bamboo.planRepository.repositoryUrl"
-
-      "bamboo.planRepository.branch": "bamboo.planRepository.branch"
+      "bamboo_buildNumber": "bambooBuildNumber"
+      "bamboo_buildResultsUrl": "bambooBuildResultsUrl"
+      "bamboo_planRepository_repositoryUrl": "bambooPlanRepositoryRepositoryUrl"
+      "bamboo_planKey": "bambooPlanKey"
+      "bamboo_buildKey": "bambooBuildKey"
+      "bamboo_agentId": "bambooAgentId"
+      "bamboo_planRepository_revision": "gitSha"
+      "bamboo_planRepository_branch": "gitBranch"
+      "bamboo_planRepository_username": "gitAuthor"
+      "bamboo_planRepository_repositoryURL": "gitRemoteOrigin"
     }, {clear: true})
 
     expectsName("bamboo")
     expectsCiParams({
-      bambooResultsUrl: "bamboo.resultsUrl"
-      bambooBuildNumber: "123"
-      bambooBuildResultsUrl: "bamboo.buildResultsUrl"
-      bambooPlanRepositoryRepositoryUrl: "bamboo.planRepository.repositoryUrl"
+      bambooBuildNumber: "bambooBuildNumber"
+      bambooBuildResultsUrl: "bambooBuildResultsUrl"
+      bambooPlanRepositoryRepositoryUrl: "bambooPlanRepositoryRepositoryUrl"
+      bambooPlanKey: "bambooPlanKey"
+      bambooBuildKey: "bambooBuildKey"
+      bambooAgentId: "bambooAgentId"
     })
     expectsCommitParams({
-      branch: "bamboo.planRepository.branch"
+      sha: "gitSha"
+      branch: "gitBranch"
+      authorName: "gitAuthor"
+      remoteOrigin: "gitRemoteOrigin"
     })
 
   it "bitbucket", ->


### PR DESCRIPTION
Enables and extends Bamboo + Git variables for use with CI/CD flows

Closes #4895 

### User facing changelog
We now collect more environment variables for Bamboo CI when recording for the Dashboard.

### Additional details
Cypress will now listen for the following Bamboo Variables:
ex: bamboo_VAR
- buildNumber
- buildResultsUrl
- planRepository_repositoryUrl
- planKey
- buildKey
- agentId

Also getting variables with underscores due to how Bamboo exports bash shell variables explained below.

>Bamboo variables are exported as bash shell variables. All full stops (periods) are converted to underscores. For example, the variable bamboo.my.variable is $bamboo_my_variable in bash. https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html#Bamboovariables-Systemvariables

### How has the user experience changed?

When using Bamboo and recording runs for the Dashboard, the relevant information will be available instead of null.

### PR Tasks

- [X] Have tests been added/updated?
- [X ] Has a PR for user-facing changes been opened in [`cypress-documentation`]
https://github.com/cypress-io/cypress-documentation/pull/2386