### PR TITLE
Downgrade execa to 1.0.0 (to actually support Node 8.0.0)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -33,7 +33,7 @@
     "common-tags": "1.8.0",
     "debug": "4.1.1",
     "eventemitter2": "4.1.2",
-    "execa": "2.0.0",
+    "execa": "1.0.0",
     "executable": "4.1.1",
     "extract-zip": "1.6.7",
     "fs-extra": "8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11436,20 +11436,6 @@ execa@1.0.0, execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-2.0.0.tgz#5524c9739710e603e97c6dfc3f6ff6bff2819885"
-  integrity sha512-+ym7S09yUVPHEhYBsdLm53ZjCmCSeAQVtM/iN9dDj9tbvcBnCeBXTXHPWR9HXzht+vslGROteM8bSUdr4YszUg==
-  dependencies:
-    cross-spawn "^6.0.5"
-    get-stream "^5.0.0"
-    is-stream "^2.0.0"
-    merge-stream "^2.0.0"
-    npm-run-path "^3.0.0"
-    p-finally "^2.0.0"
-    signal-exit "^3.0.2"
-    strip-final-newline "^2.0.0"
-
 execa@3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-3.4.0.tgz#c08ed4550ef65d858fac269ffc8572446f37eb89"


### PR DESCRIPTION
- Closes #6512

### User facing changelog

- We fixed an issue where Cypress would not install using Node.js 8 due to a dependency's code not being compatible with Node.js version lower than 8.12.0.
- Downgraded `execa` from `3.0.0` to `1.0.0`. 

### Additional details

- execa 1.0.0 engines allows code to run in Node.js 8.0.0
- This supersedes #6513 (which only fixed the issue with node_engines and not the actual use of code that will not work in 8.0.0)
- Our tests against node versions was not properly failing after last PR: #6559 

### How has the user experience changed?

**Should no longer see the errors below during install:**

`yarn`

```
error execa@3.3.0: The engine "node" is incompatible with this module. Expected version "^8.12.0 || >=9.7.0". Got "8.0.0"
error Found incompatible module.
```

`npm install`

```
> cypress@4.0.2 postinstall /Users/jennifer/Dev/cypress-transform-test/node_modules/cypress
> node index.js --exec install

/Users/jennifer/Dev/cypress-transform-test/node_modules/execa/index.js:18
	const env = extendEnv ? {...process.env, ...envOption} : envOption;
	                         ^^^

SyntaxError: Unexpected token ...
    at createScript (vm.js:74:10)
    at Object.runInThisContext (vm.js:116:10)
    at Module._compile (module.js:533:28)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/jennifer/Dev/cypress-transform-test/node_modules/cypress/lib/util.js:18:13)
```