### PR TITLE
Issue #6216 -- have .its() receive the number 0 as parameter

### DIFF
--- a/packages/driver/README.md
+++ b/packages/driver/README.md
@@ -77,6 +77,8 @@ If you want to run tests in Chrome and keep it open after the spec finishes, you
 
 ```bash
 npm run cypress:run -- --config testFiles=e2e/focus_blur_spec.js --browser chrome --no-exit
+```
+
 If you would like to run a particular integration test, see the GUI and poke around during the test, you can an exclusive test like:
 
 ```bash

--- a/packages/driver/src/cy/commands/connectors.coffee
+++ b/packages/driver/src/cy/commands/connectors.coffee
@@ -179,7 +179,8 @@ module.exports = (Commands, Cypress, cy, state, config) ->
         consoleProps: ->
           Subject: subject
 
-    if not str
+    ## check for false positive (negative?) with 0 given as index
+    if not str and str isnt 0
       $utils.throwErrByPath("invoke_its.null_or_undefined_property_name", {
         onFail: options._log
         args: { cmd: name, identifier: if isCmdIts then "property" else "function" }
@@ -251,9 +252,12 @@ module.exports = (Commands, Cypress, cy, state, config) ->
       previousProp = pathsArray[index - 1]
       valIsNullOrUndefined = _.isNil(acc)
 
+      ## to allow the falsy value 0 to be used
+      propIsValid = !!prop or prop is 0
+
       ## if we're attempting to tunnel into
       ## a null or undefined object...
-      if prop and valIsNullOrUndefined
+      if propIsValid and valIsNullOrUndefined
         if index is 0
           ## give an error stating the current subject is nil
           traversalErr = subjectNullOrUndefinedErr(prop, acc)
@@ -265,7 +269,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
         return acc
 
       ## if we have no more properties to traverse
-      if not prop
+      if not propIsValid
         if valIsNullOrUndefined
           ## set traversal error that the final value is null or undefined
           traversalErr = propertyValueNullOrUndefinedErr(previousProp, acc)

--- a/packages/driver/src/cy/commands/connectors.coffee
+++ b/packages/driver/src/cy/commands/connectors.coffee
@@ -168,6 +168,9 @@ module.exports = (Commands, Cypress, cy, state, config) ->
 
       return ".#{str}(" + $utils.stringify(args) + ")"
 
+    ## to allow the falsy value 0 to be used
+    isProp = (str) -> !!str or str is 0
+
     message = getMessage()
 
     traversalErr = null
@@ -180,7 +183,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
           Subject: subject
 
     ## check for false positive (negative?) with 0 given as index
-    if not str and str isnt 0
+    if not isProp(str)
       $utils.throwErrByPath("invoke_its.null_or_undefined_property_name", {
         onFail: options._log
         args: { cmd: name, identifier: if isCmdIts then "property" else "function" }
@@ -252,12 +255,9 @@ module.exports = (Commands, Cypress, cy, state, config) ->
       previousProp = pathsArray[index - 1]
       valIsNullOrUndefined = _.isNil(acc)
 
-      ## to allow the falsy value 0 to be used
-      propIsValid = !!prop or prop is 0
-
       ## if we're attempting to tunnel into
       ## a null or undefined object...
-      if propIsValid and valIsNullOrUndefined
+      if isProp(prop) and valIsNullOrUndefined
         if index is 0
           ## give an error stating the current subject is nil
           traversalErr = subjectNullOrUndefinedErr(prop, acc)
@@ -269,7 +269,7 @@ module.exports = (Commands, Cypress, cy, state, config) ->
         return acc
 
       ## if we have no more properties to traverse
-      if not propIsValid
+      if not isProp(prop)
         if valIsNullOrUndefined
           ## set traversal error that the final value is null or undefined
           traversalErr = propertyValueNullOrUndefinedErr(previousProp, acc)

--- a/packages/driver/test/cypress/integration/commands/connectors_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/connectors_spec.coffee
@@ -813,6 +813,11 @@ describe "src/cy/commands/connectors", ->
       it "works with numerical indexes", ->
         cy.wrap(['foo', 'bar']).its(1).should('eq', 'bar')
 
+      it "works with 0 as a value if object has property 0", ->
+        cy.wrap(["foo", "bar"]).its(0).should("eq", "foo")
+        cy.wrap({"0": "whoa"}).its(0).should("eq", "whoa")
+        cy.wrap([###empty###, "spooky"]).its(0).should("not.exist")
+
       it "reduces into dot separated values", ->
         obj = {
           foo: {

--- a/packages/driver/test/cypress/integration/commands/connectors_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/connectors_spec.coffee
@@ -345,6 +345,16 @@ describe "src/cy/commands/connectors", ->
 
           cy.noop([_.noop, fn]).invoke(1).should('be.true')
 
+        it "works with 0 as a value if object has property 0", ->
+          i = 0
+          fn = ->
+            if i++ is 0 then "cy.noop is undocumented"
+            else "and I don't understand what it is"
+
+          cy.wrap([fn, "bar"]).invoke(0).should("eq", "cy.noop is undocumented")
+          cy.wrap({"0": fn}).invoke(0).should("eq", "and I don't understand what it is")
+
+
         it "forwards any additional arguments", ->
           cy.noop(@obj).invoke("bar", 1, 2).then (num) ->
             expect(num).to.eq 3


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6216 

### User facing changelog

`its()` now supports 0 as a value for indexes or object keys

### Additional details

Many times a developer will intuitively reach for the first item in an array for tests or checks
(or for anything if I'm honest), and until now trying to reach that property using `.its(0)` threw an error.
Now developers world-wide would be able to check the first index of their array in a cypress environment. Well, I'm sure you could still have done it with `.its("0")` but just isn't as cool.

The tests check for edge cases, other than that I didn't do anything unexpected
<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
this didn't work, now it does, it's the intuitive thing to do, so it's pretty chill
```javascript
 cy.wrap(["cake","hamburger"]).its(0).should("eq","cake");
```
<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->

Is there anything to add to cypress-documentation? This now works as planned, I didn't add any new features to the mental model of how `.its()` operates
