### PR TITLE
Replace @cypress/underscore.inflection dep

### DIFF
--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -9,9 +9,7 @@
     "postinstall": "patch-package",
     "start": "node test/support/server.js"
   },
-  "dependencies": {
-    "ordinal": "1.0.3"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/code-frame": "7.8.3",
     "@cypress/bower-kendo-ui": "0.0.2",
@@ -57,6 +55,7 @@
     "mocha": "7.0.1",
     "moment": "2.24.0",
     "morgan": "1.9.1",
+    "ordinal": "1.0.3",
     "react-15.6.1": "npm:react@15.6.1",
     "react-16.0.0": "npm:react@16.0.0",
     "react-dom-15.6.1": "npm:react-dom@15.6.1",

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -9,11 +9,13 @@
     "postinstall": "patch-package",
     "start": "node test/support/server.js"
   },
+  "dependencies": {
+    "ordinal": "1.0.3"
+  },
   "devDependencies": {
     "@babel/code-frame": "7.8.3",
     "@cypress/bower-kendo-ui": "0.0.2",
     "@cypress/sinon-chai": "1.1.0",
-    "@cypress/underscore.inflection": "1.0.1",
     "@cypress/unique-selector": "0.4.2",
     "@cypress/what-is-circular": "1.0.1",
     "@packages/coffee": "*",

--- a/packages/driver/src/config/lodash.d.ts
+++ b/packages/driver/src/config/lodash.d.ts
@@ -1,13 +1,10 @@
 // const _ = require('lodash')
 import _ from 'lodash'
-import underscoreInflection from '@cypress/underscore.inflection'
 
 import clean from 'underscore.string/clean'
 import count from 'underscore.string/count'
 import isBlank from 'underscore.string/isBlank'
 import toBoolean from 'underscore.string/toBoolean'
-
-const inflection = underscoreInflection(_)
 
 // only export exactly what we need, nothing more!
 _.mixin({
@@ -15,7 +12,6 @@ _.mixin({
   count,
   isBlank,
   toBoolean,
-  ordinalize: inflection.ordinalize,
 })
 
 declare module 'lodash' {
@@ -24,7 +20,6 @@ declare module 'lodash' {
     count(...args): LoDashExplicitWrapper<TValue>
     isBlank(...args): LoDashExplicitWrapper<TValue>
     toBoolean(...args): LoDashExplicitWrapper<TValue>
-    ordinalize(...args): LoDashExplicitWrapper<TValue>
   }
 
   export interface LodashStatic<TValue> {
@@ -32,7 +27,6 @@ declare module 'lodash' {
     count(...args): LoDashExplicitWrapper<TValue>
     isBlank(...args): LoDashExplicitWrapper<TValue>
     toBoolean(...args): LoDashExplicitWrapper<TValue>
-    ordinalize(...args): LoDashExplicitWrapper<TValue>
   }
 }
 

--- a/packages/driver/src/config/lodash.js
+++ b/packages/driver/src/config/lodash.js
@@ -1,14 +1,11 @@
 const _ = require('lodash')
 
-const inflection = require('@cypress/underscore.inflection')(_)
-
 // only export exactly what we need, nothing more!
 _.mixin({
   clean: require('underscore.string/clean'),
   count: require('underscore.string/count'),
   isBlank: require('underscore.string/isBlank'),
   toBoolean: require('underscore.string/toBoolean'),
-  ordinalize: inflection.ordinalize,
 })
 
 export default _

--- a/packages/driver/src/cy/commands/waiting.js
+++ b/packages/driver/src/cy/commands/waiting.js
@@ -1,5 +1,6 @@
 const _ = require('lodash')
 const Promise = require('bluebird')
+const ordinal = require('ordinal')
 
 const $errUtils = require('../../cypress/error_utils')
 
@@ -14,7 +15,7 @@ const getNumRequests = (state, alias) => {
 
   state('aliasRequests', requests)
 
-  return [index, _.ordinalize(requests[alias])]
+  return [index, ordinal(requests[alias])]
 }
 
 const throwErr = (arg) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1615,11 +1615,6 @@
   resolved "https://registry.yarnpkg.com/@cypress/sinon-chai/-/sinon-chai-2.9.0.tgz#ebd1ea59eb8ebe9f2283a85afad167ee57776199"
   integrity sha512-6tPzu+wpPJzqxnQjvIwSy8mzTwok3SrxxxCFwUS22K+x/GxAzENHiPDpfVKYjFYhB66YHzvkkw3Vm+hFTJypKw==
 
-"@cypress/underscore.inflection@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@cypress/underscore.inflection/-/underscore.inflection-1.0.1.tgz#33dc215ffe1e32d7d70511a0c28ecc918a2177f0"
-  integrity sha512-Id5nDp6NXKew1gGIlS+aEtaOrd9rB5nTcSJUor/fOwVWT2xOXJAjAdry0XE92vLe7EdaQJ4hxKLZyAqQuryjyg==
-
 "@cypress/unique-selector@0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@cypress/unique-selector/-/unique-selector-0.4.2.tgz#ac4f12d2a0306e9d8ac1d49a12ad40dfbf2f1aeb"
@@ -19006,6 +19001,11 @@ ordered-read-streams@^1.0.0:
   integrity sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=
   dependencies:
     readable-stream "^2.0.1"
+
+ordinal@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ordinal/-/ordinal-1.0.3.tgz#1a3c7726a61728112f50944ad7c35c06ae3a0d4d"
+  integrity sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==
 
 original@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
### User Facing Changelog

### Additional Details

- I'm trying to get rid of our weird, old forked deps we require.
- This is technically a breaking change. We used to export this ‘ordinalize’ method on the `Cypress._.` utility method. But, I would argue that this is very confusing - changing the behavior of lodash when we’ve only documented it as a pure extension of lodash. See #7222. I very highly doubt anyone has even found this method.
- I could extend the new dep to be a part of `Cypress._.` is we really felt it necessary to not break this.

### How has the user experience changed?

#### Before

<img width="547" alt="Screen Shot 2020-06-04 at 4 51 10 PM" src="https://user-images.githubusercontent.com/1271364/83746222-cdfc9d80-a684-11ea-98f3-6854c107f072.png">

#### After

<img width="581" alt="Screen Shot 2020-06-04 at 4 59 39 PM" src="https://user-images.githubusercontent.com/1271364/83746257-d81e9c00-a684-11ea-82f0-fd66bb888320.png">



### PR Tasks

- [ ] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->