### PR TITLE
Add spec loading state and animation

### DIFF
--- a/packages/reporter/src/runnables/runnables.scss
+++ b/packages/reporter/src/runnables/runnables.scss
@@ -272,7 +272,7 @@
       width: 160px;
 
       div {
-        animation: scaling 1.65s linear infinite;
+        animation: scaling 1.65s ease-in-out infinite;
         border-radius: 50%;
         height: 40px;
         margin: 0 -5px;

--- a/packages/reporter/src/runnables/runnables.scss
+++ b/packages/reporter/src/runnables/runnables.scss
@@ -280,38 +280,38 @@
         width: 40px;
       }
 
-      div:nth-child(1){
+      div:nth-child(1) {
         animation-delay:0.1s;
         background: #56b790;
       }
 
-      div:nth-child(2){
+      div:nth-child(2) {
         animation-delay:0.2s;
         background: #4a88cc;
       }
 
-      div:nth-child(3){
+      div:nth-child(3) {
         animation-delay:0.3s;
         background: #b96162;
       }
 
-      div:nth-child(4){
+      div:nth-child(4) {
         animation-delay:0.4s;
         background: #e3b065;
       }
 
-      div:nth-child(5){
+      div:nth-child(5) {
         animation-delay:0.5s;
         background: #a9abad;
       }
 
-      @keyframes scaling{
-        0%, 20%, 80%, 100%{
+      @keyframes scaling {
+        0%, 20%, 80%, 100% {
           opacity: 100%;
           transform: scale(0.5);
         }
 
-        50%{
+        50% {
           opacity: 50%;
           transform: scale(1);
         }

--- a/packages/reporter/src/runnables/runnables.scss
+++ b/packages/reporter/src/runnables/runnables.scss
@@ -263,4 +263,65 @@
       margin-right: 5px;
     }
   }
+
+  .runnable-loading {
+    .runnable-loading-animation {
+      display: flex;
+      margin: 3.5rem auto 1.5rem;
+      padding: 0 5px;
+      width: 160px;
+
+      div {
+        animation: scaling 1.65s linear infinite;
+        border-radius: 50%;
+        height: 40px;
+        margin: 0 -5px;
+        transform: scale(0.5);
+        width: 40px;
+      }
+
+      div:nth-child(1){
+        animation-delay:0.1s;
+        background: #56b790;
+      }
+
+      div:nth-child(2){
+        animation-delay:0.2s;
+        background: #4a88cc;
+      }
+
+      div:nth-child(3){
+        animation-delay:0.3s;
+        background: #b96162;
+      }
+
+      div:nth-child(4){
+        animation-delay:0.4s;
+        background: #e3b065;
+      }
+
+      div:nth-child(5){
+        animation-delay:0.5s;
+        background: #a9abad;
+      }
+
+      @keyframes scaling{
+        0%, 20%, 80%, 100%{
+          opacity: 100%;
+          transform: scale(0.5);
+        }
+
+        50%{
+          opacity: 50%;
+          transform: scale(1);
+        }
+      }
+    }
+
+    .runnable-loading-title {
+      font-family: $muli;
+      font-size: 20px;
+      text-align: center;
+    }
+  }
 }

--- a/packages/reporter/src/runnables/runnables.tsx
+++ b/packages/reporter/src/runnables/runnables.tsx
@@ -17,6 +17,19 @@ const noTestsError = (specPath: string) => ({
   message: 'We could not detect any tests in the above file. Write some tests and re-run.',
 })
 
+const Loading = () => (
+  <div className="runnable-loading">
+    <div className="runnable-loading-animation">
+      <div />
+      <div />
+      <div />
+      <div />
+      <div />
+    </div>
+    <div className="runnable-loading-title">Your tests are loading...</div>
+  </div>
+)
+
 interface RunnablesListProps {
   runnables: RunnableArray
 }
@@ -30,7 +43,9 @@ const RunnablesList = observer(({ runnables }: RunnablesListProps) => (
 ))
 
 function content ({ isReady, runnables }: RunnablesStore, specPath: string, error?: Error) {
-  if (!isReady) return null
+  if (!isReady) {
+    return <Loading />
+  }
 
   // show error if there are no tests, but only if there
   // there isn't an error passed down that supercedes it


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7700

### User facing changelog

Adds a loading state so that a user knows when their tests are loading, especially if it takes longer than usual

### How has the user experience changed?

New loading state:

![ezgif-6-6aa0b47815bd](https://user-images.githubusercontent.com/7033952/84671552-86340c80-aef5-11ea-99d3-39960bbd461c.gif)

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
