### PR TITLE
Handle --project "" command line argument

### DIFF
--- a/cli/__snapshots__/errors_spec.js
+++ b/cli/__snapshots__/errors_spec.js
@@ -35,6 +35,7 @@ exports['errors individual has the following errors 1'] = [
   "incompatibleHeadlessFlags",
   "invalidCacheDirectory",
   "invalidCypressEnv",
+  "invalidRunProjectPath",
   "invalidSmokeTestDisplayError",
   "missingApp",
   "missingDependency",
@@ -44,6 +45,7 @@ exports['errors individual has the following errors 1'] = [
   "removed",
   "smokeTestFailure",
   "unexpected",
+  "unknownError",
   "versionMismatch"
 ]
 

--- a/cli/lib/cypress.js
+++ b/cli/lib/cypress.js
@@ -9,13 +9,25 @@ const run = require('./exec/run')
 const util = require('./util')
 
 const cypressModuleApi = {
+  /**
+   * Opens Cypress GUI
+   * @see https://on.cypress.io/module-api#cypress-open
+   */
   open (options = {}) {
     options = util.normalizeModuleOptions(options)
 
     return open.start(options)
   },
 
+  /**
+   * Runs Cypress tests in the current project
+   * @see https://on.cypress.io/module-api#cypress-run
+   */
   run (options = {}) {
+    if (!run.isValidProject(options.project)) {
+      return Promise.reject(new Error(`Invalid project path parameter: ${options.project}`))
+    }
+
     options = util.normalizeModuleOptions(options)
 
     return tmp.fileAsync()

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -15,7 +15,18 @@ const requiredDependenciesUrl = `${docsUrl}/required-dependencies`
 
 const hr = '----------'
 
+const genericErrorSolution = stripIndent`
+  Search for an existing issue or open a GitHub issue at
+
+    ${chalk.blue(util.issuesUrl)}
+`
+
 // common errors Cypress application can encounter
+const unknownError = {
+  description: 'Unknown Cypress CLI error',
+  solution: genericErrorSolution,
+}
+
 const failedDownload = {
   description: 'The Cypress App could not be downloaded.',
   solution: stripIndent`
@@ -26,11 +37,7 @@ const failedDownload = {
 
 const failedUnzip = {
   description: 'The Cypress App could not be unzipped.',
-  solution: stripIndent`
-    Search for an existing issue or open a GitHub issue at
-
-      ${chalk.blue(util.issuesUrl)}
-  `,
+  solution: genericErrorSolution,
 }
 
 const missingApp = (binaryDir) => {
@@ -390,6 +397,7 @@ module.exports = {
   getError,
   hr,
   errors: {
+    unknownError,
     nonZeroExitCodeXvfb,
     missingXvfb,
     missingApp,

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -31,9 +31,9 @@ const unknownError = {
 const invalidRunProjectPath = {
   description: 'Invalid --project path',
   solution: stripIndent`
-    Provide valid project path.
+    Please provide a valid project path.
 
-    Read our documentation for ${chalk.cyan('cypress run')} command at:
+    Learn more about ${chalk.cyan('cypress run')} at:
 
       ${chalk.blue(runDocumentationUrl)}
   `,

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -9,7 +9,7 @@ const state = require('./tasks/state')
 
 const docsUrl = 'https://on.cypress.io'
 const requiredDependenciesUrl = `${docsUrl}/required-dependencies`
-const runDocumentationUrl = `${docsUrl}/command-line#cypress-run`
+const runDocumentationUrl = `${docsUrl}/cypress-run`
 
 // TODO it would be nice if all error objects could be enforced via types
 // to only have description + solution properties

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -9,6 +9,7 @@ const state = require('./tasks/state')
 
 const docsUrl = 'https://on.cypress.io'
 const requiredDependenciesUrl = `${docsUrl}/required-dependencies`
+const runDocumentationUrl = `${docsUrl}/command-line#cypress-run`
 
 // TODO it would be nice if all error objects could be enforced via types
 // to only have description + solution properties
@@ -25,6 +26,17 @@ const genericErrorSolution = stripIndent`
 const unknownError = {
   description: 'Unknown Cypress CLI error',
   solution: genericErrorSolution,
+}
+
+const invalidRunProjectPath = {
+  description: 'Invalid --project path',
+  solution: stripIndent`
+    Provide valid project path.
+
+    Read our documentation for ${chalk.cyan('cypress run')} command at:
+
+      ${chalk.blue(runDocumentationUrl)}
+  `,
 }
 
 const failedDownload = {
@@ -416,5 +428,6 @@ module.exports = {
     smokeTestFailure,
     childProcessKilled,
     incompatibleHeadlessFlags,
+    invalidRunProjectPath,
   },
 }

--- a/cli/lib/exec/run.js
+++ b/cli/lib/exec/run.js
@@ -163,6 +163,7 @@ const processRunOptions = (options = {}) => {
 
 module.exports = {
   processRunOptions,
+  isValidProject,
   // resolves with the number of failed tests
   start (options = {}) {
     _.defaults(options, {

--- a/cli/lib/exec/run.js
+++ b/cli/lib/exec/run.js
@@ -25,6 +25,24 @@ const throwInvalidOptionError = (details) => {
 }
 
 /**
+ * Typically a user passes a string path to the project.
+ * But "cypress open" allows using `false` to open in global mode,
+ * and the user can accidentally execute `cypress run --project false`
+ * which should be invalid.
+ */
+const isValidProject = (v) => {
+  if (typeof v === 'boolean') {
+    return false
+  }
+
+  if (v === '' || v === 'false' || v === 'true') {
+    return false
+  }
+
+  return true
+}
+
+/**
  * Maps options collected by the CLI
  * and forms list of CLI arguments to the server.
  *
@@ -36,7 +54,7 @@ const throwInvalidOptionError = (details) => {
 const processRunOptions = (options = {}) => {
   debug('processing run options %o', options)
 
-  if (typeof options.project === 'boolean' || options.project === '') {
+  if (!isValidProject(options.project)) {
     debug('invalid project option %o', { project: options.project })
 
     return throwInvalidOptionError(errors.invalidRunProjectPath)

--- a/cli/lib/exec/run.js
+++ b/cli/lib/exec/run.js
@@ -36,6 +36,12 @@ const throwInvalidOptionError = (details) => {
 const processRunOptions = (options = {}) => {
   debug('processing run options %o', options)
 
+  if (typeof options.project === 'boolean' || options.project === '') {
+    debug('invalid project option %o', { project: options.project })
+
+    return throwInvalidOptionError(errors.invalidRunProjectPath)
+  }
+
   const args = ['--run-project', options.project]
 
   if (options.browser) {

--- a/cli/lib/exec/run.js
+++ b/cli/lib/exec/run.js
@@ -6,8 +6,33 @@ const spawn = require('./spawn')
 const verify = require('../tasks/verify')
 const { exitWithError, errors } = require('../errors')
 
-// maps options collected by the CLI
-// and forms list of CLI arguments to the server
+/**
+ * Throws an error with "details" property from
+ * "errors" object.
+ * @param {Object} details - Error details
+ */
+const throwInvalidOptionError = (details) => {
+  if (!details) {
+    details = errors.unknownError
+  }
+
+  // throw this error synchronously, it will be caught later on and
+  // the details will be propagated to the promise chain
+  const err = new Error()
+
+  err.details = details
+  throw err
+}
+
+/**
+ * Maps options collected by the CLI
+ * and forms list of CLI arguments to the server.
+ *
+ * Note: there is lightweight validation, with errors
+ * thrown synchronously.
+ *
+ * @returns {string[]} list of CLI arguments
+ */
 const processRunOptions = (options = {}) => {
   debug('processing run options %o', options)
 
@@ -55,12 +80,7 @@ const processRunOptions = (options = {}) => {
 
   if (options.headless) {
     if (options.headed) {
-      // throw this error synchronously, it will be caught later on and
-      // the details will be propagated to the promise chain
-      const err = new Error()
-
-      err.details = errors.incompatibleHeadlessFlags
-      throw err
+      return throwInvalidOptionError(errors.incompatibleHeadlessFlags)
     }
 
     args.push('--headed', !options.headless)

--- a/cli/test/lib/cypress_spec.js
+++ b/cli/test/lib/cypress_spec.js
@@ -157,7 +157,7 @@ describe('cypress', function () {
     })
 
     it('rejects if project is false', () => {
-      return expect(cypress.run({ project: true })).to.be.rejected
+      return expect(cypress.run({ project: false })).to.be.rejected
     })
   })
 })

--- a/cli/test/lib/cypress_spec.js
+++ b/cli/test/lib/cypress_spec.js
@@ -159,7 +159,7 @@ describe('cypress', function () {
     it('rejects if project is false', () => {
       return expect(cypress.run({ project: false })).to.be.rejected
     })
-    
+
     it('passes quiet: true', () => {
       const opts = {
         quiet: true,

--- a/cli/test/lib/cypress_spec.js
+++ b/cli/test/lib/cypress_spec.js
@@ -147,5 +147,17 @@ describe('cypress', function () {
         expect(args).to.deep.eq(opts)
       })
     })
+
+    it('rejects if project is an empty string', () => {
+      return expect(cypress.run({ project: '' })).to.be.rejected
+    })
+
+    it('rejects if project is true', () => {
+      return expect(cypress.run({ project: true })).to.be.rejected
+    })
+
+    it('rejects if project is false', () => {
+      return expect(cypress.run({ project: true })).to.be.rejected
+    })
   })
 })

--- a/cli/test/lib/exec/run_spec.js
+++ b/cli/test/lib/exec/run_spec.js
@@ -15,6 +15,23 @@ describe('exec run', function () {
   })
 
   context('.processRunOptions', function () {
+    it('allows string --project option', () => {
+      const args = run.processRunOptions({
+        project: '/path/to/project',
+      })
+
+      expect(args).to.deep.equal(['--run-project', '/path/to/project'])
+    })
+
+    it('throws an error for empty string --project', () => {
+      expect(() => run.processRunOptions({ project: '' })).to.throw()
+    })
+
+    it('throws an error for boolean --project', () => {
+      expect(() => run.processRunOptions({ project: false })).to.throw()
+      expect(() => run.processRunOptions({ project: true })).to.throw()
+    })
+
     it('passes --browser option', () => {
       const args = run.processRunOptions({
         browser: 'test browser',

--- a/cli/test/lib/exec/run_spec.js
+++ b/cli/test/lib/exec/run_spec.js
@@ -32,6 +32,11 @@ describe('exec run', function () {
       expect(() => run.processRunOptions({ project: true })).to.throw()
     })
 
+    it('throws an error for --project "false" or "true"', () => {
+      expect(() => run.processRunOptions({ project: 'false' })).to.throw()
+      expect(() => run.processRunOptions({ project: 'true' })).to.throw()
+    })
+
     it('passes --browser option', () => {
       const args = run.processRunOptions({
         browser: 'test browser',

--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -34,17 +34,24 @@ const normalizeBackslash = (s) => {
   return s
 }
 
+/**
+ * remove stray double quote from runProject and other path properties
+ * due to bug in NPM passing arguments with backslash at the end
+ * @see https://github.com/cypress-io/cypress/issues/535
+ *
+ */
 const normalizeBackslashes = (options) => {
-  // remove stray double quote from runProject and other path properties
-  // due to bug in NPM passing arguments with
-  // backslash at the end
-  // https://github.com/cypress-io/cypress/issues/535
   // these properties are paths and likely to have backslash on Windows
   const pathProperties = ['runProject', 'project', 'appPath', 'execPath', 'configFile']
 
   pathProperties.forEach((property) => {
-    if (options[property]) {
+    // sometimes a string parameter might get parsed into a boolean
+    // for example "--project ''" will be transformed in "project: true"
+    // which we should treat as undefined
+    if (typeof options[property] === 'string') {
       options[property] = normalizeBackslash(options[property])
+    } else {
+      delete options[property]
     }
   })
 
@@ -148,6 +155,8 @@ const sanitizeAndConvertNestedArgs = (str, argname) => {
 }
 
 module.exports = {
+  normalizeBackslashes,
+
   toObject (argv) {
     debug('argv array: %o', argv)
 
@@ -210,7 +219,12 @@ module.exports = {
 
     let { spec } = options
     const { env, config, reporterOptions, outputPath, tag } = options
-    const project = options.project || options.runProject
+    let project = options.project || options.runProject
+
+    // only accept project if it is a string
+    if (typeof project !== 'string') {
+      project = undefined
+    }
 
     if (spec) {
       const resolvePath = (p) => {

--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -51,7 +51,10 @@ const normalizeBackslashes = (options) => {
     if (typeof options[property] === 'string') {
       options[property] = normalizeBackslash(options[property])
     } else {
-      delete options[property]
+      // configFile is a special case that can be set to false
+      if (property !== 'configFile') {
+        delete options[property]
+      }
     }
   })
 

--- a/packages/server/test/unit/args_spec.js
+++ b/packages/server/test/unit/args_spec.js
@@ -30,6 +30,8 @@ describe('lib/util/args', () => {
         // string properties
         project: true,
         appPath: '/foo/bar',
+        // this option can be string or false
+        configFile: false,
         // unknown properties will be preserved
         somethingElse: 42,
       }
@@ -37,6 +39,7 @@ describe('lib/util/args', () => {
 
       expect(output).to.deep.equal({
         appPath: '/foo/bar',
+        configFile: false,
         somethingElse: 42,
       })
     })

--- a/packages/server/test/unit/args_spec.js
+++ b/packages/server/test/unit/args_spec.js
@@ -24,12 +24,42 @@ describe('lib/util/args', () => {
     })
   })
 
+  context('normalizeBackslashes', () => {
+    it('sets non-string properties to undefined', () => {
+      const input = {
+        // string properties
+        project: true,
+        appPath: '/foo/bar',
+        // unknown properties will be preserved
+        somethingElse: 42,
+      }
+      const output = argsUtil.normalizeBackslashes(input)
+
+      expect(output).to.deep.equal({
+        appPath: '/foo/bar',
+        somethingElse: 42,
+      })
+    })
+  })
+
   context('--project', () => {
     it('sets projectRoot', function () {
       const projectRoot = path.resolve(cwd, './foo/bar')
       const options = this.setup('--project', './foo/bar')
 
       expect(options.projectRoot).to.eq(projectRoot)
+    })
+
+    it('is undefined if not specified', function () {
+      const options = this.setup()
+
+      expect(options.projectRoot).to.eq(undefined)
+    })
+
+    it('handles bool project parameter', function () {
+      const options = this.setup('--project', true)
+
+      expect(options.projectRoot).to.eq(undefined)
     })
   })
 

--- a/packages/server/test/unit/args_spec.js
+++ b/packages/server/test/unit/args_spec.js
@@ -43,6 +43,16 @@ describe('lib/util/args', () => {
         somethingElse: 42,
       })
     })
+
+    it('handles empty project path string', () => {
+      const input = {
+        project: '',
+      }
+      const output = argsUtil.normalizeBackslashes(input)
+
+      // empty project path remains
+      expect(output).to.deep.equal(input)
+    })
   })
 
   context('--project', () => {


### PR DESCRIPTION
- Closes #7743

### User facing changelog

- `cypress run` will no longer crash when provided an empty string to the `--project` flag.

### Additional details

Our string normalization did not check if the parameter is a string before proceeding. This fix makes it more robust.

### How has the user experience changed?

No crashing

### PR Tasks

- [x] Have tests been added/updated?
  * [x] test `args` normalize method and related functions
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
