### PR TITLE
internal: add ability to test recipe and particular PR

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -194,8 +194,8 @@ commands:
       browser:
         description: Name of the browser to use
         type: enum
-        enum: ["electron", "chrome", "firefox"]
-        default: "electron"
+        enum: ["", "electron", "chrome", "firefox"]
+        default: ""
       command:
         description: Test command to run to start Cypress tests
         type: string
@@ -260,9 +260,18 @@ commands:
       - when:
           condition: << parameters.folder >>
           steps:
-            - run:
-                working_directory: /tmp/<<parameters.repo>>/<< parameters.folder >>
-                command: <<parameters.command>> -- --browser <<parameters.browser>>
+            - when:
+                condition: << parameters.browser >>
+                steps:
+                - run:
+                    working_directory: /tmp/<<parameters.repo>>/<< parameters.folder >>
+                    command: <<parameters.command>> -- --browser <<parameters.browser>>
+            - unless:
+                condition: << parameters.browser >>
+                steps:
+                - run:
+                    working_directory: /tmp/<<parameters.repo>>/<< parameters.folder >>
+                    command: <<parameters.command>>
             - store_artifacts:
                 name: screenshots
                 path: /tmp/<<parameters.repo>>/<< parameters.folder >>/cypress/screenshots

--- a/circle.yml
+++ b/circle.yml
@@ -204,6 +204,14 @@ commands:
         description: Url to wait-on before starting tests
         type: string
         default: ""
+      folder:
+        description: Subfolder to test in
+        type: string
+        default: ""
+      pull_request_id:
+        description: Pull request number to check out before installing and testing
+        type: integer
+        default: 0
     steps:
       - attach_workspace:
           at: ~/
@@ -213,6 +221,14 @@ commands:
       - run:
           name: Cloning project <<parameters.repo>>
           command: git clone --depth 1 https://github.com/cypress-io/<<parameters.repo>>.git /tmp/<<parameters.repo>>
+      - when:
+          condition: << parameters.pull_request_id >>
+          steps:
+            - run:
+                name: Check out PR << parameters.pull_request_id >>
+                command: |
+                  git fetch origin pull/<< parameters.pull_request_id >>/head:pr-<< parameters.pull_request_id >>
+                  git checkout pr-<< parameters.pull_request_id >>
       - run:
           command: npm install
           working_directory: /tmp/<<parameters.repo>>
@@ -239,16 +255,32 @@ commands:
             - run:
                 name: Wait-on <<parameters.wait-on>>
                 command: npx wait-on <<parameters.wait-on>> --timeout 120000
-      - run:
-          working_directory: /tmp/<<parameters.repo>>
-          command: <<parameters.command>> -- --browser <<parameters.browser>>
+      - when:
+          condition: << parameters.folder >>
+          steps:
+            - run:
+                working_directory: /tmp/<<parameters.repo>>/<< parameters.folder >>
+                command: <<parameters.command>> -- --browser <<parameters.browser>>
+            - store_artifacts:
+                name: screenshots
+                path: /tmp/<<parameters.repo>>/<< parameters.folder >>/cypress/screenshots
+            - store_artifacts:
+                name: videos
+                path: /tmp/<<parameters.repo>>/<< parameters.folder >>/cypress/videos
+      - unless:
+          condition: << parameters.folder >>
+          steps:
+          - run:
+              working_directory: /tmp/<<parameters.repo>>
+              command: <<parameters.command>> -- --browser <<parameters.browser>>
+          - store_artifacts:
+              name: screenshots
+              path: /tmp/<<parameters.repo>>/cypress/screenshots
+          - store_artifacts:
+              name: videos
+              path: /tmp/<<parameters.repo>>/cypress/videos
       - store-npm-logs
-      - store_artifacts:
-          name: screenshots
-          path: /tmp/<<parameters.repo>>/cypress/screenshots
-      - store_artifacts:
-          name: videos
-          path: /tmp/<<parameters.repo>>/cypress/videos
+
 
 jobs:
   ## code checkout and yarn installs
@@ -1204,6 +1236,15 @@ jobs:
           repo: cypress-example-recipes
           command: npm run test:ci:firefox
 
+  test-binary-against-recipe-pull-request:
+    <<: *defaults
+    steps:
+      - test-binary-against-repo:
+          repo: cypress-example-recipes
+          command: npm run test:ci
+          pull_request_id: 492
+          folder: examples/testing-dom__form-interactions
+
   "test-binary-against-kitchensink":
     <<: *defaults
     steps:
@@ -1511,6 +1552,15 @@ linux-workflow: &linux-workflow
           - build-binary
           - build-npm-package
     - test-binary-against-kitchensink:
+        requires:
+          - build-binary
+          - build-npm-package
+    - test-binary-against-recipe-pull-request:
+        name: Test jQuery update recipe
+        filters:
+          branches:
+            only:
+              - test-recipe-pr
         requires:
           - build-binary
           - build-npm-package

--- a/circle.yml
+++ b/circle.yml
@@ -204,10 +204,15 @@ commands:
         description: Url to wait-on before starting tests
         type: string
         default: ""
+      # if the repo to clone and test is a monorepo, you can
+      # run tests inside a specific subfolder
       folder:
         description: Subfolder to test in
         type: string
         default: ""
+      # you can test new features in the test runner against recipes or other repos
+      # by opening a pull request in those repos and running this test job
+      # against a pull request number in the example repo
       pull_request_id:
         description: Pull request number to check out before installing and testing
         type: integer
@@ -1261,12 +1266,14 @@ jobs:
     steps:
       - test-binary-against-repo:
           repo: cypress-example-kitchensink
+          browser: "electron"
 
   test-binary-against-awesome-typescript-loader:
     <<: *defaults
     steps:
       - test-binary-against-repo:
           repo: cypress-test-awesome-typescript-loader
+          browser: "electron"
 
   "test-binary-against-kitchensink-firefox":
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -226,9 +226,11 @@ commands:
           steps:
             - run:
                 name: Check out PR << parameters.pull_request_id >>
+                working_directory: /tmp/<<parameters.repo>>
                 command: |
                   git fetch origin pull/<< parameters.pull_request_id >>/head:pr-<< parameters.pull_request_id >>
                   git checkout pr-<< parameters.pull_request_id >>
+                  git log
       - run:
           command: npm install
           working_directory: /tmp/<<parameters.repo>>


### PR DESCRIPTION
- Closes #7584

### For developers

When working on a new or breaking feature in the Test Runner repo, you might want to be testing it against an external repo, and that external repo also has changes. In this case you open PR in this repo and in the example repo. You can define new test jobs that test the beta version of the Test Runner against a PR in an example repo.

Example defined in this PR: test test runner against a PR in cypress-example-recipes.

First, define a job

```yml
test-binary-against-recipe-pull-request:
  <<: *defaults
  steps:
    - test-binary-against-repo:
        repo: cypress-example-recipes
        command: npm run test:ci
        pull_request_id: 492
        folder: examples/testing-dom__form-interactions
```

Then add this job to the Linux workflow

```yml
- test-binary-against-recipe-pull-request:
    name: Test jQuery update recipe
    filters:
      branches:
        only:
          - test-recipe-pr
    requires:
      - build-binary
      - build-npm-package
```

The current branch `test-recipe-pr` will build the test runner and test it against PR 492 from cypress-example-recipes.

### Additional details
Once we merge the test runner PR, we merge the PR in the cypress-example-recipes into a branch with the upcoming release version like 4.7.1, because we automatically test those branches. Once the TR is released, we can merge all dev branches in the example repos.
