### PR TITLE
Fix test script, add Mocha result checks to internal Cypress te…

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -129,10 +129,10 @@ commands:
           at: ~/
       - run:
           command: yarn lerna exec --scope @packages/server "yarn test ./test/e2e/<< parameters.chunk >>*spec* --browser << parameters.browser >>"
-      - verify-mocha-results
       - store_test_results:
           path: /tmp/cypress
       - store-npm-logs
+      - verify-mocha-results
 
   store-npm-logs:
     description: Saves any NPM debug logs as artifacts in case there is a problem
@@ -330,14 +330,14 @@ jobs:
       - run: yarn lerna run build-prod --stream
       # run unit tests from each individual package
       - run: yarn test
-      - verify-mocha-results:
-          expectedResultCount: 6
       - store_test_results:
           path: /tmp/cypress
       # CLI tests generate HTML files with sample CLI command output
       - store_artifacts:
           path: cli/test/html
       - store-npm-logs
+      - verify-mocha-results:
+          expectedResultCount: 6
 
   lint-types:
     <<: *defaults
@@ -361,11 +361,11 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: yarn test-unit --scope @packages/server
-      - verify-mocha-results:
-          expectedResultCount: 1
       - store_test_results:
           path: /tmp/cypress
       - store-npm-logs
+      - verify-mocha-results:
+          expectedResultCount: 1
 
   "server-integration-tests":
     <<: *defaults
@@ -374,11 +374,11 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: yarn test-integration --scope @packages/server
-      - verify-mocha-results:
-          expectedResultCount: 1
       - store_test_results:
           path: /tmp/cypress
       - store-npm-logs
+      - verify-mocha-results:
+          expectedResultCount: 1
 
   "server-performance-tests":
       <<: *defaults
@@ -387,13 +387,13 @@ jobs:
           at: ~/
       - run:
           command: yarn lerna exec --scope @packages/server "yarn test-performance"
-      - verify-mocha-results:
-          expectedResultCount: 1
       - store_test_results:
           path: /tmp/cypress
       - store_artifacts:
           path: /tmp/artifacts
       - store-npm-logs
+      - verify-mocha-results:
+          expectedResultCount: 1
 
   "server-e2e-tests-chrome-1":
     <<: *defaults
@@ -591,7 +591,8 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          command: yarn workspace @packages/desktop-gui build-prod
+          command: yarn build-prod
+          working_directory: packages/desktop-gui
       - run:
           name: Desktop GUI server
           command: yarn start
@@ -601,12 +602,15 @@ jobs:
           command: |
             CYPRESS_KONFIG_ENV=production \
             CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-            yarn lerna exec --scope @packages/desktop-gui "yarn cypress:run --record --parallel --group 2x-desktop-gui"
+            yarn cypress:run --record --parallel --group 2x-desktop-gui
+          working_directory: packages/desktop-gui
       - store_test_results:
           path: /tmp/cypress
       - store_artifacts:
           path: /tmp/artifacts
       - store-npm-logs
+      - verify-mocha-results:
+          expectedResultCount: 1
 
   desktop-gui-visual-tests:
     <<: *defaults
@@ -615,7 +619,8 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          command: yarn lerna exec --scope @packages/desktop-gui "yarn build-prod"
+          command: yarn build-prod
+          working_directory: packages/desktop-gui
       - run:
           name: Desktop GUI server
           command: yarn start
@@ -625,9 +630,13 @@ jobs:
           # will use PERCY_TOKEN environment variable if available
           command: |
             CYPRESS_KONFIG_ENV=production \
-            yarn lerna exec --scope @packages/desktop-gui "yarn percy exec -- yarn cypress:run --spec cypress/integration/settings_spec.js"
+            yarn percy exec -- yarn cypress:run --spec cypress/integration/settings_spec.js
+          working_directory: packages/desktop-gui
       # we don't really need any artifacts - we are only interested in visual screenshots
       - store-npm-logs
+      - verify-mocha-results:
+          expectedResultCount: 1
+
 
   "reporter-integration-tests":
     <<: *defaults
@@ -635,12 +644,14 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          command:  yarn workspace @packages/reporter build-for-tests
+          command: yarn build-for-tests
+          working_directory: packages/reporter
       - run:
           command: |
             CYPRESS_KONFIG_ENV=production \
             CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-            yarn lerna exec  --scope @packages/reporter "yarn cypress:run --record --parallel --group reporter"
