### PR TITLE
Fix deprecation warnings from Electron 8 upgrade

### DIFF
--- a/packages/desktop-gui/cypress/integration/ipc_bus_spec.js
+++ b/packages/desktop-gui/cypress/integration/ipc_bus_spec.js
@@ -1,0 +1,33 @@
+import ipcBus from '../../src/lib/ipc-bus'
+
+const RANDOM_NUMBER = 0.5
+
+describe('IPC bus', () => {
+  beforeEach(() => {
+    cy.stub(Math, 'random').returns(RANDOM_NUMBER)
+    cy.stub(window.ipc, 'on').returns()
+    cy.stub(window.ipc, 'send').returns()
+  })
+
+  it('sends event as expected', () => {
+    ipcBus('foo:bar', 'baz', 'quux')
+
+    expect(window.ipc.send).to.be.calledWith('request', RANDOM_NUMBER, 'foo:bar', 'baz', 'quux')
+  })
+
+  it('removes functions & elements from the args', () => {
+    const obj = {
+      el: document.querySelector('div'),
+      fn: () => {},
+      str: 'foo',
+    }
+
+    ipcBus('bar', obj)
+
+    expect(window.ipc.send).to.be.calledWith('request', RANDOM_NUMBER, 'bar', {
+      el: null,
+      fn: null,
+      str: 'foo',
+    })
+  })
+})

--- a/packages/desktop-gui/src/lib/ipc-bus.js
+++ b/packages/desktop-gui/src/lib/ipc-bus.js
@@ -10,6 +10,16 @@ const addMsg = (id, event, fn) => {
   }
 }
 
+const nullifyUnserializableValues = (obj) => {
+  // nullify values that cannot be cloned
+  // https://github.com/cypress-io/cypress/issues/6750
+  return _.cloneDeepWith(obj, (val) => {
+    if (_.isFunction(val) || _.isElement(val)) {
+      return null
+    }
+  })
+}
+
 const removeMsgsByEvent = (event) => {
   msgs = _.omitBy(msgs, (msg) => {
     return msg.event === event
@@ -96,15 +106,7 @@ const ipcBus = (...args) => {
     }
   }
 
-  // remove nodes that cannot be cloned
-  // https://github.com/cypress-io/cypress/issues/6750
-  args = args.map((arg) => {
-    return _.cloneDeepWith(arg, (val) => {
-      if (_.isFunction(val) || _.isElement(val)) {
-        return null
-      }
-    })
-  })
+  args = nullifyUnserializableValues(args)
 
   // pass in request, id, and remaining args
   ipc.send(...['request', id].concat(args))

--- a/packages/desktop-gui/src/lib/ipc-bus.js
+++ b/packages/desktop-gui/src/lib/ipc-bus.js
@@ -62,18 +62,6 @@ const ipcBus = (...args) => {
   // get the last argument
   const lastArg = args.pop()
 
-  // remove nodes that cannot be cloned
-  // https://github.com/cypress-io/cypress/issues/6750
-  args = args.map((arg) => {
-    return _.cloneDeepWith(arg, (val) => {
-      if (_.isFunction(val) || _.isElement(val)) {
-        return null
-      }
-
-      return val
-    })
-  })
-
   let fn
 
   // enable the last arg to be a function
@@ -107,6 +95,16 @@ const ipcBus = (...args) => {
       })
     }
   }
+
+  // remove nodes that cannot be cloned
+  // https://github.com/cypress-io/cypress/issues/6750
+  args = args.map((arg) => {
+    return _.cloneDeepWith(arg, (val) => {
+      if (_.isFunction(val) || _.isElement(val)) {
+        return null
+      }
+    })
+  })
 
   // pass in request, id, and remaining args
   ipc.send(...['request', id].concat(args))

