### PR TITLE
fix: Prevent "after all" hook from masking previous errors

### DIFF
--- a/packages/driver/cypress/integration/issues/4062_spec.js
+++ b/packages/driver/cypress/integration/issues/4062_spec.js
@@ -1,0 +1,17 @@
+describe('4062', () => {
+  after(() => {
+    cy.get('h2').first()
+  })
+
+  it('make a test fail', () => {
+    const inputValue = 'fake'
+
+    cy.on('fail', (err) => {
+      expect(err.message).to.contain(inputValue)
+      expect(err.name).to.eql('AssertionError')
+    })
+
+    cy.visit('https://example.cypress.io/commands/actions')
+    cy.get('.action-email').should('have.value', inputValue)
+  })
+})

--- a/packages/driver/cypress/integration/issues/5681_spec.js
+++ b/packages/driver/cypress/integration/issues/5681_spec.js
@@ -1,0 +1,24 @@
+describe('5681', () => {
+  let error = new ReferenceError('notExistingFunction is not defined')
+
+  before((done) => {
+    cy.on('fail', (err) => {
+      expect(err.message).to.eql(error.message)
+      expect(err.name).to.eql(error.name)
+
+      done()
+    })
+
+    // generate a syntax error
+    // eslint-disable-next-line
+    notExistingFunction()
+  })
+
+  after(() => {
+    cy.get('.action-email').type('fake@email.com')
+  })
+
+  it('green test', () => {
+    cy.visit('https://example.cypress.io/commands/actions')
+  })
+})

--- a/packages/driver/src/cypress/runner.js
+++ b/packages/driver/src/cypress/runner.js
@@ -547,6 +547,12 @@ const hookFailed = (hook, err, hookName, getTest, getTestFromHookOrFindTest) => 
   // in which case we need to lookup the test
   const test = getTest() || getTestFromHookOrFindTest(hook)
 
+  // https://github.com/cypress-io/cypress/issues/4062
+  // https://github.com/cypress-io/cypress/issues/5681
+  if (test.state === 'failed' && hookName === 'after all') {
+    return
+  }
+
   test.err = err
   test.state = 'failed'
   test.duration = hook.duration // TODO: nope (?)


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

* Closes https://github.com/cypress-io/cypress/issues/4062
* Closes https://github.com/cypress-io/cypress/issues/5681

### User facing changelog
`After all` hook errors no longer mask previous errors.

### Additional details
Now the runner shows the correct error:

```js
describe('4062', () => {
    after(() => {
      cy.get('h2').first()
    })
  
    it('make a test fail', () => {
      cy.visit('https://example.cypress.io/commands/actions')
      cy.get('.action-email').should('have.value', 'fake')
    })
  })
```

![Screenshot 2020-07-23 at 17 44 58](https://user-images.githubusercontent.com/6031800/88311439-2b21e080-cd11-11ea-87e1-a4576ba77958.png)

```js
describe('5681', () => {
  before(() => {
    notExistingFunction()
  })

  after(() => {
    cy.get('.action-email').type('fake@email.com')
  })

  it('green test', () => {
    cy.visit('https://example.cypress.io/commands/actions')
  })
})
```

![Screenshot 2020-07-23 at 18 19 16](https://user-images.githubusercontent.com/6031800/88311448-2d843a80-cd11-11ea-8af0-4c15367151dc.png)

I'm having issues to make the test for the issue `4062` work (because the assertions regarding the error message return the test as a "passing test").

### How has the user experience changed?
They will see first error to fix.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

* [ ] Have tests been added/updated?



┆Issue is synchronized with this [Jira Bug](https://cypress-io.atlassian.net/browse/TR-170) by [Unito](https://www.unito.io/learn-more)
