### PR TITLE
Fix using Chromium installed via snapcraft

### DIFF
--- a/packages/desktop-gui/cypress/integration/project_nav_spec.js
+++ b/packages/desktop-gui/cypress/integration/project_nav_spec.js
@@ -257,7 +257,7 @@ describe('Project Nav', function () {
           const browserArg = this.ipc.launchBrowser.getCall(0).args[0].browser
 
           expect(browserArg).to.have.keys([
-            'family', 'name', 'path', 'version', 'majorVersion', 'displayName', 'info', 'isChosen', 'custom', 'warning', 'channel',
+            'family', 'name', 'path', 'profilePath', 'version', 'majorVersion', 'displayName', 'info', 'isChosen', 'custom', 'warning', 'channel',
           ])
 
           expect(browserArg.path).to.include('/')

--- a/packages/desktop-gui/src/lib/browser-model.js
+++ b/packages/desktop-gui/src/lib/browser-model.js
@@ -7,6 +7,7 @@ export default class Browser {
   @observable channel
   @observable version
   @observable path
+  @observable profilePath
   @observable majorVersion
   @observable info
   @observable custom
@@ -20,6 +21,7 @@ export default class Browser {
     this.channel = browser.channel
     this.version = browser.version
     this.path = browser.path
+    this.profilePath = browser.profilePath
     this.majorVersion = browser.majorVersion
     this.info = browser.info
     this.custom = browser.custom

--- a/packages/launcher/__snapshots__/browsers_spec.ts.js
+++ b/packages/launcher/__snapshots__/browsers_spec.ts.js
@@ -5,7 +5,6 @@ exports['browsers returns the expected list of browsers 1'] = [
     "channel": "stable",
     "displayName": "Chrome",
     "versionRegex": {},
-    "profile": true,
     "binary": [
       "google-chrome",
       "chrome",
@@ -18,7 +17,6 @@ exports['browsers returns the expected list of browsers 1'] = [
     "channel": "stable",
     "displayName": "Chromium",
     "versionRegex": {},
-    "profile": true,
     "binary": [
       "chromium-browser",
       "chromium"
@@ -30,7 +28,6 @@ exports['browsers returns the expected list of browsers 1'] = [
     "channel": "canary",
     "displayName": "Canary",
     "versionRegex": {},
-    "profile": true,
     "binary": "google-chrome-canary"
   },
   {
@@ -40,7 +37,6 @@ exports['browsers returns the expected list of browsers 1'] = [
     "displayName": "Firefox",
     "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
-    "profile": true,
     "binary": "firefox"
   },
   {
@@ -50,7 +46,6 @@ exports['browsers returns the expected list of browsers 1'] = [
     "displayName": "Firefox Developer Edition",
     "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
-    "profile": true,
     "binary": [
       "firefox-developer-edition",
       "firefox"
@@ -63,7 +58,6 @@ exports['browsers returns the expected list of browsers 1'] = [
     "displayName": "Firefox Nightly",
     "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
-    "profile": true,
     "binary": [
       "firefox-nightly",
       "firefox-trunk"
@@ -75,7 +69,6 @@ exports['browsers returns the expected list of browsers 1'] = [
     "channel": "stable",
     "displayName": "Edge",
     "versionRegex": {},
-    "profile": true,
     "binary": "edge"
   },
   {
@@ -84,7 +77,6 @@ exports['browsers returns the expected list of browsers 1'] = [
     "channel": "canary",
     "displayName": "Edge Canary",
     "versionRegex": {},
-    "profile": true,
     "binary": "edge-canary"
   },
   {
@@ -93,7 +85,6 @@ exports['browsers returns the expected list of browsers 1'] = [
     "channel": "beta",
     "displayName": "Edge Beta",
     "versionRegex": {},
-    "profile": true,
     "binary": "edge-beta"
   },
   {
@@ -102,7 +93,6 @@ exports['browsers returns the expected list of browsers 1'] = [
     "channel": "dev",
     "displayName": "Edge Dev",
     "versionRegex": {},
-    "profile": true,
     "binary": "edge-dev"
   }
 ]

--- a/packages/launcher/__snapshots__/darwin_spec.ts.js
+++ b/packages/launcher/__snapshots__/darwin_spec.ts.js
@@ -5,7 +5,6 @@ exports['darwin browser detection detects browsers as expected 1'] = [
     "channel": "stable",
     "displayName": "Chrome",
     "versionRegex": {},
-    "profile": true,
     "binary": [
       "google-chrome",
       "chrome",
@@ -26,7 +25,6 @@ exports['darwin browser detection detects browsers as expected 1'] = [
     "channel": "stable",
     "displayName": "Chromium",
     "versionRegex": {},
-    "profile": true,
     "binary": [
       "chromium-browser",
       "chromium"
@@ -46,7 +44,6 @@ exports['darwin browser detection detects browsers as expected 1'] = [
     "channel": "canary",
     "displayName": "Canary",
     "versionRegex": {},
-    "profile": true,
     "binary": "google-chrome-canary",
     "path": "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
     "version": "someVersion",
@@ -64,7 +61,6 @@ exports['darwin browser detection detects browsers as expected 1'] = [
     "displayName": "Firefox",
     "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
-    "profile": true,
     "binary": "firefox",
     "path": "/Applications/Firefox.app/Contents/MacOS/firefox-bin",
     "version": "someVersion",
@@ -82,7 +78,6 @@ exports['darwin browser detection detects browsers as expected 1'] = [
     "displayName": "Firefox Developer Edition",
     "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
-    "profile": true,
     "binary": [
       "firefox-developer-edition",
       "firefox"
@@ -103,7 +98,6 @@ exports['darwin browser detection detects browsers as expected 1'] = [
     "displayName": "Firefox Nightly",
     "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
-    "profile": true,
     "binary": [
       "firefox-nightly",
       "firefox-trunk"
@@ -123,7 +117,6 @@ exports['darwin browser detection detects browsers as expected 1'] = [
     "channel": "stable",
     "displayName": "Edge",
     "versionRegex": {},
-    "profile": true,
     "binary": "edge",
     "path": "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
     "version": "someVersion",
@@ -140,7 +133,6 @@ exports['darwin browser detection detects browsers as expected 1'] = [
     "channel": "canary",
     "displayName": "Edge Canary",
     "versionRegex": {},
-    "profile": true,
     "binary": "edge-canary",
     "path": "/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary",
     "version": "someVersion",
@@ -157,7 +149,6 @@ exports['darwin browser detection detects browsers as expected 1'] = [
     "channel": "beta",
     "displayName": "Edge Beta",
     "versionRegex": {},
-    "profile": true,
     "binary": "edge-beta",
     "path": "/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta",
     "version": "someVersion",
@@ -174,7 +165,6 @@ exports['darwin browser detection detects browsers as expected 1'] = [
     "channel": "dev",
     "displayName": "Edge Dev",
     "versionRegex": {},
-    "profile": true,
     "binary": "edge-dev",
     "path": "/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev",
     "version": "someVersion",

--- a/packages/launcher/__snapshots__/windows_spec.ts.js
+++ b/packages/launcher/__snapshots__/windows_spec.ts.js
@@ -5,7 +5,6 @@ exports['windows browser detection detects browsers as expected 1'] = [
     "channel": "stable",
     "displayName": "Chrome",
     "versionRegex": {},
-    "profile": true,
     "binary": [
       "google-chrome",
       "chrome",
@@ -26,7 +25,6 @@ exports['windows browser detection detects browsers as expected 1'] = [
     "channel": "stable",
     "displayName": "Chromium",
     "versionRegex": {},
-    "profile": true,
     "binary": [
       "chromium-browser",
       "chromium"
@@ -46,7 +44,6 @@ exports['windows browser detection detects browsers as expected 1'] = [
     "channel": "canary",
     "displayName": "Canary",
     "versionRegex": {},
-    "profile": true,
     "binary": "google-chrome-canary",
     "path": "C:/Users/flotwig/AppData/Local/Google/Chrome SxS/Application/chrome.exe",
     "version": "3.4.5",
@@ -64,7 +61,6 @@ exports['windows browser detection detects browsers as expected 1'] = [
     "displayName": "Firefox",
     "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
-    "profile": true,
     "binary": "firefox",
     "path": "C:/Program Files/Mozilla Firefox/firefox.exe",
     "version": "72",
@@ -82,7 +78,6 @@ exports['windows browser detection detects browsers as expected 1'] = [
     "displayName": "Firefox Developer Edition",
     "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
-    "profile": true,
     "binary": [
       "firefox-developer-edition",
       "firefox"
@@ -103,7 +98,6 @@ exports['windows browser detection detects browsers as expected 1'] = [
     "displayName": "Firefox Nightly",
     "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
-    "profile": true,
     "binary": [
       "firefox-nightly",
       "firefox-trunk"
@@ -123,7 +117,6 @@ exports['windows browser detection detects browsers as expected 1'] = [
     "channel": "stable",
     "displayName": "Edge",
     "versionRegex": {},
-    "profile": true,
     "binary": "edge",
     "path": "C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe",
     "version": "11",
@@ -140,7 +133,6 @@ exports['windows browser detection detects browsers as expected 1'] = [
     "channel": "canary",
     "displayName": "Edge Canary",
     "versionRegex": {},
-    "profile": true,
     "binary": "edge-canary",
     "path": "C:/Users/flotwig/AppData/Local/Microsoft/Edge SxS/Application/msedge.exe",
     "version": "14",
@@ -157,7 +149,6 @@ exports['windows browser detection detects browsers as expected 1'] = [
     "channel": "beta",
     "displayName": "Edge Beta",
     "versionRegex": {},
-    "profile": true,
     "binary": "edge-beta",
     "path": "C:/Program Files (x86)/Microsoft/Edge Beta/Application/msedge.exe",
     "version": "12",
@@ -174,7 +165,6 @@ exports['windows browser detection detects browsers as expected 1'] = [
     "channel": "dev",
     "displayName": "Edge Dev",
     "versionRegex": {},
-    "profile": true,
     "binary": "edge-dev",
     "path": "C:/Program Files (x86)/Microsoft/Edge Dev/Application/msedge.exe",
     "version": "13",

--- a/packages/launcher/lib/browsers.ts
+++ b/packages/launcher/lib/browsers.ts
@@ -12,7 +12,6 @@ export const browsers: Browser[] = [
     channel: 'stable',
     displayName: 'Chrome',
     versionRegex: /Google Chrome (\S+)/m,
-    profile: true,
     binary: ['google-chrome', 'chrome', 'google-chrome-stable'],
   },
   {
@@ -22,7 +21,6 @@ export const browsers: Browser[] = [
     channel: 'stable',
     displayName: 'Chromium',
     versionRegex: /Chromium (\S+)/m,
-    profile: true,
     binary: ['chromium-browser', 'chromium'],
   },
   {
@@ -31,7 +29,6 @@ export const browsers: Browser[] = [
     channel: 'canary',
     displayName: 'Canary',
     versionRegex: /Google Chrome Canary (\S+)/m,
-    profile: true,
     binary: 'google-chrome-canary',
   },
   {
@@ -42,7 +39,6 @@ export const browsers: Browser[] = [
     info: firefoxInfo,
     // Mozilla Firefox 70.0.1
     versionRegex: /^Mozilla Firefox ([^\sab]+)$/m,
-    profile: true,
     binary: 'firefox',
   },
   {
@@ -53,7 +49,6 @@ export const browsers: Browser[] = [
     info: firefoxInfo,
     // Mozilla Firefox 73.0b12
     versionRegex: /^Mozilla Firefox (\S+b\S*)$/m,
-    profile: true,
     // ubuntu PPAs install it as firefox
     binary: ['firefox-developer-edition', 'firefox'],
   },
@@ -65,7 +60,6 @@ export const browsers: Browser[] = [
     info: firefoxInfo,
     // Mozilla Firefox 74.0a1
     versionRegex: /^Mozilla Firefox (\S+a\S*)$/m,
-    profile: true,
     // ubuntu PPAs install it as firefox-trunk
     binary: ['firefox-nightly', 'firefox-trunk'],
   },
@@ -75,7 +69,6 @@ export const browsers: Browser[] = [
     channel: 'stable',
     displayName: 'Edge',
     versionRegex: /Microsoft Edge (\S+)/m,
-    profile: true,
     binary: 'edge',
   },
   {
@@ -84,7 +77,6 @@ export const browsers: Browser[] = [
     channel: 'canary',
     displayName: 'Edge Canary',
     versionRegex: /Microsoft Edge Canary (\S+)/m,
-    profile: true,
     binary: 'edge-canary',
   },
   {
@@ -93,7 +85,6 @@ export const browsers: Browser[] = [
     channel: 'beta',
     displayName: 'Edge Beta',
     versionRegex: /Microsoft Edge Beta (\S+)/m,
-    profile: true,
     binary: 'edge-beta',
   },
   {
@@ -102,7 +93,6 @@ export const browsers: Browser[] = [
     channel: 'dev',
     displayName: 'Edge Dev',
     versionRegex: /Microsoft Edge Dev (\S+)/m,
-    profile: true,
     binary: 'edge-dev',
   },
 ]

--- a/packages/launcher/lib/detect.ts
+++ b/packages/launcher/lib/detect.ts
@@ -99,6 +99,7 @@ function checkOneBrowser (browser: Browser): Promise<boolean | FoundBrowser> {
     'type',
     'version',
     'path',
+    'profilePath',
     'custom',
     'warning',
     'info',

--- a/packages/launcher/lib/linux/index.ts
+++ b/packages/launcher/lib/linux/index.ts
@@ -52,6 +52,7 @@ export function getVersionString (path: string) {
   log('finding version string using command "%s --version"', path)
 
   return utils.getOutput(path, ['--version'])
+  .timeout(5000, `Timed out getting version for ${path}`)
   .then(prop('stdout'))
   .then(trim)
   .then(tap(partial(log, ['stdout: "%s"'])))

--- a/packages/launcher/lib/linux/index.ts
+++ b/packages/launcher/lib/linux/index.ts
@@ -51,7 +51,7 @@ function getLinuxBrowser (
 export function getVersionString (path: string) {
   log('finding version string using command "%s --version"', path)
 
-  return utils.execa(path, ['--version'])
+  return utils.getOutput(path, ['--version'])
   .then(prop('stdout'))
   .then(trim)
   .then(tap(partial(log, ['stdout: "%s"'])))

--- a/packages/launcher/lib/linux/index.ts
+++ b/packages/launcher/lib/linux/index.ts
@@ -3,6 +3,7 @@ import { partial, trim, tap, prop } from 'ramda'
 import { FoundBrowser, Browser } from '../types'
 import { notInstalledErr } from '../errors'
 import { utils } from '../utils'
+import Bluebird from 'bluebird'
 
 function getLinuxBrowser (
   name: string,
@@ -51,7 +52,7 @@ function getLinuxBrowser (
 export function getVersionString (path: string) {
   log('finding version string using command "%s --version"', path)
 
-  return utils.getOutput(path, ['--version'])
+  return Bluebird.resolve(utils.getOutput(path, ['--version']))
   .timeout(5000, `Timed out getting version for ${path}`)
   .then(prop('stdout'))
   .then(trim)

--- a/packages/launcher/lib/linux/index.ts
+++ b/packages/launcher/lib/linux/index.ts
@@ -46,8 +46,8 @@ function getLinuxBrowser (
 
   const maybeSetSnapProfilePath = (versionString: string) => {
     if (os.platform() === 'linux' && name === 'chromium' && versionString.endsWith('snap')) {
-      // when running as a snap, chromium can only write to one directory
-      // @see https://cs.chromium.org/chromium/src/chrome/installer/linux/snap/snapcraft.yaml.in?l=59-61&rcl=6fb05bb3738f37392dde9cd2783637f09d5aa3f4
+      // when running as a snap, chromium can only write to certain directories
+      // @see https://github.com/cypress-io/cypress/issues/7020
       foundBrowser.profilePath = path.join(os.homedir(), 'snap', 'chromium', 'current')
     }
   }

--- a/packages/launcher/lib/types.ts
+++ b/packages/launcher/lib/types.ts
@@ -33,7 +33,8 @@ export type Browser = {
   displayName: string
   /** RegExp to use to extract version from something like "Google Chrome 58.0.3029.110" */
   versionRegex: RegExp
-  profile?: boolean
+  /** If set, this is the base path that will be used for setting userDataDir. Useful for creating profiles in snap confinement. */
+  profilePath?: string
   /** A single binary name or array of binary names for this browser. Not used on Windows. */
   binary: string | string[]
   /** optional warning that will be shown in the GUI */

--- a/packages/launcher/lib/utils.ts
+++ b/packages/launcher/lib/utils.ts
@@ -1,6 +1,41 @@
 import execa from 'execa'
+import cp from 'child_process'
+import Bluebird from 'bluebird'
 
 // export an object for easy method stubbing
 export const utils = {
   execa,
+  getOutput: (cmd: string, args: string[]): Bluebird<{ stdout: string, stderr: string }> => {
+    if (process.platform === 'win32') {
+      // execa has better support for windows spawning conventions
+      throw new Error('getOutput should not be used on Windows - use execa instead')
+    }
+
+    return new Bluebird((resolve, reject) => {
+      let stdout = ''
+      let stderr = ''
+
+      const proc = cp.spawn(cmd, args)
+
+      const finish = () => {
+        proc.kill()
+        resolve({ stderr, stdout })
+      }
+
+      proc.on('exit', finish)
+
+      proc.stdout.on('data', (chunk) => {
+        stdout += chunk
+      })
+
+      proc.stderr.on('data', (chunk) => {
+        stderr += chunk
+      })
+
+      proc.on('error', (err) => {
+        proc.kill()
+        reject(err)
+      })
+    })
+  },
 }

--- a/packages/launcher/lib/utils.ts
+++ b/packages/launcher/lib/utils.ts
@@ -5,7 +5,7 @@ import Bluebird from 'bluebird'
 // export an object for easy method stubbing
 export const utils = {
   execa,
-  getOutput: (cmd: string, args: string[]): Bluebird<{ stdout: string, stderr: string }> => {
+  getOutput: (cmd: string, args: string[]): Bluebird<{ stdout: string, stderr?: string }> => {
     if (process.platform === 'win32') {
       // execa has better support for windows spawning conventions
       throw new Error('getOutput should not be used on Windows - use execa instead')

--- a/packages/launcher/test/fixtures.ts
+++ b/packages/launcher/test/fixtures.ts
@@ -3,14 +3,12 @@ export const goalBrowsers = [
     displayName: 'Test Browser',
     name: 'test-browser-name',
     versionRegex: /test-browser v(\S+)$/m,
-    profile: true,
     binary: 'test-browser',
   },
   {
     displayName: 'Foo Browser',
     name: 'foo-browser',
     versionRegex: /foo-browser v(\S+)$/m,
-    profile: true,
     binary: ['foo-browser', 'foo-bar-browser'],
   },
 ]

--- a/packages/launcher/test/unit/darwin_spec.ts
+++ b/packages/launcher/test/unit/darwin_spec.ts
@@ -24,7 +24,7 @@ function generatePlist (key, value) {
 }
 
 function stubBrowser (findAppParams: darwinUtil.FindAppParams) {
-  (utils.execa as unknown as SinonStub)
+  (utils.getOutput as unknown as SinonStub)
   .withArgs(`mdfind 'kMDItemCFBundleIdentifier=="${findAppParams.appId}"' | head -1`)
   .resolves({ stdout: `/Applications/${findAppParams.appName}` })
 
@@ -36,7 +36,7 @@ function stubBrowser (findAppParams: darwinUtil.FindAppParams) {
 describe('darwin browser detection', () => {
   beforeEach(() => {
     sinon.stub(fse, 'readFile').rejects({ code: 'ENOENT' })
-    sinon.stub(utils, 'execa').resolves({ stdout: '' })
+    sinon.stub(utils, 'getOutput').resolves({ stdout: '' })
   })
 
   it('detects browsers as expected', async () => {

--- a/packages/launcher/test/unit/detect_spec.ts
+++ b/packages/launcher/test/unit/detect_spec.ts
@@ -53,7 +53,7 @@ describe('browser detection', () => {
     let execa: SinonStub
 
     beforeEach(() => {
-      execa = sinon.stub(utils, 'execa')
+      execa = sinon.stub(utils, 'getOutput')
 
       execa.withArgs('/Applications/My Shiny New Browser.app', ['--version'])
       .resolves({ stdout: 'foo-browser v100.1.2.3' })

--- a/packages/launcher/test/unit/linux_spec.ts
+++ b/packages/launcher/test/unit/linux_spec.ts
@@ -14,7 +14,7 @@ describe('linux browser detection', () => {
   let execa: SinonStub
 
   beforeEach(() => {
-    execa = sinon.stub(utils, 'execa')
+    execa = sinon.stub(utils, 'getOutput')
 
     execa.withArgs('test-browser', ['--version'])
     .resolves({ stdout: 'test-browser v100.1.2.3' })

--- a/packages/launcher/test/unit/linux_spec.ts
+++ b/packages/launcher/test/unit/linux_spec.ts
@@ -60,7 +60,7 @@ describe('linux browser detection', () => {
         displayName: 'Chromium',
         majorVersion: 1,
         path: 'chromium',
-        profilePath: '/home/foo/.config/chromium',
+        profilePath: '/home/foo/snap/chromium/current',
         version: '1.2.3',
       })
     }

--- a/packages/launcher/test/unit/linux_spec.ts
+++ b/packages/launcher/test/unit/linux_spec.ts
@@ -100,7 +100,6 @@ describe('linux browser detection', () => {
       {
         name: 'foo-browser',
         versionRegex: /v(\S+)$/,
-        profile: true,
         binary: ['foo-browser', 'foo-bar-browser'],
       },
     ]

--- a/packages/launcher/test/unit/linux_spec.ts
+++ b/packages/launcher/test/unit/linux_spec.ts
@@ -8,6 +8,7 @@ import { detect } from '../../lib/detect'
 import { goalBrowsers } from '../fixtures'
 import { expect } from 'chai'
 import { utils } from '../../lib/utils'
+import os from 'os'
 import sinon, { SinonStub } from 'sinon'
 
 describe('linux browser detection', () => {
@@ -41,6 +42,30 @@ describe('linux browser detection', () => {
 
     // @ts-ignore
     return linuxHelper.detect(goal).then(checkBrowser)
+  })
+
+  // https://github.com/cypress-io/cypress/pull/7039
+  it('sets profilePath on snapcraft chromium', () => {
+    execa.withArgs('chromium', ['--version'])
+    .resolves({ stdout: 'Chromium 1.2.3 snap' })
+
+    sinon.stub(os, 'platform').returns('linux')
+    sinon.stub(os, 'homedir').returns('/home/foo')
+
+    const checkBrowser = ([browser]) => {
+      expect(browser).to.deep.equal({
+        channel: 'stable',
+        name: 'chromium',
+        family: 'chromium',
+        displayName: 'Chromium',
+        majorVersion: 1,
+        path: 'chromium',
+        profilePath: '/home/foo/.config/chromium',
+        version: '1.2.3',
+      })
+    }
+
+    return detect().then(checkBrowser)
   })
 
   // https://github.com/cypress-io/cypress/issues/6669

--- a/packages/launcher/test/unit/windows_spec.ts
+++ b/packages/launcher/test/unit/windows_spec.ts
@@ -28,7 +28,7 @@ describe('windows browser detection', () => {
   beforeEach(() => {
     sinon.stub(fse, 'pathExists').resolves(false)
     sinon.stub(os, 'homedir').returns(HOMEDIR)
-    sinon.stub(utils, 'execa').resolves({ stdout: '' })
+    sinon.stub(utils, 'execa').rejects()
   })
 
   it('detects browsers as expected', async () => {

--- a/packages/server/lib/browsers/utils.ts
+++ b/packages/server/lib/browsers/utils.ts
@@ -16,7 +16,7 @@ const appData = require('../util/app_data')
 const profileCleaner = require('../util/profile_cleaner')
 
 const PATH_TO_BROWSERS = appData.path('browsers')
-const pathToProfiles = path.join(PATH_TO_BROWSERS, '*')
+const legacyPathToProfiles = path.join(PATH_TO_BROWSERS, '*')
 
 const getAppDataPath = (browser) => {
   if (!browser || !browser.profilePath) {
@@ -95,9 +95,9 @@ const ensureCleanCache = async function (browser, isTextTerminal) {
 // we now store profiles inside the Cypress binary folder
 // so we need to remove the legacy root profiles that existed before
 function removeLegacyProfiles () {
-  return profileCleaner.removeRootProfile(pathToProfiles, [
-    path.join(pathToProfiles, 'run-*'),
-    path.join(pathToProfiles, 'interactive'),
+  return profileCleaner.removeRootProfile(legacyPathToProfiles, [
+    path.join(legacyPathToProfiles, 'run-*'),
+    path.join(legacyPathToProfiles, 'interactive'),
   ])
 }
 

--- a/packages/server/lib/browsers/utils.ts
+++ b/packages/server/lib/browsers/utils.ts
@@ -18,10 +18,22 @@ const profileCleaner = require('../util/profile_cleaner')
 const PATH_TO_BROWSERS = appData.path('browsers')
 const pathToProfiles = path.join(PATH_TO_BROWSERS, '*')
 
+const getAppDataPath = (browser) => {
+  if (!browser || !browser.profilePath) {
+    return PATH_TO_BROWSERS
+  }
+
+  return path.join(browser.profilePath, 'Cypress')
+}
+
+const getProfileWildcard = (browser) => {
+  return path.join(getAppDataPath(browser), '*')
+}
+
 const getBrowserPath = (browser) => {
   // TODO need to check if browser.name is an unempty string
   return path.join(
-    PATH_TO_BROWSERS,
+    getAppDataPath(browser),
     `${browser.name}-${browser.channel}`,
   )
 }
@@ -89,7 +101,7 @@ function removeLegacyProfiles () {
   ])
 }
 
-const removeOldProfiles = function () {
+const removeOldProfiles = function (browser) {
   // a profile is considered old if it was used
   // in a previous run for a PID that is either
   // no longer active, or isnt a cypress related process
@@ -97,7 +109,7 @@ const removeOldProfiles = function () {
 
   return Bluebird.all([
     removeLegacyProfiles(),
-    profileCleaner.removeInactiveByPid(pathToProfiles, 'run-'),
+    profileCleaner.removeInactiveByPid(getProfileWildcard(browser), 'run-'),
     profileCleaner.removeInactiveByPid(pathToPartitions, 'run-'),
   ])
 }

--- a/packages/server/lib/browsers/utils.ts
+++ b/packages/server/lib/browsers/utils.ts
@@ -15,12 +15,12 @@ const extension = require('@packages/extension')
 const appData = require('../util/app_data')
 const profileCleaner = require('../util/profile_cleaner')
 
-const PATH_TO_BROWSERS = appData.path('browsers')
-const legacyPathToProfiles = path.join(PATH_TO_BROWSERS, '*')
+const pathToBrowsers = appData.path('browsers')
+const legacyProfilesWildcard = path.join(pathToBrowsers, '*')
 
 const getAppDataPath = (browser) => {
   if (!browser || !browser.profilePath) {
-    return PATH_TO_BROWSERS
+    return pathToBrowsers
   }
 
   return path.join(browser.profilePath, 'Cypress')
@@ -95,9 +95,9 @@ const ensureCleanCache = async function (browser, isTextTerminal) {
 // we now store profiles inside the Cypress binary folder
 // so we need to remove the legacy root profiles that existed before
 function removeLegacyProfiles () {
-  return profileCleaner.removeRootProfile(legacyPathToProfiles, [
-    path.join(legacyPathToProfiles, 'run-*'),
-    path.join(legacyPathToProfiles, 'interactive'),
+  return profileCleaner.removeRootProfile(legacyProfilesWildcard, [
+    path.join(legacyProfilesWildcard, 'run-*'),
+    path.join(legacyProfilesWildcard, 'interactive'),
   ])
 }
 

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -619,8 +619,8 @@ const createAndOpenProject = function (socketId, options) {
   })
 }
 
-const removeOldProfiles = () => {
-  return browserUtils.removeOldProfiles()
+const removeOldProfiles = (browser) => {
+  return browserUtils.removeOldProfiles(browser)
   .catch((err) => {
     // dont make removing old browsers profiles break the build
     return errors.warning('CANNOT_REMOVE_OLD_BROWSER_PROFILES', err.stack)
@@ -1368,10 +1368,9 @@ module.exports = {
         // speed the initial booting time
         return Promise.all([
           system.info(),
-          browserUtils.ensureAndGetByNameOrPath(browserName, false, userBrowsers),
+          browserUtils.ensureAndGetByNameOrPath(browserName, false, userBrowsers).tap(removeOldProfiles),
           this.findSpecs(config, specPattern),
           trashAssets(config),
-          removeOldProfiles(),
         ])
         .spread((sys = {}, browser = {}, specs = []) => {
         // return only what is return to the specPattern

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -1559,7 +1559,7 @@ describe('lib/cypress', () => {
         osVersion: 'v1',
       })
 
-      sinon.stub(browsers, 'ensureAndGetByNameOrPath').returns({
+      sinon.stub(browsers, 'ensureAndGetByNameOrPath').resolves({
         version: '59.1.2.3',
         displayName: 'Electron',
       })


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7020 

### User facing changelog

- Fixed a bug preventing Cypress from launching on systems where Chromium was installed via Snapcraft.

### Additional details

- in `cypress open`, project would never load and spinner would run forever. on `cypress run`, no output is printed to the console (browser detection runs before anything is printed)
- mysteriously, execa would hang on --version when used with the snap
- switched to using cp instead since execa is only really used for windows benefits and it works fine
- added a 5s timeout to getVersionString since it should never take that long
- [x] still having issue due to snap sandboxing, cannot create browser profile: https://github.com/cypress-io/cypress/issues/7020#issuecomment-614737938
	- instead of writing to the usual appdata dir, write to `$HOME/snap/chromium/current/Cypress` since that's the only place this chromium can write
	- [x] tested locally, would also like @Bkucera to test on his system

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
