### PR TITLE
Downgrade execa to 2.0.0 (which supports Node.js 8.0.0)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -33,7 +33,7 @@
     "common-tags": "1.8.0",
     "debug": "4.1.1",
     "eventemitter2": "4.1.2",
-    "execa": "3.3.0",
+    "execa": "2.0.0",
     "executable": "4.1.1",
     "extract-zip": "1.6.7",
     "fs-extra": "8.1.0",


### PR DESCRIPTION
- Closes #6512

### User facing changelog

- We fixed an issue where Cypress would not install using Node.js 8 due to a dependency's engine restricting Node.js version to at least 8.12.0.
- Downgraded `execa` from `3.0.0` to `2.0.0`. 

### Additional details

- execa 2.0.0 engines allows Node.js 8.0.0
- Opened issue for us to test Cypress against Node.js 8.0.0 specifically https://github.com/cypress-io/cypress-test-node-versions/issues/47

### How has the user experience changed?

**Should no longer see the errors below during install:**

`yarn`

```
error execa@3.3.0: The engine "node" is incompatible with this module. Expected version "^8.12.0 || >=9.7.0". Got "8.0.0"
error Found incompatible module.
```

`npm install`

```
> cypress@4.0.2 postinstall /Users/jennifer/Dev/cypress-transform-test/node_modules/cypress
> node index.js --exec install

/Users/jennifer/Dev/cypress-transform-test/node_modules/execa/index.js:18
	const env = extendEnv ? {...process.env, ...envOption} : envOption;
	                         ^^^

SyntaxError: Unexpected token ...
    at createScript (vm.js:74:10)
    at Object.runInThisContext (vm.js:116:10)
    at Module._compile (module.js:533:28)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/jennifer/Dev/cypress-transform-test/node_modules/cypress/lib/util.js:18:13)
```