### PR TITLE
fix path typo for chromium mac

### DIFF
--- a/packages/launcher/lib/darwin/index.ts
+++ b/packages/launcher/lib/darwin/index.ts
@@ -19,7 +19,7 @@ const detectChrome = partial(findApp, [
 ])
 const detectChromium = partial(findApp, [
   'Chromium.app',
-  'Contents/DMacOS/Chromium',
+  'Contents/MacOS/Chromium',
   'org.chromium.Chromium',
   'CFBundleShortVersionString',
 ])


### PR DESCRIPTION
Closes #6357

### User facing changelog

correct path for detecting Chromium on MacOS

### Additional details

- cypress crashes as described on #6357 

### How has the user experience changed?

- Tests can't run

### PR Tasks

- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->

