### PR TITLE
throw specific error when cannot parse Cypress arguments

### DIFF
--- a/packages/server/__snapshots__/args_spec.coffee.js
+++ b/packages/server/__snapshots__/args_spec.coffee.js
@@ -7,7 +7,7 @@ The error was: Cannot read property 'split' of undefined
 `
 
 exports['invalid reporter options error'] = `
-Cypress encountered an error while parsing the argument reporter options
+Cypress encountered an error while parsing the argument reporterOptions
 
 You passed: abc
 

--- a/packages/server/__snapshots__/args_spec.coffee.js
+++ b/packages/server/__snapshots__/args_spec.coffee.js
@@ -1,0 +1,23 @@
+exports['invalid env error'] = `
+Cypress encountered an error while parsing the argument env
+
+You passed: nonono
+
+The error was: Cannot read property 'split' of undefined
+`
+
+exports['invalid reporter options error'] = `
+Cypress encountered an error while parsing the argument reporter options
+
+You passed: abc
+
+The error was: Cannot read property 'split' of undefined
+`
+
+exports['invalid config error'] = `
+Cypress encountered an error while parsing the argument config
+
+You passed: xyz
+
+The error was: Cannot read property 'split' of undefined
+`

--- a/packages/server/__snapshots__/cypress_spec.js
+++ b/packages/server/__snapshots__/cypress_spec.js
@@ -1,25 +1,52 @@
-exports['could not parse config error'] = `
-Cypress encountered an error while parsing the argument config
+exports['RECORD_PARAMS_WITHOUT_RECORDING-ciBuildId 1'] = `
+You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
 
-You passed: xyz
+The --ci-build-id flag you passed was: ciBuildId123
 
-The error was: Cannot read property 'split' of undefined
+These flags can only be used when recording to the Cypress Dashboard service.
+
+https://on.cypress.io/record-params-without-recording
 `
 
-exports['could not parse env error'] = `
-Cypress encountered an error while parsing the argument env
+exports['INCORRECT_CI_BUILD_ID_USAGE 1'] = `
+You passed the --ci-build-id flag but did not provide either a --group or --parallel flag.
 
-You passed: a123
+The --ci-build-id flag you passed was: ciBuildId123
 
-The error was: Cannot read property 'split' of undefined
+The --ci-build-id flag is used to either group or parallelize multiple runs together.
+
+https://on.cypress.io/incorrect-ci-build-id-usage
 `
 
-exports['could not parse reporter options error'] = `
-Cypress encountered an error while parsing the argument reporter options
+exports['RECORD_PARAMS_WITHOUT_RECORDING-group 1'] = `
+You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
 
-You passed: nonono
+The --group flag you passed was: e2e-tests
 
-The error was: Cannot read property 'split' of undefined
+These flags can only be used when recording to the Cypress Dashboard service.
+
+https://on.cypress.io/record-params-without-recording
+`
+
+exports['RECORD_PARAMS_WITHOUT_RECORDING-parallel 1'] = `
+You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
+
+The --parallel flag you passed was: true
+
+These flags can only be used when recording to the Cypress Dashboard service.
+
+https://on.cypress.io/record-params-without-recording
+`
+
+exports['RECORD_PARAMS_WITHOUT_RECORDING-group-parallel 1'] = `
+You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
+
+The --group flag you passed was: electron-smoke-tests
+The --parallel flag you passed was: true
+
+These flags can only be used when recording to the Cypress Dashboard service.
+
+https://on.cypress.io/record-params-without-recording
 `
 
 exports['INDETERMINATE_CI_BUILD_ID-group 1'] = `
