### PR TITLE
Detect 64-bit Firefox on Windows

### DIFF
--- a/packages/launcher/__snapshots__/spec.ts.js
+++ b/packages/launcher/__snapshots__/spec.ts.js
@@ -1,0 +1,128 @@
+exports['windows browser detection detects browsers as expected 1'] = [
+  {
+    "name": "chrome",
+    "family": "chromium",
+    "channel": "stable",
+    "displayName": "Chrome",
+    "versionRegex": {},
+    "profile": true,
+    "binary": [
+      "google-chrome",
+      "chrome",
+      "google-chrome-stable"
+    ],
+    "version": "1.2.3",
+    "path": "C:/Program Files (x86)/Google/Chrome/Application/chrome.exe"
+  },
+  {
+    "name": "chromium",
+    "family": "chromium",
+    "channel": "stable",
+    "displayName": "Chromium",
+    "versionRegex": {},
+    "profile": true,
+    "binary": [
+      "chromium-browser",
+      "chromium"
+    ],
+    "version": "2.3.4",
+    "path": "C:/Program Files (x86)/Google/chrome-win32/chrome.exe"
+  },
+  {
+    "name": "chrome",
+    "family": "chromium",
+    "channel": "canary",
+    "displayName": "Canary",
+    "versionRegex": {},
+    "profile": true,
+    "binary": "google-chrome-canary",
+    "version": "3.4.5",
+    "path": "C:/Users/flotwig/AppData/Local/Google/Chrome SxS/Application/chrome.exe"
+  },
+  {
+    "name": "firefox",
+    "family": "firefox",
+    "channel": "stable",
+    "displayName": "Firefox",
+    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
+    "versionRegex": {},
+    "profile": true,
+    "binary": "firefox",
+    "version": "72",
+    "path": "C:/Program Files/Mozilla Firefox/firefox.exe"
+  },
+  {
+    "name": "firefox",
+    "family": "firefox",
+    "channel": "dev",
+    "displayName": "Firefox Developer Edition",
+    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
+    "versionRegex": {},
+    "profile": true,
+    "binary": [
+      "firefox-developer-edition",
+      "firefox"
+    ],
+    "version": "73",
+    "path": "C:/Program Files (x86)/Firefox Developer Edition/firefox.exe"
+  },
+  {
+    "name": "firefox",
+    "family": "firefox",
+    "channel": "nightly",
+    "displayName": "Firefox Nightly",
+    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
+    "versionRegex": {},
+    "profile": true,
+    "binary": [
+      "firefox-nightly",
+      "firefox-trunk"
+    ],
+    "version": "74",
+    "path": "C:/Program Files/Firefox Nightly/firefox.exe"
+  },
+  {
+    "name": "edge",
+    "family": "chromium",
+    "channel": "stable",
+    "displayName": "Edge",
+    "versionRegex": {},
+    "profile": true,
+    "binary": "edge",
+    "version": "11",
+    "path": "C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe"
+  },
+  {
+    "name": "edge",
+    "family": "chromium",
+    "channel": "canary",
+    "displayName": "Edge Canary",
+    "versionRegex": {},
+    "profile": true,
+    "binary": "edge-canary",
+    "version": "14",
+    "path": "C:/Users/flotwig/AppData/Local/Microsoft/Edge SxS/Application/msedge.exe"
+  },
+  {
+    "name": "edge",
+    "family": "chromium",
+    "channel": "beta",
+    "displayName": "Edge Beta",
+    "versionRegex": {},
+    "profile": true,
+    "binary": "edge-beta",
+    "version": "12",
+    "path": "C:/Program Files (x86)/Microsoft/Edge Beta/Application/msedge.exe"
+  },
+  {
+    "name": "edge",
+    "family": "chromium",
+    "channel": "dev",
+    "displayName": "Edge Dev",
+    "versionRegex": {},
+    "profile": true,
+    "binary": "edge-dev",
+    "version": "13",
+    "path": "C:/Program Files (x86)/Microsoft/Edge Dev/Application/msedge.exe"
+  }
+]

