### PR TITLE
create link to specific 'node-version' link, no hashtag

### DIFF
--- a/packages/desktop-gui/src/settings/node-version.jsx
+++ b/packages/desktop-gui/src/settings/node-version.jsx
@@ -6,7 +6,7 @@ import ipc from '../lib/ipc'
 
 const openHelp = (e) => {
   e.preventDefault()
-  ipc.externalOpen('https://on.cypress.io/configuration#Node-Version')
+  ipc.externalOpen('https://on.cypress.io/node-version')
 }
 
 const renderLearnMore = () => {


### PR DESCRIPTION
## Todo

- [x] Wait for on package change to be merged and *released* https://github.com/cypress-io/cypress-services/pull/2064

- Closes #6237

### User facing changelog

We fixed a broken 'Learn more' link within the Node.js Version panel of the Test Runner Settings.

### Additional details

Hashtags should not be included in on links since this cannot be fixed from the on package.

### How has the user experience changed?

N/A

### PR Tasks

- [NA] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
