### PR TITLE
Provide more narrow type for click position

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -658,13 +658,13 @@ declare namespace Cypress {
     /**
      * Click a DOM element at specific corner / side.
      *
-     * @param {String} position - The position where the click should be issued.
+     * @param {PositionType} position - The position where the click should be issued.
      * The `center` position is the default position.
      * @see https://on.cypress.io/click
      * @example
      *    cy.get('button').click('topRight')
      */
-    click(position: string, options?: Partial<ClickOptions>): Chainable<Subject>
+    click(position: PositionType, options?: Partial<ClickOptions>): Chainable<Subject>
     /**
      * Click a DOM element at specific coordinates
      *
@@ -795,13 +795,13 @@ declare namespace Cypress {
     /**
      * Double-click a DOM element at specific corner / side.
      *
-     * @param {String} position - The position where the click should be issued.
+     * @param {PositionType} position - The position where the click should be issued.
      * The `center` position is the default position.
      * @see https://on.cypress.io/dblclick
      * @example
      *    cy.get('button').dblclick('topRight')
      */
-    dblclick(position: string, options?: Partial<ClickOptions>): Chainable<Subject>
+    dblclick(position: PositionType, options?: Partial<ClickOptions>): Chainable<Subject>
     /**
      * Double-click a DOM element at specific coordinates
      *
@@ -825,13 +825,13 @@ declare namespace Cypress {
     /**
      * Right-click a DOM element at specific corner / side.
      *
-     * @param {String} position - The position where the click should be issued.
+     * @param {PositionType} position - The position where the click should be issued.
      * The `center` position is the default position.
      * @see https://on.cypress.io/click
      * @example
      *    cy.get('button').rightclick('topRight')
      */
-    rightclick(position: string, options?: Partial<ClickOptions>): Chainable<Subject>
+    rightclick(position: PositionType, options?: Partial<ClickOptions>): Chainable<Subject>
     /**
      * Right-click a DOM element at specific coordinates
      *


### PR DESCRIPTION
- Narrow the type for `click`-family's `position` argument to `PositionType` (was `string`)
- Intellisense now gives feedback for valid arguments to click/dblclick/rightclick

<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6341 <!-- issue number here -->

### User facing changelog

- Provide type information for valid click positions

<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [x] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
