### PR TITLE
Replace forked dep with current xvfb-maybe version

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -190,7 +190,7 @@
     "through2": "^2.0.0",
     "ws": "5.2.2",
     "xvfb": "cypress-io/node-xvfb#22e3783c31d81ebe64d8c0df491ea00cdc74726a",
-    "xvfb-maybe": "cypress-io/xvfb-maybe#c4a810c42d603949cd63b8cf245f6c239331d370"
+    "xvfb-maybe": "0.2.1"
   },
   "files": [
     "config",

--- a/packages/server/test/scripts/run.js
+++ b/packages/server/test/scripts/run.js
@@ -70,8 +70,9 @@ if (isWindows()) {
   commandAndArguments.command = 'xvfb-maybe'
   // this should always match cli/lib/exec/xvfb.js
   commandAndArguments.args = [
-    '-- ' +
-    '-as -screen 0 1280x1024x24',
+    `-as`,
+    `"-screen 0 1280x1024x24"`,
+    `--`,
     'node',
   ]
 }

--- a/packages/server/test/scripts/run.js
+++ b/packages/server/test/scripts/run.js
@@ -71,7 +71,7 @@ if (isWindows()) {
   // this should always match cli/lib/exec/xvfb.js
   commandAndArguments.args = [
     '-- ' +
-    '"-as \\"-screen 0 1280x1024x24\\""',
+    '-as -screen 0 1280x1024x24',
     'node',
   ]
 }

--- a/packages/server/test/scripts/run.js
+++ b/packages/server/test/scripts/run.js
@@ -70,7 +70,7 @@ if (isWindows()) {
   commandAndArguments.command = 'xvfb-maybe'
   // this should always match cli/lib/exec/xvfb.js
   commandAndArguments.args = [
-    '--xvfb-run-args ' +
+    '-- ' +
     '"-as \\"-screen 0 1280x1024x24\\""',
     'node',
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -25544,12 +25544,12 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.0, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-xvfb-maybe@cypress-io/xvfb-maybe#c4a810c42d603949cd63b8cf245f6c239331d370:
-  version "0.1.3"
-  resolved "https://codeload.github.com/cypress-io/xvfb-maybe/tar.gz/c4a810c42d603949cd63b8cf245f6c239331d370"
+xvfb-maybe@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/xvfb-maybe/-/xvfb-maybe-0.2.1.tgz#ed8cb132957b7848b439984c66f010ea7f24361b"
+  integrity sha1-7YyxMpV7eEi0OZhMZvAQ6n8kNhs=
   dependencies:
     debug "^2.2.0"
-    shell-quote "^1.6.1"
     which "^1.2.4"
 
 xvfb@cypress-io/node-xvfb#22e3783c31d81ebe64d8c0df491ea00cdc74726a:


### PR DESCRIPTION
- partially address #6730 
- partially address lint failure of #7254 

## User Changelog

N/a

## Additional details

- Our fork of xvfb-maybe is no longer necessary since the commit we needed was implemented in the main npm package. 
- Our forked commit: https://github.com/cypress-io/xvfb-maybe/commit/c4a810c42d603949cd63b8cf245f6c239331d370
- Their commit: https://github.com/anaisbetts/xvfb-maybe/commit/895e18d21df7e39990913148865c8ce6e665a1c8
- I paired with brian to get the correct args sent after moving over, phew 😓 