### PR TITLE
Fix flaky internal Firefox test - expected 'assert' to equal 'invoke'

### DIFF
--- a/packages/driver/test/cypress/integration/commands/connectors_spec.js
+++ b/packages/driver/test/cypress/integration/commands/connectors_spec.js
@@ -335,7 +335,7 @@ describe('src/cy/commands/connectors', () => {
         beforeEach(function () {
           delete this.remoteWindow.$.fn.foo
 
-          Cypress.config('defaultCommandTimeout', 100)
+          Cypress.config('defaultCommandTimeout', 200)
 
           this.logs = []
 


### PR DESCRIPTION
- close #7494 

### User Facing Changelog

N/A

### Additional Details

- This used to fail occasionally in Firefox due to the command timing out before the commands had printed, so I bumped up the command timeout.
- I recreated this by running the test 100 times - it failed about 4 times in Firefox. 
- With patch, I ran the test 500 times and it never failed, so I think the flake is addressed.

#### Passing state

<img width="542" alt="Screen Shot 2020-05-27 at 2 16 24 PM" src="https://user-images.githubusercontent.com/1271364/82993258-4ed4ed00-a026-11ea-8552-a49a188a5d2d.png">

#### Failing state

<img width="542" alt="Screen Shot 2020-05-27 at 2 20 06 PM" src="https://user-images.githubusercontent.com/1271364/82993298-5d230900-a026-11ea-95dc-108bc0a54ca9.png">

### PR Tasks

- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->


