### PR TITLE
Fix "Cannot read property '__error' of null" error

### DIFF
--- a/packages/driver/src/cypress/xml_http_request.js
+++ b/packages/driver/src/cypress/xml_http_request.js
@@ -93,10 +93,9 @@ class XMLHttpRequest {
   }
 
   _getFixtureError () {
-    const body = this.response && this.response.body
-    const err = body.__error
+    const err = this.response?.body?.__error
 
-    if (body && err) {
+    if (err) {
       return err
     }
   }

--- a/packages/driver/test/cypress/integration/cypress/xml_http_request_spec.js
+++ b/packages/driver/test/cypress/integration/cypress/xml_http_request_spec.js
@@ -1,0 +1,44 @@
+import $XHR from '../../../../src/cypress/xml_http_request'
+
+describe('src/cypress/xml_http_request', () => {
+  let xhr
+  let $xhr
+
+  beforeEach(() => {
+    xhr = {
+      id: '1',
+      url: 'http://example.com',
+      method: 'GET',
+    }
+
+    $xhr = $XHR.create(xhr)
+  })
+
+  context('._getFixtureError', () => {
+    it('returns __error property on response body', () => {
+      $xhr.response = {
+        body: {
+          __error: 'Something went wrong',
+        },
+      }
+
+      const err = $xhr._getFixtureError()
+
+      expect(err).to.equal('Something went wrong')
+    })
+
+    it('returns undefined if response does not exist', () => {
+      const err = $xhr._getFixtureError()
+
+      expect(err).to.be.undefined
+    })
+
+    it('returns undefined if response body does not exist', () => {
+      $xhr.response = {}
+
+      const err = $xhr._getFixtureError()
+
+      expect(err).to.be.undefined
+    })
+  })
+})


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7518 

### User facing changelog

- Fixed a regression in 4.6.0 where an XHR response without a body would cause the error `Cannot read property '__error' of null`

### Additional Details

- This was introduced from an error during decaffeination in https://github.com/cypress-io/cypress/pull/7227

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
