### PR TITLE
internal: fix error on yarn add dependency command

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@types/enzyme": "3.9.1",
     "@types/enzyme-adapter-react-16": "1.0.5",
     "@types/execa": "0.9.0",
-    "@types/fs-extra": "8.0.1",
+    "@types/fs-extra": "^8.0.1",
     "@types/glob": "7.1.1",
     "@types/lodash": "4.14.149",
     "@types/markdown-it": "0.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3876,14 +3876,7 @@
   resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.28.tgz#c054e8af4d9dd75db4e63abc76f885168714d4b3"
   integrity sha1-wFTor02d11205jq8dviFFocU1LM=
 
-"@types/fs-extra@8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.0.1.tgz#a2378d6e7e8afea1564e44aafa2e207dadf77686"
-  integrity sha512-J00cVDALmi/hJOYsunyT52Hva5TnJeKP5yd1r+mH/ZU0mbYZflR0Z5kw5kITtKTRYMhm1JMClOFYdHnQszEvqw==
-  dependencies:
-    "@types/node" "*"
-
-"@types/fs-extra@^8.1.0":
+"@types/fs-extra@^8.0.1", "@types/fs-extra@^8.1.0":
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.1.tgz#1e49f22d09aa46e19b51c0b013cb63d0d923a068"
   integrity sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==


### PR DESCRIPTION
- fixes erroring `yarn add ...` command for developers in the cypress repo
- we can use carrots `^` for devDependencies versions since we use yarn.lock

caused by https://github.com/yarnpkg/yarn/issues/7807