### PR TITLE
fix: set explicit screen when spawning own xvfb

### DIFF
--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -119,9 +119,6 @@ module.exports = {
           electronArgs.unshift('--no-sandbox')
         }
 
-        // docker containers have 64M by default, sometimes even less
-        electronArgs.push('--disable-dev-shm-usage')
-
         // strip dev out of child process options
         let stdioOptions = _.pick(options, 'env', 'detached', 'stdio')
 

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -119,6 +119,9 @@ module.exports = {
           electronArgs.unshift('--no-sandbox')
         }
 
+        // docker containers have 64M by default, sometimes even less
+        electronArgs.push('--disable-dev-shm-usage')
+
         // strip dev out of child process options
         let stdioOptions = _.pick(options, 'env', 'detached', 'stdio')
 

--- a/cli/lib/exec/xvfb.js
+++ b/cli/lib/exec/xvfb.js
@@ -9,6 +9,7 @@ const util = require('../util')
 
 const xvfb = Promise.promisifyAll(new Xvfb({
   timeout: 30000, // milliseconds
+  xvfb_args: ['-screen', '0', '1280x1024x24'], // need to explicitly define screen otherwise electron will crash
   onStderrData (data) {
     if (debugXvfb.enabled) {
       debugXvfb(data.toString())


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6184

### User facing changelog

Fixes `cypress verify` crash on some systems caused by not defined `-screen`. 

### Additional details

`cypress verify` crashes in a docker image with this environment: 

```console
root@6c2f9da07ecd:/app# uname -a 
Linux 6c2f9da07ecd 4.9.184-linuxkit #1 SMP Tue Jul 2 22:58:16 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
root@6c2f9da07ecd:/app# cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=18.04
DISTRIB_CODENAME=bionic
DISTRIB_DESCRIPTION="Ubuntu 18.04.3 LTS"
root@6c2f9da07ecd:/app# apt list xvfb 
Listing... Done
xvfb/bionic-updates,now 2:1.19.6-1ubuntu4.3 amd64 [installed]
N: There are 2 additional versions. Please use the '-a' switch to see them.
root@6c2f9da07ecd:/app# node -v 
v10.14.2
root@6c2f9da07ecd:/app# ./node_modules/.bin/cypress -v 
Cypress package version: 3.8.2
Cypress binary version: 3.8.2
root@6c2f9da07ecd:/app# file /root/.cache/Cypress/3.8.2/Cypress/Cypress 
/root/.cache/Cypress/3.8.2/Cypress/Cypress: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/l, for GNU/Linux 3.2.0, BuildID[sha1]=5b4fa88bff30493405377c54ef4308de9e5db705, stripped
```

When I run it with `ELECTRON_ENABLE_STACK_DUMPING` I get this: 

```console 
root@6c2f9da07ecd:/app# ELECTRON_ENABLE_STACK_DUMPING=1 ./node_modules/.bin/cypress verify 
It looks like this is your first time using Cypress: 3.8.2

 ✖  Verifying Cypress can run /root/.cache/Cypress/3.8.2/Cypress
   → Cypress Version: 3.8.2
Cypress failed to start.

This is usually caused by a missing library or dependency.

The error below should indicate which dependency is missing.

https://on.cypress.io/required-dependencies

If you are using Docker, we provide containers with all required dependencies installed.

----------

Received signal 11 SEGV_MAPERR fffff4109b7ba15a
#0 0x55720269a3d9 (/root/.cache/Cypress/3.8.2/Cypress/Cypress+0x35d13d8)
r8: 0000000000000000  r9: 00007ffc516aaa30 r10: 00007ffc516aa988 r11: 000000000000000e
r12: 00007ffc516aaadc r13: 00007fa6dfe4f720 r14: fffff4109b7ba12a r15: 00007fa6e1448200
di: 0000000000000000  si: 0000000000000020  bp: 0000000000000000  bx: 00000bedcf1caf20
dx: 0000000000000001  ax: 0000000000000030  cx: 0000000000000001  sp: 00007ffc516aaab0
ip: 00007fa6e142c2dd efl: 0000000000010246 cgf: 002b000000000033 erf: 0000000000000005
trp: 000000000000000e msk: 0000000000000000 cr2: fffff4109b7ba15a
[end of stack trace]
Calling _exit(1). Core file will not be generated.

----------

Platform: linux (Ubuntu Linux - 18.04)
Cypress Version: 3.8.2
```

Directly running `Xvfb` and invoking cypress binary from node works well:

```console
root@6c2f9da07ecd:/app# Xvfb :1 -screen 0 1280x800x24 &
[1] 9546
root@6c2f9da07ecd:/app# node -e "require('child_process').spawnSync('/root/.cache/Cypress/3.8.2/Cypress/Cypress', ['--no-sandbox', '--smoke-test', '--ping=89'], { env: { DISPLAY: ':1' }, stdio: 'inherit' });"
It looks like you are running the Cypress binary directly.

This is not the recommended approach, and Cypress may not work correctly.

Please install the 'cypress' NPM package and follow the instructions here:

https://on.cypress.io/installing-cypress
89
```


Even checked with `xwd` what is in the framebuffer and all fine. 

So I got suspicious Xvfb is not working and added `ps aux` before and after smoke test is executed and turned out that Xvfb is missing `-screen`. Not sure if this should not be handled in `@cypress/xvfb`, up to maintainers.

Feel free to cancel if you already have fix elsewhere.

### How has the user experience changed?

**Before**
<img width="948" alt="Screenshot 2020-01-20 23 24 20" src="https://user-images.githubusercontent.com/546887/72761382-205c8680-3bdc-11ea-941a-13e6849d54e5.png">

**After**
<img width="948" alt="Screenshot 2020-01-20 23 24 35" src="https://user-images.githubusercontent.com/546887/72761392-25b9d100-3bdc-11ea-9973-971650e53375.png">

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?

