### PR TITLE
Fix 'This socket has been ended by the other party'

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -63,7 +63,7 @@
     "getos": "3.1.1",
     "glob": "7.1.3",
     "graceful-fs": "4.2.0",
-    "http-proxy": "1.18.0",
+    "http-proxy": "cypress-io/node-http-proxy#9322b4b69b34f13a6f3874e660a35df3305179c6",
     "http-status-codes": "1.4.0",
     "human-interval": "0.1.6",
     "image-size": "0.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13132,10 +13132,18 @@ http-proxy-agent@^2.1.0:
     agent-base "4"
     debug "3.1.0"
 
-http-proxy@1.18.0, http-proxy@^1.17.0:
+http-proxy@^1.17.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.0.tgz#dbe55f63e75a347db7f3d99974f2692a314a6a3a"
   integrity sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==
+  dependencies:
+    eventemitter3 "^4.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
+
+http-proxy@cypress-io/node-http-proxy#9322b4b69b34f13a6f3874e660a35df3305179c6:
+  version "1.18.0"
+  resolved "https://codeload.github.com/cypress-io/node-http-proxy/tar.gz/9322b4b69b34f13a6f3874e660a35df3305179c6"
   dependencies:
     eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6458 

### User facing changelog

- Fixed an issue where Cypress could crash with a "This socket has been ended by the other party" error when testing applications that make use of websockets.

### Additional details

- see https://github.com/http-party/node-http-proxy/issues/1432 for details

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [na] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