@@ -125,65 +152,6 @@ Because the ciBuildId could not be auto-detected you must pass the --ci-build-id
 https://on.cypress.io/indeterminate-ci-build-id
 `
 
-exports['INCORRECT_CI_BUILD_ID_USAGE 1'] = `
-You passed the --ci-build-id flag but did not provide either a --group or --parallel flag.
-
-The --ci-build-id flag you passed was: ciBuildId123
-
-The --ci-build-id flag is used to either group or parallelize multiple runs together.
-
-https://on.cypress.io/incorrect-ci-build-id-usage
-`
-
-exports['RECORD_PARAMS_WITHOUT_RECORDING-ciBuildId 1'] = `
-You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
-
-The --ci-build-id flag you passed was: ciBuildId123
-
-These flags can only be used when recording to the Cypress Dashboard service.
-
-https://on.cypress.io/record-params-without-recording
-`
-
-exports['RECORD_PARAMS_WITHOUT_RECORDING-group 1'] = `
-You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
-
-The --group flag you passed was: e2e-tests
-
-These flags can only be used when recording to the Cypress Dashboard service.
-
-https://on.cypress.io/record-params-without-recording
-`
-
-exports['RECORD_PARAMS_WITHOUT_RECORDING-parallel 1'] = `
-You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
-
-The --parallel flag you passed was: true
-
-These flags can only be used when recording to the Cypress Dashboard service.
-
-https://on.cypress.io/record-params-without-recording
-`
-
-exports['RECORD_PARAMS_WITHOUT_RECORDING-tag 1'] = `
-You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
-
-These flags can only be used when recording to the Cypress Dashboard service.
-
-https://on.cypress.io/record-params-without-recording
-`
-
-exports['RECORD_PARAMS_WITHOUT_RECORDING-group-parallel 1'] = `
-You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
-
-The --group flag you passed was: electron-smoke-tests
-The --parallel flag you passed was: true
-
-These flags can only be used when recording to the Cypress Dashboard service.
-
-https://on.cypress.io/record-params-without-recording
-`
-
 exports['DASHBOARD_RUN_GROUP_NAME_NOT_UNIQUE 1'] = `
 You passed the --group flag, but this group name has already been used for this run.
 
@@ -287,4 +255,36 @@ The --parallel flag you passed was: true
 The --ciBuildId flag you passed was: ciBuildId123
 
 https://on.cypress.io/stale-run
+`
+
+exports['RECORD_PARAMS_WITHOUT_RECORDING-tag 1'] = `
+You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
+
+These flags can only be used when recording to the Cypress Dashboard service.
+
+https://on.cypress.io/record-params-without-recording
+`
+
+exports['could not parse config error'] = `
+Cypress encountered an error while parsing the argument config
+
+You passed: xyz
+
+The error was: Cannot read property 'split' of undefined
+`
+
+exports['could not parse env error'] = `
+Cypress encountered an error while parsing the argument env
+
+You passed: a123
+
+The error was: Cannot read property 'split' of undefined
+`
+
+exports['could not parse reporter options error'] = `
+Cypress encountered an error while parsing the argument reporter options
+
+You passed: nonono
+
+The error was: Cannot read property 'split' of undefined
 `

--- a/packages/server/__snapshots__/cypress_spec.js
+++ b/packages/server/__snapshots__/cypress_spec.js
@@ -1,52 +1,25 @@
-exports['RECORD_PARAMS_WITHOUT_RECORDING-ciBuildId 1'] = `
-You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
+exports['could not parse config error'] = `
+Cypress encountered an error while parsing the argument config
 
-The --ci-build-id flag you passed was: ciBuildId123
+You passed: xyz
 
-These flags can only be used when recording to the Cypress Dashboard service.
-
-https://on.cypress.io/record-params-without-recording
+The error was: Cannot read property 'split' of undefined
 `
 
-exports['INCORRECT_CI_BUILD_ID_USAGE 1'] = `
-You passed the --ci-build-id flag but did not provide either a --group or --parallel flag.
+exports['could not parse env error'] = `
+Cypress encountered an error while parsing the argument env
 
-The --ci-build-id flag you passed was: ciBuildId123
+You passed: a123
 
