### PR TITLE
Add .git dir to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -32,3 +32,4 @@ packages/server/test/support/fixtures/projects/e2e/cypress/integration/stdout_ex
 **/.vscode
 **/.history
 **/.cy
+**/.git


### PR DESCRIPTION
- close #6843 

## User facing changelog

N/A

## Additional details

I had a decaffeinate PR that failed eslint because it was linting a `.git` file. This should fix that.