### PR TITLE
fix: remove postinstall-postinstall

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -83,7 +83,6 @@
     "mock-fs": "4.9.0",
     "mocked-env": "1.2.4",
     "nock": "9.6.1",
-    "postinstall-postinstall": "2.0.0",
     "proxyquire": "2.1.0",
     "resolve-pkg": "2.0.0",
     "shelljs": "0.8.3",

--- a/package.json
+++ b/package.json
@@ -160,7 +160,6 @@
     "patch-package": "6.2.0",
     "plist": "2.1.0",
     "pluralize": "8.0.0",
-    "postinstall-postinstall": "2.0.0",
     "prefixed-list": "1.0.1",
     "pretty-ms": "5.0.0",
     "print-arch": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8213,10 +8213,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-circular-json@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.4.0.tgz#c448ea998b7fe31ecf472ec29c6b608e2e2a62fd"
-  integrity sha512-tKV502ADgm9Z37s6B1QOohegjJJrCl2iyMMb1+8ITHrh1fquW8Jdbkb4s5r4Iwutr1UfL1qvkqvc1wZZlLvwow==
+circular-json@0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.5.9.tgz#932763ae88f4f7dead7a0d09c8a51a4743a53b1d"
+  integrity sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -9466,7 +9466,7 @@ debug@*, debug@4.1.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, de
   dependencies:
     ms "^2.1.1"
 
-debug@2, debug@2.6.9, debug@^2.1.1, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9, debug@~2.6.4:
+debug@2, debug@2.6.9, debug@^2.1.1, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -19464,11 +19464,6 @@ postinstall-build@2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/postinstall-build/-/postinstall-build-2.1.3.tgz#9d1886ab2949619f4c206afbe1aea95debe45c94"
   integrity sha1-nRiGqylJYZ9MIGr74a6pXevkXJQ=
-
-postinstall-postinstall@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.0.0.tgz#7ba6711b4420575c4f561638836a81faad47f43f"
-  integrity sha512-3f6qWexsHiT4WKtZc5DRb0FPLilHtARi5KpY4fqban/DJNn8/YhZH8U7dVKVz51WbOxEnR31gV+qYQhvEdHtdQ==
 
 prebuild-install@^5.2.4:
   version "5.3.3"


### PR DESCRIPTION
Resolves #6477 

### User facing changelog
Not able to do a fresh `yarn install` as the `postinstall` script is breaking, throwing
> postinstall-postinstall@2.0.0 postinstall /home/ubuntu/environment/cypress/node_modules/postinstall-postinstall
> node ./run.js
00h00m00s 0/0: : ERROR: [Errno 2] No such file or directory: 'run'
child_process.js:669
    throw err;
    ^
Error: Command failed: yarn run postinstall
ERROR: [Errno 2] No such file or directory: 'run'

Ref - https://github.com/cypress-io/cypress/issues/6477#issuecomment-587462492

Just can't understand the use-case for `postinstall-postinstall` package here. As after removing the package everything (build and install) seems to be working fine

![Screenshot from 2020-02-18 19-05-10](https://user-images.githubusercontent.com/18121502/74769255-1481e400-52b0-11ea-982b-0584d15f1300.png)

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?


Feel free to close the PR, if there is a valid use-case, but we have to figure out a solution on why is it failing