### PR TITLE
Ignore invalid Set-Cookie values

### DIFF
--- a/packages/server/__snapshots__/2_cookies_spec.coffee.js
+++ b/packages/server/__snapshots__/2_cookies_spec.coffee.js
@@ -33,6 +33,7 @@ exports['e2e cookies with baseurl'] = `
       ✓ can set and clear cookie
       in a cy.visit
         ✓ can successfully send cookies as a Cookie header
+        ✓ ignores invalid set-cookie headers that contain control chars
         with Domain = superdomain
           ✓ is set properly with no redirects
           ✓ is set properly with redirects
@@ -48,6 +49,7 @@ exports['e2e cookies with baseurl'] = `
           ✓ can set cookies on lots of redirects, ending with same domain
       in a cy.request
         ✓ can successfully send cookies as a Cookie header
+        ✓ ignores invalid set-cookie headers that contain control chars
         with Domain = superdomain
           ✓ is set properly with no redirects
           ✓ is set properly with redirects
@@ -63,14 +65,14 @@ exports['e2e cookies with baseurl'] = `
           ✓ can set cookies on lots of redirects, ending with same domain
 
 
-  30 passing
+  32 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        30                                                                               │
-  │ Passing:      30                                                                               │
+  │ Tests:        32                                                                               │
+  │ Passing:      32                                                                               │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -94,81 +96,9 @@ exports['e2e cookies with baseurl'] = `
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  cookies_spec_baseurl.coffee              XX:XX       30       30        -        -        - │
+  │ ✔  cookies_spec_baseurl.coffee              XX:XX       32       32        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX       30       30        -        -        -  
-
-
-`
-
-exports['e2e cookies with no baseurl'] = `
-
-====================================================================================================
-
-  (Run Starting)
-
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Cypress:    1.2.3                                                                              │
-  │ Browser:    FooBrowser 88                                                                      │
-  │ Specs:      1 found (cookies_spec_no_baseurl.coffee)                                           │
-  │ Searched:   cypress/integration/cookies_spec_no_baseurl.coffee                                 │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-────────────────────────────────────────────────────────────────────────────────────────────────────
-                                                                                                    
-  Running:  cookies_spec_no_baseurl.coffee                                                  (1 of 1)
-
-
-  cookies
-    with whitelist
-      ✓ can get all cookies
-      ✓ resets cookies between tests correctly
-      ✓ should be only two left now
-      ✓ handles undefined cookies
-    without whitelist
-      ✓ sends cookies to localhost:2121
-      ✓ handles expired cookies secure
-      ✓ issue: #224 sets expired cookies between redirects
-      ✓ issue: #1321 failing to set or parse cookie
-      ✓ issue: #2724 does not fail on invalid cookies
-
-
-  9 passing
-
-
-  (Results)
-
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        9                                                                                │
-  │ Passing:      9                                                                                │
-  │ Failing:      0                                                                                │
-  │ Pending:      0                                                                                │
-  │ Skipped:      0                                                                                │
-  │ Screenshots:  0                                                                                │
-  │ Video:        true                                                                             │
-  │ Duration:     X seconds                                                                        │
-  │ Spec Ran:     cookies_spec_no_baseurl.coffee                                                   │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Video)
-
-  -  Started processing:  Compressing to 32 CRF                                                     
-  -  Finished processing: /XXX/XXX/XXX/cypress/videos/cookies_spec_no_baseurl.coffee.     (X second)
-                          mp4                                                                       
-
-
-====================================================================================================
-
-  (Run Finished)
-
-
-       Spec                                              Tests  Passing  Failing  Pending  Skipped  
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  cookies_spec_no_baseurl.coffee           XX:XX        9        9        -        -        - │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        9        9        -        -        -  
+    ✔  All specs passed!                        XX:XX       32       32        -        -        -  
 
 
 `

--- a/packages/server/__snapshots__/2_cookies_spec.coffee.js
+++ b/packages/server/__snapshots__/2_cookies_spec.coffee.js
@@ -102,3 +102,75 @@ exports['e2e cookies with baseurl'] = `
 
 
 `
+
+exports['e2e cookies with no baseurl'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      1 found (cookies_spec_no_baseurl.coffee)                                           │
+  │ Searched:   cypress/integration/cookies_spec_no_baseurl.coffee                                 │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  cookies_spec_no_baseurl.coffee                                                  (1 of 1)
+
+
+  cookies
+    with whitelist
+      ✓ can get all cookies
+      ✓ resets cookies between tests correctly
+      ✓ should be only two left now
+      ✓ handles undefined cookies
+    without whitelist
+      ✓ sends cookies to localhost:2121
+      ✓ handles expired cookies secure
+      ✓ issue: #224 sets expired cookies between redirects
+      ✓ issue: #1321 failing to set or parse cookie
+      ✓ issue: #2724 does not fail on invalid cookies
+
+
+  9 passing
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        9                                                                                │
+  │ Passing:      9                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     cookies_spec_no_baseurl.coffee                                                   │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/cookies_spec_no_baseurl.coffee.     (X second)
+                          mp4                                                                       
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✔  cookies_spec_no_baseurl.coffee           XX:XX        9        9        -        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✔  All specs passed!                        XX:XX        9        9        -        -        -  
+
+
+`

