### PR TITLE
Don’t remove stack from uncaught errors

### DIFF
--- a/packages/driver/src/cy/chai.js
+++ b/packages/driver/src/cy/chai.js
@@ -198,8 +198,8 @@ chai.use((chai, u) => {
     }
   }
 
-  const overrideChaiAsserts = function (assertFn) {
-    chai.Assertion.prototype.assert = createPatchedAssert(assertFn)
+  const overrideChaiAsserts = function (specWindow, assertFn) {
+    chai.Assertion.prototype.assert = createPatchedAssert(specWindow, assertFn)
 
     const _origGetmessage = function (obj, args) {
       const negate = chaiUtils.flag(obj, 'negate')
@@ -408,7 +408,7 @@ chai.use((chai, u) => {
     })
   }
 
-  const createPatchedAssert = (assertFn) => {
+  const createPatchedAssert = (specWindow, assertFn) => {
     return (function (...args) {
       let err
       const passed = chaiUtils.test(this, args)
@@ -430,9 +430,19 @@ chai.use((chai, u) => {
 
       assertFn(passed, message, value, actual, expected, err)
 
-      if (err) {
-        throw err
-      }
+      if (!err) return
+
+      // stack from chai AssertionError instances are useless, because
+      // the chai code is served from `top`, which binds to `top`'s Error
+      // but assertions fail inside the spec window and then err.stack
+      // will not include the frames from the spec window (a different window)
+      // for security purposes. therefore, we instantiate a new error on
+      // the spec window to get a better stack
+      const betterStackErr = new specWindow.Error(err.message)
+
+      err.stack = $errUtils.replacedStack(err, betterStackErr)
+
+      throw err
     })
   }
 
@@ -483,7 +493,7 @@ chai.use((chai, u) => {
 
     overrideChaiInspect()
     overrideChaiObjDisplay()
-    overrideChaiAsserts(assertFn)
+    overrideChaiAsserts(specWindow, assertFn)
 
     return setSpecWindowGlobals(specWindow)
   }

--- a/packages/driver/src/cy/chai.js
+++ b/packages/driver/src/cy/chai.js
@@ -340,7 +340,10 @@ chai.use((chai, u) => {
                 return `Not enough elements found. Found '${len1}', expected '${len2}'.`
               }
 
-              e1.message = getLongLengthMessage(obj.length, length)
+              const newMessage = getLongLengthMessage(obj.length, length)
+
+              $errUtils.modifyErrMsg(e1, newMessage, () => newMessage)
+
               throw e1
             }
 
@@ -400,7 +403,10 @@ chai.use((chai, u) => {
               return `Expected to find element: \`${obj.selector}\`, but never found it.`
             }
 
-            e1.message = getLongExistsMessage(obj)
+            const newMessage = getLongExistsMessage(obj)
+
+            $errUtils.modifyErrMsg(e1, newMessage, () => newMessage)
+
             throw e1
           }
         }

--- a/packages/driver/src/cy/commands/navigation.coffee
+++ b/packages/driver/src/cy/commands/navigation.coffee
@@ -386,20 +386,18 @@ module.exports = (Commands, Cypress, cy, state, config) ->
       cy.clearTimeout("reload")
 
       cleanup = null
-      options = null
+      options = _.defaults({}, userOptions, {
+        log: true
+        timeout: config("pageLoadTimeout")
+      })
 
       reload = ->
         new Promise (resolve, reject) ->
           forceReload ?= false
-          userOptions     ?= {}
+          userOptions ?= {}
 
           if not _.isObject(userOptions)
             throwArgsErr()
-
-          options = _.defaults {}, userOptions, {
-            log: true
-            timeout: config("pageLoadTimeout")
-          }
 
           if not _.isBoolean(forceReload)
             throwArgsErr()

--- a/packages/driver/src/cy/errors.coffee
+++ b/packages/driver/src/cy/errors.coffee
@@ -53,14 +53,14 @@ create = (state, config, log) ->
 
     uncaughtErrObj = $errUtils.errObjByPath($errorMessages, uncaughtErrLookup)
 
-    err.name = "Uncaught " + err.name
-
     uncaughtErrProps = $errUtils.modifyErrMsg(err, uncaughtErrObj.message, (msg1, msg2) ->
       return "#{msg1}\n\n#{msg2}"
     )
     _.defaults(uncaughtErrProps, uncaughtErrObj)
 
     uncaughtErr = $errUtils.mergeErrProps(err, uncaughtErrProps)
+
+    $errUtils.modifyErrName(err, "Uncaught #{err.name}")
 
     uncaughtErr.onFail = ->
       if l = current and current.getLastLog()

--- a/packages/driver/src/cypress/error_utils.js
+++ b/packages/driver/src/cypress/error_utils.js
@@ -60,6 +60,10 @@ const replacedStack = (err, newStackErr) => {
   const newStackErrString = newStackErr.toString()
   const stackLines = newStackErr.stack.replace(newStackErrString, '')
 
+  // sometimes the new stack doesn't include any lines, so just stick
+  // with the original stack
+  if (!stackLines) return err.stack
+
   return `${errString}${stackLines}`
 }
 

--- a/packages/driver/src/cypress/error_utils.js
+++ b/packages/driver/src/cypress/error_utils.js
@@ -18,6 +18,23 @@ const mergeErrProps = (origErr, ...newProps) => {
   return _.extend(origErr, ...newProps)
 }
 
+const replaceNameInStack = (err, newName) => {
+  const { name, stack } = err
+
+  if (!stack) return stack
+
+  return stack.replace(name, newName)
+}
+
+const modifyErrName = (err, newName) => {
+  const newStack = replaceNameInStack(err, newName)
+
+  err.name = newName
+  err.stack = newStack
+
+  return err
+}
+
 const replaceMsgInStack = (err, newMsg) => {
   const { message, name, stack } = err
 
@@ -294,6 +311,7 @@ module.exports = {
   makeErrFromObj,
   mergeErrProps,
   modifyErrMsg,
+  modifyErrName,
   normalizeErrorStack,
   normalizeMsgNewLines,
   processErr,

--- a/packages/driver/src/cypress/error_utils.js
+++ b/packages/driver/src/cypress/error_utils.js
@@ -51,14 +51,19 @@ const replaceMsgInStack = (err, newMsg) => {
   return stack.replace(name, `${name}: ${newMsg}`)
 }
 
+const newLineAtBeginningRe = /^\n+/
+
 const replacedStack = (err, newStackErr) => {
   // if err already lacks a stack or we've removed the stack
   // for some reason, keep it stackless
   if (!err.stack) return err.stack
 
   const errString = err.toString()
-  const newStackErrStringRe = new RegExp(`${newStackErr.toString()}\n?`)
-  const stackLines = newStackErr.stack.replace(newStackErrStringRe, '')
+
+  const newStackErrString = newStackErr.toString()
+  const stackLines = newStackErr.stack
+  .replace(newStackErrString, '')
+  .replace(newLineAtBeginningRe, '')
 
   // sometimes the new stack doesn't include any lines, so just stick
   // with the original stack

--- a/packages/driver/src/cypress/error_utils.js
+++ b/packages/driver/src/cypress/error_utils.js
@@ -51,6 +51,18 @@ const replaceMsgInStack = (err, newMsg) => {
   return stack.replace(name, `${name}: ${newMsg}`)
 }
 
+const replacedStack = (err, newStackErr) => {
+  // if err already lacks a stack or we've removed the stack
+  // for some reason, keep it stackless
+  if (!err.stack) return err.stack
+
+  const errString = err.toString()
+  const newStackErrString = newStackErr.toString()
+  const stackLines = newStackErr.stack.replace(newStackErrString, '')
+
+  return `${errString}${stackLines}`
+}
+
 const modifyErrMsg = (err, newErrMsg, cb) => {
   err = normalizeErrorStack(err)
 
@@ -314,6 +326,7 @@ module.exports = {
   modifyErrName,
   normalizeErrorStack,
   normalizeMsgNewLines,
+  replacedStack,
   processErr,
   throwErr,
   throwErrByPath,

--- a/packages/driver/src/cypress/error_utils.js
+++ b/packages/driver/src/cypress/error_utils.js
@@ -57,14 +57,14 @@ const replacedStack = (err, newStackErr) => {
   if (!err.stack) return err.stack
 
   const errString = err.toString()
-  const newStackErrString = newStackErr.toString()
-  const stackLines = newStackErr.stack.replace(newStackErrString, '')
+  const newStackErrStringRe = new RegExp(`${newStackErr.toString()}\n?`)
+  const stackLines = newStackErr.stack.replace(newStackErrStringRe, '')
 
   // sometimes the new stack doesn't include any lines, so just stick
   // with the original stack
   if (!stackLines) return err.stack
 
-  return `${errString}${stackLines}`
+  return `${errString}\n${stackLines}`
 }
 
 const modifyErrMsg = (err, newErrMsg, cb) => {

--- a/packages/driver/src/cypress/runner.js
+++ b/packages/driver/src/cypress/runner.js
@@ -815,9 +815,6 @@ const create = function (specWindow, mocha, Cypress, cy) {
     // else  do the same thing as mocha here
     err = $errUtils.appendErrMsg(err, append())
 
-    // remove this error's stack since it gives no valuable context
-    err.stack = ''
-
     const throwErr = function () {
       throw err
     }

--- a/packages/driver/test/cypress/integration/cypress/error_utils_spec.js
+++ b/packages/driver/test/cypress/integration/cypress/error_utils_spec.js
@@ -366,4 +366,29 @@ describe('driver/src/cypress/error_utils', () => {
       expect(newErr.stack).not.to.include('\nError')
     })
   })
+
+  context('.modifyErrName', () => {
+    it('returns same error', () => {
+      const err = new Error('message')
+      const result = $errUtils.modifyErrName(err, 'New Name')
+
+      expect(result).to.equal(err)
+    })
+
+    it('replaces name in err', () => {
+      const err = new Error('message')
+      const result = $errUtils.modifyErrName(err, 'New Name')
+
+      expect(result.name).to.equal('New Name')
+    })
+
+    it('replaces stack to include new name', () => {
+      const err = new Error('message')
+
+      $errUtils.normalizeErrorStack(err)
+      const result = $errUtils.modifyErrName(err, 'New Name')
+
+      expect(result.stack).to.include('New Name: message')
+    })
+  })
 })

--- a/packages/driver/test/cypress/integration/cypress/error_utils_spec.js
+++ b/packages/driver/test/cypress/integration/cypress/error_utils_spec.js
@@ -391,4 +391,27 @@ describe('driver/src/cypress/error_utils', () => {
       expect(result.stack).to.include('New Name: message')
     })
   })
+
+  context('.replacedStack', () => {
+    it('returns original stack if it is falsey', () => {
+      const err = new Error('message')
+
+      err.stack = ''
+      const stack = $errUtils.replacedStack(err)
+
+      expect(stack).to.equal('')
+    })
+
+    it('replaces stack in error with new stack', () => {
+      const err = new Error('message')
+      const newStackErr = new Error('different')
+
+      newStackErr.stack = 'new stack'
+      const stack = $errUtils.replacedStack(err, newStackErr)
+
+      expect(stack).to.include('message')
+      expect(stack).to.include('new stack')
+      expect(stack).not.to.include('different')
+    })
+  })
 })

--- a/packages/driver/test/cypress/integration/cypress/error_utils_spec.js
+++ b/packages/driver/test/cypress/integration/cypress/error_utils_spec.js
@@ -409,9 +409,7 @@ describe('driver/src/cypress/error_utils', () => {
       newStackErr.stack = 'new stack'
       const stack = $errUtils.replacedStack(err, newStackErr)
 
-      expect(stack).to.include('message')
-      expect(stack).to.include('new stack')
-      expect(stack).not.to.include('different')
+      expect(stack).to.equal('Error: message\nnew stack')
     })
   })
 })

