### PR TITLE
Support option `bufferEncoding` in `cy.request()` and `cy.writeFile()`

### DIFF
--- a/packages/driver/src/cy/commands/files.js
+++ b/packages/driver/src/cy/commands/files.js
@@ -121,7 +121,7 @@ module.exports = (Commands, Cypress, cy) => {
         contents = JSON.stringify(contents, null, 2)
       }
 
-      return Cypress.backend('write:file', fileName, contents, _.pick(options, ['encoding', 'flag']))
+      return Cypress.backend('write:file', fileName, contents, _.pick(options, ['encoding', 'flag', 'decodeContentFromBase64']))
       .then(({ contents, filePath }) => {
         consoleProps['File Path'] = filePath
         consoleProps['Contents'] = contents

--- a/packages/driver/src/cy/commands/files.js
+++ b/packages/driver/src/cy/commands/files.js
@@ -121,7 +121,7 @@ module.exports = (Commands, Cypress, cy) => {
         contents = JSON.stringify(contents, null, 2)
       }
 
-      return Cypress.backend('write:file', fileName, contents, _.pick(options, ['encoding', 'flag', 'decodeContentFromBase64']))
+      return Cypress.backend('write:file', fileName, contents, _.pick(options, ['encoding', 'flag', 'bufferEncoding']))
       .then(({ contents, filePath }) => {
         consoleProps['File Path'] = filePath
         consoleProps['Contents'] = contents

--- a/packages/driver/src/cy/commands/request.js
+++ b/packages/driver/src/cy/commands/request.js
@@ -25,9 +25,9 @@ const REQUEST_DEFAULTS = {
   form: null,
   gzip: true,
   timeout: null,
+  bufferEncoding: null,
   followRedirect: true,
   failOnStatusCode: true,
-  encodeBodyToBase64: false,
   retryOnNetworkFailure: true,
   retryOnStatusCodeFailure: false,
 }

--- a/packages/driver/src/cy/commands/request.js
+++ b/packages/driver/src/cy/commands/request.js
@@ -27,6 +27,7 @@ const REQUEST_DEFAULTS = {
   timeout: null,
   followRedirect: true,
   failOnStatusCode: true,
+  encodeBodyToBase64: false,
   retryOnNetworkFailure: true,
   retryOnStatusCodeFailure: false,
 }

--- a/packages/server/lib/files.coffee
+++ b/packages/server/lib/files.coffee
@@ -26,6 +26,8 @@ module.exports = {
       encoding: options.encoding or "utf8"
       flag: options.flag or "w"
     }
+    if (!!options.decodeContentFromBase64)
+      contents = Buffer.from(contents, 'base64')
     fs.outputFile(filePath, contents, writeOptions)
     .then ->
       {

--- a/packages/server/lib/files.coffee
+++ b/packages/server/lib/files.coffee
@@ -26,8 +26,8 @@ module.exports = {
       encoding: options.encoding or "utf8"
       flag: options.flag or "w"
     }
-    if (!!options.decodeContentFromBase64)
-      contents = Buffer.from(contents, 'base64')
+    if (!!options.bufferEncoding && Buffer.isEncoding(options.bufferEncoding))
+      contents = Buffer.from(contents, options.bufferEncoding)
     fs.outputFile(filePath, contents, writeOptions)
     .then ->
       {


### PR DESCRIPTION
<!--
Thanks for contributing!
Read our contribution guidelines here:
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md
-->

If merged with https://github.com/cypress-io/request/pull/4:
- Closes #3576 
- Closes #2029

### User facing changelog

Support `bufferEncoding` boolean option, in [`cy.request()`](https://docs.cypress.io/api/commands/request.html) and [`cy.writeFile()`](https://docs.cypress.io/api/commands/writefile.html).

### Additional details

The root cause of the concerned issues, seems to be in the encoding and decoding of the data that happen all the way long starting from the request instantiation, passing from cypress server to client, then back to cypress server, until writing the file. The resulted PDF file is shown to have the expected number of pages, but the seems to be empty if opened. Also the file does have a reasonable size, yet not precisely as expected.

As a solution, which is proven to be working locally, the value of the `bufferEncoding` option:

- [in `cy.request()`]: will be passed to `responseFullBuffer.toString(ENCODING)` to specify the desired encoding of the string, but for binary files, it is best to use `latin1` (or its alias `binary` as per Node documentation). For images, `base64` might be very useful, as it will simplify the way to have a data url, example: `data:MIME_TYPE,base64:RESPONSE_ENCODED_TO_BASE64`
- [in `cy.writeFile()`]: will passed to `Buffer.from(contentValuePassed, ENCODING)`, to enable converting/decoding a string content to buffer before writing the file.

In general, the possible values of `bufferEncoding` are as listed in [Node documentation](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings):

- `utf8`
- `utf16le`
- `latin1`
- `base64`
- `hex`
- `ascii`
- `binary` alias for latin1
- `ucs2` alias for utf16le

**Note:** The first implementation of this solution was a bit different, as explained in [this comment](https://github.com/cypress-io/cypress/issues/3576#issuecomment-629560092) and as might be noticeable in the commits. I thought at first about a boolean option, called `encodeBodyToBase64`, which would solve the issue, and it indeed solved the issue. But then I wondered why not having all the encoding options supported.

### Analysis

For the particular issues in consideration, I tested all the possible values of `bufferEncoding` against a sample PDF file of size _66851 bytes_. And made few statistics shown below.

Explanation of the testing stages:

**Stage 1**: in the heart of `cy.request()`, during the transformation of the response.body buffer into string. Where the logged values are:

- full buffer size (as received from request)
- first byte in the buffer
- last byte in the buffer
- size of string resulted from the buffer->string transformation (through `buffer.toString(ENCODING)`)

**Stage 2**: in the heart of `cy.writeFile()`, during the transformation of the string of file content passed to `cy.writeFile()` into buffer. The logged values in this stage are:

- size of the string (the content value passed to `cy.writeFile()`)
- size of buffer resulted from the string->buffer transformation (through `Buffer.from(content, ENCODING)`)
- first byte in the buffer
- last byte in the buffer

| Criterion                                                                                          | binary<br>[latin1] | ascii | base64 | hex    | utf16le<br>[ucs2] | utf8       |
| -------------------------------------------------------------------------------------------------- | ------------------ | ----- | ------ | ------ | ----------------- | ---------- |
| Full buffer size in stage 1                                                                        | 66851              | 66851 | 66851  | 66851  | 66851             | 66851      |
| Full buffer size in stage 2                                                                        | 66851              | 66851 | 66851  | 66851  | **66850**         | **101377** |
| First byte in the buffer of stage 1                                                                | 37                 | 37    | 37     | 37     | 37                | 37         |
| First byte in the buffer of stage 2                                                                | 37                 | 37    | 37     | 37     | 37                | 37         |
| First byte in the buffer of stage 1                                                                | 70                 | 70    | 70     | 70     | 70                | 70         |
| First byte in the buffer of stage 2                                                                | 70                 | 70    | 70     | 70     | 70                | 70         |
| Size of string value in stage 1<br>(after responseBuffer->string transformation)                   | 66851              | 66851 | 89136  | 133702 | 33425             | 64703      |
| Size of string value in stage 2<br>(before content->buffer transformation)                         | 66851              | 66851 | 89136  | 133702 | 33425             | 64703      |
| Percentage of string size / buffer size<br>(more data transfer between cypress client and server?) | 100%               | 100%  | 133.3% | 100%   | 50%               | 96.7%      |
| PDF file seems to have the expected content (PDF viewer / Chrome)                                  | **✓**              | **✓** | **✓**  | **✓**  | **✓**             | **✗**      |
| Both stages has the exact same buffer value                                                        | **✓**              | **✓** | **✓**  | **✓**  | **✗**             | **✗**      |

_All sizes are in bytes_

As shown above, the "**buffer<->string**" transformation of the sample PDF content, resulted eventually into the invalid or unexpected PDF content in case of `utf8` and `utf16le` (and its alias `ucs2`). Also, I am not sure that the decrease in string size than buffer size is expected!

The best results are from `ascii` and `binary` encoding. As both did not only guarantee the result file to be exactly as expected, but also the transformation to string did not result into more bytes to be transferred between cypress client and server.

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

The resulted PDF file from the following example will be valid.

```js
/// <reference types="Cypress" />

context('Download Pdf', () => {
  it('Download Pdf', () => {
    const pdfUrl = 'http://www.pdf995.com/samples/pdf.pdf';

    // Will work if bufferEncoding is any of: 'ascii', 'binary', 'base64', 'hex'
    // but not: 'utf8' nor 'utf16le'
    // the best for optimization: 'ascii', 'binary'
    const bufferEncoding = 'base64';
    cy.request({ url: pdfUrl, gzip: false, bufferEncoding: 'base64' }).then(
      (response) => {
        const filePath = `temp/test.pdf`;

        cy.writeFile(filePath, response.body, {
          encoding: 'binary',
          bufferEncoding: 'base64',
        });
      }
    );
  });
});
```

### PR Tasks (TODO)

<!--
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
