### PR TITLE
Before XHR URLs are whitelisted, strip query params and hashes

### DIFF
--- a/packages/driver/cypress/integration/commands/xhr_spec.js
+++ b/packages/driver/cypress/integration/commands/xhr_spec.js
@@ -2296,6 +2296,34 @@ describe('src/cy/commands/xhr', () => {
           expect(resp).to.eq('{ \'bar\' }\n')
         })
       })
+
+      // https://github.com/cypress-io/cypress/issues/7280
+      it('ignores query params when whitelisting routes', () => {
+        cy.server()
+        cy.route(/url-with-query-param/, { foo: 'bar' }).as('getQueryParam')
+        cy.window().then((win) => {
+          win.$.get('/url-with-query-param?resource=foo.js')
+
+          return null
+        })
+
+        cy.wait('@getQueryParam').its('response.body')
+        .should('deep.equal', { foo: 'bar' })
+      })
+
+      // https://github.com/cypress-io/cypress/issues/7280
+      it('ignores hashes when whitelisting routes', () => {
+        cy.server()
+        cy.route(/url-with-hash/, { foo: 'bar' }).as('getHash')
+        cy.window().then((win) => {
+          win.$.get('/url-with-hash#foo.js')
+
+          return null
+        })
+
+        cy.wait('@getHash').its('response.body')
+        .should('deep.equal', { foo: 'bar' })
+      })
     })
 
     describe('route setup', () => {

--- a/packages/driver/src/cypress/server.js
+++ b/packages/driver/src/cypress/server.js
@@ -66,8 +66,16 @@ const warnOnForce404Default = (obj) => {
 }
 
 const whitelist = (xhr) => {
+  const url = new URL(xhr.url)
+
+  // https://github.com/cypress-io/cypress/issues/7280
+  // we want to strip the xhr's URL of any hash and query params before
+  // checking the REGEX for matching file extensions
+  url.search = ''
+  url.hash = ''
+
   // whitelist if we're GET + looks like we're fetching regular resources
-  return xhr.method === 'GET' && regularResourcesRe.test(xhr.url)
+  return xhr.method === 'GET' && regularResourcesRe.test(url.href)
 }
 
 const serverDefaults = {


### PR DESCRIPTION
- close #7280 

### User Changelog

- `cy.wait()` will now correctly resolve when waiting for XHR requests that contain static resource-like text in the XHR's query params or hash (like `.js`, .`html`, `.css`)

### Additional Details

- This prevents the whitelist regex from unknowingly matching urls that have
ignored extensions in their query params or hash like `fake-url?resource=script.js` or `fake-url#referrer.html`


### How has the user experience changed?

Previously if you were waiting for an XHR request that had `.js`, `.html`, `.css`, etc *anywhere* in the URL, it would be ignored (since we ignore static resources).

```js
it('test cy.route()', () => {
  cy.server()
  cy.route('fake-url?resource=script.js').as('getFakeUrl')
  cy.visit('https://example.com')
  // wait used to never resolve because it matched having .js in it's route
  // this passes after this PR!
  cy.wait('@getFakeUrl') 
})
```

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->