--- a/packages/server/lib/request.coffee
+++ b/packages/server/lib/request.coffee
@@ -490,6 +490,8 @@ module.exports = (options = {}) ->
         debug('parsing cookie %o', { cyCookie, toughCookie: cookie })
 
         if not cookie
+          ## ignore invalid cookies (same as browser behavior)
+          ## https://github.com/cypress-io/cypress/issues/6890
           debug('tough-cookie failed to parse, ignoring')
           return
 

--- a/packages/server/lib/request.coffee
+++ b/packages/server/lib/request.coffee
@@ -519,7 +519,7 @@ module.exports = (options = {}) ->
 
         automationFn(automationCmd, cookie)
         .catch (err) ->
-          debug('automation failed clearing cookie %o', { automationCmd, cookie, err })
+          debug('automation threw an error during cookie change %o', { automationCmd, cyCookie, cookie, err })
 
     sendStream: (headers, automationFn, options = {}) ->
       _.defaults options, {

--- a/packages/server/lib/request.coffee
+++ b/packages/server/lib/request.coffee
@@ -489,6 +489,10 @@ module.exports = (options = {}) ->
 
         debug('parsing cookie %o', { cyCookie, toughCookie: cookie })
 
+        if not cookie
+          debug('tough-cookie failed to parse, ignoring')
+          return
+
         cookie.name = cookie.key
 
         if not cookie.domain
@@ -504,14 +508,18 @@ module.exports = (options = {}) ->
         if isFinite(expiry)
           cookie.expiry = expiry / 1000
 
-        cookie = _.pick(cookie, SERIALIZABLE_COOKIE_PROPS)
-
-        if expiry <= 0
-          return automationFn('clear:cookie', cookie)
-
         cookie.sameSite = convertSameSiteToughToExtension(cookie.sameSite, cyCookie)
 
-        automationFn('set:cookie', cookie)
+        cookie = _.pick(cookie, SERIALIZABLE_COOKIE_PROPS)
+
+        automationCmd = 'set:cookie'
+
+        if expiry <= 0
+          automationCmd = 'clear:cookie'
+
+        automationFn(automationCmd, cookie)
+        .catch (err) ->
+          debug('automation failed clearing cookie %o', { automationCmd, cookie, err })
 
     sendStream: (headers, automationFn, options = {}) ->
       _.defaults options, {

--- a/packages/server/test/e2e/2_cookies_spec.coffee
+++ b/packages/server/test/e2e/2_cookies_spec.coffee
@@ -105,6 +105,17 @@ onServer = (app) ->
     res.setHeader("Set-Cookie", header)
     res.type('html').end()
 
+  app.get "/invalidControlCharCookie", (req, res) ->
+    ## `http` lib throws an error if we use .setHeader to set this
+    res.connection.end("""
+    HTTP/1.1 200 OK
+    Content-Type: text/html
+    Set-Cookie: ___utmvaFvuoaRv=TkE\u0001sCvZ; path=/; Max-Age=900
+    Set-Cookie: _valid=true; path=/; Max-Age=900
+
+    foo
+    """)
+
 haveRoot = !process.env.USE_HIGH_PORTS && process.geteuid() == 0
 
 if not haveRoot

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/cookies_spec_baseurl.coffee
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/cookies_spec_baseurl.coffee
@@ -195,6 +195,18 @@ describe "cookies", ->
               c: 's:PtCc3lNiuqN0AtR9ffgKUnUsDzR5n_4B.qzFDJDvqx8PZNvmOkmcexDs7fRJLOel56Z8Ii6PL+Fo'
             })
 
+        ## https://github.com/cypress-io/cypress/issues/6890
+        it "ignores invalid set-cookie headers that contain control chars", ->
+          cy[cmd]("/invalidControlCharCookie")
+
+          cy.request("/requestCookies")
+          .then (res) ->
+            return res.body
+          .then (cookies) ->
+            expect(cookies).to.deep.eq({
+              _valid: 'true'
+            })
+
         context "with Domain = superdomain", ->
           requestCookiesUrl = "#{Cypress.config('baseUrl')}/requestCookies"
           setDomainCookieUrl = "#{Cypress.config('baseUrl')}/setDomainCookie?domain=#{setCookieDomain}"


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6890

### User facing changelog

- Fixed an issue where invalid `Set-Cookie` values could cause requests to fail with a "cannot read property key of undefined" error. Now, invalid `Set-Cookie` values will be ignored.

### Additional details

- previously, this error was hidden behind the "Parse Error: Invalid header character", which was fixed in #5988 
- some users who were experiencing that error before 4.3.0 are now seeing this error
- correct way forward is to ignore the invalid values: https://github.com/cypress-io/cypress/issues/6890#issuecomment-609913483

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
