### PR TITLE
Update regex for matching Cypress version in tests to replace more version types

### DIFF
--- a/packages/server/test/support/helpers/e2e.ts
+++ b/packages/server/test/support/helpers/e2e.ts
@@ -151,7 +151,7 @@ const normalizeStdout = function (str, options: any = {}) {
   .replace(/(\s+?)(\d+ms|\d+:\d+:?\d+)/g, replaceDurationInTables)
   .replace(/(coffee|js)-\d{3}/g, '$1-456')
   // Cypress: 2.1.0 -> Cypress: 1.2.3
-  .replace(/(Cypress\:\s+)(\d\.\d\.\d)/g, '$11.2.3')
+  .replace(/(Cypress\:\s+)(\d+\.\d+\.\d+)/g, '$11.2.3')
   // Node Version: 10.2.3 (Users/jane/node) -> Node Version: X (foo/bar/node)
   .replace(/(Node Version\:\s+v)(\d+\.\d+\.\d+)( \(.*\)\s+)/g, replaceNodeVersion)
   // 15 seconds -> X second

--- a/scripts/binary/zip.js
+++ b/scripts/binary/zip.js
@@ -73,7 +73,7 @@ const checkZipSize = function (zipPath) {
   const zipSize = filesize(stats.size, { round: 0 })
 
   console.log(`zip file size ${zipSize}`)
-  const MAX_ALLOWED_SIZE_MB = os.platform() === 'win32' ? 245 : 190
+  const MAX_ALLOWED_SIZE_MB = os.platform() === 'win32' ? 245 : 200
   const MAX_ZIP_FILE_SIZE = megaBytes(MAX_ALLOWED_SIZE_MB)
 
   if (stats.size > MAX_ZIP_FILE_SIZE) {


### PR DESCRIPTION
### Current Behavior

Our build is failing as well as all our e2e tests with snapshots were failing because it wasn't replacing the Cypress version in the snapshots.

**Failing CI of build**: https://circleci.com/gh/cypress-io/cypress/388898

<img width="675" alt="Screen Shot 2020-07-09 at 11 28 39 AM" src="https://user-images.githubusercontent.com/1271364/86998961-81523800-c1d7-11ea-9b21-818f7ade804e.png">

**Failing CI of snapshot**: https://circleci.com/gh/cypress-io/cypress/388840 

![Screen Shot 2020-07-09 at 10 20 37 AM](https://user-images.githubusercontent.com/1271364/86995638-9b881800-c1cf-11ea-807a-f80fb603d953.png)

### Changes

- This updates the max zip file size from 190 to 200.
- This updates the regex to match more variations of the Cypress version number. 

### Before

![Screen Shot 2020-07-09 at 10 30 08 AM](https://user-images.githubusercontent.com/1271364/86995671-b490c900-c1cf-11ea-8e4e-fde2a60c5dea.png)

### After

![Screen Shot 2020-07-09 at 10 29 47 AM](https://user-images.githubusercontent.com/1271364/86995679-ba86aa00-c1cf-11ea-96a7-c1f881874f34.png)

