### PR TITLE
Ignore dangling node in DOM tree.

### DIFF
--- a/packages/driver/src/dom/transform.ts
+++ b/packages/driver/src/dom/transform.ts
@@ -33,7 +33,11 @@ interface TransformInfo {
 }
 
 const extractTransformInfoFromElements = ($el: any, list: TransformInfo[] = []): TransformInfo[] => {
-  list.push(extractTransformInfo($el))
+  const info = extractTransformInfo($el)
+
+  if (info !== null) {
+    list.push(info)
+  }
 
   const $parent = $el.parent()
 
@@ -44,15 +48,17 @@ const extractTransformInfoFromElements = ($el: any, list: TransformInfo[] = []):
   return extractTransformInfoFromElements($parent, list)
 }
 
-const extractTransformInfo = ($el): TransformInfo => {
+const extractTransformInfo = ($el): TransformInfo | null => {
   const el = $el[0]
   const style = getComputedStyle(el)
 
-  return {
-    backfaceVisibility: style.getPropertyValue('backface-visibility') as BackfaceVisibility,
-    transformStyle: style.getPropertyValue('transform-style') as TransformStyle,
-    transform: style.getPropertyValue('transform'),
-  }
+  return style.getPropertyValue('backface-visibility') !== ''
+    ? {
+      backfaceVisibility: style.getPropertyValue('backface-visibility') as BackfaceVisibility,
+      transformStyle: style.getPropertyValue('transform-style') as TransformStyle,
+      transform: style.getPropertyValue('transform'),
+    }
+    : null
 }
 
 const existsInvisibleBackface = (list: TransformInfo[]) => {

--- a/packages/driver/src/dom/transform.ts
+++ b/packages/driver/src/dom/transform.ts
@@ -52,18 +52,22 @@ const extractTransformInfo = ($el): TransformInfo | null => {
   const el = $el[0]
   const style = getComputedStyle(el)
 
+  const backfaceVisibility = style.getPropertyValue('backface-visibility')
+  
   // When an element is not in the DOM tree, getComputedStyle() returns empty string.
   // In an edge case from frameworks like `vue-fragment`
   // `parentNode` is modified and out of the DOM tree.
   // @see https://github.com/cypress-io/cypress/pull/6787
   // @see https://github.com/cypress-io/cypress/issues/6745
-  return style.getPropertyValue('backface-visibility') !== ''
-    ? {
-      backfaceVisibility: style.getPropertyValue('backface-visibility') as BackfaceVisibility,
-      transformStyle: style.getPropertyValue('transform-style') as TransformStyle,
-      transform: style.getPropertyValue('transform'),
-    }
-    : null
+  if (backfaceVisibility === '') {
+    return null
+  }
+  
+  return {
+    backfaceVisibility as BackfaceVisibility,
+    transformStyle: style.getPropertyValue('transform-style') as TransformStyle,
+    transform: style.getPropertyValue('transform'),
+  }
 }
 
 const existsInvisibleBackface = (list: TransformInfo[]) => {

--- a/packages/driver/src/dom/transform.ts
+++ b/packages/driver/src/dom/transform.ts
@@ -35,7 +35,7 @@ interface TransformInfo {
 const extractTransformInfoFromElements = ($el: any, list: TransformInfo[] = []): TransformInfo[] => {
   const info = extractTransformInfo($el)
 
-  if (info !== null) {
+  if (info) {
     list.push(info)
   }
 

--- a/packages/driver/src/dom/transform.ts
+++ b/packages/driver/src/dom/transform.ts
@@ -52,6 +52,11 @@ const extractTransformInfo = ($el): TransformInfo | null => {
   const el = $el[0]
   const style = getComputedStyle(el)
 
+  // When an element is not in the DOM tree, getComputedStyle() returns empty string.
+  // In an edge case from frameworks like `vue-fragment`
+  // `parentNode` is modified and out of the DOM tree.
+  // @see https://github.com/cypress-io/cypress/pull/6787
+  // @see https://github.com/cypress-io/cypress/issues/6745
   return style.getPropertyValue('backface-visibility') !== ''
     ? {
       backfaceVisibility: style.getPropertyValue('backface-visibility') as BackfaceVisibility,

--- a/packages/driver/src/dom/transform.ts
+++ b/packages/driver/src/dom/transform.ts
@@ -11,7 +11,7 @@ export const detectVisibility = ($el: any) => {
   return elIsTransformedToZero(list) ? 'transformed' : 'visible'
 }
 
-type BackfaceVisibility = 'hidden' | 'visible'
+type BackfaceVisibility = 'hidden' | 'visible' | ''
 type TransformStyle = 'flat' | 'preserve-3d'
 type Matrix2D = [
   number, number, number,
@@ -52,8 +52,8 @@ const extractTransformInfo = ($el): TransformInfo | null => {
   const el = $el[0]
   const style = getComputedStyle(el)
 
-  const backfaceVisibility = style.getPropertyValue('backface-visibility')
-  
+  const backfaceVisibility = style.getPropertyValue('backface-visibility') as BackfaceVisibility
+
   // When an element is not in the DOM tree, getComputedStyle() returns empty string.
   // In an edge case from frameworks like `vue-fragment`
   // `parentNode` is modified and out of the DOM tree.
@@ -62,9 +62,9 @@ const extractTransformInfo = ($el): TransformInfo | null => {
   if (backfaceVisibility === '') {
     return null
   }
-  
+
   return {
-    backfaceVisibility as BackfaceVisibility,
+    backfaceVisibility,
     transformStyle: style.getPropertyValue('transform-style') as TransformStyle,
     transform: style.getPropertyValue('transform'),
   }

--- a/packages/driver/test/cypress/fixtures/dangling-element.html
+++ b/packages/driver/test/cypress/fixtures/dangling-element.html
@@ -34,18 +34,18 @@
 
     container.classList.add('container')
 
-    const content = document.createElement('div')
+    const p = document.createElement('p')
 
-    content.innerText = 'hello world'
-    content.classList.add('hello')
+    p.innerText = 'hello world'
+    p.classList.add('hello')
 
     parent.appendChild(container)
-    container.appendChild(content)
+    container.appendChild(p)
 
-    // 2. vue-fragment adds content to the parent.
-    // but forcefully set the content's parentNode to container.
-    parent.appendChild(content)
-    freeze(content, 'parentNode', container)
+    // 2. vue-fragment adds the p to the parent.
+    // but forcefully set the p's parentNode to container.
+    parent.appendChild(p)
+    freeze(p, 'parentNode', container)
 
     // 3. vue-fragment removes container from the parent.
     // but forcefully set the container's parentNode to parent.

--- a/packages/driver/test/cypress/fixtures/dangling-element.html
+++ b/packages/driver/test/cypress/fixtures/dangling-element.html
@@ -23,8 +23,8 @@
       })
     }
 
-    // If you want to see what's going on visually, 
-    // 
+    // If you want to see what's going on here visually, 
+    // check https://github.com/cypress-io/cypress/pull/6787
 
     // 1. What vue does by default: 
     // Create component and append it to the DOM tree.

--- a/packages/driver/test/cypress/fixtures/dangling-element.html
+++ b/packages/driver/test/cypress/fixtures/dangling-element.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Dangling element</title>
+  </head>
+  <body>
+    <div>Some content</div>
+  </body>
+  <script>
+    // Simplified version of what vue-fragment do.
+    // https://github.com/y-nk/vue-fragment/blob/master/src/component.js
+
+    const freeze = (object, property, value) => {
+      Object.defineProperty(object, property, {
+        configurable: true,
+        get () {
+          return value
+        },
+        set (v) {
+          // eslint-disable-next-line no-console
+          console.warn(`tried to set frozen property ${property} with ${v}`)
+        },
+      })
+    }
+
+    // If you want to see what's going on visually, 
+    // 
+
+    // 1. What vue does by default: 
+    // Create component and append it to the DOM tree.
+    const parent = document.getElementsByTagName('body')[0]
+
+    const container = document.createElement('div')
+
+    container.classList.add('container')
+
+    const content = document.createElement('div')
+
+    content.innerText = 'hello world'
+    content.classList.add('hello')
+
+    parent.appendChild(container)
+    container.appendChild(content)
+
+    // 2. vue-fragment adds content to the parent.
+    // but forcefully set the content's parentNode to container.
+    parent.appendChild(content)
+    freeze(content, 'parentNode', container)
+
+    // 3. vue-fragment removes container from the parent.
+    // but forcefully set the container's parentNode to parent.
+    parent.removeChild(container)
+    freeze(container, 'parentNode', parent)
+  </script>
+</html>

--- a/packages/driver/test/cypress/integration/dom/visibility_spec.ts
+++ b/packages/driver/test/cypress/integration/dom/visibility_spec.ts
@@ -835,6 +835,11 @@ describe('src/cypress/dom/visibility', () => {
           expect(el).to.be.visible
         })
 
+        it('is visible even if there is a dangling element in the tree', () => {
+          cy.visit('/fixtures/dangling-element.html')
+          cy.get('.hello')
+        })
+
         it('is hidden when an element is scaled to X axis in 0', () => {
           const el = add(`<div style="transform: scaleX(0)">ScaleX(0)</div>`)
 

--- a/packages/driver/test/cypress/integration/dom/visibility_spec.ts
+++ b/packages/driver/test/cypress/integration/dom/visibility_spec.ts
@@ -835,6 +835,7 @@ describe('src/cypress/dom/visibility', () => {
           expect(el).to.be.visible
         })
 
+        // https://github.com/cypress-io/cypress/issues/6745
         it('is visible even if there is a dangling element in the tree', () => {
           cy.visit('/fixtures/dangling-element.html')
           cy.get('.hello')


### PR DESCRIPTION
- Closes #6745

### User facing changelog

`vue-fragment` made `isVisible` fail. It is fixed in this PR.

### Additional details

#### Why was this change necessary?

Because of the manipulation of `parentNode` by `vue-fragment`. Dangling elements are created and they return empty string. [Because `getComputedStyle()` returns empty strings when the element is not in the DOM tree.](https://bugs.chromium.org/p/chromium/issues/detail?id=558165)

#### What is affected by this change?

N/A

#### Any implementation details to explain?

Created a test file that replicate the behavior. They're done in these 3 steps.

**Step 1. Create new DOM tree**
![Screenshot from 2020-03-20 15-14-21](https://user-images.githubusercontent.com/8130013/77143184-d140ae00-6ac5-11ea-83d6-b3430f85819a.png)

**Step 2. Add paragraph to parent and set parentNode to container**
![Screenshot from 2020-03-20 15-14-21 (copy)](https://user-images.githubusercontent.com/8130013/77143186-d56ccb80-6ac5-11ea-8fec-296a20719fa9.png)

**Step 3. Remove container and set parentNode to parent**
![Screenshot from 2020-03-20 15-14-23](https://user-images.githubusercontent.com/8130013/77143193-da317f80-6ac5-11ea-80a5-4380ac94f3e5.png)

Because of the Step 3, container is not in the DOM tree, but it's the parent of paragraph. So, it can be accessed and the bug occurred. 

### How has the user experience changed?

`cy.get()` works even if `vue-fragment` is used. 

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
