### PR TITLE
chore(driver): remove dead code in cy.visit

### DIFF
--- a/packages/driver/src/cy/commands/navigation.js
+++ b/packages/driver/src/cy/commands/navigation.js
@@ -634,11 +634,11 @@ module.exports = (Commands, Cypress, cy, state, config) => {
       }
 
       let userOptions = options
+      let userOptions = options
 
       if (userOptions.url && url) {
         $utils.throwErrByPath('visit.no_duplicate_url', { args: { optionsUrl: userOptions.url, url } })
       }
-
       if (_.isObject(url) && _.isEqual(userOptions, {})) {
         // options specified as only argument
         userOptions = url

--- a/packages/driver/src/cy/commands/navigation.js
+++ b/packages/driver/src/cy/commands/navigation.js
@@ -634,11 +634,9 @@ module.exports = (Commands, Cypress, cy, state, config) => {
       }
 
       let userOptions = options
-      let userOptions = options
-
-      if (userOptions.url && url) {
-        $utils.throwErrByPath('visit.no_duplicate_url', { args: { optionsUrl: userOptions.url, url } })
-      }
+<!--
+Explain the change(s) for every user to read in our changelog.
+-->
       if (_.isObject(url) && _.isEqual(userOptions, {})) {
         // options specified as only argument
         userOptions = url

--- a/packages/driver/src/cy/commands/navigation.js
+++ b/packages/driver/src/cy/commands/navigation.js
@@ -634,9 +634,7 @@ module.exports = (Commands, Cypress, cy, state, config) => {
       }
 
       let userOptions = options
-<!--
-Explain the change(s) for every user to read in our changelog.
--->
+
       if (_.isObject(url) && _.isEqual(userOptions, {})) {
         // options specified as only argument
         userOptions = url


### PR DESCRIPTION
`$utils.throwErrByPath` isn't a function anymore, but it doesn't matter because this error is already handled correctly above

<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes <!-- issue number here -->

### User facing changelog

n/a - not user-facing

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [na] Have tests been added/updated?
- [na] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