--- a/packages/launcher/lib/detect.ts
+++ b/packages/launcher/lib/detect.ts
@@ -138,7 +138,9 @@ export const detect = (goalBrowsers?: Browser[]): Bluebird<FoundBrowser[]> => {
   const removeDuplicates = uniqBy((browser: FoundBrowser) => {
     return props(['name', 'version'], browser)
   })
-  const compactFalse = (browsers: any[]) => compact(browsers) as FoundBrowser[]
+  const compactFalse = (browsers: any[]) => {
+    return compact(browsers) as FoundBrowser[]
+  }
 
   log('detecting if the following browsers are present %o', goalBrowsers)
 

--- a/packages/launcher/lib/windows/index.ts
+++ b/packages/launcher/lib/windows/index.ts
@@ -11,13 +11,13 @@ import { Browser, FoundBrowser } from '../types'
 function formFullAppPath (name: string) {
   const prefix = 'C:/Program Files (x86)/Google/Chrome/Application'
 
-  return normalize(join(prefix, `${name}.exe`))
+  return [normalize(join(prefix, `${name}.exe`))]
 }
 
 function formChromiumAppPath () {
   const exe = 'C:/Program Files (x86)/Google/chrome-win32/chrome.exe'
 
-  return normalize(exe)
+  return [normalize(exe)]
 }
 
 function formChromeCanaryAppPath () {
@@ -32,25 +32,16 @@ function formChromeCanaryAppPath () {
     'chrome.exe'
   )
 
-  return normalize(exe)
+  return [normalize(exe)]
 }
 
-function formFirefoxAppPath () {
-  const exe = 'C:/Program Files (x86)/Mozilla Firefox/firefox.exe'
-
-  return normalize(exe)
-}
-
-function formFirefoxDeveloperEditionAppPath () {
-  const exe = 'C:/Program Files (x86)/Firefox Developer Edition/firefox.exe'
-
-  return normalize(exe)
-}
-
-function formFirefoxNightlyAppPath () {
-  const exe = 'C:/Program Files (x86)/Firefox Nightly/firefox.exe'
-
-  return normalize(exe)
+function getFirefoxPaths (editionFolder) {
+  return () => {
+    return (['Program Files', 'Program Files (x86)'])
+    .map((programFiles) => {
+      return normalize(`C:/${programFiles}/${editionFolder}/firefox.exe`)
+    })
+  }
 }
 
 function formEdgeCanaryAppPath () {
@@ -65,10 +56,10 @@ function formEdgeCanaryAppPath () {
     'msedge.exe'
   )
 
-  return normalize(exe)
+  return [normalize(exe)]
 }
 
-type NameToPath = (name: string) => string
+type NameToPath = (name: string) => string[]
 
 type WindowsBrowserPaths = {
   [name: string]: {
@@ -85,14 +76,20 @@ const formPaths: WindowsBrowserPaths = {
     stable: formChromiumAppPath,
   },
   firefox: {
-    stable: formFirefoxAppPath,
-    dev: formFirefoxDeveloperEditionAppPath,
-    nightly: formFirefoxNightlyAppPath,
+    stable: getFirefoxPaths('Mozilla Firefox'),
+    dev: getFirefoxPaths('Firefox Developer Edition'),
+    nightly: getFirefoxPaths('Firefox Nightly'),
   },
   edge: {
-    stable: () => normalize('C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe'),
-    beta: () => normalize('C:/Program Files (x86)/Microsoft/Edge Beta/Application/msedge.exe'),
-    dev: () => normalize('C:/Program Files (x86)/Microsoft/Edge Dev/Application/msedge.exe'),
+    stable: () => {
+      return [normalize('C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe')]
+    },
+    beta: () => {
+      return [normalize('C:/Program Files (x86)/Microsoft/Edge Beta/Application/msedge.exe')]
+    },
+    dev: () => {
+      return [normalize('C:/Program Files (x86)/Microsoft/Edge Dev/Application/msedge.exe')]
+    },
     canary: formEdgeCanaryAppPath,
   },
 }
@@ -112,40 +109,56 @@ function getWindowsBrowser (browser: Browser): Promise<FoundBrowser> {
     throw notInstalledErr(browser.name)
   }
 
-  const formFullAppPathFn: any = get(formPaths, [browser.name, browser.channel], formFullAppPath)
+  const formFullAppPathFn: NameToPath = get(formPaths, [browser.name, browser.channel], formFullAppPath)
 
-  const exePath = formFullAppPathFn(browser.name)
+  const exePaths = formFullAppPathFn(browser.name)
 
-  log('exe path %s', exePath)
+  log('looking at possible paths... %o', { browser, exePaths })
 
-  return pathExists(exePath)
-  .then((exists) => {
-    log('found %s ?', exePath, exists)
+  // shift and try paths 1-by-1 until we find one that works
+  const tryNextExePath = async () => {
+    const exePath = exePaths.shift()
 
-    if (!exists) {
-      throw notInstalledErr(`Browser ${browser.name} file not found at ${exePath}`)
+    if (!exePath) {
+      // exhausted available paths
+      throw notInstalledErr(browser.name)
     }
 
-    return getVersionString(exePath)
-    .then(tap(log))
-    .then(getVersion)
-    .then((version: string) => {
-      log('browser %s at \'%s\' version %s', browser.name, exePath, version)
+    return pathExists(exePath)
+    .then((exists) => {
+      log('found %s ?', exePath, exists)
 
-      return {
-        name: browser.name,
-        version,
-        path: exePath,
-      } as FoundBrowser
+      if (!exists) {
+        return tryNextExePath()
+      }
+
+      return getVersionString(exePath)
+      .then(tap(log))
+      .then(getVersion)
+      .then((version: string) => {
+        log('browser %s at \'%s\' version %s', browser.name, exePath, version)
+
+        return {
+          name: browser.name,
+          version,
+          path: exePath,
+        } as FoundBrowser
+      })
     })
-  })
-  .catch(() => {
-    throw notInstalledErr(browser.name)
-  })
+    .catch((err) => {
+      log('error while looking up exe, trying next exePath %o', { exePath, exePaths, err })
+
+      return tryNextExePath()
+    })
+  }
+
+  return tryNextExePath()
 }
 
 export function getVersionString (path: string) {
-  const doubleEscape = (s: string) => s.replace(/\\/g, '\\\\')
+  const doubleEscape = (s: string) => {
+    return s.replace(/\\/g, '\\\\')
+  }
 
   // on Windows using "--version" seems to always start the full
   // browser, no matter what one does.
@@ -159,8 +172,7 @@ export function getVersionString (path: string) {
     '/value',
   ]
 
-  return execa('wmic', args)
-  .then((result) => result.stdout)
+  return execa.stdout('wmic', args)
   .then(trim)
 }
 

--- a/packages/launcher/lib/windows/index.ts
+++ b/packages/launcher/lib/windows/index.ts
@@ -1,6 +1,6 @@
 import execa from 'execa'
-import { pathExists } from 'fs-extra'
-import { homedir } from 'os'
+import fse from 'fs-extra'
+import os from 'os'
 import { join, normalize } from 'path'
 import { tap, trim } from 'ramda'
 import { get } from 'lodash'
@@ -21,7 +21,7 @@ function formChromiumAppPath () {
 }
 
 function formChromeCanaryAppPath () {
-  const home = homedir()
+  const home = os.homedir()
   const exe = join(
     home,
     'AppData',
@@ -45,7 +45,7 @@ function getFirefoxPaths (editionFolder) {
 }
 
 function formEdgeCanaryAppPath () {
-  const home = homedir()
+  const home = os.homedir()
   const exe = join(
     home,
     'AppData',
@@ -124,7 +124,7 @@ function getWindowsBrowser (browser: Browser): Promise<FoundBrowser> {
       throw notInstalledErr(browser.name)
     }
 
-    return pathExists(exePath)
+    return fse.pathExists(exePath)
     .then((exists) => {
       log('found %s ?', exePath, exists)
 

--- a/packages/launcher/test/unit/windows/spec.ts
+++ b/packages/launcher/test/unit/windows/spec.ts
@@ -63,7 +63,6 @@ describe('windows browser detection', () => {
       .then((foundBrowser) => {
         return _.merge(browser, foundBrowser)
       })
-      .catch(() => {})
     }))
 
     snapshot(detected)

--- a/packages/launcher/test/unit/windows/spec.ts
+++ b/packages/launcher/test/unit/windows/spec.ts
@@ -1,0 +1,71 @@
+import _ from 'lodash'
+import * as windowsHelper from '../../../lib/windows'
+import { normalize } from 'path'
+import execa from 'execa'
+import sinon, { SinonStub } from 'sinon'
+import { browsers } from '../../../lib/browsers'
+import Bluebird from 'bluebird'
+import fse from 'fs-extra'
+import os from 'os'
+import snapshot from 'snap-shot-it'
+
+function stubBrowser (path: string, version: string) {
+  path = normalize(path.replace(/\\/g, '\\\\'))
+
+  ;(execa.stdout as SinonStub)
+  .withArgs('wmic', ['datafile', 'where', `name="${path}"`, 'get', 'Version', '/value'])
+  .resolves(`Version=${version}`)
+
+  ;(fse.pathExists as SinonStub)
+  .withArgs(path)
+  .resolves(true)
+}
+
+const HOMEDIR = 'C:/Users/flotwig'
+
+describe('windows browser detection', () => {
+  beforeEach(() => {
+    sinon.stub(fse, 'pathExists').resolves(false)
+    sinon.stub(os, 'homedir').returns(HOMEDIR)
+    sinon.stub(execa, 'stdout').resolves('')
+  })
+
+  afterEach(() => {
+    execa.stdout.restore()
+  })
+
+  it('detects browsers as expected', async () => {
+    stubBrowser('C:/Program Files (x86)/Google/Chrome/Application/chrome.exe', '1.2.3')
+    stubBrowser('C:/Program Files (x86)/Google/chrome-win32/chrome.exe', '2.3.4')
+
+    // canary is installed in homedir
+    stubBrowser(`${HOMEDIR}/AppData/Local/Google/Chrome SxS/Application/chrome.exe`, '3.4.5')
+
+    // have 32-bit and 64-bit ff - 64-bit will be preferred
+    stubBrowser('C:/Program Files (x86)/Mozilla Firefox/firefox.exe', '72')
+    stubBrowser('C:/Program Files/Mozilla Firefox/firefox.exe', '72')
+
+    // 32-bit dev edition
+    stubBrowser('C:/Program Files (x86)/Firefox Developer Edition/firefox.exe', '73')
+
+    // 64-bit nightly edition
+    stubBrowser('C:/Program Files/Firefox Nightly/firefox.exe', '74')
+
+    stubBrowser('C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe', '11')
+    stubBrowser('C:/Program Files (x86)/Microsoft/Edge Beta/Application/msedge.exe', '12')
+    stubBrowser('C:/Program Files (x86)/Microsoft/Edge Dev/Application/msedge.exe', '13')
+
+    // edge canary is installed in homedir
+    stubBrowser(`${HOMEDIR}/AppData/Local/Microsoft/Edge SxS/Application/msedge.exe`, '14')
+
+    const detected = (await Bluebird.mapSeries(browsers, (browser) => {
+      return windowsHelper.detect(browser)
+      .then((foundBrowser) => {
+        return _.merge(browser, foundBrowser)
+      })
+      .catch(() => {})
+    }))
+
+    snapshot(detected)
+  })
+})


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6355 

### User facing changelog

- Added 64-bit Firefox paths to Windows browser detection. 64-bit Firefox will now be detected correctly on Windows.

### Additional details

- [x] also added tests for windows browser launcher, because there were none :smile: 
- [x] manually validated on winodws

### How has the user experience changed?


### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
