### PR TITLE
Throw error when the type of the expected value for 'css', 'prop', or 'attr' assertions is an object.

### DIFF
--- a/packages/driver/src/cypress/chai_jquery.js
+++ b/packages/driver/src/cypress/chai_jquery.js
@@ -2,6 +2,7 @@ const _ = require('lodash')
 const $ = require('jquery')
 const $dom = require('../dom')
 const $elements = require('../dom/elements')
+const $errUtils = require('./error_utils')
 
 const selectors = {
   visible: 'visible',
@@ -283,6 +284,10 @@ const $chaiJquery = (chai, chaiUtils, callbacks = {}) => {
 
       // when we only have 1 argument dont worry about val
       if (arguments.length === 1) {
+        if (_.isPlainObject(name)) {
+          $errUtils.throwErrByPath('chai.no_plain_object')
+        }
+
         assert(
           this,
           accessor,

--- a/packages/driver/src/cypress/chai_jquery.js
+++ b/packages/driver/src/cypress/chai_jquery.js
@@ -285,7 +285,7 @@ const $chaiJquery = (chai, chaiUtils, callbacks = {}) => {
 
       // when we only have 1 argument dont worry about val
       if (arguments.length === 1) {
-        if (_.isPlainObject(name)) {
+        if (!_.isString(name)) {
           $errUtils.throwErrByPath('chai.no_plain_object', {
             args: {
               actual: $utils.stringifyActualObj(name),

--- a/packages/driver/src/cypress/chai_jquery.js
+++ b/packages/driver/src/cypress/chai_jquery.js
@@ -2,6 +2,7 @@ const _ = require('lodash')
 const $ = require('jquery')
 const $dom = require('../dom')
 const $elements = require('../dom/elements')
+const $utils = require('./utils')
 const $errUtils = require('./error_utils')
 
 const selectors = {
@@ -285,7 +286,11 @@ const $chaiJquery = (chai, chaiUtils, callbacks = {}) => {
       // when we only have 1 argument dont worry about val
       if (arguments.length === 1) {
         if (_.isPlainObject(name)) {
-          $errUtils.throwErrByPath('chai.no_plain_object')
+          $errUtils.throwErrByPath('chai.no_plain_object', {
+            args: {
+              actual: $utils.stringifyActualObj(name),
+            },
+          })
         }
 
         assert(

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -176,7 +176,9 @@ module.exports = {
 
         This can sometimes happen if a previous assertion changed the subject.`
     },
-    no_plain_object: 'Expected value should not be an object',
+    no_plain_object (obj) {
+      return `TypeError: expected ${obj.actual} to be a string`
+    },
   },
 
   check_uncheck: {

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -176,6 +176,7 @@ module.exports = {
 
         This can sometimes happen if a previous assertion changed the subject.`
     },
+    no_plain_object: 'Expected value should not be an object',
   },
 
   check_uncheck: {

--- a/packages/driver/test/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/test/cypress/integration/commands/assertions_spec.js
@@ -2514,7 +2514,7 @@ describe('src/cy/commands/assertions', () => {
       })
 
       // https://github.com/cypress-io/cypress/issues/7353
-      it('throws when the type of the expected value is object', (done) => {
+      it('throws when the type of the expected value is not string', (done) => {
         cy.on('fail', (err) => {
           expect(err.message).to.eq('TypeError: expected {} to be a string')
 
@@ -2643,7 +2643,7 @@ describe('src/cy/commands/assertions', () => {
       })
 
       // https://github.com/cypress-io/cypress/issues/7353
-      it('throws when the type of the expected value is object', (done) => {
+      it('throws when the type of the expected value is not string', (done) => {
         cy.on('fail', (err) => {
           expect(err.message).to.eq('TypeError: expected {} to be a string')
 
@@ -2726,7 +2726,7 @@ describe('src/cy/commands/assertions', () => {
       })
 
       // https://github.com/cypress-io/cypress/issues/7353
-      it('throws when the type of the expected value is object', (done) => {
+      it('throws when the type of the expected value is not string', (done) => {
         cy.on('fail', (err) => {
           expect(err.message).to.eq('TypeError: expected {} to be a string')
 

--- a/packages/driver/test/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/test/cypress/integration/commands/assertions_spec.js
@@ -2516,7 +2516,7 @@ describe('src/cy/commands/assertions', () => {
       // https://github.com/cypress-io/cypress/issues/7353
       it('throws when the type of the expected value is object', (done) => {
         cy.on('fail', (err) => {
-          expect(err.message).to.eq('Expected value should not be an object')
+          expect(err.message).to.eq('TypeError: expected {} to be a string')
 
           done()
         })
@@ -2645,7 +2645,7 @@ describe('src/cy/commands/assertions', () => {
       // https://github.com/cypress-io/cypress/issues/7353
       it('throws when the type of the expected value is object', (done) => {
         cy.on('fail', (err) => {
-          expect(err.message).to.eq('Expected value should not be an object')
+          expect(err.message).to.eq('TypeError: expected {} to be a string')
 
           done()
         })
@@ -2728,7 +2728,7 @@ describe('src/cy/commands/assertions', () => {
       // https://github.com/cypress-io/cypress/issues/7353
       it('throws when the type of the expected value is object', (done) => {
         cy.on('fail', (err) => {
-          expect(err.message).to.eq('Expected value should not be an object')
+          expect(err.message).to.eq('TypeError: expected {} to be a string')
 
           done()
         })

--- a/packages/driver/test/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/test/cypress/integration/commands/assertions_spec.js
@@ -2512,6 +2512,19 @@ describe('src/cy/commands/assertions', () => {
 
         expect({}).to.have.attr('foo')
       })
+
+      // https://github.com/cypress-io/cypress/issues/7353
+      it('throws when the type of the expected value is object', (done) => {
+        cy.on('fail', (err) => {
+          expect(err.message).to.eq('Expected value should not be an object')
+
+          done()
+        })
+
+        const $div = cy.$$('<div foo="bar" fizz="buzz">foo</div>')
+
+        expect($div).to.have.attr({})
+      })
     })
 
     context('prop', () => {
@@ -2628,6 +2641,19 @@ describe('src/cy/commands/assertions', () => {
 
         expect({}).to.have.prop('foo')
       })
+
+      // https://github.com/cypress-io/cypress/issues/7353
+      it('throws when the type of the expected value is object', (done) => {
+        cy.on('fail', (err) => {
+          expect(err.message).to.eq('Expected value should not be an object')
+
+          done()
+        })
+
+        const $div = cy.$$('<input type="checkbox" />')
+
+        expect($div).to.have.prop({})
+      })
     })
 
     context('css', () => {
@@ -2697,6 +2723,19 @@ describe('src/cy/commands/assertions', () => {
         })
 
         expect({}).to.have.css('foo')
+      })
+
+      // https://github.com/cypress-io/cypress/issues/7353
+      it('throws when the type of the expected value is object', (done) => {
+        cy.on('fail', (err) => {
+          expect(err.message).to.eq('Expected value should not be an object')
+
+          done()
+        })
+
+        const $div = cy.$$('<div style="display: none; position: absolute;">div</div>')
+
+        expect($div).to.have.css({})
       })
     })
   })


### PR DESCRIPTION
- Closes #7353

### User facing changelog

When the type of the expected value for 'css', 'prop', or 'attr' assertions is an object, it fails.

### Additional details

- Why was this change necessary? It always passed.
- What is affected by this change? N/A
- Any implementation details to explain? N/A

### How has the user experience changed?

**Before:**
![Screenshot from 2020-06-05 17-15-17](https://user-images.githubusercontent.com/8130013/83853534-614ed500-a750-11ea-8923-65155172358b.png)

**After:**
![Screenshot from 2020-06-05 17-15-51](https://user-images.githubusercontent.com/8130013/83853537-61e76b80-a750-11ea-9381-ea1e59f81613.png)


### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
