### PR TITLE
fix pollution of :contains pseudo selector

### DIFF
--- a/packages/driver/src/cy/commands/querying.js
+++ b/packages/driver/src/cy/commands/querying.js
@@ -1,28 +1,10 @@
 const _ = require('lodash')
-const $ = require('jquery')
 const Promise = require('bluebird')
 
 const $dom = require('../../dom')
 const $utils = require('../../cypress/utils')
 
-const $expr = $.expr[':']
-
-const $contains = $expr.contains
-
-const restoreContains = () => {
-  return $expr.contains = $contains
-}
-
-const whitespaces = /\s+/g
-
 module.exports = (Commands, Cypress, cy) => {
-  // restore initially when a run starts
-  restoreContains()
-
-  // restore before each test and whenever we stop
-  Cypress.on('test:before:run', restoreContains)
-  Cypress.on('stop', restoreContains)
-
   Commands.addAll({
     focused (options = {}) {
       _.defaults(options, {
@@ -483,46 +465,9 @@ module.exports = (Commands, Cypress, cy) => {
         options._log.set({ $el })
       }
 
-      // When multiple space characters are considered as a single whitespace in all tags except <pre>.
-      const normalizeWhitespaces = (elem) => {
-        let testText = elem.textContent || elem.innerText || $.text(elem)
-
-        if (elem.tagName === 'PRE') {
-          return testText
-        }
-
-        return testText.replace(whitespaces, ' ')
-      }
-
-      if (_.isRegExp(text)) {
-        if (options.matchCase === false && !text.flags.includes('i')) {
-          text = new RegExp(text.source, text.flags + 'i') // eslint-disable-line prefer-template
-        }
-
-        // taken from jquery's normal contains method
-        $expr.contains = (elem) => {
-          let testText = normalizeWhitespaces(elem)
-
-          return text.test(testText)
-        }
-      }
-
-      if (_.isString(text)) {
-        $expr.contains = (elem) => {
-          let testText = normalizeWhitespaces(elem)
-
-          if (!options.matchCase) {
-            testText = testText.toLowerCase()
-            text = text.toLowerCase()
-          }
-
-          return testText.includes(text)
-        }
-      }
-
-      // find elements by the :contains psuedo selector
+      // find elements by the :cy-contains psuedo selector
       // and any submit inputs with the attributeContainsWord selector
-      const selector = $dom.getContainsSelector(text, filter)
+      const selector = $dom.getContainsSelector(text, filter, options)
 
       const resolveElements = () => {
         const getOpts = _.extend(_.clone(options), {
@@ -563,11 +508,6 @@ module.exports = (Commands, Cypress, cy) => {
 
       return Promise
       .try(resolveElements)
-      // always restore contains in case
-      // we used a regexp!
-      .finally(() => {
-        restoreContains()
-      })
     },
   })
 

--- a/packages/driver/src/dom/elements.ts
+++ b/packages/driver/src/dom/elements.ts
@@ -945,7 +945,23 @@ const getElements = ($el) => {
   return els
 }
 
-const getContainsSelector = (text, filter = '') => {
+const whitespaces = /\s+/g
+
+// When multiple space characters are considered as a single whitespace in all tags except <pre>.
+const normalizeWhitespaces = (elem) => {
+  let testText = elem.textContent || elem.innerText || $(elem).text()
+
+  if (elem.tagName === 'PRE') {
+    return testText
+  }
+
+  return testText.replace(whitespaces, ' ')
+}
+const getContainsSelector = (text, filter = '', options: {
+  matchCase?: boolean
+} = {}) => {
+  const $expr = $.expr[':']
+
   const escapedText = $utils.escapeQuotes(text)
 
   // they may have written the filter as
@@ -953,8 +969,41 @@ const getContainsSelector = (text, filter = '') => {
   // https://github.com/cypress-io/cypress/issues/2407
   const filters = filter.trim().split(',')
 
+  let cyContainsSelector
+
+  if (_.isRegExp(text)) {
+    if (options.matchCase === false && !text.flags.includes('i')) {
+      text = new RegExp(text.source, text.flags + 'i') // eslint-disable-line prefer-template
+    }
+
+    // taken from jquery's normal contains method
+    cyContainsSelector = function (elem) {
+      let testText = normalizeWhitespaces(elem)
+
+      return text.test(testText)
+    }
+  } else if (_.isString(text)) {
+    cyContainsSelector = function (elem) {
+      let testText = normalizeWhitespaces(elem)
+
+      if (!options.matchCase) {
+        testText = testText.toLowerCase()
+        text = text.toLowerCase()
+      }
+
+      return testText.includes(text)
+    }
+  } else {
+    cyContainsSelector = $expr.contains
+  }
+
+  // we set the `cy-contains` jquery selector which will only be used
+  // in the context of cy.contains(...) command and selector playground.
+  $expr['cy-contains'] = cyContainsSelector
+
   const selectors = _.map(filters, (filter) => {
-    return `${filter}:not(script,style):contains('${escapedText}'), ${filter}[type='submit'][value~='${escapedText}']`
+    // use custom cy-contains selector that is registered above
+    return `${filter}:not(script,style):cy-contains('${escapedText}'), ${filter}[type='submit'][value~='${escapedText}']`
   })
 
   return selectors.join()

--- a/packages/driver/test/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/test/cypress/integration/commands/assertions_spec.js
@@ -356,6 +356,7 @@ describe('src/cy/commands/assertions', () => {
         cy.contains('Nested Find').should('have.length', 2)
       })
 
+      // https://github.com/cypress-io/cypress/issues/6384
       it('can chain contains assertions off of cy.contains', () => {
         cy.timeout(100)
         cy.contains('foo')

--- a/packages/driver/test/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/test/cypress/integration/commands/assertions_spec.js
@@ -355,6 +355,25 @@ describe('src/cy/commands/assertions', () => {
 
         cy.contains('Nested Find').should('have.length', 2)
       })
+
+      it('can chain contains assertions off of cy.contains', () => {
+        cy.timeout(100)
+        cy.contains('foo')
+        .should('not.contain', 'asdfasdf')
+
+        cy.contains('foo')
+        .should('contain', 'foo')
+
+        cy.contains(/foo/)
+        .should('not.contain', 'asdfsadf')
+
+        cy.contains(/foo/)
+        .should('contain', 'foo')
+
+        // this isn't valid: .should('contain') does not support regex
+        // cy.contains(/foo/)
+        // .should('contain', /foo/)
+      })
     })
 
     describe('have.class', () => {

--- a/packages/driver/test/cypress/plugins/index.js
+++ b/packages/driver/test/cypress/plugins/index.js
@@ -7,6 +7,7 @@ const fs = require('fs-extra')
 const Promise = require('bluebird')
 const webpack = require('@cypress/webpack-preprocessor')
 
+process.env.NO_LIVERELOAD = '1'
 const webpackOptions = require('@packages/runner/webpack.config.ts').default
 
 /**

--- a/packages/web-config/webpack.config.base.ts
+++ b/packages/web-config/webpack.config.base.ts
@@ -15,7 +15,7 @@ execa.sync('rebuild-node-sass', { cwd: path.join(__dirname, './node_modules/.bin
 
 const env = process.env.NODE_ENV === 'production' ? 'production' : 'development'
 const args = process.argv.slice(2)
-const liveReloadEnabled = !args.includes('--no-livereload')
+const liveReloadEnabled = !(args.includes('--no-livereload') || process.env.NO_LIVERELOAD)
 const watchModeEnabled = args.includes('--watch') || args.includes('-w')
 
 // opt out of livereload with arg --no-livereload

--- a/yarn.lock
+++ b/yarn.lock
@@ -8177,10 +8177,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-circular-json@0.5.9:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.5.9.tgz#932763ae88f4f7dead7a0d09c8a51a4743a53b1d"
-  integrity sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==
+circular-json@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.4.0.tgz#c448ea998b7fe31ecf472ec29c6b608e2e2a62fd"
+  integrity sha512-tKV502ADgm9Z37s6B1QOohegjJJrCl2iyMMb1+8ITHrh1fquW8Jdbkb4s5r4Iwutr1UfL1qvkqvc1wZZlLvwow==
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -9430,7 +9430,7 @@ debug@*, debug@4.1.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, de
   dependencies:
     ms "^2.1.1"
 
-debug@2, debug@2.6.9, debug@^2.1.1, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
+debug@2, debug@2.6.9, debug@^2.1.1, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9, debug@~2.6.4:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -22099,11 +22099,10 @@ socket.io-circular-parser@cypress-io/socket.io-circular-parser#4d3076af68ea8192c
   version "3.1.2-patch1"
   resolved "https://codeload.github.com/cypress-io/socket.io-circular-parser/tar.gz/4d3076af68ea8192c2e53f9d185eaa166359b4c5"
   dependencies:
-    circular-json "^0.4.0"
+    circular-json "0.5.9"
     component-emitter "1.2.1"
-    debug "~2.6.4"
+    debug "~4.1.0"
     has-binary2 cypress-io/has-binary#8580a33df21e8b36a43f57872a82c60829636a92
-    isarray "2.0.1"
 
 socket.io-client@2.3.0:
   version "2.3.0"


### PR DESCRIPTION
- fixes issue introduced by #5653 
- TODO: this should be revisited eventually. Right now there are 2 different `contains` variants - `cy.contains(…)` (which accepts options), and `expect(…).contain(…)` / `cy.get(…).should('contain', …)` (which do not accept options)

- Closes #6384 

### User facing changelog
fix regression introduced in `4.0` causing incorrect assertion when chaining `.should('contain', …)` on a `cy.contains(…)`
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
