### PR TITLE
chore: add transform-async-to-promises to webpack

### DIFF
--- a/packages/web-config/package.json
+++ b/packages/web-config/package.json
@@ -19,6 +19,7 @@
     "ansi-escapes": "4.3.0",
     "autoprefixer": "9.7.4",
     "babel-loader": "8.1.0",
+    "babel-plugin-transform-async-to-promises": "0.8.15",
     "browser-resolve": "1.11.3",
     "chai": "4.2.0",
     "chalk": "2.4.2",

--- a/packages/web-config/webpack.config.base.ts
+++ b/packages/web-config/webpack.config.base.ts
@@ -79,6 +79,7 @@ const getCommonConfig = () => {
                 // "istanbul",
                 [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
                 [require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }],
+                require.resolve('babel-plugin-transform-async-to-promises'),
               ],
               presets: [
                 require.resolve('@babel/preset-env'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6279,6 +6279,11 @@ babel-plugin-transform-async-to-generator@^6.24.1:
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-async-to-promises@0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.15.tgz#13b6d8ef13676b4e3c576d3600b85344bb1ba346"
+  integrity sha512-fDXP68ZqcinZO2WCiimCL9zhGjGXOnn3D33zvbh+yheZ/qOrNVVDDIBtAaM3Faz8TRvQzHiRKsu3hfrBAhEncQ==
+
 babel-plugin-transform-class-constructor-call@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz#80dc285505ac067dcb8d6c65e2f6f11ab7765ef9"


### PR DESCRIPTION
### User facing changelog

n/a - not user facing

### Additional details

enables using `async function` syntax in the driver. otherwise, the error "regeneratorRuntime is not defined" is thrown.

@Bkucera is there a better way to do this? this was what was most obvious to me, but maybe I'm missing something
