### PR TITLE
fix error thrown when mouseup element is detached before click

### DIFF
--- a/packages/driver/src/cy/mouse.js
+++ b/packages/driver/src/cy/mouse.js
@@ -540,7 +540,7 @@ const create = (state, keyboard, focused, Cypress) => {
         }
 
         // Only send click event if mousedown element is not detached.
-        if ($elements.isDetachedEl(mouseDownPhase.targetEl)) {
+        if ($elements.isDetachedEl(mouseDownPhase.targetEl) || $elements.isDetached(mouseUpPhase.targetEl)) {
           return { skipClickEventReason: 'element was detached' }
         }
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->
- fix an edge case where we needed to check for mouseup target element detached state before click
<!-- Example: "Closes #1234" -->

- fix #6923

### User facing changelog
- Bug fix: Cypress no longer throws an error when elements are detached from the DOM during a 'mouseup' handler.
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
