### PR TITLE
adding __bundled endpoint to expose bundled assets for specs making network requests

### DIFF
--- a/packages/server/lib/plugins/preprocessor.coffee
+++ b/packages/server/lib/plugins/preprocessor.coffee
@@ -6,8 +6,7 @@ Promise = require("bluebird")
 appData = require("../util/app_data")
 cwd = require("../cwd")
 plugins = require("../plugins")
-savedState = require("../saved_state")
-resolve = require('./resolve')
+resolve = require("./resolve")
 
 errorMessage = (err = {}) ->
   (err.stack ? err.annotated ? err.message ? err.toString())
@@ -29,9 +28,6 @@ clientSideError = (err) ->
     })
   }())
   """
-
-getOutputPath = (config, filePath) ->
-  appData.projectsPath(savedState.toHashName(config.projectRoot), "bundles", filePath)
 
 baseEmitter = new EE()
 fileObjects = {}
@@ -83,7 +79,7 @@ module.exports = {
       fileObject = fileObjects[filePath] = _.extend(new EE(), {
         filePath,
         shouldWatch,
-        outputPath: getOutputPath(config, baseFilePath)
+        outputPath: appData.getBundledFilePath(config.projectRoot, baseFilePath)
       })
 
       fileObject.on "rerun", ->

--- a/packages/server/lib/routes.js
+++ b/packages/server/lib/routes.js
@@ -60,7 +60,8 @@ module.exports = ({ app, config, getRemoteState, networkProxy, project, onError 
     res.sendFile(file, { etag: false })
   })
 
-  app.get('/__bundled/*', (req, res) => {
+  // special fallback - serve dist'd (bundled/static) files from the project path folder
+  app.get('/__cypress/bundled/*', (req, res) => {
     const file = AppData.getBundledFilePath(config.projectRoot, path.join('src', req.params[0]))
 
     debug(`Serving dist'd bundle at file path: %o`, { path: file, url: req.url })

--- a/packages/server/lib/routes.js
+++ b/packages/server/lib/routes.js
@@ -3,6 +3,7 @@ const la = require('lazy-ass')
 const check = require('check-more-types')
 const debug = require('debug')('cypress:server:routes')
 
+const AppData = require('./util/app_data')
 const CacheBuster = require('./util/cache_buster')
 const spec = require('./controllers/spec')
 const reporter = require('./controllers/reporter')
@@ -55,6 +56,14 @@ module.exports = ({ app, config, getRemoteState, networkProxy, project, onError 
   // special fallback - serve local files from the project's root folder
   app.get('/__root/*', (req, res) => {
     const file = path.join(config.projectRoot, req.params[0])
+
+    res.sendFile(file, { etag: false })
+  })
+
+  app.get('/__bundled/*', (req, res) => {
+    const file = AppData.getBundledFilePath(config.projectRoot, path.join('src', req.params[0]))
+
+    debug(`Serving dist'd bundle at file path: %o`, { path: file, url: req.url })
 
     res.sendFile(file, { etag: false })
   })

--- a/packages/server/lib/saved_state.js
+++ b/packages/server/lib/saved_state.js
@@ -1,10 +1,7 @@
 const _ = require('lodash')
 const debug = require('debug')('cypress:server:saved_state')
-const md5 = require('md5')
 const path = require('path')
 const Promise = require('bluebird')
-const sanitize = require('sanitize-filename')
-
 const appData = require('./util/app_data')
 const cwd = require('./cwd')
 const FileUtil = require('./util/file')
@@ -28,21 +25,6 @@ reporterWidth
 showedOnBoardingModal
 preferredOpener
 `.trim().split(/\s+/)
-
-const toHashName = function (projectRoot) {
-  if (!projectRoot) {
-    throw new Error('Missing project path')
-  }
-
-  if (!path.isAbsolute(projectRoot)) {
-    throw new Error(`Expected project absolute path, not just a name ${projectRoot}`)
-  }
-
-  const name = sanitize(path.basename(projectRoot))
-  const hash = md5(projectRoot)
-
-  return `${name}-${hash}`
-}
 
 const formStatePath = (projectRoot) => {
   return Promise.try(() => {
@@ -73,7 +55,7 @@ const formStatePath = (projectRoot) => {
     if (projectRoot) {
       debug(`state path for project ${projectRoot}`)
 
-      return path.join(toHashName(projectRoot), fileName)
+      return path.join(appData.toHashName(projectRoot), fileName)
     }
 
     debug('state path for global mode')
@@ -139,5 +121,4 @@ const create = (projectRoot, isTextTerminal) => {
 module.exports = {
   create,
   formStatePath,
-  toHashName,
 }

--- a/packages/server/lib/util/app_data.js
+++ b/packages/server/lib/util/app_data.js
@@ -8,6 +8,8 @@ const log = require('debug')('cypress:server:appdata')
 const pkg = require('@packages/root')
 const fs = require('../util/fs')
 const cwd = require('../cwd')
+const md5 = require('md5')
+const sanitize = require('sanitize-filename')
 
 const PRODUCT_NAME = pkg.productName || pkg.name
 const OS_DATA_PATH = ospath.data()
@@ -30,7 +32,28 @@ const isProduction = () => {
   return process.env.CYPRESS_INTERNAL_ENV === 'production'
 }
 
+const toHashName = (projectRoot) => {
+  if (!projectRoot) {
+    throw new Error('Missing project path')
+  }
+
+  if (!path.isAbsolute(projectRoot)) {
+    throw new Error(`Expected project absolute path, not just a name ${projectRoot}`)
+  }
+
+  const name = sanitize(path.basename(projectRoot))
+  const hash = md5(projectRoot)
+
+  return `${name}-${hash}`
+}
+
 module.exports = {
+  toHashName,
+
+  getBundledFilePath (projectRoot, filePath) {
+    return this.projectsPath(toHashName(projectRoot), 'bundles', filePath)
+  },
+
   ensure () {
     const ensure = () => {
       return this.removeSymlink()

--- a/packages/server/test/unit/saved_state_spec.js
+++ b/packages/server/test/unit/saved_state_spec.js
@@ -9,31 +9,6 @@ const appData = require(`${root}lib/util/app_data`)
 const savedState = require(`${root}lib/saved_state`)
 
 describe('lib/saved_state', () => {
-  describe('#toHashName', () => {
-    const projectRoot = '/foo/bar'
-
-    it('starts with folder name', () => {
-      const hash = savedState.toHashName(projectRoot)
-
-      expect(hash).to.match(/^bar-/)
-    })
-
-    it('computed for given path', () => {
-      const hash = savedState.toHashName(projectRoot)
-      const expected = 'bar-1df481b1ec67d4d8bec721f521d4937d'
-
-      expect(hash).to.equal(expected)
-    })
-
-    it('does not handle empty project path', () => {
-      const tryWithoutPath = () => {
-        return savedState.toHashName()
-      }
-
-      expect(tryWithoutPath).to.throw('Missing project path')
-    })
-  })
-
   context('#create', () => {
     beforeEach(() => {
       return savedState.create().then((state) => {

--- a/packages/server/test/unit/util/app_data_spec.js
+++ b/packages/server/test/unit/util/app_data_spec.js
@@ -1,0 +1,42 @@
+require('../../spec_helper')
+
+const AppData = require(`${root}../lib/util/app_data`)
+
+describe('lib/util/app_data', () => {
+  context('#toHashName', () => {
+    const projectRoot = '/foo/bar'
+
+    it('starts with folder name', () => {
+      const hash = AppData.toHashName(projectRoot)
+
+      expect(hash).to.match(/^bar-/)
+    })
+
+    it('computed for given path', () => {
+      const hash = AppData.toHashName(projectRoot)
+      const expected = 'bar-1df481b1ec67d4d8bec721f521d4937d'
+
+      expect(hash).to.equal(expected)
+    })
+
+    it('does not handle empty project path', () => {
+      const tryWithoutPath = () => {
+        return AppData.toHashName()
+      }
+
+      expect(tryWithoutPath).to.throw('Missing project path')
+    })
+  })
+
+  context('#getBundledFilePath', () => {
+    it('provides an absolute path to the bundled file', () => {
+      const projectRoot = '/foo/bar'
+      const expectedPrefix = 'bar-1df481b1ec67d4d8bec721f521d4937d'
+      const imagePath = '/img/123.png'
+      const result = AppData.getBundledFilePath(projectRoot, imagePath)
+
+      expect(result).to.contain(expectedPrefix)
+      expect(result).to.contain(imagePath)
+    })
+  })
+})


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

### User facing changelog

- Internal-only Route to expose bundled assets added for experimental Component Testing plugin

<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

- This is to support component testing.
- Build configurations output files and source code expects that it can import those files under a static server.
- When writing component tests for [@bahmutov/cypress-x-unit-testing](https://github.com/bahmutov/cypress-react-unit-test/tree/feature/cypress-mount-mode#basic-examples) users are unable to component test anything that loads static or dynamically imported assets
- This change only affects the Cypress server
- Allows locally bundled assets to be accessed under the Cypress server via the `/__bundled/*` path
- Supports static assets, images, and chunked bundles in [@bahmutov/cypress-x-unit-testing](https://github.com/bahmutov/cypress-react-unit-test/tree/feature/cypress-mount-mode#basic-examples)

### How has the user experience changed?

- It hasn't, this feature is experimental

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
