### PR TITLE
Fix internal driver tests exiting with wrong exitCode

### DIFF
--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -16,18 +16,14 @@ debug('starting the CLI in dev mode with args %o', {
   args,
 })
 
-execa(pathToCli, args, { stdio: 'inherit' })
-.then(({ code }) => {
+const exit = ({ exitCode }) => {
   if (typeof code !== 'number') {
-    // eslint-disable-next-line no-console
-    console.error(`missing exit code from execa (code: ${code})`)
-    process.exit(1)
+    throw new Error(`missing exit code from execa (received ${exitCode})`)
   }
 
-  debug('exiting normally %o', { code })
-  process.exit(code)
-})
-.catch((err) => {
-  debug('exiting due to error %o', { err })
-  process.exit(err.exitCode || 1)
-})
+  process.exit(exitCode)
+}
+
+execa(pathToCli, args, { stdio: 'inherit' })
+.then(exit)
+.catch(exit)

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -18,6 +18,12 @@ debug('starting the CLI in dev mode with args %o', {
 
 execa(pathToCli, args, { stdio: 'inherit' })
 .then(({ code }) => {
+  if (typeof code !== 'number') {
+    // eslint-disable-next-line no-console
+    console.error(`missing exit code from execa (code: ${code})`)
+    process.exit(1)
+  }
+
   debug('exiting normally %o', { code })
   process.exit(code)
 })

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -16,10 +16,12 @@ debug('starting the CLI in dev mode with args %o', {
   args,
 })
 
-const exit = ({ code }) => {
-  process.exit(code)
-}
-
 execa(pathToCli, args, { stdio: 'inherit' })
-.then(exit)
-.catch(exit)
+.then(({ code }) => {
+  debug('exiting normally %o', { code })
+  process.exit(code)
+})
+.catch((err) => {
+  debug('exiting due to error %o', { err })
+  process.exit(err.exitCode || 1)
+})


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7052

### User facing changelog

<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details
- https://github.com/cypress-io/cypress/commit/abf4d858694e1be3ae6b93da42c6678ad22ba290#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R138 upgraded execa, from execa 2.0.0+ onwards, errors no longer have a `code` prop, only an `exitCode` prop
- affected `cypress` script used by `driver`'s `cypress:run`
- did not add a verify:mocha:results stage to driver tests

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [na] Have tests been added/updated?
- [na] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
