### PR TITLE
Pass -no-remote when launching firefox

### DIFF
--- a/packages/server/lib/browsers/firefox.ts
+++ b/packages/server/lib/browsers/firefox.ts
@@ -292,6 +292,7 @@ export async function open (browser: Browser, url, options: any = {}) {
       '-new-instance',
       '-foreground',
       '-start-debugger-server', // uses the port+host defined in devtools.debugger.remote
+      '-no-remote', // @see https://github.com/cypress-io/cypress/issues/6380
     ],
   })
 

--- a/packages/server/lib/browsers/firefox.ts
+++ b/packages/server/lib/browsers/firefox.ts
@@ -12,6 +12,12 @@ import { Browser } from './types'
 
 const debug = Debug('cypress:server:browsers:firefox')
 
+// Firefox warns when the profile is from a newer version
+// to help avoid this, use a different profile dir for every channel
+const _getProfileDir = (browser, isTextTerminal) => {
+  return utils.getProfileDir({ name: `${browser.name}-${browser.channel}` }, isTextTerminal)
+}
+
 const defaultPreferences = {
   /**
    * Taken from https://github.com/puppeteer/puppeteer/blob/8b49dc62a62282543ead43541316e23d3450ff3c/lib/Launcher.js#L520
@@ -353,7 +359,7 @@ export async function open (browser: Browser, url, options: any = {}) {
     launchOptions.extensions = [extensionDest]
   }
 
-  const profileDir = utils.getProfileDir(browser, options.isTextTerminal)
+  const profileDir = _getProfileDir(browser, options.isTextTerminal)
 
   const profile = new FirefoxProfile({
     destinationDirectory: profileDir,

--- a/packages/server/lib/browsers/firefox.ts
+++ b/packages/server/lib/browsers/firefox.ts
@@ -12,12 +12,6 @@ import { Browser } from './types'
 
 const debug = Debug('cypress:server:browsers:firefox')
 
-// Firefox warns when the profile is from a newer version
-// to help avoid this, use a different profile dir for every channel
-const _getProfileDir = (browser, isTextTerminal) => {
-  return utils.getProfileDir({ name: `${browser.name}-${browser.channel}` }, isTextTerminal)
-}
-
 const defaultPreferences = {
   /**
    * Taken from https://github.com/puppeteer/puppeteer/blob/8b49dc62a62282543ead43541316e23d3450ff3c/lib/Launcher.js#L520
@@ -359,7 +353,7 @@ export async function open (browser: Browser, url, options: any = {}) {
     launchOptions.extensions = [extensionDest]
   }
 
-  const profileDir = _getProfileDir(browser, options.isTextTerminal)
+  const profileDir = utils.getProfileDir(browser, options.isTextTerminal)
 
   const profile = new FirefoxProfile({
     destinationDirectory: profileDir,

--- a/packages/server/lib/browsers/utils.ts
+++ b/packages/server/lib/browsers/utils.ts
@@ -21,7 +21,7 @@ const pathToProfiles = path.join(PATH_TO_BROWSERS, '*')
 const getBrowserPath = (browser) => {
   return path.join(
     PATH_TO_BROWSERS,
-    `${browser.name}`
+    `${browser.name}-${browser.channel}`
   )
 }
 

--- a/packages/server/test/e2e/4_before_browser_launch_spec.ts
+++ b/packages/server/test/e2e/4_before_browser_launch_spec.ts
@@ -4,6 +4,7 @@ const Fixtures = require('../support/helpers/fixtures')
 
 const browser = {
   name: 'chrome',
+  channel: 'stable',
 }
 const isTextTerminal = true // we're always in run mode
 const PATH_TO_CHROME_PROFILE = browserUtils.getProfileDir(browser, isTextTerminal)

--- a/packages/server/test/unit/browsers/firefox_spec.ts
+++ b/packages/server/test/unit/browsers/firefox_spec.ts
@@ -84,10 +84,10 @@ describe('lib/browsers/firefox', () => {
   })
 
   beforeEach(() => {
-    sinon.stub(utils, 'getProfileDir').returns('/path/to/appData/firefox-stable/interactive')
+    sinon.stub(utils, 'getProfileDir').returns('/path/to/appData/firefox/interactive')
 
     mockfs({
-      '/path/to/appData/firefox-stable/interactive': {},
+      '/path/to/appData/firefox/interactive': {},
     })
 
     sinon.stub(protocol, '_connectAsync').resolves(null)
@@ -98,7 +98,7 @@ describe('lib/browsers/firefox', () => {
 
   context('#open', () => {
     beforeEach(function () {
-      this.browser = { name: 'firefox', channel: 'stable' }
+      this.browser = { name: 'firefox' }
       this.options = {
         proxyUrl: 'http://proxy-url',
         socketIoRoute: 'socket/io/route',
@@ -254,7 +254,7 @@ describe('lib/browsers/firefox', () => {
           '-start-debugger-server',
           '-no-remote',
           '-profile',
-          '/path/to/appData/firefox-stable/interactive',
+          '/path/to/appData/firefox/interactive',
         ])
       })
     })
@@ -267,7 +267,7 @@ describe('lib/browsers/firefox', () => {
 
     it('does not clear user profile if already exists', function () {
       mockfs({
-        '/path/to/appData/firefox-stable/interactive/': {
+        '/path/to/appData/firefox/interactive/': {
           'xulstore.json': '[foo xulstore.json]',
           'chrome': { 'userChrome.css': '[foo userChrome.css]' },
         },
@@ -275,7 +275,7 @@ describe('lib/browsers/firefox', () => {
 
       return firefox.open(this.browser, 'http://', this.options).then(() => {
         // @ts-ignore
-        expect(specUtil.getFsPath('/path/to/appData/firefox-stable/interactive')).containSubset({
+        expect(specUtil.getFsPath('/path/to/appData/firefox/interactive')).containSubset({
           'xulstore.json': '[foo xulstore.json]',
           'chrome': { 'userChrome.css': '[foo userChrome.css]' },
         })
@@ -285,7 +285,7 @@ describe('lib/browsers/firefox', () => {
     it('creates xulstore.json if not exist', function () {
       return firefox.open(this.browser, 'http://', this.options).then(() => {
         // @ts-ignore
-        expect(specUtil.getFsPath('/path/to/appData/firefox-stable/interactive')).containSubset({
+        expect(specUtil.getFsPath('/path/to/appData/firefox/interactive')).containSubset({
           'xulstore.json': '{"chrome://browser/content/browser.xhtml":{"main-window":{"width":1280,"height":1024,"sizemode":"maximized"}}}\n',
         })
       })
@@ -293,13 +293,13 @@ describe('lib/browsers/firefox', () => {
 
     it('creates chrome/userChrome.css if not exist', function () {
       return firefox.open(this.browser, 'http://', this.options).then(() => {
-        expect(specUtil.getFsPath('/path/to/appData/firefox-stable/interactive/chrome/userChrome.css')).ok
+        expect(specUtil.getFsPath('/path/to/appData/firefox/interactive/chrome/userChrome.css')).ok
       })
     })
 
     it('clears browser cache', function () {
       mockfs({
-        '/path/to/appData/firefox-stable/interactive/': {
+        '/path/to/appData/firefox/interactive/': {
           'CypressCache': { 'foo': 'bar' },
         },
       })
@@ -308,7 +308,7 @@ describe('lib/browsers/firefox', () => {
 
       return firefox.open(this.browser, 'http://', this.options).then(() => {
         // @ts-ignore
-        expect(specUtil.getFsPath('/path/to/appData/firefox-stable/interactive')).containSubset({
+        expect(specUtil.getFsPath('/path/to/appData/firefox/interactive')).containSubset({
           'CypressCache': {},
         })
       })

--- a/packages/server/test/unit/browsers/firefox_spec.ts
+++ b/packages/server/test/unit/browsers/firefox_spec.ts
@@ -252,6 +252,7 @@ describe('lib/browsers/firefox', () => {
           '-new-instance',
           '-foreground',
           '-start-debugger-server',
+          '-no-remote',
           '-profile',
           '/path/to/appData/firefox/interactive',
         ])

--- a/packages/server/test/unit/browsers/firefox_spec.ts
+++ b/packages/server/test/unit/browsers/firefox_spec.ts
@@ -84,10 +84,10 @@ describe('lib/browsers/firefox', () => {
   })
 
   beforeEach(() => {
-    sinon.stub(utils, 'getProfileDir').returns('/path/to/appData/firefox/interactive')
+    sinon.stub(utils, 'getProfileDir').returns('/path/to/appData/firefox-stable/interactive')
 
     mockfs({
-      '/path/to/appData/firefox/interactive': {},
+      '/path/to/appData/firefox-stable/interactive': {},
     })
 
     sinon.stub(protocol, '_connectAsync').resolves(null)
@@ -98,7 +98,7 @@ describe('lib/browsers/firefox', () => {
 
   context('#open', () => {
     beforeEach(function () {
-      this.browser = { name: 'firefox' }
+      this.browser = { name: 'firefox', channel: 'stable' }
       this.options = {
         proxyUrl: 'http://proxy-url',
         socketIoRoute: 'socket/io/route',
@@ -254,7 +254,7 @@ describe('lib/browsers/firefox', () => {
           '-start-debugger-server',
           '-no-remote',
           '-profile',
-          '/path/to/appData/firefox/interactive',
+          '/path/to/appData/firefox-stable/interactive',
         ])
       })
     })
@@ -267,7 +267,7 @@ describe('lib/browsers/firefox', () => {
 
     it('does not clear user profile if already exists', function () {
       mockfs({
-        '/path/to/appData/firefox/interactive/': {
+        '/path/to/appData/firefox-stable/interactive/': {
           'xulstore.json': '[foo xulstore.json]',
           'chrome': { 'userChrome.css': '[foo userChrome.css]' },
         },
@@ -275,7 +275,7 @@ describe('lib/browsers/firefox', () => {
 
       return firefox.open(this.browser, 'http://', this.options).then(() => {
         // @ts-ignore
-        expect(specUtil.getFsPath('/path/to/appData/firefox/interactive')).containSubset({
+        expect(specUtil.getFsPath('/path/to/appData/firefox-stable/interactive')).containSubset({
           'xulstore.json': '[foo xulstore.json]',
           'chrome': { 'userChrome.css': '[foo userChrome.css]' },
         })
@@ -285,7 +285,7 @@ describe('lib/browsers/firefox', () => {
     it('creates xulstore.json if not exist', function () {
       return firefox.open(this.browser, 'http://', this.options).then(() => {
         // @ts-ignore
-        expect(specUtil.getFsPath('/path/to/appData/firefox/interactive')).containSubset({
+        expect(specUtil.getFsPath('/path/to/appData/firefox-stable/interactive')).containSubset({
           'xulstore.json': '{"chrome://browser/content/browser.xhtml":{"main-window":{"width":1280,"height":1024,"sizemode":"maximized"}}}\n',
         })
       })
@@ -293,13 +293,13 @@ describe('lib/browsers/firefox', () => {
 
     it('creates chrome/userChrome.css if not exist', function () {
       return firefox.open(this.browser, 'http://', this.options).then(() => {
-        expect(specUtil.getFsPath('/path/to/appData/firefox/interactive/chrome/userChrome.css')).ok
+        expect(specUtil.getFsPath('/path/to/appData/firefox-stable/interactive/chrome/userChrome.css')).ok
       })
     })
 
     it('clears browser cache', function () {
       mockfs({
-        '/path/to/appData/firefox/interactive/': {
+        '/path/to/appData/firefox-stable/interactive/': {
           'CypressCache': { 'foo': 'bar' },
         },
       })
@@ -308,7 +308,7 @@ describe('lib/browsers/firefox', () => {
 
       return firefox.open(this.browser, 'http://', this.options).then(() => {
         // @ts-ignore
-        expect(specUtil.getFsPath('/path/to/appData/firefox/interactive')).containSubset({
+        expect(specUtil.getFsPath('/path/to/appData/firefox-stable/interactive')).containSubset({
           'CypressCache': {},
         })
       })


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6380 

### User facing changelog

- Fixed an issue where Cypress could fail to launch Firefox if another instance of Firefox is running.
- Fixed an issue where users could receive a "launched older version" error when launching Firefox Stable after launching Firefox Developer Edition or Firefox Nightly, or launching Firefox Developer edition after launching Firefox Nightly.

### Additional details

- prevents firefox from trying to connect to other running instances of FF
- puppeteer passes it: https://github.com/puppeteer/puppeteer/blob/8b49dc62a62282543ead43541316e23d3450ff3c/lib/Launcher.js#L488
- [x] also made it so browsers use `name-channel` for the profile directories

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
