### PR TITLE
Parse key value pairs sent to ELECTRON_EXTRA_LAUNCH_ARGS

### DIFF
--- a/packages/server/lib/environment.js
+++ b/packages/server/lib/environment.js
@@ -73,7 +73,14 @@ try {
       // https://github.com/cypress-io/cypress/issues/7994
       const [key, value] = arg.split('=')
 
-      value ? app.commandLine.appendSwitch(key, value) : app.commandLine.appendSwitch(key)
+      // because this is an environment variable, everything is a string
+      // thus we don't have to worry about casting
+      // --foo=false for example will be "--foo", "false"
+      if (value) {
+        app.commandLine.appendSwitch(key, value)
+      } else {
+        app.commandLine.appendSwitch(key)
+      }
     })
   }
 } catch (e) {

--- a/packages/server/lib/environment.js
+++ b/packages/server/lib/environment.js
@@ -67,7 +67,14 @@ try {
   if (process.env.ELECTRON_EXTRA_LAUNCH_ARGS) {
     const electronLaunchArguments = process.env.ELECTRON_EXTRA_LAUNCH_ARGS.split(' ')
 
-    electronLaunchArguments.forEach(app.commandLine.appendArgument)
+    electronLaunchArguments.forEach((arg) => {
+      // arg can be just key --disable-http-cache
+      // or key value --remote-debugging-port=8315
+      // https://github.com/cypress-io/cypress/issues/7994
+      const [key, value] = arg.split('=')
+
+      value ? app.commandLine.appendSwitch(key, value) : app.commandLine.appendSwitch(key)
+    })
   }
 } catch (e) {
   debug('environment error %s', e.message)

--- a/packages/server/test/unit/environment_spec.js
+++ b/packages/server/test/unit/environment_spec.js
@@ -47,13 +47,11 @@ describe('lib/environment', () => {
   context('parses ELECTRON_EXTRA_LAUNCH_ARGS', () => {
     let restore = null
 
-    beforeEach(() => {
-      return restore = mockedEnv({
+    it('sets launch args', () => {
+      restore = mockedEnv({
         ELECTRON_EXTRA_LAUNCH_ARGS: '--foo --bar=baz --quux=true',
       })
-    })
 
-    it('sets launch args', () => {
       sinon.stub(app.commandLine, 'appendSwitch')
       require(`${root}lib/environment`)
       expect(app.commandLine.appendSwitch).to.have.been.calledWith('--foo')
@@ -62,8 +60,36 @@ describe('lib/environment', () => {
       expect(app.commandLine.appendSwitch).to.have.been.calledWith('--quux', 'true')
     })
 
+    it('sets launch args with zero', () => {
+      restore = mockedEnv({
+        ELECTRON_EXTRA_LAUNCH_ARGS: '--foo --bar=baz --quux=0',
+      })
+
+      sinon.stub(app.commandLine, 'appendSwitch')
+      require(`${root}lib/environment`)
+      expect(app.commandLine.appendSwitch).to.have.been.calledWith('--foo')
+      expect(app.commandLine.appendSwitch).to.have.been.calledWith('--bar', 'baz')
+
+      expect(app.commandLine.appendSwitch).to.have.been.calledWith('--quux', '0')
+    })
+
+    it('sets launch args with false', () => {
+      restore = mockedEnv({
+        ELECTRON_EXTRA_LAUNCH_ARGS: '--foo --bar=baz --quux=false',
+      })
+
+      sinon.stub(app.commandLine, 'appendSwitch')
+      require(`${root}lib/environment`)
+      expect(app.commandLine.appendSwitch).to.have.been.calledWith('--foo')
+      expect(app.commandLine.appendSwitch).to.have.been.calledWith('--bar', 'baz')
+
+      expect(app.commandLine.appendSwitch).to.have.been.calledWith('--quux', 'false')
+    })
+
     return afterEach(() => {
-      return restore()
+      if (restore) {
+        return restore()
+      }
     })
   })
 

--- a/packages/server/test/unit/environment_spec.js
+++ b/packages/server/test/unit/environment_spec.js
@@ -54,12 +54,12 @@ describe('lib/environment', () => {
     })
 
     it('sets launch args', () => {
-      sinon.stub(app.commandLine, 'appendArgument')
+      sinon.stub(app.commandLine, 'appendSwitch')
       require(`${root}lib/environment`)
-      expect(app.commandLine.appendArgument).to.have.been.calledWith('--foo')
-      expect(app.commandLine.appendArgument).to.have.been.calledWith('--bar=baz')
+      expect(app.commandLine.appendSwitch).to.have.been.calledWith('--foo')
+      expect(app.commandLine.appendSwitch).to.have.been.calledWith('--bar', 'baz')
 
-      expect(app.commandLine.appendArgument).to.have.been.calledWith('--quux=true')
+      expect(app.commandLine.appendSwitch).to.have.been.calledWith('--quux', 'true')
     })
 
     return afterEach(() => {


### PR DESCRIPTION
- close #7994 

### User facing changelog

Key value pairs sent to `ELECTRON_EXTRA_LAUNCH_ARGS` as `key=value` will now be properly read in.

### Additional details

- `appendArgument` doesn't seem to support key value pairs, the Electron docs even suggest using `appendSwitch` here if you need a key value pair. https://www.electronjs.org/docs/api/command-line#commandlineappendargumentvalue
- If using `appendSwitch`, it accepts 2 args not a `key=value` string. https://www.electronjs.org/docs/api/command-line-switches

### How has the user experience changed?

- The args were just ignored before, now they should be read in.

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/2993