### PR TITLE
fix(launcher): Increase getVersionString timeout to 30s

### DIFF
--- a/packages/launcher/lib/linux/index.ts
+++ b/packages/launcher/lib/linux/index.ts
@@ -67,7 +67,7 @@ export function getVersionString (path: string) {
   log('finding version string using command "%s --version"', path)
 
   return Bluebird.resolve(utils.getOutput(path, ['--version']))
-  .timeout(30000, `Timed out getting version for ${path}`)
+  .timeout(30000, `Timed out after 30 seconds getting browser version for ${path}`)
   .then(prop('stdout'))
   .then(trim)
   .then(tap(partial(log, ['stdout: "%s"'])))

--- a/packages/launcher/lib/linux/index.ts
+++ b/packages/launcher/lib/linux/index.ts
@@ -67,7 +67,7 @@ export function getVersionString (path: string) {
   log('finding version string using command "%s --version"', path)
 
   return Bluebird.resolve(utils.getOutput(path, ['--version']))
-  .timeout(5000, `Timed out getting version for ${path}`)
+  .timeout(30000, `Timed out getting version for ${path}`)
   .then(prop('stdout'))
   .then(trim)
   .then(tap(partial(log, ['stdout: "%s"'])))


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->


### User facing changelog

- Fixed an issue where browsers would not be detected on macOS or Linux if they take longer than 5 seconds to exit from a `--version` command. Timeout has been bumped to 30 seconds.

### Additional details


Users have reported hitting this limit in GitHub Actions while detecting browsers.

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [na] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
