### PR TITLE
fix(driver): fix firefox moveToStart,moveToEnd, add tests

### DIFF
--- a/packages/driver/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/click_spec.js
@@ -8,7 +8,7 @@ const { getCommandLogWithText,
   shouldBeCalled,
   shouldBeCalledOnce,
   shouldNotBeCalled,
-  getCaretPosition,
+  expectCaret,
 } = require('../../../support/utils')
 
 const fail = function (str) {
@@ -801,28 +801,20 @@ describe('src/cy/commands/actions/click', () => {
     it('places cursor at the end of [contenteditable]', () => {
       cy.get('[contenteditable]:first')
       .invoke('html', '<div><br></div>').click()
-      .then(($el) => {
-        expect(getCaretPosition($el.get(0))).to.eq(0)
-      })
+      .then(expectCaret(0))
 
       cy.get('[contenteditable]:first')
       .invoke('html', 'foo').click()
-      .then(($el) => {
-        expect(getCaretPosition($el.get(0))).to.eq(3)
-      })
+      .then(expectCaret(3))
 
       cy.get('[contenteditable]:first')
       .invoke('html', '<div>foo</div>').click()
-      .then(($el) => {
-        expect(getCaretPosition($el.get(0))).to.eq(3)
-      })
+      .then(expectCaret(3))
 
       cy.get('[contenteditable]:first')
       // firefox headless: prevent contenteditable from disappearing (dont set to empty)
       .invoke('html', '<br>').click()
-      .then(($el) => {
-        expect(getCaretPosition($el.get(0))).to.eq(0)
-      })
+      .then(expectCaret(0))
     })
 
     it('can click SVG elements', () => {

--- a/packages/driver/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/click_spec.js
@@ -8,6 +8,7 @@ const { getCommandLogWithText,
   shouldBeCalled,
   shouldBeCalledOnce,
   shouldNotBeCalled,
+  getCaretPosition,
 } = require('../../../support/utils')
 
 const fail = function (str) {
@@ -801,51 +802,25 @@ describe('src/cy/commands/actions/click', () => {
       cy.get('[contenteditable]:first')
       .invoke('html', '<div><br></div>').click()
       .then(($el) => {
-        const range = $el.get(0).ownerDocument.getSelection().getRangeAt(0)
-
-        expect(range.startContainer.outerHTML).to.eql('<div><br></div>')
-        expect(range.startOffset).to.eql(0)
-        expect(range.endContainer.outerHTML).to.eql('<div><br></div>')
-
-        expect(range.endOffset).to.eql(0)
+        expect(getCaretPosition($el.get(0))).to.eq(0)
       })
 
       cy.get('[contenteditable]:first')
       .invoke('html', 'foo').click()
       .then(($el) => {
-        const range = $el.get(0).ownerDocument.getSelection().getRangeAt(0)
-
-        expect(range.startContainer.nodeValue).to.eql('foo')
-        expect(range.startOffset).to.eql(3)
-        expect(range.endContainer.nodeValue).to.eql('foo')
-
-        expect(range.endOffset).to.eql(3)
+        expect(getCaretPosition($el.get(0))).to.eq(3)
       })
 
       cy.get('[contenteditable]:first')
       .invoke('html', '<div>foo</div>').click()
       .then(($el) => {
-        const range = $el.get(0).ownerDocument.getSelection().getRangeAt(0)
-
-        expect(range.startContainer.nodeValue).to.eql('foo')
-        expect(range.startOffset).to.eql(3)
-        expect(range.endContainer.nodeValue).to.eql('foo')
-
-        expect(range.endOffset).to.eql(3)
+        expect(getCaretPosition($el.get(0))).to.eq(3)
       })
 
       cy.get('[contenteditable]:first')
-      // firefox: prevent contenteditable from disappearing (dont set to empty)
-      .invoke('html', '<br>').click()
+      .invoke('html', '').click()
       .then(($el) => {
-        const el = $el.get(0)
-        const range = el.ownerDocument.getSelection().getRangeAt(0)
-
-        expect(range.startContainer).to.eql(el)
-        expect(range.startOffset).to.eql(0)
-        expect(range.endContainer).to.eql(el)
-
-        expect(range.endOffset).to.eql(0)
+        expect(getCaretPosition($el.get(0))).to.eq(0)
       })
     })
 

--- a/packages/driver/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/click_spec.js
@@ -818,7 +818,8 @@ describe('src/cy/commands/actions/click', () => {
       })
 
       cy.get('[contenteditable]:first')
-      .invoke('html', '').click()
+      // firefox headless: prevent contenteditable from disappearing (dont set to empty)
+      .invoke('html', '<br>').click()
       .then(($el) => {
         expect(getCaretPosition($el.get(0))).to.eq(0)
       })

--- a/packages/driver/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_spec.js
@@ -2795,22 +2795,23 @@ describe('src/cy/commands/actions/type - #type', () => {
     // https://github.com/cypress-io/cypress/issues/5502
     describe('moves the cursor from in-between to the start or the end', () => {
       it('input', () => {
-        cy
-        .get('input:first').clear().type('123{moveToStart}456{moveToEnd}789')
+        cy.get('input:first')
+        .type('123{moveToStart}456{moveToEnd}789')
         .should('have.value', '456123789')
       })
 
       it('contenteditable', () => {
-        cy
-        .get('[contenteditable]:first').invoke('text', '').type('123{moveToStart}456{enter}{moveToEnd}789')
+        cy.get('[contenteditable]:first')
+        .type('123{moveToStart}456{enter}{moveToEnd}789')
         .then(($div) => {
-          expect($div.get(0).innerText).to.eql('456\n123789')
+          // trim() is added for Firefox. It adds \n at the back as default.
+          expect($div.get(0).innerText.trim()).to.eql('456\n123789')
         })
       })
 
       it('textarea', () => {
-        cy
-        .get('textarea:first').clear().type('123{moveToStart}456{enter}{moveToEnd}789')
+        cy.get('textarea:first')
+        .type('123{moveToStart}456{enter}{moveToEnd}789')
         .should('have.value', '456\n123789')
       })
     })

--- a/packages/driver/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_spec.js
@@ -2791,30 +2791,6 @@ describe('src/cy/commands/actions/type - #type', () => {
       .type('{{}\n  foo:   1\n  bar:   2\n  baz:   3\n}')
       .should('have.prop', 'value', expected)
     })
-
-    // https://github.com/cypress-io/cypress/issues/5502
-    describe('moves the cursor from in-between to the start or the end', () => {
-      it('input', () => {
-        cy.get('input:first')
-        .type('123{moveToStart}456{moveToEnd}789')
-        .should('have.value', '456123789')
-      })
-
-      it('contenteditable', () => {
-        cy.get('[contenteditable]:first')
-        .type('123{moveToStart}456{enter}{moveToEnd}789')
-        .then(($div) => {
-          // trim() is added for Firefox. It adds \n at the back as default.
-          expect($div.get(0).innerText.trim()).to.eql('456\n123789')
-        })
-      })
-
-      it('textarea', () => {
-        cy.get('textarea:first')
-        .type('123{moveToStart}456{enter}{moveToEnd}789')
-        .should('have.value', '456\n123789')
-      })
-    })
   })
 
   describe('assertion verification', () => {

--- a/packages/driver/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_spec.js
@@ -2791,6 +2791,29 @@ describe('src/cy/commands/actions/type - #type', () => {
       .type('{{}\n  foo:   1\n  bar:   2\n  baz:   3\n}')
       .should('have.prop', 'value', expected)
     })
+
+    // https://github.com/cypress-io/cypress/issues/5502
+    describe('moves the cursor from in-between to the start or the end', () => {
+      it('input', () => {
+        cy
+        .get('input:first').clear().type('123{moveToStart}456{moveToEnd}789')
+        .should('have.value', '456123789')
+      })
+
+      it('contenteditable', () => {
+        cy
+        .get('[contenteditable]:first').invoke('text', '').type('123{moveToStart}456{enter}{moveToEnd}789')
+        .then(($div) => {
+          expect($div.get(0).innerText).to.eql('456\n123789')
+        })
+      })
+
+      it('textarea', () => {
+        cy
+        .get('textarea:first').clear().type('123{moveToStart}456{enter}{moveToEnd}789')
+        .should('have.value', '456\n123789')
+      })
+    })
   })
 
   describe('assertion verification', () => {

--- a/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
@@ -53,12 +53,7 @@ describe('src/cy/commands/actions/type - #type special chars', () => {
         cy.get('[contenteditable]:first')
         .type('123{enter}456{enter}789{enter}abc{moveToStart}def{moveToEnd}ghi')
         .then(($div) => {
-          expect($div.get(0).innerText.trim()).to.eql(
-            // NOTE: for some reason firefox will insert a '\n' after you moveToStart and type,
-            // but this is what the browser does if you selectall + leftarrow
-            // so we'll say it's technically correct.
-            Cypress.isBrowser('firefox') ? 'def\n123\n456\n789\nabcghi' : 'def123\n456\n789\nabcghi',
-          )
+          expect($div.get(0).innerText.trim()).to.eql('def123\n456\n789\nabcghi')
         })
       })
 

--- a/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
@@ -53,7 +53,12 @@ describe('src/cy/commands/actions/type - #type special chars', () => {
         cy.get('[contenteditable]:first')
         .type('123{enter}456{enter}789{enter}abc{moveToStart}def{moveToEnd}ghi')
         .then(($div) => {
-          expect($div.get(0).innerText.trim()).to.eql('def123\n456\n789\nabcghi')
+          expect($div.get(0).innerText.trim()).to.eql(
+            // NOTE: for some reason firefox will insert a '\n' after you moveToStart and type,
+            // but this is what the browser does if you selectall + leftarrow
+            // so we'll say it's technically correct.
+            Cypress.isBrowser('firefox') ? 'def\n123\n456\n789\nabcghi' : 'def123\n456\n789\nabcghi',
+          )
         })
       })
 

--- a/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
@@ -48,12 +48,22 @@ describe('src/cy/commands/actions/type - #type special chars', () => {
       .should('have.value', '456123789')
     })
 
-    it('contenteditable', () => {
-      cy.get('[contenteditable]:first')
-      .type('123{enter}456{enter}789{enter}abc{moveToStart}def{moveToEnd}ghi')
-      .then(($div) => {
-        // trim() is added for Firefox. It adds \n at the back as default.
-        expect($div.get(0).innerText.trim()).to.eql('def123\n456\n789\nabcghi')
+    describe('contenteditable', () => {
+      it('basic tests', () => {
+        cy.get('[contenteditable]:first')
+        .type('123{enter}456{enter}789{enter}abc{moveToStart}def{moveToEnd}ghi')
+        .then(($div) => {
+          expect($div.get(0).innerText.trim()).to.eql('def123\n456\n789\nabcghi')
+        })
+      })
+
+      it('bare text in front and back of an element', () => {
+        cy.get('[contenteditable]:first')
+        .invoke('html', '123<div>456</div>789')
+        .type('abc{moveToStart}def{moveToEnd}ghi')
+        .then(($div) => {
+          expect($div.get(0).innerText.trim()).to.eql('def123\n456\n789abcghi')
+        })
       })
     })
 

--- a/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
@@ -40,6 +40,30 @@ describe('src/cy/commands/actions/type - #type special chars', () => {
     cy.visit('/fixtures/dom.html')
   })
 
+  // https://github.com/cypress-io/cypress/issues/5502
+  describe('moves the cursor from in-between to the start or the end', () => {
+    it('input', () => {
+      cy.get('input:first')
+      .type('123{moveToStart}456{moveToEnd}789')
+      .should('have.value', '456123789')
+    })
+
+    it('contenteditable', () => {
+      cy.get('[contenteditable]:first')
+      .type('123{enter}456{enter}789{enter}abc{moveToStart}def{moveToEnd}ghi')
+      .then(($div) => {
+        // trim() is added for Firefox. It adds \n at the back as default.
+        expect($div.get(0).innerText.trim()).to.eql('def123\n456\n789\nabcghi')
+      })
+    })
+
+    it('textarea', () => {
+      cy.get('textarea:first')
+      .type('123{enter}456{enter}789{enter}abc{moveToStart}def{moveToEnd}ghi')
+      .should('have.value', 'def123\n456\n789\nabcghi')
+    })
+  })
+
   context('parseSpecialCharSequences: false', () => {
     it('types special character sequences literally', (done) => {
       cy.get(':text:first').invoke('val', 'foo')

--- a/packages/driver/cypress/support/utils.js
+++ b/packages/driver/cypress/support/utils.js
@@ -105,18 +105,11 @@ export const trimInnerText = ($el) => {
   return _.trimEnd($el.get(0).innerText, '\n')
 }
 
-// Copied and adapted from https://jsfiddle.net/cpatik/3QAeC/
-export function getCaretPosition (element) {
-  let caretOffset = 0
-
-  let range = element.ownerDocument.getSelection().getRangeAt(0)
-  let preCaretRange = range.cloneRange()
-
-  preCaretRange.selectNodeContents(element)
-  preCaretRange.setEnd(range.endContainer, range.endOffset)
-  caretOffset = preCaretRange.toString().length
-
-  return caretOffset
+export const expectCaret = (start, end) => {
+  return ($el) => {
+    end = end == null ? start : end
+    expect(Cypress.dom.getSelectionBounds($el.get(0))).to.deep.eq({ start, end })
+  }
 }
 
 Cypress.Commands.add('getAll', getAllFn)

--- a/packages/driver/cypress/support/utils.js
+++ b/packages/driver/cypress/support/utils.js
@@ -105,6 +105,20 @@ export const trimInnerText = ($el) => {
   return _.trimEnd($el.get(0).innerText, '\n')
 }
 
+// Copied and adapted from https://jsfiddle.net/cpatik/3QAeC/
+export function getCaretPosition (element) {
+  let caretOffset = 0
+
+  let range = element.ownerDocument.getSelection().getRangeAt(0)
+  let preCaretRange = range.cloneRange()
+
+  preCaretRange.selectNodeContents(element)
+  preCaretRange.setEnd(range.endContainer, range.endOffset)
+  caretOffset = preCaretRange.toString().length
+
+  return caretOffset
+}
+
 Cypress.Commands.add('getAll', getAllFn)
 
 const chaiSubset = require('chai-subset')

--- a/packages/driver/src/dom/elements.ts
+++ b/packages/driver/src/dom/elements.ts
@@ -1365,6 +1365,7 @@ export {
   getContainsSelector,
   getFirstDeepestElement,
   getFirstCommonAncestor,
+  getTagName,
   getFirstParentWithTagName,
   getFirstFixedOrStickyPositionParent,
   getFirstStickyPositionParent,

--- a/packages/driver/src/dom/selection.ts
+++ b/packages/driver/src/dom/selection.ts
@@ -608,7 +608,7 @@ const _moveSelectionTo = function (toStart: boolean, el: HTMLElement, options = 
     // However, IE can always* set selection range, so only modern browsers (with the selection API) will need this
     const direction = toStart ? 'backward' : 'forward'
 
-    selection.modify('move', direction, 'line')
+    selection.modify('move', direction, 'documentboundary')
 
     return
   }

--- a/packages/driver/src/dom/selection.ts
+++ b/packages/driver/src/dom/selection.ts
@@ -593,9 +593,25 @@ const _moveSelectionTo = function (toStart: boolean, el: HTMLElement, options = 
       // it appends text after HTML elements like <div>foo</div>bar.
       // Because of that, we need to select the last element manually here.
       if (toStart) {
-        el = root.children[0] as HTMLElement
+        const firstEl = root.children[0] as HTMLElement
+
+        if (firstEl) {
+          // If root's innerText doesn't start with firstEl's innerText,
+          // it means that bare text is in front of that element like 123<div>456</div>
+          el = root.innerText.startsWith(firstEl.innerText) ? firstEl : root
+        } else {
+          el = root
+        }
       } else {
-        el = root.children[root.children.length - 1] as HTMLElement
+        const lastEl = root.children[root.children.length - 1] as HTMLElement
+
+        if (lastEl) {
+          // If root's innerText doesn't end with lastEl's innerText,
+          // it means that bare text is in the behind of that element like <div>123</div>456
+          el = root.innerText.endsWith(lastEl.innerText) ? lastEl : root
+        } else {
+          el = root
+        }
       }
 
       // el can be undefined when content editable is empty.

--- a/packages/driver/src/dom/selection.ts
+++ b/packages/driver/src/dom/selection.ts
@@ -563,16 +563,22 @@ const _moveSelectionTo = function (toStart: boolean, el: HTMLElement, options = 
   }
 
   if ($elements.isContentEditable(el)) {
-    // When el is contentEditable, it is usually not a whole content editable element.
-    // It's a small one inside the big editor.
-    // So, we need to find the root contentEditable that contains the entire editable text.
-    const rootContentEditable = (el) => {
-      return $elements.isContentEditable(el.parentElement)
-        ? rootContentEditable(el.parentElement)
-        : el
-    }
+    if (doc.designMode === 'on') {
+      // When designMode is 'on', we don't have to find the root content editable,
+      // because everything is editable. And the entire document should be selected.
+      el = doc.documentElement
+    } else {
+      // When el is contentEditable, it is usually not a whole content editable element.
+      // It's a small one inside the big editor.
+      // So, we need to find the root contentEditable that contains the entire editable text.
+      const rootContentEditable = (el) => {
+        return $elements.isContentEditable(el.parentElement)
+          ? rootContentEditable(el.parentElement)
+          : el
+      }
 
-    el = rootContentEditable(el)
+      el = rootContentEditable(el)
+    }
 
     // Select all in contenteditable.
     let range = doc.createRange()

--- a/packages/driver/src/dom/selection.ts
+++ b/packages/driver/src/dom/selection.ts
@@ -563,6 +563,17 @@ const _moveSelectionTo = function (toStart: boolean, el: HTMLElement, options = 
   }
 
   if ($elements.isContentEditable(el)) {
+    // When el is contentEditable, it is usually not a whole content editable element.
+    // It's a small one inside the big editor.
+    // So, we need to find the root contentEditable that contains the entire editable text.
+    const rootContentEditable = (el) => {
+      return $elements.isContentEditable(el.parentElement)
+        ? rootContentEditable(el.parentElement)
+        : el
+    }
+
+    el = rootContentEditable(el)
+
     // Select all in contenteditable.
     let range = doc.createRange()
 

--- a/packages/driver/src/dom/selection.ts
+++ b/packages/driver/src/dom/selection.ts
@@ -140,7 +140,7 @@ const getHostContenteditable = function (el: HTMLElement) {
       return (curEl as Document).documentElement
     }
 
-    return el.ownerDocument.documentElement
+    return el.ownerDocument!.documentElement
   }
 
   return curEl


### PR DESCRIPTION
- Closes #5502

- Fix issue with moveToStart/End only moving to end of line instead of whole text editable in firefox
It's because it doesn't select to the start or the end when the text becomes long. You can check this behavior at the example here.

I had to use collapse functions. They work in all modern browsers.

### User facing changelog

Added tests for undocumented features, {moveToStart} and {moveToEnd}.

### Additional details

- Why was this change necessary? To reveal these features to the users.
- What is affected by this change? N/A
- Any implementation details to explain? N/A

### How has the user experience changed?

N/A

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/2991
