### PR TITLE
Update PR template type definitions link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,5 +40,5 @@ Delete tasks if they are not applicable.
 - [ ] Have tests been added/updated?
 - [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
 - [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
-- [ ] Have API changes been updated in the [`type definitions`](cli/types/index.d.ts)?
+- [ ] Have API changes been updated in the [`type definitions`](cli/types/cypress.d.ts)?
 - [ ] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?


### PR DESCRIPTION
### Details

Fixes the link in our PR template to the correct type definitions after the changes made in #7403