--- a/packages/desktop-gui/src/lib/ipc-bus.js
+++ b/packages/desktop-gui/src/lib/ipc-bus.js
@@ -62,6 +62,18 @@ const ipcBus = (...args) => {
   // get the last argument
   const lastArg = args.pop()
 
+  // remove nodes that cannot be cloned
+  // https://github.com/cypress-io/cypress/issues/6750
+  args = args.map((arg) => {
+    return _.cloneDeepWith(arg, (val) => {
+      if (_.isFunction(val) || _.isElement(val)) {
+        return null
+      }
+
+      return val
+    })
+  })
+
   let fn
 
   // enable the last arg to be a function

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -32,6 +32,12 @@ require && require.extensions && delete require.extensions['.coffee.md']
 // https://github.com/electron/electron/blob/master/docs/api/process.md#processenablepromiseapis
 process.enablePromiseAPIs = process.env.CYPRESS_INTERNAL_ENV !== 'production'
 
+// don't show any electron deprecation warnings in prod
+process.noDeprecation = process.env.CYPRESS_INTERNAL_ENV === 'production'
+
+// always show stack traces for Electron deprecation warnings
+process.traceDeprecation = true
+
 require('./lib/util/suppress_unauthorized_warning').suppress()
 
 module.exports = require('./lib/cypress').start(process.argv)

--- a/packages/server/lib/gui/events.coffee
+++ b/packages/server/lib/gui/events.coffee
@@ -28,8 +28,6 @@ removeUnserializableValues = (obj) =>
     if _.isFunction(val)
       return null
 
-    return val
-
 handleEvent = (options, bus, event, id, type, arg) ->
   debug("got request for event: %s, %o", type, arg)
 

--- a/packages/server/lib/gui/events.coffee
+++ b/packages/server/lib/gui/events.coffee
@@ -21,12 +21,23 @@ chromePolicyCheck = require("../util/chrome_policy_check")
 browsers    = require("../browsers")
 konfig      = require("../konfig")
 
+removeUnserializableValues = (obj) =>
+  ## remove values that cannot be cloned
+  ## https://github.com/cypress-io/cypress/issues/6750
+  _.cloneDeepWith obj, (val) =>
+    if _.isFunction(val)
+      return null
+
+    return val
+
 handleEvent = (options, bus, event, id, type, arg) ->
   debug("got request for event: %s, %o", type, arg)
 
-  sendResponse = (data = {}) ->
+  sendResponse = (originalData = {}) ->
     try
-      debug("sending ipc data %o", {type: type, data: data})
+      data = removeUnserializableValues(originalData)
+
+      debug("sending ipc data %o", { type, data, originalData })
       event.sender.send("response", data)
 
   sendErr = (err) ->
@@ -318,7 +329,9 @@ handleEvent = (options, bus, event, id, type, arg) ->
       throw new Error("No ipc event registered for: '#{type}'")
 
 module.exports = {
-  handleEvent: handleEvent
+  removeUnserializableValues
+
+  handleEvent
 
   stop: ->
     ipc.removeAllListeners()

--- a/packages/server/lib/gui/events.coffee
+++ b/packages/server/lib/gui/events.coffee
@@ -21,8 +21,8 @@ chromePolicyCheck = require("../util/chrome_policy_check")
 browsers    = require("../browsers")
 konfig      = require("../konfig")
 
-removeUnserializableValues = (obj) =>
-  ## remove values that cannot be cloned
+nullifyUnserializableValues = (obj) =>
+  ## nullify values that cannot be cloned
   ## https://github.com/cypress-io/cypress/issues/6750
   _.cloneDeepWith obj, (val) =>
     if _.isFunction(val)
@@ -33,7 +33,7 @@ handleEvent = (options, bus, event, id, type, arg) ->
 
   sendResponse = (originalData = {}) ->
     try
-      data = removeUnserializableValues(originalData)
+      data = nullifyUnserializableValues(originalData)
 
       debug("sending ipc data %o", { type, data, originalData })
       event.sender.send("response", data)
@@ -327,7 +327,7 @@ handleEvent = (options, bus, event, id, type, arg) ->
       throw new Error("No ipc event registered for: '#{type}'")
 
 module.exports = {
-  removeUnserializableValues
+  nullifyUnserializableValues
 
   handleEvent
 

--- a/packages/server/lib/modes/interactive.js
+++ b/packages/server/lib/modes/interactive.js
@@ -5,6 +5,7 @@ const { app } = require('electron')
 const image = require('electron').nativeImage
 const Promise = require('bluebird')
 const cyIcons = require('@cypress/icons')
+const electronApp = require('../util/electron-app')
 const savedState = require('../saved_state')
 const menu = require('../gui/menu')
 const Events = require('../gui/events')
@@ -117,6 +118,8 @@ module.exports = {
         return app.on('ready', resolve)
       })
     }
+
+    electronApp.allowRendererProcessReuse()
 
     return Promise.any([
       waitForReady(),

--- a/packages/server/lib/util/electron-app.js
+++ b/packages/server/lib/util/electron-app.js
@@ -8,14 +8,22 @@ const scale = () => {
   }
 }
 
+const allowRendererProcessReuse = () => {
+  const { app } = require('electron')
+
+  // @see https://github.com/electron/electron/issues/18397
+  // NOTE: in Electron 9, this can be removed, since it will be the new default
+  app.allowRendererProcessReuse = true
+}
+
+// NOTE: this function is only called in run mode
 const waitForReady = () => {
   const debug = require('debug')('cypress:server:electron-app')
 
   const Promise = require('bluebird')
   const { app } = require('electron')
 
-  // @see https://github.com/electron/electron/issues/18397
-  app.allowRendererProcessReuse = true
+  allowRendererProcessReuse()
 
   // electron >= 5.0.0 will exit the app if all browserwindows are closed,
   // this is obviously undesirable in run mode
@@ -42,6 +50,8 @@ const isRunning = () => {
 }
 
 module.exports = {
+  allowRendererProcessReuse,
+
   scale,
 
   waitForReady,

--- a/packages/server/test/unit/gui/events_spec.coffee
+++ b/packages/server/test/unit/gui/events_spec.coffee
@@ -158,7 +158,7 @@ describe "lib/gui/events", ->
       it "calls Windows#open with args and resolves with return of Windows.open", ->
         @handleEvent("window:open", {type: "INDEX"})
         .then (assert) =>
-          assert.sendCalledWith(@win)
+          assert.sendCalledWith(events.removeUnserializableValues(@win))
 
       it "catches errors", ->
         err = new Error("foo")

--- a/packages/server/test/unit/gui/events_spec.coffee
+++ b/packages/server/test/unit/gui/events_spec.coffee
@@ -158,7 +158,7 @@ describe "lib/gui/events", ->
       it "calls Windows#open with args and resolves with return of Windows.open", ->
         @handleEvent("window:open", {type: "INDEX"})
         .then (assert) =>
-          assert.sendCalledWith(events.removeUnserializableValues(@win))
+          assert.sendCalledWith(events.nullifyUnserializableValues(@win))
 
       it "catches errors", ->
         err = new Error("foo")


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6750 

### User facing changelog

- Fixed a regression in 4.2.0 where Electron deprecation warnings were printed to `stderr` in `open` mode.

### Additional details

- now, objects sent via IPC in `open` mode are cloned to exclude functions and elements, to make the Structured Clone Algorithm usable: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
- previously, `allowRendererProcessReuse` was only set in `run` mode, now it's set in `open` mode too to get rid of the warning
- now we set `noDeprecation` when the env is `production`, so no deprecation warnings will be printed in built binaries

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
