### PR TITLE
Fix type error from merged Error Improvements PR

### DIFF
--- a/packages/reporter/src/errors/err-model.spec.ts
+++ b/packages/reporter/src/errors/err-model.spec.ts
@@ -69,6 +69,7 @@ describe('Err model', () => {
     })
 
     it('does nothing if props is null', () => {
+      // @ts-ignore
       err.update(null)
       expect(err.name).to.equal('BadError')
     })


### PR DESCRIPTION
I merged in Error Improvements directly after TypeScript fixes (should have pulled them in first to see the types passed). Fixing up some type errs found in that.

## User Changelog

n/a