### PR TITLE
[WIP] Network emulation for Chrome

### DIFF
--- a/packages/driver/src/cy/commands/network.js
+++ b/packages/driver/src/cy/commands/network.js
@@ -1,0 +1,20 @@
+module.exports = (Commands, Cypress) => {
+  Commands.addAll({
+    network: (options = {}) => {
+      Cypress.automation('remote:debugger:protocol', {
+        command: 'Network.enable',
+      })
+
+      Cypress.automation('remote:debugger:protocol', {
+        command: 'Network.emulateNetworkConditions',
+        params: {
+          offline: options.offline,
+          'latency': 0,
+          'downloadThroughput': 0,
+          'uploadThroughput': 0,
+          'connectionType': 'none',
+        },
+      })
+    },
+  })
+}

--- a/packages/driver/src/cypress/commands.coffee
+++ b/packages/driver/src/cypress/commands.coffee
@@ -27,6 +27,7 @@ builtInCommands = [
   require("../cy/commands/local_storage")
   require("../cy/commands/location")
   require("../cy/commands/misc")
+  require("../cy/commands/network")
   require("../cy/commands/popups")
   require("../cy/commands/navigation")
   require("../cy/commands/querying")

--- a/packages/driver/test/cypress/fixtures/network.html
+++ b/packages/driver/test/cypress/fixtures/network.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Network Fixture</title>
+</head>
+<body>
+<p>
+    We are currently <span id="network-status"></span>.
+</p>
+<script>
+window.addEventListener('offline', function () { document.getElementById('network-status').innerText = 'offline' })
+window.addEventListener('online', function () {document.getElementById('network-status').innerText = 'online' })
+document.getElementById('network-status').innerText = window.navigator.onLine ? 'online' : 'offline'
+</script>
+</body>
+</html>

--- a/packages/driver/test/cypress/integration/commands/network_spec.js
+++ b/packages/driver/test/cypress/integration/commands/network_spec.js
@@ -1,0 +1,13 @@
+describe('src/cy/commands/network', () => {
+  before(() => {
+    cy.visit('/fixtures/network.html')
+  })
+
+  it('switches between offline and online', () => {
+    cy.contains('We are currently online.')
+    cy.network({ offline: true })
+    cy.contains('We are currently offline.')
+    cy.network({ offline: false })
+    cy.contains('We are currently online.')
+  })
+})


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

- Closes #235 

### User facing changelog

- Added new command `cy.network()` that simulates network conditions

### Additional details

This allows you to simulate network conditions, such as being offline or on a slow 3G network. 

### How has the user experience changed?

It allows the following:

```js
    cy.contains('We are currently online.')
    cy.network({ offline: true })
    cy.contains('We are currently offline.')
    cy.network({ offline: false })
    cy.contains('We are currently online.')
```

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [x] ~~Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?~~ not applicable
- [x] Does it work in Chrome?
- [x] Does it work in Electron?
- [ ] Does it work in Firefox?
    - Perhaps not possible yet: https://bugzilla.mozilla.org/show_bug.cgi?id=1553849
- [ ] Makes service-workers behave like they're offline
    - We need to send `Target.sendMessageToTarget` for each target that is available, with the `message`-parameter containing `method: Network.emulateNetworkConditions` and the `params` that we already use here. 
- [x] `cy.request` should be unaffected
    - [ ] A test has been written to confirm this behavior

