### PR TITLE
Fix issue where click hangs if subject has a shadow root and shadow dom support is not enabled

### DIFF
--- a/cli/schema/cypress.schema.json
+++ b/cli/schema/cypress.schema.json
@@ -237,7 +237,7 @@
     "experimentalShadowDomSupport": {
       "type": "boolean",
       "default": false,
-      "description": "Enables shadow DOM support. Adds the `cy.shadow()` command and the `ignoreShadowBoundaries` option to some DOM commands."
+      "description": "Enables shadow DOM support. Adds the `cy.shadow()` command and the `includeShadowDom` option to some DOM commands."
     }
   }
 }

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2175,11 +2175,11 @@ declare namespace Cypress {
    */
   interface Shadow {
     /**
-     * Ignore shadow boundary and continue searching
+     * Include shadow DOM in search
      *
      * @default: false
      */
-    ignoreShadowBoundaries: boolean
+    includeShadowDom: boolean
   }
 
   /**
@@ -2456,7 +2456,7 @@ declare namespace Cypress {
     experimentalSourceRewriting: boolean
     /**
      * Enables shadow DOM support. Adds the `cy.shadow()` command and
-     * the `ignoreShadowBoundaries` option to some DOM commands.
+     * the `includeShadowDom` option to some DOM commands.
      */
     experimentalShadowDomSupport: boolean
   }

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -524,9 +524,9 @@ namespace CypressShadowTests {
   .find('.bar')
   .click()
 
-  cy.get('.foo', { ignoreShadowBoundaries: true }).click()
+  cy.get('.foo', { includeShadowDom: true }).click()
 
   cy
   .get('.foo')
-  .find('.bar', {ignoreShadowBoundaries: true})
+  .find('.bar', {includeShadowDom: true})
 }

--- a/packages/driver/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/click_spec.js
@@ -3666,12 +3666,12 @@ describe('src/cy/commands/actions/click', () => {
   })
 })
 
-describe('composed events', () => {
+describe('shadow dom', () => {
   beforeEach(() => {
     cy.visit('/fixtures/shadow-dom.html')
   })
 
-  it('should compose click events', (done) => {
+  it('composes click events', (done) => {
     const el = cy.$$('#shadow-element-3')[0].shadowRoot.querySelector('p')
 
     cy.$$('#parent-of-shadow-container-0').on('click', () => {
@@ -3683,7 +3683,7 @@ describe('composed events', () => {
     .click()
   })
 
-  it('should compose dblclick events', (done) => {
+  it('composes dblclick events', (done) => {
     const el = cy.$$('#shadow-element-3')[0].shadowRoot.querySelector('p')
 
     cy.$$('#parent-of-shadow-container-0').on('dblclick', () => {
@@ -3695,7 +3695,7 @@ describe('composed events', () => {
     .dblclick()
   })
 
-  it('should compose right click events', (done) => {
+  it('composes right click events', (done) => {
     const el = cy.$$('#shadow-element-3')[0].shadowRoot.querySelector('p')
 
     cy.$$('#parent-of-shadow-container-0').on('contextmenu', () => {
@@ -3705,6 +3705,15 @@ describe('composed events', () => {
     cy
     .get(el)
     .rightclick()
+  })
+
+  // https://github.com/cypress-io/cypress/issues/7679
+  it('does not hang when experimentalShadowDomSupport is false and clicking on custom element', () => {
+    Cypress.config('experimentalShadowDomSupport', false)
+    // needs some size or it's considered invisible and click will fail its prerequisites
+    cy.$$('#shadow-element-1').css({ padding: 2 })
+
+    cy.get('#shadow-element-1').click()
   })
 })
 

--- a/packages/driver/src/dom/elements.ts
+++ b/packages/driver/src/dom/elements.ts
@@ -1220,8 +1220,10 @@ const elementFromPoint = (doc, x, y) => {
   // if the node has a shadow root, we must behave like
   // the browser and find the inner element of the shadow
   // root at that same point.
-  while (node?.shadowRoot) {
-    node = node.shadowRoot.elementFromPoint(x, y)
+  if (Cypress.config('experimentalShadowDomSupport')) {
+    while (node?.shadowRoot) {
+      node = node.shadowRoot.elementFromPoint(x, y)
+    }
   }
 
   // if we never found an inner/deep element, use the

--- a/packages/server/lib/experiments.ts
+++ b/packages/server/lib/experiments.ts
@@ -54,7 +54,7 @@ const _summaries: StringValues = {
   experimentalComponentTesting: 'Framework-specific component testing, uses `componentFolder` to load component specs',
   experimentalSourceRewriting: 'Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm.',
   experimentalGetCookiesSameSite: 'Adds `sameSite` values to the objects yielded from `cy.setCookie()`, `cy.getCookie()`, and `cy.getCookies()`. This will become the default behavior in Cypress 5.0.',
-  experimentalShadowDomSupport: 'Enables support for shadow DOM traversal, introduces the `shadow()` command and the `ignoreShadowBoundaries` option to traversal commands.',
+  experimentalShadowDomSupport: 'Enables support for shadow DOM traversal, introduces the `shadow()` command and the `includeShadowDom` option to traversal commands.',
 }
 
 /**


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7679 

### User facing changelog

- Fixed an issue where a click would hang if the subject had a shadow root and shadow DOM support was not enabled.

### Additional details

Also fixed TypeScript types and descriptions that referenced the old option name `ignoreShadowBoundaries`.

### How has the user experience changed?

Clicks no longer hang when the subject has a shadow root and shadow dom support is not enabled.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](../cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](../cli/schema/cypress.schema.json)?
