### PR TITLE
internal: add env variable to force scaffolding

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1085,6 +1085,51 @@ jobs:
             echo "console.log('hello world')" > hello.ts
             npx tsc hello.ts --noEmit
 
+  # testing scaffolding examples and running them
+  # against example.cypress.io
+  test-cypress-scaffold:
+    parameters:
+      executor:
+        description: Executor name to use
+        type: executor
+        default: cy-doc
+      wd:
+        description: Working directory, should be OUTSIDE cypress monorepo folder
+        type: string
+        default: /root/test-scaffold
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      # make sure we have cypress.zip received
+      - run: ls -l
+      - run: ls -l cypress.zip cypress.tgz
+      - run: mkdir << parameters.wd >>
+      - run: node --version
+      - run: npm --version
+      - run:
+          name: Create new NPM package ⚗️
+          working_directory: << parameters.wd >>
+          command: npm init -y
+      - run:
+          name: Install dependencies 📦
+          working_directory: << parameters.wd >>
+          environment:
+            CYPRESS_INSTALL_BINARY: /root/cypress/cypress.zip
+          # let's install Cypress, Jest and any other package that might conflict
+          # https://github.com/cypress-io/cypress/issues/6690
+          command: |
+            npm install /root/cypress/cypress.tgz \
+              typescript jest @types/jest enzyme @types/enzyme
+      - run:
+          name: Scaffold and test examples 🏗
+          working_directory: << parameters.wd >>
+          environment:
+            CYPRESS_INTERNAL_FORCE_SCAFFOLD: '1'
+          command: |
+            echo '{}' > cypress.json
+            npx cypress run
+
   test-full-typescript-project:
     parameters:
       executor:
@@ -1454,6 +1499,10 @@ linux-workflow: &linux-workflow
           - build-binary
           - build-npm-package
     - test-types-cypress-and-jest:
+        requires:
+          - build-binary
+          - build-npm-package
+    - test-cypress-scaffold:
         requires:
           - build-binary
           - build-npm-package

--- a/packages/server/lib/project.js
+++ b/packages/server/lib/project.js
@@ -582,6 +582,11 @@ class Project extends EE {
     push(scaffold.support(cfg.supportFolder, cfg))
 
     // if we're in headed mode add these other scaffolding tasks
+    debug('scaffold flags %o', {
+      isTextTerminal: cfg.isTextTerminal,
+      CYPRESS_INTERNAL_FORCE_SCAFFOLD: process.env.CYPRESS_INTERNAL_FORCE_SCAFFOLD,
+    })
+
     const scaffoldExamples = !cfg.isTextTerminal || process.env.CYPRESS_INTERNAL_FORCE_SCAFFOLD
 
     if (scaffoldExamples) {

--- a/packages/server/lib/project.js
+++ b/packages/server/lib/project.js
@@ -581,11 +581,15 @@ class Project extends EE {
     // and example support file if dir doesnt exist
     push(scaffold.support(cfg.supportFolder, cfg))
 
-    // if we're in headed mode add these other scaffolding
-    // tasks
-    if (!cfg.isTextTerminal) {
+    // if we're in headed mode add these other scaffolding tasks
+    const scaffoldExamples = !cfg.isTextTerminal || process.env.CYPRESS_INTERNAL_FORCE_SCAFFOLD
+
+    if (scaffoldExamples) {
+      debug('will scaffold integration and fixtures folder')
       push(scaffold.integration(cfg.integrationFolder, cfg))
       push(scaffold.fixture(cfg.fixturesFolder, cfg))
+    } else {
+      debug('will not scaffold integration or fixtures folder')
     }
 
     return Promise.all(scaffolds)

--- a/packages/server/test/unit/project_spec.js
+++ b/packages/server/test/unit/project_spec.js
@@ -473,7 +473,8 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
     describe('forced', () => {
       let resetEnv
 
-      beforeEach(() => {
+      beforeEach(function () {
+        this.obj.isTextTerminal = true
         resetEnv = mockedEnv({
           CYPRESS_INTERNAL_FORCE_SCAFFOLD: '1',
         })
@@ -487,6 +488,31 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
         return this.project.scaffold(this.obj).then(() => {
           expect(scaffold.integration).to.be.calledWith(this.obj.integrationFolder)
           expect(scaffold.fixture).to.be.calledWith(this.obj.fixturesFolder)
+          expect(scaffold.support).to.be.calledWith(this.obj.supportFolder)
+        })
+      })
+    })
+
+    describe('not forced', () => {
+      let resetEnv
+
+      beforeEach(function () {
+        this.obj.isTextTerminal = true
+
+        resetEnv = mockedEnv({
+          CYPRESS_INTERNAL_FORCE_SCAFFOLD: undefined,
+        })
+      })
+
+      afterEach(() => {
+        resetEnv()
+      })
+
+      it('does not scaffold integration folder', function () {
+        return this.project.scaffold(this.obj).then(() => {
+          expect(scaffold.integration).to.not.be.calledWith(this.obj.integrationFolder)
+          expect(scaffold.fixture).to.not.be.calledWith(this.obj.fixturesFolder)
+          // still scaffolds support folder due to old logic
           expect(scaffold.support).to.be.calledWith(this.obj.supportFolder)
         })
       })

--- a/packages/server/test/unit/project_spec.js
+++ b/packages/server/test/unit/project_spec.js
@@ -1,5 +1,6 @@
 require('../spec_helper')
 
+const mockedEnv = require('mocked-env')
 const path = require('path')
 const commitInfo = require('@cypress/commit-info')
 const tsnode = require('ts-node')
@@ -466,6 +467,28 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
 
       return this.project.scaffold(this.obj).then(() => {
         expect(scaffold.plugins).not.to.be.called
+      })
+    })
+
+    describe('forced', () => {
+      let resetEnv
+
+      beforeEach(() => {
+        resetEnv = mockedEnv({
+          CYPRESS_INTERNAL_FORCE_SCAFFOLD: '1',
+        })
+      })
+
+      afterEach(() => {
+        resetEnv()
+      })
+
+      it('calls scaffold when forced by environment variable', function () {
+        return this.project.scaffold(this.obj).then(() => {
+          expect(scaffold.integration).to.be.calledWith(this.obj.integrationFolder)
+          expect(scaffold.fixture).to.be.calledWith(this.obj.fixturesFolder)
+          expect(scaffold.support).to.be.calledWith(this.obj.supportFolder)
+        })
       })
     })
   })


### PR DESCRIPTION
- Closes #7554

### User facing changelog

Nothing, this is an internal feature useful to testing

### Additional details

We now will be able to easily run 2 tests
- install the newly built Cypress NPM and binary and have it scaffold a new project and run the tests
- scaffold new project and check if it still passes against different Kitchensink HTML pages https://github.com/cypress-io/cypress-example-kitchensink/issues/420

### How has the user experience changed?

You can scaffold new Cypress project with example specs

```
npm init -y
npm i -D cypress
echo '{}' >> cypress.json
CYPRESS_INTERNAL_FORCE_SCAFFOLD=1 npx cypress run
```

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated? Added unit tests and e2e test job
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
