### PR TITLE
fix(proxy): added support for jira getParent function even when not minified

### DIFF
--- a/packages/proxy/lib/http/util/security.ts
+++ b/packages/proxy/lib/http/util/security.ts
@@ -6,6 +6,7 @@ const topOrParentEqualityBeforeRe = /((?:window|self)(?:\.|\[['"](?:top|self)['"
 const topOrParentEqualityAfterRe = /(top|parent)((?:["']\])?\s*[!=]==?\s*(?:window|self))/g
 const topOrParentLocationOrFramesRe = /([^\da-zA-Z\(\)])?(top|parent)([.])(location|frames)/g
 const jiraTopWindowGetterRe = /(!function\s*\((\w{1})\)\s*{\s*return\s*\w{1}\s*(?:={2,})\s*\w{1}\.parent)(\s*}\(\w{1}\))/g
+const jiraTopWindowGetterUnMinifiedRe = /(function\s*\w{1,}\s*\((\w{1})\)\s*{\s*return\s*\w{1}\s*(?:={2,})\s*\w{1}\.parent)(\s*;\s*})/g
 
 export function strip (html: string) {
   return html
@@ -13,6 +14,7 @@ export function strip (html: string) {
   .replace(topOrParentEqualityAfterRe, 'self$2')
   .replace(topOrParentLocationOrFramesRe, '$1self$3$4')
   .replace(jiraTopWindowGetterRe, '$1 || $2.parent.__Cypress__$3')
+  .replace(jiraTopWindowGetterUnMinifiedRe, '$1 || $2.parent.__Cypress__$3')
 }
 
 export function stripStream () {
@@ -24,11 +26,13 @@ export function stripStream () {
         topOrParentEqualityAfterRe,
         topOrParentLocationOrFramesRe,
         jiraTopWindowGetterRe,
+        jiraTopWindowGetterUnMinifiedRe,
       ],
       [
         '$1self',
         'self$2',
         '$1self$3$4',
+        '$1 || $2.parent.__Cypress__$3',
         '$1 || $2.parent.__Cypress__$3',
       ],
     ),

--- a/packages/proxy/test/unit/http/util/security.spec.ts
+++ b/packages/proxy/test/unit/http/util/security.spec.ts
@@ -153,6 +153,28 @@ for (; !function (n) {
 function(n){for(;!function(l){return l===l.parent}(l)&&function(l){try{if(void 0==l.location.href)return!1}catch(l){return!1}return!0}(l.parent);)l=l.parent;return l}\
 `
 
+      const jira3 = `\
+function satisfiesSameOrigin(w) {
+    try {
+        // Accessing location.href from a window on another origin will throw an exception.
+        if ( w.location.href == undefined) {
+            return false;
+        }
+    } catch (e) {
+        return false;
+    }
+    return true;
+}
+
+function isTopMostWindow(w) {
+    return w === w.parent;
+}
+
+while (!isTopMostWindow(parentOf) && satisfiesSameOrigin(parentOf.parent)) {
+    parentOf = parentOf.parent;
+}\
+`
+
       expect(security.strip(jira)).to.eq(`\
 for (; !function (n) {
   return n === n.parent || n.parent.__Cypress__
@@ -161,6 +183,28 @@ for (; !function (n) {
 
       expect(security.strip(jira2)).to.eq(`\
 function(n){for(;!function(l){return l===l.parent || l.parent.__Cypress__}(l)&&function(l){try{if(void 0==l.location.href)return!1}catch(l){return!1}return!0}(l.parent);)l=l.parent;return l}\
+`)
+
+      expect(security.strip(jira3)).to.eq(`\
+function satisfiesSameOrigin(w) {
+    try {
+        // Accessing location.href from a window on another origin will throw an exception.
+        if ( w.location.href == undefined) {
+            return false;
+        }
+    } catch (e) {
+        return false;
+    }
+    return true;
+}
+
+function isTopMostWindow(w) {
+    return w === w.parent || w.parent.__Cypress__;
+}
+
+while (!isTopMostWindow(parentOf) && satisfiesSameOrigin(parentOf.parent)) {
+    parentOf = parentOf.parent;
+}\
 `)
     })
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Improve fix for issue #1436 - #1437

### User facing changelog

<!--
Explain the change(s) for every user to read in our changelog.
-->
Added support for running cypress tests on Jira plugins even when Jira scripts were not minified.

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Issue #1436 was still occurring when running jira in none-minified mode, which was making impossible to run cypress test on jira plugins.

The fix just add an additional regular expression to catch also the case where the Jira getParentWindow is not minified.

### How has the user experience changed?

No change.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
