### PR TITLE
Update types for configuration values that allow string or false

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2349,7 +2349,7 @@ declare namespace Cypress {
      * Path to folder containing fixture files (Pass false to disable)
      * @default "cypress/fixtures"
      */
-    fixturesFolder: string
+    fixturesFolder: string | false
     /**
      * Path to folder containing integration test files
      * @default "cypress/integration"
@@ -2364,7 +2364,7 @@ declare namespace Cypress {
      * Path to plugins file. (Pass false to disable)
      * @default "cypress/plugins/index.js"
      */
-    pluginsFile: string
+    pluginsFile: string | false
     /**
      * If `nodeVersion === 'system'` and a `node` executable is found, this will be the full filesystem path to that executable.
      * @default null
@@ -2379,12 +2379,12 @@ declare namespace Cypress {
      * Path to folder where screenshots will be saved from [cy.screenshot()](https://on.cypress.io/screenshot) command or after a headless or CI run’s test failure
      * @default "cypress/screenshots"
      */
-    screenshotsFolder: string
+    screenshotsFolder: string | false
     /**
      * Path to file to load before test files load. This file is compiled and bundled. (Pass false to disable)
      * @default "cypress/support/index.js"
      */
-    supportFile: string
+    supportFile: string | false
     /**
      * Path to folder where videos will be saved after a headless or CI run
      * @default "cypress/videos"
@@ -2399,7 +2399,7 @@ declare namespace Cypress {
      * The quality setting for the video compression, in Constant Rate Factor (CRF). The value can be false to disable compression or a value between 0 and 51, where a lower value results in better quality (at the expense of a higher file size).
      * @default 32
      */
-    videoCompression: number
+    videoCompression: number | false
     /**
      * Whether Cypress will record a video of the test run when running headlessly.
      * @default true

--- a/cli/types/tests/plugins-config.ts
+++ b/cli/types/tests/plugins-config.ts
@@ -8,6 +8,10 @@ const pluginConfig2: Cypress.PluginConfig = (on, config) => {
   config // $ExpectType PluginConfigOptions
   config.baseUrl // $ExpectType: string
   config.configFile // $ExpectType: string | false
+  config.fixturesFolder // $ExpectType: string | false
+  config.pluginsFile // $ExpectType: string | false
+  config.screenshotsFolder // $ExpectType: string | false
+  config.videoCompression // $ExpectType: number | false
   config.projectRoot // $ExpectType: string
 
   on('before:browser:launch', (browser, options) => {


### PR DESCRIPTION
- close #7654 

### User facing changelog

Configuration types for `fixturesFolder`, `pluginsFile`, `screenshotsFolders` and `videoCompression` have been updated to allow `false` types.

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Have API changes been updated in the [`type definitions`](cli/types/cypress.d.ts)?