### PR TITLE
Add a call to action to the new AST error

### DIFF
--- a/packages/driver/src/cypress/error_messages.coffee
+++ b/packages/driver/src/cypress/error_messages.coffee
@@ -843,7 +843,7 @@ module.exports = {
 
   proxy:
     js_rewriting_failed: """
-    An error occurred in the Cypress proxy layer while rewriting your source code. This is a bug in Cypress.
+    An error occurred in the Cypress proxy layer while rewriting your source code. This is a bug in Cypress. Open an issue if you see this message.
 
     JS URL: {{url}}
 


### PR DESCRIPTION
### User Changelog

N/A - this is pre-release fix

### Additional Details

Error messages should detail next steps for the user. What should they do if they’re seeing the error? It’s my understanding that users should not see this error at all - so the proper call to action would be to open an issue in our repo.