### PR TITLE
Make TypeScript always transpile modules to CommonJS style

### DIFF
--- a/packages/server/lib/plugins/child/run_plugins.js
+++ b/packages/server/lib/plugins/child/run_plugins.js
@@ -189,7 +189,7 @@ module.exports = (ipc, pluginsFile, projectRoot) => {
         compiler: tsPath,
         transpileOnly: true,
         compilerOptions: {
-
+          module: 'CommonJS',
           esModuleInterop: true,
         },
       })

--- a/packages/server/lib/project.js
+++ b/packages/server/lib/project.js
@@ -112,6 +112,10 @@ class Project extends EE {
         tsnode.register({
           compiler: tsPath,
           transpileOnly: true,
+          compilerOptions: {
+            module: 'CommonJS',
+            esModuleInterop: true,
+          },
         })
       } catch (e) {
         debug(`typescript doesn't exist. ts-node setup passed.`)

--- a/packages/server/test/unit/project_spec.js
+++ b/packages/server/test/unit/project_spec.js
@@ -351,6 +351,10 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
           expect(register).to.be.calledWith({
             transpileOnly: true,
             compiler: projTsPath,
+            compilerOptions: {
+              module: 'CommonJS',
+              esModuleInterop: true,
+            },
           })
         })
       })


### PR DESCRIPTION
- Closes #7151
- Closes #7043
- Closes #7011

### User facing changelog

Cypress ignore typescript module configuration in tsconfig file and transpile code to only CommonJS style. 

### Additional details

#### Why was this change necessary?

TypeScript can transpile modules in different styles. But node can only execute CommonJS style. 

#### What is affected by this change?

N/A

#### Any implementation details to explain?

I added this option to `run_plugins.js` for similar cases. 


### How has the user experience changed?

N/A

### About testing

Like #7072, it should be tested on the master branch.

### PR Tasks

- [N/A] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
