### PR TITLE
Update window message: display 'yarn upgrade' instead of `yarn add`

### DIFF
--- a/packages/desktop-gui/cypress/integration/update_banner_spec.js
+++ b/packages/desktop-gui/cypress/integration/update_banner_spec.js
@@ -115,7 +115,8 @@ describe('Update Banner', function () {
     it('modal has info about updating package.json', function () {
       cy.get('.modal').contains(`npm install --save-dev cypress@${NEW_VERSION}`)
 
-      cy.get('.modal').contains(`yarn add cypress@${NEW_VERSION}`)
+      cy.get('.modal').contains(`yarn upgrade cypress@${NEW_VERSION}`)
+      cy.percySnapshot()
     })
 
     it('links to \'open\' doc on click of open command', function () {

--- a/packages/desktop-gui/src/update/update-banner.jsx
+++ b/packages/desktop-gui/src/update/update-banner.jsx
@@ -86,8 +86,7 @@ class UpdateBanner extends Component {
         <li>
           <span>If using npm, run <code>npm install --save-dev cypress@{appStore.newVersion}</code></span>
           <br/>
-          <span>If using yarn, run <code>yarn add cypress@{appStore.newVersion}</code></span>
-
+          <span>If using yarn, run <code>yarn upgrade cypress@{appStore.newVersion}</code></span>
         </li>
         <li>
           <span>Run <a href='#' onClick={this._openCyOpenDoc}><code>node_modules/.bin/cypress open</code></a> to open the new version.</span>


### PR DESCRIPTION
- Partially addresses #4883

### User facing changelog

The update window in the Test Runner now encourages yarn users to `yarn upgrade` Cypress instead of `yarn add` to help prevent installing 2 versions of Cypress when using yarn workspaces. 

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

#### Before

<img width="568" alt="Screen Shot 2020-04-22 at 12 42 28 PM" src="https://user-images.githubusercontent.com/1271364/79946834-c6978100-8496-11ea-8584-2ace0abf2cb2.png">

#### After

<img width="568" alt="Screen Shot 2020-04-22 at 12 59 21 PM" src="https://user-images.githubusercontent.com/1271364/79948069-242ccd00-8499-11ea-85c4-e3cd38779526.png">


### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
