### PR TITLE
Split hooks in command log

### DIFF
--- a/packages/driver/src/cypress/runner.js
+++ b/packages/driver/src/cypress/runner.js
@@ -91,18 +91,6 @@ const testAfterRun = (test, Cypress) => {
   }
 }
 
-const getTestCountForHook = (test, hookName) => {
-  if (test.hookCounts == null) {
-    test.hookCounts = {}
-  }
-
-  if (test.hookCounts[hookName] == null) {
-    test.hookCounts[hookName] = 0
-  }
-
-  return ++test.hookCounts[hookName]
-}
-
 const setTestTimingsForHook = (test, hookName, obj) => {
   if (test.timings == null) {
     test.timings = {}
@@ -149,6 +137,20 @@ const getHookName = (hook) => {
   const name = hook.title.match(betweenQuotesRe)
 
   return name && name[1]
+}
+
+const getHookDisplayName = (hook, test) => {
+  const hookName = getHookName(hook)
+
+  if (test.hookCounts == null) {
+    test.hookCounts = {}
+  }
+
+  if (test.hookCounts[hookName] == null) {
+    test.hookCounts[hookName] = 0
+  }
+
+  return `${hookName} (${++test.hookCounts[hookName]})`
 }
 
 const forceGc = (obj) => {
@@ -978,7 +980,7 @@ const create = (specWindow, mocha, Cypress, cy) => {
       }
 
       // if this isnt a hook, then the name is 'test'
-      let hookName = runnable.type === 'hook' ? getHookName(runnable) : 'test'
+      const hookName = runnable.type === 'hook' ? getHookDisplayName(runnable, test) : 'test'
 
       // if we haven't yet fired this event for this test
       // that means that we need to reset the previous state
@@ -1067,8 +1069,6 @@ const create = (specWindow, mocha, Cypress, cy) => {
           return null
         })
       }
-
-      hookName = `${hookName} (${getTestCountForHook(test, hookName)})`
 
       // our runnable is about to run, so let cy know. this enables
       // us to always have a correct runnable set even when we are

--- a/packages/driver/src/cypress/runner.js
+++ b/packages/driver/src/cypress/runner.js
@@ -91,6 +91,18 @@ const testAfterRun = (test, Cypress) => {
   }
 }
 
+const getTestCountForHook = (test, hookName) => {
+  if (test.hookCounts == null) {
+    test.hookCounts = {}
+  }
+
+  if (test.hookCounts[hookName] == null) {
+    test.hookCounts[hookName] = 0
+  }
+
+  return ++test.hookCounts[hookName]
+}
+
 const setTestTimingsForHook = (test, hookName, obj) => {
   if (test.timings == null) {
     test.timings = {}
@@ -966,7 +978,7 @@ const create = (specWindow, mocha, Cypress, cy) => {
       }
 
       // if this isnt a hook, then the name is 'test'
-      const hookName = runnable.type === 'hook' ? getHookName(runnable) : 'test'
+      let hookName = runnable.type === 'hook' ? getHookName(runnable) : 'test'
 
       // if we haven't yet fired this event for this test
       // that means that we need to reset the previous state
@@ -1055,6 +1067,8 @@ const create = (specWindow, mocha, Cypress, cy) => {
           return null
         })
       }
+
+      hookName = `${hookName} (${getTestCountForHook(test, hookName)})`
 
       // our runnable is about to run, so let cy know. this enables
       // us to always have a correct runnable set even when we are

--- a/packages/reporter/src/hooks/hooks.spec.tsx
+++ b/packages/reporter/src/hooks/hooks.spec.tsx
@@ -31,34 +31,46 @@ describe('<Hooks />', () => {
     expect(component.find(Hook).length).to.equal(3)
   })
 
