### PR TITLE
Use onload event to mitigate <area> flaky test.

### DIFF
--- a/packages/driver/test/cypress/integration/e2e/focus_blur_spec.js
+++ b/packages/driver/test/cypress/integration/e2e/focus_blur_spec.js
@@ -669,7 +669,7 @@ describe('intercept blur methods correctly', () => {
     cy.wrap($svg).focus().should('have.focus')
   })
 
-  it('focus area', () => {
+  it('focus area', (done) => {
     cy.visit('http://localhost:3500/fixtures/active-elements.html').then(() => {
       cy.$$(`
       <map name="map">
@@ -677,14 +677,16 @@ describe('intercept blur methods correctly', () => {
       href="#"
       target="_blank" alt="area" />
       </map>
-      <img usemap="#map" src="/__cypress/static/favicon.ico" alt="image" />
+      <img id="test-image" usemap="#map" src="/__cypress/static/favicon.ico" alt="image" />
       `).appendTo(cy.$$('body'))
 
-      cy.get('area')
-      // NOTE: wait needed for firefox, otherwise element is not yet ready/loaded
-      .wait(100)
-      .focus()
-      .should('have.focus')
+      cy.$$('#test-image').on('load', () => {
+        cy.get('area')
+        .focus()
+        .should('have.focus')
+
+        done()
+      })
     })
   })
 


### PR DESCRIPTION
- Closes #7388

### User facing changelog

Use onload event to mitigate <area> flaky test.

### Additional details

- Why was this change necessary? Fix flaky test.
- What is affected by this change? N/A
- Any implementation details to explain? N/A

### How has the user experience changed?

N/A

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
