### PR TITLE
 cli: downgrade chalk

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -963,19 +963,19 @@ jobs:
       - run:
           name: Install Cypress binary
           working_directory: test-binary
-          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip yarn cypress install
+          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip $(npm bin)/cypress install
       - run:
           name: Verify Cypress binary
           working_directory: test-binary
-          command: yarn cypress verify
+          command: $(npm bin)/cypress verify
       - run:
           name: Print Cypress version
           working_directory: test-binary
-          command: yarn cypress version
+          command: $(npm bin)/cypress version
       - run:
           name: Cypress info
           working_directory: test-binary
-          command: yarn cypress info
+          command: $(npm bin)/cypress info
 
   # install NPM + binary zip and run against staging API
   "test-binary-against-staging":

--- a/circle.yml
+++ b/circle.yml
@@ -938,6 +938,26 @@ jobs:
           command: $(yarn bin)/cypress info
       - store-npm-logs
 
+  test-npm-module-on-minimum-node-version:
+    <<: *defaults
+    docker:
+      - image: cypress/base:8.0.0
+    steps:
+      # make sure we have cypress.zip received
+      - run: ls -l
+      - run: ls -l cypress.zip cypress.tgz
+      - run: mkdir test-binary
+      - run:
+          name: Create new NPM package
+          working_directory: test-binary
+          command: npm init -y
+      - run:
+          # install NPM from built NPM package folder
+          name: Install Cypress
+          working_directory: test-binary
+          # force installing the freshly built binary
+          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip npm i /root/cypress/cypress.tgz
+
   # install NPM + binary zip and run against staging API
   "test-binary-against-staging":
     <<: *defaults
@@ -1247,6 +1267,10 @@ linux-workflow: &linux-workflow
               - develop
         requires:
           - build-binary
+    - test-npm-module-on-minimum-node-version:
+        requires:
+          - build-binary
+          - build-npm-package
     - post-pre-release-install-comment:
         context: test-runner:commit-status-checks
         filters:

--- a/circle.yml
+++ b/circle.yml
@@ -969,6 +969,10 @@ jobs:
           working_directory: test-binary
           command: yarn cypress verify
       - run:
+          name: Print Cypress version
+          working_directory: test-binary
+          command: yarn cypress version
+      - run:
           name: Cypress info
           working_directory: test-binary
           command: yarn cypress info

--- a/circle.yml
+++ b/circle.yml
@@ -960,6 +960,18 @@ jobs:
           # force installing the freshly built binary
           # use Yarn because npm v5.0.0 is hopelessly broken
           command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip yarn add /root/cypress/cypress.tgz
+      - run:
+          name: Install Cypress binary
+          working_directory: test-binary
+          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip yarn cypress install
+      - run:
+          name: Verify Cypress binary
+          working_directory: test-binary
+          command: yarn cypress verify
+      - run:
+          name: Cypress info
+          working_directory: test-binary
+          command: yarn cypress info
 
   # install NPM + binary zip and run against staging API
   "test-binary-against-staging":

--- a/circle.yml
+++ b/circle.yml
@@ -949,6 +949,8 @@ jobs:
       - run: ls -l
       - run: ls -l cypress.zip cypress.tgz
       - run: mkdir test-binary
+      # upgrade NPM, otherwise NPM v5 gets so many errors
+      - run: npm i -g npm
       - run:
           name: Create new NPM package
           working_directory: test-binary

--- a/circle.yml
+++ b/circle.yml
@@ -943,6 +943,8 @@ jobs:
     docker:
       - image: cypress/base:8.0.0
     steps:
+      - attach_workspace:
+          at: ~/
       # make sure we have cypress.zip received
       - run: ls -l
       - run: ls -l cypress.zip cypress.tgz

--- a/circle.yml
+++ b/circle.yml
@@ -950,7 +950,7 @@ jobs:
       - run: ls -l cypress.zip cypress.tgz
       - run: mkdir test-binary
       # upgrade NPM, otherwise NPM v5 gets so many errors
