### PR TITLE
Add test for cy.spy, cy.stub.callThroughWithNew on constructors

### DIFF
--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -10,6 +10,7 @@
     "clean-deps": "rm -rf node_modules",
     "cypress:open": "node ../../scripts/cypress open --project ./test",
     "cypress:run": "node ../../scripts/cypress run --project ./test",
+    "postinstall": "npx patch-package",
     "prestart": "npm run check-deps-pre",
     "start": "../coffee/node_modules/.bin/coffee test/support/server.coffee"
   },

--- a/packages/driver/patches/sinon+8.1.1.patch
+++ b/packages/driver/patches/sinon+8.1.1.patch
@@ -1,0 +1,19 @@
+diff --git a/node_modules/sinon/lib/sinon/util/core/function-to-string.js b/node_modules/sinon/lib/sinon/util/core/function-to-string.js
+index fa0265b..a50bdf6 100644
+--- a/node_modules/sinon/lib/sinon/util/core/function-to-string.js
++++ b/node_modules/sinon/lib/sinon/util/core/function-to-string.js
+@@ -9,8 +9,12 @@ module.exports = function toString() {
+             thisValue = this.getCall(i).thisValue;
+ 
+             for (prop in thisValue) {
+-                if (thisValue[prop] === this) {
+-                    return prop;
++                try {
++                    if (thisValue[prop] === this) {
++                        return prop;
++                    }
++                } catch (e) {
++                    // no-op - accessing props can throw an error, nothing to do here
+                 }
+             }
+         }

--- a/packages/driver/test/cypress/integration/commands/agents_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/agents_spec.coffee
@@ -483,6 +483,11 @@ describe "src/cy/commands/agents", ->
       @obj.foo()
       expect(@originalCalled).to.be.true
 
+    it "can spy on constructors", ->
+      cy.spy(window, 'Notification').as('Notification')
+      new Notification('Hello')
+      cy.get('@Notification').should('have.been.calledWith', 'Hello')
+
     context "#as", ->
       ## same as cy.stub(), so just some smoke tests here
       beforeEach ->

--- a/packages/driver/test/cypress/integration/commands/agents_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/agents_spec.coffee
@@ -36,6 +36,11 @@ describe "src/cy/commands/agents", ->
         @obj.foo()
         expect(@originalCalled).to.be.false
 
+      it "can callThrough on constructors", ->
+        cy.stub(window, 'Notification').callThroughWithNew().as('Notification')
+        new Notification('Hello')
+        cy.get('@Notification').should('have.been.calledWith', 'Hello')
+
     describe ".stub(obj, 'method', replacerFn)", ->
       beforeEach ->
         @originalCalled = false


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6129 

### User facing changelog

Technically this is part of the sinon.js changelog... but...

- Constructors can now be spied upon with `cy.spy`.

### Additional details

- [x] ~~waiting on sinon PR to merge so the toString Cypress does on spies will work~~ using patch-package for now, will open up a pending PR to remove that once this is merged

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