--- a/packages/server/__snapshots__/1_commands_outside_of_test_spec.coffee.js
+++ b/packages/server/__snapshots__/1_commands_outside_of_test_spec.coffee.js
@@ -91,7 +91,7 @@ When Cypress detects uncaught errors originating from your test code it will aut
 Cypress could not associate this error to any specific test.
 
 We dynamically generated a new test to display this failure.
-  
+      [stack trace lines]
 
 
 

--- a/packages/server/__snapshots__/1_commands_outside_of_test_spec.coffee.js
+++ b/packages/server/__snapshots__/1_commands_outside_of_test_spec.coffee.js
@@ -91,7 +91,7 @@ When Cypress detects uncaught errors originating from your test code it will aut
 Cypress could not associate this error to any specific test.
 
 We dynamically generated a new test to display this failure.
-  
+  AssertionError: expected true to be false
 
 
 
@@ -181,7 +181,7 @@ Cypress could not associate this error to any specific test.
 We dynamically generated a new test to display this failure.
 
 https://on.cypress.io/cannot-execute-commands-outside-test
-  
+      [stack trace lines]
 
 
 

--- a/packages/server/__snapshots__/1_commands_outside_of_test_spec.coffee.js
+++ b/packages/server/__snapshots__/1_commands_outside_of_test_spec.coffee.js
@@ -91,7 +91,7 @@ When Cypress detects uncaught errors originating from your test code it will aut
 Cypress could not associate this error to any specific test.
 
 We dynamically generated a new test to display this failure.
