### PR TITLE
Fix loading mappings.wasm on authenticated URLs

### DIFF
--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -61,7 +61,7 @@
     "react-dom-16.0.0": "npm:react-dom@16.0.0",
     "setimmediate": "1.0.5",
     "sinon": "8.1.1",
-    "source-map": "0.7.3",
+    "source-map": "0.8.0-beta.0",
     "text-mask-addons": "3.8.0",
     "underscore": "1.9.1",
     "underscore.string": "3.3.5",

--- a/packages/server/test/e2e/3_issue_7481.ts
+++ b/packages/server/test/e2e/3_issue_7481.ts
@@ -1,0 +1,18 @@
+const e2e = require('../support/helpers/e2e')
+
+const PORT = 3333
+
+describe('e2e issue 7481', () => {
+  e2e.setup({
+    servers: {
+      port: PORT,
+    },
+  })
+
+  e2e.it('does not error loading authenticated url', {
+    spec: 'simple_passing_spec.coffee',
+    config: {
+      baseUrl: `http://username:password@localhost:${PORT}/`,
+    },
+  })
+})

--- a/packages/web-config/package.json
+++ b/packages/web-config/package.json
@@ -17,6 +17,7 @@
     "@types/mock-require": "2.0.0",
     "@types/webpack": "4.41.0",
     "ansi-escapes": "4.3.0",
+    "arraybuffer-loader": "1.0.8",
     "autoprefixer": "9.7.4",
     "babel-loader": "8.1.0",
     "browser-resolve": "1.11.3",

--- a/packages/web-config/webpack.config.base.ts
+++ b/packages/web-config/webpack.config.base.ts
@@ -156,15 +156,11 @@ const getCommonConfig = () => {
           ],
         },
         {
-          test: /\.(wasm)$/,
+          test: /\.wasm$/,
           type: 'javascript/auto',
           use: [
             {
-              loader: require.resolve('file-loader'),
-              options: {
-                name: './wasm/[name].[ext]',
-                publicPath: '/__cypress/runner',
-              },
+              loader: require.resolve('arraybuffer-loader'),
             },
           ],
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5402,6 +5402,13 @@ array.prototype.flat@^1.2.3:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
+arraybuffer-loader@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/arraybuffer-loader/-/arraybuffer-loader-1.0.8.tgz#3e326be5cdf6454782362823d43a8c33bb1dd276"
+  integrity sha512-CwUVCcxCgcgZUu2w741OV6Xj1tvRVQebq22RCyGXiLgJOJ4e4M/59EPYdtK2MLfIN28t1TDvuh2ojstNq3Kh5g==
+  dependencies:
+    loader-utils "^1.1.0"
+
 arraybuffer.slice@~0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
@@ -23020,10 +23027,12 @@ source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, sourc
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+source-map@0.8.0-beta.0:
+  version "0.8.0-beta.0"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.8.0-beta.0.tgz#d4c1bb42c3f7ee925f005927ba10709e0d1d1f11"
+  integrity sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==
+  dependencies:
+    whatwg-url "^7.0.0"
 
 source-map@^0.1.40:
   version "0.1.43"


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7481

### User facing changelog

- Fixed an issue where authenticated URLs would error with `Request cannot be constructed from a URL that includes credentials: /__cypress/runner/./wasm/mappings.wasm`

### Additional details

For the sake of source maps and all their goodness, we use the [source-map](https://github.com/mozilla/source-map) package. It needs to load a `mappings.wasm` file in order to parse the source map. Previously, we provided a url to the `mappings.wasm` file and the `source-map` package loaded it asynchronously via `fetch`.

This worked fine in most cases but failed when the URL was authenticated, because the `fetch` needs to be authenticated too.

The fix is that, instead of having the `mappings.wasm` loaded asynchronously, we provide it to the `source-map` package synchronously as an `ArrayBuffer`. Therefore, no `fetch` and no issues with loading it regardless of the URL.

### How has the user experience changed?

Any spec run on an authenticated URL would error and fail immediately. Now those specs run normally.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
