### PR TITLE
Fix `darwin` install comment

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1444,6 +1444,7 @@ mac-workflow: &mac-workflow
     - post-pre-release-install-comment:
         context: test-runner:commit-status-checks
         name: Post Mac pre-release install comment
+        executor: mac
         filters:
           branches:
             only:

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ macBuildFilters: &macBuildFilters
   filters:
     branches:
       only:
-        - develop
+        - fix-mac-install-comment
 
 defaults: &defaults
   parallelism: 1
@@ -33,7 +33,7 @@ testBinaryFirefox: &testBinaryFirefox
   filters:
     branches:
       only:
-        - develop
+        - fix-mac-install-comment
   requires:
     - build-npm-package
     - build-binary
@@ -1248,7 +1248,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - develop
+              - fix-mac-install-comment
         requires:
           - build
     - test-kitchensink:
@@ -1259,7 +1259,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - develop
+              - fix-mac-install-comment
         requires:
           - build
     - build-npm-package:
@@ -1270,7 +1270,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - develop
+              - fix-mac-install-comment
         requires:
           - build-npm-package
     - build-binary:
@@ -1281,7 +1281,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - develop
+              - fix-mac-install-comment
         requires:
           - build-binary
     - test-npm-module-on-minimum-node-version:
@@ -1293,7 +1293,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - develop
+              - fix-mac-install-comment
         requires:
           - upload-npm-package
           - upload-binary
@@ -1302,7 +1302,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - develop
+              - fix-mac-install-comment
         requires:
           - upload-npm-package
           - upload-binary
@@ -1310,7 +1310,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - develop
+              - fix-mac-install-comment
         requires:
           - build-npm-package
           - build-binary
@@ -1319,7 +1319,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - develop
+              - fix-mac-install-comment
         requires:
           - build-npm-package
           - build-binary
@@ -1379,7 +1379,7 @@ mac-workflow: &mac-workflow
         filters:
           branches:
             only:
-              - develop
+              - fix-mac-install-comment
 
     - upload-npm-package:
         name: Mac NPM package upload
@@ -1388,7 +1388,7 @@ mac-workflow: &mac-workflow
         filters:
           branches:
             only:
-              - develop
+              - fix-mac-install-comment
         requires:
           - Mac NPM package
 
@@ -1407,7 +1407,7 @@ mac-workflow: &mac-workflow
         filters:
           branches:
             only:
-              - develop
+              - fix-mac-install-comment
         requires:
           - Mac binary
 
@@ -1424,7 +1424,7 @@ mac-workflow: &mac-workflow
         filters:
           branches:
             only:
-              - develop
+              - fix-mac-install-comment
         requires:
           - Mac NPM package
           - Mac binary
@@ -1436,7 +1436,7 @@ mac-workflow: &mac-workflow
         filters:
           branches:
             only:
-              - develop
+              - fix-mac-install-comment
         requires:
           - Mac NPM package
           - Mac binary
@@ -1448,7 +1448,7 @@ mac-workflow: &mac-workflow
         filters:
           branches:
             only:
-              - develop
+              - fix-mac-install-comment
         requires:
           - Mac NPM package upload
           - Mac binary upload
@@ -1460,7 +1460,7 @@ mac-workflow: &mac-workflow
         filters:
           branches:
             only:
-              - develop
+              - fix-mac-install-comment
         requires:
           - Mac NPM package upload
           - Mac binary upload

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ macBuildFilters: &macBuildFilters
   filters:
     branches:
       only:
-        - fix-mac-install-comment
+        - develop
 
 defaults: &defaults
   parallelism: 1
@@ -33,7 +33,7 @@ testBinaryFirefox: &testBinaryFirefox
   filters:
     branches:
       only:
-        - fix-mac-install-comment
+        - develop
   requires:
     - build-npm-package
     - build-binary
@@ -1248,7 +1248,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - fix-mac-install-comment
+              - develop
         requires:
           - build
     - test-kitchensink:
@@ -1259,7 +1259,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - fix-mac-install-comment
+              - develop
         requires:
           - build
     - build-npm-package:
@@ -1270,7 +1270,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - fix-mac-install-comment
+              - develop
         requires:
           - build-npm-package
     - build-binary:
@@ -1281,7 +1281,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - fix-mac-install-comment
+              - develop
         requires:
           - build-binary
     - test-npm-module-on-minimum-node-version:
@@ -1293,7 +1293,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - fix-mac-install-comment
+              - develop
         requires:
           - upload-npm-package
           - upload-binary
@@ -1302,7 +1302,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - fix-mac-install-comment
+              - develop
         requires:
           - upload-npm-package
           - upload-binary
@@ -1310,7 +1310,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - fix-mac-install-comment
+              - develop
         requires:
           - build-npm-package
           - build-binary
@@ -1319,7 +1319,7 @@ linux-workflow: &linux-workflow
         filters:
           branches:
             only:
-              - fix-mac-install-comment
+              - develop
         requires:
           - build-npm-package
           - build-binary
@@ -1379,7 +1379,7 @@ mac-workflow: &mac-workflow
         filters:
           branches:
             only:
-              - fix-mac-install-comment
+              - develop
 
     - upload-npm-package:
         name: Mac NPM package upload
@@ -1388,7 +1388,7 @@ mac-workflow: &mac-workflow
         filters:
           branches:
             only:
-              - fix-mac-install-comment
+              - develop
         requires:
           - Mac NPM package
 
@@ -1407,7 +1407,7 @@ mac-workflow: &mac-workflow
         filters:
           branches:
             only:
-              - fix-mac-install-comment
+              - develop
         requires:
           - Mac binary
 
@@ -1424,7 +1424,7 @@ mac-workflow: &mac-workflow
         filters:
           branches:
             only:
-              - fix-mac-install-comment
+              - develop
         requires:
           - Mac NPM package
           - Mac binary
@@ -1436,7 +1436,7 @@ mac-workflow: &mac-workflow
         filters:
           branches:
             only:
-              - fix-mac-install-comment
+              - develop
         requires:
           - Mac NPM package
           - Mac binary
@@ -1448,7 +1448,7 @@ mac-workflow: &mac-workflow
         filters:
           branches:
             only:
-              - fix-mac-install-comment
+              - develop
         requires:
           - Mac NPM package upload
           - Mac binary upload
@@ -1460,7 +1460,7 @@ mac-workflow: &mac-workflow
         filters:
           branches:
             only:
-              - fix-mac-install-comment
+              - develop
         requires:
           - Mac NPM package upload
           - Mac binary upload


### PR DESCRIPTION


### User facing changelog

n/a

### Additional details

- fixes the install comments on `develop` - previously, darwin builds would say "[Circle has built](https://circleci.com/gh/cypress-io/cypress/281921) the `linux x64` version of the Test Runner."
	- this PR makes it so they say `darwin x64` by using the `mac` executor
