### PR TITLE
Fix failure to exit/relaunch Firefox on Windows

### DIFF
--- a/packages/server/lib/browsers/firefox.ts
+++ b/packages/server/lib/browsers/firefox.ts
@@ -3,13 +3,16 @@ import Bluebird from 'bluebird'
 import fs from 'fs-extra'
 import Debug from 'debug'
 import getPort from 'get-port'
+import os from 'os'
 import path from 'path'
 import urlUtil from 'url'
 import FirefoxProfile from 'firefox-profile'
 import firefoxUtil from './firefox-util'
 import utils from './utils'
 import * as launcherDebug from '@packages/launcher/lib/log'
-import { Browser } from './types'
+import { Browser, BrowserInstance } from './types'
+import { EventEmitter } from 'events'
+
 const errors = require('../errors')
 
 const debug = Debug('cypress:server:browsers:firefox')
@@ -287,7 +290,24 @@ const defaultPreferences = {
   'marionette.log.level': launcherDebug.log.enabled ? 'Debug' : undefined,
 }
 
-export async function open (browser: Browser, url, options: any = {}) {
+export function _createDetachedInstance (quitFn: () => Promise<void>): BrowserInstance {
+  const detachedInstance: BrowserInstance = new EventEmitter() as BrowserInstance
+
+  detachedInstance.kill = () => {
+    quitFn()
+    .catch((err) => {
+      debug('error thrown while force-exiting detached instance, continuing %o', { err })
+    })
+    .then(() => {
+      debug('force-exit of detached instance completed')
+      detachedInstance.emit('exit')
+    })
+  }
+
+  return detachedInstance
+}
+
+export async function open (browser: Browser, url, options: any = {}): Bluebird<BrowserInstance> {
   const defaultLaunchOptions = utils.getDefaultLaunchOptions({
     extensions: [] as string[],
     preferences: _.extend({}, defaultPreferences),
@@ -414,10 +434,14 @@ export async function open (browser: Browser, url, options: any = {}) {
 
   const browserInstance = await utils.launch(browser, 'about:blank', launchOptions.args)
 
-  await firefoxUtil.setup({ extensions: launchOptions.extensions, url, foxdriverPort, marionettePort })
-  .catch((err) => {
+  const [, { marionetteQuit }] = await firefoxUtil.setup({ extensions: launchOptions.extensions, url, foxdriverPort, marionettePort })
+  .tapCatch((err) => {
     errors.throw('FIREFOX_COULD_NOT_CONNECT', err)
   })
+
+  if (os.platform() === 'win32') {
+    return _createDetachedInstance(marionetteQuit)
+  }
 
   return browserInstance
 }

--- a/packages/server/lib/browsers/types.ts
+++ b/packages/server/lib/browsers/types.ts
@@ -1,7 +1,12 @@
 import { FoundBrowser } from '@packages/launcher'
+import { EventEmitter } from 'events'
 
 export type Browser = FoundBrowser & {
   majorVersion: number
   isHeadless: boolean
   isHeaded: boolean
+}
+
+export type BrowserInstance = EventEmitter & {
+  kill: () => void
 }

--- a/packages/server/test/e2e/1_firefox_spec.ts
+++ b/packages/server/test/e2e/1_firefox_spec.ts
@@ -56,4 +56,11 @@ describe('e2e firefox', function () {
     project: Fixtures.projectPath('screen-size'),
     spec: 'maximized.spec.js',
   })
+
+  // https://github.com/cypress-io/cypress/issues/6392
+  e2e.it.only('can run multiple specs', {
+    browser: 'firefox',
+    project: Fixtures.projectPath('e2e'),
+    spec: 'simple_spec.coffee,simple_passing_spec.coffee',
+  })
 })


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6392 

### User facing changelog

- Fixed an issue where Firefox would not exit properly when running multiple spec files on Windows, which prevented users from using `cypress run` with multiple spec files on Windows.

### Additional details

- `cmd.exe` shell spawns Firefox on Windows
	- on POSIX-like OS's, we can spawn firefox directly, so this issue does not exist
- Firefox detaches from `cmd.exe`, so when we do `proc.kill`, nothing is exited
- solution: use Marionette to force-quit Firefox on Windows (#7106 contains a different approach, using OS process list to find Firefox's process and kill it)
	- :warning: doesn't seem to close the top-level Firefox process :/

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
