### PR TITLE
[internal] fix timeout w/ --no-exit

### DIFF
--- a/packages/server/test/support/helpers/e2e.js
+++ b/packages/server/test/support/helpers/e2e.js
@@ -452,6 +452,10 @@ const e2e = {
       noExit,
     })
 
+    if (options.noExit) {
+      options.timeout = 3000000
+    }
+
     if (options.exit != null) {
       throw new Error(`
       passing { exit: false } to e2e options is no longer supported


### PR DESCRIPTION
fix setting options.timeout when `--no-exit` passed to tests cli command