### PR TITLE
fix: cy.route swallows the error about missing fixture #7818

### DIFF
--- a/packages/driver/cypress/integration/commands/fixtures_spec.js
+++ b/packages/driver/cypress/integration/commands/fixtures_spec.js
@@ -50,6 +50,10 @@ describe('src/cy/commands/fixtures', () => {
       cy.fixture('example').should('deep.eq', { example: true })
     })
 
+    it('works with null.json', () => {
+      cy.fixture('null.json').should('equal', null)
+    })
+
     it('can read a fixture without extension with multiple dots in the name', () => {
       cy.fixture('foo.bar.baz').should('deep.eq', { quux: 'quuz' })
     })

--- a/packages/driver/cypress/integration/commands/xhr_spec.js
+++ b/packages/driver/cypress/integration/commands/xhr_spec.js
@@ -2150,6 +2150,19 @@ describe('src/cy/commands/xhr', () => {
         .wrap({ foo: 'bar' }).as('foo')
         .route(/foo/, '@bar')
       })
+
+      // https://github.com/cypress-io/cypress/issues/7818
+      it('throws when fixture cannot be found', (done) => {
+        cy.on('fail', (err) => {
+          expect(err.message).to.contains('A fixture file could not be found at any of the following paths:')
+          done()
+        })
+
+        cy.route(/foo/, 'fx:NOT_EXISTING_FILE_FIXTURE')
+        cy.window().then((win) => {
+          win.$.get('/foo')
+        })
+      })
     })
 
     describe('.log', () => {

--- a/packages/driver/src/cy/commands/fixtures.js
+++ b/packages/driver/src/cy/commands/fixtures.js
@@ -58,10 +58,8 @@ module.exports = (Commands, Cypress, cy, state, config) => {
       return Cypress.backend('get:fixture', fixture, _.pick(options, 'encoding'))
       .timeout(timeout)
       .then((response) => {
-        const err = response.__error
-
-        if (err) {
-          return $errUtils.throwErr(err)
+        if (response && response.__error) {
+          return $errUtils.throwErr(response.__error)
         }
 
         // add the fixture to the cache

--- a/packages/driver/src/cy/commands/xhr.js
+++ b/packages/driver/src/cy/commands/xhr.js
@@ -200,7 +200,7 @@ const startXhrServer = (cy, state, config) => {
     },
 
     onFixtureError (xhr, err) {
-      err = $errUtils.cypressErr(err)
+      err = $errUtils.cypressErr({ message: err })
 
       return this.onError(xhr, err)
     },
@@ -469,6 +469,15 @@ module.exports = (Commands, Cypress, cy, state, config) => {
 
             return route()
           })
+        }
+
+        // look ahead to see if fixture exists
+        const fixturesRe = /^(fx:|fixture:)/
+
+        if (hasResponse && fixturesRe.test(options.response)) {
+          const fixtureName = options.response.replace(fixturesRe, '')
+
+          return cy.now('fixture', fixtureName).then(() => route())
         }
 
         return route()


### PR DESCRIPTION
- Closes #7818
- Closes #8010 

### User facing changelog

- cy.route throws an error when fixture cannot be found.
- In addition I've fixed the `fixture` command which raised an error for `null.json`. BTW. did you know that if the fixture contains following key in the returned object `__error` then `cy.fixture` throws an error :) ?

### Additional details

- Why was this change necessary?
To provide better error message in case of missing fixture or problem with parsing

- What is affected by this change?
`cy.route` calls `cy.fixture` if response meets criteria of fixture shortcut `fx:` | `fixture:`. With this additional check we can raise an error even before HTTP request is sent.

### How has the user experience changed?

If fixture file doesn't exists, or there is a problem with fixture, `cy.route` will raise an error.

Before:
![image](https://user-images.githubusercontent.com/3865478/87590038-74a57680-c6e6-11ea-977a-cd530f689a8f.png)

<img width="566" alt="Screen Shot 2020-07-17 at 1 16 51 PM" src="https://user-images.githubusercontent.com/1271364/87756996-de7d6780-c82f-11ea-9c97-13a468f1f79d.png">

Now:
![image](https://user-images.githubusercontent.com/3865478/87591323-6eb09500-c6e8-11ea-9644-329d1a529318.png)



### PR Tasks
- [x] Have tests been added/updated?


