### PR TITLE
Update types to allow for alias 'key' for 'keys' with chai chainers

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3074,6 +3074,22 @@ declare namespace Cypress {
      */
     (chainer: 'equal', value: any): Chainable<Subject>
     /**
+   * Causes all `.key` assertions that follow in the chain to require that the target have all of the given keys. This is the opposite of `.any`, which only requires that the target have at least one of the given keys.
+   * @example
+   *    cy.wrap({ a: 1, b: 2 }).should('have.all.key', 'a', 'b')
+   * @see http://chaijs.com/api/bdd/#method_all
+   * @see https://on.cypress.io/assertions
+   */
+    (chainer: 'have.all.key', ...value: string[]): Chainable<Subject>
+    /**
+     * Causes all `.key` assertions that follow in the chain to only require that the target have at least one of the given keys. This is the opposite of `.all`, which requires that the target have all of the given keys.
+     * @example
+     *    cy.wrap({ a: 1, b: 2 }).should('have.any.key', 'a')
+     * @see http://chaijs.com/api/bdd/#method_any
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'have.any.key', ...value: string[]): Chainable<Subject>
+    /**
      * Causes all `.keys` assertions that follow in the chain to require that the target have all of the given keys. This is the opposite of `.any`, which only requires that the target have at least one of the given keys.
      * @example
      *    cy.wrap({ a: 1, b: 2 }).should('have.all.keys', 'a', 'b')

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -88,6 +88,10 @@ cy.wrap({ a: 1, b: 2 }).should('have.all.keys', 'a', 'b')
 
 cy.wrap({ a: 1, b: 2 }).should('have.any.keys', 'a')
 
+cy.wrap({ a: 1, b: 2 }).should('have.all.key', 'a', 'b')
+
+cy.wrap({ a: 1, b: 2 }).should('have.any.key', 'a')
+
 cy.wrap({ x: {a: 1 }}).should('have.deep.property', 'x', { a: 1 })
 
 cy.wrap([1, 2, 3]).should('have.length', 3)


### PR DESCRIPTION
- Close #7665 

### User Facing Changelog

- TypeScript types now allow for the ‘key’ keyword when chaining off ‘any’ or ‘all’ chainers.

### Additional Details

- `key` is an alias of `keys` in Chai

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/2873
- [x] Have API changes been updated in the [`type definitions`](../cli/types/cypress.d.ts)?