### PR TITLE
Add Safari not supported error message

### DIFF
--- a/packages/server/lib/errors.coffee
+++ b/packages/server/lib/errors.coffee
@@ -105,9 +105,18 @@ getMsgByType = (type, arg1 = {}, arg2, arg3) ->
     when "BROWSER_NOT_FOUND_BY_NAME"
       str = """
       Can't run because you've entered an invalid browser name.
+      """
 
-      Browser: '#{arg1}' was not found on your system.
-
+      if arg1 is 'safari'
+        str += """
+        Browser: '#{arg1}' is not supported.
+        """
+      else
+        str += """
+        Browser: '#{arg1}' was not found on your system.
+        """
+      
+      str += """
       Available browsers found are: #{arg2}
       """
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6979 

### User facing changelog

Error message now appropriately indicates that Safari is not supported.

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Change in the error message helps users understand exactly why the error occurred. 
I have modified ```packages/server/lib/errors.coffee``` to achieve the changes. 
Specifically, I have made changes to the ```getMsgByType``` function. 

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
--> I do not know how to test the changes made.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
