### PR TITLE
e2e tests: use snapshot instead of stdout contains assertion in e2e test

### DIFF
--- a/packages/server/__snapshots__/8_network_error_handling_spec.coffee.js
+++ b/packages/server/__snapshots__/8_network_error_handling_spec.coffee.js
@@ -326,3 +326,146 @@ exports['e2e network error handling Cypress does not delay a 304 Not Modified be
 
 
 `
+
+exports['e2e network error handling Cypress tests run as expected 1'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      1 found (network_error_handling_spec.js)                                           │
+  │ Searched:   cypress/integration/network_error_handling_spec.js                                 │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  network_error_handling_spec.js                                                  (1 of 1)
+
+
+  network error handling
+    cy.visit() retries
+      1) fails after retrying 5x
+      ✓ works on the third try after two failed requests
+      ✓ works on the third try after two 500 errors
+      ✓ re-sends a <form> body on failures
+    cy.request() retries
+      2) fails after retrying 5x
+      ✓ works on the third try after two failed requests
+      ✓ works on the third try after two 500 errors
+    subresource retries
+      ✓ on <img> tags
+      ✓ on <script> tags
+
+
+  7 passing
+  2 failing
+
+  1) network error handling cy.visit() retries fails after retrying 5x:
+     CypressError: \`cy.visit()\` failed trying to load:
+
+http://localhost:13370/immediate-reset?visit
+
+We attempted to make an http request to this URL but the request failed without a response.
+
+We received this error at the network level:
+
+  > Error: socket hang up
+
+Common situations why this would fail:
+  - you don't have internet access
+  - you forgot to run / boot your web server
+  - your web server isn't accessible
+  - you have weird network configuration settings on your computer
+
+The stack trace for this error is:
+
+Error: socket hang up
+    [stack trace lines]
+
+  
+
+  2) network error handling cy.request() retries fails after retrying 5x:
+     CypressError: \`cy.request()\` failed trying to load:
+
+http://localhost:13370/immediate-reset?request
+
+We attempted to make an http request to this URL but the request failed without a response.
+
+We received this error at the network level:
+
+  > Error: socket hang up
+
+-----------------------------------------------------------
+
+The request we sent was:
+
+Method: GET
+URL: http://localhost:13370/immediate-reset?request
+
+-----------------------------------------------------------
+
+Common situations why this would fail:
+  - you don't have internet access
+  - you forgot to run / boot your web server
+  - your web server isn't accessible
+  - you have weird network configuration settings on your computer
+
+The stack trace for this error is:
+
+RequestError: Error: socket hang up
+    [stack trace lines]
+
+
+https://on.cypress.io/request
+  
+
+
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        9                                                                                │
+  │ Passing:      7                                                                                │
+  │ Failing:      2                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  2                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     network_error_handling_spec.js                                                   │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Screenshots)
+
+  -  /XXX/XXX/XXX/cypress/screenshots/network_error_handling_spec.js/network error ha     (1280x720)
+     ndling -- cy.visit() retries -- fails after retrying 5x (failed).png                           
+  -  /XXX/XXX/XXX/cypress/screenshots/network_error_handling_spec.js/network error ha     (1280x720)
+     ndling -- cy.request() retries -- fails after retrying 5x (failed).png                         
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/network_error_handling_spec.js.     (X second)
+                          mp4                                                                       
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✖  network_error_handling_spec.js           XX:XX        9        7        2        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✖  1 of 1 failed (100%)                     XX:XX        9        7        2        -        -  
+
+
+`

--- a/packages/server/test/e2e/8_network_error_handling_spec.coffee
+++ b/packages/server/test/e2e/8_network_error_handling_spec.coffee
@@ -313,16 +313,8 @@ describe "e2e network error handling", ->
         spec: "network_error_handling_spec.js"
         video: false
         expectedExitCode: 2
+        snapshot: true
       }).then ({ stdout }) ->
-        expect(stdout).to.contain('1) network error handling cy.visit() retries fails after retrying 5x:')
-        expect(stdout).to.contain('CypressError: `cy.visit()` failed trying to load:')
-        expect(stdout).to.contain('http://localhost:13370/immediate-reset?visit')
-        expect(stdout).to.contain('We attempted to make an http request to this URL but the request failed without a response.')
-        expect(stdout).to.contain('We received this error at the network level:')
-        expect(stdout).to.contain('> Error: socket hang up')
-        expect(stdout).to.contain('2) network error handling cy.request() retries fails after retrying 5x:')
-        expect(stdout).to.contain('http://localhost:13370/immediate-reset?request')
-
         ## sometimes <img>, <script> get retried 2x by chrome instead of 1x
 
         if counts['/immediate-reset?load-img'] == 10


### PR DESCRIPTION
change an e2e test to use a snapshot instead of contains assertions
<!-- Example: "Closes #1234" -->

- Closes N/A

