### PR TITLE
add tag to Cypress NPM module API options

### DIFF
--- a/cli/types/cypress-npm-api.d.ts
+++ b/cli/types/cypress-npm-api.d.ts
@@ -238,6 +238,10 @@ declare module 'cypress' {
      */
     group: string
     /**
+     * Tag string for the recorded run, like "production,nightly"
+     */
+    tag: string
+    /**
      * Display the browser instead of running headlessly
      */
     headed: boolean

--- a/cli/types/tests/cypress-npm-api-test.ts
+++ b/cli/types/tests/cypress-npm-api-test.ts
@@ -4,6 +4,9 @@ import cypress from 'cypress'
 
 cypress.run // $ExpectType (options?: Partial<CypressRunOptions> | undefined) => Promise<CypressRunResult>
 cypress.open // $ExpectType (options?: Partial<CypressOpenOptions> | undefined) => Promise<void>
+cypress.run({
+  tag: 'production,nightly'
+})
 cypress.run({}).then(results => {
   results // $ExpectType CypressRunResult
 })


### PR DESCRIPTION
- Closes #6795

### User facing changelog

This should not work without TS warning that the property `tag` does not exist
```js
const cypress = require('cypress')
await cypress.run({
  record: true,
  tag: 'staging'
})
```

See https://on.cypress.io/module-api#cypress-run

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
