### PR TITLE
fix: Update visibility check for `position: fixed` combined with `pointer-events: none`

### DIFF
--- a/packages/driver/cypress/integration/dom/visibility_spec.ts
+++ b/packages/driver/cypress/integration/dom/visibility_spec.ts
@@ -244,6 +244,12 @@ describe('src/cypress/dom/visibility', () => {
   <button style='position: fixed; top: 0;'>position: fixed</button>
 </div>`)
 
+      this.$childPointerEventsNone = add(`\
+<div style="position: fixed; top: 40px;">
+  <span style="pointer-events: none;">child pointer-events: none</span>
+</div>\
+`)
+
       this.$descendentPosAbs = add(`\
 <div style='width: 0; height: 100px; overflow: hidden;'>
   <div style='height: 500px; width: 500px; position: absolute;'>
@@ -288,6 +294,18 @@ describe('src/cypress/dom/visibility', () => {
       this.$parentDisplayNone = add(`\
 <div id="none" style='display: none;'>
   <span>parent display: none</span>
+</div>\
+`)
+
+      this.$parentPointerEventsNone = add(`\
+<div style="pointer-events: none;">
+  <span style="position: fixed; top: 20px;">parent pointer-events: none</span>
+</div>\
+`)
+
+      this.$parentPointerEventsNoneCovered = add(`\
+<div style="pointer-events: none;">
+  <span style="position: fixed;">parent pointer-events: none</span>
 </div>\
 `)
 
@@ -688,7 +706,7 @@ describe('src/cypress/dom/visibility', () => {
         expect(this.$coveredUpPosFixed.find('#coveredUpPosFixed')).not.to.be.visible
       })
 
-      it('is hidden if position: fixed and off screent', function () {
+      it('is hidden if position: fixed and off screen', function () {
         expect(this.$offScreenPosFixed).to.be.hidden
         expect(this.$offScreenPosFixed).not.to.be.visible
       })
@@ -701,6 +719,21 @@ describe('src/cypress/dom/visibility', () => {
       it('is hidden if only the parent has position absolute', function () {
         expect(this.$parentPosAbs.find('span')).to.be.hidden
         expect(this.$parentPosAbs.find('span')).to.not.be.visible
+      })
+
+      it('is visible if position: fixed and parent has pointer-events: none', function () {
+        expect(this.$parentPointerEventsNone.find('span')).to.be.visible
+        expect(this.$parentPointerEventsNone.find('span')).to.not.be.hidden
+      })
+
+      it('is not visible if covered when position: fixed and parent has pointer-events: none', function () {
+        expect(this.$parentPointerEventsNoneCovered.find('span')).to.be.hidden
+        expect(this.$parentPointerEventsNoneCovered.find('span')).to.not.be.visible
+      })
+
+      it('is visible if pointer-events: none and parent has position: fixed', function () {
+        expect(this.$childPointerEventsNone.find('span')).to.be.visible
+        expect(this.$childPointerEventsNone.find('span')).to.not.be.hidden
       })
     })
 

--- a/packages/driver/cypress/integration/dom/visibility_spec.ts
+++ b/packages/driver/cypress/integration/dom/visibility_spec.ts
@@ -245,7 +245,7 @@ describe('src/cypress/dom/visibility', () => {
 </div>`)
 
       this.$childPointerEventsNone = add(`\
-<div style="position: fixed; top: 40px;">
+<div style="position: fixed; top: 60px;">
   <span style="pointer-events: none;">child pointer-events: none</span>
 </div>\
 `)
@@ -305,8 +305,9 @@ describe('src/cypress/dom/visibility', () => {
 
       this.$parentPointerEventsNoneCovered = add(`\
 <div style="pointer-events: none;">
-  <span style="position: fixed;">parent pointer-events: none</span>
-</div>\
+  <span style="position: fixed; top: 40px;">parent pointer-events: none</span>
+</div>
+<span style="position: fixed; top: 40px; background: red;">covering the element with pointer-events: none</span>\
 `)
 
       this.$elOutOfParentBoundsToLeft = add(`\

--- a/packages/driver/src/dom/visibility.js
+++ b/packages/driver/src/dom/visibility.js
@@ -242,9 +242,9 @@ const elIsNotElementFromPoint = function ($el) {
   // not visible
 
   // we also check if the element at point is a
-  // visible parent since pointer-events: none
+  // parent that contains the element since pointer-events: none
   // will cause elAtCenterPoint to fall through to parent
-  return !($elements.isDescendent($el, $elAtPoint) || ($elAtPoint && $elements.isDescendent($elAtPoint, $el) && !isHidden($elAtPoint)))
+  return !($elements.isDescendent($el, $elAtPoint) || ($elAtPoint && $elements.isDescendent($elAtPoint, $el) && !elIsOutOfBoundsOfAncestorsOverflow($el)))
 }
 
 const elIsOutOfBoundsOfAncestorsOverflow = function ($el, $ancestor = $el.parent()) {

--- a/packages/driver/src/dom/visibility.js
+++ b/packages/driver/src/dom/visibility.js
@@ -244,7 +244,7 @@ const elIsNotElementFromPoint = function ($el) {
   // we also check if the element at point is a
   // parent since pointer-events: none
   // will cause elAtCenterPoint to fall through to parent
-  return !($elements.isDescendent($el, $elAtPoint) || ($elAtPoint && $elements.isDescendent($elAtPoint, $el)))
+  return !($elements.isDescendent($el, $elAtPoint) || ($elAtPoint && $elements.isAncestor($el, $elAtPoint)))
 }
 
 const elIsOutOfBoundsOfAncestorsOverflow = function ($el, $ancestor = $el.parent()) {

--- a/packages/driver/src/dom/visibility.js
+++ b/packages/driver/src/dom/visibility.js
@@ -242,9 +242,9 @@ const elIsNotElementFromPoint = function ($el) {
   // not visible
 
   // we also check if the element at point is a
-  // parent that contains the element since pointer-events: none
+  // parent since pointer-events: none
   // will cause elAtCenterPoint to fall through to parent
-  return !($elements.isDescendent($el, $elAtPoint) || ($elAtPoint && $elements.isDescendent($elAtPoint, $el) && !elIsOutOfBoundsOfAncestorsOverflow($el)))
+  return !($elements.isDescendent($el, $elAtPoint) || ($elAtPoint && $elements.isDescendent($elAtPoint, $el)))
 }
 
 const elIsOutOfBoundsOfAncestorsOverflow = function ($el, $ancestor = $el.parent()) {

--- a/packages/driver/src/dom/visibility.js
+++ b/packages/driver/src/dom/visibility.js
@@ -240,7 +240,11 @@ const elIsNotElementFromPoint = function ($el) {
   // if the element at point is not a descendent
   // of our $el then we know it's being covered or its
   // not visible
-  return !$elements.isDescendent($el, $elAtPoint)
+
+  // we also check if the element at point is a
+  // visible parent since pointer-events: none
+  // will cause elAtCenterPoint to fall through to parent
+  return !($elements.isDescendent($el, $elAtPoint) || ($elAtPoint && $elements.isDescendent($elAtPoint, $el) && !isHidden($elAtPoint)))
 }
 
 const elIsOutOfBoundsOfAncestorsOverflow = function ($el, $ancestor = $el.parent()) {


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6675

### User facing changelog

Fixes a bug where `position: fixed` combined with `pointer-events: none` can cause an element to be reported as hidden when it is actually visible

### Additional details

`document.elementFromPoint` ignores elements that have `pointer-events: none`, and gets the element underneath instead. Previously, we would just check that that element was the same element or a descendant of the one we were trying to check. This adds another check if the element is a parent, which covers the case that the click fell through (and due to the other checks beforehand, does not accidentally misreport a hidden element as visible).

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
