### PR TITLE
fix(proxy): omit CSP report only header

### DIFF
--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -272,6 +272,7 @@ const OmitProblematicHeaders: ResponseMiddleware = function () {
     'x-frame-options',
     'content-length',
     'content-security-policy',
+    'content-security-policy-report-only',
     'connection',
   ])
 

--- a/packages/server/test/integration/http_requests_spec.js
+++ b/packages/server/test/integration/http_requests_spec.js
@@ -2072,6 +2072,27 @@ describe('Routes', () => {
         })
       })
 
+      it('omits content-security-policy-report-only', function () {
+        nock(this.server._remoteOrigin)
+        .get('/bar')
+        .reply(200, 'OK', {
+          'Content-Type': 'text/html',
+          'content-security-policy-report-only': 'foobar;',
+        })
+
+        return this.rp({
+          url: 'http://localhost:8080/bar',
+          headers: {
+            'Cookie': '__cypress.initial=false',
+          },
+        })
+        .then((res) => {
+          expect(res.statusCode).to.eq(200)
+
+          expect(res.headers).not.to.have.property('content-security-policy-report-only')
+        })
+      })
+
       it('omits document-domain from Feature-Policy header', function () {
         nock(this.server._remoteOrigin)
         .get('/bar')


### PR DESCRIPTION
Since Cypress omits the blocking CSP header, it should also omit the
report-only CSP header. This fixes a lot of `unsafe-inline` script-src
warnings that I have seen when running cypress.

A test has been added to checked that this header is removed.