-The --ci-build-id flag is used to either group or parallelize multiple runs together.
-
-https://on.cypress.io/incorrect-ci-build-id-usage
+The error was: Cannot read property 'split' of undefined
 `
 
-exports['RECORD_PARAMS_WITHOUT_RECORDING-group 1'] = `
-You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
+exports['could not parse reporter options error'] = `
+Cypress encountered an error while parsing the argument reporter options
 
-The --group flag you passed was: e2e-tests
+You passed: nonono
 
-These flags can only be used when recording to the Cypress Dashboard service.
-
-https://on.cypress.io/record-params-without-recording
-`
-
-exports['RECORD_PARAMS_WITHOUT_RECORDING-parallel 1'] = `
-You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
-
-The --parallel flag you passed was: true
-
-These flags can only be used when recording to the Cypress Dashboard service.
-
-https://on.cypress.io/record-params-without-recording
-`
-
-exports['RECORD_PARAMS_WITHOUT_RECORDING-group-parallel 1'] = `
-You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
-
-The --group flag you passed was: electron-smoke-tests
-The --parallel flag you passed was: true
-
-These flags can only be used when recording to the Cypress Dashboard service.
-
-https://on.cypress.io/record-params-without-recording
+The error was: Cannot read property 'split' of undefined
 `
 
 exports['INDETERMINATE_CI_BUILD_ID-group 1'] = `
@@ -152,6 +125,65 @@ Because the ciBuildId could not be auto-detected you must pass the --ci-build-id
 https://on.cypress.io/indeterminate-ci-build-id
 `
 
+exports['INCORRECT_CI_BUILD_ID_USAGE 1'] = `
+You passed the --ci-build-id flag but did not provide either a --group or --parallel flag.
+
+The --ci-build-id flag you passed was: ciBuildId123
+
+The --ci-build-id flag is used to either group or parallelize multiple runs together.
+
+https://on.cypress.io/incorrect-ci-build-id-usage
+`
+
+exports['RECORD_PARAMS_WITHOUT_RECORDING-ciBuildId 1'] = `
+You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
+
+The --ci-build-id flag you passed was: ciBuildId123
+
+These flags can only be used when recording to the Cypress Dashboard service.
+
+https://on.cypress.io/record-params-without-recording
+`
+
+exports['RECORD_PARAMS_WITHOUT_RECORDING-group 1'] = `
+You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
+
+The --group flag you passed was: e2e-tests
+
+These flags can only be used when recording to the Cypress Dashboard service.
+
+https://on.cypress.io/record-params-without-recording
+`
+
+exports['RECORD_PARAMS_WITHOUT_RECORDING-parallel 1'] = `
+You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
+
+The --parallel flag you passed was: true
+
+These flags can only be used when recording to the Cypress Dashboard service.
+
+https://on.cypress.io/record-params-without-recording
+`
+
+exports['RECORD_PARAMS_WITHOUT_RECORDING-tag 1'] = `
+You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
+
+These flags can only be used when recording to the Cypress Dashboard service.
+
+https://on.cypress.io/record-params-without-recording
+`
+
+exports['RECORD_PARAMS_WITHOUT_RECORDING-group-parallel 1'] = `
+You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
+
+The --group flag you passed was: electron-smoke-tests
+The --parallel flag you passed was: true
+
+These flags can only be used when recording to the Cypress Dashboard service.
+
+https://on.cypress.io/record-params-without-recording
+`
+
 exports['DASHBOARD_RUN_GROUP_NAME_NOT_UNIQUE 1'] = `
 You passed the --group flag, but this group name has already been used for this run.
 
@@ -255,12 +287,4 @@ The --parallel flag you passed was: true
 The --ciBuildId flag you passed was: ciBuildId123
 
 https://on.cypress.io/stale-run
-`
-
-exports['RECORD_PARAMS_WITHOUT_RECORDING-tag 1'] = `
-You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.
-
-These flags can only be used when recording to the Cypress Dashboard service.
-
-https://on.cypress.io/record-params-without-recording
 `

