### PR TITLE
Handle uncaught errors thrown as strings

### DIFF
--- a/packages/driver/test/cypress/integration/e2e/uncaught_errors_spec.js
+++ b/packages/driver/test/cypress/integration/e2e/uncaught_errors_spec.js
@@ -89,7 +89,7 @@ describe('uncaught errors', () => {
       done()
     })
 
-    return cy
+    cy
     .visit('/fixtures/jquery.html')
     .window().then((win) => {
       return win.$('button:first').on('click', () => {
@@ -122,7 +122,7 @@ describe('uncaught errors', () => {
       done()
     })
 
-    return cy
+    cy
     .visit('/fixtures/jquery.html')
     .window().then((win) => {
       return win.$('<a href=\'/fixtures/visit_error.html\'>visit</a>')
@@ -142,5 +142,24 @@ describe('uncaught errors', () => {
     })
 
     cy.visit('/fixtures/global-error.html')
+  })
+
+  it('creates error object from error that is just a string', (done) => {
+    cy.once('uncaught:exception', (err) => {
+      expect(err).not.to.be.a('string')
+      expect(err.message).to.include('string error')
+
+      done()
+
+      return false
+    })
+
+    cy
+    .visit('/fixtures/jquery.html')
+    .window().then((win) => {
+      return win.$('button:first').on('click', () => {
+        throw 'string error'
+      })
+    }).get('button:first').click()
   })
 })

--- a/packages/driver/test/cypress/integration/e2e/uncaught_errors_spec.js
+++ b/packages/driver/test/cypress/integration/e2e/uncaught_errors_spec.js
@@ -144,6 +144,7 @@ describe('uncaught errors', () => {
     cy.visit('/fixtures/global-error.html')
   })
 
+  // https://github.com/cypress-io/cypress/issues/7590
   it('creates error object from error that is just a string', (done) => {
     cy.once('uncaught:exception', (err) => {
       expect(err).not.to.be.a('string')


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7590

### User facing changelog

- Fixed an issue where errors thrown as strings would not display correctly.

### Additional details

If a user application threw an error as a string (`throw 'some error'` as opposed to `throw new Error('some error')`, an internal error `Cannot read property 'split' of undefined` would be displayed and the `uncaught:exception` event would be called with the error as a string instead of as an object with typical error properties.

### How has the user experience changed?

If there is a string exception in an application, the test will now fail with the correct error. If the `uncaught:exception` event is being used, it will be called with an error object now, as it should.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
