### PR TITLE
Improve cy.task errors

### DIFF
--- a/packages/driver/src/cy/commands/task.js
+++ b/packages/driver/src/cy/commands/task.js
@@ -90,7 +90,13 @@ module.exports = (Commands, Cypress, cy) => {
 
         $errUtils.throwErrByPath('task.failed', {
           onFail: options._log,
-          args: { task, error: err?.stack || err?.message || err },
+          args: { task, error: err?.message || err },
+          errProps: {
+            appendToStack: {
+              title: 'From Node.js Internals',
+              content: err?.stack || err,
+            },
+          },
         })
       })
     },

--- a/packages/driver/test/cypress/integration/commands/task_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/task_spec.coffee
@@ -151,7 +151,7 @@ describe "src/cy/commands/task", ->
           expect(lastLog.get("state")).to.eq("failed")
 
           expect(err.message).to.include("`cy.task('foo')` failed with the following error:")
-          expect(err.message).to.include("Error: task failed")
+          expect(err.message).to.include("> task failed")
           done()
 
         cy.task("foo")

--- a/packages/server/__snapshots__/6_task_spec.coffee.js
+++ b/packages/server/__snapshots__/6_task_spec.coffee.js
@@ -103,7 +103,11 @@ https://on.cypress.io/api/task
   2) includes stack trace in error:
      CypressError: \`cy.task('errors')\` failed with the following error:
 
-> Error: Error thrown in task handler
+> Error thrown in task handler
+      [stack trace lines]
+  
+  From Node.js Internals:
+    Error: Error thrown in task handler
       [stack trace lines]
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7263 

### User facing changelog

- N/A as long as this goes in next release with error improvements. It's just an extension of that and doesn't need to be called out explicitly.

### How has the user experience changed?

Before:

![Screen Shot 2020-05-07 at 12 33 49 PM](https://user-images.githubusercontent.com/1157043/81320338-077ac280-905f-11ea-80fa-a1fa763ef3cb.png)

After (default):

![Screen Shot 2020-05-07 at 12 38 20 PM](https://user-images.githubusercontent.com/1157043/81321279-5ecd6280-9060-11ea-8689-6c793c8d3dba.png)

After (stack trace open):

![Screen Shot 2020-05-07 at 12 38 28 PM](https://user-images.githubusercontent.com/1157043/81321291-6260e980-9060-11ea-8bc9-20c59d7c0bb3.png)


### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