--- a/packages/server/__snapshots__/cypress_spec.js
+++ b/packages/server/__snapshots__/cypress_spec.js
@@ -282,7 +282,7 @@ The error was: Cannot read property 'split' of undefined
 `
 
 exports['could not parse reporter options error'] = `
-Cypress encountered an error while parsing the argument reporter options
+Cypress encountered an error while parsing the argument reporterOptions
 
 You passed: nonono
 

--- a/packages/server/lib/cypress.js
+++ b/packages/server/lib/cypress.js
@@ -151,7 +151,15 @@ module.exports = {
     // for https://github.com/cypress-io/cypress/issues/5466
     argv = R.without('--', argv)
 
-    const options = argsUtils.toObject(argv)
+    let options
+
+    try {
+      options = argsUtils.toObject(argv)
+    } catch (argumentsError) {
+      debug('could not parse CLI arguments: %o', argv)
+
+      return exitErr(argumentsError)
+    }
 
     debug('from argv %o got options %o', argv, options)
 

--- a/packages/server/lib/cypress.js
+++ b/packages/server/lib/cypress.js
@@ -39,6 +39,8 @@ const exitErr = (err) => {
 
   return require('./errors').logException(err)
   .then(() => {
+    debug('calling exit 1')
+
     return exit(1)
   })
 }
@@ -158,6 +160,7 @@ module.exports = {
     } catch (argumentsError) {
       debug('could not parse CLI arguments: %o', argv)
 
+      // note - this is promise-returned call
       return exitErr(argumentsError)
     }
 

--- a/packages/server/lib/errors.coffee
+++ b/packages/server/lib/errors.coffee
@@ -525,7 +525,6 @@ getMsgByType = (type, arg1 = {}, arg2) ->
 
         #{chalk.blue(arg2)}
         """
-
     when "RENDERER_CRASHED"
       """
       We detected that the Chromium Renderer process just crashed.
@@ -881,6 +880,21 @@ getMsgByType = (type, arg1 = {}, arg2) ->
       """
       Failed to connect to Chrome, retrying in 1 second (attempt #{chalk.yellow(arg1)}/32)
       """
+    when "COULD_NOT_PARSE_ARGUMENTS"
+      if arg2
+        """
+        Cypress could not parse its arguments
+
+        #{arg1}
+
+        #{chalk.yellow(arg2)}
+        """
+      else
+        """
+        Cypress could not parse its arguments
+
+        #{chalk.yellow(arg1)}
+        """
 
 get = (type, arg1, arg2) ->
   msg = getMsgByType(type, arg1, arg2)

--- a/packages/server/lib/errors.coffee
+++ b/packages/server/lib/errors.coffee
@@ -62,7 +62,7 @@ trimMultipleNewLines = (str) ->
 isCypressErr = (err) ->
   Boolean(err.isCypressErr)
 
-getMsgByType = (type, arg1 = {}, arg2) ->
+getMsgByType = (type, arg1 = {}, arg2, arg3) ->
   switch type
     when "CANNOT_TRASH_ASSETS"
       """
@@ -881,23 +881,16 @@ getMsgByType = (type, arg1 = {}, arg2) ->
       Failed to connect to Chrome, retrying in 1 second (attempt #{chalk.yellow(arg1)}/32)
       """
     when "COULD_NOT_PARSE_ARGUMENTS"
-      if arg2
         """
-        Cypress could not parse its arguments
+        Cypress encountered an error while parsing the argument #{chalk.gray(arg1)}
 
-        #{arg1}
+        You passed: #{arg2}
 
-        #{chalk.yellow(arg2)}
-        """
-      else
-        """
-        Cypress could not parse its arguments
-
-        #{chalk.yellow(arg1)}
+        The error was: #{arg3}
         """
 
-get = (type, arg1, arg2) ->
-  msg = getMsgByType(type, arg1, arg2)
+get = (type, arg1, arg2, arg3) ->
+  msg = getMsgByType(type, arg1, arg2, arg3)
 
   if _.isObject(msg)
     details = msg.details
@@ -918,8 +911,8 @@ warning = (type, arg1, arg2) ->
 
   return null
 
-throwErr = (type, arg1, arg2) ->
-  throw get(type, arg1, arg2)
+throwErr = (type, arg1, arg2, arg3) ->
+  throw get(type, arg1, arg2, arg3)
 
 clone = (err, options = {}) ->
   _.defaults options, {

--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -1,4 +1,6 @@
 const _ = require('lodash')
+const la = require('lazy-ass')
+const is = require('check-more-types')
 const path = require('path')
 const debug = require('debug')('cypress:server:args')
 const minimist = require('minimist')
@@ -108,32 +110,41 @@ const JSONOrCoerce = (str) => {
   return coerceUtil(str)
 }
 
-const sanitizeAndConvertNestedArgs = (str) => {
+const sanitizeAndConvertNestedArgs = (str, argname) => {
+  la(is.unemptyString(argname), 'missing config argname to be parsed')
+
+  try {
   // if this is valid JSON then just
   // parse it and call it a day
-  const parsed = tryJSONParse(str)
+    const parsed = tryJSONParse(str)
 
-  if (parsed) {
-    return parsed
+    if (parsed) {
+      return parsed
+    }
+
+    // invalid JSON, so assume mixed usage
+    // first find foo={a:b,b:c} and bar=[1,2,3]
+    // syntax and turn those into
+    // foo: a:b|b:c
+    // bar: 1|2|3
+
+    return _
+    .chain(str)
+    .replace(nestedObjectsInCurlyBracesRe, commasToPipes)
+    .replace(nestedArraysInSquareBracketsRe, commasToPipes)
+    .split(',')
+    .map((pair) => {
+      return pair.split(everythingAfterFirstEqualRe)
+    })
+    .fromPairs()
+    .mapValues(JSONOrCoerce)
+    .value()
+  } catch (err) {
+    debug('could not pass config %s value %s', argname, str)
+    debug('error %o', err)
+
+    return errors.throw('COULD_NOT_PARSE_ARGUMENTS', argname, str, err.message)
   }
-
-  // invalid JSON, so assume mixed usage
-  // first find foo={a:b,b:c} and bar=[1,2,3]
-  // syntax and turn those into
-  // foo: a:b|b:c
-  // bar: 1|2|3
-
-  return _
-  .chain(str)
-  .replace(nestedObjectsInCurlyBracesRe, commasToPipes)
-  .replace(nestedArraysInSquareBracketsRe, commasToPipes)
-  .split(',')
-  .map((pair) => {
-    return pair.split(everythingAfterFirstEqualRe)
-  })
-  .fromPairs()
-  .mapValues(JSONOrCoerce)
-  .value()
 }
 
 module.exports = {
@@ -220,7 +231,7 @@ module.exports = {
     }
 
     if (env) {
-      options.env = sanitizeAndConvertNestedArgs(env)
+      options.env = sanitizeAndConvertNestedArgs(env, 'env')
     }
 
     const proxySource = proxyUtil.loadSystemProxySettings()
@@ -235,21 +246,13 @@ module.exports = {
     }
 
     if (reporterOptions) {
-      options.reporterOptions = sanitizeAndConvertNestedArgs(reporterOptions)
+      options.reporterOptions = sanitizeAndConvertNestedArgs(reporterOptions, 'reporter options')
     }
 
     if (config) {
       // convert config to an object
       // and store the config
-      debug('parsing config:', config)
-      try {
-        options.config = sanitizeAndConvertNestedArgs(config)
-      } catch (err) {
-        debug('could not pass config %o', config)
-        debug('error %o', err)
-
-        return errors.throw('COULD_NOT_PARSE_ARGUMENTS', 'invalid config', config)
-      }
+      options.config = sanitizeAndConvertNestedArgs(config, 'config')
     }
 
     // get a list of the available config keys

--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -5,6 +5,7 @@ const minimist = require('minimist')
 const coerceUtil = require('./coerce')
 const configUtil = require('../config')
 const proxyUtil = require('./proxy')
+const errors = require('../errors')
 
 const nestedObjectsInCurlyBracesRe = /\{(.+?)\}/g
 const nestedArraysInSquareBracketsRe = /\[(.+?)\]/g
@@ -239,8 +240,16 @@ module.exports = {
 
     if (config) {
       // convert config to an object
-      // annd store the config
-      options.config = sanitizeAndConvertNestedArgs(config)
+      // and store the config
+      debug('parsing config:', config)
+      try {
+        options.config = sanitizeAndConvertNestedArgs(config)
+      } catch (err) {
+        debug('could not pass config %o', config)
+        debug('error %o', err)
+
+        return errors.throw('COULD_NOT_PARSE_ARGUMENTS', 'invalid config', config)
+      }
     }
 
     // get a list of the available config keys

--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -246,7 +246,7 @@ module.exports = {
     }
 
     if (reporterOptions) {
-      options.reporterOptions = sanitizeAndConvertNestedArgs(reporterOptions, 'reporter options')
+      options.reporterOptions = sanitizeAndConvertNestedArgs(reporterOptions, 'reporterOptions')
     }
 
     if (config) {

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -140,20 +140,22 @@ describe('lib/cypress', () => {
       expect(process.exit).to.be.calledWith(code)
     }
 
+    // returns error object
     this.expectExitWithErr = (type, msg1, msg2) => {
       expect(errors.log, 'error was logged').to.be.calledWithMatch({ type })
       expect(process.exit, 'process.exit was called').to.be.calledWith(1)
-      if (msg1) {
-        const err = errors.log.getCall(0).args[0]
 
+      const err = errors.log.getCall(0).args[0]
+
+      if (msg1) {
         expect(err.message, 'error text').to.include(msg1)
       }
 
       if (msg2) {
-        const err = errors.log.getCall(0).args[0]
-
         expect(err.message, 'second error text').to.include(msg2)
       }
+
+      return err
     }
   })
 
@@ -200,9 +202,27 @@ describe('lib/cypress', () => {
     it('exits if config cannot be parsed', function () {
       return cypress.start(['--config', 'xyz'])
       .then(() => {
-        // error message includes both "why" the error happened (invalid config)
-        // and the original config details ("xyz")
-        this.expectExitWithErr('COULD_NOT_PARSE_ARGUMENTS', 'invalid config', 'xyz')
+        const err = this.expectExitWithErr('COULD_NOT_PARSE_ARGUMENTS')
+
+        snapshot('could not parse config error', stripAnsi(err.message))
+      })
+    })
+
+    it('exits if env cannot be parsed', function () {
+      return cypress.start(['--env', 'a123'])
+      .then(() => {
+        const err = this.expectExitWithErr('COULD_NOT_PARSE_ARGUMENTS')
+
+        snapshot('could not parse env error', stripAnsi(err.message))
+      })
+    })
+
+    it('exits if reporter options cannot be parsed', function () {
+      return cypress.start(['--reporterOptions', 'nonono'])
+      .then(() => {
+        const err = this.expectExitWithErr('COULD_NOT_PARSE_ARGUMENTS')
+
+        snapshot('could not parse reporter options error', stripAnsi(err.message))
       })
     })
   })

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -140,13 +140,19 @@ describe('lib/cypress', () => {
       expect(process.exit).to.be.calledWith(code)
     }
 
-    this.expectExitWithErr = (type, msg) => {
-      expect(errors.log).to.be.calledWithMatch({ type })
-      expect(process.exit).to.be.calledWith(1)
-      if (msg) {
+    this.expectExitWithErr = (type, msg1, msg2) => {
+      expect(errors.log, 'error was logged').to.be.calledWithMatch({ type })
+      expect(process.exit, 'process.exit was called').to.be.calledWith(1)
+      if (msg1) {
         const err = errors.log.getCall(0).args[0]
 
-        expect(err.message).to.include(msg)
+        expect(err.message, 'error text').to.include(msg1)
+      }
+
+      if (msg2) {
+        const err = errors.log.getCall(0).args[0]
+
+        expect(err.message, 'second error text').to.include(msg2)
       }
     }
   })
@@ -186,6 +192,17 @@ describe('lib/cypress', () => {
     it('validates returned list', () => {
       return browserUtils.getBrowsers().then((list) => {
         expect(v.isValidBrowserList('browsers', list)).to.be.true
+      })
+    })
+  })
+
+  context('error handling', function () {
+    it('exits if config cannot be parsed', function () {
+      return cypress.start(['--config', 'xyz'])
+      .then(() => {
+        // error message includes both "why" the error happened (invalid config)
+        // and the original config details ("xyz")
+        this.expectExitWithErr('COULD_NOT_PARSE_ARGUMENTS', 'invalid config', 'xyz')
       })
     })
   })

--- a/packages/server/test/unit/args_spec.coffee
+++ b/packages/server/test/unit/args_spec.coffee
@@ -3,7 +3,9 @@ require("../spec_helper")
 _        = require("lodash")
 path     = require("path")
 os       = require("os")
-argsUtil = require("#{root}lib/util/args")
+snapshot = require("snap-shot-it")
+stripAnsi = require("strip-ansi")
+argsUtil  = require("#{root}lib/util/args")
 proxyUtil = require("#{root}lib/util/proxy")
 getWindowsProxyUtil = require("#{root}lib/util/get-windows-proxy")
 
@@ -74,6 +76,17 @@ describe "lib/util/args", ->
         bar: "qux="
       })
 
+    it "throws if env string cannot be parsed", ->
+      expect () =>
+        @setup("--env", "nonono")
+      .to.throw
+
+      # now look at the error
+      try
+        @setup("--env", "nonono")
+      catch err
+        snapshot("invalid env error", stripAnsi(err.message))
+
   context "--reporterOptions", ->
     it "converts to object literal", ->
       reporterOpts = {
@@ -111,6 +124,17 @@ describe "lib/util/args", ->
           toConsole: true
         }
       })
+
+    it "throws if reporter string cannot be parsed", ->
+      expect () =>
+        @setup("--reporterOptions", "abc")
+      .to.throw
+
+      # now look at the error
+      try
+        @setup("--reporterOptions", "abc")
+      catch err
+        snapshot("invalid reporter options error", stripAnsi(err.message))
 
   context "--config", ->
     it "converts to object literal", ->
@@ -181,8 +205,7 @@ describe "lib/util/args", ->
       try
         @setup("--config", "xyz")
       catch err
-        expect(err.message, "specifies config").to.include("invalid config")
-        expect(err.message, "tells invalid string").to.include("xyz")
+        snapshot("invalid config error", stripAnsi(err.message))
 
   context ".toArray", ->
     beforeEach ->

--- a/packages/server/test/unit/args_spec.coffee
+++ b/packages/server/test/unit/args_spec.coffee
@@ -172,6 +172,18 @@ describe "lib/util/args", ->
       options = @setup("--port", 2222)
       expect(options.config.port).to.eq(2222)
 
+    it "throws if config string cannot be parsed", ->
+      expect () =>
+        @setup("--config", "xyz")
+      .to.throw
+
+      # now look at the error
+      try
+        @setup("--config", "xyz")
+      catch err
+        expect(err.message, "specifies config").to.include("invalid config")
+        expect(err.message, "tells invalid string").to.include("xyz")
+
   context ".toArray", ->
     beforeEach ->
       @obj = {config: {foo: "bar"}, project: "foo/bar"}


### PR DESCRIPTION
- Closes #6279

### User facing changelog

Cypress can silently fail to parse custom config string, or fail with a weird "cannot call split of undefined" error. This change catches config-parsing errors, prints an error message and the config string before exiting.

Example error message

```
Cypress encountered an error while parsing the argument config

You passed: xyz

The error was: Cannot read property 'split' of undefined
```

Same guard for parsing `env` and `reporterOptions` arguments.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
