### PR TITLE
Use console.error for logging specs found in debug mode

### DIFF
--- a/packages/server/lib/util/specs.js
+++ b/packages/server/lib/util/specs.js
@@ -232,7 +232,7 @@ const find = (config, specPattern) => {
     })
 
     /* eslint-disable no-console */
-    console.log(table.toString())
+    console.error(table.toString())
   }
 
   return Promise.all([


### PR DESCRIPTION
Use `stderr` for debugging information instead of `stdout`, otherwise `e2e` tests will always fail with `DEBUG` enabled because it causes the `stdout` snapshots to differ.