### PR TITLE
check if configuration is visible before proceeding

### DIFF
--- a/packages/desktop-gui/cypress/integration/settings_spec.js
+++ b/packages/desktop-gui/cypress/integration/settings_spec.js
@@ -84,6 +84,17 @@ describe('Settings', () => {
     })
   })
 
+  /**
+   * Opens "Configuration" panel of the Settings tab
+   * and checks that configuration element is fully visible.
+   * This helps to ensure no flake down the line
+   */
+  const openConfiguration = () => {
+    cy.contains('Configuration').click()
+    cy.get('.config-vars').should('be.visible')
+    .invoke('height').should('be.gt', 400)
+  }
+
   describe('configuration panel', () => {
     describe('displays config', () => {
       beforeEach(function () {
@@ -92,7 +103,7 @@ describe('Settings', () => {
         this.getProjectStatus.resolve(this.projectStatuses[0])
 
         this.goToSettings()
-        cy.contains('Configuration').click()
+        openConfiguration()
       })
 
       it('displays config section', () => {
@@ -296,7 +307,7 @@ describe('Settings', () => {
 
         this.goToSettings()
 
-        cy.contains('Configuration').click()
+        openConfiguration()
       })
 
       it('displays updated config', function () {
@@ -318,7 +329,7 @@ describe('Settings', () => {
 
         this.goToSettings()
 
-        cy.contains('Configuration').click()
+        openConfiguration()
       })
 
       it('notes that cypress.json is disabled', () => {
@@ -334,7 +345,7 @@ describe('Settings', () => {
 
         this.goToSettings()
 
-        cy.contains('Configuration').click()
+        openConfiguration()
       })
 
       it('notes that a custom config is in use', () => {
@@ -550,7 +561,7 @@ describe('Settings', () => {
       this.getProjectStatus.resolve(this.projectStatuses[0])
       this.openProject.resolve(this.config)
       this.goToSettings()
-      cy.contains('Configuration').click()
+      openConfiguration()
 
       cy.contains('http://localhost:7777').then(() => {
         this.ipc.openProject.onCall(1).rejects(this.err)
@@ -762,7 +773,7 @@ describe('Settings', () => {
       this.getProjectStatus.resolve(this.projectStatuses[0])
       this.openProject.resolve(this.config)
       this.goToSettings()
-      cy.contains('Configuration').click()
+      openConfiguration()
 
       cy.contains('http://localhost:7777').then(() => {
         this.ipc.openProject.onCall(1).rejects(this.err)


### PR DESCRIPTION
- closes #6817

## Before

Almost all elements the test interacted with were invisible because the configuration still has not finished expanding

<img width="1360" alt="Screen Shot 2020-03-23 at 4 02 52 PM" src="https://user-images.githubusercontent.com/2212006/77359703-5f18d500-6d22-11ea-9bb6-4386f26850ae.png">

## After

Everything is visible

<img width="1361" alt="Screen Shot 2020-03-23 at 4 12 56 PM" src="https://user-images.githubusercontent.com/2212006/77359724-6a6c0080-6d22-11ea-94a3-3661512c439a.png">
