### PR TITLE
fix(ff): use fixed inputFPS instead of vfr to prevent dropped frames

### DIFF
--- a/packages/server/lib/video_capture.js
+++ b/packages/server/lib/video_capture.js
@@ -171,7 +171,7 @@ module.exports = {
           // assume 18 fps. This number comes from manual measurement of avg fps coming from firefox.
           .inputFPS(18)
 
-          // 'vsync vfr' (variable framerate) works perfectly but fails on page navigation
+          // 'vsync vfr' (variable framerate) works perfectly but fails on top page navigation
           // since video timestamp resets to 0, timestamps already written will be dropped
           // .outputOption('-vsync vfr')
 

--- a/packages/server/lib/video_capture.js
+++ b/packages/server/lib/video_capture.js
@@ -167,10 +167,18 @@ module.exports = {
         if (options.webmInput) {
           cmd
           .inputFormat('webm')
-          .outputOption('-vsync vfr')
+
+          // assume 18 fps. This number comes from manual measurement of avg fps coming from firefox.
+          .inputFPS(18)
+
+          // 'vsync vfr' (variable framerate) works perfectly but fails on page navigation
+          // since video timestamp resets to 0, timestamps already written will be dropped
+          // .outputOption('-vsync vfr')
+
           // this is to prevent the error "invalid data input" error
           // when input frames have an odd resolution
           .videoFilters(`crop='floor(in_w/2)*2:floor(in_h/2)*2'`)
+
           // same as above but scales instead of crops
           // .videoFilters("scale=trunc(iw/2)*2:trunc(ih/2)*2")
         } else {

--- a/packages/server/lib/video_capture.js
+++ b/packages/server/lib/video_capture.js
@@ -169,6 +169,7 @@ module.exports = {
           .inputFormat('webm')
 
           // assume 18 fps. This number comes from manual measurement of avg fps coming from firefox.
+          // TODO: replace this with the 'vfr' option below when dropped frames issue is fixed.
           .inputFPS(18)
 
           // 'vsync vfr' (variable framerate) works perfectly but fails on top page navigation


### PR DESCRIPTION
- use static `inputFPS(18)` instead of variable framerate when capturing frames from webm input

<!-- Example: "Closes #1234" -->

- Closes #6369

### User facing changelog

<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [NO] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
