### PR TITLE
extract Netlify CI information

### DIFF
--- a/packages/server/__snapshots__/cypress_spec.js
+++ b/packages/server/__snapshots__/cypress_spec.js
@@ -77,6 +77,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 - shippable
 - teamfoundation
 - travis
+- netlify
 
 Because the ciBuildId could not be auto-detected you must pass the --ci-build-id flag manually.
 
@@ -111,6 +112,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 - shippable
 - teamfoundation
 - travis
+- netlify
 
 Because the ciBuildId could not be auto-detected you must pass the --ci-build-id flag manually.
 
@@ -146,6 +148,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 - shippable
 - teamfoundation
 - travis
+- netlify
 
 Because the ciBuildId could not be auto-detected you must pass the --ci-build-id flag manually.
 

--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -346,7 +346,6 @@ const _providerCiParams = () => {
     netlify: extract([
       'BUILD_ID',
       'CONTEXT',
-      'REPOSITORY_URL',
       'URL',
       'DEPLOY_URL',
       'DEPLOY_PRIME_URL',
@@ -519,7 +518,7 @@ const _providerCommitParams = () => {
     netlify: {
       sha: env.COMMIT_REF,
       branch: env.BRANCH,
-      remoteOrigin: env.REPOSITORY_URL
+      remoteOrigin: env.REPOSITORY_URL,
     },
   }
 }

--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -519,6 +519,7 @@ const _providerCommitParams = () => {
     netlify: {
       sha: env.COMMIT_REF,
       branch: env.BRANCH,
+      remoteOrigin: env.REPOSITORY_URL
     },
   }
 }

--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -101,6 +101,7 @@ const CI_PROVIDERS = {
   'teamfoundation': isTeamFoundation,
   'travis': 'TRAVIS',
   'wercker': isWercker,
+  netlify: 'NETLIFY',
 }
 
 const _detectProviderName = () => {
@@ -341,6 +342,16 @@ const _providerCiParams = () => {
       'TRAVIS_PULL_REQUEST_SHA',
     ]),
     wercker: null,
+    // https://docs.netlify.com/configure-builds/environment-variables/#deploy-urls-and-metadata
+    netlify: extract([
+      'BUILD_ID',
+      'CONTEXT',
+      'REPOSITORY_URL',
+      'URL',
+      'DEPLOY_URL',
+      'DEPLOY_PRIME_URL',
+      'DEPLOY_ID',
+    ]),
   }
 }
 
@@ -505,6 +516,10 @@ const _providerCommitParams = () => {
       // defaultBranch: ???
     },
     wercker: null,
+    netlify: {
+      sha: env.COMMIT_REF,
+      branch: env.BRANCH,
+    },
   }
 }
 

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -752,6 +752,42 @@ describe "lib/util/ci_provider", ->
     expectsCiParams(null)
     expectsCommitParams(null)
 
+  it "netlify", ->
+    resetEnv = mockedEnv({
+      NETLIFY: "true"
+
+      BUILD_ID: "buildId"
+      CONTEXT: "deployContent"
+      REPOSITORY_URL: "repositoryUrl"
+      # deploy env variables
+      URL: "url"
+      DEPLOY_URL: "individualDeployUrl"
+      DEPLOY_PRIME_URL: "primeDeployUrl"
+      DEPLOY_ID: "deployId"
+
+      COMMIT_REF: "commit"
+      BRANCH: "branch"
+      HEAD: "head"
+      CACHED_COMMIT_REF: "previousCommit"
+      PULL_REQUEST: "pullRequestTrueOrFalse"
+      REVIEW_ID: "pullRequestReviewId"
+    }, {clear: true})
+
+    expectsName("netlify")
+    expectsCiParams({
+      buildId: "buildId"
+      context: "deployContent"
+      repositoryUrl: "repositoryUrl"
+      url: "url"
+      deployUrl: "individualDeployUrl"
+      deployPrimeUrl: "primeDeployUrl"
+      deployId: "deployId"
+    })
+    expectsCommitParams({
+      sha: "commit"
+      branch: "branch"
+    })
+
   it "azure", ->
     resetEnv = mockedEnv({
       # these two variables tell us it is Azure CI

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -758,7 +758,6 @@ describe "lib/util/ci_provider", ->
 
       BUILD_ID: "buildId"
       CONTEXT: "deployContent"
-      REPOSITORY_URL: "repositoryUrl"
       # deploy env variables
       URL: "url"
       DEPLOY_URL: "individualDeployUrl"

--- a/packages/server/test/unit/ci_provider_spec.coffee
+++ b/packages/server/test/unit/ci_provider_spec.coffee
@@ -771,13 +771,13 @@ describe "lib/util/ci_provider", ->
       CACHED_COMMIT_REF: "previousCommit"
       PULL_REQUEST: "pullRequestTrueOrFalse"
       REVIEW_ID: "pullRequestReviewId"
+      REPOSITORY_URL: "repositoryUrl"
     }, {clear: true})
 
     expectsName("netlify")
     expectsCiParams({
       buildId: "buildId"
       context: "deployContent"
-      repositoryUrl: "repositoryUrl"
       url: "url"
       deployUrl: "individualDeployUrl"
       deployPrimeUrl: "primeDeployUrl"
@@ -786,6 +786,7 @@ describe "lib/util/ci_provider", ->
     expectsCommitParams({
       sha: "commit"
       branch: "branch"
+      remoteOrigin: "repositoryUrl"
     })
 
   it "azure", ->


### PR DESCRIPTION
- Closes #6780

### User facing changelog

When recording to Cypress Dashboard from Netlify builds (for example when using https://github.com/cypress-io/netlify-plugin-cypress) the Dashboard will show branch and CI information

### Additional details

Before you could see blank spots https://dashboard.cypress.io/projects/4b7344/runs/14211/specs

After this change (and Dashboard fix), the missing information should be there


### How has the user experience changed?

Nothing for the user to do

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
