### PR TITLE
[internal] fix flake firefox xhr_spec: bump timeout

### DIFF
--- a/packages/driver/test/cypress/integration/commands/xhr_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/xhr_spec.coffee
@@ -1580,26 +1580,24 @@ describe "src/cy/commands/xhr", ->
           done()
 
         cy.route()
-      _.times 50, ->
 
-        it "sets err on log when caused by the XHR response", (done) ->
-          @route.restore()
+      it "sets err on log when caused by the XHR response", (done) ->
+        @route.restore()
 
-          cy.on "fail", (err) =>
-            lastLog = @lastLog
+        cy.on "fail", (err) =>
+          lastLog = @lastLog
 
-            ## route + window + xhr log === 3
-            expect(@logs.length).to.eq(3)
-            expect(lastLog.get("name")).to.eq("xhr")
-            expect(err).to.eq(lastLog.get("error"))
-            done()
+          ## route + window + xhr log === 3
+          expect(@logs.length).to.eq(3)
+          expect(lastLog.get("name")).to.eq("xhr")
+          expect(err).to.eq(lastLog.get("error"))
+          done()
 
-          cy
-            .route(/foo/, {}).as("getFoo")
-            .window().then (win) ->
-              win.$.get("foo_bar").done ->
-                foo.bar()
-      
+        cy
+          .route(/foo/, {}).as("getFoo")
+          .window().then (win) ->
+            win.$.get("foo_bar").done ->
+              foo.bar()
 
       ## FIXME: I have no idea why this is skipped, this test is rly old
       it.skip "explodes if response fixture signature errors", (done) ->

--- a/packages/driver/test/cypress/integration/commands/xhr_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/xhr_spec.coffee
@@ -1,6 +1,4 @@
-_ = Cypress._
-$ = Cypress.$
-Promise = Cypress.Promise
+{ _, $, Promise } = Cypress
 
 describe "src/cy/commands/xhr", ->
   before ->
@@ -1491,7 +1489,7 @@ describe "src/cy/commands/xhr", ->
 
     describe "errors", ->
       beforeEach ->
-        Cypress.config("defaultCommandTimeout", 50)
+        Cypress.config("defaultCommandTimeout", 100)
 
         @logs = []
 
@@ -1582,24 +1580,26 @@ describe "src/cy/commands/xhr", ->
           done()
 
         cy.route()
+      _.times 50, ->
 
-      it "sets err on log when caused by the XHR response", (done) ->
-        @route.restore()
+        it "sets err on log when caused by the XHR response", (done) ->
+          @route.restore()
 
-        cy.on "fail", (err) =>
-          lastLog = @lastLog
+          cy.on "fail", (err) =>
+            lastLog = @lastLog
 
-          ## route + window + xhr log === 3
-          expect(@logs.length).to.eq(3)
-          expect(lastLog.get("name")).to.eq("xhr")
-          expect(err).to.eq(lastLog.get("error"))
-          done()
+            ## route + window + xhr log === 3
+            expect(@logs.length).to.eq(3)
+            expect(lastLog.get("name")).to.eq("xhr")
+            expect(err).to.eq(lastLog.get("error"))
+            done()
 
-        cy
-          .route(/foo/, {}).as("getFoo")
-          .window().then (win) ->
-            win.$.get("foo_bar").done ->
-              foo.bar()
+          cy
+            .route(/foo/, {}).as("getFoo")
+            .window().then (win) ->
+              win.$.get("foo_bar").done ->
+                foo.bar()
+      
 
       ## FIXME: I have no idea why this is skipped, this test is rly old
       it.skip "explodes if response fixture signature errors", (done) ->


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->
just need to bump a little timeout

should fix flaky `sets err on log when caused by the XHR response`


<!-- Example: "Closes #1234" -->

- Closes #7276

