### PR TITLE
Fix: skip sending stdout on PUT /instances

### DIFF
--- a/packages/server/lib/modes/record.js
+++ b/packages/server/lib/modes/record.js
@@ -227,7 +227,7 @@ const updateInstance = (options = {}) => {
       error,
       video,
       hooks,
-      stdout: null,
+      stdout: null, // don't send stdout with the instance payload to prevent requests that are too large. stdout will later get uploaded separately anyway.
       instanceId,
       screenshots,
       reporterStats,

--- a/packages/server/lib/modes/record.js
+++ b/packages/server/lib/modes/record.js
@@ -209,12 +209,11 @@ const updateInstanceStdout = (options = {}) => {
 }
 
 const updateInstance = (options = {}) => {
-  const { instanceId, results, captured, group, parallel, ciBuildId } = options
+  const { instanceId, results, group, parallel, ciBuildId } = options
   let { stats, tests, hooks, video, screenshots, reporterStats, error } = results
 
   video = Boolean(video)
   const cypressConfig = options.config
-  const stdout = captured.toString()
 
   // get rid of the path property
   screenshots = _.map(screenshots, (screenshot) => {
@@ -228,7 +227,7 @@ const updateInstance = (options = {}) => {
       error,
       video,
       hooks,
-      stdout,
+      stdout: null,
       instanceId,
       screenshots,
       reporterStats,
@@ -696,7 +695,6 @@ const createRunAndRecordSpecs = (options = {}) => {
           group,
           config,
           results,
-          captured,
           parallel,
           ciBuildId,
           instanceId,

--- a/packages/server/test/unit/api_spec.js
+++ b/packages/server/test/unit/api_spec.js
@@ -560,7 +560,7 @@ describe('lib/api', () => {
         screenshots: [],
         cypressConfig: {},
         reporterStats: {},
-        stdout: 'foo\nbar\nbaz',
+        stdout: null,
       }
 
       this.putProps = _.omit(this.updateProps, 'instanceId')


### PR DESCRIPTION
- Closes #7548

### User facing change log

- Dashboard upload of `stdout` is deferred until after the video/image uploads complete

### Additional details

`stdout` does not need to be sent on both `PUT /instances/:id` and `PUT /instances/:id/stdout`. Sending in the first could cause the request to the dashboard to fail if the payload size is too large, which will prevent the run from completing, prevent any asset uploads, etc.

### How has the user experience changed?

Stdout will be delayed from appearing in the dashboard until after any assets have uploaded

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
