### PR TITLE
Move stack trace below code frame in runner

### DIFF
--- a/packages/reporter/cypress/integration/test_errors_spec.js
+++ b/packages/reporter/cypress/integration/test_errors_spec.js
@@ -252,11 +252,6 @@ describe('test errors', function () {
       this.setError(this.commandErr)
     })
 
-    it('hovering shows tooltip', function () {
-      cy.get('.runnable-err-print').trigger('mouseover')
-      cy.get('.cy-tooltip').should('have.text', 'Print error to console')
-    })
-
     it('clicking prints to console', function () {
       cy.spy(this.runner, 'emit')
       cy.get('.runnable-err-print').click().should(() => {
@@ -272,6 +267,15 @@ describe('test errors', function () {
     it('does not collapse test when clicking', () => {
       cy.get('.runnable-err-print').click()
       cy.get('.command-wrapper').should('be.visible')
+    })
+
+    it('does not expand or collapse stack trace when clicking', () => {
+      cy.get('.runnable-err-print').click()
+      cy.get('.runnable-err-stack-trace').should('not.be.visible')
+      cy.contains('View stack trace').click()
+      cy.get('.runnable-err-stack-trace').should('be.visible')
+      cy.get('.runnable-err-print').click()
+      cy.get('.runnable-err-stack-trace').should('be.visible')
     })
   })
 

--- a/packages/reporter/src/collapsible/collapsible.scss
+++ b/packages/reporter/src/collapsible/collapsible.scss
@@ -12,7 +12,7 @@
     margin-left: 5px;
   }
 
-  .is-open > .collapsible-header > .collapsible-more {
+  .is-open > .collapsible-header-wrapper > .collapsible-header > .collapsible-more {
     display: none;
   }
 
@@ -21,7 +21,7 @@
     margin-right: 3px;
   }
 
-  .is-open > .collapsible-header > .collapsible-indicator {
+  .is-open > .collapsible-header-wrapper > .collapsible-header > .collapsible-indicator {
     @extend .#{$fa-css-prefix}-caret-down;
   }
 }

--- a/packages/reporter/src/collapsible/collapsible.scss
+++ b/packages/reporter/src/collapsible/collapsible.scss
@@ -12,7 +12,7 @@
     margin-right: 3px;
   }
 
-  .is-open > .collapsible-header-wrapper > .collapsible-header > .collapsible-indicator {
+  .is-open > .collapsible-header-wrapper > .collapsible-header > .collapsible-header-inner > .collapsible-indicator {
     @extend .#{$fa-css-prefix}-caret-down;
   }
 }

--- a/packages/reporter/src/collapsible/collapsible.scss
+++ b/packages/reporter/src/collapsible/collapsible.scss
@@ -7,15 +7,6 @@
     display: block;
   }
 
-  .collapsible-more {
-    display: inline-block;
-    margin-left: 5px;
-  }
-
-  .is-open > .collapsible-header-wrapper > .collapsible-header > .collapsible-more {
-    display: none;
-  }
-
   .collapsible-indicator {
     @extend .#{$fa-css-prefix}-caret-right;
     margin-right: 3px;

--- a/packages/reporter/src/collapsible/collapsible.spec.tsx
+++ b/packages/reporter/src/collapsible/collapsible.spec.tsx
@@ -19,7 +19,7 @@ describe('<Collapsible />', () => {
   it('renders with headerClass on the header when specified', () => {
     const component = shallow(<Collapsible headerClass='foo' />)
 
-    expect(component.find('.collapsible-header')).to.have.className('foo')
+    expect(component.find('.collapsible-header-wrapper')).to.have.className('foo')
   })
 
   it('renders with headerStyle when specified', () => {

--- a/packages/reporter/src/collapsible/collapsible.tsx
+++ b/packages/reporter/src/collapsible/collapsible.tsx
@@ -5,9 +5,11 @@ import { onEnterOrSpace } from '../lib/util'
 
 interface Props {
   isOpen?: boolean
+  headerWrapperClass?: string
   headerClass?: string
   headerStyle?: CSSProperties
   header?: ReactNode
+  headerExtras?: ReactNode
   contentClass?: string
 }
 
@@ -18,6 +20,7 @@ interface State {
 class Collapsible extends Component<Props, State> {
   static defaultProps = {
     isOpen: false,
+    headerWrapperClass: '',
     headerClass: '',
     headerStyle: {},
     contentClass: '',
@@ -38,19 +41,22 @@ class Collapsible extends Component<Props, State> {
   render () {
     return (
       <div className={cs('collapsible', { 'is-open': this.state.isOpen })}>
-        <div
-          aria-expanded={this.state.isOpen}
-          className={cs('collapsible-header', this.props.headerClass)}
-          onClick={this._onClick}
-          onKeyPress={onEnterOrSpace(this._onKeyPress)}
-          role='button'
-          style={this.props.headerStyle}
-          tabIndex={0}
-        >
-          <i className='collapsible-indicator fa-fw fas' />
-          <span className='collapsible-header-text'>
-            {this.props.header}
-          </span>
+        <div className={cs('collapsible-header-wrapper', this.props.headerWrapperClass)}>
+          <div
+            aria-expanded={this.state.isOpen}
+            className={cs('collapsible-header', this.props.headerClass)}
+            onClick={this._onClick}
+            onKeyPress={onEnterOrSpace(this._onKeyPress)}
+            role='button'
+            style={this.props.headerStyle}
+            tabIndex={0}
+          >
+            <i className='collapsible-indicator fa-fw fas' />
+            <span className='collapsible-header-text'>
+              {this.props.header}
+            </span>
+          </div>
+          { this.props.headerExtras }
         </div>
         <div className={cs('collapsible-content', this.props.contentClass)}>
           {this.props.children}

--- a/packages/reporter/src/collapsible/collapsible.tsx
+++ b/packages/reporter/src/collapsible/collapsible.tsx
@@ -51,10 +51,12 @@ class Collapsible extends Component<Props, State> {
             style={this.props.headerStyle}
             tabIndex={0}
           >
-            <i className='collapsible-indicator fa-fw fas' />
-            <span className='collapsible-header-text'>
-              {this.props.header}
-            </span>
+            <div tabIndex={-1}>
+              <i className='collapsible-indicator fa-fw fas' />
+              <span className='collapsible-header-text'>
+                {this.props.header}
+              </span>
+            </div>
           </div>
           {this.props.headerExtras}
         </div>

--- a/packages/reporter/src/collapsible/collapsible.tsx
+++ b/packages/reporter/src/collapsible/collapsible.tsx
@@ -5,7 +5,6 @@ import { onEnterOrSpace } from '../lib/util'
 
 interface Props {
   isOpen?: boolean
-  headerWrapperClass?: string
   headerClass?: string
   headerStyle?: CSSProperties
   header?: ReactNode
@@ -20,7 +19,6 @@ interface State {
 class Collapsible extends Component<Props, State> {
   static defaultProps = {
     isOpen: false,
-    headerWrapperClass: '',
     headerClass: '',
     headerStyle: {},
     contentClass: '',
@@ -41,17 +39,17 @@ class Collapsible extends Component<Props, State> {
   render () {
     return (
       <div className={cs('collapsible', { 'is-open': this.state.isOpen })}>
-        <div className={cs('collapsible-header-wrapper', this.props.headerWrapperClass)}>
+        <div className={cs('collapsible-header-wrapper', this.props.headerClass)}>
           <div
             aria-expanded={this.state.isOpen}
-            className={cs('collapsible-header', this.props.headerClass)}
+            className='collapsible-header'
             onClick={this._onClick}
             onKeyPress={onEnterOrSpace(this._onKeyPress)}
             role='button'
             style={this.props.headerStyle}
             tabIndex={0}
           >
-            <div tabIndex={-1}>
+            <div className="collapsible-header-inner" tabIndex={-1}>
               <i className='collapsible-indicator fa-fw fas' />
               <span className='collapsible-header-text'>
                 {this.props.header}

--- a/packages/reporter/src/collapsible/collapsible.tsx
+++ b/packages/reporter/src/collapsible/collapsible.tsx
@@ -56,7 +56,7 @@ class Collapsible extends Component<Props, State> {
               {this.props.header}
             </span>
           </div>
-          { this.props.headerExtras }
+          {this.props.headerExtras}
         </div>
         <div className={cs('collapsible-content', this.props.contentClass)}>
           {this.props.children}

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -16,7 +16,7 @@
       margin-right: 3px;
     }
 
-    .hook-name {
+    .hook-name > .collapsible-header {
       border-bottom: 1px solid transparent;
       text-transform: uppercase;
       color: #959595;
@@ -36,6 +36,10 @@
       &:hover:focus {
         border-bottom: 1px dotted #959595;
         color: #333;
+      }
+
+      > .collapsible-header-inner:focus {
+        outline: 0;
       }
 
       .hook-failed-message {

--- a/packages/reporter/src/errors/errors.scss
+++ b/packages/reporter/src/errors/errors.scss
@@ -130,11 +130,16 @@
     }
   }
 
+  .runnable-err-stack-wrapper {
+    display: flex;
+  }
+
   .runnable-err-stack-expander {
     background: #ffeaec;
     cursor: pointer;
     outline: none;
     padding: 8px 5px;
+    width: 100%;
 
     &:hover,
     &:focus {
@@ -157,9 +162,7 @@
   }
 
   .runnable-err-stack-trace {
-    background: rgba(254, 224, 227, 0.45);
     font-family: $monospace;
-    margin-left: 15px;
     overflow: auto;
     padding: 10px;
 

--- a/packages/reporter/src/errors/errors.scss
+++ b/packages/reporter/src/errors/errors.scss
@@ -91,21 +91,6 @@
     }
   }
 
-  .runnable-err-print {
-    background: none;
-    border: solid 2px $err-text;
-    border-radius: 3px;
-    color: $err-text;
-    font-size: 8px;
-    padding: 0.4em;
-
-    &:hover,
-    &:focus {
-      background: rgba(255, 255, 255, 0.6);
-      outline: none;
-    }
-  }
-
   .runnable-err-docs-url {
     margin-left: 0.5em;
     cursor: pointer;
@@ -132,32 +117,57 @@
 
   .runnable-err-stack-wrapper {
     display: flex;
-  }
 
-  .runnable-err-stack-expander {
-    background: #ffeaec;
-    cursor: pointer;
-    outline: none;
-    padding: 8px 5px;
-    width: 100%;
+    .runnable-err-stack-expander {
+      background: #ffeaec;
+      cursor: pointer;
+      flex-grow: 1;
+      outline: none;
+      padding: 8px 5px;
 
-    &:hover,
-    &:focus {
-      background: #fee0e3;
+      &:hover,
+      &:focus {
+        background: #fee0e3;
+      }
+
+      .collapsible-header-text {
+        color: #4f4f4f;
+        font-size: 13px;
+      }
+
+      .collapsible-indicator {
+        line-height: 18px;
+        color: #bbbcbd !important;
+      }
+
+      .collapsible-more {
+        display: none;
+      }
     }
 
-    .collapsible-header-text {
+    .runnable-err-print {
+      background: #ffeaec;
       color: #4f4f4f;
+      cursor: pointer;
       font-size: 13px;
-    }
+      padding: 8px 10px;
 
-    .collapsible-indicator {
-      line-height: 18px;
-      color: #bbbcbd !important;
-    }
+      &:hover,
+      &:focus {
+        background: #fee0e3;
+      }
 
-    .collapsible-more {
-      display: none;
+      i {
+        border: solid 1px #4f4f4f;
+        border-radius: 4px;
+        font-size: 6px;
+        padding: 3px;
+        vertical-align: middle;
+      }
+
+      span {
+        vertical-align: middle;
+      }
     }
   }
 

--- a/packages/reporter/src/errors/errors.scss
+++ b/packages/reporter/src/errors/errors.scss
@@ -161,6 +161,7 @@
 
       &:hover,
       &:focus {
+        outline: none;
         background: #fee0e3;
       }
 

--- a/packages/reporter/src/errors/errors.scss
+++ b/packages/reporter/src/errors/errors.scss
@@ -133,7 +133,7 @@
         background: #ffeaec;
         cursor: pointer;
         outline: none;
-        padding: 8px 5px;
+        padding: 7px 5px;
         width: 100%;
 
         &:hover {
@@ -157,7 +157,7 @@
       color: #4f4f4f;
       cursor: pointer;
       font-size: 13px;
-      padding: 8px 10px;
+      padding: 7px 10px;
 
       &:hover,
       &:focus {
@@ -169,7 +169,7 @@
         border: solid 1px #4f4f4f;
         border-radius: 4px;
         font-size: 6px;
-        padding: 3px;
+        padding: 4px 3px;
         vertical-align: middle;
       }
 

--- a/packages/reporter/src/errors/errors.scss
+++ b/packages/reporter/src/errors/errors.scss
@@ -115,14 +115,14 @@
     }
   }
 
-  .runnable-err-stack-wrapper {
+  .runnable-err-stack-expander {
     display: flex;
 
-    .runnable-err-stack-expander {
+    .collapsible-header {
       flex-grow: 1;
 
       &:focus {
-        outline: none;
+        outline: 0;
 
         div {
           background: #fee0e3;

--- a/packages/reporter/src/errors/errors.scss
+++ b/packages/reporter/src/errors/errors.scss
@@ -119,29 +119,36 @@
     display: flex;
 
     .runnable-err-stack-expander {
-      background: #ffeaec;
-      cursor: pointer;
       flex-grow: 1;
-      outline: none;
-      padding: 8px 5px;
 
-      &:hover,
       &:focus {
-        background: #fee0e3;
+        outline: none;
+
+        div {
+          background: #fee0e3;
+        }
       }
 
-      .collapsible-header-text {
-        color: #4f4f4f;
-        font-size: 13px;
-      }
+      div {
+        background: #ffeaec;
+        cursor: pointer;
+        outline: none;
+        padding: 8px 5px;
+        width: 100%;
 
-      .collapsible-indicator {
-        line-height: 18px;
-        color: #bbbcbd !important;
-      }
+        &:hover {
+          background: #fee0e3;
+        }
 
-      .collapsible-more {
-        display: none;
+        .collapsible-header-text {
+          color: #4f4f4f;
+          font-size: 13px;
+        }
+
+        .collapsible-indicator {
+          line-height: 18px;
+          color: #bbbcbd !important;
+        }
       }
     }
 

--- a/packages/reporter/src/errors/errors.scss
+++ b/packages/reporter/src/errors/errors.scss
@@ -189,7 +189,7 @@
   .test-err-code-frame {
     background-color: #fff;
     border: 1px solid #ffe4e7;
-    margin: 10px;
+    margin: 0 10px 10px;
 
     .runnable-err-file-path {
       &:before {

--- a/packages/reporter/src/errors/errors.scss
+++ b/packages/reporter/src/errors/errors.scss
@@ -131,23 +131,24 @@
   }
 
   .runnable-err-stack-expander {
+    background: #ffeaec;
     cursor: pointer;
     outline: none;
-    padding: 0 10px 2px 5px;
+    padding: 8px 5px;
 
     &:hover,
     &:focus {
-      color: lighten($err-text, 10%);
+      background: #fee0e3;
     }
 
     .collapsible-header-text {
-      text-decoration: underline;
+      color: #4f4f4f;
       font-size: 13px;
     }
 
     .collapsible-indicator {
       line-height: 18px;
-      color: #eb535e !important;
+      color: #bbbcbd !important;
     }
 
     .collapsible-more {
@@ -156,10 +157,11 @@
   }
 
   .runnable-err-stack-trace {
-    overflow: auto;
-    padding: 10px;
+    background: rgba(254, 224, 227, 0.45);
     font-family: $monospace;
     margin-left: 15px;
+    overflow: auto;
+    padding: 10px;
 
     .err-stack-line {
       white-space: pre;

--- a/packages/reporter/src/errors/test-error.tsx
+++ b/packages/reporter/src/errors/test-error.tsx
@@ -75,13 +75,15 @@ const TestError = observer((props: TestErrorProps) => {
         </div>
         {codeFrame && <ErrorCodeFrame codeFrame={codeFrame} />}
         {err.stack &&
-        <Collapsible
-          header='View stack trace'
-          headerClass='runnable-err-stack-expander'
-          contentClass='runnable-err-stack-trace'
-        >
-          <ErrorStack err={err} />
-        </Collapsible>
+          <Collapsible
+            header='View stack trace'
+            headerClass='runnable-err-stack-expander'
+            headerWrapperClass='runnable-err-stack-wrapper'
+            headerExtras={<div>Print to console</div>}
+            contentClass='runnable-err-stack-trace'
+          >
+            <ErrorStack err={err} />
+          </Collapsible>
         }
       </div>
     </div>

--- a/packages/reporter/src/errors/test-error.tsx
+++ b/packages/reporter/src/errors/test-error.tsx
@@ -62,12 +62,6 @@ const TestError = observer((props: TestErrorProps) => {
             <i className='fas fa-exclamation-circle'></i>
             {err.name}
           </div>
-
-          <Tooltip title='Print error to console' className='cy-tooltip'>
-            <button className='runnable-err-print' onClick={onPrint}>
-              <i className='fas fa-terminal'></i>
-            </button>
-          </Tooltip>
         </div>
         <div className='runnable-err-message'>
           <span dangerouslySetInnerHTML={{ __html: formattedMessage(err.message) }}></span>
@@ -79,7 +73,11 @@ const TestError = observer((props: TestErrorProps) => {
             header='View stack trace'
             headerClass='runnable-err-stack-expander'
             headerWrapperClass='runnable-err-stack-wrapper'
-            headerExtras={<div>Print to console</div>}
+            headerExtras={
+              <div className="runnable-err-print" onClick={onPrint}>
+                <i className="fas fa-terminal" /> <span>Print to console</span>
+              </div>
+            }
             contentClass='runnable-err-stack-trace'
           >
             <ErrorStack err={err} />

--- a/packages/reporter/src/errors/test-error.tsx
+++ b/packages/reporter/src/errors/test-error.tsx
@@ -2,14 +2,13 @@ import _ from 'lodash'
 import React, { MouseEvent } from 'react'
 import { observer } from 'mobx-react'
 import Markdown from 'markdown-it'
-// @ts-ignore
-import Tooltip from '@cypress/react-tooltip'
 
 import Collapsible from '../collapsible/collapsible'
 import ErrorCodeFrame from '../errors/error-code-frame'
 import ErrorStack from '../errors/error-stack'
 
 import events from '../lib/events'
+import { onEnterOrSpace } from '../lib/util'
 import TestModel from '../test/test-model'
 
 interface DocsUrlProps {
@@ -39,10 +38,14 @@ const TestError = observer((props: TestErrorProps) => {
 
   md.enable(['backticks', 'emphasis', 'escape'])
 
-  const onPrint = (e: MouseEvent) => {
+  const onPrint = () => {
+    events.emit('show:error', props.model.id)
+  }
+
+  const _onPrintClick = (e: MouseEvent) => {
     e.stopPropagation()
 
-    events.emit('show:error', props.model.id)
+    onPrint()
   }
 
   const formattedMessage = (message?: string) => {
@@ -74,7 +77,13 @@ const TestError = observer((props: TestErrorProps) => {
             headerClass='runnable-err-stack-expander'
             headerWrapperClass='runnable-err-stack-wrapper'
             headerExtras={
-              <div className="runnable-err-print" onClick={onPrint}>
+              <div
+                className="runnable-err-print"
+                onClick={_onPrintClick}
+                onKeyPress={onEnterOrSpace(onPrint)}
+                role='button'
+                tabIndex={0}
+              >
                 <i className="fas fa-terminal" /> <span>Print to console</span>
               </div>
             }

--- a/packages/reporter/src/errors/test-error.tsx
+++ b/packages/reporter/src/errors/test-error.tsx
@@ -75,7 +75,6 @@ const TestError = observer((props: TestErrorProps) => {
           <Collapsible
             header='View stack trace'
             headerClass='runnable-err-stack-expander'
-            headerWrapperClass='runnable-err-stack-wrapper'
             headerExtras={
               <div
                 className="runnable-err-print"

--- a/packages/reporter/src/errors/test-error.tsx
+++ b/packages/reporter/src/errors/test-error.tsx
@@ -73,17 +73,16 @@ const TestError = observer((props: TestErrorProps) => {
           <span dangerouslySetInnerHTML={{ __html: formattedMessage(err.message) }}></span>
           <DocsUrl url={err.docsUrl} />
         </div>
-
-        {err.stack &&
-          <Collapsible
-            header='View stack trace'
-            headerClass='runnable-err-stack-expander'
-            contentClass='runnable-err-stack-trace'
-          >
-            <ErrorStack err={err} />
-          </Collapsible>
-        }
         {codeFrame && <ErrorCodeFrame codeFrame={codeFrame} />}
+        {err.stack &&
+        <Collapsible
+          header='View stack trace'
+          headerClass='runnable-err-stack-expander'
+          contentClass='runnable-err-stack-trace'
+        >
+          <ErrorStack err={err} />
+        </Collapsible>
+        }
       </div>
     </div>
   )

--- a/packages/reporter/src/runnables/runnables.scss
+++ b/packages/reporter/src/runnables/runnables.scss
@@ -82,12 +82,12 @@
       }
     }
 
-    &.suite.runnable-pending > div .runnable-wrapper,
+    &.suite.runnable-pending > div > .runnable-wrapper,
     &.test.runnable-pending > .runnable-wrapper {
       border-left: 5px solid lighten($pending, 25%);
     }
 
-    &.suite.runnable-passed > div .runnable-wrapper,
+    &.suite.runnable-passed > div > .runnable-wrapper,
     &.test.runnable-passed > .runnable-wrapper {
       border-left: 5px solid $pass;
     }
@@ -103,12 +103,12 @@
       }
     }
 
-    &.suite.runnable-skipped > div .runnable-wrapper,
+    &.suite.runnable-skipped > div > .runnable-wrapper,
     &.test.runnable-skipped > .runnable-wrapper {
       border-left: 5px solid #9a9aaa;
     }
 
-    &.suite.runnable-failed > div .runnable-wrapper {
+    &.suite.runnable-failed > div > .runnable-wrapper {
       border-left: 5px solid $fail;
     }
 
@@ -119,7 +119,7 @@
       }
     }
 
-    &.suite > div .runnable-wrapper {
+    &.suite > div > .runnable-wrapper {
       .runnable-title {
         color: #111;
         font-weight: 800;
@@ -127,11 +127,13 @@
       }
     }
 
-    &.suite > div .runnable-wrapper:focus {
-      outline: 0;
+    &.suite > div > .runnable-wrapper {
+      .collapsible-header:focus, .collapsible-header-inner:focus {
+        outline: 0;
 
-      .runnable-title {
-        outline: 1px dotted;
+        .runnable-title {
+          outline: 1px dotted;
+        }
       }
     }
 
@@ -162,6 +164,14 @@
     padding: 5px 15px 5px 5px;
     overflow: hidden;
     border-left: 5px solid transparent;
+  }
+
+  .collapsible > .runnable-wrapper {
+    padding: 0;
+
+    .collapsible-header {
+      padding: 5px 15px 5px 5px;
+    }
   }
 
   .runnable-title {

--- a/packages/reporter/src/runnables/runnables.scss
+++ b/packages/reporter/src/runnables/runnables.scss
@@ -82,12 +82,12 @@
       }
     }
 
-    &.suite.runnable-pending > div > .runnable-wrapper,
+    &.suite.runnable-pending > div .runnable-wrapper,
     &.test.runnable-pending > .runnable-wrapper {
       border-left: 5px solid lighten($pending, 25%);
     }
 
-    &.suite.runnable-passed > div > .runnable-wrapper,
+    &.suite.runnable-passed > div .runnable-wrapper,
     &.test.runnable-passed > .runnable-wrapper {
       border-left: 5px solid $pass;
     }
@@ -103,12 +103,12 @@
       }
     }
 
-    &.suite.runnable-skipped > div > .runnable-wrapper,
+    &.suite.runnable-skipped > div .runnable-wrapper,
     &.test.runnable-skipped > .runnable-wrapper {
       border-left: 5px solid #9a9aaa;
     }
 
-    &.suite.runnable-failed > div > .runnable-wrapper {
+    &.suite.runnable-failed > div .runnable-wrapper {
       border-left: 5px solid $fail;
 
       .collapsible-more {
@@ -128,7 +128,7 @@
       }
     }
 
-    &.suite > div > .runnable-wrapper {
+    &.suite > div .runnable-wrapper {
       .runnable-title {
         color: #111;
         font-weight: 800;
@@ -136,7 +136,7 @@
       }
     }
 
-    &.suite > div > .runnable-wrapper:focus {
+    &.suite > div .runnable-wrapper:focus {
       outline: 0;
 
       .runnable-title {
@@ -195,7 +195,7 @@
     }
   }
 
-  .suite > div > .runnable-wrapper,
+  .suite > div .runnable-wrapper,
   .test .runnable-content-region {
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -233,7 +233,7 @@
     display: flex;
   }
 
-  .test > .runnable-wrapper > .collapsible > .collapsible-header {
+  .test > .runnable-wrapper > .collapsible > .collapsible-header-wrapper > .collapsible-header {
     .collapsible-indicator,
     .collapsible-more {
       display: none;

--- a/packages/reporter/src/runnables/runnables.scss
+++ b/packages/reporter/src/runnables/runnables.scss
@@ -110,15 +110,6 @@
 
     &.suite.runnable-failed > div .runnable-wrapper {
       border-left: 5px solid $fail;
-
-      .collapsible-more {
-        border-radius: 3px;
-        background-color: $fail;
-        color: #FFF;
-        padding: 0 4px 0 3px;
-        font-size: 10px;
-        margin-left: 2px;
-      }
     }
 
     &.test.runnable-failed {
@@ -234,8 +225,7 @@
   }
 
   .test > .runnable-wrapper > .collapsible > .collapsible-header-wrapper > .collapsible-header {
-    .collapsible-indicator,
-    .collapsible-more {
+    .collapsible-indicator {
       display: none;
     }
   }


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7563

### User facing changelog

Moves the location of the stack trace and print to console button to below the code frame in an error message

### How has the user experience changed?

Before:
![Screen Shot 2020-06-02 at 7 02 05 PM](https://user-images.githubusercontent.com/7033952/83578049-c2359d80-a503-11ea-8fc4-7ef6e581e010.png)

After:
![Screen Shot 2020-06-03 at 12 51 01 AM](https://user-images.githubusercontent.com/7033952/83597072-561f5d80-a534-11ea-8072-3e9e33162e33.png)

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/2853
