### PR TITLE
fix: Introduce CypressCommandLine namespace to type NPM module api

### DIFF
--- a/cli/types/cypress-npm-api.d.ts
+++ b/cli/types/cypress-npm-api.d.ts
@@ -6,7 +6,7 @@
 // in the future the NPM module itself will be in TypeScript
 // but for now describe it as an ambient module
 
-declare namespace CypressCmd {
+declare namespace CypressCommandLine {
   /**
    * All options that one can pass to "cypress.run"
    * @see https://on.cypress.io/module-api#cypress-run
@@ -351,19 +351,19 @@ declare module 'cypress' {
      })
      ```
      */
-    run(options?: Partial<CypressCmd.CypressRunOptions>): Promise<CypressCmd.CypressRunResult | CypressCmd.CypressFailedRunResult>,
+    run(options?: Partial<CypressCommandLine.CypressRunOptions>): Promise<CypressCommandLine.CypressRunResult | CypressCommandLine.CypressFailedRunResult>,
     /**
      * Opens Cypress GUI. Resolves with void when the
      * GUI is closed.
      * @see https://on.cypress.io/module-api#cypress-open
      */
-    open(options?: Partial<CypressCmd.CypressOpenOptions>): Promise<void>
+    open(options?: Partial<CypressCommandLine.CypressOpenOptions>): Promise<void>
 
     /**
      * Utility functions for parsing CLI arguments the same way
      * Cypress does
      */
-    cli: CypressCmd.CypressCliParser
+    cli: CypressCommandLine.CypressCliParser
   }
 
   // export Cypress NPM module interface

--- a/cli/types/cypress-npm-api.d.ts
+++ b/cli/types/cypress-npm-api.d.ts
@@ -6,7 +6,7 @@
 // in the future the NPM module itself will be in TypeScript
 // but for now describe it as an ambient module
 
-declare module 'cypress' {
+declare namespace CypressCmd {
   /**
    * All options that one can pass to "cypress.run"
    * @see https://on.cypress.io/module-api#cypress-run
@@ -324,7 +324,9 @@ declare module 'cypress' {
      */
     parseRunArguments(args: string[]): Promise<Partial<CypressRunOptions>>
   }
+}
 
+declare module 'cypress' {
   /**
    * Cypress NPM module interface.
    * @see https://on.cypress.io/module-api
@@ -349,19 +351,19 @@ declare module 'cypress' {
      })
      ```
      */
-    run(options?: Partial<CypressRunOptions>): Promise<CypressRunResult | CypressFailedRunResult>,
+    run(options?: Partial<CypressCmd.CypressRunOptions>): Promise<CypressCmd.CypressRunResult | CypressCmd.CypressFailedRunResult>,
     /**
      * Opens Cypress GUI. Resolves with void when the
      * GUI is closed.
      * @see https://on.cypress.io/module-api#cypress-open
      */
-    open(options?: Partial<CypressOpenOptions>): Promise<void>
+    open(options?: Partial<CypressCmd.CypressOpenOptions>): Promise<void>
 
     /**
      * Utility functions for parsing CLI arguments the same way
      * Cypress does
      */
-    cli: CypressCliParser
+    cli: CypressCmd.CypressCliParser
   }
 
   // export Cypress NPM module interface

--- a/cli/types/tests/cypress-npm-api-test.ts
+++ b/cli/types/tests/cypress-npm-api-test.ts
@@ -40,5 +40,5 @@ const runConfig: Cypress.ConfigOptions = {
 cypress.run({ config: runConfig })
 
 cypress.run({}).then((results) => {
-  results as CypressCmd.CypressRunResult // $ExpectType CypressRunResult
+  results as CypressCommandLine.CypressRunResult // $ExpectType CypressRunResult
 })

--- a/cli/types/tests/cypress-npm-api-test.ts
+++ b/cli/types/tests/cypress-npm-api-test.ts
@@ -38,3 +38,7 @@ const runConfig: Cypress.ConfigOptions = {
   },
 }
 cypress.run({ config: runConfig })
+
+cypress.run({}).then((results) => {
+  results as CypressCmd.CypressRunResult // $ExpectType CypressRunResult
+})


### PR DESCRIPTION
- Closes #7309 

### User facing changelog

Moved types inside `'cypress'` module to `CypressCmd` namespace to make them usable. 

### Additional details

- Why was this change necessary? Types defined in `cypress-npm-api.d.ts` weren't usable for users who want to create their own TypeScript commands.
- What is affected by this change? N/A
- Any implementation details to explain? N/A

### How has the user experience changed?

N/A

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
