### PR TITLE
remove 'electron' as known browser family during validation error.

### DIFF
--- a/packages/server/__snapshots__/3_config_spec.coffee.js
+++ b/packages/server/__snapshots__/3_config_spec.coffee.js
@@ -149,6 +149,6 @@ Expected \`viewportWidth\` to be a number. Instead the value was: \`"foo"\`
 exports['e2e config catches invalid browser in the configuration file 1'] = `
 We found an invalid value in the file: \`cypress.json\`
 
-Found an error while validating the \`browsers\` list. Expected \`family\` to be either electron, chromium or firefox. Instead the value was: \`{"name":"bad browser","family":"unknown family","displayName":"Bad browser","version":"no version","path":"/path/to","majorVersion":123}\`
+Found an error while validating the \`browsers\` list. Expected \`family\` to be either chromium or firefox. Instead the value was: \`{"name":"bad browser","family":"unknown family","displayName":"Bad browser","version":"no version","path":"/path/to","majorVersion":123}\`
 
 `

--- a/packages/server/__snapshots__/validation_spec.coffee.js
+++ b/packages/server/__snapshots__/validation_spec.coffee.js
@@ -71,7 +71,7 @@ exports['lib/util/validation #isValidBrowser passes valid browsers and forms err
         "displayName": "Bad family browser",
         "family": "unknown family"
       },
-      "expect": "Expected `family` to be either electron, chromium or firefox. Instead the value was: `{\"name\":\"bad family\",\"displayName\":\"Bad family browser\",\"family\":\"unknown family\"}`"
+      "expect": "Expected `family` to be either chromium or firefox. Instead the value was: `{\"name\":\"bad family\",\"displayName\":\"Bad family browser\",\"family\":\"unknown family\"}`"
     }
   ]
 }

--- a/packages/server/__snapshots__/validation_spec.coffee.js
+++ b/packages/server/__snapshots__/validation_spec.coffee.js
@@ -63,7 +63,7 @@ exports['lib/util/validation #isValidBrowser passes valid browsers and forms err
         "name": "No display name",
         "family": "chromium"
       },
-      "expect": "Expected `displayName` to be a non-empty string. Instead the value was: `{\"name\":\"No display name\",\"family\":\"electron\"}`"
+      "expect": "Expected `displayName` to be a non-empty string. Instead the value was: `{\"name\":\"No display name\",\"family\":\"chromium\"}`"
     },
     {
       "given": {

--- a/packages/server/__snapshots__/validation_spec.coffee.js
+++ b/packages/server/__snapshots__/validation_spec.coffee.js
@@ -61,7 +61,7 @@ exports['lib/util/validation #isValidBrowser passes valid browsers and forms err
     {
       "given": {
         "name": "No display name",
-        "family": "electron"
+        "family": "chromium"
       },
       "expect": "Expected `displayName` to be a non-empty string. Instead the value was: `{\"name\":\"No display name\",\"family\":\"electron\"}`"
     },

--- a/packages/server/lib/util/validation.js
+++ b/packages/server/lib/util/validation.js
@@ -48,7 +48,7 @@ const isValidBrowser = (browser) => {
   }
 
   // TODO: this is duplicated with browsers/index
-  const knownBrowserFamilies = ['electron', 'chromium', 'firefox']
+  const knownBrowserFamilies = ['chromium', 'firefox']
 
   if (!is.oneOf(knownBrowserFamilies)(browser.family)) {
     return errMsg('family', browser, commaListsOr`either ${knownBrowserFamilies}`)

--- a/packages/server/test/unit/config_spec.coffee
+++ b/packages/server/test/unit/config_spec.coffee
@@ -1123,7 +1123,7 @@ describe "lib/config", ->
       }
       browserTwo = {
         name: "fake electron",
-        family: "electron",
+        family: "chromium",
         displayName: "Electron",
         version: "x.y.z",
         # Electron browser is built-in, no external path

--- a/packages/server/test/unit/validation_spec.coffee
+++ b/packages/server/test/unit/validation_spec.coffee
@@ -42,7 +42,7 @@ describe "lib/util/validation", ->
         # invalid browser, missing displayName
         {
           name: "No display name",
-          family: "electron"
+          family: "chromium"
         },
         {
           name: "bad family",


### PR DESCRIPTION
### User facing changelog 

We fixed an error message that would display the wrong available browser families during validation.

### Additional details

May have been a good TODO to implement to avoid this 😅 

```
// TODO: this is duplicated with browsers/index
const knownBrowserFamilies = ['chromium', 'firefox']
```

### How has the user experience changed?

#### Before

```
Expected `family` to be either electron, chromium or firefox. Instead the value was: ...
```

#### After

```
Expected `family` to be either chromium or firefox. Instead the value was: ...
```

### PR Tasks

- [x] Have tests been added/updated?
