### PR TITLE
Add ensureScrollability option to scrollTo command

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2591,6 +2591,12 @@ declare namespace Cypress {
      * @default 'swing'
      */
     easing: 'swing' | 'linear',
+    /**
+     * Ensure element is scrollable. Error if element is not scrollable
+     *
+     * @default true
+     */
+    ensureScrollable: boolean,
   }
 
   interface ScrollIntoViewOptions extends ScrollToOptions {

--- a/packages/driver/cypress/integration/commands/actions/scroll_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/scroll_spec.js
@@ -530,6 +530,17 @@ describe('src/cy/commands/actions/scroll', () => {
 
           cy.get('#scroll-to-both').scrollTo('25px', { easing: 'flower' })
         })
+
+        it('throws if ensureScrollable is not a boolean', (done) => {
+          cy.on('fail', (err) => {
+            expect(err.message).to.include('`cy.scrollTo()` `ensureScrollable` option must be a boolean. You passed: `force`')
+            expect(err.docsUrl).to.eq('https://on.cypress.io/scrollto')
+
+            done()
+          })
+
+          cy.get('button:first').scrollTo('bottom', { ensureScrollable: 'force' })
+        })
       })
     })
 

--- a/packages/driver/cypress/integration/commands/actions/scroll_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/scroll_spec.js
@@ -429,7 +429,7 @@ describe('src/cy/commands/actions/scroll', () => {
         cy.on('fail', (err) => {
           expect(err.message).to.include('`cy.scrollTo()` failed because this element is not scrollable:')
           expect(err.message).to.include(`\`<button>button</button>\``)
-          expect(err.message).to.include('Make sure you\'re targeting the correct element or use  `{ensureScrollable: false}` to disable the scrollable check.')
+          expect(err.message).to.include('Make sure you\'re targeting the correct element or use `{ensureScrollable: false}` to disable the scrollable check.')
           expect(err.docsUrl).to.eq('https://on.cypress.io/scrollto')
 
           done()

--- a/packages/driver/cypress/integration/commands/actions/scroll_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/scroll_spec.js
@@ -429,7 +429,7 @@ describe('src/cy/commands/actions/scroll', () => {
         cy.on('fail', (err) => {
           expect(err.message).to.include('`cy.scrollTo()` failed because this element is not scrollable:')
           expect(err.message).to.include(`\`<button>button</button>\``)
-          expect(err.message).to.include('Fix this problem, or use `{ensureScrollable: false}` to disable the scrollability check.')
+          expect(err.message).to.include('Make sure you\'re targeting the correct element or use  `{ensureScrollable: false}` to disable the scrollable check.')
           expect(err.docsUrl).to.eq('https://on.cypress.io/scrollto')
 
           done()

--- a/packages/driver/cypress/integration/commands/actions/scroll_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/scroll_spec.js
@@ -352,14 +352,15 @@ describe('src/cy/commands/actions/scroll', () => {
           expect($container.get(0).scrollLeft).to.eq(500)
         })
       })
+
       // https://github.com/cypress-io/cypress/issues/1924
       it('skips scrollability check', () => {
         const scrollTo = cy.spy($.fn, 'scrollTo')
 
-        cy.get('button:first').scrollTo('bottom', { ensureScrollability: false }).then(() => {
+        cy.get('button:first').scrollTo('bottom', { ensureScrollable: false }).then(() => {
           cy.stub(cy, 'ensureScrollability')
 
-          expect(scrollTo).to.be.calledWithMatch({}, { ensureScrollability: false })
+          expect(scrollTo).to.be.calledWithMatch({}, { ensureScrollable: false })
           expect(cy.ensureScrollability).not.to.be.called
         })
       })
@@ -427,6 +428,9 @@ describe('src/cy/commands/actions/scroll', () => {
       it('throws when subject isn\'t scrollable', (done) => {
         cy.on('fail', (err) => {
           expect(err.message).to.include('`cy.scrollTo()` failed because this element is not scrollable:')
+          expect(err.message).to.include(`\`<button>button</button>\``)
+          expect(err.message).to.include('Fix this problem, or use `{ensureScrollable: false}` to disable the scrollability check.')
+          expect(err.docsUrl).to.eq('https://on.cypress.io/scrollto')
 
           done()
         })

--- a/packages/driver/cypress/integration/commands/actions/scroll_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/scroll_spec.js
@@ -352,6 +352,17 @@ describe('src/cy/commands/actions/scroll', () => {
           expect($container.get(0).scrollLeft).to.eq(500)
         })
       })
+
+      it('skips scrollability check', () => {
+        const scrollTo = cy.spy($.fn, 'scrollTo')
+
+        cy.get('button:first').scrollTo('bottom', { ensureScrollability: false }).then(() => {
+          cy.stub(cy, 'ensureScrollability')
+
+          expect(scrollTo).to.be.calledWithMatch({}, { ensureScrollability: false })
+          expect(cy.ensureScrollability).not.to.be.called
+        })
+      })
     })
 
     describe('assertion verification', () => {

--- a/packages/driver/cypress/integration/commands/actions/scroll_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/scroll_spec.js
@@ -352,7 +352,7 @@ describe('src/cy/commands/actions/scroll', () => {
           expect($container.get(0).scrollLeft).to.eq(500)
         })
       })
-
+      // https://github.com/cypress-io/cypress/issues/1924
       it('skips scrollability check', () => {
         const scrollTo = cy.spy($.fn, 'scrollTo')
 

--- a/packages/driver/src/cy/commands/actions/scroll.js
+++ b/packages/driver/src/cy/commands/actions/scroll.js
@@ -262,6 +262,7 @@ module.exports = (Commands, Cypress, cy, state) => {
         duration: 0,
         easing: 'swing',
         axis: 'xy',
+        ensureScrollability: true,
         x,
         y,
       })
@@ -274,6 +275,10 @@ module.exports = (Commands, Cypress, cy, state) => {
 
       if (!((options.easing === 'swing') || (options.easing === 'linear'))) {
         $errUtils.throwErrByPath('scrollTo.invalid_easing', { args: { easing: options.easing } })
+      }
+
+      if (!_.isBoolean(options.ensureScrollability)) {
+        $errUtils.throwErrByPath('scrollTo.invalid_ensureScrollability', { args: { ensureScrollability: options.ensureScrollability } })
       }
 
       // if we cannot parse an integer out of y or x
@@ -333,6 +338,10 @@ module.exports = (Commands, Cypress, cy, state) => {
       }
 
       const ensureScrollability = () => {
+        if (!options.ensureScrollability) {
+          return
+        }
+
         try {
           // make sure our container can even be scrolled
           return cy.ensureScrollability($container, 'scrollTo')
@@ -350,6 +359,7 @@ module.exports = (Commands, Cypress, cy, state) => {
             axis: options.axis,
             easing: options.easing,
             duration: options.duration,
+            ensureScrollability: options.ensureScrollability,
             done () {
               return resolve(options.$el)
             },

--- a/packages/driver/src/cy/commands/actions/scroll.js
+++ b/packages/driver/src/cy/commands/actions/scroll.js
@@ -262,7 +262,7 @@ module.exports = (Commands, Cypress, cy, state) => {
         duration: 0,
         easing: 'swing',
         axis: 'xy',
-        ensureScrollability: true,
+        ensureScrollable: true,
         x,
         y,
       })
@@ -277,8 +277,8 @@ module.exports = (Commands, Cypress, cy, state) => {
         $errUtils.throwErrByPath('scrollTo.invalid_easing', { args: { easing: options.easing } })
       }
 
-      if (!_.isBoolean(options.ensureScrollability)) {
-        $errUtils.throwErrByPath('scrollTo.invalid_ensureScrollability', { args: { ensureScrollability: options.ensureScrollability } })
+      if (!_.isBoolean(options.ensureScrollable)) {
+        $errUtils.throwErrByPath('scrollTo.invalid_ensureScrollable', { args: { ensureScrollable: options.ensureScrollable } })
       }
 
       // if we cannot parse an integer out of y or x
@@ -340,7 +340,7 @@ module.exports = (Commands, Cypress, cy, state) => {
       const ensureScrollability = () => {
         // Some elements are not scrollable, user may opt out of error checking
         // https://github.com/cypress-io/cypress/issues/1924
-        if (!options.ensureScrollability) {
+        if (!options.ensureScrollable) {
           return
         }
 
@@ -361,7 +361,7 @@ module.exports = (Commands, Cypress, cy, state) => {
             axis: options.axis,
             easing: options.easing,
             duration: options.duration,
-            ensureScrollability: options.ensureScrollability,
+            ensureScrollable: options.ensureScrollable,
             done () {
               return resolve(options.$el)
             },

--- a/packages/driver/src/cy/commands/actions/scroll.js
+++ b/packages/driver/src/cy/commands/actions/scroll.js
@@ -338,6 +338,8 @@ module.exports = (Commands, Cypress, cy, state) => {
       }
 
       const ensureScrollability = () => {
+        // Some elements are not scrollable, user may opt out of error checking
+        // https://github.com/cypress-io/cypress/issues/1924
         if (!options.ensureScrollability) {
           return
         }

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -368,11 +368,15 @@ module.exports = {
       message: 'Invalid position argument: `{{position}}`. Position may only be {{validPositions}}.',
       docsUrl: 'https://on.cypress.io/element-cannot-be-interacted-with',
     },
-    not_scrollable: [
-      `${cmd('{{cmd}}')} failed because this element is not scrollable:`,
-      '`{{node}}\`',
-      '',
-    ].join('\n'),
+    not_scrollable: {
+      message: stripIndent`\
+        ${cmd('{{cmd}}')} failed because this element is not scrollable:
+  
+        \`{{node}}\`
+  
+        Fix this problem, or use \`{ensureScrollable: false}\` to disable the scrollability check.`,
+      docsUrl: 'https://on.cypress.io/scrollto',
+    },
     not_visible: {
       message: stripIndent`\
         ${cmd('{{cmd}}')} failed because this element is not visible:

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -1163,8 +1163,8 @@ module.exports = {
       message: `${cmd('scrollTo')} can only be used to scroll 1 element, you tried to scroll {{num}} elements.\n\n`,
       docsUrl: 'https://on.cypress.io/scrollto',
     },
-    invalid_ensureScrollability: {
-      message: `${cmd('scrollTo')} \`{{ensureScrollability}}\` option must be a boolean. You passed: \`{{ensureScrollability}}\``,
+    invalid_ensureScrollable: {
+      message: `${cmd('scrollTo')} \`{{ensureScrollable}}\` option must be a boolean. You passed: \`{{ensureScrollable}}\``,
       docsUrl: 'https://on.cypress.io/scrollto',
     },
   },

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -374,7 +374,7 @@ module.exports = {
   
         \`{{node}}\`
   
-        Fix this problem, or use \`{ensureScrollable: false}\` to disable the scrollability check.`,
+        Make sure you're targeting the correct element or use \`{ensureScrollable: false}\` to disable the scrollable check.`,
       docsUrl: 'https://on.cypress.io/scrollto',
     },
     not_visible: {

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -1163,6 +1163,10 @@ module.exports = {
       message: `${cmd('scrollTo')} can only be used to scroll 1 element, you tried to scroll {{num}} elements.\n\n`,
       docsUrl: 'https://on.cypress.io/scrollto',
     },
+    invalid_ensureScrollability: {
+      message: `${cmd('scrollTo')} \`{{ensureScrollability}}\` option must be a boolean. You passed: \`{{ensureScrollability}}\``,
+      docsUrl: 'https://on.cypress.io/scrollto',
+    },
   },
 
   screenshot: {

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -1168,7 +1168,7 @@ module.exports = {
       docsUrl: 'https://on.cypress.io/scrollto',
     },
     invalid_ensureScrollable: {
-      message: `${cmd('scrollTo')} \`{{ensureScrollable}}\` option must be a boolean. You passed: \`{{ensureScrollable}}\``,
+      message: `${cmd('scrollTo')} \`ensureScrollable\` option must be a boolean. You passed: \`{{ensureScrollable}}\``,
       docsUrl: 'https://on.cypress.io/scrollto',
     },
   },


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes https://github.com/cypress-io/cypress/issues/1924

### User facing changelog

You can now pass the `ensureScrollability: false` option to `.scrollTo()` to skip the scroll ability check of an element. Addresses https://github.com/cypress-io/cypress/issues/1924.

### Additional details

- I've used `ensureScrollability`, but it seems quite a long name for an option. Suggestions are welcome.
- I'll open a PR to update the documentation once or if the PR is approved and we agree on the option naming.

### How has the user experience changed?

Now users can use `scrollTo()` on an element that can have a variable height without getting an error.

#### Before

<img width="523" alt="Screen Shot 2020-07-20 at 10 56 11 AM" src="https://user-images.githubusercontent.com/1271364/87899740-14ad2800-ca78-11ea-9014-7165d3a23a98.png">

#### After

Passing `ensureScrollable: false`

<img width="522" alt="Screen Shot 2020-07-20 at 10 58 14 AM" src="https://user-images.githubusercontent.com/1271364/87899752-2393da80-ca78-11ea-9dde-cffb24fe5d90.png">

Passing incorrect arg to `ensureScrollable`

<img width="521" alt="Screen Shot 2020-07-20 at 10 58 34 AM" src="https://user-images.githubusercontent.com/1271364/87899760-2e4e6f80-ca78-11ea-8806-0338218a64a2.png">

Trying to scroll unscrollable el without `ensureScrollable: false`

<img width="493" alt="Screen Shot 2020-07-20 at 11 05 51 AM" src="https://user-images.githubusercontent.com/1271364/87900013-07dd0400-ca79-11ea-884c-e8f7571661e3.png">



### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