-      - run: npm i -g npm@5.0.4
+      - run: npm i -g npm@5.1.0
       - run:
           name: Create new NPM package
           working_directory: test-binary

--- a/circle.yml
+++ b/circle.yml
@@ -952,10 +952,6 @@ jobs:
       # upgrade NPM, otherwise NPM v5 gets so many errors
       - run: npm i -g npm@5.1.0
       - run:
-          name: Create new NPM package
-          working_directory: test-binary
-          command: npm init -y
-      - run:
           # install NPM from built NPM package folder
           name: Install Cypress
           working_directory: test-binary

--- a/circle.yml
+++ b/circle.yml
@@ -949,6 +949,8 @@ jobs:
       - run: ls -l
       - run: ls -l cypress.zip cypress.tgz
       - run: mkdir test-binary
+      - run: node --version
+      - run: npm --version
       - run:
           name: Create new NPM package
           working_directory: test-binary

--- a/circle.yml
+++ b/circle.yml
@@ -949,14 +949,17 @@ jobs:
       - run: ls -l
       - run: ls -l cypress.zip cypress.tgz
       - run: mkdir test-binary
-      # upgrade NPM, otherwise NPM v5 gets so many errors
-      - run: npm i -g npm@5.1.0
+      - run:
+          name: Create new NPM package
+          working_directory: test-binary
+          command: npm init -y
       - run:
           # install NPM from built NPM package folder
           name: Install Cypress
           working_directory: test-binary
           # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip npm i /root/cypress/cypress.tgz
+          # use Yarn because npm v5.0.0 is hopelessly broken
+          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip yarn add /root/cypress/cypress.tgz
 
   # install NPM + binary zip and run against staging API
   "test-binary-against-staging":

--- a/circle.yml
+++ b/circle.yml
@@ -942,6 +942,7 @@ jobs:
     <<: *defaults
     docker:
       - image: cypress/base:8.0.0
+        user: node
     steps:
       - attach_workspace:
           at: ~/

--- a/circle.yml
+++ b/circle.yml
@@ -950,7 +950,7 @@ jobs:
       - run: ls -l cypress.zip cypress.tgz
       - run: mkdir test-binary
       # upgrade NPM, otherwise NPM v5 gets so many errors
-      - run: npm i -g npm
+      - run: npm i -g npm@5.0.4
       - run:
           name: Create new NPM package
           working_directory: test-binary

--- a/circle.yml
+++ b/circle.yml
@@ -942,7 +942,6 @@ jobs:
     <<: *defaults
     docker:
       - image: cypress/base:8.0.0
-        user: node
     steps:
       - attach_workspace:
           at: ~/
@@ -955,16 +954,9 @@ jobs:
           working_directory: test-binary
           command: npm init -y
       - run:
-          # install NPM from built NPM package folder
           name: Install Cypress
           working_directory: test-binary
-          # force installing the freshly built binary
-          # use Yarn because npm v5.0.0 is hopelessly broken
-          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip yarn add /root/cypress/cypress.tgz
-      - run:
-          name: Install Cypress binary
-          working_directory: test-binary
-          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip $(npm bin)/cypress install
+          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip npm install /root/cypress/cypress.tgz
       - run:
           name: Verify Cypress binary
           working_directory: test-binary

--- a/cli/package.json
+++ b/cli/package.json
@@ -27,7 +27,7 @@
     "arch": "2.1.1",
     "bluebird": "3.7.2",
     "cachedir": "2.3.0",
-    "chalk": "3.0.0",
+    "chalk": "2.4.2",
     "check-more-types": "2.24.0",
     "commander": "4.1.0",
     "common-tags": "1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8085,7 +8085,7 @@ chai@4.2.0, chai@^4.1.2:
     pathval "^1.1.0"
     type-detect "^4.0.5"
 
-chalk@*, chalk@3.0.0:
+chalk@*:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
   integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==


### PR DESCRIPTION
- Closes #6568 (downgrade Chalk)
- [x] add another built job that installs our NPM package on the minimum supported Node version image
- internal build process

## User changes

The NPM module installs on Node v8.0.0