### PR TITLE
fix typedefs for cy.screenshot options, Cypress.log

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2504,7 +2504,7 @@ declare namespace Cypress {
     onBeforeScreenshot: ($el: JQuery) => void
     onAfterScreenshot: ($el: JQuery, props: {
       path: string,
-      size: 12,
+      size: number,
       dimensions: {
         width: number,
         height: number

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2501,8 +2501,22 @@ declare namespace Cypress {
     disableTimersAndAnimations: boolean
     padding: Padding
     scale: boolean
-    beforeScreenshot(doc: Document): void
-    afterScreenshot(doc: Document): void
+    onBeforeScreenshot: ($el: JQuery) => void
+    onAfterScreenshot: ($el: JQuery, props: {
+      path: string,
+      size: 12,
+      dimensions: {
+        width: number,
+        height: number
+      },
+      multipart: boolean,
+      pixelRatio: number,
+      takenAt: string,
+      name: string,
+      blackout: string[],
+      duration: number,
+      testAttemptIndex: number
+    }) => void
   }
 
   interface ScreenshotDefaultsOptions extends ScreenshotOptions {
@@ -4708,7 +4722,7 @@ declare namespace Cypress {
     name: string
     /** Override *name* for display purposes only */
     displayName: string
-    message: any[]
+    message: any[] | string
     /** Return an object that will be printed in the dev tools console */
     consoleProps(): ObjectLike
   }

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -4722,7 +4722,7 @@ declare namespace Cypress {
     name: string
     /** Override *name* for display purposes only */
     displayName: string
-    message: any[] | string
+    message: any[] | any
     /** Return an object that will be printed in the dev tools console */
     consoleProps(): ObjectLike
   }

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -4722,7 +4722,7 @@ declare namespace Cypress {
     name: string
     /** Override *name* for display purposes only */
     displayName: string
-    message: any[] | any
+    message: any
     /** Return an object that will be printed in the dev tools console */
     consoleProps(): ObjectLike
   }


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes N/A
### User facing changelog
Fixed type definitions for `cy.screenshot` and `Cypress.log` options 
<!--
Explain the change(s) for every user to read in our changelog.
-->



### post-merge tasks
- [ ] need to merge incorrect Screenshot.defaults options in cypress-example-kitchensink https://github.com/cypress-io/cypress-example-kitchensink/pull/425
<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->


