### PR TITLE
Remove `--browser canary` backwards-compatibility

### DIFF
--- a/packages/server/__snapshots__/browsers_spec.coffee.js
+++ b/packages/server/__snapshots__/browsers_spec.coffee.js
@@ -1,0 +1,19 @@
+exports['lib/browsers/index .ensureAndGetByNameOrPath throws when no browser can be found 1'] = `
+Can't run because you've entered an invalid browser name.
+
+Browser: 'browserNotGonnaBeFound' was not found on your system.
+
+Available browsers found are: chrome, electron
+`
+
+exports['lib/browsers/index .ensureAndGetByNameOrPath throws a special error when canary is passed 1'] = `
+Can't run because you've entered an invalid browser name.
+
+Browser: 'canary' was not found on your system.
+
+Available browsers found are: chrome, chrome:canary, firefox
+
+Note: In Cypress 4.0, Canary must be launched as \`chrome:canary\`, not \`canary\`.
+
+See https://on.cypress.io/migration-guide for more information on breaking changes in 4.0.
+`

--- a/packages/server/lib/browsers/index.js
+++ b/packages/server/lib/browsers/index.js
@@ -23,7 +23,7 @@ const kill = function (unbind) {
       instance.removeAllListeners()
     }
 
-    instance.once('exit', function (...args) {
+    instance.once('exit', (...args) => {
       debug('browser process killed')
 
       return resolve.apply(null, args)
@@ -61,11 +61,6 @@ const isValidPathToBrowser = (str) => {
 }
 
 const parseBrowserOption = (opt) => {
-  // for backwards compatibility pre-4.x
-  if (opt === 'canary') {
-    opt = 'chrome:canary'
-  }
-
   // it's a name or a path
   if (!_.isString(opt) || !opt.includes(':')) {
     return {

--- a/packages/server/lib/errors.coffee
+++ b/packages/server/lib/errors.coffee
@@ -97,13 +97,22 @@ getMsgByType = (type, arg1 = {}, arg2, arg3) ->
       #{arg1}
       """
     when "BROWSER_NOT_FOUND_BY_NAME"
-      """
+      str = """
       Can't run because you've entered an invalid browser name.
 
       Browser: '#{arg1}' was not found on your system.
 
       Available browsers found are: #{arg2}
       """
+
+      if arg1 is 'canary'
+        str += """
+        \n\nNote: In Cypress 4.0, Canary must be launched as `chrome:canary`, not `canary`.
+
+        See https://on.cypress.io/migration-guide for more information on breaking changes in 4.0.
+        """
+
+      return str
     when "BROWSER_NOT_FOUND_BY_PATH"
       msg = """
       We could not identify a known browser at the path you provided: `#{arg1}`

--- a/packages/server/test/unit/browsers/browsers_spec.coffee
+++ b/packages/server/test/unit/browsers/browsers_spec.coffee
@@ -1,5 +1,6 @@
 require("../../spec_helper")
 
+_ = require("lodash")
 Promise = require("bluebird")
 Windows = require("#{root}../lib/gui/windows")
 browsers = require("#{root}../lib/browsers")
@@ -36,12 +37,22 @@ describe "lib/browsers/index", ->
         expect(browser).to.deep.eq({ name: "foo", channel: "stable" })
 
     it "throws when no browser can be found", ->
-      browsers.ensureAndGetByNameOrPath("browserNotGonnaBeFound")
-      .then ->
-        throw new Error("should have failed")
-      .catch (err) ->
-        expect(err.type).to.eq("BROWSER_NOT_FOUND_BY_NAME")
-        expect(err.message).to.contain("'browserNotGonnaBeFound' was not found on your system")
+      expect(browsers.ensureAndGetByNameOrPath("browserNotGonnaBeFound"))
+      .to.be.rejectedWith({ type: 'BROWSER_NOT_FOUND_BY_NAME' })
+      .then (err) ->
+        snapshot(err.message)
+
+    it "throws a special error when canary is passed", ->
+      sinon.stub(utils, "getBrowsers").resolves([
+        { name: "chrome", channel: "stable" }
+        { name: "chrome", channel: "canary" }
+        { name: "firefox", channel: "stable" }
+      ])
+
+      expect(browsers.ensureAndGetByNameOrPath("canary"))
+      .to.be.rejectedWith({ type: 'BROWSER_NOT_FOUND_BY_NAME' })
+      .then (err) ->
+        snapshot(err.message)
 
   context ".open", ->
     it "throws an error if browser family doesn't exist", ->

--- a/packages/server/test/unit/browsers/browsers_spec.coffee
+++ b/packages/server/test/unit/browsers/browsers_spec.coffee
@@ -1,6 +1,5 @@
 require("../../spec_helper")
 
-_ = require("lodash")
 Promise = require("bluebird")
 Windows = require("#{root}../lib/gui/windows")
 browsers = require("#{root}../lib/browsers")


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes <!-- issue number here -->

### User facing changelog

- n/a - part of earlier --browser changes

### Additional details

n/a

### How has the user experience changed?

`--browser canary` will not work in 4.x

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here --> https://github.com/cypress-io/cypress-documentation/pull/1710/commits/648a08e64e7634e1a33d2e83ecbbc009f8715958