### PR TITLE
Ensure that the window's parent is a window before checking for props of AutIframe

### DIFF
--- a/packages/driver/cypress/fixtures/generic.html
+++ b/packages/driver/cypress/fixtures/generic.html
@@ -19,11 +19,4 @@
 
     <a id="dimensions" href="/fixtures/dimensions.html">dimensions</a>
   </body>
-  <script>
-    // This is defined to create a global parent which
-    // can cause issues when calling win.parent later 
-    // since the win.parent is now this element
-    // https://github.com/cypress-io/cypress/issues/6412
-    var parent = document.querySelector(".foo")
-  </script>
 </html>

--- a/packages/driver/cypress/fixtures/generic.html
+++ b/packages/driver/cypress/fixtures/generic.html
@@ -19,4 +19,11 @@
 
     <a id="dimensions" href="/fixtures/dimensions.html">dimensions</a>
   </body>
+  <script>
+    // This is defined to create a global parent which
+    // can cause issues when calling win.parent later 
+    // since the win.parent is now this element
+    // https://github.com/cypress-io/cypress/issues/6412
+    var parent = document.querySelector(".foo")
+  </script>
 </html>

--- a/packages/driver/cypress/fixtures/global_parent_definition.html
+++ b/packages/driver/cypress/fixtures/global_parent_definition.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Global Parent Fixture</title>
+</head>
+
+<body>
+  <span class="foo">Foo</span>
+</body>
+<script>
+  // This is defined to create a global parent which
+  // can cause issues when calling win.parent later 
+  // since the win.parent is now this element
+  // https://github.com/cypress-io/cypress/issues/6412
+  var parent = document.querySelector(".foo")
+</script>
+
+</html>

--- a/packages/driver/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/click_spec.js
@@ -4456,6 +4456,8 @@ describe('mouse state', () => {
 
           expect(targetRect.top).gt(iframeRect.top)
           expect(targetRect.bottom).lt(iframeRect.bottom)
+          expect(targetRect.left).gt(iframeRect.left)
+          expect(targetRect.right).lt(iframeRect.right)
         })
       })
     })

--- a/packages/driver/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_spec.js
@@ -13,7 +13,8 @@ const {
 
 const expectTextEndsWith = (expected) => {
   return ($el) => {
-    const text = $el.text().trim()
+    // only want to compare the body text, not text in <script> tag
+    const text = $el[0].innerText.trim()
 
     const passed = text.endsWith(expected)
 

--- a/packages/driver/cypress/integration/issues/6412_spec.ts
+++ b/packages/driver/cypress/integration/issues/6412_spec.ts
@@ -1,0 +1,8 @@
+// https://github.com/cypress-io/cypress/issues/6412
+
+describe('issue #6412: Illegal invocation when global parent defined', () => {
+  it('does not throw - clicks element', () => {
+    cy.visit('/fixtures/global_parent_definition.html')
+    cy.get('.foo').click()
+  })
+})

--- a/packages/driver/src/dom/coordinates.js
+++ b/packages/driver/src/dom/coordinates.js
@@ -6,7 +6,13 @@ const getElementAtPointFromViewport = (doc, x, y) => {
   return $elements.elementFromPoint(doc, x, y)
 }
 
-const isAutIframe = (win) => !$elements.getNativeProp(win.parent, 'frameElement')
+const isAutIframe = (win) => {
+  const parent = win.parent
+
+  // https://github.com/cypress-io/cypress/issues/6412
+  // ensure the parent is a Window before checking prop
+  return $window.isWindow(parent) && !$elements.getNativeProp(parent, 'frameElement')
+}
 
 const getFirstValidSizedRect = (el) => {
   return _.find(el.getClientRects(), (rect) => {
@@ -53,8 +59,10 @@ const getElementPositioning = ($el) => {
     let curWindow = win
     let frame
 
+    // https://github.com/cypress-io/cypress/issues/6412
+    // ensure the parent is a Window before checking prop
     // walk up from a nested iframe so we continually add the x + y values
-    while (!isAutIframe(curWindow) && curWindow.parent !== curWindow) {
+    while ($window.isWindow(curWindow) && !isAutIframe(curWindow) && curWindow.parent !== curWindow) {
       frame = $elements.getNativeProp(curWindow, 'frameElement')
 
       if (curWindow && frame) {


### PR DESCRIPTION
- Close #6412 

### User facing changelog

- Using Cypress commands to traverse the DOM on an application with a global `parent` variable will no longer throw `Illegal Invocation` errors.

### Additional details

- When the AUT has a global variable called `parent`, our calls to `win.parent` actually return this global variable instead of the window's parent as expected. 
- Honestly, I would love a better way to target the actual `window.parent` when it's overwritten, but I couldn't find a way to do this for the AUT window + any other nested iframes this could also be defined in.
- Doing the work for this actually highlighted another bug on calculating the highlight coordinates when clicking on an element within an iframe with global parent definition. I decided not to address this as part of this work as it seems very rare. https://github.com/cypress-io/cypress/issues/7869

### How has the user experience changed?

#### Before

<img width="508" alt="Screen Shot 2020-07-02 at 1 41 40 PM" src="https://user-images.githubusercontent.com/1271364/86327789-d20ee180-bc69-11ea-9179-baeb7ae332d0.png">


#### After

No more illegal invocation error - tests run normally.

<img width="441" alt="Screen Shot 2020-07-02 at 1 42 19 PM" src="https://user-images.githubusercontent.com/1271364/86327835-e521b180-bc69-11ea-9374-7e337c222d89.png">


### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
