### PR TITLE
Quote strings in DEBUG logs for easier reading

### DIFF
--- a/packages/launcher/lib/linux/index.ts
+++ b/packages/launcher/lib/linux/index.ts
@@ -17,7 +17,7 @@ function getLinuxBrowser (
     }
 
     log(
-      'Could not extract version from %s using regex %s',
+      'Could not extract version from "%s" using regex %s',
       stdout,
       versionRegex,
     )
@@ -53,7 +53,7 @@ export function getVersionString (path: string) {
   return execa
   .stdout(path, ['--version'])
   .then(trim)
-  .then(tap(partial(log, ['stdout: %s'])))
+  .then(tap(partial(log, ['stdout: "%s"'])))
 }
 
 export function detect (browser: Browser) {

--- a/packages/launcher/lib/linux/index.ts
+++ b/packages/launcher/lib/linux/index.ts
@@ -17,9 +17,10 @@ function getLinuxBrowser (
     }
 
     log(
-      'Could not extract version from "%s" using regex %s',
-      stdout,
-      versionRegex,
+      'Could not extract version from stdout using regex: %o', {
+        stdout,
+        versionRegex,
+      },
     )
 
     throw notInstalledErr(binary)


### PR DESCRIPTION
So, I was looking at logs https://github.com/cypress-io/cypress/issues/6669 from the `cypress:launcher` trying to figure out why we weren’t detecting someones browser and just see the below. 

I thought that Running without a11y support was some kind of log from Cypress talking about a11y? I dunno. This was confusing and would have been clearer to distinguish Cypress logs from the actual strings we found with quotation marks in the DEBUG logs like below:

### Before

```
cypress:launcher stdout: Running without a11y support!
Mozilla Firefox 68.5.0esr +75ms
cypress:launcher Could not extract version from Running without a11y support!
Mozilla Firefox 68.5.0esr using regex /^Mozilla Firefox ([^\sab]+)$/ +1ms
```

### After

```
cypress:launcher stdout: “Running without a11y support!
Mozilla Firefox 68.5.0esr” +75ms
cypress:launcher Could not extract version from stdout using regex: {
  stdout: Running without a11y support! Mozilla Firefox 68.5.0esr,
  versionRegex: /^Mozilla Firefox ([^\sab]+)$/ 
} +1ms
```