### PR TITLE
fix typedefs: add taskTimeout to cypress config

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2297,6 +2297,11 @@ declare namespace Cypress {
      */
     responseTimeout: number
     /**
+     * Time, in milliseconds, to wait for a task to finish executing during a cy.task() command
+     * @default 60000
+     */
+    taskTimeout: number
+    /**
      * Path to folder where application files will attempt to be served from
      * @default root project folder
      */

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -40,6 +40,8 @@ namespace CypressConfigTests {
   Cypress.config('baseUrl', '.') // $ExpectType void
   Cypress.config('baseUrl', null) // $ExpectType void
   Cypress.config({ baseUrl: '.', }) // $ExpectType void
+
+  Cypress.config('taskTimeout') // $ExpectType number
 }
 
 namespace CypressEnvTests {


### PR DESCRIPTION
fix #7531

### User facing changelog
- Fix type definitions for Cypress config value `taskTimeout`
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Have API changes been updated in the [`type definitions`](cli/types/cypress.d.ts)?