+            yarn cypress:run --record --parallel --group reporter
+          working_directory: packages/reporter
       - store_test_results:
           path: /tmp/cypress
       - store_artifacts:
@@ -653,12 +664,14 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          command: yarn workspace @packages/ui-components build-for-tests
+          command: yarn build-for-tests
+          working_directory: packages/ui-components
       - run:
           command: |
             CYPRESS_KONFIG_ENV=production \
             CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-            yarn lerna exec --scope @packages/ui-components "yarn cypress:run --record --parallel --group ui-components"
+            yarn cypress:run --record --parallel --group ui-components
+          working_directory: packages/ui-components
       - store_test_results:
           path: /tmp/cypress
       - store_artifacts:
@@ -1057,7 +1070,6 @@ jobs:
           browser: firefox
           command: "npm run cypress:run"
           wait-on: "http://localhost:2222"
-
 
   "test-binary-against-realworld-firefox":
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -112,8 +112,7 @@ commands:
       - store_artifacts:
           path: /tmp/artifacts
       - store-npm-logs
-      - verify-mocha-results:
-          expectedResultCount: 1
+      - verify-mocha-results
 
   run-e2e-tests:
     parameters:
@@ -610,7 +609,7 @@ jobs:
           path: /tmp/artifacts
       - store-npm-logs
       - verify-mocha-results:
-          expectedResultCount: 1
+          expectedResultCount: 10
 
   desktop-gui-visual-tests:
     <<: *defaults
@@ -634,8 +633,7 @@ jobs:
           working_directory: packages/desktop-gui
       # we don't really need any artifacts - we are only interested in visual screenshots
       - store-npm-logs
-      - verify-mocha-results:
-          expectedResultCount: 1
+      - verify-mocha-results
 
 
   "reporter-integration-tests":

--- a/circle.yml
+++ b/circle.yml
@@ -96,7 +96,7 @@ commands:
       - attach_workspace:
           at: ~/
       - run:
-          command: yarn lerna exec --scope @packages/driver "yarn start"
+          command: yarn workspace @packages/driver start
           background: true
       - run:
           command: yarn wait-on http://localhost:3500

--- a/circle.yml
+++ b/circle.yml
@@ -106,7 +106,7 @@ commands:
             CYPRESS_KONFIG_ENV=production \
             CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
             yarn cypress:run --record --parallel --group 5x-driver-<< parameters.browser >> --browser << parameters.browser >>
-            working_directory: packages/driver
+          working_directory: packages/driver
       - verify-mocha-results
       - store_test_results:
           path: /tmp/cypress

--- a/circle.yml
+++ b/circle.yml
@@ -86,6 +86,33 @@ commands:
             else
               echo "**** Not updating Chrome. Running tests in '<< parameters.browser >>' ****"
             fi
+
+  run-driver-integration-tests:
+    parameters:
+      browser:
+        description: browser shortname to target
+        type: string
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          command: yarn lerna exec --scope @packages/driver "yarn start"
+          background: true
+      - run:
+          command: yarn wait-on http://localhost:3500
+      - run:
+          command: |
+            CYPRESS_KONFIG_ENV=production \
+            CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
+            yarn lerna exec --scope @packages/driver "yarn cypress:run --record --parallel --group 5x-driver-<< parameters.browser >> --browser << parameters.browser >>"
+      - store_test_results:
+          path: /tmp/cypress
+      - store_artifacts:
+          path: /tmp/artifacts
+      - store-npm-logs
+      - verify-mocha-results
+          expectedResultCount: 1
+
   run-e2e-tests:
     parameters:
       browser:
@@ -538,69 +565,22 @@ jobs:
     <<: *defaults
     parallelism: 5
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          command: yarn lerna exec --scope @packages/driver "yarn start"
-          background: true
-      - run:
-          command: yarn wait-on http://localhost:3500
-      - run:
-          command: |
-            CYPRESS_KONFIG_ENV=production \
-            CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-            yarn lerna exec --scope @packages/driver "yarn cypress:run --record --parallel --group 5x-driver-chrome --browser chrome"
-      - store_test_results:
-          path: /tmp/cypress
-      - store_artifacts:
-          path: /tmp/artifacts
-      - store-npm-logs
+      - run-driver-integration-tests
+          browser: chrome
 
