### PR TITLE
Change lodash to caret semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "lerna": "3.20.2",
     "lint-staged": "9.4.1",
     "listr": "0.14.3",
-    "lodash": "4.17.19",
+    "lodash": "^4.17.19",
     "make-empty-github-commit": "1.2.0",
     "mocha": "3.5.3",
     "mocha-banner": "1.1.2",

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   "minor": {
     "automerge": false
   },
-  "rangeStrategy": "pin",
+  "rangeStrategy": "bump",
   "packageRules": [
     {
       "packagePatterns": "^@types/",


### PR DESCRIPTION
### User facing changelog
Change `lodash` to use caret semver range due to frequent security issues.

### Additional details
This allows consumers to update `lodash` versions to address security issues without using special tools like Yarn Resolutions or npm overrides. Since `lodash` is a volatile package in regards to security updates, this seems like a good tradeoff to make.

This changes the Renovate configuration originally specified by @bahmutov in https://github.com/cypress-io/cypress/pull/2992

Renovate `rangeStrategy` Docs:
https://docs.renovatebot.com/configuration-options/#rangestrategy

### How has the user experience changed?
* Users can update `lodash` without updating `cypress`
* Bots such as Dependabot can do this automatically

### PR Tasks
None applicable.



┆Issue is synchronized with this [Jira Features](https://cypress-io.atlassian.net/browse/TR-136) by [Unito](https://www.unito.io/learn-more)
