### PR TITLE
fix(ff): set more default preferences, disable auto-updating prompt

### DIFF
--- a/packages/server/lib/browsers/firefox.ts
+++ b/packages/server/lib/browsers/firefox.ts
@@ -13,6 +13,208 @@ import { Browser } from './types'
 const debug = Debug('cypress:server:browsers:firefox')
 
 const defaultPreferences = {
+  /**
+   * Taken from https://github.com/puppeteer/puppeteer/blob/8b49dc62a62282543ead43541316e23d3450ff3c/lib/Launcher.js#L520
+   * with minor modifications
+   * BEGIN: Copyright 2017 Google Inc. All rights reserved. Licensed under the Apache License, Version 2.0
+   */
+
+  // Make sure Shield doesn't hit the network.
+  'app.normandy.api_url': '',
+  // Disable Firefox old build background check
+  'app.update.checkInstallTime': false,
+  // Disable automatically upgrading Firefox
+  'app.update.disabledForTesting': true,
+
+  // Increase the APZ content response timeout to 1 minute
+  'apz.content_response_timeout': 60000,
+
+  // Prevent various error message on the console
+  // jest-puppeteer asserts that no error message is emitted by the console
+  'browser.contentblocking.features.standard': '-tp,tpPrivate,cookieBehavior0,-cm,-fp',
+
+  // Enable the dump function: which sends messages to the system
+  // console
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1543115
+  'browser.dom.window.dump.enabled': true,
+  // Disable topstories
+  'browser.newtabpage.activity-stream.feeds.section.topstories': false,
+  // Always display a blank page
+  'browser.newtabpage.enabled': false,
+  // Background thumbnails in particular cause grief: and disabling
+  // thumbnails in general cannot hurt
+  'browser.pagethumbnails.capturing_disabled': true,
+
+  // Disable safebrowsing components.
+  'browser.safebrowsing.blockedURIs.enabled': false,
+  'browser.safebrowsing.downloads.enabled': false,
+  'browser.safebrowsing.malware.enabled': false,
+  'browser.safebrowsing.passwords.enabled': false,
+  'browser.safebrowsing.phishing.enabled': false,
+
+  // Disable updates to search engines.
+  'browser.search.update': false,
+  // Do not restore the last open set of tabs if the browser has crashed
+  'browser.sessionstore.resume_from_crash': false,
+  // Skip check for default browser on startup
+  'browser.shell.checkDefaultBrowser': false,
+
+  // Disable newtabpage
+  'browser.startup.homepage': 'about:blank',
+  // Do not redirect user when a milstone upgrade of Firefox is detected
+  'browser.startup.homepage_override.mstone': 'ignore',
+  // Start with a blank page about:blank
+  'browser.startup.page': 0,
+
+  // Do not allow background tabs to be zombified on Android: otherwise for
+  // tests that open additional tabs: the test harness tab itself might get
+  // unloaded
+  'browser.tabs.disableBackgroundZombification': false,
+  // Do not warn when closing all other open tabs
+  'browser.tabs.warnOnCloseOtherTabs': false,
+  // Do not warn when multiple tabs will be opened
+  'browser.tabs.warnOnOpen': false,
+
+  // Disable the UI tour.
+  'browser.uitour.enabled': false,
+  // Turn off search suggestions in the location bar so as not to trigger
+  // network connections.
+  'browser.urlbar.suggest.searches': false,
+  // Disable first run splash page on Windows 10
+  'browser.usedOnWindows10.introURL': '',
+  // Do not warn on quitting Firefox
+  'browser.warnOnQuit': false,
+
+  // Do not show datareporting policy notifications which can
+  // interfere with tests
+  'datareporting.healthreport.about.reportUrl': '',
+  'datareporting.healthreport.documentServerURI': '',
+  'datareporting.healthreport.logging.consoleEnabled': false,
+  'datareporting.healthreport.service.enabled': false,
+  'datareporting.healthreport.service.firstRun': false,
+  'datareporting.healthreport.uploadEnabled': false,
+  'datareporting.policy.dataSubmissionEnabled': false,
+  'datareporting.policy.dataSubmissionPolicyAccepted': false,
+  'datareporting.policy.dataSubmissionPolicyBypassNotification': true,
+
+  // DevTools JSONViewer sometimes fails to load dependencies with its require.js.
+  // This doesn't affect Puppeteer but spams console (Bug 1424372)
+  'devtools.jsonview.enabled': false,
+
+  // Disable popup-blocker
+  'dom.disable_open_during_load': false,
+
+  // Enable the support for File object creation in the content process
+  // Required for |Page.setFileInputFiles| protocol method.
+  'dom.file.createInChild': true,
+
+  // Disable the ProcessHangMonitor
+  'dom.ipc.reportProcessHangs': false,
+
+  // Disable slow script dialogues
+  'dom.max_chrome_script_run_time': 0,
+  'dom.max_script_run_time': 0,
+
+  // Only load extensions from the application and user profile
+  // AddonManager.SCOPE_PROFILE + AddonManager.SCOPE_APPLICATION
+  'extensions.autoDisableScopes': 0,
+  'extensions.enabledScopes': 5,
+
+  // Disable metadata caching for installed add-ons by default
+  'extensions.getAddons.cache.enabled': false,
+
+  // Disable installing any distribution extensions or add-ons.
+  'extensions.installDistroAddons': false,
+
+  // Disabled screenshots extension
+  'extensions.screenshots.disabled': true,
+
+  // Turn off extension updates so they do not bother tests
+  'extensions.update.enabled': false,
+
+  // Turn off extension updates so they do not bother tests
+  'extensions.update.notifyUser': false,
+
+  // Make sure opening about:addons will not hit the network
+  'extensions.webservice.discoverURL': '',
+
+  // Allow the application to have focus even it runs in the background
+  'focusmanager.testmode': true,
+  // Disable useragent updates
+  'general.useragent.updates.enabled': false,
+  // Always use network provider for geolocation tests so we bypass the
+  // macOS dialog raised by the corelocation provider
+  'geo.provider.testing': true,
+  // Do not scan Wifi
+  'geo.wifi.scan': false,
+  // No hang monitor
+  'hangmonitor.timeout': 0,
+  // Show chrome errors and warnings in the error console
+  'javascript.options.showInConsole': true,
+
+  // Disable download and usage of OpenH264: and Widevine plugins
+  'media.gmp-manager.updateEnabled': false,
+  // Prevent various error message on the console
+  // jest-puppeteer asserts that no error message is emitted by the console
+  'network.cookie.cookieBehavior': 0,
+
+  // Do not prompt for temporary redirects
+  'network.http.prompt-temp-redirect': false,
+
+  // Disable speculative connections so they are not reported as leaking
+  // when they are hanging around
+  'network.http.speculative-parallel-limit': 0,
+
+  // Do not automatically switch between offline and online
+  'network.manage-offline-status': false,
+
+  // Make sure SNTP requests do not hit the network
+  'network.sntp.pools': '',
+
+  // Disable Flash.
+  'plugin.state.flash': 0,
+
+  'privacy.trackingprotection.enabled': false,
+
+  // Enable Remote Agent
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1544393
+  'remote.enabled': true,
+
+  // Don't do network connections for mitm priming
+  'security.certerrors.mitm.priming.enabled': false,
+  // Local documents have access to all other local documents,
+  // including directory listings
+  'security.fileuri.strict_origin_policy': false,
+  // Do not wait for the notification button security delay
+  'security.notification_enable_delay': 0,
+
+  // Ensure blocklist updates do not hit the network
+  'services.settings.server': '',
+
+  // Do not automatically fill sign-in forms with known usernames and
+  // passwords
+  'signon.autofillForms': false,
+  // Disable password capture, so that tests that include forms are not
+  // influenced by the presence of the persistent doorhanger notification
+  'signon.rememberSignons': false,
+
+  // Disable first-run welcome page
+  'startup.homepage_welcome_url': 'about:blank',
+
+  // Disable first-run welcome page
+  'startup.homepage_welcome_url.additional': '',
+
+  // Disable browser animations (tabs, fullscreen, sliding alerts)
+  'toolkit.cosmeticAnimations.enabled': false,
+
+  'toolkit.telemetry.server': `''`,
+  // Prevent starting into safe mode after application crashes
+  'toolkit.startup.max_resumed_crashes': -1,
+
+  /**
+   * END: Copyright 2017 Google Inc. All rights reserved.
+   */
+
   'network.proxy.type': 1,
 
   // necessary for adding extensions
@@ -24,17 +226,6 @@ const defaultPreferences = {
   'devtools.debugger.prompt-connection': false,
   // "devtools.debugger.remote-websocket": true
   'devtools.chrome.enabled': true,
-  // http://hg.mozilla.org/mozilla-central/file/1dd81c324ac7/build/automation.py.in//l372
-  // Only load extensions from the application and user profile.
-  // AddonManager.SCOPE_PROFILE + AddonManager.SCOPE_APPLICATION
-  'extensions.enabledScopes': 5,
-  // Disable metadata caching for installed add-ons by default.
-  'extensions.getAddons.cache.enabled': false,
-  // Disable intalling any distribution add-ons.
-  'extensions.installDistroAddons': false,
-
-  'app.normandy.api_url': '',
-  // https://github.com/SeleniumHQ/selenium/blob/master/javascript/firefox-driver/webdriver.json
   'app.update.auto': false,
   'app.update.enabled': false,
   'browser.displayedE10SNotice': 4,
@@ -45,76 +236,39 @@ const defaultPreferences = {
   'browser.link.open_newwindow': 2,
   'browser.offline': false,
   'browser.reader.detectedFirstArticle': true,
-  'browser.search.update': false,
   'browser.selfsupport.url': '',
-  'browser.sessionstore.resume_from_crash': false,
-  'browser.shell.checkDefaultBrowser': false,
   'browser.tabs.warnOnClose': false,
-  'browser.tabs.warnOnOpen': false,
-  'datareporting.healthreport.service.enabled': false,
-  'datareporting.healthreport.uploadEnabled': false,
-  'datareporting.healthreport.service.firstRun': false,
-  'datareporting.healthreport.logging.consoleEnabled': false,
-  'datareporting.policy.dataSubmissionEnabled': false,
-  'datareporting.policy.dataSubmissionPolicyAccepted': false,
-  'datareporting.policy.dataSubmissionPolicyBypassNotification': false,
   'devtools.errorconsole.enabled': true,
-  'dom.disable_open_during_load': false,
-  'extensions.autoDisableScopes': 10,
   'extensions.blocklist.enabled': false,
   'extensions.checkCompatibility.nightly': false,
   'extensions.logging.enabled': true,
-  'extensions.update.enabled': false,
-  'extensions.update.notifyUser': false,
   'javascript.enabled': true,
-  'network.manage-offline-status': false,
   'network.http.phishy-userpass-length': 255,
   'offline-apps.allow_by_default': true,
   'prompts.tab_modal.enabled': false,
   'security.fileuri.origin_policy': 3,
-  'security.fileuri.strict_origin_policy': false,
-  'signon.rememberSignons': false,
   'toolkit.networkmanager.disable': true,
   'toolkit.telemetry.prompted': 2,
   'toolkit.telemetry.enabled': false,
   'toolkit.telemetry.rejected': true,
   'xpinstall.signatures.required': false,
   'xpinstall.whitelist.required': false,
-  'browser.dom.window.dump.enabled': true,
   'browser.laterrun.enabled': false,
   'browser.newtab.url': 'about:blank',
-  'browser.newtabpage.enabled': false,
-  'browser.startup.page': 0,
-  'browser.startup.homepage': 'about:blank',
-  'browser.startup.homepage_override.mstone': 'ignore',
-  'browser.usedOnWindows10.introURL': 'about:blank',
-  'dom.max_chrome_script_run_time': 30,
-  'dom.max_script_run_time': 30,
   'dom.report_all_js_exceptions': true,
-  'javascript.options.showInConsole': true,
   'network.captive-portal-service.enabled': false,
   'security.csp.enable': false,
-  'startup.homepage_welcome_url': 'about:blank',
-  'startup.homepage_welcome_url.additional': 'about:blank',
   'webdriver_accept_untrusted_certs': true,
   'webdriver_assume_untrusted_issuer': true,
-  // prevent going into safe mode after crash
-  'toolkit.startup.max_resumed_crashes': -1,
   'toolkit.legacyUserProfileCustomizations.stylesheets': true,
+
   // setting to true hides system window bar, but causes weird resizing issues.
   'browser.tabs.drawInTitlebar': false,
-
-  'geo.provider.testing': true,
 
   // allow playing videos w/o user interaction
   'media.autoplay.default': 0,
 
   'browser.safebrowsing.enabled': false,
-  'browser.safebrowsing.blockedURIs.enabled': false,
-  'browser.safebrowsing.downloads.enabled': false,
-  'browser.safebrowsing.passwords.enabled': false,
-  'browser.safebrowsing.malware.enabled': false,
-  'browser.safebrowsing.phishing.enabled': false,
 
   // allow capturing screen through getUserMedia(...)
   // and auto-accept the permissions prompt
@@ -124,6 +278,7 @@ const defaultPreferences = {
   'dom.min_background_timeout_value': 4,
   'dom.timeout.enable_budget_timer_throttling': false,
 
+  // allow getUserMedia APIs on insecure domains
   'media.devices.insecure.enabled':	true,
   'media.getusermedia.insecure.enabled': true,
 }


### PR DESCRIPTION
this should do it



<!-- Example: "Closes #1234" -->

- Closes #6346

### User facing changelog
firefox will no longer prompt the user to update the browser

<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [NO] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
