### PR TITLE
chore: make NODE_OPTIONS fork with --inspect args

### DIFF
--- a/packages/server/lib/util/node_options.ts
+++ b/packages/server/lib/util/node_options.ts
@@ -33,11 +33,7 @@ export function needsOptions (): boolean {
 function getCurrentInspectFlag (): string | undefined {
   const flag = process.execArgv.find((v) => v.startsWith('--inspect'))
 
-  if (flag) {
-    return flag.split('=')[0]
-  }
-
-  return
+  return flag ? flag.split('=')[0] : undefined
 }
 
 /**

--- a/packages/server/lib/util/node_options.ts
+++ b/packages/server/lib/util/node_options.ts
@@ -28,6 +28,19 @@ export function needsOptions (): boolean {
 }
 
 /**
+ * Retrieve the current inspect flag, if the process was launched with one.
+ */
+function getCurrentInspectFlag (): string | undefined {
+  const flag = process.execArgv.find((v) => v.startsWith('--inspect'))
+
+  if (flag) {
+    return flag.split('=')[0]
+  }
+
+  return
+}
+
+/**
  * Fork the current process using the good NODE_OPTIONS and pipe stdio
  * through the current process. On exit, copy the error code too.
  */
@@ -41,9 +54,16 @@ export function forkWithCorrectOptions (): void {
     ORIGINAL_NODE_OPTIONS: process.env.ORIGINAL_NODE_OPTIONS,
   })
 
+  const launchArgs = process.argv.slice(1)
+  const inspectFlag = getCurrentInspectFlag()
+
+  if (inspectFlag) {
+    launchArgs.unshift(`${inspectFlag}=${process.debugPort + 1}`)
+  }
+
   cp.spawn(
     process.execPath,
-    process.argv.slice(1),
+    launchArgs,
     { stdio: 'inherit' },
   )
   .on('error', () => {})


### PR DESCRIPTION

<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

### User facing changelog

n/a - internal only

### Additional details

Now, the server will pass on `--inspect` or `--inspect-brk` arguments to the forked process if the NODE_OPTIONS check fails.

This fixes the behavior of the `yarn dev-debug` command in root.


### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [na] Have tests been added/updated?
- [na] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](../cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](../cli/schema/cypress.schema.json)?