-  # "driver-integration-tests-electron":
-  #   <<: *defaults
-  #   parallelism: 5
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/
-  #     - run:
-  #         command: npm start
-  #         background: true
-  #         working_directory: packages/driver
-  #     - run:
-  #         command: $(npm bin)/wait-on http://localhost:3500
-  #         working_directory: packages/driver
-  #     - run:
-  #         command: |
-  #           CYPRESS_KONFIG_ENV=production \
-  #           CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-  #           npm run cypress:run --record --parallel --group 5x-driver-electron --browser electron
-  #         working_directory: packages/driver
-  #     - store_test_results:
-  #         path: /tmp/cypress
-  #     - store_artifacts:
-  #         path: /tmp/artifacts
-  #     - store-npm-logs
+  "driver-integration-tests-electron":
+    <<: *defaults
+    parallelism: 5
+    steps:
+      - run-driver-integration-tests
+          browser: electron
 
   "driver-integration-tests-firefox":
     <<: *defaults
     parallelism: 5
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          command: yarn workspace @packages/driver start
-          background: true
-      - run:
-          command: $(yarn bin)/wait-on http://localhost:3500
-      - run:
-          command: |
-            CYPRESS_KONFIG_ENV=production \
-            CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-            yarn lerna exec --scope @packages/driver "yarn cypress:run --record --parallel --group 5x-driver-firefox --browser firefox"
-      - store_test_results:
-          path: /tmp/cypress
-      - store_artifacts:
-          path: /tmp/artifacts
+      - run-driver-integration-tests
+          browser: firefox
 
   "desktop-gui-integration-tests-2x":
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -110,7 +110,7 @@ commands:
       - store_artifacts:
           path: /tmp/artifacts
       - store-npm-logs
-      - verify-mocha-results
+      - verify-mocha-results:
           expectedResultCount: 1
 
   run-e2e-tests:
@@ -565,21 +565,21 @@ jobs:
     <<: *defaults
     parallelism: 5
     steps:
-      - run-driver-integration-tests
+      - run-driver-integration-tests:
           browser: chrome
 
-  "driver-integration-tests-electron":
-    <<: *defaults
-    parallelism: 5
-    steps:
-      - run-driver-integration-tests
-          browser: electron
+  # "driver-integration-tests-electron":
+  #   <<: *defaults
+  #   parallelism: 5
+  #   steps:
+  #     - run-driver-integration-tests:
+  #         browser: electron
 
   "driver-integration-tests-firefox":
     <<: *defaults
     parallelism: 5
     steps:
-      - run-driver-integration-tests
+      - run-driver-integration-tests:
           browser: firefox
 
   "desktop-gui-integration-tests-2x":

--- a/circle.yml
+++ b/circle.yml
@@ -106,13 +106,13 @@ commands:
             CYPRESS_KONFIG_ENV=production \
             CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
             yarn cypress:run --record --parallel --group 5x-driver-<< parameters.browser >> --browser << parameters.browser >>
-          working_directory: packages/driver
+            working_directory: packages/driver
+      - verify-mocha-results
       - store_test_results:
           path: /tmp/cypress
       - store_artifacts:
           path: /tmp/artifacts
       - store-npm-logs
-      - verify-mocha-results
 
   run-e2e-tests:
     parameters:
@@ -128,10 +128,10 @@ commands:
           at: ~/
       - run:
           command: yarn lerna exec --scope @packages/server "yarn test ./test/e2e/<< parameters.chunk >>*spec* --browser << parameters.browser >>"
+      - verify-mocha-results
       - store_test_results:
           path: /tmp/cypress
       - store-npm-logs
-      - verify-mocha-results
 
   store-npm-logs:
     description: Saves any NPM debug logs as artifacts in case there is a problem
@@ -329,14 +329,14 @@ jobs:
       - run: yarn lerna run build-prod --stream
       # run unit tests from each individual package
       - run: yarn test
+      - verify-mocha-results:
+          expectedResultCount: 6
       - store_test_results:
           path: /tmp/cypress
       # CLI tests generate HTML files with sample CLI command output
       - store_artifacts:
           path: cli/test/html
       - store-npm-logs
-      - verify-mocha-results:
-          expectedResultCount: 6
 
   lint-types:
     <<: *defaults
