### PR TITLE
Handle env values containing exponential operators

### DIFF
--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -92,7 +92,8 @@ const pipesToCommas = (str) => {
 
 const tryJSONParse = (str) => {
   try {
-    return JSON.parse(str)
+    // https://github.com/cypress-io/cypress/issues/6891
+    return JSON.parse(str) === Infinity ? null : JSON.parse(str)
   } catch (err) {
     return null
   }

--- a/packages/server/test/unit/args_spec.js
+++ b/packages/server/test/unit/args_spec.js
@@ -159,7 +159,7 @@ describe('lib/util/args', () => {
         return snapshot('invalid env error', stripAnsi(err.message))
       }
     })
-
+    // https://github.com/cypress-io/cypress/issues/6891
     it('handles values containing exponential operators', function () {
       const options = this.setup('--env', 'foo=bar,hash=769e98018')
 

--- a/packages/server/test/unit/args_spec.js
+++ b/packages/server/test/unit/args_spec.js
@@ -159,6 +159,15 @@ describe('lib/util/args', () => {
         return snapshot('invalid env error', stripAnsi(err.message))
       }
     })
+
+    it('handles values containing exponential operators', function () {
+      const options = this.setup('--env', 'foo=bar,hash=769e98018')
+
+      expect(options.config.env).to.deep.eq({
+        foo: 'bar',
+        hash: '769e98018',
+      })
+    })
   })
 
   context('--reporterOptions', () => {

--- a/packages/server/test/unit/args_spec.js
+++ b/packages/server/test/unit/args_spec.js
@@ -159,6 +159,7 @@ describe('lib/util/args', () => {
         return snapshot('invalid env error', stripAnsi(err.message))
       }
     })
+
     // https://github.com/cypress-io/cypress/issues/6891
     it('handles values containing exponential operators', function () {
       const options = this.setup('--env', 'foo=bar,hash=769e98018')


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes https://github.com/cypress-io/cypress/issues/6891

### User facing changelog

We now handle values containing exponential operators passed to `--env` command line option. Fixes: https://github.com/cypress-io/cypress/issues/6891

### Additional details

Debugging and suggestions for fixing the issue are in the issue comments.

Logs:
```zsh
node $(yarn bin cypress) open --dev --global --env WSD_VERSION_HASH=769e98018

cypress:server:args argv array: [ '/Users/user/.npm/_npx/19508/lib/node_modules/node/bin/node', '/Users/username/cypress/scripts/start.js', '--env', 'WSD_VERSION_HASH=769e98018', '--cwd', '/Users/username/cypress' ] +0ms

...

cypress:server:args argv options: { _: [ '/Users/username/cypress/packages/electron/dist/Cypress/Cypress.app/Contents/MacOS/Cypress' ], 'max-http-header-size': '1048576 --http-parser=legacy', config: { env: { WSD_VERSION_HASH: '769e98018' } }, cwd: '/Users/username/cypress', invokedFromCli: true } +0ms
```

### How has the user experience changed?

Now they will be able to pass values containing exponential operators to the `--env` command line option.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
