### PR TITLE
Pass `--immutable` to `yarn` in CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,7 @@ install:
   - has-env GH
   # clean cache to prevent install permission issues
   - yarn cache clean
-  - yarn || yarn || yarn
+  - yarn --immutable || yarn --immutable || yarn --immutable
   - .\node_modules\.bin\print-arch
 
 # Post-install test scripts.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,7 @@ install:
   - has-env GH
   # clean cache to prevent install permission issues
   - yarn cache clean
-  - yarn --immutable || yarn --immutable || yarn --immutable
+  - yarn --frozen-lockfile || yarn --frozen-lockfile || yarn --frozen-lockfile
   - .\node_modules\.bin\print-arch
 
 # Post-install test scripts.

--- a/circle.yml
+++ b/circle.yml
@@ -236,7 +236,7 @@ jobs:
       - run: ls $(yarn global bin)/../lib/node_modules
 
       # try several times, because flaky NPM installs ...
-      - run: yarn || yarn
+      - run: yarn --immutable || yarn --immutable
       - run:
           name: Top level packages
           command: yarn list --depth=0 || true

--- a/circle.yml
+++ b/circle.yml
@@ -236,7 +236,7 @@ jobs:
       - run: ls $(yarn global bin)/../lib/node_modules
 
       # try several times, because flaky NPM installs ...
-      - run: yarn --immutable || yarn --immutable
+      - run: yarn --frozen-lockfile || yarn --frozen-lockfile
       - run:
           name: Top level packages
           command: yarn list --depth=0 || true


### PR DESCRIPTION
This will cause CI to fail if the yarn.lock is out of date.

https://yarnpkg.com/cli/install

> If the --immutable option is set, Yarn will abort with an error exit code if anything in the install artifacts (yarn.lock, .pnp.js, ...) was to be modified.