### PR TITLE
Strip document-domain directive from feature-policy header when…

### DIFF
--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -249,7 +249,13 @@ const MaybeStripDocumentDomainFeaturePolicy: ResponseMiddleware = function () {
     if (directives['document-domain']) {
       delete directives['document-domain']
 
-      this.res.set('feature-policy', stringifyFeaturePolicy(directives))
+      const policy = stringifyFeaturePolicy(directives)
+
+      if (policy) {
+        this.res.set('feature-policy', policy)
+      } else {
+        this.res.removeHeader('feature-policy')
+      }
     }
   }
 

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -232,6 +232,7 @@ const OmitProblematicHeaders: ResponseMiddleware = function () {
     'content-length',
     'content-security-policy',
     'connection',
+    'feature-policy',
   ])
 
   this.res.set(headers)

--- a/packages/proxy/test/unit/http/response-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/response-middleware.spec.ts
@@ -14,6 +14,7 @@ describe('http/response-middleware', function () {
       'SetInjectionLevel',
       'OmitProblematicHeaders',
       'MaybePreventCaching',
+      'MaybeStripDocumentDomainFeaturePolicy',
       'CopyCookiesFromIncomingRes',
       'MaybeSendRedirectToClient',
       'CopyResponseStatusCode',
@@ -24,7 +25,6 @@ describe('http/response-middleware', function () {
       'MaybeRemoveSecurity',
       'GzipBody',
       'SendResponseBodyToClient',
-      'MaybeStripDocumentDomainFeaturePolicy',
     ])
   })
 

--- a/packages/proxy/test/unit/http/response-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/response-middleware.spec.ts
@@ -1,6 +1,10 @@
 import _ from 'lodash'
 import ResponseMiddleware from '../../../lib/http/response-middleware'
 import { expect } from 'chai'
+import sinon from 'sinon'
+import {
+  testMiddleware,
+} from './helpers'
 
 describe('http/response-middleware', function () {
   it('exports the members in the correct order', function () {
@@ -21,5 +25,35 @@ describe('http/response-middleware', function () {
       'GzipBody',
       'SendResponseBodyToClient',
     ])
+  })
+
+  describe('OmitProblematicHeaders', function () {
+    let ctx
+    const { OmitProblematicHeaders } = ResponseMiddleware
+    const headers = {
+      pragma: 'no-cache',
+      'feature-policy': 'autoplay \'self\'; document-domain \'none\', camera \'none\'',
+      'referrer-policy': 'same-origin',
+    }
+
+    beforeEach(function () {
+      ctx = {
+        res: {
+          set: sinon.stub(),
+        },
+        incomingRes: {
+          headers,
+        },
+      }
+    })
+
+    it('removes the feature-policy header', function () {
+      return testMiddleware([OmitProblematicHeaders], ctx)
+      .then(() => {
+        const expectedHeaders = _.omit(headers, 'feature-policy')
+
+        expect(ctx.res.set).to.be.calledWith(expectedHeaders)
+      })
+    })
   })
 })


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6480 

### User facing changelog

Cypress will now strip the [`document-domain`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy/document-domain) directive from the [`Feature-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy) response header, as its allowlist could prevent the tests from running properly (see #6480)

### Additional details

#### Why was this change necessary?
If a server was set up to serve resources with the `document-domain 'none'` directive, Cypress would either fail to run the test (with `"chromeWebSecurity": true`) or fail to log/intercept/mock requests and responses (with `"chromeWebSecurity": false`)

#### What is affected by this change?
Any response given by the server is stripped of the aforementioned directive, if present

#### Any implementation details to explain?
I went for the quicker route of stripping the whole header instead of just the directive. If this is too broad a stroke I can change the implementation and strip only the directive instead (but I would probably need some pointers re where to do it, I'm not sure if `OmitProblematicHeaders` would be the right place for that)

**UPDATE** We now only strip the `document-domain` directive, leaving the other header's directives in place

### How has the user experience changed?

#### Before
<img width="480" alt="before" src="https://user-images.githubusercontent.com/6400898/79222956-c37a1080-7e58-11ea-8e80-82162a40a6af.png">

_(with `"chromeWebSecurity": true`)_

#### After
<img width="476" alt="after" src="https://user-images.githubusercontent.com/6400898/79222953-c248e380-7e58-11ea-9c79-d7659655a20a.png">

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->