### PR TITLE
Position arrow icons to the far right for nested folders.

### DIFF
--- a/packages/desktop-gui/cypress/integration/specs_list_spec.js
+++ b/packages/desktop-gui/cypress/integration/specs_list_spec.js
@@ -215,6 +215,16 @@ describe('Specs List', function () {
           cy.get('.file').should('have.length', this.numSpecs)
           cy.get('.folder').should('have.length', 10)
         })
+
+        it('folders arrow icons positioning', () => {
+          cy.get('.folder.level-0').within(() => {
+            cy.get('.folder-name *').first().should('have.class', 'folder-collapse-icon')
+          })
+
+          cy.get('.folder.level-1, .folder.level-2').within(() => {
+            cy.get('.folder-name *').last().should('have.class', 'folder-collapse-icon')
+          })
+        })
       })
 
       context('collapsing specs', function () {

--- a/packages/desktop-gui/src/specs/specs-list.jsx
+++ b/packages/desktop-gui/src/specs/specs-list.jsx
@@ -133,12 +133,13 @@ class SpecsList extends Component {
 
   _folderContent (spec, nestingLevel) {
     const isExpanded = spec.isExpanded
+    const arrowIcon = <i className={`folder-collapse-icon fas fa-fw ${isExpanded ? 'fa-caret-down' : 'fa-caret-right'}`}></i>
 
     return (
       <li key={spec.path} className={`folder level-${nestingLevel} ${isExpanded ? 'folder-expanded' : 'folder-collapsed'}`}>
         <div>
           <div className="folder-name" onClick={this._selectSpecFolder.bind(this, spec)}>
-            <i className={`folder-collapse-icon fas fa-fw ${isExpanded ? 'fa-caret-down' : 'fa-caret-right'}`}></i>
+            {nestingLevel === 0 && arrowIcon}
             {nestingLevel !== 0 ? <i className={`far fa-fw ${isExpanded ? 'fa-folder-open' : 'fa-folder'}`}></i> : null}
             {
               nestingLevel === 0 ?
@@ -154,6 +155,7 @@ class SpecsList extends Component {
                 </> :
                 spec.displayName
             }
+            {nestingLevel !== 0 && arrowIcon}
           </div>
           {
             isExpanded ?


### PR DESCRIPTION
- Closes  #6275

### User facing changelog
- Position arrow icon to far right for nested folders.

### Additional details
- The arrow icon's indicating the folder status in the tree view is redundant and could be confusing.

### How has the user experience changed?
- **Before**:
![cypress_before](https://user-images.githubusercontent.com/26286907/77502033-b924b200-6e6a-11ea-8871-5113c33937ca.gif)

- **After**:
![cypress_after](https://user-images.githubusercontent.com/26286907/77623025-645b6700-6f50-11ea-8317-496c9ebe5518.gif)

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] ~~Has the original issue been tagged with a release in ZenHub?~~
- [ ] ~~Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?~~
- [ ] ~~Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?~~
- [ ] ~~Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?~~
