### PR TITLE
Make should('have.value') work with <progress>, <meter>, <li>

### DIFF
--- a/packages/driver/src/cypress/chai_jquery.js
+++ b/packages/driver/src/cypress/chai_jquery.js
@@ -1,6 +1,7 @@
 const _ = require('lodash')
 const $ = require('jquery')
 const $dom = require('../dom')
+const $elements = require('../dom/elements')
 
 const selectors = {
   visible: 'visible',
@@ -179,9 +180,10 @@ const $chaiJquery = (chai, chaiUtils, callbacks = {}) => {
 
   chai.Assertion.addMethod('value', function (value) {
     const $el = wrap(this)
-    const tagName = $el.prop('tagName')
 
-    if (tagName !== 'PROGRESS' && tagName !== 'METER' && tagName !== 'LI') {
+    // some elements return a number for the .value property
+    // in this case, we don't want to cast the expected value to a string
+    if (!$elements.isValueNumberTypeElement($el[0])) {
       value = maybeCastNumberToString(value)
     }
 

--- a/packages/driver/src/cypress/chai_jquery.js
+++ b/packages/driver/src/cypress/chai_jquery.js
@@ -178,7 +178,12 @@ const $chaiJquery = (chai, chaiUtils, callbacks = {}) => {
   })
 
   chai.Assertion.addMethod('value', function (value) {
-    value = maybeCastNumberToString(value)
+    const $el = wrap(this)
+    const tagName = $el.prop('tagName')
+
+    if (tagName !== 'PROGRESS' && tagName !== 'METER' && tagName !== 'LI') {
+      value = maybeCastNumberToString(value)
+    }
 
     assertDom(
       this,
@@ -188,7 +193,7 @@ const $chaiJquery = (chai, chaiUtils, callbacks = {}) => {
       value,
     )
 
-    const actual = wrap(this).val()
+    const actual = $el.val()
 
     return assertPartial(
       this,

--- a/packages/driver/src/dom/elements.ts
+++ b/packages/driver/src/dom/elements.ts
@@ -40,6 +40,7 @@ const focusableWhenNotDisabledSelectors = [
 
 const inputTypeNeedSingleValueChangeRe = /^(date|time|week|month|datetime-local)$/
 const canSetSelectionRangeElementRe = /^(text|search|URL|tel|password)$/
+const valueIsNumberTypeRe = /progress|meter|li/
 
 declare global {
   interface Window {
@@ -323,6 +324,14 @@ const setNativeProp = function<T, K extends keyof T> (obj: T, prop: K, val) {
   }
 
   return retProp
+}
+
+interface HTMLValueIsNumberTypeElement extends HTMLElement {
+  value: number
+}
+
+const isValueNumberTypeElement = (el: HTMLElement): el is HTMLValueIsNumberTypeElement => {
+  return valueIsNumberTypeRe.test(getTagName(el))
 }
 
 export interface HTMLSingleValueChangeInputElement extends HTMLInputElement {
@@ -1183,6 +1192,7 @@ export {
   isFocused,
   isFocusedOrInFocused,
   isInputAllowingImplicitFormSubmission,
+  isValueNumberTypeElement,
   isNeedSingleValueChangeInputElement,
   canSetSelectionRangeElement,
   stringify,

--- a/packages/driver/test/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/test/cypress/integration/commands/assertions_spec.js
@@ -1700,6 +1700,27 @@ describe('src/cy/commands/assertions', () => {
         })
       })
 
+      // https://github.com/cypress-io/cypress/issues/7603
+      describe('when the type of value attr must be number', () => {
+        it('<progress>', () => {
+          cy.$$('<progress id="progress" value="0.72">72%</progress>').appendTo(cy.$$('body'))
+          cy.get('#progress').should('have.value', 0.72)
+          cy.get('#progress').should('not.have.value', '0.72')
+        })
+
+        it('<meter>', () => {
+          cy.$$('<meter id="meter" min="0" max="100" low="33" high="66" optimum="80" value="50">at 50/100</meter>').appendTo(cy.$$('body'))
+          cy.get('#meter').should('have.value', 50)
+          cy.get('#meter').should('not.have.value', '50')
+        })
+
+        it('<li>', () => {
+          cy.$$('<li id="li" value="3">Cypress</li>').appendTo(cy.$$('body'))
+          cy.get('#li').should('have.value', 3)
+          cy.get('#li').should('not.have.value', '3')
+        })
+      })
+
       it('throws when obj is not DOM', function (done) {
         cy.on('fail', (err) => {
           expect(this.logs.length).to.eq(1)


### PR DESCRIPTION
- Closes #7603

### User facing changelog

`should('have.value')` works with `<progress>`, `<meter>`, `<li>`.

### Additional details

- Why was this change necessary? Regression
- What is affected by this change? N/A
- Any implementation details to explain? N/A

### How has the user experience changed?

**Before:**

![Screenshot from 2020-06-08 19-09-42](https://user-images.githubusercontent.com/8130013/84019316-10431900-a9bc-11ea-806d-3405287e569c.png)


**After:**

![Screenshot from 2020-06-08 19-10-52](https://user-images.githubusercontent.com/8130013/84019326-1638fa00-a9bc-11ea-98dd-8cb692cd598c.png)
![Screenshot from 2020-06-08 19-10-58](https://user-images.githubusercontent.com/8130013/84019332-189b5400-a9bc-11ea-9630-5f3a87fed0cb.png)

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
