### PR TITLE
Fix broken Screenshot link in cli/types/index.d.ts

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -381,7 +381,7 @@ declare namespace Cypress {
     }
 
     /**
-     * @see https://on.cypress.io/api/screenshot-api
+     * @see https://on.cypress.io/screenshot-api
      */
     Screenshot: {
       defaults(options: Partial<ScreenshotDefaultsOptions>): void


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6359

### User facing changelog

<!--
Explain the change(s) for every user to read in our changelog.
-->

Update Cypress.Screenshot JSDoc link in cli/types/index.d.ts

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

Previous JSDoc with broken link
```
    /**
     * @see https://on.cypress.io/api/screenshot-api
     */
    Screenshot: {
      defaults(options: Partial<ScreenshotDefaultsOptions>): void
    }
```

Updated JSDoc with working link
```
    /**
     * @see https://on.cypress.io/screenshot-api
     */
    Screenshot: {
      defaults(options: Partial<ScreenshotDefaultsOptions>): void
    }
```

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?

