### PR TITLE
Do not silence cli commands

### DIFF
--- a/cli/__snapshots__/cache_spec.js
+++ b/cli/__snapshots__/cache_spec.js
@@ -35,3 +35,23 @@ exports['lib/tasks/cache .list some versions have never been opened 1'] = `
 │ 2.3.4   │ unknown      │
 └─────────┴──────────────┘
 `
+
+exports['cache list with silent log level'] = `
+┌─────────┬───────────┐
+│ version │ last used │
+├─────────┼───────────┤
+│ 1.2.3   │ unknown   │
+├─────────┼───────────┤
+│ 2.3.4   │ unknown   │
+└─────────┴───────────┘
+`
+
+exports['cache list with warn log level'] = `
+┌─────────┬───────────┐
+│ version │ last used │
+├─────────┼───────────┤
+│ 1.2.3   │ unknown   │
+├─────────┼───────────┤
+│ 2.3.4   │ unknown   │
+└─────────┴───────────┘
+`

--- a/cli/__snapshots__/cli_spec.js
+++ b/cli/__snapshots__/cli_spec.js
@@ -428,3 +428,13 @@ exports['cli CYPRESS_INTERNAL_ENV allows and warns when staging environment 1'] 
   -------
 
 `
+
+exports['cli version and binary version with npm log silent'] = `
+Cypress package version: 1.2.3
+Cypress binary version: X.Y.Z
+`
+
+exports['cli version and binary version with npm log warn'] = `
+Cypress package version: 1.2.3
+Cypress binary version: X.Y.Z
+`

--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -154,8 +154,8 @@ function showVersions () {
   return require('./exec/versions')
   .getVersions()
   .then((versions = {}) => {
-    logger.log('Cypress package version:', versions.package)
-    logger.log('Cypress binary version:', versions.binary)
+    logger.always('Cypress package version:', versions.package)
+    logger.always('Cypress binary version:', versions.binary)
     process.exit(0)
   })
   .catch(util.logErrorExit1)

--- a/cli/lib/logger.js
+++ b/cli/lib/logger.js
@@ -26,6 +26,11 @@ const log = (...messages) => {
   console.log(...messages) // eslint-disable-line no-console
 }
 
+const always = (...messages) => {
+  logs.push(messages.join(' '))
+  console.log(...messages) // eslint-disable-line no-console
+}
+
 // splits long text into lines and calls log()
 // on each one to allow easy unit testing for specific message
 const logLines = (text) => {
@@ -46,6 +51,7 @@ module.exports = {
   log,
   warn,
   error,
+  always,
   logLines,
   print,
   reset,

--- a/cli/lib/tasks/cache.js
+++ b/cli/lib/tasks/cache.js
@@ -15,9 +15,8 @@ const colors = {
   values: chalk.green,
 }
 
-// TODO: rename this function
-const path = () => {
-  logger.log(state.getCacheDir())
+const logCachePath = () => {
+  logger.always(state.getCacheDir())
 
   return undefined
 }
@@ -84,7 +83,7 @@ const getCachedVersions = () => {
 }
 
 module.exports = {
-  path,
+  path: logCachePath,
   clear,
   list,
   getCachedVersions,

--- a/cli/lib/tasks/cache.js
+++ b/cli/lib/tasks/cache.js
@@ -25,6 +25,10 @@ const clear = () => {
   return fs.removeAsync(state.getCacheDir())
 }
 
+/**
+ * Collects all cached versions, finds when each was used
+ * and prints a table with results to the terminal
+ */
 const list = () => {
   return getCachedVersions()
   .then((binaries) => {
@@ -39,7 +43,7 @@ const list = () => {
       return table.push([versionString, lastUsed])
     })
 
-    logger.log(table.toString())
+    logger.always(table.toString())
   })
 }
 

--- a/cli/test/lib/cli_spec.js
+++ b/cli/test/lib/cli_spec.js
@@ -13,6 +13,7 @@ const install = require(`${lib}/tasks/install`)
 const snapshot = require('../support/snapshot')
 const debug = require('debug')('test')
 const execa = require('execa-wrap')
+const mockedEnv = require('mocked-env')
 
 describe('cli', () => {
   require('mocha-banner').register()
@@ -131,6 +132,15 @@ describe('cli', () => {
   })
 
   context('cypress version', () => {
+    let restoreEnv
+
+    afterEach(() => {
+      if (restoreEnv) {
+        restoreEnv()
+        restoreEnv = null
+      }
+    })
+
     const binaryDir = '/binary/dir'
 
     beforeEach(() => {
@@ -158,6 +168,38 @@ describe('cli', () => {
       this.exec('version')
       process.exit.callsFake(() => {
         snapshot('cli version and binary version 2', logger.print())
+        done()
+      })
+    })
+
+    it('reports package and binary message with npm log silent', (done) => {
+      restoreEnv = mockedEnv({
+        npm_config_loglevel: 'silent',
+      })
+
+      sinon.stub(util, 'pkgVersion').returns('1.2.3')
+      sinon.stub(state, 'getBinaryPkgVersionAsync').resolves('X.Y.Z')
+
+      this.exec('version')
+      process.exit.callsFake(() => {
+        // should not be empty!
+        snapshot('cli version and binary version with npm log silent', logger.print())
+        done()
+      })
+    })
+
+    it('reports package and binary message with npm log warn', (done) => {
+      restoreEnv = mockedEnv({
+        npm_config_loglevel: 'warn',
+      })
+
+      sinon.stub(util, 'pkgVersion').returns('1.2.3')
+      sinon.stub(state, 'getBinaryPkgVersionAsync').resolves('X.Y.Z')
+
+      this.exec('version')
+      process.exit.callsFake(() => {
+        // should not be empty!
+        snapshot('cli version and binary version with npm log warn', logger.print())
         done()
       })
     })

--- a/cli/test/lib/tasks/cache_spec.js
+++ b/cli/test/lib/tasks/cache_spec.js
@@ -11,6 +11,7 @@ const moment = require('moment')
 const stripAnsi = require('strip-ansi')
 const path = require('path')
 const termToHtml = require('term-to-html')
+const mockedEnv = require('mocked-env')
 
 const outputHtmlFolder = path.join(__dirname, '..', '..', 'html')
 
@@ -72,10 +73,37 @@ describe('lib/tasks/cache', () => {
   }
 
   describe('.path', () => {
+    let restoreEnv
+
+    afterEach(() => {
+      if (restoreEnv) {
+        restoreEnv()
+        restoreEnv = null
+      }
+    })
+
     it('lists path to cache', () => {
       cache.path()
       expect(this.stdout.toString()).to.eql('/.cache/Cypress\n')
       defaultSnapshot()
+    })
+
+    it('lists path to cache with silent npm loglevel', () => {
+      restoreEnv = mockedEnv({
+        npm_config_loglevel: 'silent',
+      })
+
+      cache.path()
+      expect(this.stdout.toString()).to.eql('/.cache/Cypress\n')
+    })
+
+    it('lists path to cache with silent npm warn', () => {
+      restoreEnv = mockedEnv({
+        npm_config_loglevel: 'warn',
+      })
+
+      cache.path()
+      expect(this.stdout.toString()).to.eql('/.cache/Cypress\n')
     })
   })
 


### PR DESCRIPTION
- Closes #2705

### User facing changelog

Cypress no longer hides output from these commands when npm log level is `silent` or `warn`

- `cypress --version`
- `cypress version`
- `cypress cache path`
- `cypress cache list`

### Additional details

this PR does not refactor the entire log or touch install progress messages like https://github.com/cypress-io/cypress/pull/2706 so the change should be easy to merge

### How has the user experience changed?

**before**

No output when running commands. For example from our Docker images

```
$ docker run -it --entrypoint=cypress cypress/included:4.2.0 --version
~/git/cypress-docker-images on master
```

**after**
prints versions

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
