### PR TITLE
add Cypress.sinon type

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -208,6 +208,15 @@ declare namespace Cypress {
      */
     Promise: Bluebird.BluebirdStatic
     /**
+     * Cypress includes Sinon.js library used in `cy.spy` and `cy.stub`.
+     *
+     * @see https://sinonjs.org/
+     * @see https://on.cypress.io/stubs-spies-and-clocks
+     * @see https://example.cypress.io/commands/spies-stubs-clocks
+     */
+    sinon: sinon.SinonApi
+
+    /**
      * Cypress version string. i.e. "1.1.2"
      * @see https://on.cypress.io/version
      * @example

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -13,6 +13,13 @@ namespace CypressMomentTests {
   Cypress.moment().startOf('week') // $ExpectType Moment
 }
 
+namespace CypressSinonTests {
+  Cypress.sinon // $ExpectType SinonApi
+  const stub = cy.stub()
+  stub(2, 'foo')
+  expect(stub).to.have.been.calledWith(Cypress.sinon.match.number, Cypress.sinon.match('foo'))
+}
+
 namespace CypressJqueryTests {
   Cypress.$ // $ExpectType JQueryStatic
   Cypress.$('selector') // $ExpectType JQuery<HTMLElement>


### PR DESCRIPTION
- Closes #6720

### User facing changelog

Added TypeScript for property `Cypress.sinon`

### Additional details

This property exists on the object, but we did not have the type for it

### How has the user experience changed?

Errors are gone, see the issue for screenshots

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?

Related docs PR: https://github.com/cypress-io/cypress-documentation/pull/2608