### PR TITLE
Fix flaky internal test: e2e domain passes [firefox] 

### DIFF
--- a/packages/server/test/e2e/4_domain_spec.coffee
+++ b/packages/server/test/e2e/4_domain_spec.coffee
@@ -16,6 +16,7 @@ describe "e2e domain", ->
   e2e.it "passes", {
     spec: "domain*"
     snapshot: true
+    video: false
     config: {
       hosts
     }


### PR DESCRIPTION
- closes #7409 

### User Changelog

N/A

### Additional details

- Do not record video for test since it would fail sometimes to record video in Firefox.
- Ideally it would be nice to find the cause of these ffmpeg failures to record in Firefox as a more permanent solution.