### PR TITLE
Fix issue with finding elements in shadow dom under specific conditions

### DIFF
--- a/packages/driver/cypress/fixtures/shadow-dom.html
+++ b/packages/driver/cypress/fixtures/shadow-dom.html
@@ -37,9 +37,9 @@
       }
 
       if (window.location.search.includes('wrap-qsa')) {
-        const qsa = document.querySelectorAll;
+        const realQuerySelectorAll = document.querySelectorAll;
         document.querySelectorAll = function (...args) {
-          return qsa.apply(document, args);
+          return realQuerySelectorAll.apply(document, args);
         };
       }
     </script>

--- a/packages/driver/cypress/fixtures/shadow-dom.html
+++ b/packages/driver/cypress/fixtures/shadow-dom.html
@@ -35,6 +35,13 @@
           }
         })
       }
+
+      if (window.location.search.includes('wrap-qsa')) {
+        const qsa = document.querySelectorAll;
+        document.querySelectorAll = function (...args) {
+          return qsa.apply(document, args);
+        };
+      }
     </script>
   </body>
 </html>

--- a/packages/driver/cypress/integration/commands/querying_spec.js
+++ b/packages/driver/cypress/integration/commands/querying_spec.js
@@ -946,6 +946,12 @@ describe('src/cy/commands/querying', () => {
         cy.get('.in-and-out', { includeShadowDom: true })
         .should('have.length', 2)
       })
+
+      // https://github.com/cypress-io/cypress/issues/7676
+      it('does not error when querySelectorAll is wrapped and snapshots are off', () => {
+        cy.visit('/fixtures/shadow-dom.html?wrap-qsa=true')
+        cy.get('.shadow-1', { includeShadowDom: true })
+      })
     })
 
     describe('.log', () => {

--- a/packages/driver/cypress/integration/commands/traversals_spec.js
+++ b/packages/driver/cypress/integration/commands/traversals_spec.js
@@ -407,6 +407,12 @@ describe('src/cy/commands/traversals', () => {
           expect($element[0]).to.eq(el)
         })
       })
+
+      // https://github.com/cypress-io/cypress/issues/7676
+      it('does not error when querySelectorAll is wrapped and snapshots are off', () => {
+        cy.visit('/fixtures/shadow-dom.html?wrap-qsa=true')
+        cy.get('#shadow-element-1').find('.shadow-1', { includeShadowDom: true })
+      })
     })
 
     describe('closest', () => {

--- a/packages/driver/src/cy/commands/querying.js
+++ b/packages/driver/src/cy/commands/querying.js
@@ -276,24 +276,21 @@ module.exports = (Commands, Cypress, cy, state) => {
       }
 
       const getElements = () => {
-        // attempt to query for the elements by withinSubject context
-        // and catch any sizzle errors!
         let $el
 
         try {
-          // only support shadow traversal if we're not searching
-          // within a subject and have been explicitly told to ignore
-          // boundaries.
-          if (!options.includeShadowDom) {
-            $el = cy.$$(selector, options.withinSubject)
-          } else {
+          let scope = options.withinSubject
+
+          if (options.includeShadowDom) {
             const root = options.withinSubject || cy.state('document')
             const elementsWithShadow = $dom.findAllShadowRoots(root)
 
-            elementsWithShadow.push(root)
-
-            $el = cy.$$(selector, elementsWithShadow)
+            scope = elementsWithShadow.concat(root)
           }
+
+          // attempt to query for the elements by withinSubject context
+          // and catch any sizzle errors!
+          $el = cy.$$(selector, scope)
 
           // jQuery v3 has removed its deprecated properties like ".selector"
           // https://jquery.com/upgrade-guide/3.0/breaking-change-deprecated-context-and-selector-properties-removed

--- a/packages/driver/src/cy/commands/querying.js
+++ b/packages/driver/src/cy/commands/querying.js
@@ -288,8 +288,6 @@ module.exports = (Commands, Cypress, cy, state) => {
             scope = elementsWithShadow.concat(root)
           }
 
-          // attempt to query for the elements by withinSubject context
-          // and catch any sizzle errors!
           $el = cy.$$(selector, scope)
 
           // jQuery v3 has removed its deprecated properties like ".selector"
@@ -299,16 +297,17 @@ module.exports = (Commands, Cypress, cy, state) => {
           if ($el.selector == null) {
             $el.selector = selector
           }
-        } catch (e) {
-          e.onFail = () => {
+        } catch (err) {
+          // this is usually a sizzle error (invalid selector)
+          err.onFail = () => {
             if (options.log === false) {
-              return e
+              return err
             }
 
-            options._log.error(e)
+            options._log.error(err)
           }
 
-          throw e
+          throw err
         }
 
         // if that didnt find anything and we have a within subject


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7676

### User facing changelog

- Fixed a bug where querying shadow dom could cause the error `Cannot read property 'length' of undefined` in run mode

### Additional details

The root cause of this issue is that the framework Salesforce uses (_Aura_) wraps the native `document.querySelectorAll`. jQuery (via Sizzle) [determines that `document.querySelectorAll` is not available](https://github.com/jquery/sizzle/blob/af163873d7cdfc57f18b16c04b1915209533f0b1/src/sizzle.js#L796) in that case, because it doesn't think it's native (even though _Aura_ calls the native method within its wrapper). This causes jQuery to fall back to other methods of querying, which don't work well with shadow dom and result in the error at issue. 

Why does it only happen in run mode? Because there is no snapshotting. In interactive mode, an early XHR causes a snapshot, which queries the dom, which makes jQuery determine `querySelectorAll` support before the _Aura_ code runs. This can also be reproduced in open mode with `Cypress.config('numTestsKeptInMemory', 0)`. 

This leads to the solution seen in this PR. When a page is loaded, before user scripts are run, we do a noop query (`cy.$$('body')`) to make jQuery check for `querySelectorAll` early and determine that it's there and it's native. From then on, it appropriately uses it for querying the dom.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](../cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](../cli/schema/cypress.schema.json)?
