### PR TITLE
feat: Add configuration option for disabling screenshots

### DIFF
--- a/cli/schema/cypress.schema.json
+++ b/cli/schema/cypress.schema.json
@@ -124,7 +124,7 @@
       "default": "cypress/plugins/index.js",
       "description": "Path to plugins file. (Pass false to disable)"
     },
-    "screenshot": {
+    "screenshotOnRunFailure": {
       "type": "boolean",
       "default": true,
       "description": "Whether Cypress will take a screenshot when a test fails during cypress run"

--- a/cli/schema/cypress.schema.json
+++ b/cli/schema/cypress.schema.json
@@ -127,7 +127,7 @@
     "screenshot": {
       "type": "boolean",
       "default": true,
-      "description": "Whether Cypress will screenshot a failed test run when running headlessly"
+      "description": "Whether Cypress will take a screenshot when a test fails during cypress run"
     },
     "screenshotsFolder": {
       "type": "string",

--- a/cli/schema/cypress.schema.json
+++ b/cli/schema/cypress.schema.json
@@ -124,6 +124,11 @@
       "default": "cypress/plugins/index.js",
       "description": "Path to plugins file. (Pass false to disable)"
     },
+    "screenshot": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether Cypress will screenshot a failed test run when running headlessly"
+    },
     "screenshotsFolder": {
       "type": "string",
       "default": "cypress/screenshots",

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2425,7 +2425,7 @@ declare namespace Cypress {
      * Whether Cypress will take a screenshot when a test fails during cypress run.
      * @default true
      */
-    screenshot: boolean
+    screenshotOnRunFailure: boolean
     /**
      * Path to folder where screenshots will be saved from [cy.screenshot()](https://on.cypress.io/screenshot) command or after a headless or CI run’s test failure
      * @default "cypress/screenshots"

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2422,7 +2422,7 @@ declare namespace Cypress {
      */
     resolvedNodeVersion: string
     /**
-     * Whether Cypress will screenshot a failed test run when running headlessly.
+     * Whether Cypress will take a screenshot when a test fails during cypress run.
      * @default true
      */
     screenshot: boolean

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2422,6 +2422,11 @@ declare namespace Cypress {
      */
     resolvedNodeVersion: string
     /**
+     * Whether Cypress will screenshot a failed test run when running headlessly.
+     * @default true
+     */
+    screenshot: boolean
+    /**
      * Path to folder where screenshots will be saved from [cy.screenshot()](https://on.cypress.io/screenshot) command or after a headless or CI run’s test failure
      * @default "cypress/screenshots"
      */

--- a/packages/driver/cypress/integration/commands/screenshot_spec.js
+++ b/packages/driver/cypress/integration/commands/screenshot_spec.js
@@ -94,9 +94,9 @@ describe('src/cy/commands/screenshot', () => {
       })
     })
 
-    it('is noop when screenshot is false', () => {
+    it('is noop when screenshotOnRunFailure is false', () => {
       Cypress.config('isInteractive', false)
-      Cypress.config('screenshot', false)
+      Cypress.config('screenshotOnRunFailure', false)
 
       cy.spy(Cypress, 'action').log(false)
 

--- a/packages/driver/cypress/integration/commands/screenshot_spec.js
+++ b/packages/driver/cypress/integration/commands/screenshot_spec.js
@@ -94,6 +94,25 @@ describe('src/cy/commands/screenshot', () => {
       })
     })
 
+    it('is noop when screenshot is false', () => {
+      Cypress.config('isInteractive', false)
+      Cypress.config('screenshot', false)
+
+      cy.spy(Cypress, 'action').log(false)
+
+      const test = {
+        err: new Error,
+      }
+
+      const runnable = cy.state('runnable')
+
+      Cypress.action('runner:runnable:after:run:async', test, runnable)
+      .then(() => {
+        expect(Cypress.action).not.to.be.calledWith('cy:test:set:state')
+        expect(Cypress.automation).not.to.be.called
+      })
+    })
+
     it('sends before/after events', function () {
       Cypress.config('isInteractive', false)
       this.screenshotConfig.scale = false

--- a/packages/driver/src/cy/commands/screenshot.js
+++ b/packages/driver/src/cy/commands/screenshot.js
@@ -388,7 +388,7 @@ module.exports = function (Commands, Cypress, cy, state, config) {
   Cypress.on('runnable:after:run:async', (test, runnable) => {
     const screenshotConfig = $Screenshot.getConfig()
 
-    if (!test.err || !screenshotConfig.screenshotOnRunFailure || config('isInteractive') || test.err.isPending || !config('screenshot')) {
+    if (!test.err || !screenshotConfig.screenshotOnRunFailure || config('isInteractive') || test.err.isPending || !config('screenshotOnRunFailure')) {
       return
     }
 

--- a/packages/driver/src/cy/commands/screenshot.js
+++ b/packages/driver/src/cy/commands/screenshot.js
@@ -388,7 +388,7 @@ module.exports = function (Commands, Cypress, cy, state, config) {
   Cypress.on('runnable:after:run:async', (test, runnable) => {
     const screenshotConfig = $Screenshot.getConfig()
 
-    if (!test.err || !screenshotConfig.screenshotOnRunFailure || config('isInteractive') || test.err.isPending) {
+    if (!test.err || !screenshotConfig.screenshotOnRunFailure || config('isInteractive') || test.err.isPending || !config('screenshot')) {
       return
     }
 

--- a/packages/server/lib/config.js
+++ b/packages/server/lib/config.js
@@ -76,7 +76,7 @@ viewportHeight                  responseTimeout
 video                           taskTimeout
 videoCompression
 videoUploadOnPasses
-screenshot
+screenshotOnRunFailure
 watchForFileChanges
 waitForAnimations               resolvedNodeVersion
 nodeVersion                     resolvedNodePath
@@ -143,7 +143,7 @@ const CONFIG_DEFAULTS = {
   video: true,
   videoCompression: 32,
   videoUploadOnPasses: true,
-  screenshot: true,
+  screenshotOnRunFailure: true,
   modifyObstructiveCode: true,
   chromeWebSecurity: true,
   waitForAnimations: true,
@@ -214,7 +214,7 @@ const validationRules = {
   videoCompression: v.isNumberOrFalse,
   videosFolder: v.isString,
   videoUploadOnPasses: v.isBoolean,
-  screenshot: v.isBoolean,
+  screenshotOnRunFailure: v.isBoolean,
   viewportHeight: v.isNumber,
   viewportWidth: v.isNumber,
   waitForAnimations: v.isBoolean,

--- a/packages/server/lib/config.js
+++ b/packages/server/lib/config.js
@@ -76,6 +76,7 @@ viewportHeight                  responseTimeout
 video                           taskTimeout
 videoCompression
 videoUploadOnPasses
+screenshot
 watchForFileChanges
 waitForAnimations               resolvedNodeVersion
 nodeVersion                     resolvedNodePath
@@ -142,6 +143,7 @@ const CONFIG_DEFAULTS = {
   video: true,
   videoCompression: 32,
   videoUploadOnPasses: true,
+  screenshot: true,
   modifyObstructiveCode: true,
   chromeWebSecurity: true,
   waitForAnimations: true,
@@ -212,6 +214,7 @@ const validationRules = {
   videoCompression: v.isNumberOrFalse,
   videosFolder: v.isString,
   videoUploadOnPasses: v.isBoolean,
+  screenshot: v.isBoolean,
   viewportHeight: v.isNumber,
   viewportWidth: v.isNumber,
   waitForAnimations: v.isBoolean,

--- a/packages/server/test/unit/config_spec.js
+++ b/packages/server/test/unit/config_spec.js
@@ -593,6 +593,20 @@ describe('lib/config', () => {
         })
       })
 
+      context('screenshot', () => {
+        it('passes if a boolean', function () {
+          this.setup({ screenshot: false })
+
+          return this.expectValidationPasses()
+        })
+
+        it('fails if not a boolean', function () {
+          this.setup({ screenshot: 42 })
+
+          return this.expectValidationFails('be a boolean')
+        })
+      })
+
       context('viewportHeight', () => {
         it('passes if a number', function () {
           this.setup({ viewportHeight: 10 })
@@ -1125,6 +1139,7 @@ describe('lib/config', () => {
             video: { value: true, from: 'default' },
             videoCompression: { value: 32, from: 'default' },
             videoUploadOnPasses: { value: true, from: 'default' },
+            screenshot: { value: true, from: 'default' },
             videosFolder: { value: 'cypress/videos', from: 'default' },
             supportFile: { value: 'cypress/support', from: 'default' },
             pluginsFile: { value: 'cypress/plugins', from: 'default' },
@@ -1201,6 +1216,7 @@ describe('lib/config', () => {
             video: { value: true, from: 'default' },
             videoCompression: { value: 32, from: 'default' },
             videoUploadOnPasses: { value: true, from: 'default' },
+            screenshot: { value: true, from: 'default' },
             videosFolder: { value: 'cypress/videos', from: 'default' },
             supportFile: { value: 'cypress/support', from: 'default' },
             pluginsFile: { value: 'cypress/plugins', from: 'default' },

--- a/packages/server/test/unit/config_spec.js
+++ b/packages/server/test/unit/config_spec.js
@@ -593,15 +593,15 @@ describe('lib/config', () => {
         })
       })
 
-      context('screenshot', () => {
+      context('screenshotOnRunFailure', () => {
         it('passes if a boolean', function () {
-          this.setup({ screenshot: false })
+          this.setup({ screenshotOnRunFailure: false })
 
           return this.expectValidationPasses()
         })
 
         it('fails if not a boolean', function () {
-          this.setup({ screenshot: 42 })
+          this.setup({ screenshotOnRunFailure: 42 })
 
           return this.expectValidationFails('be a boolean')
         })
@@ -1139,7 +1139,7 @@ describe('lib/config', () => {
             video: { value: true, from: 'default' },
             videoCompression: { value: 32, from: 'default' },
             videoUploadOnPasses: { value: true, from: 'default' },
-            screenshot: { value: true, from: 'default' },
+            screenshotOnRunFailure: { value: true, from: 'default' },
             videosFolder: { value: 'cypress/videos', from: 'default' },
             supportFile: { value: 'cypress/support', from: 'default' },
             pluginsFile: { value: 'cypress/plugins', from: 'default' },
@@ -1216,7 +1216,7 @@ describe('lib/config', () => {
             video: { value: true, from: 'default' },
             videoCompression: { value: 32, from: 'default' },
             videoUploadOnPasses: { value: true, from: 'default' },
-            screenshot: { value: true, from: 'default' },
+            screenshotOnRunFailure: { value: true, from: 'default' },
             videosFolder: { value: 'cypress/videos', from: 'default' },
             supportFile: { value: 'cypress/support', from: 'default' },
             pluginsFile: { value: 'cypress/plugins', from: 'default' },


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes https://github.com/cypress-io/cypress/issues/5029

### User facing changelog

Now you can disable screenshots by setting `screenshotOnRunFailure` to `false` in the configuration. 

### Additional details

- Any suggestions about the configuration option name?
- A PR for the documentation still needs to be opened (I will wait for this PR to be approved to do so)

### How has the user experience changed?

It will be easier to disable screenshots.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/3021
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [x] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
