### PR TITLE
fix: Throw error when assertion contains only one language chainer

### DIFF
--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -431,14 +431,34 @@ describe('src/cy/commands/assertions', () => {
         cy.noop({}).should('dee.eq', {})
       })
 
-      it('throws err when assertion contains only one language chainer', (done) => {
-        cy.on('fail', (err) => {
-          expect(err.message).to.eq('The chainer `be` contains only one language chainer. Please use a valid assertion.')
+      describe('language chainers err', () => {
+        // https://github.com/cypress-io/cypress/issues/883
+        const langChainers = ['to', 'be', 'been', 'is', 'that', 'which', 'and', 'has', 'have', 'with', 'at', 'of', 'same', 'but', 'does', 'still']
+        const langChainerCombos = ['be.and.have.same', 'to.have']
 
-          done()
+        langChainers.forEach((langChainer) => {
+          it(`throws err when assertion contains only one language chainer: ${langChainer}`, (done) => {
+            cy.on('fail', (err) => {
+              expect(err.message).to.eq(`The chainer \`${langChainer}\` is a language chainer provided to improve the readability of your assertions, not an actual assertion. Please provide a valid assertion.`)
+
+              done()
+            })
+
+            cy.noop(true).should(langChainer, true)
+          })
         })
 
-        cy.noop(true).should('be', true)
+        langChainerCombos.forEach((langChainerCombos) => {
+          it(`throws err when assertion contains only language chainers: ${langChainerCombos}`, (done) => {
+            cy.on('fail', (err) => {
+              expect(err.message).to.eq(`The chainer \`${langChainerCombos}\` is a language chainer provided to improve the readability of your assertions, not an actual assertion. Please provide a valid assertion.`)
+
+              done()
+            })
+
+            cy.noop(true).should(langChainerCombos, true)
+          })
+        })
       })
 
       it('throws err when ends with a non available chainable', (done) => {

--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -440,6 +440,7 @@ describe('src/cy/commands/assertions', () => {
           it(`throws err when assertion contains only one language chainer: ${langChainer}`, (done) => {
             cy.on('fail', (err) => {
               expect(err.message).to.eq(`The chainer \`${langChainer}\` is a language chainer provided to improve the readability of your assertions, not an actual assertion. Please provide a valid assertion.`)
+              expect(err.docsUrl).to.eq('https://on.cypress.io/assertions')
 
               done()
             })
@@ -452,6 +453,7 @@ describe('src/cy/commands/assertions', () => {
           it(`throws err when assertion contains only language chainers: ${langChainerCombos}`, (done) => {
             cy.on('fail', (err) => {
               expect(err.message).to.eq(`The chainer \`${langChainerCombos}\` is a language chainer provided to improve the readability of your assertions, not an actual assertion. Please provide a valid assertion.`)
+              expect(err.docsUrl).to.eq('https://on.cypress.io/assertions')
 
               done()
             })

--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -431,6 +431,16 @@ describe('src/cy/commands/assertions', () => {
         cy.noop({}).should('dee.eq', {})
       })
 
+      it('throws err when assertion contains only one language chainer', (done) => {
+        cy.on('fail', (err) => {
+          expect(err.message).to.eq('The chainer `be` contains only one language chainer. Please use a valid assertion.')
+
+          done()
+        })
+
+        cy.noop(true).should('be', true)
+      })
+
       it('throws err when ends with a non available chainable', (done) => {
         cy.on('fail', (err) => {
           expect(err.message).to.eq('The chainer `eq2` was not found. Could not build assertion.')

--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -434,7 +434,6 @@ describe('src/cy/commands/assertions', () => {
       describe('language chainers err', () => {
         // https://github.com/cypress-io/cypress/issues/883
         const langChainers = ['to', 'be', 'been', 'is', 'that', 'which', 'and', 'has', 'have', 'with', 'at', 'of', 'same', 'but', 'does', 'still']
-        const langChainerCombos = ['be.and.have.same', 'to.have']
 
         langChainers.forEach((langChainer) => {
           it(`throws err when assertion contains only one language chainer: ${langChainer}`, (done) => {
@@ -446,19 +445,6 @@ describe('src/cy/commands/assertions', () => {
             })
 
             cy.noop(true).should(langChainer, true)
-          })
-        })
-
-        langChainerCombos.forEach((langChainerCombos) => {
-          it(`throws err when assertion contains only language chainers: ${langChainerCombos}`, (done) => {
-            cy.on('fail', (err) => {
-              expect(err.message).to.eq(`The chainer \`${langChainerCombos}\` is a language chainer provided to improve the readability of your assertions, not an actual assertion. Please provide a valid assertion.`)
-              expect(err.docsUrl).to.eq('https://on.cypress.io/assertions')
-
-              done()
-            })
-
-            cy.noop(true).should(langChainerCombos, true)
           })
         })
       })

--- a/packages/driver/src/cy/commands/asserting.js
+++ b/packages/driver/src/cy/commands/asserting.js
@@ -85,26 +85,6 @@ module.exports = function (Commands, Cypress, cy, state) {
             throw err
           }
         } else {
-          const validLastLanguageChainers = [
-            'visible',
-            'hidden',
-            'selected',
-            'checked',
-            'enabled',
-            'disabled',
-            'focus',
-            'focused',
-            'true',
-            'false',
-          ]
-
-          // https://github.com/cypress-io/cypress/issues/883
-          if (!validLastLanguageChainers.find((chainer) => chainer === value) && !isCheckingExistence) {
-            err = $errUtils.cypressErrByPath('should.language_chainer', { args: { originalChainers } })
-            err.retry = false
-            throwAndLogErr(err)
-          }
-
           return memo[value]
         }
       } else {
@@ -126,6 +106,12 @@ module.exports = function (Commands, Cypress, cy, state) {
       const newExp = _.reduce(chainers, (memo, value) => {
         if (!(value in memo)) {
           err = $errUtils.cypressErrByPath('should.chainer_not_found', { args: { chainer: value } })
+          err.retry = false
+          throwAndLogErr(err)
+        }
+
+        if (chainers.length < 2 && !_.isFunction(memo[value]) && !isCheckingExistence) {
+          err = $errUtils.cypressErrByPath('should.language_chainer', { args: { chainer: value } })
           err.retry = false
           throwAndLogErr(err)
         }

--- a/packages/driver/src/cy/commands/asserting.js
+++ b/packages/driver/src/cy/commands/asserting.js
@@ -110,6 +110,12 @@ module.exports = function (Commands, Cypress, cy, state) {
           throwAndLogErr(err)
         }
 
+        if (chainers.length < 2 && !_.isFunction(memo[value]) && !isCheckingExistence) {
+          err = $errUtils.cypressErrByPath('should.language_chainer', { args: { chainer: value } })
+          err.retry = false
+          throwAndLogErr(err)
+        }
+
         return applyChainer(memo, value)
       }, exp)
 

--- a/packages/driver/src/cy/commands/asserting.js
+++ b/packages/driver/src/cy/commands/asserting.js
@@ -111,7 +111,7 @@ module.exports = function (Commands, Cypress, cy, state) {
         }
 
         if (chainers.length < 2 && !_.isFunction(memo[value]) && !isCheckingExistence) {
-          err = $errUtils.cypressErrByPath('should.language_chainer', { args: { chainer: value } })
+          err = $errUtils.cypressErrByPath('should.language_chainer', { args: { originalChainers } })
           err.retry = false
           throwAndLogErr(err)
         }

--- a/packages/driver/src/cy/commands/asserting.js
+++ b/packages/driver/src/cy/commands/asserting.js
@@ -110,6 +110,8 @@ module.exports = function (Commands, Cypress, cy, state) {
           throwAndLogErr(err)
         }
 
+        // https://github.com/cypress-io/cypress/issues/883
+        // A single chainer used that is not an actual assertion, like '.should('be', 'true')'
         if (chainers.length < 2 && !_.isFunction(memo[value]) && !isCheckingExistence) {
           err = $errUtils.cypressErrByPath('should.language_chainer', { args: { originalChainers } })
           err.retry = false

--- a/packages/driver/src/cy/commands/asserting.js
+++ b/packages/driver/src/cy/commands/asserting.js
@@ -85,6 +85,26 @@ module.exports = function (Commands, Cypress, cy, state) {
             throw err
           }
         } else {
+          const validLastLanguageChainers = [
+            'visible',
+            'hidden',
+            'selected',
+            'checked',
+            'enabled',
+            'disabled',
+            'focus',
+            'focused',
+            'true',
+            'false',
+          ]
+
+          // https://github.com/cypress-io/cypress/issues/883
+          if (!validLastLanguageChainers.find((chainer) => chainer === value) && !isCheckingExistence) {
+            err = $errUtils.cypressErrByPath('should.language_chainer', { args: { originalChainers } })
+            err.retry = false
+            throwAndLogErr(err)
+          }
+
           return memo[value]
         }
       } else {
@@ -106,12 +126,6 @@ module.exports = function (Commands, Cypress, cy, state) {
       const newExp = _.reduce(chainers, (memo, value) => {
         if (!(value in memo)) {
           err = $errUtils.cypressErrByPath('should.chainer_not_found', { args: { chainer: value } })
-          err.retry = false
-          throwAndLogErr(err)
-        }
-
-        if (chainers.length < 2 && !_.isFunction(memo[value]) && !isCheckingExistence) {
-          err = $errUtils.cypressErrByPath('should.language_chainer', { args: { chainer: value } })
           err.retry = false
           throwAndLogErr(err)
         }

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -1361,7 +1361,7 @@ module.exports = {
 
   should: {
     chainer_not_found: 'The chainer `{{chainer}}` was not found. Could not build assertion.',
-    language_chainer: 'The chainer `{{chainer}}` contains only one language chainer. Please use a valid assertion.',
+    language_chainer: 'The chainer `{{chainer}}` is a language chainer provided to improve the readability of your assertions, not an actual assertion. Please provide a valid assertion.',
     eventually_deprecated: 'The `eventually` assertion chainer has been deprecated. This is now the default behavior so you can safely remove this word and everything should work as before.',
   },
 

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -1361,6 +1361,7 @@ module.exports = {
 
   should: {
     chainer_not_found: 'The chainer `{{chainer}}` was not found. Could not build assertion.',
+    language_chainer: 'The chainer `{{chainer}}` contains only one language chainer. Please use a valid assertion.',
     eventually_deprecated: 'The `eventually` assertion chainer has been deprecated. This is now the default behavior so you can safely remove this word and everything should work as before.',
   },
 

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -1361,7 +1361,10 @@ module.exports = {
 
   should: {
     chainer_not_found: 'The chainer `{{chainer}}` was not found. Could not build assertion.',
-    language_chainer: 'The chainer `{{originalChainers}}` is a language chainer provided to improve the readability of your assertions, not an actual assertion. Please provide a valid assertion.',
+    language_chainer: {
+      message: 'The chainer `{{originalChainers}}` is a language chainer provided to improve the readability of your assertions, not an actual assertion. Please provide a valid assertion.',
+      docsUrl: 'https://on.cypress.io/assertions',
+    },
     eventually_deprecated: 'The `eventually` assertion chainer has been deprecated. This is now the default behavior so you can safely remove this word and everything should work as before.',
   },
 

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -1361,7 +1361,7 @@ module.exports = {
 
   should: {
     chainer_not_found: 'The chainer `{{chainer}}` was not found. Could not build assertion.',
-    language_chainer: 'The chainer `{{chainer}}` is a language chainer provided to improve the readability of your assertions, not an actual assertion. Please provide a valid assertion.',
+    language_chainer: 'The chainer `{{originalChainers}}` is a language chainer provided to improve the readability of your assertions, not an actual assertion. Please provide a valid assertion.',
     eventually_deprecated: 'The `eventually` assertion chainer has been deprecated. This is now the default behavior so you can safely remove this word and everything should work as before.',
   },
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

* Closes https://github.com/cypress-io/cypress/issues/883

### User facing changelog
An error is now thrown when incorrectly using a single language chainer instead of an actual assertion, which would previously lead to falsely passing assertions.

### How has the user experience changed?
Previously false positives caused by the usage of one language chain as an assertion will now fail with message: 

>The chainer `be` is a language chainer provided to improve the readability of your assertions, not an actual assertion. Please provide a valid assertion.
>https://on.cypress.io/assertions

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

* [x] Have tests been added/updated?



┆Issue is synchronized with this [Jira Bug](https://cypress-io.atlassian.net/browse/TR-171) by [Unito](https://www.unito.io/learn-more)
