### PR TITLE
chore: use absolute links for GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,5 +40,5 @@ Delete tasks if they are not applicable.
 - [ ] Have tests been added/updated?
 - [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
 - [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
-- [ ] Have API changes been updated in the [`type definitions`](../cli/types/cypress.d.ts)?
-- [ ] Have new configuration options been added to the [`cypress.schema.json`](../cli/schema/cypress.schema.json)?
+- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
+- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?


### PR DESCRIPTION
Fixes the links in the GitHub PR template

Because the links actually go to different places (404 currently from a PR) based on whether they're viewed in the GitHub file explorer or from a PR, it makes sense to just use an absolute link so it works every time