### PR TITLE
fix(rewriter): make workers self-exit to avoid SIGABRTs

### DIFF
--- a/packages/rewriter/lib/threads/types.ts
+++ b/packages/rewriter/lib/threads/types.ts
@@ -9,6 +9,10 @@ export type RewriteRequest = {
   isHtml?: boolean
   source: string
   /**
+   * If true, terminate the worker.
+   */
+  shutdown?: true
+  /**
    * If true, return the sourcemap and not the generated source.
    */
   sourceMap?: true

--- a/packages/rewriter/lib/threads/worker.ts
+++ b/packages/rewriter/lib/threads/worker.ts
@@ -17,6 +17,10 @@ parentPort!.postMessage(true)
 let _idCounter = 0
 
 parentPort!.on('message', (req: RewriteRequest) => {
+  if (req.shutdown) {
+    return process.exit()
+  }
+
   const startedAt = Date.now()
 
   function _deferSourceMapRewrite (deferredSourceMap) {


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

### User facing changelog

- Fixed a bug in `experimentalSourceRewriting` where Cypress could exit with a SIGABRT instead of exiting normally.

### Additional details

- try to let the threads shut themselves down to avoid https://github.com/electron/electron/issues/23366
- users were still encountering the SIGABRT when simply using `worker.terminate` from the main thread, which was the original workaround: https://github.com/cypress-io/cypress/issues/7297#issuecomment-635849687

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
