### PR TITLE
fix: typedefs for isBrowser

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -75,7 +75,7 @@ declare namespace Cypress {
     (task: 'firefox:force:gc'): Promise<void>
   }
 
-  type BrowserName = 'electron' | 'chrome' | 'chromium' | 'firefox' | string
+  type BrowserName = 'electron' | 'chrome' | 'chromium' | 'firefox' | 'edge' | 'brave' | string
 
   type BrowserChannel = 'stable' | 'canary' | 'beta' | 'dev' | 'nightly' | string
 
@@ -335,11 +335,12 @@ declare namespace Cypress {
     isCy(obj: any): obj is Chainable
 
     /**
-     * Checks if you're running in the supplied browser family.
-     * e.g. isBrowser('Chrome') will be true for the browser 'Canary'
-     * @param name browser family name to check
+     * Returns true if currently running the supplied browser name or matcher object.
+     * @example isBrowser('chrome') will be true for the browser 'chrome:canary' and 'chrome:stable'
+     * @example isBrowser({ name: 'firefox' channel: 'dev' }) will be true only for the browser 'firefox:dev' (Firefox Developer Edition)
+     * @param matcher browser name or matcher object to check.
      */
-    isBrowser(name: string): boolean
+    isBrowser(name: BrowserName | Partial<Browser>): boolean
 
     /**
      * Internal options for "cy.log" used in custom commands.

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -75,7 +75,7 @@ declare namespace Cypress {
     (task: 'firefox:force:gc'): Promise<void>
   }
 
-  type BrowserName = 'electron' | 'chrome' | 'chromium' | 'firefox' | 'edge' | 'brave' | string
+  type BrowserName = 'electron' | 'chrome' | 'chromium' | 'firefox' | 'edge' | string
 
   type BrowserChannel = 'stable' | 'canary' | 'beta' | 'dev' | 'nightly' | string
 
@@ -337,7 +337,7 @@ declare namespace Cypress {
     /**
      * Returns true if currently running the supplied browser name or matcher object.
      * @example isBrowser('chrome') will be true for the browser 'chrome:canary' and 'chrome:stable'
-     * @example isBrowser({ name: 'firefox' channel: 'dev' }) will be true only for the browser 'firefox:dev' (Firefox Developer Edition)
+     * @example isBrowser({ name: 'firefox', channel: 'dev' }) will be true only for the browser 'firefox:dev' (Firefox Developer Edition)
      * @param matcher browser name or matcher object to check.
      */
     isBrowser(name: BrowserName | Partial<Browser>): boolean

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -344,9 +344,14 @@ namespace CypressBrowserTests {
   Cypress.isBrowser('firefox')// $ExpectType boolean
   Cypress.isBrowser('edge')// $ExpectType boolean
   Cypress.isBrowser('brave')// $ExpectType boolean
+
+  // does not error to allow for user supplied browser
+  Cypress.isBrowser('safari')// $ExpectType boolean
+
   Cypress.isBrowser({channel: 'stable'})// $ExpectType boolean
   Cypress.isBrowser({family: 'chromium'})// $ExpectType boolean
   Cypress.isBrowser({name: 'chrome'})// $ExpectType boolean
+  
   Cypress.isBrowser({family: 'foo'}) // $ExpectError
   Cypress.isBrowser() // $ExpectError
 }

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -345,13 +345,13 @@ namespace CypressBrowserTests {
   Cypress.isBrowser('edge')// $ExpectType boolean
   Cypress.isBrowser('brave')// $ExpectType boolean
 
-  // does not error to allow for user supplied browser
+  // does not error to allow for user supplied browsers
   Cypress.isBrowser('safari')// $ExpectType boolean
 
   Cypress.isBrowser({channel: 'stable'})// $ExpectType boolean
   Cypress.isBrowser({family: 'chromium'})// $ExpectType boolean
   Cypress.isBrowser({name: 'chrome'})// $ExpectType boolean
-  
+
   Cypress.isBrowser({family: 'foo'}) // $ExpectError
   Cypress.isBrowser() // $ExpectError
 }

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -338,3 +338,15 @@ namespace CypressLocationTests {
   cy.location('path') // $ExpectError
   cy.location('pathname') // $ExpectType Chainable<string>
 }
+
+namespace CypressBrowserTests {
+  Cypress.isBrowser('chrome')// $ExpectType boolean
+  Cypress.isBrowser('firefox')// $ExpectType boolean
+  Cypress.isBrowser('edge')// $ExpectType boolean
+  Cypress.isBrowser('brave')// $ExpectType boolean
+  Cypress.isBrowser({channel: 'stable'})// $ExpectType boolean
+  Cypress.isBrowser({family: 'chromium'})// $ExpectType boolean
+  Cypress.isBrowser({name: 'chrome'})// $ExpectType boolean
+  Cypress.isBrowser({family: 'foo'}) // $ExpectError
+  Cypress.isBrowser() // $ExpectError
+}


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6447
### User facing changelog
Fix incorrect type definition for `Cypress.isBrowser()` api
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
