### PR TITLE
Fix proxy slowdown with intercepted HTTPS requests

### DIFF
--- a/packages/network/lib/agent.ts
+++ b/packages/network/lib/agent.ts
@@ -349,6 +349,7 @@ class HttpsAgent extends https.Agent {
 
       const connectReq = buildConnectReqHead(hostname, port, proxy)
 
+      proxySocket.setNoDelay(true)
       proxySocket.write(connectReq)
     })
   }

--- a/packages/network/lib/agent.ts
+++ b/packages/network/lib/agent.ts
@@ -262,10 +262,6 @@ class HttpsAgent extends https.Agent {
   }
 
   createConnection (options: HttpsRequestOptions, cb: http.SocketCallback) {
-    // allow requests to use older TLS versions
-    // https://github.com/cypress-io/cypress/issues/5446
-    options.minVersion = 'TLSv1'
-
     if (process.env.HTTPS_PROXY) {
       const proxy = getProxyForUrl(options.href)
 

--- a/packages/server/lib/request.coffee
+++ b/packages/server/lib/request.coffee
@@ -15,6 +15,7 @@ SERIALIZABLE_COOKIE_PROPS = ['name', 'value', 'domain', 'expiry', 'path', 'secur
 NETWORK_ERRORS = "ECONNREFUSED ECONNRESET EPIPE EHOSTUNREACH EAI_AGAIN ENOTFOUND".split(" ")
 VERBOSE_REQUEST_OPTS = "followRedirect strictSSL".split(" ")
 HTTP_CLIENT_REQUEST_EVENTS = "abort connect continue information socket timeout upgrade".split(" ")
+TLS_VERSION_ERROR_RE =  /TLSV1_ALERT_PROTOCOL_VERSION|UNSUPPORTED_PROTOCOL/
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"
 
@@ -81,7 +82,15 @@ maybeRetryOnNetworkFailure = (err, options = {}) ->
 
   debug("received an error making http request %o", merge(opts, { err }))
 
-  if not isRetriableError(err, retryOnNetworkFailure)
+  isTlsVersionError = TLS_VERSION_ERROR_RE.test(err.message)
+
+  if isTlsVersionError
+    ## because doing every connection via TLSv1 can lead to slowdowns, we set it only on failure
+    ## https://github.com/cypress-io/cypress/pull/6705
+    debug('detected TLS version error, setting min version to TLSv1')
+    opts.minVersion = 'TLSv1'
+
+  if not isTlsVersionError and not isRetriableError(err, retryOnNetworkFailure)
     return onElse()
 
   ## else see if we have more delays left...

--- a/packages/server/test/performance/proxy_performance_spec.js
+++ b/packages/server/test/performance/proxy_performance_spec.js
@@ -374,7 +374,7 @@ describe('Proxy Performance', function () {
 
       // slice(1) since first test is used as baseline above
       testCases.slice(1).map((testCase) => {
-        let multiplier = 2
+        let multiplier = 3
 
         if (testCase.httpsUpstreamProxy) {
           multiplier *= 1.5

--- a/packages/server/test/performance/proxy_performance_spec.js
+++ b/packages/server/test/performance/proxy_performance_spec.js
@@ -358,10 +358,9 @@ describe('Proxy Performance', function () {
   })
 
   URLS_UNDER_TEST.map((urlUnderTest) => {
-    const testCases = _.cloneDeep(TEST_CASES)
-
     describe(urlUnderTest, function () {
       let baseline
+      const testCases = _.cloneDeep(TEST_CASES)
 
       before(function () {
         // run baseline test
@@ -375,12 +374,18 @@ describe('Proxy Performance', function () {
 
       // slice(1) since first test is used as baseline above
       testCases.slice(1).map((testCase) => {
-        it(`${testCase.name} loads 1000 images less than 2x as slowly as Chrome`, function () {
+        let multiplier = 2
+
+        if (testCase.httpsUpstreamProxy) {
+          multiplier *= 1.5
+        }
+
+        it(`${testCase.name} loads 1000 images less than ${multiplier}x as slowly as Chrome`, function () {
           debug('Current test: ', testCase.name)
 
           return runBrowserTest(urlUnderTest, testCase)
           .then((results) => {
-            expect(results['Total']).to.be.lessThan(2 * baseline['Total'])
+            expect(results['Total']).to.be.lessThan(multiplier * baseline['Total'])
           })
         })
       })

--- a/packages/server/test/performance/proxy_performance_spec.js
+++ b/packages/server/test/performance/proxy_performance_spec.js
@@ -109,7 +109,7 @@ const average = (arr) => {
 }
 
 const percentile = (sortedArr, p) => {
-  const i = Math.floor(p / 100 * sortedArr.length - 1)
+  const i = Math.floor(p / 100 * (sortedArr.length - 1))
 
   return Math.round(sortedArr[i])
 }

--- a/packages/server/test/performance/proxy_performance_spec.js
+++ b/packages/server/test/performance/proxy_performance_spec.js
@@ -377,6 +377,8 @@ describe('Proxy Performance', function () {
         let multiplier = 3
 
         if (testCase.httpsUpstreamProxy) {
+          // there is extra slowdown when the HTTPS upstream is used, so slightly increase the multiplier
+          // maybe from higher CPU utilization with debugging-proxy and HTTPS
           multiplier *= 1.5
         }
 

--- a/packages/server/test/performance/proxy_performance_spec.js
+++ b/packages/server/test/performance/proxy_performance_spec.js
@@ -167,6 +167,8 @@ const getResultsFromHar = (har) => {
 
   results['Min'] = mins.total
 
+  expect(timings.total.length).to.be.at.least(1000)
+
   ;[1, 5, 25, 50, 75, 95, 99, 99.7].forEach((p) => {
     results[`${p}% <=`] = percentile(timings.total, p)
   })

--- a/packages/server/test/performance/proxy_performance_spec.js
+++ b/packages/server/test/performance/proxy_performance_spec.js
@@ -373,12 +373,12 @@ describe('Proxy Performance', function () {
 
       // slice(1) since first test is used as baseline above
       testCases.slice(1).map((testCase) => {
-        it(`${testCase.name} loads 1000 images, with 75% loading no more than 2x as slow as the slowest baseline request`, function () {
+        it(`${testCase.name} loads 1000 images less than 2x as slowly as Chrome`, function () {
           debug('Current test: ', testCase.name)
 
           return runBrowserTest(urlUnderTest, testCase)
           .then((results) => {
-            expect(results['75% <=']).to.be.lessThan(baseline['Max'] * 2)
+            expect(results['Total']).to.be.lessThan(2 * baseline['Total'])
           })
         })
       })


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6659

### User facing changelog

- Fixed a regression introduced in v3.8.3 where HTTPS requests could experience slowdown.

### Additional details

- in #5446, we set the TLS minimum version to TLSv1
- however, this also caused slowdowns in the proxy, which are visible in the `server-performance-spec`s if you look before and after this got merged
- all *intercepted (not passthru) HTTPS* connections were affected
- this PR makes it so that minVersion is set to TLSv1 only if the initial connection failed with a TLS version mismatch error
- this PR also fixes the `proxy_performance_spec`
    - previously, the heuristics it was using were way too loose, and also easy to misunderstand
	- now, it's as simple as "our proxy should never be more than 3x as slow as regular Chrome, under any conditions"
	- 4.5x for the case where our proxy goes through another HTTPS upstream proxy
- also noticed that requests that used an HTTPS upstream were slower - after adding `setNoDelay(true)`, they are slightly faster, though not as fast as requests with an HTTP upstream

### How has the user experience changed?

- faster for everyone,
- except for people who use TLSv1 - but they're in for a reckoning anyways when Chrome 81 and Firefox 74 deprecate their TLSv1 support: https://portswigger.net/daily-swig/tls-1-0-1-1-end-of-life-countdown-heads-into-the-danger-zone
	- this will result in 1 more socket retry per TLSv1 connection. however, Cypress keeps HTTPS sockets alive, so this is only an upfront cost and is not paid on every single request

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
