### PR TITLE
Fix the type of $$.

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -1900,7 +1900,7 @@ declare namespace Cypress {
      * @example
      *    cy.$$('p')
      */
-    $$: JQueryStatic
+    $$<TElement extends Element = HTMLElement>(selector: JQuery.Selector, context?: Element | Document | JQuery): JQuery<TElement>
   }
 
   interface SinonSpyAgent<A extends sinon.SinonSpy> {

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -456,3 +456,9 @@ cy.writeFile('../file.path', '', {
 cy.get('foo').click()
 cy.get('foo').rightclick()
 cy.get('foo').dblclick()
+
+// cy.$$() is not jQuery(). It only queries.
+// $ExpectError
+cy.$$.escapeSelector
+cy.$$('.warning')
+cy.$$('.warning', cy.$$('.notice'))


### PR DESCRIPTION
- Closes #2027

### User facing changelog

Fix the type of `cy.$$`.

### Additional details

- Why was this change necessary?

`cy.$$` and `Cypress.$` are different. But they use the same type. 

- What is affected by this change?

N/A

- Any implementation details to explain?

Copied related type from `jQuery.d.ts`.

### How has the user experience changed?

Using jQuery utility functions with `cy.$$` like `cy.$$.escapeSelector` now fails.

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? cypress-io/cypress-documentation#2465
- [x] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
