### PR TITLE
feat: Show warning when configuration option is not valid

### DIFF
--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -923,6 +923,13 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
         Enable write permissions to this directory to ensure screenshots and videos are stored.
 
         If you don't require screenshots or videos to be stored you can safely ignore this warning.`
+    case 'INVALID_CONFIG_OPTION':
+      return stripIndent`\
+        Warning:
+      
+        ${arg1.map((arg) => `\`${arg}\` is not a valid configuration option`)}
+
+        https://on.cypress.io/configuration`
     default:
   }
 }

--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -287,6 +287,20 @@ module.exports = {
       options.config = {}
     }
 
+    const invalidConfigOptions = _.keys(options.config).reduce((invalid, option) => {
+      if (!configKeys.find((configKey) => configKey === option)) {
+        invalid.push(option)
+      }
+
+      return invalid
+    }, [])
+
+    if (invalidConfigOptions.length && !options.invokedFromCli) {
+      const err = errors.get('INVALID_CONFIG_OPTION', invalidConfigOptions)
+
+      errors.log(err)
+    }
+
     _.extend(options.config, configValues)
 
     // remove them from the root options object

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -144,11 +144,11 @@ describe('lib/cypress', () => {
     }
 
     // returns error object
-    this.expectExitWithErr = (type, msg1, msg2) => {
+    this.expectExitWithErr = (type, msg1, msg2, call = 0) => {
       expect(errors.log, 'error was logged').to.be.calledWithMatch({ type })
       expect(process.exit, 'process.exit was called').to.be.calledWith(1)
 
-      const err = errors.log.getCall(0).args[0]
+      const err = errors.log.getCall(call).args[0]
 
       if (msg1) {
         expect(err.message, 'error text').to.include(msg1)
@@ -895,8 +895,8 @@ describe('lib/cypress', () => {
         '--config=trashAssetsBeforeHeadlessRuns=false',
       ])
       .then(() => {
-        this.expectExitWithErr('RENAMED_CONFIG_OPTION', 'trashAssetsBeforeHeadlessRuns')
-        this.expectExitWithErr('RENAMED_CONFIG_OPTION', 'trashAssetsBeforeRuns')
+        this.expectExitWithErr('RENAMED_CONFIG_OPTION', 'trashAssetsBeforeHeadlessRuns', null, 1)
+        this.expectExitWithErr('RENAMED_CONFIG_OPTION', 'trashAssetsBeforeRuns', null, 1)
       })
     })
 
@@ -917,8 +917,8 @@ describe('lib/cypress', () => {
         '--config=screenshotOnHeadlessFailure=false',
       ])
       .then(() => {
-        this.expectExitWithErr('SCREENSHOT_ON_HEADLESS_FAILURE_REMOVED', 'screenshotOnHeadlessFailure')
-        this.expectExitWithErr('SCREENSHOT_ON_HEADLESS_FAILURE_REMOVED', 'You now configure this behavior in your test code')
+        this.expectExitWithErr('SCREENSHOT_ON_HEADLESS_FAILURE_REMOVED', 'screenshotOnHeadlessFailure', null, 1)
+        this.expectExitWithErr('SCREENSHOT_ON_HEADLESS_FAILURE_REMOVED', 'You now configure this behavior in your test code', null, 1)
       })
     })
 

--- a/packages/server/test/unit/args_spec.js
+++ b/packages/server/test/unit/args_spec.js
@@ -6,6 +6,7 @@ const snapshot = require('snap-shot-it')
 const stripAnsi = require('strip-ansi')
 const argsUtil = require(`${root}lib/util/args`)
 const getWindowsProxyUtil = require(`${root}lib/util/get-windows-proxy`)
+const errors = require(`${root}lib/errors`)
 
 const cwd = process.cwd()
 
@@ -287,6 +288,16 @@ describe('lib/util/args', () => {
       expect(options.config.supportFile).to.eq('path/to/support_file')
 
       expect(options).not.to.have.property('foo')
+    })
+
+    it('throws a warning if config option is not valid', function () {
+      sinon.spy(errors, 'get')
+      sinon.spy(errors, 'log')
+
+      this.setup('--config', 'foo=bar,baz=foo')
+
+      expect(errors.get).to.be.calledWith('INVALID_CONFIG_OPTION')
+      expect(errors.log).to.be.calledOnce
     })
 
     it('overrides port in config', function () {


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes https://github.com/cypress-io/cypress/issues/428

### User facing changelog

Users will see a warning message when a configuration option is not valid.

### Additional details
![Screenshot 2020-07-28 at 10 26 22](https://user-images.githubusercontent.com/6031800/88639249-da1d3e00-d0bc-11ea-87bd-31ab46bc8df9.png)

### How has the user experience changed?

It will be faster to debug an error related to a typo in the configuration options.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?
