### PR TITLE
Check that response is null or undefined when showing as 'stubbed' instead of 'falsy'

### DIFF
--- a/packages/driver/cypress/integration/commands/xhr_spec.js
+++ b/packages/driver/cypress/integration/commands/xhr_spec.js
@@ -865,6 +865,34 @@ describe('src/cy/commands/xhr', () => {
           })
         })
 
+        // https://github.com/cypress-io/cypress/issues/8018
+        it('logs empty string response as stubbed', () => {
+          cy
+          .server()
+          .route(/foo/, '').as('getFoo')
+          .window().then((win) => {
+            win.$.get('foo')
+
+            return null
+          }).then(function () {
+            const { lastLog } = this
+
+            expect(lastLog.pick('name', 'displayName', 'event', 'alias', 'aliasType', 'state')).to.deep.eq({
+              name: 'xhr',
+              displayName: 'xhr stub',
+              event: true,
+              alias: 'getFoo',
+              aliasType: 'route',
+              state: 'pending',
+            })
+
+            const snapshots = lastLog.get('snapshots')
+
+            expect(snapshots.length).to.eq(1)
+            expect(snapshots[0].name).to.eq('request')
+          })
+        })
+
         it('does not end xhr requests when the associated command ends', () => {
           let logs = null
 

--- a/packages/driver/src/cy/commands/xhr.js
+++ b/packages/driver/src/cy/commands/xhr.js
@@ -41,7 +41,7 @@ const unavailableErr = () => {
   return $errUtils.throwErrByPath('server.unavailable')
 }
 
-const getDisplayName = (route) => route && route.response ? 'xhr stub' : 'xhr'
+const getDisplayName = (route) => _.isNil(route?.response) ? 'xhr' : 'xhr stub'
 
 const stripOrigin = (url) => {
   const location = $Location.create(url)
@@ -126,7 +126,7 @@ const startXhrServer = (cy, state, config) => {
             'Matched URL': route?.url,
             Status: xhr.statusMessage,
             Duration: xhr.duration,
-            'Stubbed': route && route.response != null ? 'Yes' : 'No',
+            Stubbed: _.isNil(route?.response) ? 'No' : 'Yes',
             Request: xhr.request,
             Response: xhr.response,
             XHR: xhr._getXhr(),


### PR DESCRIPTION
- Closes #8018 

### User facing changelog

- Stubbed responses responding with an empty string to `cy.route()` now correctly display as 'xhr stub' in the Test Runner's Command Log.

### Additional details

- We were doing a ternary operator before which would return as not stubbed if the `cy.route()` response was falsy (like `response: ''`). 
- Now we check if the `route` or `response` are `null` or `undefined` to determine if it's stubbed.

### How has the user experience changed?

#### Before

Shows `xhr` next to empty stubbed response. `cy.route('GET', 'comments/*', '')`

<img width="580" alt="Screen Shot 2020-07-20 at 3 54 19 PM" src="https://user-images.githubusercontent.com/1271364/87924553-104b3400-caa5-11ea-8f5c-75fbd462ba89.png">


#### After

Shows `xhr stub` next to empty stubbed response. `cy.route('GET', 'comments/*', '')`

<img width="496" alt="Screen Shot 2020-07-20 at 4 20 13 PM" src="https://user-images.githubusercontent.com/1271364/87924454-f1e53880-caa4-11ea-87ca-547aa455438f.png">



### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->