-  AssertionError: expected true to be false
+  
 
 
 

--- a/packages/server/__snapshots__/6_uncaught_spec_errors_spec.coffee.js
+++ b/packages/server/__snapshots__/6_uncaught_spec_errors_spec.coffee.js
@@ -32,7 +32,7 @@ When Cypress detects uncaught errors originating from your test code it will aut
 Cypress could not associate this error to any specific test.
 
 We dynamically generated a new test to display this failure.
-  
+      [stack trace lines]
 
 
 
@@ -114,7 +114,7 @@ When Cypress detects uncaught errors originating from your test code it will aut
 Cypress could not associate this error to any specific test.
 
 We dynamically generated a new test to display this failure.
-  
+      [stack trace lines]
 
 
 

--- a/packages/server/__snapshots__/6_uncaught_support_file_spec.coffee.js
+++ b/packages/server/__snapshots__/6_uncaught_support_file_spec.coffee.js
@@ -31,7 +31,7 @@ When Cypress detects uncaught errors originating from your test code it will aut
 Cypress could not associate this error to any specific test.
 
 We dynamically generated a new test to display this failure.
-  
+      [stack trace lines]
 
 
 

--- a/packages/server/__snapshots__/7_record_spec.coffee.js
+++ b/packages/server/__snapshots__/7_record_spec.coffee.js
@@ -177,7 +177,7 @@ When Cypress detects uncaught errors originating from your test code it will aut
 Cypress could not associate this error to any specific test.
 
 We dynamically generated a new test to display this failure.
