### PR TITLE
Update project error UI

### DIFF
--- a/packages/desktop-gui/cypress/integration/error_message_spec.js
+++ b/packages/desktop-gui/cypress/integration/error_message_spec.js
@@ -128,17 +128,41 @@ describe('Error Message', function () {
     this.start()
 
     cy.get('.error').contains('ReferenceError: alsdkjf is not defined')
-    cy.get('details').should('not.have.attr', 'open')
-    cy.get('details').click().should('have.attr', 'open')
-    cy.get('summary').should('contain', 'ReferenceError')
+    cy.get('details.details-body').should('not.have.attr', 'open')
+    cy.get('details.details-body').click().should('have.attr', 'open')
+    cy.get('details.details-body > summary').should('contain', 'ReferenceError')
   })
 
   it('doesn\'t show error details if not provided', function () {
     cy.stub(this.ipc, 'onProjectError').yields(null, this.err)
     this.start()
 
+    cy.get('details.details-body > summary').should('not.exist')
+  })
+
+  it('shows error stack trace if provided', function () {
+    const err = new Error('foo')
+
+    err.stack = 'bar'
+
+    cy.stub(this.ipc, 'onProjectError').yields(null, err)
+    this.start()
+
+    cy.get('.error').contains('foo')
+    cy.get('details.stacktrace').should('not.have.attr', 'open')
+    cy.get('details.stacktrace').click().should('have.attr', 'open')
+    cy.get('details.stacktrace').should('contain', 'bar')
+  })
+
+  it('doesn\'t show error stack trace if not provided', function () {
+    const err = new Error()
+
+    delete err.stack
+    cy.stub(this.ipc, 'onProjectError').yields(null, err)
+    this.start()
+
     cy.get('.error')
-    cy.get('summary').should('not.exist')
+    cy.get('details.stacktrace > summary').should('not.be.visible')
   })
 
   it('shows abbreviated error details if only one line', function () {
@@ -155,7 +179,7 @@ describe('Error Message', function () {
     this.start()
 
     cy.get('.error').contains('ReferenceError: alsdkjf is not defined')
-    cy.get('summary').should('not.exist')
+    cy.get('details.details-body > summary').should('not.exist')
   })
 
   it('opens links outside of electron', function () {
@@ -197,7 +221,7 @@ describe('Error Message', function () {
     this.ipc.openProject.rejects(this.detailsErr)
     this.start()
 
-    cy.get('details').click()
+    cy.get('details.details-body').click()
     cy.get('nav').should('be.visible')
     cy.get('footer').should('be.visible')
   })
@@ -207,7 +231,7 @@ describe('Error Message', function () {
     this.ipc.openProject.rejects(this.detailsErr)
     this.start()
 
-    cy.get('details').click()
+    cy.get('details.details-body').click()
     cy.contains('Try Again').should('be.visible')
     cy.get('.full-alert pre').should('have.css', 'overflow', 'auto')
   })

--- a/packages/desktop-gui/cypress/integration/settings_spec.js
+++ b/packages/desktop-gui/cypress/integration/settings_spec.js
@@ -490,6 +490,7 @@ describe('Settings', () => {
   describe('errors', () => {
     beforeEach(function () {
       this.err = {
+        title: 'Foo Title',
         message: 'Port \'2020\' is already in use.',
         name: 'Error',
         port: 2020,
@@ -514,11 +515,11 @@ describe('Settings', () => {
     })
 
     it('displays errors', () => {
-      cy.contains('Can\'t start server')
+      cy.contains('Foo Title')
     })
 
     it('displays config after error is fixed', function () {
-      cy.contains('Can\'t start server').then(() => {
+      cy.contains('Foo Title').then(() => {
         this.ipc.openProject.onCall(1).resolves(this.config)
 
         this.ipc.onConfigChanged.yield()

--- a/packages/desktop-gui/src/lib/ipc.js
+++ b/packages/desktop-gui/src/lib/ipc.js
@@ -64,5 +64,6 @@ register('updater:run', false)
 register('window:open')
 register('window:close')
 register('onboarding:closed')
+register('set:clipboard:text')
 
 export default ipc

--- a/packages/desktop-gui/src/project/error-message.jsx
+++ b/packages/desktop-gui/src/project/error-message.jsx
@@ -40,7 +40,7 @@ const ErrorDetails = observer(({ err }) => {
   if (detailsBody) {
     return (
       <pre>
-        <details>
+        <details className='details-body'>
           <summary>{detailsTitle}</summary>
           {detailsBody}
         </details>
@@ -97,7 +97,7 @@ class ErrorMessage extends Component {
               </div>
             )}
             {err.stack2 && (
-              <details>
+              <details className='stacktrace'>
                 <summary>Stack trace</summary>
                 <pre>{err.stack2}</pre>
               </details>

--- a/packages/desktop-gui/src/project/error-message.jsx
+++ b/packages/desktop-gui/src/project/error-message.jsx
@@ -76,6 +76,12 @@ class ErrorMessage extends Component {
                 <p>To fix, stop the other running process or change the port in {configFileFormatted(this.props.project.configFile)}</p>
               </div>
             )}
+            {err.stack2 && (
+              <details>
+                <summary>Stack trace</summary>
+                <pre>{err.stack2}</pre>
+              </details>
+            )}
           </span>
           <button
             className='btn btn-default btn-sm'

--- a/packages/desktop-gui/src/project/error-message.jsx
+++ b/packages/desktop-gui/src/project/error-message.jsx
@@ -9,16 +9,19 @@ import Markdown from 'markdown-it'
 
 const _copyErrorDetails = (err) => {
   let details = [
-    `Message: ${err.message}`,
-    `Details: ${err.details}`,
+    `**Message:** ${err.message}`,
   ]
 
+  if (err.details) {
+    details.push(`**Details:** ${err.details}`)
+  }
+
   if (err.title) {
-    details.unshift(`Title: ${err.title}`)
+    details.unshift(`**Title:** ${err.title}`)
   }
 
   if (err.stack2) {
-    details.push(`Stack trace: \`\`\`\n${err.stack2}\n\`\`\``)
+    details.push(`**Stack trace:**\n\`\`\`\n${err.stack2}\n\`\`\``)
   }
 
   ipc.setClipboardText(details.join('\n\n'))

--- a/packages/desktop-gui/src/project/error-message.jsx
+++ b/packages/desktop-gui/src/project/error-message.jsx
@@ -61,7 +61,7 @@ class ErrorMessage extends Component {
         <div className='full-alert alert alert-danger error'>
           <p className='header'>
             <i className='fas fa-exclamation-triangle'></i>{' '}
-            <strong>{err.title || 'Can\'t start server'}</strong>
+            <strong>{err.title || 'An unexpected error occurred'}</strong>
           </p>
           <span className='alert-content'>
             <div ref={(node) => this.errorMessageNode = node} dangerouslySetInnerHTML={{

--- a/packages/desktop-gui/src/project/error-message.jsx
+++ b/packages/desktop-gui/src/project/error-message.jsx
@@ -7,6 +7,23 @@ import { configFileFormatted } from '../lib/config-file-formatted'
 
 import Markdown from 'markdown-it'
 
+const _copyErrorDetails = (err) => {
+  let details = [
+    `Message: ${err.message}`,
+    `Details: ${err.details}`,
+  ]
+
+  if (err.title) {
+    details.unshift(`Title: ${err.title}`)
+  }
+
+  if (err.stack2) {
+    details.push(`Stack trace: \`\`\`\n${err.stack2}\n\`\`\``)
+  }
+
+  ipc.setClipboardText(details.join('\n\n'))
+}
+
 const md = new Markdown({
   html: true,
   linkify: true,
@@ -83,6 +100,15 @@ class ErrorMessage extends Component {
               </details>
             )}
           </span>
+          <button
+            className='btn btn-default btn-sm'
+            onClick={() => {
+              _copyErrorDetails(err)
+            }}
+          >
+            <i className='fas fa-copy'></i>{' '}
+            Copy to Clipboard
+          </button>
           <button
             className='btn btn-default btn-sm'
             onClick={this.props.onTryAgain}

--- a/packages/desktop-gui/src/project/project-model.js
+++ b/packages/desktop-gui/src/project/project-model.js
@@ -209,6 +209,9 @@ export default class Project {
   }
 
   @action setError (err = {}) {
+    // for some reason, the original `stack` is unavailable on `err` once it is set on the model
+    // `stack2` remains usable though, for some reason
+    err.stack2 = err.stack
     this.error = err
   }
 

--- a/packages/server/lib/gui/events.coffee
+++ b/packages/server/lib/gui/events.coffee
@@ -1,6 +1,5 @@
 _           = require("lodash")
 ipc         = require("electron").ipcMain
-
 { shell, clipboard } = require('electron')
 debug       = require('debug')('cypress:server:events')
 pluralize   = require("pluralize")

--- a/packages/server/lib/gui/events.coffee
+++ b/packages/server/lib/gui/events.coffee
@@ -1,6 +1,7 @@
 _           = require("lodash")
 ipc         = require("electron").ipcMain
-shell       = require("electron").shell
+
+{ shell, clipboard } = require('electron')
 debug       = require('debug')('cypress:server:events')
 pluralize   = require("pluralize")
 stripAnsi   = require("strip-ansi")
@@ -298,6 +299,10 @@ handleEvent = (options, bus, event, id, type, arg) ->
           err.message = subErr.message or "#{subErr.code} #{subErr.address}:#{subErr.port}"
         err.apiUrl = apiUrl
         sendErr(err)
+
+    when "set:clipboard:text"
+      clipboard.writeText(arg)
+      sendNull()
 
     else
       throw new Error("No ipc event registered for: '#{type}'")

--- a/packages/server/lib/gui/events.coffee
+++ b/packages/server/lib/gui/events.coffee
@@ -110,7 +110,10 @@ handleEvent = (options, bus, event, id, type, arg) ->
         onBrowserClose: ->
           send({browserClosed: true})
       })
-      .catch(sendErr)
+      .catch (err) =>
+        err.title ?= 'Error launching browser'
+
+        sendErr(err)
 
     when "begin:auth"
       onMessage = (msg) ->

--- a/packages/server/test/unit/gui/events_spec.coffee
+++ b/packages/server/test/unit/gui/events_spec.coffee
@@ -699,3 +699,25 @@ describe "lib/gui/events", ->
           expect(err.name).to.equal("ECONNREFUSED 127.0.0.1:1234")
           expect(err.message).to.equal("ECONNREFUSED 127.0.0.1:1234")
           expect(err.apiUrl).to.equal(konfig("api_url"))
+
+    describe "launch:browser", ->
+      it "launches browser via openProject", ->
+        sinon.stub(openProject, 'launch').callsFake (browser, spec, opts) ->
+          expect(browser).to.eq('foo')
+          expect(spec).to.eq('bar')
+
+          opts.onBrowserOpen()
+          opts.onBrowserClose()
+
+          Promise.resolve()
+
+        @handleEvent("launch:browser", { browser: 'foo', spec: 'bar' }).then =>
+          expect(@send.getCall(0).args[1].data).to.include({ browserOpened: true })
+          expect(@send.getCall(1).args[1].data).to.include({ browserClosed: true })
+
+      it "wraps error titles if not set", ->
+        err = new Error('foo')
+        sinon.stub(openProject, 'launch').rejects(err)
+
+        @handleEvent("launch:browser", {}).then =>
+          expect(@send.getCall(0).args[1].__error).to.include({ message: 'foo', title: 'Error launching browser' })


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6416

### User facing changelog


### Additional details

- selecting "copy to clipboard" will copy a markdown-formatted version of the error to the clipboard
- error titles can be specified to override the default "An unexpected error occurred"
	- currently browser launch errors and plugin errors have custom titles



### How has the user experience changed?

#### Before

All project-level errors pretty much look like this:

![image](https://user-images.githubusercontent.com/1151760/74541098-ffebc780-4f0e-11ea-9425-e1a1c9a82f98.png)

#### After

**Examples of browser launch errors**

![image](https://user-images.githubusercontent.com/1151760/74358528-97c2a780-4d8f-11ea-85bf-03a43290a14a.png)

![image](https://user-images.githubusercontent.com/1151760/74360817-c2aefa80-4d93-11ea-9f6f-d3eac323837a.png)

**Example of plugin error**

![image](https://user-images.githubusercontent.com/1151760/74363061-ce042500-4d97-11ea-8bb6-f750bae80e70.png)

![image](https://user-images.githubusercontent.com/1151760/74363108-e4aa7c00-4d97-11ea-9fca-4b8009fb04db.png)

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
