### PR TITLE
fix(server): fix excess debug logs from foxdriver

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,6 +8,7 @@
     "clean-deps": "rm -rf node_modules",
     "codecov": "codecov",
     "dev": "node index.js",
+    "docker": "cd ../.. && WORKING_DIR=/packages/server ./scripts/run-docker-local.sh",
     "repl": "node repl.js",
     "start": "node ../../scripts/cypress open --dev --global",
     "test": "node ./test/scripts/run.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,6 +9,7 @@
     "codecov": "codecov",
     "dev": "node index.js",
     "docker": "cd ../.. && WORKING_DIR=/packages/server ./scripts/run-docker-local.sh",
+    "postinstall": "patch-package",
     "repl": "node repl.js",
     "start": "node ../../scripts/cypress open --dev --global",
     "test": "node ./test/scripts/run.js",
@@ -195,6 +196,11 @@
     "lib"
   ],
   "productName": "Cypress",
+  "workspaces": {
+    "nohoist": [
+      "@benmalka/foxdriver"
+    ]
+  },
   "optionalDependencies": {
     "registry-js": "1.8.0"
   }

--- a/packages/server/patches/@benmalka+foxdriver+0.4.0.patch
+++ b/packages/server/patches/@benmalka+foxdriver+0.4.0.patch
@@ -1,0 +1,49 @@
+diff --git a/node_modules/@benmalka/foxdriver/build/logger.js b/node_modules/@benmalka/foxdriver/build/logger.js
+index c28401c..bfb5da4 100644
+--- a/node_modules/@benmalka/foxdriver/build/logger.js
++++ b/node_modules/@benmalka/foxdriver/build/logger.js
+@@ -5,9 +5,7 @@ Object.defineProperty(exports, "__esModule", {
+ });
+ exports.default = Logger;
+ 
+-var _npmlog = require("npmlog");
+-
+-var _npmlog2 = _interopRequireDefault(_npmlog);
++const debug = require('debug')('@benmalka/foxdriver')
+ 
+ var _package = require("../package.json");
+ 
+@@ -20,11 +18,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
+  */
+ const NPM_LEVELS = ['silly', 'verbose', 'debug', 'info', 'http', 'warn', 'error', 'chrome', 'firefox'];
+ 
+-_npmlog2.default.addLevel('debug', 1000, {
+-  fg: 'blue',
+-  bg: 'black'
+-}, 'dbug');
+-
+ function Logger(component) {
+   const wrappedLogger = {};
+   const prefix = _package2.default.name + (component ? `:${component}` : '');
+@@ -34,10 +27,8 @@ function Logger(component) {
+ 
+   Object.defineProperty(wrappedLogger, 'level', {
+     get: () => {
+-      return _npmlog2.default.level;
+     },
+     set: newValue => {
+-      _npmlog2.default.level = newValue;
+     },
+     enumerable: true,
+     configurable: true
+@@ -48,8 +39,8 @@ function Logger(component) {
+ 
+   for (let level of NPM_LEVELS) {
+     wrappedLogger[level] = (...args) => {
+-      if (!process.env.DEBUG) return;
+-      return _npmlog2.default[level](prefix, ...args);
++      // @see https://github.com/cypress-io/cypress/issues/7723
++      debug(prefix, ...args)
+     };
+   }
+ 

--- a/packages/server/test/e2e/1_firefox_spec.ts
+++ b/packages/server/test/e2e/1_firefox_spec.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import util from 'util'
 import fs from 'fs-extra'
 
-import e2e from '../support/helpers/e2e'
+import e2e, { expect } from '../support/helpers/e2e'
 import Bluebird from 'bluebird'
 import Fixtures from '../support/helpers/fixtures'
 
@@ -56,5 +56,16 @@ describe('e2e firefox', function () {
     browser: 'firefox',
     project: Fixtures.projectPath('screen-size'),
     spec: 'maximized.spec.js',
+    onRun: async (exec) => {
+      const { stderr } = await exec({
+        processEnv: {
+          // trigger foxdriver's built-in debug logs
+          DEBUG: process.env.DEBUG || 'foo',
+        },
+      })
+
+      // @see https://github.com/cypress-io/cypress/issues/7723
+      expect(stderr).not.to.include('foxdriver')
+    },
   })
 })

--- a/scripts/run-docker-local.sh
+++ b/scripts/run-docker-local.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set e+x
 
 echo "This script should be run from cypress's root"
@@ -12,6 +13,6 @@ echo "You should be able to edit files locally"
 echo "but execute the code in the container"
 
 docker run -v $PWD:/home/person/cypress \
-  -w /home/person/cypress \
+  -w /home/person/cypress${WORKING_DIR:-} \
   -it $name \
   /bin/bash


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7723 

### User facing changelog

- Fixed a bug where debug logs from the `@benmalka/foxdriver` module would always appear if any `DEBUG` environment variable was set.

### Additional details

- now `DEBUG=@benmalka/foxdriver` can be used to isolate this log stream

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](../cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](../cli/schema/cypress.schema.json)?
