### PR TITLE
Fix focus style on Desktop-GUI nav for Support/Doc links

### DIFF
--- a/packages/desktop-gui/src/app/nav.scss
+++ b/packages/desktop-gui/src/app/nav.scss
@@ -171,7 +171,7 @@
     > li > a,
     > li > span > a  {
       &:hover,
-      a:focus {
+      &:focus {
         color: #fff;
         background-color: #3b414a;
       }


### PR DESCRIPTION
- close #7491 

### User Facing Changelog

- The navigation links in the Test Runner now display the correct style when focused.

### Additional Details

- This was introduced in [this line](https://github.com/cypress-io/cypress/pull/4737/files#diff-c9f9a34b0bec300315b49e3f34132190R136) of #4737 in 3.4.1 release. Just a miswritten css selector. 
- There are no tests for this! Cypress cannot simulate css psuedo selector states on click, etc.

### How has the user experience changed?

#### Before

<img width="971" alt="Screen Shot 2020-05-27 at 1 23 44 PM" src="https://user-images.githubusercontent.com/1271364/82987311-5348d800-a01d-11ea-8cf7-4ee81265a6ef.png">

#### After

<img width="932" alt="Screen Shot 2020-05-27 at 2 03 46 PM" src="https://user-images.githubusercontent.com/1271364/82990912-e6d0d780-a022-11ea-8d15-19dd1deefa24.png">

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated? No 😢 See notes.
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->