### PR TITLE
fix(server): handle more CDP connection errors

### DIFF
--- a/packages/server/lib/browsers/protocol.js
+++ b/packages/server/lib/browsers/protocol.js
@@ -91,9 +91,6 @@ const getWsTargetFor = (port) => {
   }
 
   return _connectAsync(connectOpts)
-  .catch((err) => {
-    errors.throw('CDP_COULD_NOT_CONNECT', port, err)
-  })
   .then(() => {
     const retry = () => {
       debug('attempting to find CRI target... %o', { retryIndex })
@@ -116,8 +113,9 @@ const getWsTargetFor = (port) => {
 
     return retry()
   })
-  .tapCatch((err) => {
+  .catch((err) => {
     debug('failed to connect to CDP %o', { connectOpts, err })
+    errors.throw('CDP_COULD_NOT_CONNECT', port, err)
   })
 }
 

--- a/packages/server/test/unit/browsers/protocol_spec.ts
+++ b/packages/server/test/unit/browsers/protocol_spec.ts
@@ -43,24 +43,44 @@ describe('lib/browsers/protocol', () => {
   })
 
   context('.getWsTargetFor', () => {
+    const expectedCdpFailedError = stripIndents`
+      Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 20 seconds.
+
+      This usually indicates there was a problem opening the Chrome browser.
+
+      The CDP port requested was ${chalk.yellow('12345')}.
+
+      Error details:
+    `
+
     it('rejects if CDP connection fails', () => {
       const innerErr = new Error('cdp connection failure')
 
       sinon.stub(connect, 'createRetryingSocket').callsArgWith(1, innerErr)
       const p = protocol.getWsTargetFor(12345)
 
-      const expectedError = stripIndents`
-        Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 20 seconds.
+      return expect(p).to.eventually.be.rejected
+      .and.property('message').include(expectedCdpFailedError)
+      .and.include(innerErr.message)
+    })
 
-        This usually indicates there was a problem opening the Chrome browser.
+    it('rejects if CRI.List fails', () => {
+      const innerErr = new Error('cdp connection failure')
 
-        The CDP port requested was ${chalk.yellow('12345')}.
+      sinon.stub(Bluebird, 'delay').resolves()
 
-        Error details:
-      `
+      sinon.stub(CRI, 'List')
+      .withArgs({ host, port: 12345, getDelayMsForRetry: sinon.match.func })
+      .rejects(innerErr)
 
-      expect(p).to.eventually.be.rejected
-      .and.property('message').include(expectedError)
+      const end = sinon.stub()
+
+      sinon.stub(connect, 'createRetryingSocket').callsArgWith(1, null, { end })
+
+      const p = protocol.getWsTargetFor(12345)
+
+      return expect(p).to.eventually.be.rejected
+      .and.property('message').include(expectedCdpFailedError)
       .and.include(innerErr.message)
     })
 


### PR DESCRIPTION
- Closes #6518 (provides a better error when there is some issue launching Chrome)

### User facing changelog

- Improved error handling when Cypress launches Chromium-family browsers.

### Additional details

Moving this .catch statement to clean up errors, for example, the error that occurs in #6518 will now be wrapped by this.

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
