### PR TITLE
fix: Cypress.Commands.add Type Signature for @typescript-eslint/no-misused-promises rule

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -355,9 +355,9 @@ declare namespace Cypress {
      * @see https://on.cypress.io/api/commands
      */
     Commands: {
-      add(name: string, fn: (...args: any[]) => void): void
-      add(name: string, options: CommandOptions, fn: (...args: any[]) => void): void
-      overwrite(name: string, fn: (...args: any[]) => void): void
+      add(name: string, fn: (...args: any[]) => void | Chainable): void
+      add(name: string, options: CommandOptions, fn: (...args: any[]) => void | Chainable): void
+      overwrite(name: string, fn: (...args: any[]) => void | Chainable): void
     }
 
     /**

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -355,9 +355,9 @@ declare namespace Cypress {
      * @see https://on.cypress.io/api/commands
      */
     Commands: {
-      add(name: string, fn: (...args: any[]) => void | Chainable): void
-      add(name: string, options: CommandOptions, fn: (...args: any[]) => void | Chainable): void
-      overwrite(name: string, fn: (...args: any[]) => void | Chainable): void
+      add(name: string, fn: (...args: any[]) => CanReturnChainable): void
+      add(name: string, options: CommandOptions, fn: (...args: any[]) => CanReturnChainable): void
+      overwrite(name: string, fn: (...args: any[]) => CanReturnChainable): void
     }
 
     /**
@@ -490,6 +490,8 @@ declare namespace Cypress {
      */
     off: Actions
   }
+
+  type CanReturnChainable = void | Chainable
 
   /**
    * Chainable interface for non-array Subjects

--- a/packages/server/test/support/fixtures/projects/ts-proj-with-own-tsconfig/cypress/support/.eslintrc.json
+++ b/packages/server/test/support/fixtures/projects/ts-proj-with-own-tsconfig/cypress/support/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "parserOptions": {
+    "parser": "@typescript-eslint/parser",
+    "project": "packages/server/test/support/fixtures/projects/ts-proj-with-own-tsconfig/tsconfig.json"
+  },
+  "rules": {
+    "@typescript-eslint/no-misused-promises": "error"
+  }
+}

--- a/packages/server/test/support/fixtures/projects/ts-proj-with-own-tsconfig/cypress/support/commands.ts
+++ b/packages/server/test/support/fixtures/projects/ts-proj-with-own-tsconfig/cypress/support/commands.ts
@@ -4,3 +4,10 @@
 Cypress.Commands.add('clickLink', (label: string | number | RegExp) => {
   cy.get('a').contains(label).click()
 })
+
+// https://github.com/cypress-io/cypress/issues/7510
+// The code below fails when @typescript-eslint/no-misused-promises is error
+// and the return type of function in Cypress.Commands.add doesn't support Chainable.
+Cypress.Commands.add('dataCy', (value) => {
+  return cy.get(`[data-cy=${value}]`)
+})


### PR DESCRIPTION
- Closes #7510

### User facing changelog

Fix the type signature of Cypress.Commands.add and overwrite.

### Additional details

- Why was this change necessary? Type failure for @typescript-eslint/no-misused-promises rule.
- What is affected by this change? N/A
- Any implementation details to explain? N/A

### How has the user experience changed?

N/A

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
