### PR TITLE
Improve deploy doc

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -6,19 +6,11 @@ and publish the NPM module `cypress` if you are a member of the `cypress` NPM or
 > :information_source: See the [publishing](#publishing) section for how to build, test and publish a
 new official version of the binary and `cypress` NPM package.
 
-## Set next version on CIs
-
-We build the NPM package and binary on all major platforms (Linux, Mac, Windows) on different CI
-providers. In order to set the version while building we have to set the environment variable
-with the new version on each CI provider *before starting the build*.
-
-Use script command `yarn set-next-ci-version` to do this.
-
-## Building
+## Building Locally
 
 ### Building the NPM package
 
-> :warning: Note: The steps in this section are automated in CI, and you should not generally need to do them yourself.
+> :warning: Note: The steps in this section are automated in CI, and you should not need to do them yourself when publishing.
 
 Building a new NPM package is very quick.
 
@@ -31,49 +23,15 @@ The steps above:
 - Transpile the code into ES5 to be compatible with the common Node versions
 - Put the result into the [`cli/build`](./cli/build) folder.
 
-You could publish from there, but first you need to build and upload the binary with the *same version*;
-this guarantees that when users do `npm i cypress@<x.y.z>` they can download the binary
-with the same version `x.y.z` from Cypress's CDN service.
-
 ### Building the binary
 
-> :warning: Note: The steps in this section are automated in CI, and you should not generally need to do them yourself.
+> :warning: Note: The steps in this section are automated in CI, and you should not need to do them yourself when publishing.
 
-First, you need to build, zip and upload the application binary to the Cypress server.
+The NPM package requires a corresponding binary of the same version. In production, it will try to retrieve the binary from the Cypress CDN if it is not cached locally.
 
-You can use a single command to do all tasks at once:
+You can build the Cypress binary locally by running `yarn binary-build`. You can use Docker to build a Linux binary by running `yarn binary-build-linux`.
 
-```shell
-yarn binary-deploy
-```
-
-Or you can specify each command separately:
-
-```shell
-yarn binary-build
-yarn binary-zip
-yarn binary-upload
-```
-
-You can pass options to each command to avoid answering questions, for example
-
-```shell
-yarn binary-deploy --platform darwin --version 0.20.0
-yarn binary-upload --platform darwin --version 0.20.0 --zip cypress.zip
-```
-
-If something goes wrong, see the debug messages using the `DEBUG=cypress:binary ...` environment
-variable.
-
-Because we had many problems reliably zipping the built binary, for now we need to build both the Mac and Linux binary from Mac (Linux binary is built using a Docker container), then zip it **from Mac**, then upload it.
-
-### Building Linux binary in Docker
-
-If you are using a Mac you can build the linux binary if you have docker installed.
-
-```shell
-yarn binary-build-linux
-```
+`yarn binary-zip` can be used to zip the built binary together.
 
 ## Publishing
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -106,6 +106,8 @@ In the following instructions, "X.Y.Z" is used to denote the version of Cypress 
 1. Make sure you have the correct permissions set up before proceeding:
     - An AWS account with permission to create AWS access keys for the Cypress CDN.
     - Permissions for your npm account to publish the `cypress` package.
+    - Permissions to modify environment variables for `cypress` on CircleCI and AppVeyor.
+    - Permissions to update releases in ZenHub.
 2. Make sure that you have the correct environment variables set up before proceeding:
     - Cypress AWS access key and secret in `aws_credentials_json`, which looks like this:
         ```text
@@ -128,17 +130,17 @@ In the following instructions, "X.Y.Z" is used to denote the version of Cypress 
     ```shell
     yarn move-binaries --sha <commit sha> --version <new target version>
     ```
-4. Publish the new NPM package under the dev tag.
+4. Publish the new NPM package under the `dev` tag, using your personal NPM account.
     - To find the link to the package file `cypress.tgz`:
         1. In GitHub, go to the latest commit (the one whose sha you used in the last step).
             ![commit-link](https://user-images.githubusercontent.com/1157043/80608728-33fe6100-8a05-11ea-8b53-375303757b67.png)
         2. Scroll down past the changes to the comments. The first comment should be a `cypress-bot` comment that includes a line beginning `npm install ...`. Grab the `https://cdn.../npm/X.Y.Z/<long sha>/cypress.tgz` link.
             ![cdn-tgz-link](https://user-images.githubusercontent.com/1157043/80608736-3791e800-8a05-11ea-8d75-e4f80128e857.png)
     - Publish to the NPM registry straight from the URL:
-    ```shell
-    npm publish https://cdn.../npm/X.Y.Z/<long sha>/cypress.tgz --tag dev
-    ```
-5. Double-check that the new version has been published under the `dev` tag using `npm info cypress` or [available-versions](https://github.com/bahmutov/available-versions). Example output:
+        ```shell
+        npm publish https://cdn.../npm/X.Y.Z/<long sha>/cypress.tgz --tag dev
+        ```
+5. Double-check that the new version has been published under the `dev` tag using `npm info cypress` or [available-versions](https://github.com/bahmutov/available-versions). `latest` should still point to the previous version. Example output:
     ```shell
     dist-tags:
     dev: 3.4.0     latest: 3.3.2
@@ -159,10 +161,11 @@ In the following instructions, "X.Y.Z" is used to denote the version of Cypress 
     ```shell
     npm dist-tag add cypress@X.Y.Z
     ```
-9. Run `binary-release` to update the download server's manifest, set the next CI version, and create an empty version commit:
+9. Run `binary-release` to update the [download server's manifest](https://download.cypress.io/desktop.json) and set the next CI version:
     ```shell
-    yarn run binary-release --version X.Y.Z --commit
+    yarn run binary-release --version X.Y.Z
     ```
+    > Note: Currently, there is an [issue setting the next CI version](https://github.com/cypress-io/cypress/issues/7176) that will cause this command to fail after setting the download manifest. You will need to manually update NEXT_DEV_VERSION by logging in to CircleCI and AppVeyor.
 10. If needed, push out any updated changes to the links manifest to [`on.cypress.io`](https://github.com/cypress-io/cypress-services/tree/develop/packages/on).
 11. If needed, deploy the updated [`cypress-example-kitchensink`][cypress-example-kitchensink] to `example.cypress.io` by following [these instructions under "Deployment"](./packages/example/README.md).
 12. Update the releases in [ZenHub](https://app.zenhub.com/workspaces/test-runner-5c3ea3baeb1e75374f7b0708/reports/release):


### PR DESCRIPTION
The deploy doc is great, but could use some more details to help a new deployer release a new version of Cypress.