-  
+      [stack trace lines]
 
 
 
@@ -1061,7 +1061,7 @@ When Cypress detects uncaught errors originating from your test code it will aut
 Cypress could not associate this error to any specific test.
 
 We dynamically generated a new test to display this failure.
-  
+      [stack trace lines]
 
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6964 
- Closes #6969 

### User facing changelog

- Uncaught errors now display their stack trace
- Assertion errors now include a stack trace that includes the calling code

### How has the user experience changed?

Uncaught error - stdout before:

![Screen Shot 2020-04-08 at 11 09 24 AM](https://user-images.githubusercontent.com/1157043/78800530-8c53bd00-7989-11ea-934b-60d0bd034616.png)

Uncaught error - stdout after:

![Screen Shot 2020-04-08 at 11 10 15 AM](https://user-images.githubusercontent.com/1157043/78800542-907fda80-7989-11ea-8666-553fc0d170ec.png)

Assertion error - stdout before:

<img width="1249" alt="Screen Shot 2020-04-08 at 5 59 02 PM" src="https://user-images.githubusercontent.com/1157043/78837757-b70e3780-79c2-11ea-895f-897532450a71.png">

Assertion error - stdout after:

<img width="918" alt="Screen Shot 2020-04-08 at 5 59 56 PM" src="https://user-images.githubusercontent.com/1157043/78837781-c5f4ea00-79c2-11ea-9146-09b94d9dbfba.png">


### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