@@ -360,11 +360,11 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: yarn test-unit --scope @packages/server
+      - verify-mocha-results:
+          expectedResultCount: 1
       - store_test_results:
           path: /tmp/cypress
       - store-npm-logs
-      - verify-mocha-results:
-          expectedResultCount: 1
 
   "server-integration-tests":
     <<: *defaults
@@ -373,11 +373,11 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: yarn test-integration --scope @packages/server
+      - verify-mocha-results:
+          expectedResultCount: 1
       - store_test_results:
           path: /tmp/cypress
       - store-npm-logs
-      - verify-mocha-results:
-          expectedResultCount: 1
 
   "server-performance-tests":
       <<: *defaults
@@ -386,13 +386,13 @@ jobs:
           at: ~/
       - run:
           command: yarn lerna exec --scope @packages/server "yarn test-performance"
+      - verify-mocha-results:
+          expectedResultCount: 1
       - store_test_results:
           path: /tmp/cypress
       - store_artifacts:
           path: /tmp/artifacts
       - store-npm-logs
-      - verify-mocha-results:
-          expectedResultCount: 1
 
   "server-e2e-tests-chrome-1":
     <<: *defaults
@@ -603,13 +603,12 @@ jobs:
             CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
             yarn cypress:run --record --parallel --group 2x-desktop-gui
           working_directory: packages/desktop-gui
+      - verify-mocha-results
       - store_test_results:
           path: /tmp/cypress
       - store_artifacts:
           path: /tmp/artifacts
       - store-npm-logs
-      - verify-mocha-results:
-          expectedResultCount: 10
 
   desktop-gui-visual-tests:
     <<: *defaults
@@ -631,10 +630,9 @@ jobs:
             CYPRESS_KONFIG_ENV=production \
             yarn percy exec -- yarn cypress:run --spec cypress/integration/settings_spec.js
           working_directory: packages/desktop-gui
+      - verify-mocha-results
       # we don't really need any artifacts - we are only interested in visual screenshots
       - store-npm-logs
-      - verify-mocha-results
-
 
   "reporter-integration-tests":
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -648,6 +648,7 @@ jobs:
             CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
             yarn cypress:run --record --parallel --group reporter
           working_directory: packages/reporter
+      - verify-mocha-results
       - store_test_results:
           path: /tmp/cypress
       - store_artifacts:
@@ -668,6 +669,7 @@ jobs:
             CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
             yarn cypress:run --record --parallel --group ui-components
           working_directory: packages/ui-components
+      - verify-mocha-results
       - store_test_results:
           path: /tmp/cypress
       - store_artifacts:

--- a/circle.yml
+++ b/circle.yml
@@ -96,15 +96,17 @@ commands:
       - attach_workspace:
           at: ~/
       - run:
-          command: yarn workspace @packages/driver start
+          command: yarn start
           background: true
+          working_directory: packages/driver
       - run:
           command: yarn wait-on http://localhost:3500
       - run:
           command: |
             CYPRESS_KONFIG_ENV=production \
             CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-            yarn lerna exec --scope @packages/driver "yarn cypress:run --record --parallel --group 5x-driver-<< parameters.browser >> --browser << parameters.browser >>"
+            yarn cypress:run --record --parallel --group 5x-driver-<< parameters.browser >> --browser << parameters.browser >>
+          working_directory: packages/driver
       - store_test_results:
           path: /tmp/cypress
       - store_artifacts:

--- a/packages/desktop-gui/cypress.json
+++ b/packages/desktop-gui/cypress.json
@@ -3,7 +3,7 @@
   "projectId": "ypt4pf",
   "viewportWidth": 800,
   "viewportHeight": 850,
-  "reporter": "cypress-multi-reporters",
+  "reporter": "../../node_modules/cypress-multi-reporters/index.js",
   "reporterOptions": {
     "configFile": "../../mocha-reporter-config.json"
   }

--- a/packages/desktop-gui/cypress.json
+++ b/packages/desktop-gui/cypress.json
@@ -2,5 +2,9 @@
   "baseUrl": "http://localhost:5005",
   "projectId": "ypt4pf",
   "viewportWidth": 800,
-  "viewportHeight": 850
+  "viewportHeight": 850,
+  "reporter": "cypress-multi-reporters",
+  "reporterOptions": {
+    "configFile": "../../mocha-reporter-config.json"
+  }
 }

