### PR TITLE
rename built folder on Windows

### DIFF
--- a/scripts/binary/zip.coffee
+++ b/scripts/binary/zip.coffee
@@ -89,13 +89,13 @@ linuxZipAction = (parentFolder, dest, relativeSource) ->
   .catch onError
 
 # src is built folder with packed Cypress application
-# like /root/app/build/linux-unpacked
+# like /root/app/build/linux-unpacked or build/win-unpacked
 # and we want to always have /root/app/build/Cypress
 renameFolder = (src) ->
   parentFolder = path.dirname(src)
   folderName = path.basename(src)
   if folderName is "Cypress"
-    console.log("nothing to rename, folder ends with Cypress")
+    console.log('nothing to rename, folder "%s" ends with Cypress', src)
     return Promise.resolve(src)
 
   renamed = path.join(parentFolder, "Cypress")
@@ -121,7 +121,7 @@ linuxZip = (src, dest) ->
     linuxZipAction(parentFolder, dest, relativeSource)
 
 # resolves with zipped filename
-windowsZip = (src, dest) ->
+windowsZipAction = (src, dest) ->
   # use 7Zip to zip
   # http://www.7-zip.org/
   # zips entire source directory including top level folder name
@@ -147,6 +147,11 @@ windowsZip = (src, dest) ->
   .then R.always(dest)
   .then R.tap(checkZipSize)
   .catch onError
+
+windowsZip = (src, dest) ->
+  renameFolder(src)
+  .then (renamedSource) ->
+    windowsZipAction(renamedSource, dest)
 
 zippers = {
   linux: linuxZip

--- a/scripts/win-appveyor-build.js
+++ b/scripts/win-appveyor-build.js
@@ -26,7 +26,7 @@ const isRightBranch = () => {
     process.env.APPVEYOR_REPO_COMMIT_MESSAGE || ''
   ).includes('[build binary]')
 
-  const branchesToBuildBinary = ['develop', 'try-new-electron-sign']
+  const branchesToBuildBinary = ['develop', 'windows-folder-name']
 
   return branchesToBuildBinary.includes(branch) || shouldForceBinaryBuild
 }


### PR DESCRIPTION
- closes #6858

When it builds on AppVeyor it now renames the folder before zipping

```
Zipping and upload binary
exec yarn binary-zip
yarn run v1.21.1
$ node ./scripts/binary.js zip
#zip
directory to zip C:\projects\cypress\build\win-unpacked
#zip win32
Zipping C:\projects\cypress\build\win-unpacked into C:\projects\cypress\cypress.zip
renaming C:\projects\cypress\build\win-unpacked to C:\projects\cypress\build\Cypress
windows zip: 7z a C:\projects\cypress\cypress.zip C:\projects\cypress\build\Cypress
✅ 7z finished
zip file size 161 MB
✅ zip completed
Done in 58.15s.
ls -l *.zip
exec node scripts/binary.js upload-unique-binary --file cypress.zip --version 4.2.1
#uniqueBinaryUpload
Upload unique binary options
{ file: 'cypress.zip', version: '4.2.1' }
```

The built zip https://cdn.cypress.io/beta/binary/4.2.1/win32-x64/appveyor-windows-folder-name-cbe5a94dfd57f71820aab3e5339ba348198b6161-31743604/cypress.zip passes tests https://ci.appveyor.com/project/cypress-io/cypress-test-tiny/builds/31744540