### PR TITLE
Fix issue where command is never fully ended and following assertions are displayed incorrectly

### DIFF
--- a/packages/driver/cypress/integration/cypress/cy_spec.js
+++ b/packages/driver/cypress/integration/cypress/cy_spec.js
@@ -476,4 +476,23 @@ describe('driver/src/cypress/cy', () => {
       })
     })
   })
+
+  // https://github.com/cypress-io/cypress/issues/7731
+  context('closing commands', () => {
+    beforeEach(function () {
+      this.logs = []
+
+      cy.on('log:added', (attrs, log) => {
+        this.logs.push(log)
+      })
+
+      return null
+    })
+
+    it('properly closes commands', function () {
+      expect(true).to.be.true
+      expect(this.logs.length).to.be.equal(1)
+      expect(this.logs[0].toJSON()).to.have.property('type', 'parent')
+    })
+  })
 })

--- a/packages/driver/cypress/integration/cypress/cy_spec.js
+++ b/packages/driver/cypress/integration/cypress/cy_spec.js
@@ -17,6 +17,27 @@ describe('driver/src/cypress/cy', () => {
     $(doc.body).empty().html(body)
   })
 
+  // https://github.com/cypress-io/cypress/issues/7731
+  // NOTE: this must remain the first test in the file
+  // or it will not properly check for the described issue
+  context('closing commands', () => {
+    beforeEach(function () {
+      this.logs = []
+
+      cy.on('log:added', (attrs, log) => {
+        this.logs.push(log)
+      })
+
+      return null
+    })
+
+    it('properly closes commands', function () {
+      expect(true).to.be.true
+      expect(this.logs.length).to.be.equal(1)
+      expect(this.logs[0].toJSON()).to.have.property('type', 'parent')
+    })
+  })
+
   context('hard deprecated private props', () => {
     it('throws on accessing props', () => {
       const fn = () => {
@@ -474,25 +495,6 @@ describe('driver/src/cypress/cy', () => {
       cy.get('form').eq(0).submit().then(() => {
         expect(cy.state('current').get('prev').get('args')[0].foo).to.equal('foo')
       })
-    })
-  })
-
-  // https://github.com/cypress-io/cypress/issues/7731
-  context('closing commands', () => {
-    beforeEach(function () {
-      this.logs = []
-
-      cy.on('log:added', (attrs, log) => {
-        this.logs.push(log)
-      })
-
-      return null
-    })
-
-    it('properly closes commands', function () {
-      expect(true).to.be.true
-      expect(this.logs.length).to.be.equal(1)
-      expect(this.logs[0].toJSON()).to.have.property('type', 'parent')
     })
   })
 })

--- a/packages/driver/src/cypress/cy.js
+++ b/packages/driver/src/cypress/cy.js
@@ -459,6 +459,10 @@ const create = function (specWindow, Cypress, Cookies, state, config, log) {
       // also reset recentlyReady back to null
       state('recentlyReady', null)
 
+      // we're finished with the current command
+      // so set it back to null
+      state('current', null)
+
       state('subject', subject)
 
       return subject


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7731

### User facing changelog

Fixes an issue where an assertion log would be displayed as a child while really a parent if no commands were issued in the `beforeEach` loop.

### Additional details

Fixes an internal issue where commands would not be properly closed after executing.

### How has the user experience changed?

Notice green dash to the left of "assert"

Before:

![84856479-d06fd780-b034-11ea-8dd3-6e9b98ea7eb8](https://user-images.githubusercontent.com/7033952/84857008-15e0d480-b036-11ea-9766-fb1050aadcf5.png)

After:

![Screen Shot 2020-06-17 at 1 00 29 AM](https://user-images.githubusercontent.com/7033952/84857021-1b3e1f00-b036-11ea-973e-af6fc7e70358.png)

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