--- a/packages/desktop-gui/package.json
+++ b/packages/desktop-gui/package.json
@@ -25,6 +25,7 @@
     "bootstrap-sass": "3.4.1",
     "classnames": "2.2.6",
     "cross-env": "6.0.3",
+    "cypress-multi-reporters": "1.2.4",
     "fira": "cypress-io/fira#fb63362742eea8cdce0d90825ab9264d77719e3d",
     "gravatar": "1.8.0",
     "human-interval": "0.1.6",
@@ -48,5 +49,11 @@
   "files": [
     "dist",
     "lib"
-  ]
+  ],
+  "workspaces": {
+    "nohoist": [
+      "cypress-multi-reporters",
+      "cypress-multi-reporters/**"
+    ]
+  }
 }

--- a/packages/desktop-gui/package.json
+++ b/packages/desktop-gui/package.json
@@ -49,11 +49,5 @@
   "files": [
     "dist",
     "lib"
-  ],
-  "workspaces": {
-    "nohoist": [
-      "cypress-multi-reporters",
-      "cypress-multi-reporters/**"
-    ]
-  }
+  ]
 }

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -35,6 +35,7 @@
     "clone": "2.1.2",
     "compression": "1.7.4",
     "cors": "2.8.5",
+    "cypress-multi-reporters": "1.2.4",
     "debug": "4.1.1",
     "errorhandler": "1.5.1",
     "eventemitter2": "4.1.2",

--- a/packages/driver/test/cypress.json
+++ b/packages/driver/test/cypress.json
@@ -3,5 +3,9 @@
   "baseUrl": "http://localhost:3500",
   "hosts": {
     "*.foobar.com": "127.0.0.1"
+  },
+  "reporter": "cypress-multi-reporters",
+  "reporterOptions": {
+    "configFile": "../../mocha-reporter-config.json"
   }
 }

--- a/packages/driver/test/cypress.json
+++ b/packages/driver/test/cypress.json
@@ -4,8 +4,8 @@
   "hosts": {
     "*.foobar.com": "127.0.0.1"
   },
-  "reporter": "cypress-multi-reporters",
+  "reporter": "../../../node_modules/cypress-multi-reporters/index.js",
   "reporterOptions": {
-    "configFile": "../../mocha-reporter-config.json"
+    "configFile": "../../../mocha-reporter-config.json"
   }
 }

--- a/packages/reporter/cypress.json
+++ b/packages/reporter/cypress.json
@@ -3,5 +3,9 @@
   "viewportWidth": 400,
   "viewportHeight": 450,
   "supportFile": false,
-  "pluginFile": false
+  "pluginFile": false,
+  "reporter": "../../node_modules/cypress-multi-reporters/index.js",
+  "reporterOptions": {
+    "configFile": "../../mocha-reporter-config.json"
+  }
 }

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -25,6 +25,7 @@
     "chai-enzyme": "1.0.0-beta.1",
     "classnames": "2.2.6",
     "css-element-queries": "1.2.3",
+    "cypress-multi-reporters": "1.2.4",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",
     "jsdom": "14.1.0",

--- a/packages/ui-components/cypress.json
+++ b/packages/ui-components/cypress.json
@@ -1,4 +1,8 @@
 {
   "fixturesFolder": false,
-  "projectId": "ypt4pf"
+  "projectId": "ypt4pf",
+  "reporter": "../../node_modules/cypress-multi-reporters/index.js",
+  "reporterOptions": {
+    "configFile": "../../mocha-reporter-config.json"
+  }
 }

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -24,6 +24,7 @@
     "babel-loader": "8.1.0",
     "browser-logos": "github:alrra/browser-logos",
     "classnames": "2.2.6",
