### PR TITLE
Fix testConfigOverrides not affecting viewport

### DIFF
--- a/packages/driver/cypress/integration/e2e/testConfigOverrides.spec.js
+++ b/packages/driver/cypress/integration/e2e/testConfigOverrides.spec.js
@@ -327,6 +327,7 @@ describe('per-test config', () => {
 })
 
 describe('viewport', () => {
+  // https://github.com/cypress-io/cypress/issues/7631
   it('can set viewport in testConfigOverrides', { viewportWidth: 200, viewportHeight: 100 }, () => {
     cy.visit('/fixtures/generic.html')
     cy.window().then((win) => {

--- a/packages/driver/cypress/integration/e2e/testConfigOverrides.spec.js
+++ b/packages/driver/cypress/integration/e2e/testConfigOverrides.spec.js
@@ -326,6 +326,24 @@ describe('per-test config', () => {
   })
 })
 
+describe('viewport', () => {
+  it('can set viewport in testConfigOverrides', { viewportWidth: 200, viewportHeight: 100 }, () => {
+    cy.visit('/fixtures/generic.html')
+    cy.window().then((win) => {
+      expect(win.innerWidth).eq(200)
+      expect(win.innerHeight).eq(100)
+    })
+  })
+
+  it('viewport does not leak between tests', () => {
+    cy.visit('/fixtures/generic.html')
+    cy.window().then((win) => {
+      expect(win.innerWidth).eq(1000)
+      expect(win.innerHeight).eq(660)
+    })
+  })
+})
+
 describe('testConfigOverrides baseUrl @slow', () => {
   it('visit 1', { baseUrl: 'http://localhost:3501' }, () => {
     cy.visit('/fixtures/generic.html')

--- a/packages/driver/src/cy/commands/window.js
+++ b/packages/driver/src/cy/commands/window.js
@@ -41,9 +41,9 @@ module.exports = (Commands, Cypress, cy, state) => {
     // need to restore prior to running the next test
     // after which we simply null and wait for the
     // next viewport change
-    const defaultViewport = _.pick(Cypress.config(), 'viewportWidth', 'viewportHeight')
+    const testDefaultViewport = _.pick(Cypress.config(), 'viewportWidth', 'viewportHeight')
 
-    setViewportAndSynchronize(defaultViewport.viewportWidth, defaultViewport.viewportHeight)
+    setViewportAndSynchronize(testDefaultViewport.viewportWidth, testDefaultViewport.viewportHeight)
   })
 
   const setViewportAndSynchronize = (width, height) => {

--- a/packages/driver/src/cy/commands/window.js
+++ b/packages/driver/src/cy/commands/window.js
@@ -29,8 +29,8 @@ const validOrientations = ['landscape', 'portrait']
 // refresh would cause viewport to hang
 let currentViewport = null
 
-module.exports = (Commands, Cypress, cy, state, config) => {
-  const defaultViewport = _.pick(config(), 'viewportWidth', 'viewportHeight')
+module.exports = (Commands, Cypress, cy, state) => {
+  const defaultViewport = _.pick(Cypress.config(), 'viewportWidth', 'viewportHeight')
 
   // currentViewport could already be set due to previous runs
   currentViewport = currentViewport || defaultViewport
@@ -41,6 +41,8 @@ module.exports = (Commands, Cypress, cy, state, config) => {
     // need to restore prior to running the next test
     // after which we simply null and wait for the
     // next viewport change
+    const defaultViewport = _.pick(Cypress.config(), 'viewportWidth', 'viewportHeight')
+
     setViewportAndSynchronize(defaultViewport.viewportWidth, defaultViewport.viewportHeight)
   })
 

--- a/packages/driver/src/cy/commands/window.js
+++ b/packages/driver/src/cy/commands/window.js
@@ -41,9 +41,9 @@ module.exports = (Commands, Cypress, cy, state) => {
     // need to restore prior to running the next test
     // after which we simply null and wait for the
     // next viewport change
-    const testDefaultViewport = _.pick(Cypress.config(), 'viewportWidth', 'viewportHeight')
+    const configDefaultViewport = _.pick(Cypress.config(), 'viewportWidth', 'viewportHeight')
 
-    setViewportAndSynchronize(testDefaultViewport.viewportWidth, testDefaultViewport.viewportHeight)
+    setViewportAndSynchronize(configDefaultViewport.viewportWidth, configDefaultViewport.viewportHeight)
   })
 
   const setViewportAndSynchronize = (width, height) => {


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7631 

### User facing changelog
Bug fix: fix `testConfigOverride` options not affecting `viewport` configuration. 
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
