### PR TITLE
Bring back dtslint

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -320,8 +320,7 @@ jobs:
           command: ls -la types
           working_directory: cli
       - run:
-          # Run dtslint, but permit failures for now as per https://github.com/cypress-io/cypress/pull/6819
-          command: yarn lerna exec  --scope cypress "yarn dtslint" || true
+          command: yarn lerna exec  --scope cypress "yarn dtslint"
       - run:
           command: yarn type-check --ignore-progress
       - store-npm-logs


### PR DESCRIPTION
As a first step towards #6848 this PR re-enables `dtslint` in our CI flow. 


<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->


### User facing changelog

<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

- This re-enables dtslint tests after they were paused earlier in #6819 due to failures with `ts@next`.
<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?