### PR TITLE
Fix require custom reporters when given module name

### DIFF
--- a/packages/server/lib/reporter.coffee
+++ b/packages/server/lib/reporter.coffee
@@ -347,15 +347,13 @@ class Reporter
     ## that is local (./custom-reporter.js)
     ## or one installed by the user through npm
     try
-      p = path.resolve(projectRoot, reporterName)
-
       ## try local
-      debug("trying to require local reporter with path:", p)
+      debug("trying to require local reporter with path:", reporterName)
 
       ## using path.resolve() here so we can just pass an
       ## absolute path as the reporterName which avoids
       ## joining projectRoot unnecessarily
-      return require(p)
+      return require(reporterName)
     catch err
       if err.code isnt "MODULE_NOT_FOUND"
         ## bail early if the error wasn't MODULE_NOT_FOUND

--- a/packages/server/lib/reporter.coffee
+++ b/packages/server/lib/reporter.coffee
@@ -363,12 +363,10 @@ class Reporter
         ## with the found reporter
         throw err
 
-      p = path.resolve(reporterName)
-
       ## try npm. if this fails, we're out of options, so let it throw
-      debug("trying to require local reporter with path:", p)
+      debug("trying to require local reporter directly:", reporterName)
 
-      return require(p)
+      return require(reporterName)
 
   @getSearchPathsForReporter = (reporterName, projectRoot) ->
     _.uniq([

--- a/packages/server/lib/reporter.coffee
+++ b/packages/server/lib/reporter.coffee
@@ -347,13 +347,15 @@ class Reporter
     ## that is local (./custom-reporter.js)
     ## or one installed by the user through npm
     try
+      p = path.resolve(projectRoot, reporterName)
+
       ## try local
-      debug("trying to require local reporter with path:", reporterName)
+      debug("trying to require local reporter with path:", p)
 
       ## using path.resolve() here so we can just pass an
       ## absolute path as the reporterName which avoids
       ## joining projectRoot unnecessarily
-      return require(reporterName)
+      return require(p)
     catch err
       if err.code isnt "MODULE_NOT_FOUND"
         ## bail early if the error wasn't MODULE_NOT_FOUND
@@ -361,7 +363,7 @@ class Reporter
         ## with the found reporter
         throw err
 
-      p = path.resolve(projectRoot, "node_modules", reporterName)
+      p = path.resolve(reporterName)
 
       ## try npm. if this fails, we're out of options, so let it throw
       debug("trying to require local reporter with path:", p)


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->
- use `require(...)` directly when requiring custom reporters to support hoisted modules

<!-- Example: "Closes #1234" -->

- Closes TBD <!-- issue number here -->

### User facing changelog

<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks
- [ ] add test

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
