### PR TITLE
dont automatically install the latest version of chrome in circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -87,8 +87,6 @@ commands:
     steps:
       - attach_workspace:
           at: ~/
-      - install-latest-chrome:
-          browser: << parameters.browser >>
       - run:
           command: npm run test-e2e -- --chunk << parameters.chunk >> --browser << parameters.browser >>
           working_directory: packages/server
@@ -516,8 +514,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - install-latest-chrome:
-          browser: chrome
       - run:
           command: npm start
           background: true


### PR DESCRIPTION
Precursor for https://github.com/cypress-io/cypress/issues/6328

Basically reverts intent of https://github.com/cypress-io/cypress/pull/6115 for time being so that all of Develop branches do not fail due to Chrome 80 changes. 

(cherry picked from commit a6903ead4630cd7358cf0c9ddd0dbd6a361f58f1)