### PR TITLE
fix: add more should interface definitions.

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -4809,6 +4809,15 @@ declare namespace Cypress {
      */
     (chainer: 'not.match', value: string): Chainable<Subject>
 
+    // fallback
+    /**
+     * Create an assertion. Assertions are automatically retried until they pass or time out.
+     * Ctrl+Space will invoke auto-complete in most editors.
+     * @see https://on.cypress.io/should
+     */
+    (chainers: string, value?: any): Chainable<Subject>
+    (chainers: string, value: any, match: any): Chainable<Subject>
+
     /**
      * Create an assertion. Assertions are automatically retried until they pass or time out.
      * Passing a function to `.should()` enables you to make multiple assertions on the yielded subject. This also gives you the opportunity to massage what you’d like to assert on.

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2833,7 +2833,7 @@ declare namespace Cypress {
     encoding: Encodings
   }
 
-  // Kind of onerous, but has a nice auto-complete. Also fallbacks at the end for custom stuff
+  // Kind of onerous, but has a nice auto-complete.
   /**
    * @see https://on.cypress.io/should
    *
@@ -3296,15 +3296,23 @@ declare namespace Cypress {
      * invoked after invoking the target function compared to when it’s invoked beforehand.
      * `.increase` also causes all `.by` assertions that follow in the chain to assert how much greater of a number is returned.
      * It’s often best to assert that the return value increased by the expected amount, rather than asserting it increased by any amount.
+     *
+     * When two arguments are provided, `.increase` asserts that the value of the given object `subject`’s `prop` property is greater after
+     * invoking the target function compared to beforehand.
+     *
      * @example
      *    let val = 1
      *    function addTwo() { val += 2 }
      *    function getVal() { return val }
      *    cy.wrap(addTwo).should('increase', getVal)
+     *
+     *    let myObj = { val: 1 }
+     *    function addTwo() { myObj.val += 2 }
+     *    cy.wrap(addTwo).should('increase', myObj, 'val')
      * @see http://chaijs.com/api/bdd/#method_increase
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'increase', value: object, property: string): Chainable<Subject>
+    (chainer: 'increase', value: object, property?: string): Chainable<Subject>
     /**
      * Asserts that the target matches the given regular expression `re`.
      * @example
@@ -3727,7 +3735,7 @@ declare namespace Cypress {
     /**
      * Asserts that the target’s `length` property is not less than or equal to the given number `n`.
      * @example
-     *    cy.wrap([1, 2, 3]).should('not.have.length.let', 2)
+     *    cy.wrap([1, 2, 3]).should('not.have.length.lte', 2)
      *    cy.wrap('foo').should('not.have.length.lte', 2)
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
@@ -3796,15 +3804,23 @@ declare namespace Cypress {
      * invoked after invoking the target function compared to when it’s invoked beforehand.
      * `.increase` also causes all `.by` assertions that follow in the chain to assert how much greater of a number is returned.
      * It’s often best to assert that the return value increased by the expected amount, rather than asserting it increased by any amount.
+     *
+     * When two arguments are provided, `.increase` asserts that the value of the given object `subject`’s `prop` property is greater after
+     * invoking the target function compared to beforehand.
+     *
      * @example
      *    let val = 1
      *    function addTwo() { val += 2 }
      *    function getVal() { return val }
      *    cy.wrap(() => {}).should('not.increase', getVal)
+     *
+     *    let myObj = { val: 1 }
+     *    function addTwo() { myObj.val += 2 }
+     *    cy.wrap(addTwo).should('increase', myObj, 'val')
      * @see http://chaijs.com/api/bdd/#method_increase
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.increase', value: object, property: string): Chainable<Subject>
+    (chainer: 'not.increase', value: object, property?: string): Chainable<Subject>
     /**
      * Asserts that the target does not match the given regular expression `re`.
      * @example
@@ -3843,7 +3859,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_throw
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'throw', value?: string | RegExp): Chainable<Subject>
+    (chainer: 'not.throw', value?: string | RegExp): Chainable<Subject>
     /**
      * When no arguments are provided, `.throw` invokes the target function and asserts that no error is thrown.
      * When one argument is provided, and it’s a string, `.throw` invokes the target function and asserts that no error is thrown with a message that contains that string.
@@ -3856,7 +3872,7 @@ declare namespace Cypress {
      * @see https://on.cypress.io/assertions
      */
     // tslint:disable-next-line ban-types
-    (chainer: 'throw', error: Error | Function, expected?: string | RegExp): Chainable<Subject>
+    (chainer: 'not.throw', error: Error | Function, expected?: string | RegExp): Chainable<Subject>
 
     // sinon-chai
     /**
@@ -4525,15 +4541,6 @@ declare namespace Cypress {
      * @see https://on.cypress.io/assertions
      */
     (chainer: 'not.match', value: string): Chainable<Subject>
-
-    // fallback
-    /**
-     * Create an assertion. Assertions are automatically retried until they pass or time out.
-     * Ctrl+Space will invoke auto-complete in most editors.
-     * @see https://on.cypress.io/should
-     */
-    (chainers: string, value?: any): Chainable<Subject>
-    (chainers: string, value: any, match: any): Chainable<Subject>
 
     /**
      * Create an assertion. Assertions are automatically retried until they pass or time out.

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3025,6 +3025,22 @@ declare namespace Cypress {
      */
     (chainer: 'be.undefined'): Chainable<Subject>
     /**
+     * Asserts that the target is strictly (`===`) equal to null.
+     * @example
+     *    cy.wrap(null).should('be.null')
+     * @see http://chaijs.com/api/bdd/#method_null
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.null'): Chainable<Subject>
+    /**
+     * Asserts that the target is strictly (`===`) equal to NaN.
+     * @example
+     *    cy.wrap(NaN).should('be.NaN')
+     * @see http://chaijs.com/api/bdd/#method_null
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.NaN'): Chainable<Subject>
+    /**
      * Asserts that the target is a number or a date greater than or equal to the given number or date `start`, and less than or equal to the given number or date `finish` respectively.
      * However, it’s often best to assert that the target is equal to its expected value.
      * @example
@@ -3550,6 +3566,22 @@ declare namespace Cypress {
      */
     (chainer: 'not.be.undefined'): Chainable<Subject>
     /**
+     * Asserts that the target is strictly (`===`) equal to null.
+     * @example
+     *    cy.wrap(null).should('not.be.null')
+     * @see http://chaijs.com/api/bdd/#method_null
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.null'): Chainable<Subject>
+    /**
+     * Asserts that the target is strictly (`===`) equal to NaN.
+     * @example
+     *    cy.wrap(NaN).should('not.be.NaN')
+     * @see http://chaijs.com/api/bdd/#method_nan
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.NaN'): Chainable<Subject>
+    /**
      * Asserts that the target is not a number or a date greater than or equal to the given number or date `start`, and less than or equal to the given number or date `finish` respectively.
      * However, it’s often best to assert that the target is equal to its expected value.
      * @example
@@ -3979,6 +4011,60 @@ declare namespace Cypress {
      * @see https://on.cypress.io/assertions
      */
     (chainer: 'returned' | 'have.returned', value: any): Chainable<Subject>
+    /**
+     * Assert spy was called before anotherSpy, and no spy calls occurred between spy and anotherSpy.
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledimmediatelybeforeanotherspy
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.calledImmediatelyBefore' | 'have.been.calledImmediatelyBefore', anotherSpy: sinon.SinonSpy): Chainable<Subject>
+    /**
+     * Assert spy was called after anotherSpy, and no spy calls occurred between anotherSpy and spy.
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledimmediatelyafteranotherspy
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.calledImmediatelyAfter' | 'have.been.calledImmediatelyAfter', anotherSpy: sinon.SinonSpy): Chainable<Subject>
+    /**
+     * Assert the spy was always called with obj as this
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#spyalwayscalledonobj
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.always.calledOn' | 'always.have.been.calledOn', obj: any): Chainable<Subject>
+    /**
+     * Assert spy was called at least once with the provided arguments.
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledwitharg1-arg2-
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.calledWith' | 'have.been.calledWith', ...args: any[]): Chainable<Subject>
+    /**
+     * Assert spy was always called with the provided arguments (and possibly others).
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#spyalwayscalledwitharg1-arg2-
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.always.calledWith' | 'always.have.been.calledWith', ...args: any[]): Chainable<Subject>
+    /**
+     * Assert spy was called at exactly once with the provided arguments.
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledwitharg1-arg2-
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.calledOnceWith' | 'have.been.calledOnceWith', ...args: any[]): Chainable<Subject>
+    /**
+     * Assert spy was always called with the exact provided arguments.
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#spyalwayscalledwithexactlyarg1-arg2-
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.always.calledWithExactly' | 'have.been.calledWithExactly', ...args: any[]): Chainable<Subject>
+    /**
+     * Assert spy was called at exactly once with the provided arguments.
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.calledOnceWithExactly' | 'have.been.calledOnceWithExactly', ...args: any[]): Chainable<Subject>
+    /**
+     * Assert spy always returned the provided value.
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'have.always.returned', obj: any): Chainable<Subject>
 
     // sinon-chai.not
     /**
@@ -4085,6 +4171,60 @@ declare namespace Cypress {
      * @see https://on.cypress.io/assertions
      */
     (chainer: 'not.returned' | 'not.have.returned', value: any): Chainable<Subject>
+    /**
+     * Assert spy was called before anotherSpy, and no spy calls occurred between spy and anotherSpy.
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledimmediatelybeforeanotherspy
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.calledImmediatelyBefore' | 'not.have.been.calledImmediatelyBefore', anotherSpy: sinon.SinonSpy): Chainable<Subject>
+    /**
+     * Assert spy was called after anotherSpy, and no spy calls occurred between anotherSpy and spy.
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledimmediatelyafteranotherspy
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.calledImmediatelyAfter' | 'not.have.been.calledImmediatelyAfter', anotherSpy: sinon.SinonSpy): Chainable<Subject>
+    /**
+     * Assert the spy was always called with obj as this
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#spyalwayscalledonobj
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.always.calledOn' | 'not.always.have.been.calledOn', obj: any): Chainable<Subject>
+    /**
+     * Assert spy was called at least once with the provided arguments.
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledwitharg1-arg2-
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.calledWith' | 'not.have.been.calledWith', ...args: any[]): Chainable<Subject>
+    /**
+     * Assert spy was always called with the provided arguments (and possibly others).
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#spyalwayscalledwitharg1-arg2-
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.always.calledWith' | 'not.always.have.been.calledWith', ...args: any[]): Chainable<Subject>
+    /**
+     * Assert spy was called at exactly once with the provided arguments.
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledwitharg1-arg2-
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.calledOnceWith' | 'not.have.been.calledOnceWith', ...args: any[]): Chainable<Subject>
+    /**
+     * Assert spy was always called with the exact provided arguments.
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#spyalwayscalledwithexactlyarg1-arg2-
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.always.calledWithExactly' | 'not.have.been.calledWithExactly', ...args: any[]): Chainable<Subject>
+    /**
+     * Assert spy was called at exactly once with the provided arguments.
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.calledOnceWithExactly' | 'not.have.been.calledOnceWithExactly', ...args: any[]): Chainable<Subject>
+    /**
+     * Assert spy always returned the provided value.
+     * @see http://sinonjs.org/releases/v4.1.3/spies/#
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.have.always.returned', obj: any): Chainable<Subject>
 
     // jquery-chai
     /**

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3179,7 +3179,7 @@ declare namespace Cypress {
     (chainer: 'have.any.keys' | 'include.any.keys', ...value: string[]): Chainable<Subject>
     /**
      * Causes all `.keys` assertions that follow in the chain to require the target to be a superset of the expected set, rather than an identical set.
-     * @example 
+     * @example
      *    cy.wrap({ a: 1, b: 2 }).should('include.all.keys', 'a', 'b')
      * @see http://chaijs.com/api/bdd/#method_keys
      * @see https://on.cypress.io/assertions
@@ -3414,7 +3414,7 @@ declare namespace Cypress {
      */
     (chainer: 'be.oneOf', list: ReadonlyArray<any>): Chainable<Subject>
     /**
-     * Asserts that the target is extensible, which means that new properties can be added to it. 
+     * Asserts that the target is extensible, which means that new properties can be added to it.
      * @example
      *    cy.wrap({a: 1}).should('be.extensible')
      * @see http://chaijs.com/api/bdd/#method_extensible
@@ -3998,7 +3998,7 @@ declare namespace Cypress {
      */
     (chainer: 'not.be.oneOf', list: ReadonlyArray<any>): Chainable<Subject>
     /**
-     * Asserts that the target is extensible, which means that new properties can be added to it. 
+     * Asserts that the target is extensible, which means that new properties can be added to it.
      * @example
      *    let o = Object.seal({})
      *    cy.wrap(o).should('not.be.extensible')

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3881,80 +3881,80 @@ declare namespace Cypress {
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledwithnew
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'be.always.calledWithNew'): Chainable<Subject>
+    (chainer: 'be.always.calledWithNew' | 'always.have.been.calledWithNew'): Chainable<Subject>
     /**
      * Assert if spy was always called with matching arguments (and possibly others).
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spyalwayscalledwithmatcharg1-arg2-
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'be.always.calledWithMatch', ...args: any[]): Chainable<Subject>
+    (chainer: 'be.always.calledWithMatch' | 'always.have.been.calledWithMatch', ...args: any[]): Chainable<Subject>
     /**
      * Assert spy always returned the provided value.
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spyalwaysreturnedobj
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'always.returned', value: any): Chainable<Subject>
+    (chainer: 'always.returned' | 'have.always.returned', value: any): Chainable<Subject>
     /**
      * `true` if the spy was called at least once
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalled
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'be.called'): Chainable<Subject>
+    (chainer: 'be.called' | 'have.been.called'): Chainable<Subject>
     /**
      * Assert spy was called after `anotherSpy`
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledafteranotherspy
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'be.calledAfter', spy: sinon.SinonSpy): Chainable<Subject>
+    (chainer: 'be.calledAfter' | 'have.been.calledAfter', spy: sinon.SinonSpy): Chainable<Subject>
     /**
      * Assert spy was called before `anotherSpy`
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledbeforeanotherspy
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'be.calledBefore', spy: sinon.SinonSpy): Chainable<Subject>
+    (chainer: 'be.calledBefore' | 'have.been.calledBefore', spy: sinon.SinonSpy): Chainable<Subject>
     /**
      * Assert spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher (see [matchers](http://sinonjs.org/releases/v4.1.3/spies/#matchers)).
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledonobj
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'be.calledOn', context: any): Chainable<Subject>
+    (chainer: 'be.calledOn' | 'have.been.calledOn', context: any): Chainable<Subject>
     /**
      * Assert spy was called exactly once
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledonce
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'be.calledOnce'): Chainable<Subject>
+    (chainer: 'be.calledOnce' | 'have.been.calledOnce'): Chainable<Subject>
     /**
      * Assert spy was called exactly three times
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledthrice
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'be.calledThrice'): Chainable<Subject>
+    (chainer: 'be.calledThrice' | 'have.been.calledThrice'): Chainable<Subject>
     /**
      * Assert spy was called exactly twice
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledtwice
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'be.calledTwice'): Chainable<Subject>
+    (chainer: 'be.calledTwice' | 'have.been.calledTwice'): Chainable<Subject>
     /**
      * Assert spy was called at least once with the provided arguments and no others.
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledwithexactlyarg1-arg2-
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'be.calledWithExactly', ...args: any[]): Chainable<Subject>
+    (chainer: 'be.calledWithExactly' | 'have.been.calledWithExactly', ...args: any[]): Chainable<Subject>
     /**
      * Assert spy was called with matching arguments (and possibly others).
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledwithmatcharg1-arg2-
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'be.calledWithMatch', ...args: any[]): Chainable<Subject>
+    (chainer: 'be.calledWithMatch' | 'have.been.calledWithMatch', ...args: any[]): Chainable<Subject>
     /**
      * Assert spy/stub was called the `new` operator.
      * Beware that this is inferred based on the value of the this object and the spy function’s prototype, so it may give false positives if you actively return the right kind of object.
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledwithnew
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'be.calledWithNew'): Chainable<Subject>
+    (chainer: 'be.calledWithNew' | 'have.been.calledWithNew'): Chainable<Subject>
     /**
      * Assert spy always threw an exception.
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spyalwaysthrew
@@ -3978,7 +3978,7 @@ declare namespace Cypress {
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spyreturnedobj
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'returned', value: any): Chainable<Subject>
+    (chainer: 'returned' | 'have.returned', value: any): Chainable<Subject>
 
     // sinon-chai.not
     /**
@@ -3987,80 +3987,80 @@ declare namespace Cypress {
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledwithnew
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.be.always.calledWithNew'): Chainable<Subject>
+    (chainer: 'not.be.always.calledWithNew' | 'not.always.have.been.calledWithNew'): Chainable<Subject>
     /**
      * Assert if spy was not always called with matching arguments (and possibly others).
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spyalwayscalledwithmatcharg1-arg2-
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.be.always.calledWithMatch', ...args: any[]): Chainable<Subject>
+    (chainer: 'not.be.always.calledWithMatch' | 'not.always.have.been.calledWithMatch', ...args: any[]): Chainable<Subject>
     /**
      * Assert spy not always returned the provided value.
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spyalwaysreturnedobj
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.always.returned', value: any): Chainable<Subject>
+    (chainer: 'not.always.returned' | 'not.have.always.returned', value: any): Chainable<Subject>
     /**
      * `true` if the spy was not called at least once
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalled
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.be.called'): Chainable<Subject>
+    (chainer: 'not.be.called' | 'not.have.been.called'): Chainable<Subject>
     /**
      * Assert spy was not.called after `anotherSpy`
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledafteranotherspy
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.be.calledAfter', spy: sinon.SinonSpy): Chainable<Subject>
+    (chainer: 'not.be.calledAfter' | 'not.have.been.calledAfter', spy: sinon.SinonSpy): Chainable<Subject>
     /**
      * Assert spy was not called before `anotherSpy`
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledbeforeanotherspy
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.be.calledBefore', spy: sinon.SinonSpy): Chainable<Subject>
+    (chainer: 'not.be.calledBefore' | 'not.have.been.calledBefore', spy: sinon.SinonSpy): Chainable<Subject>
     /**
      * Assert spy was not called at least once with `obj` as `this`. `calledOn` also accepts a matcher (see [matchers](http://sinonjs.org/releases/v4.1.3/spies/#matchers)).
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledonobj
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.be.calledOn', context: any): Chainable<Subject>
+    (chainer: 'not.be.calledOn' | 'not.have.been.calledOn', context: any): Chainable<Subject>
     /**
      * Assert spy was not called exactly once
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledonce
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.be.calledOnce'): Chainable<Subject>
+    (chainer: 'not.be.calledOnce' | 'not.have.been.calledOnce'): Chainable<Subject>
     /**
      * Assert spy was not called exactly three times
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledthrice
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.be.calledThrice'): Chainable<Subject>
+    (chainer: 'not.be.calledThrice' | 'not.have.been.calledThrice'): Chainable<Subject>
     /**
      * Assert spy was not called exactly twice
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledtwice
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.be.calledTwice'): Chainable<Subject>
+    (chainer: 'not.be.calledTwice' | 'not.have.been.calledTwice'): Chainable<Subject>
     /**
      * Assert spy was not called at least once with the provided arguments and no others.
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledwithexactlyarg1-arg2-
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.be.calledWithExactly', ...args: any[]): Chainable<Subject>
+    (chainer: 'not.be.calledWithExactly' | 'not.have.been.calledWithExactly', ...args: any[]): Chainable<Subject>
     /**
      * Assert spy was not called with matching arguments (and possibly others).
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledwithmatcharg1-arg2-
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.be.calledWithMatch', ...args: any[]): Chainable<Subject>
+    (chainer: 'not.be.calledWithMatch' | 'not.have.been.calledWithMatch', ...args: any[]): Chainable<Subject>
     /**
      * Assert spy/stub was not called the `new` operator.
      * Beware that this is inferred based on the value of the this object and the spy function’s prototype, so it may give false positives if you actively return the right kind of object.
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spycalledwithnew
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.be.calledWithNew'): Chainable<Subject>
+    (chainer: 'not.be.calledWithNew' | 'not.have.been.calledWithNew'): Chainable<Subject>
     /**
      * Assert spy did not always throw an exception.
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spyalwaysthrew
@@ -4084,7 +4084,7 @@ declare namespace Cypress {
      * @see http://sinonjs.org/releases/v4.1.3/spies/#spyreturnedobj
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.returned', value: any): Chainable<Subject>
+    (chainer: 'not.returned' | 'not.have.returned', value: any): Chainable<Subject>
 
     // jquery-chai
     /**

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3168,7 +3168,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_all
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'have.all.keys', ...value: string[]): Chainable<Subject>
+    (chainer: 'have.all.keys' | 'have.keys' | 'have.deep.keys' | 'have.all.deep.keys', ...value: string[]): Chainable<Subject>
     /**
      * Causes all `.keys` assertions that follow in the chain to only require that the target have at least one of the given keys. This is the opposite of `.all`, which requires that the target have all of the given keys.
      * @example
@@ -3176,7 +3176,15 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_any
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'have.any.keys', ...value: string[]): Chainable<Subject>
+    (chainer: 'have.any.keys' | 'include.any.keys', ...value: string[]): Chainable<Subject>
+    /**
+     * Causes all `.keys` assertions that follow in the chain to require the target to be a superset of the expected set, rather than an identical set.
+     * @example 
+     *    cy.wrap({ a: 1, b: 2 }).should('include.all.keys', 'a', 'b')
+     * @see http://chaijs.com/api/bdd/#method_keys
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'include.all.keys', ...value: string[]): Chainable<Subject>
     /**
      * Asserts that the target has a property with the given key `name`. See the `deep-eql` project page for info on the deep equality algorithm: https://github.com/chaijs/deep-eql.
      * @example
@@ -3194,7 +3202,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'have.length', value: number): Chainable<Subject>
+    (chainer: 'have.length' | 'have.lengthOf', value: number): Chainable<Subject>
     /**
      * Asserts that the target’s `length` property is greater than to the given number `n`.
      * @example
@@ -3203,7 +3211,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'have.length.greaterThan', value: number): Chainable<Subject>
+    (chainer: 'have.length.greaterThan' | 'have.lengthOf.greaterThan', value: number): Chainable<Subject>
     /**
      * Asserts that the target’s `length` property is greater than to the given number `n`.
      * @example
@@ -3212,7 +3220,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'have.length.gt', value: number): Chainable<Subject>
+    (chainer: 'have.length.gt' | 'have.lengthOf.gt' | 'have.length.above' | 'have.lengthOf.above', value: number): Chainable<Subject>
     /**
      * Asserts that the target’s `length` property is greater than or equal to the given number `n`.
      * @example
@@ -3221,7 +3229,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'have.length.gte', value: number): Chainable<Subject>
+    (chainer: 'have.length.gte' | 'have.lengthOf.gte' | 'have.length.at.least' | 'have.lengthOf.at.least', value: number): Chainable<Subject>
     /**
      * Asserts that the target’s `length` property is less than to the given number `n`.
      * @example
@@ -3230,7 +3238,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'have.length.lessThan', value: number): Chainable<Subject>
+    (chainer: 'have.length.lessThan' | 'have.lengthOf.lessThan', value: number): Chainable<Subject>
     /**
      * Asserts that the target’s `length` property is less than to the given number `n`.
      * @example
@@ -3239,7 +3247,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'have.length.lt', value: number): Chainable<Subject>
+    (chainer: 'have.length.lt' | 'have.lengthOf.lt' | 'have.length.below' | 'have.lengthOf.below', value: number): Chainable<Subject>
     /**
      * Asserts that the target’s `length` property is less than or equal to the given number `n`.
      * @example
@@ -3248,7 +3256,15 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'have.length.lte', value: number): Chainable<Subject>
+    (chainer: 'have.length.lte' | 'have.lengthOf.lte' | 'have.length.at.most' | 'have.lengthOf.at.most', value: number): Chainable<Subject>
+    /**
+     * Asserts that the target’s `length` property is within `start` and `finish`.
+     * @example
+     *    cy.wrap([1, 2, 3]).should('have.length.within', 1, 5)
+     * @see http://chaijs.com/api/bdd/#method_lengthof
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'have.length.within' | 'have.lengthOf.within', start: number, finish: number): Chainable<Subject>
     /**
      * Asserts that the target array has the same members as the given array `set`.
      * @example
@@ -3256,7 +3272,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_members
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'have.members', values: any[]): Chainable<Subject>
+    (chainer: 'have.members' | 'have.deep.members', values: any[]): Chainable<Subject>
     /**
      * Asserts that the target array has the same members as the given array where order matters.
      * @example
@@ -3282,7 +3298,15 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_property
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'have.property', property: string, value?: any): Chainable<Subject>
+    (chainer: 'have.property' | 'have.nested.property' | 'have.own.property' | 'have.a.property' | 'have.deep.property' | 'have.deep.own.property' | 'have.deep.nested.property', property: string, value?: any): Chainable<Subject>
+    /**
+     * Asserts that the target has its own property descriptor with the given key name.
+     * @example
+     *    cy.wrap({a: 1}).should('have.ownPropertyDescriptor', 'a', { value: 1 })
+     * @see http://chaijs.com/api/bdd/#method_ownpropertydescriptor
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'have.ownPropertyDescriptor' | 'haveOwnPropertyDescriptor', name: string, descriptor?: PropertyDescriptor): Chainable<Subject>
     /**
      * Asserts that the target string contains the given substring `str`.
      * @example
@@ -3298,7 +3322,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_include
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'include', value: any): Chainable<Subject>
+    (chainer: 'include' | 'deep.include' | 'nested.include' | 'own.include' | 'deep.own.include' | 'deep.nested.include', value: any): Chainable<Subject>
     /**
      * When the target is a string, `.include` asserts that the given string `val` is a substring of the target.
      * @example
@@ -3306,7 +3330,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_members
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'include.members', value: any[]): Chainable<Subject>
+    (chainer: 'include.members' | 'include.ordered.members' | 'include.deep.ordered.members', value: any[]): Chainable<Subject>
     /**
      * When one argument is provided, `.increase` asserts that the given function `subject` returns a greater number when it’s
      * invoked after invoking the target function compared to when it’s invoked beforehand.
@@ -3381,6 +3405,50 @@ declare namespace Cypress {
      */
     // tslint:disable-next-line ban-types
     (chainer: 'throw', error: Error | Function, expected?: string | RegExp): Chainable<Subject>
+    /**
+     * Asserts that the target is a member of the given array list.
+     * @example
+     *    cy.wrap(1).should('be.oneOf', [1, 2, 3])
+     * @see http://chaijs.com/api/bdd/#method_oneof
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.oneOf', list: ReadonlyArray<any>): Chainable<Subject>
+    /**
+     * Asserts that the target is extensible, which means that new properties can be added to it. 
+     * @example
+     *    cy.wrap({a: 1}).should('be.extensible')
+     * @see http://chaijs.com/api/bdd/#method_extensible
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.extensible'): Chainable<Subject>
+    /**
+     * Asserts that the target is sealed, which means that new properties can’t be added to it, and its existing properties can’t be reconfigured or deleted.
+     * @example
+     *    let sealedObject = Object.seal({})
+     *    let frozenObject = Object.freeze({})
+     *    cy.wrap(sealedObject).should('be.sealed')
+     *    cy.wrap(frozenObject).should('be.sealed')
+     * @see http://chaijs.com/api/bdd/#method_sealed
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.sealed'): Chainable<Subject>
+    /**
+     * Asserts that the target is frozen, which means that new properties can’t be added to it, and its existing properties can’t be reassigned to different values, reconfigured, or deleted.
+     * @example
+     *    let frozenObject = Object.freeze({})
+     *    cy.wrap(frozenObject).should('be.frozen')
+     * @see http://chaijs.com/api/bdd/#method_frozen
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.frozen'): Chainable<Subject>
+    /**
+     * Asserts that the target is a number, and isn’t `NaN` or positive/negative `Infinity`.
+     * @example
+     *    cy.wrap(1).should('be.finite')
+     * @see http://chaijs.com/api/bdd/#method_finite
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.finite'): Chainable<Subject>
 
     // chai.not
     /**
@@ -3692,7 +3760,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_all
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.have.all.keys', ...value: string[]): Chainable<Subject>
+    (chainer: 'not.have.all.keys' | 'not.have.keys' | 'not.have.deep.keys' | 'not.have.all.deep.keys', ...value: string[]): Chainable<Subject>
     /**
      * Causes all `.keys` assertions that follow in the chain to only require that the target not have at least one of the given keys. This is the opposite of `.all`, which requires that the target have all of the given keys.
      * @example
@@ -3700,7 +3768,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_any
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.have.any.keys', ...value: string[]): Chainable<Subject>
+    (chainer: 'not.have.any.keys' | 'not.include.any.keys', ...value: string[]): Chainable<Subject>
     /**
      * Asserts that the target does not have a property with the given key `name`. See the `deep-eql` project page for info on the deep equality algorithm: https://github.com/chaijs/deep-eql.
      * @example
@@ -3718,7 +3786,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.have.length', value: number): Chainable<Subject>
+    (chainer: 'not.have.length' | 'not.have.lengthOf', value: number): Chainable<Subject>
     /**
      * Asserts that the target’s `length` property is not greater than to the given number `n`.
      * @example
@@ -3727,7 +3795,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.have.length.greaterThan', value: number): Chainable<Subject>
+    (chainer: 'not.have.length.greaterThan' | 'not.have.lengthOf.greaterThan', value: number): Chainable<Subject>
     /**
      * Asserts that the target’s `length` property is not greater than to the given number `n`.
      * @example
@@ -3736,7 +3804,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.have.length.gt', value: number): Chainable<Subject>
+    (chainer: 'not.have.length.gt' | 'not.have.lengthOf.gt' | 'not.have.length.above' | 'not.have.lengthOf.above', value: number): Chainable<Subject>
     /**
      * Asserts that the target’s `length` property is not greater than or equal to the given number `n`.
      * @example
@@ -3745,7 +3813,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'have.length.gte', value: number): Chainable<Subject>
+    (chainer: 'not.have.length.gte' | 'not.have.lengthOf.gte' | 'not.have.length.at.least' | 'not.have.lengthOf.at.least', value: number): Chainable<Subject>
     /**
      * Asserts that the target’s `length` property is less than to the given number `n`.
      * @example
@@ -3754,7 +3822,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.have.length.lessThan', value: number): Chainable<Subject>
+    (chainer: 'not.have.length.lessThan' | 'not.have.lengthOf.lessThan', value: number): Chainable<Subject>
     /**
      * Asserts that the target’s `length` property is not less than to the given number `n`.
      * @example
@@ -3763,7 +3831,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.have.length.lt', value: number): Chainable<Subject>
+    (chainer: 'not.have.length.lt' | 'not.have.lengthOf.lt' | 'not.have.length.below' | 'not.have.lengthOf.below', value: number): Chainable<Subject>
     /**
      * Asserts that the target’s `length` property is not less than or equal to the given number `n`.
      * @example
@@ -3772,7 +3840,15 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_lengthof
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.have.length.lte', value: number): Chainable<Subject>
+    (chainer: 'not.have.length.lte' | 'not.have.lengthOf.lte' | 'not.have.length.at.most' | 'not.have.lengthOf.at.most', value: number): Chainable<Subject>
+    /**
+     * Asserts that the target’s `length` property is within `start` and `finish`.
+     * @example
+     *    cy.wrap([1, 2, 3]).should('not.have.length.within', 6, 12)
+     * @see http://chaijs.com/api/bdd/#method_lengthof
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.have.length.within' | 'not.have.lengthOf.within', start: number, finish: number): Chainable<Subject>
     /**
      * Asserts that the target array does not have the same members as the given array `set`.
      * @example
@@ -3780,7 +3856,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_members
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.have.members', values: any[]): Chainable<Subject>
+    (chainer: 'not.have.members' | 'not.have.deep.members', values: any[]): Chainable<Subject>
     /**
      * Asserts that the target array does not have the same members as the given array where order matters.
      * @example
@@ -3806,7 +3882,15 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_property
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.have.property', property: string, value?: any): Chainable<Subject>
+    (chainer: 'not.have.property' | 'not.have.nested.property' | 'not.have.own.property' | 'not.have.a.property' | 'not.have.deep.property' | 'not.have.deep.own.property' | 'not.have.deep.nested.property', property: string, value?: any): Chainable<Subject>
+    /**
+     * Asserts that the target has its own property descriptor with the given key name.
+     * @example
+     *    cy.wrap({a: 1}).should('not.have.ownPropertyDescriptor', 'a', { value: 2 })
+     * @see http://chaijs.com/api/bdd/#method_ownpropertydescriptor
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.have.ownPropertyDescriptor' | 'not.haveOwnPropertyDescriptor', name: string, descriptor?: PropertyDescriptor): Chainable<Subject>
     /**
      * Asserts that the target string does not contains the given substring `str`.
      * @example
@@ -3822,7 +3906,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_include
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.include', value: any): Chainable<Subject>
+    (chainer: 'not.include' | 'not.deep.include' | 'not.nested.include' | 'not.own.include' | 'not.deep.own.include' | 'not.deep.nested.include', value: any): Chainable<Subject>
     /**
      * When the target is a string, `.include` asserts that the given string `val` is not a substring of the target.
      * @example
@@ -3830,7 +3914,7 @@ declare namespace Cypress {
      * @see http://chaijs.com/api/bdd/#method_members
      * @see https://on.cypress.io/assertions
      */
-    (chainer: 'not.include.members', value: any[]): Chainable<Subject>
+    (chainer: 'not.include.members' | 'not.include.ordered.members' | 'not.include.deep.ordered.members', value: any[]): Chainable<Subject>
     /**
      * When one argument is provided, `.increase` asserts that the given function `subject` returns a greater number when it’s
      * invoked after invoking the target function compared to when it’s invoked beforehand.
@@ -3905,6 +3989,49 @@ declare namespace Cypress {
      */
     // tslint:disable-next-line ban-types
     (chainer: 'not.throw', error: Error | Function, expected?: string | RegExp): Chainable<Subject>
+    /**
+     * Asserts that the target is a member of the given array list.
+     * @example
+     *    cy.wrap(42).should('not.be.oneOf', [1, 2, 3])
+     * @see http://chaijs.com/api/bdd/#method_oneof
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.oneOf', list: ReadonlyArray<any>): Chainable<Subject>
+    /**
+     * Asserts that the target is extensible, which means that new properties can be added to it. 
+     * @example
+     *    let o = Object.seal({})
+     *    cy.wrap(o).should('not.be.extensible')
+     * @see http://chaijs.com/api/bdd/#method_extensible
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.extensible'): Chainable<Subject>
+    /**
+     * Asserts that the target is sealed, which means that new properties can’t be added to it, and its existing properties can’t be reconfigured or deleted.
+     * @example
+     *    cy.wrap({a: 1}).should('be.sealed')
+     *    cy.wrap({a: 1}).should('be.sealed')
+     * @see http://chaijs.com/api/bdd/#method_sealed
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.sealed'): Chainable<Subject>
+    /**
+     * Asserts that the target is frozen, which means that new properties can’t be added to it, and its existing properties can’t be reassigned to different values, reconfigured, or deleted.
+     * @example
+     *    cy.wrap({a: 1}).should('not.be.frozen')
+     * @see http://chaijs.com/api/bdd/#method_frozen
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.frozen'): Chainable<Subject>
+    /**
+     * Asserts that the target is a number, and isn’t `NaN` or positive/negative `Infinity`.
+     * @example
+     *    cy.wrap(NaN).should('not.be.finite')
+     *    cy.wrap(Infinity).should('not.be.finite')
+     * @see http://chaijs.com/api/bdd/#method_finite
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.finite'): Chainable<Subject>
 
     // sinon-chai
     /**

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3306,7 +3306,7 @@ declare namespace Cypress {
      *    function getVal() { return val }
      *    cy.wrap(addTwo).should('increase', getVal)
      *
-     *    let myObj = { val: 1 }
+     *    const myObj = { val: 1 }
      *    function addTwo() { myObj.val += 2 }
      *    cy.wrap(addTwo).should('increase', myObj, 'val')
      * @see http://chaijs.com/api/bdd/#method_increase
@@ -3814,7 +3814,7 @@ declare namespace Cypress {
      *    function getVal() { return val }
      *    cy.wrap(() => {}).should('not.increase', getVal)
      *
-     *    let myObj = { val: 1 }
+     *    const myObj = { val: 1 }
      *    function addTwo() { myObj.val += 2 }
      *    cy.wrap(addTwo).should('increase', myObj, 'val')
      * @see http://chaijs.com/api/bdd/#method_increase

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -97,7 +97,7 @@ cy.wrap({ x: {a: 1 }}).should('have.deep.property', 'x', { a: 1 })
 cy.wrap([1, 2, 3]).should('have.length', 3)
 cy.wrap('foo').should('have.length', 3)
 
-cy.wrap([1, 2, 3]).should('have.length.greaterThan')
+cy.wrap([1, 2, 3]).should('have.length.greaterThan', 2)
 cy.wrap('foo').should('have.length.greaterThan', 2)
 
 cy.wrap([1, 2, 3]).should('have.length.gt', 2)
@@ -128,19 +128,19 @@ cy.wrap('foobar').should('have.string', 'bar')
 
 cy.wrap('foobar').should('include', 'foo')
 
-cy.wrap('foo').should('contain.value')
-cy.wrap('foo').should('contain.text')
-cy.wrap('foo').should('contain.html')
-cy.wrap('foo').should('not.contain.value')
-cy.wrap('foo').should('not.contain.text')
-cy.wrap('foo').should('not.contain.html')
+cy.wrap('foo').should('contain.value', 'foo')
+cy.wrap('foo').should('contain.text', 'foo')
+cy.wrap('foo').should('contain.html', 'foo')
+cy.wrap('foo').should('not.contain.value', 'foo')
+cy.wrap('foo').should('not.contain.text', 'foo')
+cy.wrap('foo').should('not.contain.html', 'foo')
 
-cy.wrap('foo').should('include.value')
-cy.wrap('foo').should('include.text')
-cy.wrap('foo').should('include.html')
-cy.wrap('foo').should('not.include.value')
-cy.wrap('foo').should('not.include.text')
-cy.wrap('foo').should('not.incldue.html')
+cy.wrap('foo').should('include.value', 'foo')
+cy.wrap('foo').should('include.text', 'foo')
+cy.wrap('foo').should('include.html', 'foo')
+cy.wrap('foo').should('not.include.value', 'foo')
+cy.wrap('foo').should('not.include.text', 'foo')
+cy.wrap('foo').should('not.include.html', 'foo')
 
 // Ensure we've extended chai.Includes correctly
 expect('foo').to.include.value('foo')
@@ -256,7 +256,7 @@ cy.wrap('tester').should('not.contain', 'foo')
   cy.wrap(() => {}).should('not.decrease', myObj, 'val')
 }
 
-cy.wrap({ a: 1 }).should('not.deep.equal', { b: 1 })
+cy.wrap<{a?: number, b?: number }>({ a: 1 }).should('not.deep.equal', { b: 1 })
 
 cy.wrap(null).should('not.exist')
 
@@ -287,12 +287,12 @@ cy.wrap('foo').should('have.length.lessThan', 2)
 cy.wrap([1, 2, 3]).should('not.have.length.lt', 2)
 cy.wrap('foo').should('not.have.length.lt', 2)
 
-cy.wrap([1, 2, 3]).should('not.have.length.let', 2)
+cy.wrap([1, 2, 3]).should('not.have.length.lte', 2)
 cy.wrap('foo').should('not.have.length.lte', 2)
 
 cy.wrap([1, 2, 3]).should('not.have.members', [4, 5, 6])
 
-cy.wrap([1, 2, 3]).should('not. have.ordered.members', [4, 5, 6])
+cy.wrap([1, 2, 3]).should('not.have.ordered.members', [4, 5, 6])
 
 ;
 (Object as any).prototype.b = 2
@@ -361,7 +361,7 @@ cy.get('#result').should('not.be.focused')
 cy.get('#result').should('have.focus')
 cy.get('#result').should('not.have.focus')
 
-cy.get('#result').should('be.contain', 'text')
+cy.get('#result').should('contain', 'text')
 
 cy.get('#result').should('have.attr', 'role')
 cy.get('#result').should('have.attr', 'role', 'menu')

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -229,6 +229,12 @@ cy.wrap(true).should('not.be.undefined')
 
 cy.wrap(3).should('not.be.within', 5, 10)
 
+cy.wrap(null).should('be.null')
+cy.wrap(123).should('not.be.null')
+
+cy.wrap(NaN).should('be.NaN')
+cy.wrap('cypress').should('not.be.NaN')
+
 ;
 () => {
   let dots = ''

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -157,6 +157,9 @@ cy.wrap([1, 2, 3]).should('include.members', [1, 2])
   function addTwo() { val += 2 }
   function getVal() { return val }
   cy.wrap(addTwo).should('increase', getVal)
+
+  const myObj = { val: 1 }
+  cy.wrap(addTwo).should('increase', myObj, 'val')
 }
 
 cy.wrap('foobar').should('match', /^foo/)

--- a/cli/types/tests/kitchen-sink.ts
+++ b/cli/types/tests/kitchen-sink.ts
@@ -62,6 +62,7 @@ expect(stub).to.not.have.been.called
 stub()
 expect(stub).to.have.been.calledOnce
 cy.wrap(stub).should('have.been.calledOnce')
+cy.wrap(stub).should('be.calledOnce')
 
 namespace EventInterfaceTests {
   // window:confirm stubbing


### PR DESCRIPTION
- Closes #5573

### User facing changelog

Add more `should` interface definitions.

### Additional details

- Why was this change necessary? Help users with more auto completion.
- What is affected by this change? N/A
- Any implementation details to explain? 

To remove duplication in comments, I used union types. Without it, many functions have almost identical 4 different documentation comments.

### How has the user experience changed?

Now, auto completions like `'have.lengthOf'` work.

### Note: Why not removing fallback?

It's because there are too many valid combination for chai.js. It's simply impossible to cover all of them. And we can block valid assertions in TS codes. 

It's not hard to find them. All we need to do is running the test once.

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
