### PR TITLE
Fix typo that made user projects include bundled typescript.

### DIFF
--- a/packages/server/lib/plugins/resolve.js
+++ b/packages/server/lib/plugins/resolve.js
@@ -15,7 +15,7 @@ module.exports = {
 
     try {
       return resolve.sync('typescript', {
-        baseDir: config.projectRoot,
+        basedir: config.projectRoot,
       })
     } catch (e) {
       return null


### PR DESCRIPTION
- Closes #7036

### User facing changelog

Fixed typo that made user projects include bundled typescript.

### Additional details

#### Why was this change necessary?

This bug made `export default` and import object destruction impossible.

#### What is affected by this change?

We won't import bundled typescript to user projects.

#### Any implementation details to explain?

Because TypeScript uses duck typing, it cannot detect when an invalid field is added to an object. ([It's been discussed since 2014](https://github.com/microsoft/TypeScript/issues/202), but it seems that there's no clear answer yet.)

Because of that, I didn't notice that `baseDir` is wrong. (The right name is `basedir`.)

I fixed the typo.

Unfortunately, I guess there's no other way to test them except adding some test code to master branch tests.

### How has the user experience changed?

The test passes.

### PR Tasks

- [NA] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [NA] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
