### PR TITLE
downgrade is-installed-globally to work in windows

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -44,7 +44,7 @@
     "fs-extra": "8.1.0",
     "getos": "3.1.4",
     "is-ci": "2.0.0",
-    "is-installed-globally": "0.3.1",
+    "is-installed-globally": "0.1.0",
     "lazy-ass": "1.6.0",
     "listr": "0.14.3",
     "lodash": "4.17.15",


### PR DESCRIPTION
- error started happening in CI after merge of `4.0-release` branch https://ci.appveyor.com/project/cypress-io/cypress-test-example-repos-9fe7n/builds/30621426
- suspecting the problem is https://github.com/sindresorhus/is-installed-globally/issues/6
- downgrade `is-installed-globally` for now
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes N/A 

### User facing changelog
N/A - pre-release fix

<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
