### PR TITLE
fix: Fix issue with open hook in IDE on rerun

### DIFF
--- a/packages/driver/src/cypress/mocha.js
+++ b/packages/driver/src/cypress/mocha.js
@@ -97,7 +97,7 @@ function getInvocationDetails (specWindow, config) {
 
     // firefox throws a different stack than chromium
     // which includes this file (mocha.js) and mocha/.../common.js at the top
-    if (specWindow.Cypress && specWindow.Cypress.browser.family === 'firefox') {
+    if (specWindow.Cypress && specWindow.Cypress.isBrowser('firefox')) {
       stack = $stackUtils.stackWithLinesDroppedFromMarker(stack, 'mocha/lib/interfaces/common.js')
     }
 
@@ -114,7 +114,9 @@ function overloadMochaHook (fnName, suite, specWindow, config) {
     this._createHook = function (title, fn) {
       const hook = _createHook.call(this, title, fn)
 
-      hook.invocationDetails = getInvocationDetails(specWindow, config)
+      if (!hook.invocationDetails) {
+        hook.invocationDetails = getInvocationDetails(specWindow, config)
+      }
 
       return hook
     }
@@ -131,7 +133,9 @@ function overloadMochaTest (suite, specWindow, config) {
   const _fn = suite.addTest
 
   suite.addTest = function (test) {
-    test.invocationDetails = getInvocationDetails(specWindow, config)
+    if (!test.invocationDetails) {
+      test.invocationDetails = getInvocationDetails(specWindow, config)
+    }
 
     return _fn.call(this, test)
   }


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8094 

### User facing changelog

Fixes an issue where rerunning a test would cause the hooks `Open in IDE` button to disappear

### Additional details

Having trouble writing a test for this since runner tests don't support rerunning yet

### How has the user experience changed?

Before:

![ezgif-6-ed0eff99d105](https://user-images.githubusercontent.com/7033952/88576352-4cd1df00-d013-11ea-8241-9d461e8e3b49.gif)

After:

![ezgif-6-ccc6b187d7c3](https://user-images.githubusercontent.com/7033952/88607989-aefc0580-d04e-11ea-815d-f3aa23a3de26.gif)

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
