### PR TITLE
fix: attempt reconnection if CDP websocket in closed/closing state

### DIFF
--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -11,7 +11,7 @@ const debugVerboseSend = debugModule('cypress-verbose:server:browsers:cri-client
 // debug using cypress-verbose:server:browsers:cri-client:recv:*
 const debugVerboseReceive = debugModule('cypress-verbose:server:browsers:cri-client:recv:[<--]')
 
-const WEBSOCKET_NOT_OPEN_RE = /^WebSocket is not open/
+const WEBSOCKET_NOT_OPEN_RE = /^WebSocket is (?:not open|already in CLOSING or CLOSED state)/
 
 /**
  * Url returned by the Chrome Remote Interface

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -13,10 +13,7 @@ describe('lib/browsers/cri-client', function () {
   let send: sinon.SinonStub
   let criImport: sinon.SinonStub
   let onError: sinon.SinonStub
-
-  function getClient () {
-    return criClient.create(DEBUGGER_URL, onError)
-  }
+  let getClient: () => ReturnType<typeof create>
 
   beforeEach(function () {
     sinon.stub(Bluebird, 'promisify').returnsArg(0)
@@ -29,11 +26,17 @@ describe('lib/browsers/cri-client', function () {
       target: DEBUGGER_URL,
       local: true,
     })
-    .resolves({ send, _notifier: new EventEmitter() })
+    .resolves({
+      send,
+      close: sinon.stub(),
+      _notifier: new EventEmitter(),
+    })
 
     criClient = proxyquire('../lib/browsers/cri-client', {
       'chrome-remote-interface': criImport,
     })
+
+    getClient = () => criClient.create(DEBUGGER_URL, onError)
   })
 
   context('.create', function () {
@@ -50,6 +53,37 @@ describe('lib/browsers/cri-client', function () {
 
         client.send('Browser.getVersion', { baz: 'quux' })
         expect(send).to.be.calledWith('Browser.getVersion', { baz: 'quux' })
+      })
+
+      it('rejects if cri.send rejects', async function () {
+        const err = new Error
+
+        send.rejects(err)
+        const client = await getClient()
+
+        await expect(client.send('Browser.getVersion', { baz: 'quux' }))
+        .to.be.rejectedWith(err)
+      })
+
+      context('retries', () => {
+        ([
+          'WebSocket is not open',
+          // @see https://github.com/cypress-io/cypress/issues/7180
+          'WebSocket is already in CLOSING or CLOSED state',
+        ]).forEach((msg) => {
+          it(`with '${msg}'`, async function () {
+            const err = new Error(msg)
+
+            send.onFirstCall().rejects(err)
+            send.onSecondCall().resolves()
+
+            const client = await getClient()
+
+            await client.send('Browser.getVersion', { baz: 'quux' })
+
+            expect(send).to.be.calledTwice
+          })
+        })
       })
     })
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7180

### User facing changelog

- Fixed an issue where Cypress tests in Chromium-family browsers could randomly fail with the error "WebSocket is already in CLOSING or CLOSED state."

### Additional details

- we retry on certain connection errors, this was not one of them, now it is (since it represents a race condition, where a reconnect could still succeed)

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
