### PR TITLE
fix(types): cy.wait yields previous subject

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1942,7 +1942,7 @@ declare namespace Cypress {
      * @example
      *    cy.wait(1000) // wait for 1 second
      */
-    wait(ms: number, options?: Partial<Loggable & Timeoutable>): Chainable<undefined>
+    wait(ms: number, options?: Partial<Loggable & Timeoutable>): Chainable<Subject>
     /**
      * Wait for a specific XHR to respond.
      *

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -215,6 +215,10 @@ cy.wait(['@foo', '@bar'])
     first // $ExpectType WaitXHR
   })
 
+cy.wait(1234) // $ExpectType Chainable<undefined>
+
+cy.wrap('foo').wait(1234) // $ExpectType Chainable<string>
+
 cy.wrap([{ foo: 'bar' }, { foo: 'baz' }])
   .then(subject => {
     subject // $ExpectType { foo: string; }[]


### PR DESCRIPTION
### User facing changelog

- Updated type defitions for `cy.wait(ms)` to correctly yield the type of the previous Subject.

### Additional details

Updated types to match the docs:

![image](https://user-images.githubusercontent.com/1151760/84436601-bb90df80-ac01-11ea-9ac4-6dc43c014d64.png)



### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](cli/schema/cypress.schema.json)?
