### PR TITLE
fix dom-highlights rendering under absolute position elements

### DIFF
--- a/packages/driver/cypress/integration/e2e/dom_hitbox.spec.js
+++ b/packages/driver/cypress/integration/e2e/dom_hitbox.spec.js
@@ -63,7 +63,7 @@ describe('rect highlight', () => {
     ensureCorrectTargetPosition('#button')
   })
 
-// https://github.com/cypress-io/cypress/issues/7762
+  // https://github.com/cypress-io/cypress/issues/7762
   it('highlights above z-index elements', () => {
     cy.$$('<div id="absolute-el"></div>').css({
       position: 'absolute',

--- a/packages/driver/cypress/integration/e2e/dom_hitbox.spec.js
+++ b/packages/driver/cypress/integration/e2e/dom_hitbox.spec.js
@@ -63,6 +63,7 @@ describe('rect highlight', () => {
     ensureCorrectTargetPosition('#button')
   })
 
+// https://github.com/cypress-io/cypress/issues/7762
   it('highlights above z-index elements', () => {
     cy.$$('<div id="absolute-el"></div>').css({
       position: 'absolute',

--- a/packages/driver/cypress/integration/e2e/dom_hitbox.spec.js
+++ b/packages/driver/cypress/integration/e2e/dom_hitbox.spec.js
@@ -1,4 +1,5 @@
 const { clickCommandLog } = require('../../support/utils')
+const { _ } = Cypress
 
 // https://github.com/cypress-io/cypress/pull/5299/files
 describe('rect highlight', () => {
@@ -61,6 +62,23 @@ describe('rect highlight', () => {
     ensureCorrectHighlightPositions('#button')
     ensureCorrectTargetPosition('#button')
   })
+
+  it('highlights above z-index elements', () => {
+    cy.$$('<div id="absolute-el"></div>').css({
+      position: 'absolute',
+      zIndex: 1000,
+      top: 0,
+      left: 0,
+      height: 50,
+      width: 50,
+      padding: 20,
+      margin: 20,
+      backgroundColor: 'salmon',
+    }).appendTo(cy.$$('body'))
+
+    getAndPin('#absolute-el')
+    ensureCorrectHighlightPositions('#absolute-el')
+  })
 })
 
 const ensureCorrectTargetPosition = (sel) => {
@@ -82,11 +100,19 @@ const ensureCorrectTargetPosition = (sel) => {
 
 const ensureCorrectHighlightPositions = (sel) => {
   return cy.wrap(null, { timeout: 400 }).should(() => {
-    const dims = {
-      content: cy.$$('div[data-layer=Content]')[0].getBoundingClientRect(),
-      padding: cy.$$('div[data-layer=Padding]')[0].getBoundingClientRect(),
-      border: cy.$$('div[data-layer=Border]')[0].getBoundingClientRect(),
+    const els = {
+      content: cy.$$('div[data-layer=Content]'),
+      padding: cy.$$('div[data-layer=Padding]'),
+      border: cy.$$('div[data-layer=Border]'),
     }
+
+    const dims = _.mapValues(els, ($el) => $el[0].getBoundingClientRect())
+
+    const doc = els.content[0].ownerDocument
+
+    const contentHighlightCenter = [dims.content.x + dims.content.width / 2, dims.content.y + dims.content.height / 2]
+
+    expect(doc.elementFromPoint(...contentHighlightCenter)).eq(els.content[0])
 
     expectToBeInside(dims.content, dims.padding, 'content to be inside padding')
     expectToBeInside(dims.padding, dims.border, 'padding to be inside border')

--- a/packages/runner/src/lib/dom.js
+++ b/packages/runner/src/lib/dom.js
@@ -73,6 +73,8 @@ function addElementBoxModelLayers ($el, $body) {
   const $container = $('<div class="__cypress-highlight">')
   .css({
     opacity: 0.7,
+    position: 'absolute',
+    zIndex: 2147483647,
   })
 
   const layers = {


### PR DESCRIPTION
- fix dom highlights rendering below certain position `absolute` elements

<!-- Example: "Closes #1234" -->

- fix #7762 <!-- issue number here -->

### User facing changelog
Bug fix: fixed issue causing element highlights to be invisible when targeting absolute positioned elements
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
before: dom highlights rendering underneath `position:absolute` element:
![image](https://user-images.githubusercontent.com/14625260/85164551-85bbae80-b232-11ea-829d-8aeb5ef1b138.png)

after: correct dom highlight:
![image](https://user-images.githubusercontent.com/14625260/85164523-7ccadd00-b232-11ea-9e26-9c39bd33055c.png)

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
