### PR TITLE
show 50 lines of the logmessage of cy.get, too

### DIFF
--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -377,7 +377,7 @@
     }
   }
 
-  .command-name-log {
+  .command-name-log, .command-name-get {
     .command-message-text {
       white-space: initial;
       word-wrap: break-word;


### PR DESCRIPTION
- Closes #6145

### User facing changelog

log entries are truncated at 50 lines.
So this:

![image](https://user-images.githubusercontent.com/3234900/72370414-7aec7300-3702-11ea-93d8-0e84d0b7fc47.png)

becomes:

![image](https://user-images.githubusercontent.com/3234900/72370396-72943800-3702-11ea-8e91-1fd611c18e78.png)