+  it('properly displays hook index', () => {
+    const component = shallow(<Hooks model={model()} />)
+
+    expect(component.find(Hook).first().prop('showCount')).to.equal(true)
+  })
+
+  it('properly hides hook index', () => {
+    const component = shallow(<Hooks model={_.extend<HooksModel>({ hooks: [hookModel({ name: 'before each' }), hookModel()] })} />)
+
+    expect(component.find(Hook).first().prop('showCount')).to.equal(false)
+  })
+
   context('<Hook />', () => {
     it('renders without hook-failed class when not failed', () => {
-      const component = shallow(<Hook model={hookModel()} />)
+      const component = shallow(<Hook model={hookModel()} showCount={false} />)
 
       expect(component).not.to.have.className('hook-failed')
     })
 
     it('renders with hook-failed class when failed', () => {
-      const component = shallow(<Hook model={hookModel({ failed: true })} />)
+      const component = shallow(<Hook model={hookModel({ failed: true })} showCount={false} />)
 
       expect(component).to.have.className('hook-failed')
     })
 
     it('renders Collapsible with hook header', () => {
-      const component = shallow(<Hook model={hookModel()} />)
+      const component = shallow(<Hook model={hookModel()} showCount={false} />)
       const header = shallow(component.find('Collapsible').prop('header'))
 
       expect(header.find('.hook-failed-message')).to.have.text('(failed)')
     })
 
     it('renders Collapsible open', () => {
-      const component = shallow(<Hook model={hookModel()} />)
+      const component = shallow(<Hook model={hookModel()} showCount={false} />)
 
       expect(component.find('Collapsible').prop('isOpen')).to.be.true
     })
 
     it('renders command for each in model', () => {
-      const component = shallow(<Hook model={hookModel()} />)
+      const component = shallow(<Hook model={hookModel()} showCount={false} />)
 
       expect(component.find('Command').length).to.equal(2)
     })
@@ -66,13 +78,26 @@ describe('<Hooks />', () => {
 
   context('<HookHeader />', () => {
     it('renders the name', () => {
-      const component = shallow(<HookHeader name='before' />)
+      const component = shallow(<HookHeader name='before' showCount={false} />)
 
       expect(component.text()).to.contain('before')
     })
 
+    it('renders the name with count', () => {
+      const component = shallow(<HookHeader name='before each (1)' showCount={true} />)
+
+      expect(component.text()).to.contain('before each (1)')
+    })
+
+    it('renders the name without count', () => {
+      const component = shallow(<HookHeader name='before each (1)' showCount={false} />)
+
+      expect(component.text()).to.contain('before each')
+      expect(component.text()).not.to.contain('(1)')
+    })
+
     it('renders the failed message', () => {
-      const component = shallow(<HookHeader name='before' />)
+      const component = shallow(<HookHeader name='before' showCount={false} />)
 
       expect(component.find('.hook-failed-message')).to.have.text('(failed)')
     })

--- a/packages/reporter/src/hooks/hooks.spec.tsx
+++ b/packages/reporter/src/hooks/hooks.spec.tsx
@@ -12,7 +12,7 @@ const commandModel = () => {
 const hookModel = (props?: Partial<HookModel>) => {
   return _.extend<HookModel>({
     id: _.uniqueId('h'),
-    name: 'before',
+    name: 'before each',
     failed: false,
     commands: [commandModel(), commandModel()],
   }, props)
@@ -38,7 +38,7 @@ describe('<Hooks />', () => {
   })
 
   it('properly hides hook index', () => {
-    const component = shallow(<Hooks model={_.extend<HooksModel>({ hooks: [hookModel({ name: 'before each' }), hookModel()] })} />)
+    const component = shallow(<Hooks model={_.extend<HooksModel>({ hooks: [hookModel({ name: 'before all' }), hookModel()] })} />)
 
     expect(component.find(Hook).first().prop('showCount')).to.equal(false)
   })

--- a/packages/reporter/src/hooks/hooks.tsx
+++ b/packages/reporter/src/hooks/hooks.tsx
@@ -50,9 +50,9 @@ export interface HooksProps {
 
 const Hooks = observer(({ model }: HooksProps) => {
   const hooksCount: { [key: string]: number } = {
-    'before': 0,
+    'before all': 0,
     'before each': 0,
-    'after': 0,
+    'after all': 0,
     'after each': 0,
   }
 

--- a/packages/reporter/src/hooks/hooks.tsx
+++ b/packages/reporter/src/hooks/hooks.tsx
@@ -6,24 +6,30 @@ import Command from '../commands/command'
 import Collapsible from '../collapsible/collapsible'
 import HookModel from './hook-model'
 
-export interface HookHeaderProps {
-  name: string
+const getHookName = (name: string) => {
+  return name.replace(/ \([0-9]+\)/, '')
 }
 
-const HookHeader = ({ name }: HookHeaderProps) => (
+export interface HookHeaderProps {
+  name: string
+  showCount: boolean
+}
+
+const HookHeader = ({ name, showCount }: HookHeaderProps) => (
   <span>
-    {name} <span className='hook-failed-message'>(failed)</span>
+    {showCount ? name : getHookName(name)} <span className='hook-failed-message'>(failed)</span>
   </span>
 )
 
 export interface HookProps {
   model: HookModel
+  showCount: boolean
 }
 
-const Hook = observer(({ model }: HookProps) => (
+const Hook = observer(({ model, showCount }: HookProps) => (
   <li className={cs('hook-item', { 'hook-failed': model.failed })}>
     <Collapsible
-      header={<HookHeader name={model.name} />}
+      header={<HookHeader name={model.name} showCount={showCount} />}
       headerClass='hook-name'
       isOpen={true}
     >
@@ -42,11 +48,22 @@ export interface HooksProps {
   model: HooksModel
 }
 
-const Hooks = observer(({ model }: HooksProps) => (
-  <ul className='hooks-container'>
-    {_.map(model.hooks, (hook) => <Hook key={hook.id} model={hook} />)}
-  </ul>
-))
+const Hooks = observer(({ model }: HooksProps) => {
+  const hooksCount: { [key: string]: number } = {
+    'before': 0,
+    'before each': 0,
+    'after': 0,
+    'after each': 0,
+  }
+
+  _.map(model.hooks, (hook) => hook.name !== 'test' && hooksCount[getHookName(hook.name)]++)
+
+  return (
+    <ul className='hooks-container'>
+      {_.map(model.hooks, (hook) => <Hook key={hook.id} model={hook} showCount={hooksCount[getHookName(hook.name)] > 1} />)}
+    </ul>
+  )
+})
 
 export { Hook, HookHeader }
 

--- a/packages/runner/__snapshots__/runner.mochaEvents.spec.js
+++ b/packages/runner/__snapshots__/runner.mochaEvents.spec.js
@@ -96,7 +96,7 @@ exports['src/cypress/runner tests finish with correct state hook failures fail i
       "wallClockDuration": "match.number",
       "timings": {
         "lifecycle": "match.number",
-        "before all": [
+        "before all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
@@ -237,7 +237,7 @@ exports['src/cypress/runner tests finish with correct state hook failures fail i
       "wallClockDuration": "match.number",
       "timings": {
         "lifecycle": "match.number",
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
@@ -328,7 +328,7 @@ exports['src/cypress/runner tests finish with correct state hook failures fail i
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
@@ -357,7 +357,7 @@ exports['src/cypress/runner tests finish with correct state hook failures fail i
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
@@ -440,7 +440,7 @@ exports['src/cypress/runner tests finish with correct state hook failures fail i
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
@@ -610,7 +610,7 @@ exports['src/cypress/runner tests finish with correct state hook failures fail i
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after all": [
+        "after all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
@@ -639,7 +639,7 @@ exports['src/cypress/runner tests finish with correct state hook failures fail i
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after all": [
+        "after all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
@@ -722,7 +722,7 @@ exports['src/cypress/runner tests finish with correct state hook failures fail i
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after all": [
+        "after all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
@@ -821,14 +821,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep fail with
       "wallClockStartedAt": "match.date",
       "timings": {
         "lifecycle": "match.number",
-        "before all": [
+        "before all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -839,14 +839,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep fail with
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "after all": [
+        "after all (1)": [
           {
             "hookId": "h4",
             "fnDuration": "match.number",
@@ -898,14 +898,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep fail with
       "wallClockStartedAt": "match.date",
       "timings": {
         "lifecycle": "match.number",
-        "before all": [
+        "before all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -916,14 +916,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep fail with
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "after all": [
+        "after all (1)": [
           {
             "hookId": "h4",
             "fnDuration": "match.number",
@@ -957,14 +957,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep fail with
       "wallClockStartedAt": "match.date",
       "timings": {
         "lifecycle": "match.number",
-        "before all": [
+        "before all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -975,14 +975,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep fail with
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "after all": [
+        "after all (1)": [
           {
             "hookId": "h4",
             "fnDuration": "match.number",
@@ -1062,14 +1062,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep fail with
       "wallClockDuration": "match.number",
       "timings": {
         "lifecycle": "match.number",
-        "before all": [
+        "before all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -1080,14 +1080,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep fail with
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "after all": [
+        "after all (1)": [
           {
             "hookId": "h4",
             "fnDuration": "match.number",
@@ -1197,14 +1197,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep pass with
       "wallClockStartedAt": "match.date",
       "timings": {
         "lifecycle": "match.number",
-        "before all": [
+        "before all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -1215,14 +1215,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep pass with
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "after all": [
+        "after all (1)": [
           {
             "hookId": "h4",
             "fnDuration": "match.number",
@@ -1273,14 +1273,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep pass with
       "wallClockStartedAt": "match.date",
       "timings": {
         "lifecycle": "match.number",
-        "before all": [
+        "before all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -1291,14 +1291,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep pass with
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "after all": [
+        "after all (1)": [
           {
             "hookId": "h4",
             "fnDuration": "match.number",
@@ -1322,14 +1322,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep pass with
       "wallClockStartedAt": "match.date",
       "timings": {
         "lifecycle": "match.number",
-        "before all": [
+        "before all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -1340,14 +1340,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep pass with
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "after all": [
+        "after all (1)": [
           {
             "hookId": "h4",
             "fnDuration": "match.number",
@@ -1426,14 +1426,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep pass with
       "wallClockDuration": "match.number",
       "timings": {
         "lifecycle": "match.number",
-        "before all": [
+        "before all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -1444,14 +1444,14 @@ exports['src/cypress/runner tests finish with correct state mocha grep pass with
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "after all": [
+        "after all (1)": [
           {
             "hookId": "h4",
             "fnDuration": "match.number",
@@ -1508,14 +1508,14 @@ exports['serialize state - hooks'] = {
       "wallClockDuration": 1,
       "timings": {
         "lifecycle": 1,
-        "before all": [
+        "before all (1)": [
           {
             "hookId": "h1",
             "fnDuration": 1,
             "afterFnDuration": 1
           }
         ],
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": 1,
@@ -1526,14 +1526,14 @@ exports['serialize state - hooks'] = {
           "fnDuration": 1,
           "afterFnDuration": 1
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": 1,
             "afterFnDuration": 1
           }
         ],
-        "after all": [
+        "after all (1)": [
           {
             "hookId": "h4",
             "fnDuration": 1,
@@ -1823,14 +1823,14 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
       "wallClockStartedAt": "match.date",
       "timings": {
         "lifecycle": "match.number",
-        "before all": [
+        "before all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -1841,7 +1841,7 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
@@ -1893,14 +1893,14 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
       "wallClockStartedAt": "match.date",
       "timings": {
         "lifecycle": "match.number",
-        "before all": [
+        "before all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -1911,7 +1911,7 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
@@ -1936,14 +1936,14 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
       "wallClockStartedAt": "match.date",
       "timings": {
         "lifecycle": "match.number",
-        "before all": [
+        "before all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -1954,7 +1954,7 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
@@ -2007,14 +2007,14 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
       "wallClockDuration": "match.number",
       "timings": {
         "lifecycle": "match.number",
-        "before all": [
+        "before all (1)": [
           {
             "hookId": "h1",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -2025,7 +2025,7 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
@@ -2090,7 +2090,7 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
       "wallClockStartedAt": "match.date",
       "timings": {
         "lifecycle": "match.number",
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -2101,7 +2101,7 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
@@ -2126,7 +2126,7 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
       "wallClockStartedAt": "match.date",
       "timings": {
         "lifecycle": "match.number",
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -2137,7 +2137,7 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
@@ -2191,7 +2191,7 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
       "wallClockDuration": "match.number",
       "timings": {
         "lifecycle": "match.number",
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -2202,7 +2202,7 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
@@ -2267,7 +2267,7 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
       "wallClockStartedAt": "match.date",
       "timings": {
         "lifecycle": "match.number",
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -2278,14 +2278,14 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "after all": [
+        "after all (1)": [
           {
             "hookId": "h4",
             "fnDuration": "match.number",
@@ -2310,7 +2310,7 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
       "wallClockStartedAt": "match.date",
       "timings": {
         "lifecycle": "match.number",
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -2321,14 +2321,14 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "after all": [
+        "after all (1)": [
           {
             "hookId": "h4",
             "fnDuration": "match.number",
@@ -2420,7 +2420,7 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
       "wallClockDuration": "match.number",
       "timings": {
         "lifecycle": "match.number",
-        "before each": [
+        "before each (1)": [
           {
             "hookId": "h2",
             "fnDuration": "match.number",
@@ -2431,14 +2431,14 @@ exports['src/cypress/runner mocha events simple three tests #1'] = [
           "fnDuration": "match.number",
           "afterFnDuration": "match.number"
         },
-        "after each": [
+        "after each (1)": [
           {
             "hookId": "h3",
             "fnDuration": "match.number",
             "afterFnDuration": "match.number"
           }
         ],
-        "after all": [
+        "after all (1)": [
           {
             "hookId": "h4",
             "fnDuration": "match.number",

--- a/packages/server/__snapshots__/5_spec_isolation_spec.js
+++ b/packages/server/__snapshots__/5_spec_isolation_spec.js
@@ -80,14 +80,14 @@ exports['e2e spec isolation fails'] = {
           "error": "fail1\n\nBecause this error occurred during a `before each` hook we are skipping the remaining tests in the current suite: `beforeEach hooks`",
           "timings": {
             "lifecycle": 100,
-            "before all": [
+            "before all (1)": [
               {
                 "hookId": "h1",
                 "fnDuration": 400,
                 "afterFnDuration": 200
               }
             ],
-            "before each": [
+            "before each (1)": [
               {
                 "hookId": "h2",
                 "fnDuration": 400,
@@ -134,7 +134,7 @@ exports['e2e spec isolation fails'] = {
               "fnDuration": 400,
               "afterFnDuration": 200
             },
-            "after each": [
+            "after each (1)": [
               {
                 "hookId": "h3",
                 "fnDuration": 400,
@@ -204,7 +204,7 @@ exports['e2e spec isolation fails'] = {
               "fnDuration": 400,
               "afterFnDuration": 200
             },
-            "after all": [
+            "after all (1)": [
               {
                 "hookId": "h4",
                 "fnDuration": 400,
@@ -303,7 +303,7 @@ exports['e2e spec isolation fails'] = {
           "error": "Timed out retrying: expected true to be false",
           "timings": {
             "lifecycle": 100,
-            "before all": [
+            "before all (1)": [
               {
                 "hookId": "h1",
                 "fnDuration": 400,
@@ -451,19 +451,21 @@ exports['e2e spec isolation fails'] = {
           "error": null,
           "timings": {
             "lifecycle": 100,
-            "before all": [
+            "before all (1)": [
               {
                 "hookId": "h1",
                 "fnDuration": 400,
                 "afterFnDuration": 200
-              },
+              }
+            ],
+            "before all (2)": [
               {
                 "hookId": "h2",
                 "fnDuration": 400,
                 "afterFnDuration": 200
               }
             ],
-            "before each": [
+            "before each (1)": [
               {
                 "hookId": "h3",
                 "fnDuration": 400,
@@ -474,7 +476,7 @@ exports['e2e spec isolation fails'] = {
               "fnDuration": 400,
               "afterFnDuration": 200
             },
-            "after each": [
+            "after each (1)": [
               {
                 "hookId": "h4",
                 "fnDuration": 400,
@@ -499,7 +501,7 @@ exports['e2e spec isolation fails'] = {
           "error": null,
           "timings": {
             "lifecycle": 100,
-            "before each": [
+            "before each (1)": [
               {
                 "hookId": "h3",
                 "fnDuration": 400,
@@ -510,7 +512,7 @@ exports['e2e spec isolation fails'] = {
               "fnDuration": 400,
               "afterFnDuration": 200
             },
-            "after each": [
+            "after each (1)": [
               {
                 "hookId": "h4",
                 "fnDuration": 400,
@@ -535,7 +537,7 @@ exports['e2e spec isolation fails'] = {
           "error": null,
           "timings": {
             "lifecycle": 100,
-            "before each": [
+            "before each (1)": [
               {
                 "hookId": "h3",
                 "fnDuration": 400,
@@ -546,14 +548,14 @@ exports['e2e spec isolation fails'] = {
               "fnDuration": 400,
               "afterFnDuration": 200
             },
-            "after each": [
+            "after each (1)": [
               {
                 "hookId": "h4",
                 "fnDuration": 400,
                 "afterFnDuration": 200
               }
             ],
-            "after all": [
+            "after all (1)": [
               {
                 "hookId": "h5",
                 "fnDuration": 400,
@@ -632,14 +634,14 @@ exports['e2e spec isolation fails'] = {
           "error": null,
           "timings": {
             "lifecycle": 100,
-            "before all": [
+            "before all (1)": [
               {
                 "hookId": "h1",
                 "fnDuration": 400,
                 "afterFnDuration": 200
               }
             ],
-            "before each": [
+            "before each (1)": [
               {
                 "hookId": "h2",
                 "fnDuration": 400,


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7779 

### User facing changelog

- Splits hooks apart in test log. For example, when there are multiple nested `beforeEach` hooks, they will be displayed individually rather than merged together.

### Additional details

- Necessary for upcoming "open hooks in ide change"
- Ideally would like to implement a better system than this double loop for counting the number of each type of hook within a test

### How has the user experience changed?

Given the following test suite:
```javascript
describe('testing', () => {
  beforeEach(() => {
    expect(true).to.be.true
  })

  context('next level', () => {
    beforeEach(() => {
      expect(false).not.to.be.true
    })

    it('the test', () => {
      expect('test').to.be.equal('test')
    })
  })
})
```

Before:

![Screen Shot 2020-06-24 at 12 02 31 AM](https://user-images.githubusercontent.com/7033952/85498610-0cafb480-b5ae-11ea-8ba5-cd48e01616cf.png)

After:

![Screen Shot 2020-06-24 at 12 01 55 AM](https://user-images.githubusercontent.com/7033952/85498623-120cff00-b5ae-11ea-9fc4-9dcffc68a74b.png)

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](../cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](../cli/schema/cypress.schema.json)?
