### PR TITLE
do not inject performance tracking security context on Circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1225,7 +1225,6 @@ linux-workflow: &linux-workflow
         requires:
           - build
     - server-performance-tests:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-chrome-1:

--- a/circle.yml
+++ b/circle.yml
@@ -1228,67 +1228,51 @@ linux-workflow: &linux-workflow
         requires:
           - build
     - server-e2e-tests-chrome-1:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-chrome-2:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-chrome-3:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-chrome-4:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-chrome-5:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-chrome-6:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-chrome-7:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-chrome-8:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-electron-1:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-electron-2:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-electron-3:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-electron-4:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-electron-5:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-electron-6:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-electron-7:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-electron-8:
-        context: test-runner:performance-tracking
         requires:
           - build
     - server-e2e-tests-firefox-1:
@@ -1370,7 +1354,6 @@ linux-workflow: &linux-workflow
         requires:
           - build-npm-package
     - build-binary:
-        context: test-runner:performance-tracking
         requires:
           - build
     - upload-binary:


### PR DESCRIPTION
- closes #6399

Internal CI change. Instead of injecting security context, set environment variables on CircleCI `cypress` project