### PR TITLE
fix(type): type chars for readonly inputs if force: true

### DIFF
--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -243,7 +243,7 @@ const shouldUpdateValue = (el: HTMLElement, key: KeyDetails, options) => {
   const noneSelected = bounds.start === bounds.end
 
   if ($elements.isInput(el) || $elements.isTextarea(el)) {
-    if ($elements.isReadOnlyInputOrTextarea(el)) {
+    if ($elements.isReadOnlyInputOrTextarea(el) && !options.force) {
       return false
     }
 

--- a/packages/driver/test/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/test/cypress/integration/commands/actions/type_spec.js
@@ -83,6 +83,11 @@ describe('src/cy/commands/actions/type', () => {
       })
     })
 
+    it('types in readonly if force is enabled', () => {
+      cy.get('#readonly-attr').type('foo', { force: true })
+      .should('have.value', 'foo')
+    })
+
     it('appends subsequent type commands', () => {
       cy
       .get('input:first').type('123')


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #6116 " -->

- Closes #6116 

### User facing changelog

<!--
Explain the change(s) for every user to read in our changelog.
-->
Fixed a regression in 3.5.0 so that `cy.type(force: true)` now types characters for readonly inputs.

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->
**Before**
![image](https://user-images.githubusercontent.com/7260797/72875974-c223c680-3cf5-11ea-9621-f94685cacc14.png)
**After**
![image](https://user-images.githubusercontent.com/7260797/72876128-1b8bf580-3cf6-11ea-9628-873427d6ff31.png)


### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ X] Have tests been added/updated?
