### PR TITLE
Pause dtslint checks

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -319,8 +319,6 @@ jobs:
           command: ls -la types
           working_directory: cli
       - run:
-          command: yarn lerna exec  --scope cypress "yarn dtslint"
-      - run:
           command: yarn type-check --ignore-progress
       - store-npm-logs
 

--- a/circle.yml
+++ b/circle.yml
@@ -319,6 +319,9 @@ jobs:
           command: ls -la types
           working_directory: cli
       - run:
+          # Run dtslint, but permit failures for now as per https://github.com/cypress-io/cypress/pull/6819
+          command: yarn lerna exec  --scope cypress "yarn dtslint" || true
+      - run:
           command: yarn type-check --ignore-progress
       - store-npm-logs
 


### PR DESCRIPTION
Some of our external dependencies (Bluebird, jQuery) are currently failing on `dtslint` checks because of changes in TypeScript `@next`. (We are either on latest published versions of `@types` for these libraries, or upgrading had no effect on `dtslint`.)

`dtslint` is hard-coded to always check all available typescript versions, include the beta version `@next`.

In order to avoid these failures blocking CI, this pull-request disables the dtslint checks on Circle.

<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6814

### User facing changelog

<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?