### PR TITLE
Remove override of lodash capitalize method

### DIFF
--- a/packages/driver/src/config/lodash.d.ts
+++ b/packages/driver/src/config/lodash.d.ts
@@ -6,7 +6,6 @@ import clean from 'underscore.string/clean'
 import count from 'underscore.string/count'
 import isBlank from 'underscore.string/isBlank'
 import toBoolean from 'underscore.string/toBoolean'
-import capitalize from 'underscore.string/capitalize'
 
 const inflection = underscoreInflection(_)
 
@@ -16,7 +15,6 @@ _.mixin({
   count,
   isBlank,
   toBoolean,
-  capitalize, // its mo' better the lodash version
   ordinalize: inflection.ordinalize,
 })
 
@@ -26,7 +24,6 @@ declare module 'lodash' {
     count(...args): LoDashExplicitWrapper<TValue>
     isBlank(...args): LoDashExplicitWrapper<TValue>
     toBoolean(...args): LoDashExplicitWrapper<TValue>
-    capitalize(...args): LoDashExplicitWrapper<TValue>
     ordinalize(...args): LoDashExplicitWrapper<TValue>
   }
 
@@ -35,7 +32,6 @@ declare module 'lodash' {
     count(...args): LoDashExplicitWrapper<TValue>
     isBlank(...args): LoDashExplicitWrapper<TValue>
     toBoolean(...args): LoDashExplicitWrapper<TValue>
-    capitalize(...args): LoDashExplicitWrapper<TValue>
     ordinalize(...args): LoDashExplicitWrapper<TValue>
   }
 }

--- a/packages/driver/src/config/lodash.js
+++ b/packages/driver/src/config/lodash.js
@@ -8,7 +8,6 @@ _.mixin({
   count: require('underscore.string/count'),
   isBlank: require('underscore.string/isBlank'),
   toBoolean: require('underscore.string/toBoolean'),
-  capitalize: require('underscore.string/capitalize'), // its mo' better the lodash version
   ordinalize: inflection.ordinalize,
 })
 

--- a/packages/driver/src/cypress/error_messages.coffee
+++ b/packages/driver/src/cypress/error_messages.coffee
@@ -1,4 +1,5 @@
 _ = require("lodash")
+capitalize = require('underscore.string/capitalize')
 
 divider = (num, char) ->
   Array(num).join(char)
@@ -27,7 +28,7 @@ formatProp = (memo, field) ->
   {key, value} = field
 
   if value?
-    memo.push(_.capitalize(key) + ": " + format(value))
+    memo.push(capitalize(key) + ": " + format(value))
   memo
 
 cmd = (command, args = "") ->

--- a/packages/driver/src/cypress/server.coffee
+++ b/packages/driver/src/cypress/server.coffee
@@ -1,4 +1,5 @@
 _ = require("lodash")
+capitalize = require('underscore.string/capitalize')
 minimatch = require("minimatch")
 
 $utils = require("./utils")
@@ -16,7 +17,7 @@ setHeader = (xhr, key, val, transformer) ->
     if transformer
       val = transformer(val)
 
-    key = "X-Cypress-" + _.capitalize(key)
+    key = "X-Cypress-" + capitalize(key)
     xhr.setRequestHeader(key, encodeURI(val))
 
 normalize = (val) ->

--- a/packages/driver/src/cypress/utils.coffee
+++ b/packages/driver/src/cypress/utils.coffee
@@ -1,5 +1,6 @@
 $ = require("jquery")
 _ = require("lodash")
+capitalize = require('underscore.string/capitalize')
 methods = require("methods")
 moment = require("moment")
 
@@ -99,7 +100,7 @@ module.exports = {
     @normalizeObjWithLength(filter)
 
     whereFilterHasSameKeyButDifferentValue = (value, key) ->
-      upperKey = _.capitalize(key)
+      upperKey = capitalize(key)
 
       (_.has(filter, key) or _.has(filter, upperKey)) and
         filter[key] isnt value

--- a/packages/driver/test/cypress/integration/cypress/cypress_spec.js
+++ b/packages/driver/test/cypress/integration/cypress/cypress_spec.js
@@ -1,4 +1,5 @@
 const { $, Promise } = Cypress
+const lodash = require('lodash')
 
 describe('driver/src/cypress/index', () => {
   let CypressInstance
@@ -34,6 +35,17 @@ describe('driver/src/cypress/index', () => {
       cy.get(':foo').then(($el) => {
         expect($el.get(0)).to.eq($foo.get(0))
       })
+    })
+  })
+
+  context('_', () => {
+    it('exposes lodash methods', () => {
+      expect(Object.getOwnPropertyNames(Cypress._)).to.include.members(Object.getOwnPropertyNames(lodash))
+    })
+
+    it('has same lodash capitalize method', () => {
+      // https://github.com/cypress-io/cypress/issues/7222
+      expect(Cypress._.capitalize('FOO BAR')).to.eq(lodash.capitalize('FOO BAR'))
     })
   })
 


### PR DESCRIPTION
- close #7222 

### User Changelog

- Using `Cypress._.capitalize` now correctly behaves the same as lodash's `capitalize` method.

### Additional Details

- we've been overriding `Cypress._.capitalize` with underscore.string's capitalize method which is different from lodashs - it only uppercases the first character, whereas lodash will uppercase first character and lowercase all other chars. 
- replaced our internal uses with underscore.string's capitalize since it's "mo' better"

### How has the user experience changed?

#### Before

```js
const lodash_ = require('lodash')

it('works', () => {
  lodash_.capitalize('FOO BAR')   // Foo bar
  Cypress._.capitalize('FOO BAR') // FOO BAR
})
```

#### After

```js
const lodash_ = require('lodash')

it('works', () => {
  lodash_.capitalize('FOO BAR')   // Foo bar
  Cypress._.capitalize('FOO BAR') // Foo bar
})
```


### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->