+    "cypress-multi-reporters": "1.2.4",
     "file-loader": "4.3.0",
     "lodash": "4.17.15",
     "prop-types": "15.7.2",

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -17,8 +17,10 @@ debug('starting the CLI in dev mode with args %o', {
 })
 
 const exit = ({ exitCode }) => {
-  if (typeof code !== 'number') {
-    throw new Error(`missing exit code from execa (received ${exitCode})`)
+  if (typeof exitCode !== 'number') {
+    // eslint-disable-next-line no-console
+    console.error(`missing exit code from execa (received ${exitCode})`)
+    process.exit(1)
   }
 
   process.exit(exitCode)

--- a/yarn.lock
+++ b/yarn.lock
@@ -13205,7 +13205,16 @@ http-proxy-agent@^2.1.0:
     agent-base "4"
     debug "3.1.0"
 
-http-proxy@^1.17.0, http-proxy@cypress-io/node-http-proxy#9322b4b69b34f13a6f3874e660a35df3305179c6:
+http-proxy@^1.17.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.0.tgz#dbe55f63e75a347db7f3d99974f2692a314a6a3a"
+  integrity sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==
+  dependencies:
+    eventemitter3 "^4.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
+
+http-proxy@cypress-io/node-http-proxy#9322b4b69b34f13a6f3874e660a35df3305179c6:
   version "1.18.0"
   resolved "https://codeload.github.com/cypress-io/node-http-proxy/tar.gz/9322b4b69b34f13a6f3874e660a35df3305179c6"
   dependencies:
@@ -21968,11 +21977,10 @@ socket.io-circular-parser@cypress-io/socket.io-circular-parser#unpatched-has-bin
   version "3.1.2-patch1"
   resolved "https://codeload.github.com/cypress-io/socket.io-circular-parser/tar.gz/e274585ec04d1840fd1211dd3061d6dba2160475"
   dependencies:
-    circular-json "^0.4.0"
+    circular-json "0.5.9"
     component-emitter "1.2.1"
-    debug "~2.6.4"
-    has-binary2 cypress-io/has-binary#8580a33df21e8b36a43f57872a82c60829636a92
-    isarray "2.0.1"
+    debug "~4.1.0"
+    has-binary2 "~1.0.2"
 
 socket.io-client@2.3.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8868,6 +8868,14 @@ cypress-example-kitchensink@1.9.1:
     npm-run-all "^4.1.2"
     serve "11.3.0"
 
+cypress-multi-reporters@1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/cypress-multi-reporters/-/cypress-multi-reporters-1.2.4.tgz#bf6c95f39f9d2ce210d83e096f452a306bcd49fc"
+  integrity sha512-JTsF02I2KH1HM+cUEKeJih8EtjFv6jWVrYlRlJAnomwE5UqRQ3M7cAuw+zqBfNSTIvhOzNHtN3LyxomfhycuAQ==
+  dependencies:
+    debug "^4.1.1"
+    lodash "^4.17.11"
+
 d@1, d@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
@@ -13197,16 +13205,7 @@ http-proxy-agent@^2.1.0:
     agent-base "4"
     debug "3.1.0"
 
-http-proxy@^1.17.0:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.0.tgz#dbe55f63e75a347db7f3d99974f2692a314a6a3a"
-  integrity sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==
-  dependencies:
-    eventemitter3 "^4.0.0"
-    follow-redirects "^1.0.0"
-    requires-port "^1.0.0"
-
-http-proxy@cypress-io/node-http-proxy#9322b4b69b34f13a6f3874e660a35df3305179c6:
+http-proxy@^1.17.0, http-proxy@cypress-io/node-http-proxy#9322b4b69b34f13a6f3874e660a35df3305179c6:
   version "1.18.0"
   resolved "https://codeload.github.com/cypress-io/node-http-proxy/tar.gz/9322b4b69b34f13a6f3874e660a35df3305179c6"
   dependencies:
@@ -21969,10 +21968,11 @@ socket.io-circular-parser@cypress-io/socket.io-circular-parser#unpatched-has-bin
   version "3.1.2-patch1"
   resolved "https://codeload.github.com/cypress-io/socket.io-circular-parser/tar.gz/e274585ec04d1840fd1211dd3061d6dba2160475"
   dependencies:
-    circular-json "0.5.9"
+    circular-json "^0.4.0"
     component-emitter "1.2.1"
-    debug "~4.1.0"
-    has-binary2 "~1.0.2"
+    debug "~2.6.4"
+    has-binary2 cypress-io/has-binary#8580a33df21e8b36a43f57872a82c60829636a92
+    isarray "2.0.1"
 
 socket.io-client@2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Closes #7052 

### Additional details

- fixes cypress.js test script so it will exit with a non-zero exit code if an error occurs
- adds cypress-multi-reporters to desktop-gui and driver and reporter and ui-components so they output a junit xml report
- adds verify-mocha-results test stage to those cypress tests

