### PR TITLE
fix(types): use SinonStatic for Cypress.sinon type

### DIFF
--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -219,7 +219,7 @@ declare namespace Cypress {
      * @see https://on.cypress.io/stubs-spies-and-clocks
      * @see https://example.cypress.io/commands/spies-stubs-clocks
      */
-    sinon: sinon.SinonApi
+    sinon: sinon.SinonStatic
 
     /**
      * Cypress version string. i.e. "1.1.2"

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -14,10 +14,15 @@ namespace CypressMomentTests {
 }
 
 namespace CypressSinonTests {
-  Cypress.sinon // $ExpectType SinonApi
+  Cypress.sinon // $ExpectType SinonStatic
+
   const stub = cy.stub()
   stub(2, 'foo')
   expect(stub).to.have.been.calledWith(Cypress.sinon.match.number, Cypress.sinon.match('foo'))
+
+  const stub2 = Cypress.sinon.stub()
+  stub2(2, 'foo')
+  expect(stub2).to.have.been.calledWith(Cypress.sinon.match.number, Cypress.sinon.match('foo'))
 }
 
 namespace CypressJqueryTests {


### PR DESCRIPTION
SinonStatic is a superset of SinonApi:

```ts
type SinonStatic = SinonSandbox & LegacySandbox & SinonApi;
```

<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

### User facing changelog

- Changed type for `Cypress.sinon` to `SinonStatic`.

### Additional details

- makes sandbox methods like sinon.stub usable from Cy tests

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
