### PR TITLE
Chunking driver integration tests for external contributors

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -114,11 +114,11 @@ commands:
               yarn cypress:run --record --parallel --group 5x-driver-<< parameters.browser >> --browser << parameters.browser >>
             else
               # external PR
-              TESTFILES=$(circleci tests glob "cypress/integration/**/*_spec.*" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
+              TESTFILES=$(circleci tests glob "test/cypress/integration/**/*_spec.*" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
               echo "Test files for this machine are $TESTFILES"
 
               if [[ -z "$TESTFILES" ]]; then
-                echo "Empty list oftest files"
+                echo "Empty list of test files"
               fi
               yarn cypress:run --browser << parameters.browser >> --spec $TESTFILES
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -105,6 +105,9 @@ commands:
           environment:
             CYPRESS_KONFIG_ENV: production
           command: |
+            echo Current working directory is $PWD
+            echo Total containers $CIRCLE_NODE_TOTAL
+
             if [[ -v PACKAGES_RECORD_KEY_ReMoVe ]]; then
               # internal PR
               CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \

--- a/circle.yml
+++ b/circle.yml
@@ -116,6 +116,10 @@ commands:
               # external PR
               TESTFILES=$(circleci tests glob "cypress/integration/**/*_spec.*" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
               echo "Test files for this machine are $TESTFILES"
+
+              if [[ -z "$TESTFILES" ]]; then
+                echo "Empty list oftest files"
+              fi
               yarn cypress:run --browser << parameters.browser >> --spec $TESTFILES
             fi
           working_directory: packages/driver

--- a/circle.yml
+++ b/circle.yml
@@ -105,7 +105,7 @@ commands:
           environment:
             CYPRESS_KONFIG_ENV: production
           command: |
-            if [[ -v PACKAGES_RECORD_KEY ]]; then
+            if [[ -v PACKAGES_RECORD_KEY_ReMoVe ]]; then
               # internal PR
               CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
               yarn cypress:run --record --parallel --group 5x-driver-<< parameters.browser >> --browser << parameters.browser >>

--- a/circle.yml
+++ b/circle.yml
@@ -102,10 +102,20 @@ commands:
       - run:
           command: yarn wait-on http://localhost:3500
       - run:
+          environment:
+            CYPRESS_KONFIG_ENV: production
           command: |
-            CYPRESS_KONFIG_ENV=production \
-            CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-            yarn cypress:run --record --parallel --group 5x-driver-<< parameters.browser >> --browser << parameters.browser >>
+            # wrong variable on purpose to test internally
+            if [[ -v PACKAGES_RECORD_KEY_rEmOvE ]]; then
+              # internal PR
+              CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
+              yarn cypress:run --record --parallel --group 5x-driver-<< parameters.browser >> --browser << parameters.browser >>
+            else
+              # external PR
+              TESTFILES=$(circleci tests glob "test/cypress/integration/**/*spec.{js,jsx,ts,tsx}" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
+              echo "Test files for this machine are $TESTFILES"
+              yarn cypress:run --browser << parameters.browser >> --spec $TESTFILES
+            fi
           working_directory: packages/driver
       - verify-mocha-results
       - store_test_results:

--- a/circle.yml
+++ b/circle.yml
@@ -112,7 +112,7 @@ commands:
               yarn cypress:run --record --parallel --group 5x-driver-<< parameters.browser >> --browser << parameters.browser >>
             else
               # external PR
-              TESTFILES=$(circleci tests glob "test/cypress/integration/**/*spec.{js,jsx,ts,tsx}" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
+              TESTFILES=$(cd test; circleci tests glob "cypress/integration/**/*spec.{js,jsx,ts,tsx}" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
               echo "Test files for this machine are $TESTFILES"
               yarn cypress:run --browser << parameters.browser >> --spec $TESTFILES
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -105,7 +105,6 @@ commands:
           environment:
             CYPRESS_KONFIG_ENV: production
           command: |
-            # wrong variable on purpose to test internally
             if [[ -v PACKAGES_RECORD_KEY ]]; then
               # internal PR
               CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \

--- a/circle.yml
+++ b/circle.yml
@@ -112,7 +112,7 @@ commands:
               yarn cypress:run --record --parallel --group 5x-driver-<< parameters.browser >> --browser << parameters.browser >>
             else
               # external PR
-              TESTFILES=$(cd test; circleci tests glob "cypress/integration/**/*spec.{js,jsx,ts,tsx}" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
+              TESTFILES=$(circleci tests glob "cypress/integration/**/*spec.{js,jsx,ts,tsx}" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
               echo "Test files for this machine are $TESTFILES"
               yarn cypress:run --browser << parameters.browser >> --spec $TESTFILES
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -106,13 +106,13 @@ commands:
             CYPRESS_KONFIG_ENV: production
           command: |
             # wrong variable on purpose to test internally
-            if [[ -v PACKAGES_RECORD_KEY_rEmOvE ]]; then
+            if [[ -v PACKAGES_RECORD_KEY ]]; then
               # internal PR
               CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
               yarn cypress:run --record --parallel --group 5x-driver-<< parameters.browser >> --browser << parameters.browser >>
             else
               # external PR
-              TESTFILES=$(circleci tests glob "cypress/integration/**/*spec.{js,jsx,ts,tsx}" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
+              TESTFILES=$(circleci tests glob "cypress/integration/**/*_spec.*" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
               echo "Test files for this machine are $TESTFILES"
               yarn cypress:run --browser << parameters.browser >> --spec $TESTFILES
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -108,7 +108,7 @@ commands:
             echo Current working directory is $PWD
             echo Total containers $CIRCLE_NODE_TOTAL
 
-            if [[ -v PACKAGES_RECORD_KEY_ReMoVe ]]; then
+            if [[ -v PACKAGES_RECORD_KEY ]]; then
               # internal PR
               CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
               yarn cypress:run --record --parallel --group 5x-driver-<< parameters.browser >> --browser << parameters.browser >>


### PR DESCRIPTION
- chunk external PRs that do not have environment variables set using Circle test split
- will work for driver integration tests