### PR TITLE
Fix taking screenshots in Electron with debug logs enabled

### DIFF
--- a/packages/server/lib/browsers/electron.js
+++ b/packages/server/lib/browsers/electron.js
@@ -231,12 +231,14 @@ module.exports = {
 
       return originalSendCommand.call(webContents.debugger, message, data)
       .then((res) => {
-        if (debug.enabled && (_.get(res, 'data.length') > 100)) {
-          res = _.clone(res)
-          res.data = `${res.data.slice(0, 100)} [truncated]`
+        let debugRes = res
+
+        if (debug.enabled && (_.get(debugRes, 'data.length') > 100)) {
+          debugRes = _.clone(debugRes)
+          debugRes.data = `${debugRes.data.slice(0, 100)} [truncated]`
         }
 
-        debug('debugger: received response to %s: %o', message, res)
+        debug('debugger: received response to %s: %o', message, debugRes)
 
         return res
       }).catch((err) => {


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6662

### User facing changelog

- Fixed a bug where taking screenshots in Electron with Cypress debug logs enabled would fail.

### Additional details

truncated data object for logging was accidentally being returned instead of the original object

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
