### PR TITLE
Style browser dropdown to look more like a clickable button

### DIFF
--- a/packages/desktop-gui/src/app/nav.scss
+++ b/packages/desktop-gui/src/app/nav.scss
@@ -47,9 +47,7 @@
         font-size: 13px;
         color: #444;
         padding: 1px 20px 0 20px;
-        line-height: 35px;
-
-
+        line-height: 40px;
       }
 
       > a  {
@@ -164,14 +162,24 @@
 }
 
 .browsers-list {
+  margin: 5px;
+  border: 1px solid #c7c7c7;
+  border-radius: 4px;
+
   li {
     padding: 9px 15px;
     white-space: nowrap;
   }
 
-  .dropdown-chosen img {
-    position: relative;
-    top: -1px;
+  &>a.dropdown-chosen {
+    border-radius: 4px;
+    line-height: 28px !important;
+    background-color: #f6f6f6;
+
+    img {
+      position: relative;
+      top: -1px;
+    }
   }
 
   .browser-icon {


### PR DESCRIPTION
Close #6299

### User facing changelog 

We updated the styling of the browser select dropdown.

### Additional details

- I have de-emphasized the 'Run all tests' button also as part of this PR. We don't really want to emphasize this as much. See #1586 

### How has the user experience changed?

#### Before

<img width="799" alt="Screen Shot 2020-02-03 at 2 16 25 PM" src="https://user-images.githubusercontent.com/1271364/73634647-0fa61900-4690-11ea-9d92-ac611efc9311.png">


#### After

<img width="829" alt="Screen Shot 2020-02-03 at 2 28 17 PM" src="https://user-images.githubusercontent.com/1271364/73635294-94ddfd80-4691-11ea-8c56-f4cae4a3b032.png">



### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [NA] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
