### PR TITLE
Handle case where firefoxGcIntervals could be set to null

### DIFF
--- a/packages/driver/src/util/firefox_forced_gc.ts
+++ b/packages/driver/src/util/firefox_forced_gc.ts
@@ -1,4 +1,4 @@
-import { get, isNumber } from 'lodash'
+import { get, isNumber, isNull } from 'lodash'
 
 export function createIntervalGetter (config) {
   return () => {
@@ -8,7 +8,7 @@ export function createIntervalGetter (config) {
 
     const intervals = config('firefoxGcInterval')
 
-    if (isNumber(intervals)) {
+    if (isNumber(intervals) || isNull(intervals)) {
       return intervals
     }
 

--- a/packages/driver/test/cypress/integration/util/firefox_forced_gc_spec.ts
+++ b/packages/driver/test/cypress/integration/util/firefox_forced_gc_spec.ts
@@ -27,6 +27,15 @@ describe('driver/src/util/firefox_forced_gc', () => {
       })).to.eq(99)
     })
 
+    it('returns null if firefoxGcInterval is null', () => {
+      expect(run({
+        browser: {
+          family: 'firefox',
+        },
+        firefoxGcInterval: null,
+      })).to.eq(null)
+    })
+
     it('returns the appropriate interval for open mode', () => {
       expect(run({
         browser: {


### PR DESCRIPTION
- Closes #6825 

### User facing changelog

- `firefoxGcIntervals` can now correctly be set to `null`

### Additional details

Just wasn't handling this even though it's documented. https://on.cypress.io/configuration#firefoxGcInterval

### How has the user experience changed?

#### Before

<img width="300" alt="Screen Shot 2020-03-24 at 3 37 31 PM" src="https://user-images.githubusercontent.com/1271364/77409723-25120680-6de8-11ea-8287-e70d2c8ae961.png">


#### After

<img width="342" alt="Screen Shot 2020-03-24 at 3 57 07 PM" src="https://user-images.githubusercontent.com/1271364/77409742-2ba07e00-6de8-11ea-8b0a-a51c074ce4cc.png">


### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
