### PR TITLE
make frequent debug messages debugVerbose

### DIFF
--- a/packages/server/lib/gui/events.coffee
+++ b/packages/server/lib/gui/events.coffee
@@ -2,6 +2,7 @@ _           = require("lodash")
 ipc         = require("electron").ipcMain
 { shell, clipboard } = require('electron')
 debug       = require('debug')('cypress:server:events')
+debugVerbose= require('debug')('cypress-verbose:server:events')
 pluralize   = require("pluralize")
 stripAnsi   = require("strip-ansi")
 dialog      = require("./dialog")
@@ -22,15 +23,29 @@ browsers    = require("../browsers")
 konfig      = require("../konfig")
 
 handleEvent = (options, bus, event, id, type, arg) ->
-  debug("got request for event: %s, %o", type, arg)
+  if debug.enabled
+    if type is 'get:project:status'
+      debugVerbose("got request for event: %s, %o", type, arg)
+    else
+      debug("got request for event: %s, %o", type, arg)
 
   sendResponse = (data = {}) ->
     try
-      debug("sending ipc data %o", {type: type, data: data})
+      if debug.enabled
+        if type is 'get:project:status'
+          debugVerbose("sending ipc data %o", {type: type, data: data})
+        else
+          debug("sending ipc data %o", {type: type, data: data})
+
       event.sender.send("response", data)
 
   sendErr = (err) ->
-    debug("send error: %o", err)
+    if debug.enabled
+      if err.type is 'get:project:status' or err.type is 'NOT_LOGGED_IN'
+        debugVerbose("send error: %o", err)
+      else
+        debug("send error: %o", err)
+
     sendResponse({id: id, __error: errors.clone(err, {html: true})})
 
   send = (data) ->

--- a/packages/server/lib/project.js
+++ b/packages/server/lib/project.js
@@ -8,6 +8,7 @@ const la = require('lazy-ass')
 const check = require('check-more-types')
 const scaffoldDebug = require('debug')('cypress:server:scaffold')
 const debug = require('debug')('cypress:server:project')
+const debugVerbose = require('debug')('cypress-verbose:server:project')
 const cwd = require('./cwd')
 const api = require('./api')
 const user = require('./user')
@@ -672,7 +673,7 @@ class Project extends EE {
   }
 
   static getProjectStatuses (clientProjects = []) {
-    debug(`get project statuses for ${clientProjects.length} projects`)
+    debugVerbose(`get project statuses for ${clientProjects.length} projects`)
 
     return user.ensureAuthToken()
     .then((authToken) => {
@@ -711,7 +712,7 @@ class Project extends EE {
   }
 
   static getProjectStatus (clientProject) {
-    debug('get project status for client id %s at path %s', clientProject.id, clientProject.path)
+    debugVerbose('get project status for client id %s at path %s', clientProject.id, clientProject.path)
 
     if (!clientProject.id) {
       debug('no project id')

--- a/packages/server/lib/util/file.js
+++ b/packages/server/lib/util/file.js
@@ -2,7 +2,7 @@ const _ = require('lodash')
 const os = require('os')
 const md5 = require('md5')
 const path = require('path')
-const debug = require('debug')('cypress:server:file')
+const debug = require('debug')('cypress-verbose:server:file')
 const Promise = require('bluebird')
 const lockFile = Promise.promisifyAll(require('lockfile'))
 const fs = require('./fs')
@@ -205,7 +205,7 @@ class File {
       return lockFile.lockAsync(this._lockFilePath, { wait: LOCK_TIMEOUT })
     })
     .finally(() => {
-      return debug('gettin lock succeeded or failed for %s', this.path)
+      return debug('getting lock succeeded or failed for %s', this.path)
     })
   }
 

--- a/packages/server/lib/util/process_profiler.ts
+++ b/packages/server/lib/util/process_profiler.ts
@@ -208,7 +208,7 @@ export const _aggregateGroups = (processes: Process[]) => {
 export const _printGroupedProcesses = (groupTotals) => {
   const consoleBuffer = concatStream((buf) => {
     // get rid of trailing newline
-    debug(String(buf).trim())
+    debugVerbose(String(buf).trim())
   })
 
   // eslint-disable-next-line no-console


### PR DESCRIPTION
make really frequent debug messages only log when `cypress-verbose:*` is enabled. These are all the debug logs that would log when user is doing functionally nothing - just idling with cypress open and a spec open.

I know the logic is ugly around the events code, so suggestions welcome 