### PR TITLE
Add more debug logs around whether they have video recording disabled

### DIFF
--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -660,15 +660,12 @@ const getVideoRecordingDelay = function (startedVideoCapture) {
 const maybeStartVideoRecording = Promise.method(function (options = {}) {
   const { spec, browser, video, videosFolder } = options
 
+  debug(`video recording has been ${video ? 'enabled' : 'disabled'}. video: %s`, video)
   // bail if we've been told not to capture
   // a video recording
   if (!video) {
-    debug('video recording has been disabled. video: %s', video)
-
     return
   }
-
-  debug('video recording has been enabled. video: %s', video)
 
   // handle if this browser cannot actually
   // be recorded

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -663,8 +663,12 @@ const maybeStartVideoRecording = Promise.method(function (options = {}) {
   // bail if we've been told not to capture
   // a video recording
   if (!video) {
+    debug('video recording has been disabled. video: %s', video)
+
     return
   }
+
+  debug('video recording has been enabled. video: %s', video)
 
   // handle if this browser cannot actually
   // be recorded


### PR DESCRIPTION
### User facing changelog 

N/A

### Additional details

I want to be able to see in the DEBUG logs whether a user has turned off video recording when trying to debug why their videos are not being recorded. 

### How has the user experience changed?

When running with `DEBUG` logs, will now print either of the following messages depending on video value

```
cypress:server:run video recording has been enabled. video: true
```

```
cypress:server:run video recording has been disabled. video: false
```


### PR Tasks

- [NA] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
