### PR TITLE
[internal] fix flake: e2e spec_isolation(firefox) increase duration padding

### DIFF
--- a/packages/server/test/e2e/5_spec_isolation_spec.coffee
+++ b/packages/server/test/e2e/5_spec_isolation_spec.coffee
@@ -89,7 +89,7 @@ expectRunsToHaveCorrectStats = (runs = []) ->
       run,
       "stats.wallClockDuration",
       wallClocks,
-      wallClocks + 150, ## add 150ms to account for padding
+      wallClocks + 200, ## add 200ms to account for padding
       1234
     )
 
@@ -97,7 +97,7 @@ expectRunsToHaveCorrectStats = (runs = []) ->
       run,
       "reporterStats.duration",
       wallClocks,
-      wallClocks + 150, ## add 150ms to account for padding
+      wallClocks + 200, ## add 200ms to account for padding
       1234
     )
 


### PR DESCRIPTION
fix flake for e2e test 5_spec_isolation (firefox): [example](https://circleci.com/gh/cypress-io/cypress/324553)

needed to bump duration interval