### PR TITLE
feat(driver): Add support for `encoding` option in cy.request()

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2458,6 +2458,7 @@ declare namespace Cypress {
   interface RequestOptions extends Loggable, Timeoutable, Failable {
     auth: object
     body: RequestBody
+    encoding: Encodings
     followRedirect: boolean
     form: boolean
     gzip: boolean

--- a/packages/driver/src/cy/commands/request.js
+++ b/packages/driver/src/cy/commands/request.js
@@ -23,6 +23,7 @@ const REQUEST_DEFAULTS = {
   headers: null,
   json: null,
   form: null,
+  encoding: null,
   gzip: true,
   timeout: null,
   followRedirect: true,

--- a/packages/driver/src/cy/commands/request.js
+++ b/packages/driver/src/cy/commands/request.js
@@ -23,7 +23,7 @@ const REQUEST_DEFAULTS = {
   headers: null,
   json: null,
   form: null,
-  encoding: null,
+  encoding: 'utf8',
   gzip: true,
   timeout: null,
   followRedirect: true,

--- a/packages/driver/src/cy/commands/request.js
+++ b/packages/driver/src/cy/commands/request.js
@@ -170,6 +170,18 @@ module.exports = (Commands, Cypress, cy, state, config) => {
         })
       }
 
+      if (options.encoding) {
+        if (!_.isString(options.encoding) || !Buffer.isEncoding(options.encoding)) {
+          $errUtils.throwErrByPath('request.encoding_invalid', {
+            args: {
+              encoding: options.encoding,
+            },
+          })
+        } else {
+          options.encoding = options.encoding.toLowerCase()
+        }
+      }
+
       // if a user has `x-www-form-urlencoded` content-type set
       // with an object body, they meant to add 'form: true'
       // so we are nice and do it for them :)

--- a/packages/driver/src/cypress/error_messages.coffee
+++ b/packages/driver/src/cypress/error_messages.coffee
@@ -884,6 +884,10 @@ module.exports = {
       message: "#{cmd('request')} must be passed an object literal for the `auth` option."
       docsUrl: "https://on.cypress.io/request"
     }
+    encoding_invalid: {
+      message: "#{cmd('request')} was called with invalid encoding: `{{encoding}}`. Encoding can be: `utf8`, `utf16le`, `latin1`, `base64`, `hex`, `ascii`, `binary`, `latin1`, `ucs2`, `utf16le`, or any other encoding supported by Node's Buffer encoding."
+      docsUrl: "https://on.cypress.io/request"
+    }
     gzip_invalid: {
       message: "#{cmd('request')} requires the `gzip` option to be a boolean."
       docsUrl: "https://on.cypress.io/request"

--- a/packages/driver/test/cypress/integration/commands/request_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/request_spec.coffee
@@ -197,6 +197,17 @@ describe "src/cy/commands/request", ->
               url: "http://xn--localhost-ob26h:1234/%F0%9F%98%80"
             })
 
+      context "encoding normalization", ->
+        it "lowercases encoding", ->
+          cy.request({
+            url: "http://localhost:8080/",
+            encoding: "UtF8"
+          }).then ->
+            @expectOptionsToBe({
+              url: "http://localhost:8080/"
+              encoding: "utf8"
+            })
+
       context "gzip", ->
         it "can turn off gzipping", ->
           cy.request({
@@ -737,6 +748,22 @@ describe "src/cy/commands/request", ->
         cy.request({
           url: "http://localhost:1234/foo"
           gzip: {}
+        })
+
+      it "throws when encoding is not valid", (done) ->
+        cy.on "fail", (err) =>
+          lastLog = @lastLog
+
+          expect(@logs.length).to.eq(1)
+          expect(lastLog.get("error")).to.eq(err)
+          expect(lastLog.get("state")).to.eq("failed")
+          expect(err.message).to.eq("`cy.request()` was called with invalid encoding: `binaryX`. Encoding can be: `utf8`, `utf16le`, `latin1`, `base64`, `hex`, `ascii`, `binary`, `latin1`, `ucs2`, `utf16le`, or any other encoding supported by Node's Buffer encoding.")
+          expect(err.docsUrl).to.eq("https://on.cypress.io/request")
+          done()
+
+        cy.request({
+          url: "http://localhost:1234/foo"
+          encoding: 'binaryX'
         })
 
       it "throws when form isnt a boolean", (done) ->

--- a/packages/driver/test/cypress/integration/commands/request_spec.coffee
+++ b/packages/driver/test/cypress/integration/commands/request_spec.coffee
@@ -19,6 +19,7 @@ describe "src/cy/commands/request", ->
             failOnStatusCode: true
             retryOnNetworkFailure: true
             retryOnStatusCodeFailure: false
+            encoding: 'utf8'
             gzip: true
             followRedirect: true
             timeout: RESPONSE_TIMEOUT
@@ -197,11 +198,20 @@ describe "src/cy/commands/request", ->
               url: "http://xn--localhost-ob26h:1234/%F0%9F%98%80"
             })
 
-      context "encoding normalization", ->
+      context "encoding", ->
         it "lowercases encoding", ->
           cy.request({
             url: "http://localhost:8080/",
             encoding: "UtF8"
+          }).then ->
+            @expectOptionsToBe({
+              url: "http://localhost:8080/"
+              encoding: "utf8"
+            })
+
+        it "defaults encoding to `utf8`", ->
+          cy.request({
+            url: "http://localhost:8080/",
           }).then ->
             @expectOptionsToBe({
               url: "http://localhost:8080/"


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/.github/CONTRIBUTING.md 
-->

- Closes #2029 
- Closes #3576 

Originally, the PR https://github.com/cypress-io/cypress/pull/7380 (which describes the issue throughly and includes case analysis) was the attempt to solve the issues in consideration, but it was thought that there might be a different, yet very simple (one-line) solution.

## User facing changelog

Add support for `encoding` option in `cy.request()`

<!--
Explain the change(s) for every user to read in our changelog.
-->

## Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Introduce/use/support `encoding` option to [`cy.request()`](https://docs.cypress.io/api/commands/request.html), which is already supported by `@cypress/request` package (see [request.js:1130](https://github.com/cypress-io/request/blob/8afbb25/request.js#L1130)).

By introducing this option, the user can specify the `encoding` of the `response.body`. Which means, for instance, that the user can set the `encoding` of request to grab a zip/pdf/audio/video/… file, to `binary`, so that the [`fullBufferOfResponseBody.toString()`](https://github.com/cypress-io/request/blob/8afbb25/request.js#L1130) transformation process is done without resulting into invalid data.

Because the value of this option is eventually passed to `buffer.toString(ENCODING)`, the possible values are the ones mentioned in the [official Node documentation](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings):
- `utf8`
- `utf16le`
- `latin1`
- `base64`
- `hex`
- `ascii`
- `binary` (an alias of `latin1`)
- `ucs2` (an alias of `utf16le`)

And because the user will have the ability to assign those values. it might be good to consider validating the value before using it in beffer.toString(). For that, a validation and sanitization (lowercasing) was implemented. Also as extra validation (which might be thought as unnecessary, up to reviewers!), a PR in @cypress/request https://github.com/cypress-io/request/pull/5 was created as well.

This solution was tested with the code shown below that the exact file requested with the exact size is downloaded and written to the filesystem exactly as expected.

## How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

By setting the `encoding` option in `cy.request()` to binary, the downloaded files from the following sample test are valid, and exactly the same as expected. Like [this](https://github.com/cypress-io/cypress/commit/55aff0074e):

```js
describe('Download files by `cy.request()`->`cy.writeFile()`', () => {
  const urls = [
    'https://file-examples.com/wp-content/uploads/2017/02/zip_2MB.zip',
    'https://file-examples.com/wp-content/uploads/2017/10/file_example_PNG_500kB.png',
    'https://file-examples.com/wp-content/uploads/2017/02/file-sample_100kB.doc',
    'https://file-examples.com/wp-content/uploads/2017/02/file-sample_100kB.docx',
    'https://file-examples.com/wp-content/uploads/2017/02/file_example_XLS_50.xls',
    'https://file-examples.com/wp-content/uploads/2017/02/file_example_XLSX_1000.xlsx',
    'https://file-examples.com/wp-content/uploads/2017/10/file-example_PDF_500_kB.pdf',
  ];

  for (const url of urls) {
    const ext = url.substr(url.lastIndexOf('.') + 1);

    it(`Download ${ext.toUpperCase()} file`, () => {
      cy.request({
        url,
        encoding: 'binary', // !IMPORTANT!
      }).then((response) => {
        const filePath =
          Cypress.config('screenshotsFolder') + `/${ext}-downloaded.${ext}`;
        const expectedFileSize = response.headers['content-length'];
        console.log({ ext, size: expectedFileSize, filePath });
        // !IMPORTANT!: notice `encoding: 'binary'` below
        cy.writeFile(filePath, response.body, { encoding: 'binary' });
        cy.exec(`ls -al ${filePath} | awk '{print $5}'`).then(
          ({ stdout: actualFileSize }) => {
            expect(actualFileSize).to.equal(expectedFileSize);
          }
        );
      });
    });
  }
});
```

<img width="449" alt="Screenshot 2020-05-17 at 22 56 19" src="https://user-images.githubusercontent.com/17128077/82159880-d0dc4d80-9891-11ea-90a8-5b39116c1876.png">

Also a simple example like [this one](https://github.com/cypress-io/cypress/issues/2029#issuecomment-400508816), will be working if `encoding` is set to `binary` in _both_ `cy.request` and `cy.writeFile`

---

## Analysis of the problem's root cause

`cy.request()` is using `utf8` as the encoding value of `responseBuffer->string` transformation. How?! In [the list of options](https://github.com/cypress-io/cypress/blob/a27bd34/packages/driver/src/cy/commands/request.js#L17-L32) passed to `@cypress/request`, there is no `encoding`. Although `@cypress/request` actually [supports the encoding option](https://github.com/cypress-io/request/blob/8afbb25/request.js#L1129-L1131) during the readResponseBody process, which, [if the response body is a buffer](https://github.com/cypress-io/request/blob/8afbb25/request.js#L1108-L1112), boils down to a simple buffer->string transformation.

This analysis is about **using different encoding values (utf8, binary, …) in a `buffer->string->buffer` 2-way transformation of a sample PDF file (with size of _66851 bytes_)**, which is relevant to issue: https://github.com/cypress-io/cypress/issues/3576.

Explanation of the analysis stages:

**Stage 1**: `buffer->string`: in the heart of `cy.request()`, during the transformation of the response.body buffer into string. Where the logged values are:

- full buffer size (as received from request)
- first byte in the buffer
- last byte in the buffer
- size of string resulted from the buffer->string transformation (through `buffer.toString(ENCODING)`)

**Stage 2**: `string->buffer`: in the heart of `cy.writeFile()`, during the transformation of the string of file content passed to `cy.writeFile()` into buffer. The logged values in this stage are:

- size of the string (the content value passed to `cy.writeFile()`)
- size of buffer resulted from the string->buffer transformation (through `Buffer.from(content, ENCODING)`)
- first byte in the buffer
- last byte in the buffer

| Criterion                                                                                          | binary<br>[latin1] | ascii | base64 | hex    | utf16le<br>[ucs2] | utf8       |
| -------------------------------------------------------------------------------------------------- | ------------------ | ----- | ------ | ------ | ----------------- | ---------- |
| Full buffer size in stage 1                                                                        | 66851              | 66851 | 66851  | 66851  | 66851             | 66851      |
| Full buffer size in stage 2                                                                        | 66851              | 66851 | 66851  | 66851  | **66850**         | **101377** |
| First byte in the buffer of stage 1                                                                | 37                 | 37    | 37     | 37     | 37                | 37         |
| First byte in the buffer of stage 2                                                                | 37                 | 37    | 37     | 37     | 37                | 37         |
| First byte in the buffer of stage 1                                                                | 70                 | 70    | 70     | 70     | 70                | 70         |
| First byte in the buffer of stage 2                                                                | 70                 | 70    | 70     | 70     | 70                | 70         |
| Size of string value in stage 1<br>(after responseBuffer->string transformation)                   | 66851              | 66851 | 89136  | 133702 | 33425             | 64703      |
| Size of string value in stage 2<br>(before content->buffer transformation)                         | 66851              | 66851 | 89136  | 133702 | 33425             | 64703      |
| Percentage of string size / buffer size<br>(more data transfer between cypress client and server?) | 100%               | 100%  | 133.3% | 100%   | 50%               | 96.7%      |
| PDF file seems to have the expected content (PDF viewer / Chrome)                                  | **✓**              | **✓** | **✓**  | **✓**  | **✓**             | **✗**      |
| Both stages has the exact same buffer value. I.e: valid PDF result                                                        | **✓**              | **✓** | **✓**  | **✓**  | **✗**             | **✗**      |

### Analysis conclusion

In Node.Js, a 2-way transformation (buffer->string->buffer) of a PDF file content (i.e: binary) is likely to work as expected using encoding: `binary` (alias: `latin1`), `ascii`, `base64`, or `hex`. 

Using `utf16le` (alias: `ucs2`) or `utf8` leads to **invalid** content. Which might also be reasonably expected by reading [NodeJs documentation](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings) in case of invalid utf8 data (i.e: binary data).

The guaranteed results are from `binary`, as expected for a binary file!. And the mid-way string size is exactly the same as the buffer size before and after the transformation.

And because in cypress (by the time of this writing and as of [v4.6.0](https://github.com/cypress-io/cypress/releases/tag/v4.6.0)): `cy.request()` is executed through the cypress driver in NodeJs environment, and defaults to `utf8` encoding option under the hood, the resulted PDF content is invalid.

---

## PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] (N/A) Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in https://github.com/cypress-io/cypress-documentation/pull/2805
- [x] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [ ] (N/A) Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
