### PR TITLE
Update browser types

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -65,6 +65,7 @@ declare namespace Cypress {
   /**
    * Describes a browser Cypress can control
    */
+  // TODO in this PR: update this
   interface Browser {
     name: "electron" | "chrome" | "canary" | "chromium" | "firefox"
     displayName: "Electron" | "Chrome" | "Canary" | "Chromium" | "FireFox"

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -67,7 +67,7 @@ declare namespace Cypress {
    */
   // TODO in this PR: update this
   interface Browser {
-    name: "electron" | "chrome" | "canary" | "chromium" | "firefox"
+    name: "electron" | "chrome" | "chromium" | "firefox"
     displayName: "Electron" | "Chrome" | "Canary" | "Chromium" | "FireFox"
     version: string
     majorVersion: number

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -62,13 +62,32 @@ declare namespace Cypress {
     password: string
   }
 
+  type BrowserName = 'electron' | 'chrome' | 'chromium' | string
+
+  type BrowserChannel = 'stable' | 'canary' | 'beta' | 'dev' | string
+
+  type BrowserFamily = 'chromium'
+
   /**
    * Describes a browser Cypress can control
    */
-  // TODO in this PR: update this
   interface Browser {
-    name: "electron" | "chrome" | "chromium" | "firefox"
-    displayName: "Electron" | "Chrome" | "Canary" | "Chromium" | "FireFox"
+    /**
+     * Short browser name.
+     */
+    name: BrowserName
+    /**
+     * The underlying engine for this browser.
+     */
+    family: BrowserFamily
+    /**
+     * The release channel of the browser.
+     */
+    channel: BrowserChannel
+    /**
+     * Human-readable browser name.
+     */
+    displayName: string
     version: string
     majorVersion: number
     path: string

--- a/packages/desktop-gui/cypress/fixtures/browsers.json
+++ b/packages/desktop-gui/cypress/fixtures/browsers.json
@@ -2,7 +2,7 @@
   {
     "name": "chrome",
     "displayName": "Chrome",
-    "family": "chrome",
+    "family": "chromium",
     "version": "50.0.2661.86",
     "path": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
     "majorVersion": "50"
@@ -10,15 +10,15 @@
   {
     "name": "chromium",
     "displayName": "Chromium",
-    "family": "chrome",
+    "family": "chromium",
     "version": "49.0.2609.0",
     "path": "/Users/bmann/Downloads/chrome-mac/Chromium.app/Contents/MacOS/Chromium",
     "majorVersion": "49"
   },
   {
-    "name": "canary",
-    "displayName": "Canary",
-    "family": "chrome",
+    "name": "chrome",
+    "displayName": "Chrome Canary",
+    "family": "chromium",
     "version": "48.0",
     "path": "/Users/bmann/Downloads/chrome-mac/Canary.app/Contents/MacOS/Canary",
     "majorVersion": "48"

--- a/packages/desktop-gui/cypress/fixtures/browsers.json
+++ b/packages/desktop-gui/cypress/fixtures/browsers.json
@@ -17,7 +17,7 @@
   },
   {
     "name": "chrome",
-    "displayName": "Chrome Canary",
+    "displayName": "Canary",
     "family": "chromium",
     "version": "48.0",
     "path": "/Users/bmann/Downloads/chrome-mac/Canary.app/Contents/MacOS/Canary",

--- a/packages/desktop-gui/cypress/fixtures/config.json
+++ b/packages/desktop-gui/cypress/fixtures/config.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "chrome",
-      "displayName": "Chrome Canary",
+      "displayName": "Canary",
       "family": "chromium",
       "version": "80.0.3977.4",
       "path": "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
@@ -274,7 +274,7 @@
         },
         {
           "name": "chrome",
-          "displayName": "Chrome Canary",
+          "displayName": "Canary",
           "family": "chromium",
           "version": "48.0",
           "path": "/Users/bmann/Downloads/chrome-mac/Canary.app/Contents/MacOS/Canary",

--- a/packages/desktop-gui/cypress/fixtures/config.json
+++ b/packages/desktop-gui/cypress/fixtures/config.json
@@ -30,31 +30,31 @@
     {
       "name": "edge",
       "displayName": "Edge",
-      "family": "chrome",
+      "family": "chromium",
       "version": "79.0.309.71",
       "path": "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
       "majorVersion": "79"
     },
     {
-      "name": "edgeBeta",
+      "name": "edge",
       "displayName": "Edge Beta",
-      "family": "chrome",
+      "family": "chromium",
       "version": "79.0.309.71",
       "path": "/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta",
       "majorVersion": "79"
     },
     {
-      "name": "edgeCanary",
+      "name": "edge",
       "displayName": "Edge Canary",
-      "family": "chrome",
+      "family": "chromium",
       "version": "79.0.309.71",
       "path": "/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary",
       "majorVersion": "79"
     },
     {
-      "name": "edgeDev",
+      "name": "edge",
       "displayName": "Edge Dev",
-      "family": "chrome",
+      "family": "chromium",
       "version": "79.0.309.71",
       "path": "/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev",
       "majorVersion": "79"
@@ -62,7 +62,7 @@
     {
       "name": "electron",
       "displayName": "Electron",
-      "family": "electron",
+      "family": "chromium",
       "version": "73.0.3683.121",
       "path": "",
       "majorVersion": "73",
@@ -77,7 +77,7 @@
       "majorVersion": "69"
     },
     {
-      "name": "firefoxDeveloperEdition",
+      "name": "firefox",
       "displayName": "Firefox Developer Edition",
       "family": "firefox",
       "version": "69.0.1",
@@ -85,7 +85,7 @@
       "majorVersion": "69"
     },
     {
-      "name": "firefoxNightly",
+      "name": "firefox",
       "displayName": "Firefox Nightly",
       "family": "firefox",
       "version": "69.0.1",
@@ -282,7 +282,7 @@
         },
         {
           "name": "electron",
-          "family": "electron",
+          "family": "chromium",
           "displayName": "Electron",
           "path": "",
           "version": "99.101.1234",

--- a/packages/desktop-gui/cypress/fixtures/config.json
+++ b/packages/desktop-gui/cypress/fixtures/config.json
@@ -6,7 +6,7 @@
     {
       "name": "chrome",
       "displayName": "Chrome",
-      "family": "chrome",
+      "family": "chromium",
       "version": "78.0.3904.108",
       "path": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
       "majorVersion": "78"
@@ -14,15 +14,15 @@
     {
       "name": "chromium",
       "displayName": "Chromium",
-      "family": "chrome",
+      "family": "chromium",
       "version": "74.0.3729.0",
       "path": "/Applications/Chromium.app/Contents/MacOS/Chromium",
       "majorVersion": "74"
     },
     {
-      "name": "canary",
-      "displayName": "Canary",
-      "family": "chrome",
+      "name": "chrome",
+      "displayName": "Chrome Canary",
+      "family": "chromium",
       "version": "80.0.3977.4",
       "path": "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
       "majorVersion": "80"
@@ -259,7 +259,7 @@
         {
           "name": "chrome",
           "displayName": "Chrome",
-          "family": "chrome",
+          "family": "chromium",
           "version": "50.0.2661.86",
           "path": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
           "majorVersion": "50"
@@ -267,15 +267,15 @@
         {
           "name": "chromium",
           "displayName": "Chromium",
-          "family": "chrome",
+          "family": "chromium",
           "version": "49.0.2609.0",
           "path": "/Users/bmann/Downloads/chrome-mac/Chromium.app/Contents/MacOS/Chromium",
           "majorVersion": "49"
         },
         {
-          "name": "canary",
-          "displayName": "Canary",
-          "family": "chrome",
+          "name": "chrome",
+          "displayName": "Chrome Canary",
+          "family": "chromium",
           "version": "48.0",
           "path": "/Users/bmann/Downloads/chrome-mac/Canary.app/Contents/MacOS/Canary",
           "majorVersion": "48"

--- a/packages/desktop-gui/cypress/integration/project_nav_spec.js
+++ b/packages/desktop-gui/cypress/integration/project_nav_spec.js
@@ -256,7 +256,7 @@ describe('Project Nav', function () {
           ])
 
           expect(browserArg.path).to.include('/')
-          expect(browserArg.family).to.equal('chrome')
+          expect(browserArg.family).to.equal('chromium')
         })
 
         describe('stop browser', function () {
@@ -370,7 +370,7 @@ describe('Project Nav', function () {
           {
             'name': 'chromium',
             'displayName': 'Chromium',
-            'family': 'chrome',
+            'family': 'chromium',
             'version': '49.0.2609.0',
             'path': '/Users/bmann/Downloads/chrome-mac/Chromium.app/Contents/MacOS/Chromium',
             'majorVersion': '49',

--- a/packages/desktop-gui/src/project-nav/browsers.jsx
+++ b/packages/desktop-gui/src/project-nav/browsers.jsx
@@ -66,7 +66,7 @@ export default class Browsers extends Component {
       icon = <i className='browser-icon fas fa-check-circle green far' />
       prefixText = 'Running'
     } else {
-      icon = <BrowserIcon browserName={browser.name} />
+      icon = <BrowserIcon browserName={browser.displayName} />
       prefixText = ''
     }
 

--- a/packages/launcher/__snapshots__/browsers_spec.ts.js
+++ b/packages/launcher/__snapshots__/browsers_spec.ts.js
@@ -1,7 +1,8 @@
 exports['browsers returns the expected list of browsers 1'] = [
   {
     "name": "chrome",
-    "family": "chrome",
+    "family": "chromium",
+    "channel": "stable",
     "displayName": "Chrome",
     "versionRegex": {},
     "profile": true,
@@ -13,7 +14,8 @@ exports['browsers returns the expected list of browsers 1'] = [
   },
   {
     "name": "chromium",
-    "family": "chrome",
+    "family": "chromium",
+    "channel": "dev",
     "displayName": "Chromium",
     "versionRegex": {},
     "profile": true,
@@ -23,9 +25,10 @@ exports['browsers returns the expected list of browsers 1'] = [
     ]
   },
   {
-    "name": "canary",
-    "family": "chrome",
-    "displayName": "Canary",
+    "name": "chrome",
+    "family": "chromium",
+    "channel": "canary",
+    "displayName": "Chrome Canary",
     "versionRegex": {},
     "profile": true,
     "binary": "google-chrome-canary"

--- a/packages/launcher/__snapshots__/browsers_spec.ts.js
+++ b/packages/launcher/__snapshots__/browsers_spec.ts.js
@@ -28,7 +28,7 @@ exports['browsers returns the expected list of browsers 1'] = [
     "name": "chrome",
     "family": "chromium",
     "channel": "canary",
-    "displayName": "Chrome Canary",
+    "displayName": "Canary",
     "versionRegex": {},
     "profile": true,
     "binary": "google-chrome-canary"

--- a/packages/launcher/lib/browsers.ts
+++ b/packages/launcher/lib/browsers.ts
@@ -6,7 +6,8 @@ import { Browser, FoundBrowser } from './types'
 export const browsers: Browser[] = [
   {
     name: 'chrome',
-    family: 'chrome',
+    family: 'chromium',
+    channel: 'stable',
     displayName: 'Chrome',
     versionRegex: /Google Chrome (\S+)/,
     profile: true,
@@ -14,16 +15,18 @@ export const browsers: Browser[] = [
   },
   {
     name: 'chromium',
-    family: 'chrome',
+    family: 'chromium',
+    channel: 'dev',
     displayName: 'Chromium',
     versionRegex: /Chromium (\S+)/,
     profile: true,
     binary: ['chromium-browser', 'chromium'],
   },
   {
-    name: 'canary',
-    family: 'chrome',
-    displayName: 'Canary',
+    name: 'chrome',
+    family: 'chromium',
+    channel: 'canary',
+    displayName: 'Chrome Canary',
     versionRegex: /Google Chrome Canary (\S+)/,
     profile: true,
     binary: 'google-chrome-canary',

--- a/packages/launcher/lib/browsers.ts
+++ b/packages/launcher/lib/browsers.ts
@@ -16,7 +16,8 @@ export const browsers: Browser[] = [
   {
     name: 'chromium',
     family: 'chromium',
-    channel: 'dev',
+    // technically Chromium is always in development
+    channel: 'stable',
     displayName: 'Chromium',
     versionRegex: /Chromium (\S+)/,
     profile: true,

--- a/packages/launcher/lib/browsers.ts
+++ b/packages/launcher/lib/browsers.ts
@@ -27,7 +27,7 @@ export const browsers: Browser[] = [
     name: 'chrome',
     family: 'chromium',
     channel: 'canary',
-    displayName: 'Chrome Canary',
+    displayName: 'Canary',
     versionRegex: /Google Chrome Canary (\S+)/,
     profile: true,
     binary: 'google-chrome-canary',

--- a/packages/launcher/lib/detect.ts
+++ b/packages/launcher/lib/detect.ts
@@ -93,6 +93,7 @@ function checkOneBrowser (browser: Browser): Promise<boolean | FoundBrowser> {
   const pickBrowserProps = pick([
     'name',
     'family',
+    'channel',
     'displayName',
     'type',
     'version',

--- a/packages/launcher/lib/types.ts
+++ b/packages/launcher/lib/types.ts
@@ -1,7 +1,7 @@
 import { ChildProcess } from 'child_process'
 import * as Bluebird from 'bluebird'
 
-export type BrowserName = 'chrome' | 'chromium' | 'canary' | string
+export type BrowserName = 'chrome' | 'chromium' | string
 
 export type BrowserChannel = 'stable' | 'canary' | 'beta' | 'dev' | string
 

--- a/packages/launcher/lib/types.ts
+++ b/packages/launcher/lib/types.ts
@@ -23,7 +23,7 @@ export type Browser = {
   displayName: string
   /** RegExp to use to extract version from something like "Google Chrome 58.0.3029.110" */
   versionRegex: RegExp
-  profile: boolean
+  profile?: boolean
   /** A single binary name or array of binary names for this browser. Not used on Windows. */
   binary: string | string[]
 }
@@ -31,7 +31,7 @@ export type Browser = {
 /**
  * Represents a real browser that exists on the user's system.
  */
-export type FoundBrowser = Browser & {
+export type FoundBrowser = Omit<Browser, 'versionRegex' | 'binary'> & {
   path: string
   version: string
   majorVersion?: string

--- a/packages/launcher/lib/types.ts
+++ b/packages/launcher/lib/types.ts
@@ -3,7 +3,9 @@ import * as Bluebird from 'bluebird'
 
 export type BrowserName = 'chrome' | 'chromium' | 'canary' | string
 
-export type BrowserFamily = 'chrome' | 'electron'
+export type BrowserChannel = 'stable' | 'canary' | 'beta' | 'dev' | string
+
+export type BrowserFamily = 'chromium'
 
 export type PlatformName = 'darwin' | 'linux' | 'win32'
 
@@ -13,8 +15,11 @@ export type PlatformName = 'darwin' | 'linux' | 'win32'
 export type Browser = {
   /** short browser name */
   name: BrowserName
+  /** family is used to describe the underlying type of the browsr */
   family: BrowserFamily
-  /** Optional display name */
+  /** channel describes the stability of this browser **/
+  channel: BrowserChannel
+  /** Display name */
   displayName: string
   /** RegExp to use to extract version from something like "Google Chrome 58.0.3029.110" */
   versionRegex: RegExp
@@ -27,11 +32,10 @@ export type Browser = {
  * Represents a real browser that exists on the user's system.
  */
 export type FoundBrowser = Browser & {
-  name: string
   path: string
   version: string
   majorVersion?: string
-  /** user-supplied browser? */
+  /** is this a user-supplied browser? */
   custom?: boolean
   /** optional info that will be shown in the GUI */
   info?: string

--- a/packages/launcher/lib/types.ts
+++ b/packages/launcher/lib/types.ts
@@ -1,7 +1,9 @@
 import { ChildProcess } from 'child_process'
 import * as Bluebird from 'bluebird'
 
-export type BrowserName = 'chrome' | 'chromium' | string
+// TODO: some of these types can be combined with cli/types/index.d.ts
+
+export type BrowserName = 'electron' | 'chrome' | 'chromium' | string
 
 export type BrowserChannel = 'stable' | 'canary' | 'beta' | 'dev' | string
 
@@ -13,14 +15,21 @@ export type PlatformName = 'darwin' | 'linux' | 'win32'
  * Represents a typical browser to try to detect and turn into a `FoundBrowser`.
  */
 export type Browser = {
-  /** short browser name */
+  /**
+   * Short browser name.
+   */
   name: BrowserName
-  /** family is used to describe the underlying type of the browsr */
+  /**
+   * The underlying engine for this browser.
+   */
   family: BrowserFamily
-  /** channel describes the stability of this browser **/
+  /**
+   * The release channel of the browser.
+   */
   channel: BrowserChannel
-  /** Display name */
-  displayName: string
+  /**
+   * Human-readable browser name.
+   */
   /** RegExp to use to extract version from something like "Google Chrome 58.0.3029.110" */
   versionRegex: RegExp
   profile?: boolean

--- a/packages/launcher/lib/types.ts
+++ b/packages/launcher/lib/types.ts
@@ -30,6 +30,7 @@ export type Browser = {
   /**
    * Human-readable browser name.
    */
+  displayName: string
   /** RegExp to use to extract version from something like "Google Chrome 58.0.3029.110" */
   versionRegex: RegExp
   profile?: boolean

--- a/packages/runner/src/errors/no-automation.jsx
+++ b/packages/runner/src/errors/no-automation.jsx
@@ -22,8 +22,8 @@ const noBrowsers = () => (
 
 const browser = (browser) => (
   <span>
-    <BrowserIcon browserName={browser.name} />
-    <span>Run {displayName(browser.name)} {browser.majorVersion}</span>
+    <BrowserIcon browserName={browser.displayName} />
+    <span>Run {displayName(browser.displayName)} {browser.majorVersion}</span>
   </span>
 )
 

--- a/packages/runner/src/errors/no-automation.spec.jsx
+++ b/packages/runner/src/errors/no-automation.spec.jsx
@@ -7,14 +7,14 @@ import NoAutomation from './no-automation'
 
 const noBrowsers = []
 const browsersWithChosen = [
-  { name: 'canary', version: '52.7', majorVersion: 52 },
-  { name: 'chrome', version: '52.2', majorVersion: 52, default: true },
-  { name: 'chromium', version: '53.2', majorVersion: 53 },
+  { name: 'canary', displayName: 'Canary', version: '52.7', majorVersion: 52 },
+  { name: 'chrome', displayName: 'Chrome', version: '52.2', majorVersion: 52, default: true },
+  { name: 'chromium', displayName: 'Chromium', version: '53.2', majorVersion: 53 },
 ]
 const browsersWithoutChosen = [
-  { name: 'canary', version: '52.7', majorVersion: 52 },
-  { name: 'chrome', version: '52.2', majorVersion: 52 },
-  { name: 'chromium', version: '53.2', majorVersion: 53 },
+  { name: 'canary', displayName: 'Canary', version: '52.7', majorVersion: 52 },
+  { name: 'chrome', displayName: 'Chrome', version: '52.2', majorVersion: 52 },
+  { name: 'chromium', displayName: 'Chromium', version: '53.2', majorVersion: 53 },
 ]
 
 describe('<NoAutomation />', () => {
@@ -44,11 +44,11 @@ describe('<NoAutomation />', () => {
       expect(component.find('Dropdown').prop('others')[1]).to.eql(_.extend({}, browsersWithChosen[2], { key: 'chromium53.2' }))
     })
 
-    it('renders browser in <Dropdown /> with icon based on browser name', () => {
+    it('renders browser in <Dropdown /> with icon based on browser displayName', () => {
       const component = shallow(<NoAutomation browsers={browsersWithChosen} />)
       const browser = shallow(component.find('Dropdown').prop('renderItem')(browsersWithChosen[0]))
 
-      expect(browser.find('BrowserIcon').prop('browserName')).to.equal('canary')
+      expect(browser.find('BrowserIcon').prop('browserName')).to.equal('Canary')
     })
 
     it('renders browser in <Dropdown /> with browser name and version', () => {

--- a/packages/server/__snapshots__/3_config_spec.coffee.js
+++ b/packages/server/__snapshots__/3_config_spec.coffee.js
@@ -149,6 +149,6 @@ Expected \`viewportWidth\` to be a number. Instead the value was: \`"foo"\`
 exports['e2e config catches invalid browser in the configuration file 1'] = `
 We found an invalid value in the file: \`cypress.json\`
 
-Found an error while validating the \`browsers\` list. Expected \`family\` to be either electron, chrome or firefox. Instead the value was: \`{"name":"bad browser","family":"unknown family","displayName":"Bad browser","version":"no version","path":"/path/to","majorVersion":123}\`
+Found an error while validating the \`browsers\` list. Expected \`family\` to be either electron, chromium or firefox. Instead the value was: \`{"name":"bad browser","family":"unknown family","displayName":"Bad browser","version":"no version","path":"/path/to","majorVersion":123}\`
 
 `

--- a/packages/server/__snapshots__/3_plugins_spec.coffee.js
+++ b/packages/server/__snapshots__/3_plugins_spec.coffee.js
@@ -399,6 +399,6 @@ Expected at list one browser
 exports['e2e plugins catches invalid browser returned from plugins 1'] = `
 An invalid configuration value returned from the plugins file: \`cypress/plugins/index.coffee\`
 
-Found an error while validating the \`browsers\` list. Expected \`displayName\` to be a non-empty string. Instead the value was: \`{"name":"browser name","family":"chrome"}\`
+Found an error while validating the \`browsers\` list. Expected \`displayName\` to be a non-empty string. Instead the value was: \`{"name":"browser name","family":"chromium"}\`
 
 `

--- a/packages/server/__snapshots__/5_spec_isolation_spec.coffee.js
+++ b/packages/server/__snapshots__/5_spec_isolation_spec.coffee.js
@@ -39,7 +39,7 @@ exports['e2e spec isolation fails'] = {
           "title": [
             "\"before all\" hook"
           ],
-          "body": "function () {\n  if (Cypress.browser.family === 'chrome') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
+          "body": "function () {\n  if (Cypress.browser.family === 'chromium') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
         },
         {
           "hookId": "h2",
@@ -286,7 +286,7 @@ exports['e2e spec isolation fails'] = {
           "title": [
             "\"before all\" hook"
           ],
-          "body": "function () {\n  if (Cypress.browser.family === 'chrome') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
+          "body": "function () {\n  if (Cypress.browser.family === 'chromium') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
         }
       ],
       "tests": [
@@ -401,7 +401,7 @@ exports['e2e spec isolation fails'] = {
           "title": [
             "\"before all\" hook"
           ],
-          "body": "function () {\n  if (Cypress.browser.family === 'chrome') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
+          "body": "function () {\n  if (Cypress.browser.family === 'chromium') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
         },
         {
           "hookId": "h2",
@@ -605,7 +605,7 @@ exports['e2e spec isolation fails'] = {
           "title": [
             "\"before all\" hook"
           ],
-          "body": "function () {\n  if (Cypress.browser.family === 'chrome') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
+          "body": "function () {\n  if (Cypress.browser.family === 'chromium') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
         },
         {
           "hookId": "h2",

--- a/packages/server/__snapshots__/5_spec_isolation_spec.coffee.js
+++ b/packages/server/__snapshots__/5_spec_isolation_spec.coffee.js
@@ -39,7 +39,7 @@ exports['e2e spec isolation fails'] = {
           "title": [
             "\"before all\" hook"
           ],
-          "body": "function () {\n  if (Cypress.browser.family === 'chromium') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
+          "body": "function () {\n  if (Cypress.browser.family === 'chromium' && Cypress.browser.name !== 'electron') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
         },
         {
           "hookId": "h2",
@@ -286,7 +286,7 @@ exports['e2e spec isolation fails'] = {
           "title": [
             "\"before all\" hook"
           ],
-          "body": "function () {\n  if (Cypress.browser.family === 'chromium') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
+          "body": "function () {\n  if (Cypress.browser.family === 'chromium' && Cypress.browser.name !== 'electron') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
         }
       ],
       "tests": [
@@ -401,7 +401,7 @@ exports['e2e spec isolation fails'] = {
           "title": [
             "\"before all\" hook"
           ],
-          "body": "function () {\n  if (Cypress.browser.family === 'chromium') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
+          "body": "function () {\n  if (Cypress.browser.family === 'chromium' && Cypress.browser.name !== 'electron') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
         },
         {
           "hookId": "h2",
@@ -605,7 +605,7 @@ exports['e2e spec isolation fails'] = {
           "title": [
             "\"before all\" hook"
           ],
-          "body": "function () {\n  if (Cypress.browser.family === 'chromium') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
+          "body": "function () {\n  if (Cypress.browser.family === 'chromium' && Cypress.browser.name !== 'electron') {\n    return Cypress.automation('remote:debugger:protocol', {\n      command: 'Emulation.setDeviceMetricsOverride',\n      params: {\n        width: 1280,\n        height: 720,\n        deviceScaleFactor: 1,\n        mobile: false,\n        screenWidth: 1280,\n        screenHeight: 720\n      }\n    }).then(function () {\n      // can't tell expect() not to log, so manually throwing here\n      if (window.devicePixelRatio !== 1) {\n        throw new Error('Setting devicePixelRatio to 1 failed');\n      }\n    });\n  }\n}"
         },
         {
           "hookId": "h2",

--- a/packages/server/__snapshots__/validation_spec.coffee.js
+++ b/packages/server/__snapshots__/validation_spec.coffee.js
@@ -51,7 +51,7 @@ exports['lib/util/validation #isValidBrowser passes valid browsers and forms err
       "given": {
         "name": "Electron",
         "displayName": "Electron",
-        "family": "electron",
+        "family": "chromium",
         "path": "",
         "version": "99.101.3",
         "majorVersion": 99
@@ -71,7 +71,7 @@ exports['lib/util/validation #isValidBrowser passes valid browsers and forms err
         "displayName": "Bad family browser",
         "family": "unknown family"
       },
-      "expect": "Expected `family` to be chromium or firefox. Instead the value was: `{\"name\":\"bad family\",\"displayName\":\"Bad family browser\",\"family\":\"unknown family\"}`"
+      "expect": "Expected `family` to be either electron, chromium or firefox. Instead the value was: `{\"name\":\"bad family\",\"displayName\":\"Bad family browser\",\"family\":\"unknown family\"}`"
     }
   ]
 }

--- a/packages/server/__snapshots__/validation_spec.coffee.js
+++ b/packages/server/__snapshots__/validation_spec.coffee.js
@@ -29,7 +29,7 @@ exports['lib/util/validation #isValidBrowser passes valid browsers and forms err
       "given": {
         "name": "Chrome",
         "displayName": "Chrome Browser",
-        "family": "chrome",
+        "family": "chromium",
         "path": "/path/to/chrome",
         "version": "1.2.3",
         "majorVersion": 1
@@ -71,7 +71,7 @@ exports['lib/util/validation #isValidBrowser passes valid browsers and forms err
         "displayName": "Bad family browser",
         "family": "unknown family"
       },
-      "expect": "Expected `family` to be either electron, chrome or firefox. Instead the value was: `{\"name\":\"bad family\",\"displayName\":\"Bad family browser\",\"family\":\"unknown family\"}`"
+      "expect": "Expected `family` to be chromium or firefox. Instead the value was: `{\"name\":\"bad family\",\"displayName\":\"Bad family browser\",\"family\":\"unknown family\"}`"
     }
   ]
 }

--- a/packages/server/lib/browsers/index.js
+++ b/packages/server/lib/browsers/index.js
@@ -61,12 +61,9 @@ const isValidPathToBrowser = (str) => {
 }
 
 const parseBrowserOption = (opt) => {
-  // hard-coded for backwards compatibility
+  // for backwards compatibility pre-4.x
   if (opt === 'canary') {
-    return {
-      name: 'chrome',
-      channel: 'canary',
-    }
+    opt = 'chrome:canary'
   }
 
   // it's a name or a path

--- a/packages/server/lib/browsers/index.js
+++ b/packages/server/lib/browsers/index.js
@@ -7,7 +7,7 @@ const errors = require('../errors')
 const check = require('check-more-types')
 
 // returns true if the passed string is a known browser family name
-const isBrowserFamily = check.oneOf(['electron', 'chrome'])
+const isBrowserFamily = check.oneOf(['chromium'])
 
 let instance = null
 
@@ -41,19 +41,18 @@ const cleanup = () => {
   return instance = null
 }
 
-const getBrowserLauncherByFamily = function (family) {
-  debug('getBrowserLauncherByFamily %o', { family })
-  if (!isBrowserFamily(family)) {
-    debug('unknown browser family', family)
+const getBrowserLauncher = function (browser) {
+  debug('getBrowserLauncher %o', { browser })
+  if (!isBrowserFamily(browser.family)) {
+    debug('unknown browser family', browser.family)
   }
 
-  switch (family) {
-    case 'electron':
-      return require('./electron')
-    case 'chrome':
-      return require('./chrome')
-    default:
-      break
+  if (browser.name === 'electron') {
+    return require('./electron')
+  }
+
+  if (browser.family === 'chromium') {
+    return require('./chrome')
   }
 }
 
@@ -144,7 +143,7 @@ module.exports = {
         onBrowserClose () {},
       })
 
-      if (!(browserLauncher = getBrowserLauncherByFamily(browser.family))) {
+      if (!(browserLauncher = getBrowserLauncher(browser))) {
         return throwBrowserNotFound(browser.name, options.browsers)
       }
 

--- a/packages/server/lib/browsers/utils.ts
+++ b/packages/server/lib/browsers/utils.ts
@@ -121,7 +121,7 @@ export = {
       }
 
       // the internal version of Electron, which won't be detected by `launcher`
-      debug('adding Electron browser with version %s', version)
+      debug('adding Electron browser %o', electronBrowser)
 
       return browsers.concat(electronBrowser)
     })

--- a/packages/server/lib/browsers/utils.ts
+++ b/packages/server/lib/browsers/utils.ts
@@ -1,3 +1,5 @@
+import { FoundBrowser } from '@packages/launcher'
+
 const path = require('path')
 const debug = require('debug')('cypress:server:browsers:utils')
 const Promise = require('bluebird')
@@ -74,7 +76,7 @@ const removeOldProfiles = function () {
   ])
 }
 
-module.exports = {
+export = {
   getPort,
 
   copyExtension,
@@ -100,15 +102,17 @@ module.exports = {
 
       debug('found browsers %o', { browsers })
 
+      // @ts-ignore
       const version = process.versions.chrome || ''
 
       if (version) {
         majorVersion = parseInt(version.split('.')[0])
       }
 
-      const electronBrowser = {
+      const electronBrowser: FoundBrowser = {
         name: 'electron',
-        family: 'electron',
+        channel: 'stable',
+        family: 'chromium',
         displayName: 'Electron',
         version,
         path: '',

--- a/packages/server/lib/cypress.js
+++ b/packages/server/lib/cypress.js
@@ -102,48 +102,6 @@ module.exports = {
     return require('./open_project').open(options.project, options)
   },
 
-  runServer (options) {
-    // args = {}
-    //
-    // _.defaults options, { autoOpen: true }
-    //
-    // if not options.project
-    //   throw new Error("Missing path to project:\n\nPlease pass 'npm run server -- --project /path/to/project'\n\n")
-    //
-    // if options.debug
-    //   args.debug = "--debug"
-    //
-    // ## just spawn our own index.js file again
-    // ## but put ourselves in project mode so
-    // ## we actually boot a project!
-    // _.extend(args, {
-    //   script:  "index.js"
-    //   watch:  ["--watch", "lib"]
-    //   ignore: ["--ignore", "lib/public"]
-    //   verbose: "--verbose"
-    //   exts:   ["-e", "coffee,js"]
-    //   args:   ["--", "--config", "port=2020", "--mode", "openProject", "--project", options.project]
-    // })
-    //
-    // args = _.chain(args).values().flatten().value()
-    //
-    // cp.spawn("nodemon", args, {stdio: "inherit"})
-    //
-    // ## auto open in dev mode directly to our
-    // ## default cypress web app client
-    // if options.autoOpen
-    //   _.delay ->
-    //     require("./browsers").launch("chrome", "http://localhost:2020/__", {
-    //       proxyServer: "http://localhost:2020"
-    //     })
-    //   , 2000
-    //
-    // if options.debug
-    //   cp.spawn("node-inspector", [], {stdio: "inherit"})
-    //
-    //   require("opn")("http://127.0.0.1:8080/debug?ws=127.0.0.1:8080&port=5858")
-  },
-
   start (argv = []) {
     debug('starting cypress with argv %o', argv)
 
@@ -284,9 +242,6 @@ module.exports = {
 
       case 'interactive':
         return this.runElectron(mode, options)
-
-      case 'server':
-        return this.runServer(options)
 
       case 'openProject':
         // open + start the project

--- a/packages/server/lib/gui/events.coffee
+++ b/packages/server/lib/gui/events.coffee
@@ -216,7 +216,7 @@ handleEvent = (options, bus, event, id, type, arg) ->
       .then ->
         chromePolicyCheck.run (err) ->
           options.config.browsers.forEach (browser) ->
-            if browser.family == 'chrome'
+            if browser.family == 'chromium'
               browser.warning = errors.getMsgByType('BAD_POLICY_WARNING_TOOLTIP')
 
         openProject.create(arg, options, {

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -453,11 +453,11 @@ const getProjectId = Promise.method((project, id) => {
 const getDefaultBrowserOptsByFamily = (browser, project, writeVideoFrame) => {
   la(browserUtils.isBrowserFamily(browser.family), 'invalid browser family in', browser)
 
-  if (browser.family === 'electron') {
+  if (browser.name === 'electron') {
     return getElectronProps(browser.isHeaded, project, writeVideoFrame)
   }
 
-  if (browser.family === 'chrome') {
+  if (browser.family === 'chromium') {
     return getChromeProps(browser.isHeaded, project, writeVideoFrame)
   }
 
@@ -625,7 +625,7 @@ const browserCanBeRecorded = (browser) => {
     return true
   }
 
-  if (browser.family === 'chrome') {
+  if (browser.family === 'chromium') {
     return true
   }
 
@@ -1333,7 +1333,7 @@ module.exports = {
             errors.throw('NO_SPECS_FOUND', config.integrationFolder, specPattern)
           }
 
-          if (browser.family === 'chrome') {
+          if (browser.family === 'chromium') {
             chromePolicyCheck.run(onWarning)
           }
 

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -621,11 +621,11 @@ const trashAssets = Promise.method((config = {}) => {
 // if we've been told to record and we're not spawning a headed browser
 const browserCanBeRecorded = (browser) => {
   // TODO: enable recording Electron in headed mode too
-  if (browser.family === 'electron' && browser.isHeadless) {
+  if (browser.name === 'electron' && browser.isHeadless) {
     return true
   }
 
-  if (browser.family === 'chromium') {
+  if (browser.name !== 'electron' && browser.family === 'chromium') {
     return true
   }
 
@@ -672,7 +672,7 @@ const maybeStartVideoRecording = Promise.method(function (options = {}) {
     console.log('')
 
     // TODO update error messages and included browser name and headed mode
-    if (browser.family === 'electron' && browser.isHeaded) {
+    if (browser.name === 'electron' && browser.isHeaded) {
       errors.warning('CANNOT_RECORD_VIDEO_HEADED')
     } else {
       errors.warning('CANNOT_RECORD_VIDEO_FOR_THIS_BROWSER', browser.name)
@@ -1119,7 +1119,7 @@ module.exports = {
   runSpecs (options = {}) {
     _.defaults(options, {
       // only non-Electron browsers run headed by default
-      headed: options.browser.family !== 'electron',
+      headed: options.browser.name !== 'electron',
     })
 
     const { config, browser, sys, headed, outputPath, specs, specPattern, beforeSpecRun, afterSpecRun, runUrl, parallel, group, tag } = options

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -971,11 +971,11 @@ module.exports = {
 
       return Promise.join(
         this.waitForSocketConnection(project, socketId)
-        .then(() => {
+        .tap(() => {
           debug('socket connected', { socketId })
         }),
         this.launchBrowser(options)
-        .then(() => {
+        .tap(() => {
           debug('browser launched')
         })
       )

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -967,9 +967,17 @@ module.exports = {
     let attempts = 0
 
     const wait = () => {
+      debug('waiting for socket to connect and browser to launch...')
+
       return Promise.join(
-        this.waitForSocketConnection(project, socketId),
+        this.waitForSocketConnection(project, socketId)
+        .then(() => {
+          debug('socket connected', { socketId })
+        }),
         this.launchBrowser(options)
+        .then(() => {
+          debug('browser launched')
+        })
       )
       .timeout(timeout || 30000)
       .catch(Promise.TimeoutError, (err) => {

--- a/packages/server/lib/open_project.js
+++ b/packages/server/lib/open_project.js
@@ -1,6 +1,6 @@
 const _ = require('lodash')
 const la = require('lazy-ass')
-const debug = require('debug')('cypress:server:openproject')
+const debug = require('debug')('cypress:server:open_project')
 const Promise = require('bluebird')
 const chokidar = require('chokidar')
 const Project = require('./project')

--- a/packages/server/lib/util/validation.js
+++ b/packages/server/lib/util/validation.js
@@ -47,7 +47,8 @@ const isValidBrowser = (browser) => {
     return errMsg('name', browser, 'a non-empty string')
   }
 
-  const knownBrowserFamilies = ['electron', 'chrome', 'firefox']
+  // TODO: this is duplicated with browsers/index
+  const knownBrowserFamilies = ['electron', 'chromium', 'firefox']
 
   if (!is.oneOf(knownBrowserFamilies)(browser.family)) {
     return errMsg('family', browser, commaListsOr`either ${knownBrowserFamilies}`)

--- a/packages/server/test/e2e/4_browser_path_spec.coffee
+++ b/packages/server/test/e2e/4_browser_path_spec.coffee
@@ -32,10 +32,10 @@ describe "e2e launching browsers by path", ->
   it "works with an installed browser path", ->
     launcher.detect().then (browsers) =>
       browsers.find (browser) =>
-        browser.family == "chrome"
+        browser.family == "chromium"
     .tap (browser) =>
       if !browser
-        throw new Error("A 'chrome' family browser must be installed for this test")
+        throw new Error("A 'chromium' family browser must be installed for this test")
     .get("path")
     ## turn binary browser names ("google-chrome") into their absolute paths
     ## so that server recognizes them as a path, not as a browser name

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -50,6 +50,7 @@ const TYPICAL_BROWSERS = [
   {
     name: 'chrome',
     family: 'chromium',
+    channel: 'stable',
     displayName: 'Chrome',
     version: '60.0.3112.101',
     path: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
@@ -57,6 +58,7 @@ const TYPICAL_BROWSERS = [
   }, {
     name: 'chromium',
     family: 'chromium',
+    channel: 'stable',
     displayName: 'Chromium',
     version: '49.0.2609.0',
     path: '/Users/bmann/Downloads/chrome-mac/Chromium.app/Contents/MacOS/Chromium',
@@ -64,6 +66,7 @@ const TYPICAL_BROWSERS = [
   }, {
     name: 'chrome',
     family: 'chromium',
+    channel: 'canary',
     displayName: 'Chrome Canary',
     version: '62.0.3197.0',
     path: '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
@@ -73,7 +76,7 @@ const TYPICAL_BROWSERS = [
 
 const ELECTRON_BROWSER = {
   name: 'electron',
-  family: 'electron',
+  family: 'chromium',
   displayName: 'Electron',
   path: '',
   version: '99.101.1234',
@@ -761,7 +764,7 @@ describe('lib/cypress', () => {
         const found2 = _.find(argsSet, (args) => {
           return _.find(args, (arg) => {
             return arg.message && arg.message.includes(
-              'Available browsers found are: chrome, chromium, canary, electron'
+              'Available browsers found are: chrome, chromium, chrome:canary, electron'
             )
           })
         })

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -49,22 +49,22 @@ const { formStatePath } = require(`${root}lib/util/saved_state`)
 const TYPICAL_BROWSERS = [
   {
     name: 'chrome',
-    family: 'chrome',
+    family: 'chromium',
     displayName: 'Chrome',
     version: '60.0.3112.101',
     path: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
     majorVersion: '60',
   }, {
     name: 'chromium',
-    family: 'chrome',
+    family: 'chromium',
     displayName: 'Chromium',
     version: '49.0.2609.0',
     path: '/Users/bmann/Downloads/chrome-mac/Chromium.app/Contents/MacOS/Chromium',
     majorVersion: '49',
   }, {
-    name: 'canary',
-    family: 'chrome',
-    displayName: 'Canary',
+    name: 'chrome',
+    family: 'chromium',
+    displayName: 'Chrome Canary',
     version: '62.0.3197.0',
     path: '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
     majorVersion: '62',
@@ -172,7 +172,7 @@ describe('lib/cypress', () => {
     it('allows browser major to be a number', () => {
       const browser = {
         name: 'Edge Beta',
-        family: 'chrome',
+        family: 'chromium',
         displayName: 'Edge Beta',
         version: '80.0.328.2',
         path: '/some/path',

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -337,7 +337,7 @@ describe('lib/cypress', () => {
   context('--run-project', () => {
     beforeEach(() => {
       sinon.stub(electron.app, 'on').withArgs('ready').yieldsAsync()
-      sinon.stub(runMode, 'waitForSocketConnection')
+      sinon.stub(runMode, 'waitForSocketConnection').resolves()
       sinon.stub(runMode, 'listenForProjectEnd').resolves({ stats: { failures: 0 } })
       sinon.stub(browsers, 'open')
       sinon.stub(commitInfo, 'getRemoteOrigin').resolves('remoteOrigin')
@@ -1258,7 +1258,7 @@ describe('lib/cypress', () => {
       sinon.stub(api, 'createRun').resolves()
       sinon.stub(electron.app, 'on').withArgs('ready').yieldsAsync()
       sinon.stub(browsers, 'open')
-      sinon.stub(runMode, 'waitForSocketConnection')
+      sinon.stub(runMode, 'waitForSocketConnection').resolves()
       sinon.stub(runMode, 'waitForTestsToFinishRunning').resolves({
         stats: {
           tests: 1,

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -67,7 +67,7 @@ const TYPICAL_BROWSERS = [
     name: 'chrome',
     family: 'chromium',
     channel: 'canary',
-    displayName: 'Chrome Canary',
+    displayName: 'Canary',
     version: '62.0.3197.0',
     path: '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
     majorVersion: '62',

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/config_passing_spec.coffee
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/config_passing_spec.coffee
@@ -13,8 +13,8 @@ describe "Cypress static methods + props", ->
     { browser } = Cypress
 
     expect(browser).to.be.an("object")
-    expect(browser.name).to.be.oneOf(["electron", "chrome", "canary", "chromium"])
-    expect(browser.displayName).to.be.oneOf(["Electron", "Chrome", "Canary", "Chromium"])
+    expect(browser.name).to.be.oneOf(["electron", "chrome", "chromium"])
+    expect(browser.displayName).to.be.oneOf(["Electron", "Chrome", "Chrome Canary", "Chromium"])
     expect(browser.version).to.be.a("string")
     # we are parsing major version, so it should be a number
     expect(browser.majorVersion).to.be.a("number")

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/config_passing_spec.coffee
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/config_passing_spec.coffee
@@ -14,7 +14,7 @@ describe "Cypress static methods + props", ->
 
     expect(browser).to.be.an("object")
     expect(browser.name).to.be.oneOf(["electron", "chrome", "chromium"])
-    expect(browser.displayName).to.be.oneOf(["Electron", "Chrome", "Chrome Canary", "Chromium"])
+    expect(browser.displayName).to.be.oneOf(["Electron", "Chrome", "Canary", "Chromium"])
     expect(browser.version).to.be.a("string")
     # we are parsing major version, so it should be a number
     expect(browser.majorVersion).to.be.a("number")

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
@@ -7,7 +7,7 @@ describe('e2e headless spec', function () {
   })
 
   it('has expected HeadlessChrome useragent', function () {
-    if (Cypress.browser.family !== 'chrome') {
+    if (Cypress.browser.family !== 'chromium') {
       return
     }
 
@@ -16,7 +16,7 @@ describe('e2e headless spec', function () {
   })
 
   it('has expected launch args', function () {
-    if (Cypress.browser.family !== 'chrome') {
+    if (Cypress.browser.family !== 'chromium') {
       return
     }
 

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/headless_spec.js
@@ -7,7 +7,7 @@ describe('e2e headless spec', function () {
   })
 
   it('has expected HeadlessChrome useragent', function () {
-    if (Cypress.browser.family !== 'chromium') {
+    if (Cypress.browser.family !== 'chromium' || Cypress.browser.name === 'electron') {
       return
     }
 
@@ -16,7 +16,7 @@ describe('e2e headless spec', function () {
   })
 
   it('has expected launch args', function () {
-    if (Cypress.browser.family !== 'chromium') {
+    if (Cypress.browser.family !== 'chromium' || Cypress.browser.name === 'electron') {
       return
     }
 

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/support/index.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/support/index.js
@@ -1,5 +1,5 @@
 before(function () {
-  if (Cypress.browser.family === 'chrome') {
+  if (Cypress.browser.family === 'chromium') {
     return Cypress.automation('remote:debugger:protocol', {
       command: 'Emulation.setDeviceMetricsOverride',
       params: {

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/support/index.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/support/index.js
@@ -1,5 +1,5 @@
 before(function () {
-  if (Cypress.browser.family === 'chromium') {
+  if (Cypress.browser.family === 'chromium' && Cypress.browser.name !== 'electron') {
     return Cypress.automation('remote:debugger:protocol', {
       command: 'Emulation.setDeviceMetricsOverride',
       params: {

--- a/packages/server/test/support/fixtures/projects/plugin-returns-invalid-browser/cypress/plugins/index.coffee
+++ b/packages/server/test/support/fixtures/projects/plugin-returns-invalid-browser/cypress/plugins/index.coffee
@@ -4,6 +4,6 @@ module.exports = (onFn, config) ->
   {
     browsers: [{
       name: "browser name",
-      family: "chrome"
+      family: "chromium"
     }]
   }

--- a/packages/server/test/support/fixtures/projects/remote-debugging-port-removed/cypress/plugins.js
+++ b/packages/server/test/support/fixtures/projects/remote-debugging-port-removed/cypress/plugins.js
@@ -2,7 +2,7 @@ const la = require('lazy-ass')
 
 module.exports = (on) => {
   on('before:browser:launch', (browser = {}, args) => {
-    la(browser.family === 'chrome', 'this test can only be run with a chrome-family browser')
+    la(browser.family === 'chromium', 'this test can only be run with a chromium-family browser')
 
     // remove debugging port so that the browser connection fails
     const newArgs = args.filter((arg) => !arg.startsWith('--remote-debugging-port='))

--- a/packages/server/test/support/helpers/e2e.js
+++ b/packages/server/test/support/helpers/e2e.js
@@ -461,7 +461,8 @@ module.exports = (e2e = {
   },
 
   args (options = {}) {
-    let browser
+    debug('converting options to args %o', { options })
+
     const args = [
       // hides a user warning to go through NPM module
       `--cwd=${process.cwd()}`,
@@ -509,10 +510,8 @@ module.exports = (e2e = {
       args.push(`--reporter-options=${options.reporterOptions}`)
     }
 
-    browser = (options.browser)
-
-    if (browser) {
-      args.push(`--browser=${browser}`)
+    if (options.browser) {
+      args.push(`--browser=${options.browser}`)
     }
 
     if (options.config) {
@@ -625,6 +624,7 @@ module.exports = (e2e = {
     }
 
     return new Promise((resolve, reject) => {
+      debug('spawning Cypress %o', { args })
       const sp = cp.spawn('node', args, {
         env: _.chain(process.env)
         .omit('CYPRESS_DEBUG')

--- a/packages/server/test/unit/browsers/browsers_spec.coffee
+++ b/packages/server/test/unit/browsers/browsers_spec.coffee
@@ -16,13 +16,13 @@ describe "lib/browsers/index", ->
   context ".ensureAndGetByNameOrPath", ->
     it "returns browser by name", ->
       sinon.stub(utils, "getBrowsers").resolves([
-        { name: "foo" }
-        { name: "bar" }
+        { name: "foo", channel: "stable" }
+        { name: "bar", channel: "stable" }
       ])
 
       browsers.ensureAndGetByNameOrPath("foo")
       .then (browser) ->
-        expect(browser).to.deep.eq({ name: "foo" })
+        expect(browser).to.deep.eq({ name: "foo", channel: "stable" })
 
     it "throws when no browser can be found", ->
       browsers.ensureAndGetByNameOrPath("browserNotGonnaBeFound")

--- a/packages/server/test/unit/browsers/browsers_spec.coffee
+++ b/packages/server/test/unit/browsers/browsers_spec.coffee
@@ -8,7 +8,8 @@ utils = require("#{root}../lib/browsers/utils")
 describe "lib/browsers/index", ->
   context ".isBrowserFamily", ->
     it "allows only known browsers", ->
-      expect(browsers.isBrowserFamily("chrome")).to.be.true
+      expect(browsers.isBrowserFamily("chromium")).to.be.true
+      expect(browsers.isBrowserFamily("chrome")).to.be.false
       expect(browsers.isBrowserFamily("electron")).to.be.true
       expect(browsers.isBrowserFamily("my-favorite-browser")).to.be.false
 

--- a/packages/server/test/unit/browsers/browsers_spec.coffee
+++ b/packages/server/test/unit/browsers/browsers_spec.coffee
@@ -10,7 +10,7 @@ describe "lib/browsers/index", ->
     it "allows only known browsers", ->
       expect(browsers.isBrowserFamily("chromium")).to.be.true
       expect(browsers.isBrowserFamily("chrome")).to.be.false
-      expect(browsers.isBrowserFamily("electron")).to.be.true
+      expect(browsers.isBrowserFamily("electron")).to.be.false
       expect(browsers.isBrowserFamily("my-favorite-browser")).to.be.false
 
   context ".ensureAndGetByNameOrPath", ->

--- a/packages/server/test/unit/config_spec.coffee
+++ b/packages/server/test/unit/config_spec.coffee
@@ -1032,7 +1032,7 @@ describe "lib/config", ->
     it "keeps the list of browsers if the plugins returns empty object", ->
       browser = {
         name: "fake browser name",
-        family: "chrome",
+        family: "chromium",
         displayName: "My browser",
         version: "x.y.z",
         path: "/path/to/browser",
@@ -1064,7 +1064,7 @@ describe "lib/config", ->
     it "catches browsers=null returned from plugins", ->
       browser = {
         name: "fake browser name",
-        family: "chrome",
+        family: "chromium",
         displayName: "My browser",
         version: "x.y.z",
         path: "/path/to/browser",
@@ -1092,7 +1092,7 @@ describe "lib/config", ->
     it "allows user to filter browsers", ->
       browserOne = {
         name: "fake browser name",
-        family: "chrome",
+        family: "chromium",
         displayName: "My browser",
         version: "x.y.z",
         path: "/path/to/browser",

--- a/packages/server/test/unit/gui/events_spec.coffee
+++ b/packages/server/test/unit/gui/events_spec.coffee
@@ -475,7 +475,7 @@ describe "lib/gui/events", ->
         sinon.stub(openProject, "create").resolves()
         @options.browser = "/foo"
 
-        browsers.getAllBrowsersWith.withArgs("/foo").resolves([{family: 'chrome'}, {family: 'some other'}])
+        browsers.getAllBrowsersWith.withArgs("/foo").resolves([{family: 'chromium'}, {family: 'some other'}])
 
         sinon.stub(chromePolicyCheck, "run").callsArgWith(0, new Error)
 
@@ -488,7 +488,7 @@ describe "lib/gui/events", ->
               config: {
                 browsers: [
                   {
-                    family: "chrome"
+                    family: "chromium"
                     warning: "Cypress detected policy settings on your computer that may cause issues with using this browser. For more information, see https://on.cypress.io/bad-browser-policy"
                   },
                   {

--- a/packages/server/test/unit/modes/run_spec.js
+++ b/packages/server/test/unit/modes/run_spec.js
@@ -204,7 +204,7 @@ describe('lib/modes/run', () => {
 
       const browser = {
         name: 'chrome',
-        family: 'chrome',
+        family: 'chromium',
         isHeaded: true,
       }
 

--- a/packages/server/test/unit/modes/run_spec.js
+++ b/packages/server/test/unit/modes/run_spec.js
@@ -171,7 +171,7 @@ describe('lib/modes/run', () => {
 
       const browser = {
         name: 'electron',
-        family: 'electron',
+        family: 'chromium',
         isHeaded: false,
       }
 
@@ -632,7 +632,7 @@ describe('lib/modes/run', () => {
       })
     })
 
-    it('disables video recording on interactive mode runs', () => {
+    it('disables video recording on headed runs', () => {
       return runMode.run({ headed: true })
       .then(() => {
         expect(errors.warning).to.be.calledWith('CANNOT_RECORD_VIDEO_HEADED')
@@ -683,7 +683,7 @@ describe('lib/modes/run', () => {
         name: 'fooBrowser',
         path: 'path/to/browser',
         version: '777',
-        family: 'electron',
+        family: 'chromium',
       })
 
       sinon.stub(runMode, 'waitForSocketConnection').resolves()
@@ -748,7 +748,7 @@ describe('lib/modes/run', () => {
     })
 
     it('passes headed to openProject.launch', () => {
-      const browser = { name: 'electron', family: 'electron' }
+      const browser = { name: 'electron', family: 'chromium' }
 
       browsers.ensureAndGetByNameOrPath.resolves(browser)
 

--- a/packages/server/test/unit/validation_spec.coffee
+++ b/packages/server/test/unit/validation_spec.coffee
@@ -16,7 +16,7 @@ describe "lib/util/validation", ->
         {
           name: "Chrome",
           displayName: "Chrome Browser",
-          family: "chrome",
+          family: "chromium",
           path: "/path/to/chrome",
           version: "1.2.3",
           majorVersion: 1
@@ -34,7 +34,7 @@ describe "lib/util/validation", ->
         {
           name: "Electron",
           displayName: "Electron",
-          family: "electron",
+          family: "chromium",
           path: "",
           version: "99.101.3",
           majorVersion: 99

--- a/packages/ui-components/cypress/integration/browser-icon_spec.jsx
+++ b/packages/ui-components/cypress/integration/browser-icon_spec.jsx
@@ -44,6 +44,7 @@ describe('<BrowserIcon />', () => {
       <BrowserIcon browserName='Edge Custom' />
       <BrowserIcon browserName='Electron Custom' />
       <BrowserIcon browserName='Firefox Custom' />
+      <BrowserIcon browserName='Chromium Custom' />
     </>)
 
     cy.get('.browser-icon').eq(0)
@@ -61,6 +62,10 @@ describe('<BrowserIcon />', () => {
     cy.get('.browser-icon').eq(3)
     .should('have.attr', 'src')
     .and('include', 'firefox')
+
+    cy.get('.browser-icon').eq(4)
+    .should('have.attr', 'src')
+    .and('include', 'chromium')
   })
 
   it('displays generic logo for unsupported browsers', () => {

--- a/packages/ui-components/src/browser-icon.jsx
+++ b/packages/ui-components/src/browser-icon.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 const families = {
   chrome: /^chrome/i,
+  chromium: /^chromium/i,
   edge: /^edge/i,
   electron: /^electron/i,
   firefox: /^firefox/i,
@@ -36,6 +37,7 @@ const logoPath = (browserName) => {
   return logoPaths[browserKey] || logoPaths[familyFallback(browserKey)]
 }
 
+// browserName should be the browser's display name
 const BrowserIcon = ({ browserName }) => {
   if (logoPath(browserName)) {
     return <img className='browser-icon' src={logoPath(browserName)} />


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6243 

### User facing changelog

- Updated Cypress browser objects with a new field, `channel`, which contains the release channel of the detected browser.
- Changed the `family` of all Chromium-based browsers, including Electron, to `chromium`.
- `cypress run --browser` can now be used to specify a specific release channel of a browser, for example, `chrome:canary` to select Canary.

### Additional details

- [x] Replace all checks for family == 'chrome' with family == 'chromium'
- [x] Replace all checks for family == 'electron' with name == 'electron'
- [x] Update `--browser` arg passing to allow `name:channel`
- [x] Update 'electron' static browser definition - maybe move into TS
- [x] fix browser icons

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/2454
- [x] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
