### PR TITLE
watch spec file without assuming it is integration spec

### DIFF
--- a/packages/runner/src/iframe/iframes.jsx
+++ b/packages/runner/src/iframe/iframes.jsx
@@ -102,7 +102,7 @@ export default class Iframes extends Component {
     logger.clearLog()
     this._setScriptError(null)
 
-    this.props.eventManager.setup(config, specPath)
+    this.props.eventManager.setup(config)
 
     const $autIframe = this._loadIframes(specPath)
 

--- a/packages/runner/src/lib/event-manager.js
+++ b/packages/runner/src/lib/event-manager.js
@@ -189,7 +189,7 @@ const eventManager = {
     }
   },
 
-  setup (config, specPath) {
+  setup (config) {
     Cypress = this.Cypress = $Cypress.create(config)
 
     // expose Cypress globally
@@ -197,7 +197,7 @@ const eventManager = {
 
     this._addListeners()
 
-    ws.emit('watch:test:file', specPath)
+    ws.emit('watch:test:file', config.spec)
   },
 
   isBrowser (browserName) {

--- a/packages/server/lib/controllers/files.coffee
+++ b/packages/server/lib/controllers/files.coffee
@@ -31,11 +31,13 @@ module.exports = {
     .then (specs) =>
       @getJavascripts(config)
       .then (js) =>
-        res.render iframePath, {
+        iframeOptions = {
           title: @getTitle(test)
           domain: getRemoteState().domainName
           scripts:  JSON.stringify(js.concat(specs))
         }
+        debug("iframe %s options %o", test, iframeOptions)
+        res.render iframePath, iframeOptions
 
   getSpecs: (spec, config) ->
     debug("get specs %o", { spec })

--- a/packages/server/lib/socket.js
+++ b/packages/server/lib/socket.js
@@ -69,24 +69,19 @@ class Socket {
     })
   }
 
-  // TODO: clean this up by sending the spec object instead of
-  // the url path
-  watchTestFileByPath (config, originalFilePathOrSpecConfig, options) {
-    let filePath
+  watchTestFileByPath (config, specConfig, options) {
+    debug('watching spec with config %o', specConfig)
 
-    if (typeof originalFilePathOrSpecConfig === 'string') {
-      // files are always sent as integration/foo_spec.js
-      // need to take into account integrationFolder may be different so
-      // integration/foo_spec.js becomes cypress/my-integration-folder/foo_spec.js
-      debug('watch test file %o', originalFilePathOrSpecConfig)
-      const originalFilePath = originalFilePathOrSpecConfig
+    const cleanIntegrationPrefix = (s) => {
+      const removedIntegrationPrefix = path.join(config.integrationFolder, s.replace(`integration${path.sep}`, ''))
 
-      filePath = path.join(config.integrationFolder, originalFilePath.replace(`integration${path.sep}`, ''))
-      filePath = path.relative(config.projectRoot, filePath)
-    } else {
-      debug('watching spec with config %o', originalFilePathOrSpecConfig)
-      filePath = originalFilePathOrSpecConfig.absolute
+      return path.relative(config.projectRoot, removedIntegrationPrefix)
     }
+
+    // previously we have assumed that we pass integration spec path with "integration/" prefix
+    // now we pass spec config object that tells what kind of spec it is, has relative path already
+    // so the only special handling remains for special paths like "integration/__all"
+    const filePath = typeof specConfig === 'string' ? cleanIntegrationPrefix(specConfig) : specConfig.relative
 
     // bail if this is special path like "__all"
     // maybe the client should not ask to watch non-spec files?

--- a/packages/server/test/unit/socket_spec.coffee
+++ b/packages/server/test/unit/socket_spec.coffee
@@ -323,11 +323,12 @@ describe "lib/socket", ->
           done()
 
     context "on(watch:test:file)", ->
-      it "calls socket#watchTestFileByPath with config, filePath", (done) ->
+      it "calls socket#watchTestFileByPath with config, spec argument", (done) ->
         sinon.stub(@socket, "watchTestFileByPath")
 
-        @client.emit "watch:test:file", "path/to/file", =>
-          expect(@socket.watchTestFileByPath).to.be.calledWith(@cfg, "path/to/file")
+        specArgument = {}
+        @client.emit "watch:test:file", specArgument, =>
+          expect(@socket.watchTestFileByPath).to.be.calledWith(@cfg, specArgument)
           done()
 
     context "on(app:connect)", ->
@@ -497,6 +498,15 @@ describe "lib/socket", ->
       it "watches file by path", ->
         @socket.watchTestFileByPath(@cfg, "integration#{path.sep}test2.coffee")
         expect(preprocessor.getFile).to.be.calledWith("tests#{path.sep}test2.coffee", @cfg)
+
+      it "watches file by relative path in spec object", ->
+        # this is what happens now with component / integration specs
+        spec = {
+          absolute: "#{path.sep}foo#{path.sep}bar",
+          relative: "relative#{path.sep}to#{path.sep}root#{path.sep}test2.coffee"
+        }
+        @socket.watchTestFileByPath(@cfg, spec)
+        expect(preprocessor.getFile).to.be.calledWith(spec.relative, @cfg)
 
       it "triggers watched:file:changed event when preprocessor 'file:updated' is received", (done) ->
         sinon.stub(fs, "statAsync").resolves()


### PR DESCRIPTION
- Closes #7244

### User facing changelog

Only relevant for component testing specs, no longer the first ask for the spec going to non-existent file.

### Additional details

When clicking on the component spec, the file watch immediately points at the right file without assuming it is integration

### How has the user experience changed?

The change is under the hood, no user-facing changes

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
