### PR TITLE
feat(net-stubbing): throttle/delay for StaticResponses

### DIFF
--- a/packages/driver/src/cy/net-stubbing/events/index.ts
+++ b/packages/driver/src/cy/net-stubbing/events/index.ts
@@ -38,6 +38,10 @@ export function registerEvents (Cypress: Cypress.Cypress) {
   function emitNetEvent (eventName: string, frame: any): Promise<void> {
     // all messages from driver to server are wrapped in backend:request
     return Cypress.backend('net', eventName, frame)
+    .catch((err) => {
+      err.message = `An error was thrown while processing a network event: ${err.message}`
+      failCurrentTest(err)
+    })
   }
 
   function failCurrentTest (err: Error) {

--- a/packages/driver/src/cy/net-stubbing/static-response-utils.ts
+++ b/packages/driver/src/cy/net-stubbing/static-response-utils.ts
@@ -56,16 +56,16 @@ export function validateStaticResponse (cmd: string, staticResponse: StaticRespo
 
   if (!_.isUndefined(throttleKbps)) {
     if (_.isNumber(throttleKbps) && (throttleKbps < 0 || !_.isFinite(throttleKbps))) {
-      throw new Error('`throttleKbps` must be a finite, positive number.')
+      err('`throttleKbps` must be a finite, positive number.')
     } else if (_.isString(throttleKbps) && !getNetworkThrottlePreset(throttleKbps)) {
-      throw new Error(`An invalid \`throttleKbps\` preset was passed. Valid presets are: ${_.keys(NETWORK_THROTTLE_PRESETS).join(', ')}`)
+      err(`An invalid \`throttleKbps\` preset was passed. Valid presets are: ${_.keys(NETWORK_THROTTLE_PRESETS).join(', ')}`)
     } else if (!_.isString(throttleKbps) && !_.isNumber(throttleKbps)) {
-      throw new Error('`throttleKbps` must be a finite, positive number or a string preset.')
+      err('`throttleKbps` must be a finite, positive number or a string preset.')
     }
   }
 
   if (delayMs && (!_.isFinite(delayMs) || delayMs < 0)) {
-    throw new Error('`delayMs` must be a finite, positive number.')
+    err('`delayMs` must be a finite, positive number.')
   }
 }
 

--- a/packages/driver/src/cy/net-stubbing/static-response-utils.ts
+++ b/packages/driver/src/cy/net-stubbing/static-response-utils.ts
@@ -4,18 +4,33 @@ import {
   StaticResponse,
   BackendStaticResponse,
   FixtureOpts,
-  GenericStaticResponse,
+  ThrottleKbpsPreset,
 } from '@packages/net-stubbing/lib/types'
 import $errUtils from '../../cypress/error_utils'
 
-export const STATIC_RESPONSE_KEYS: (keyof GenericStaticResponse<void, void>)[] = ['body', 'fixture', 'statusCode', 'headers', 'forceNetworkError']
+// based off of https://source.chromium.org/chromium/chromium/src/+/master:chrome/test/chromedriver/chrome/network_list.cc
+const NETWORK_THROTTLE_PRESETS: { [preset: string]: number } = {
+  'gprs': 50,
+  'edge': 250,
+  '2g+': 450,
+  '3g': 750,
+  '3g+': 1536,
+  '4g': 4096,
+  'dsl': 2048,
+  'wifi': 30720,
+}
+
+const getNetworkThrottlePreset = (preset: ThrottleKbpsPreset) => NETWORK_THROTTLE_PRESETS[preset]
+
+// user-facing StaticResponse only
+export const STATIC_RESPONSE_KEYS: (keyof StaticResponse)[] = ['body', 'fixture', 'statusCode', 'headers', 'forceNetworkError', 'throttleKbps', 'delayMs']
 
 export function validateStaticResponse (cmd: string, staticResponse: StaticResponse): void {
   const err = (message) => {
     $errUtils.throwErrByPath('net_stubbing.invalid_static_response', { args: { cmd, message, staticResponse } })
   }
 
-  const { body, fixture, statusCode, headers, forceNetworkError } = staticResponse
+  const { body, fixture, statusCode, headers, forceNetworkError, throttleKbps, delayMs } = staticResponse
 
   if (forceNetworkError && (body || statusCode || headers)) {
     err('`forceNetworkError`, if passed, must be the only option in the StaticResponse.')
@@ -37,6 +52,20 @@ export function validateStaticResponse (cmd: string, staticResponse: StaticRespo
 
   if (headers && _.keys(_.omitBy(headers, _.isString)).length) {
     err('`headers` must be a map of strings to strings.')
+  }
+
+  if (!_.isUndefined(throttleKbps)) {
+    if (_.isNumber(throttleKbps) && (throttleKbps < 0 || !_.isFinite(throttleKbps))) {
+      throw new Error('`throttleKbps` must be a finite, positive number.')
+    } else if (_.isString(throttleKbps) && !getNetworkThrottlePreset(throttleKbps)) {
+      throw new Error(`An invalid \`throttleKbps\` preset was passed. Valid presets are: ${_.keys(NETWORK_THROTTLE_PRESETS).join(', ')}`)
+    } else if (!_.isString(throttleKbps) && !_.isNumber(throttleKbps)) {
+      throw new Error('`throttleKbps` must be a finite, positive number or a string preset.')
+    }
+  }
+
+  if (delayMs && (!_.isFinite(delayMs) || delayMs < 0)) {
+    throw new Error('`delayMs` must be a finite, positive number.')
   }
 }
 
@@ -80,7 +109,7 @@ function getFixtureOpts (fixture: string): FixtureOpts {
 }
 
 export function getBackendStaticResponse (staticResponse: Readonly<StaticResponse>): BackendStaticResponse {
-  const backendStaticResponse: BackendStaticResponse = _.omit(staticResponse, 'body', 'fixture')
+  const backendStaticResponse: BackendStaticResponse = _.omit(staticResponse, 'body', 'fixture', 'throttleKbps', 'delayMs')
 
   if (staticResponse.fixture) {
     backendStaticResponse.fixture = getFixtureOpts(staticResponse.fixture)
@@ -93,6 +122,16 @@ export function getBackendStaticResponse (staticResponse: Readonly<StaticRespons
       backendStaticResponse.body = JSON.stringify(staticResponse.body)
       _.set(backendStaticResponse, 'headers.content-type', 'application/json')
     }
+  }
+
+  if (!_.isUndefined(staticResponse.throttleKbps)) {
+    const kbps = staticResponse.throttleKbps
+
+    backendStaticResponse.throttleKbps = _.isString(kbps) ? getNetworkThrottlePreset(kbps) : kbps
+  }
+
+  if (staticResponse.delayMs) {
+    backendStaticResponse.continueResponseAt = Date.now() + staticResponse.delayMs
   }
 
   return backendStaticResponse

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -178,9 +178,16 @@ export type RouteHandler = string | StaticResponse | RouteHandlerController | ob
 /**
  * Describes a response that will be sent back to the browser to fulfill the request.
  */
-export type StaticResponse = GenericStaticResponse<string, string | object>
+export type StaticResponse = GenericStaticResponse<string, string | object, number | ThrottleKbpsPreset> & {
+  /**
+  * If set, `delayMs` will pass before the response is sent.
+  */
+ delayMs?: number
+}
 
-export interface GenericStaticResponse<Fixture, Body> {
+export type ThrottleKbpsPreset = 'gprs' | 'edge' | '2g+' | '3g' | '3g+' | '4g' | 'dsl' | 'wifi'
+
+export interface GenericStaticResponse<Fixture, Body, ThrottleKbps> {
   /**
    * If set, serve a fixture as the response body.
    */
@@ -201,6 +208,10 @@ export interface GenericStaticResponse<Fixture, Body> {
    * If `forceNetworkError` is truthy, Cypress will destroy the connection to the browser and send no response. Useful for simulating a server that is not reachable. Must not be set in combination with other options.
    */
   forceNetworkError?: boolean
+  /**
+   * If set, the `body` will be sent at `throttleKbps` kbps.
+   */
+  throttleKbps?: ThrottleKbps
 }
 
 /**

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -178,16 +178,14 @@ export type RouteHandler = string | StaticResponse | RouteHandlerController | ob
 /**
  * Describes a response that will be sent back to the browser to fulfill the request.
  */
-export type StaticResponse = GenericStaticResponse<string, string | object, number | ThrottleKbpsPreset> & {
+export type StaticResponse = GenericStaticResponse<string, string | object> & {
   /**
   * If set, `delayMs` will pass before the response is sent.
   */
  delayMs?: number
 }
 
-export type ThrottleKbpsPreset = 'gprs' | 'edge' | '2g+' | '3g' | '3g+' | '4g' | 'dsl' | 'wifi'
-
-export interface GenericStaticResponse<Fixture, Body, ThrottleKbps> {
+export interface GenericStaticResponse<Fixture, Body> {
   /**
    * If set, serve a fixture as the response body.
    */
@@ -211,7 +209,7 @@ export interface GenericStaticResponse<Fixture, Body, ThrottleKbps> {
   /**
    * If set, the `body` will be sent at `throttleKbps` kbps.
    */
-  throttleKbps?: ThrottleKbps
+  throttleKbps?: number
 }
 
 /**

--- a/packages/net-stubbing/lib/internal-types.ts
+++ b/packages/net-stubbing/lib/internal-types.ts
@@ -10,7 +10,10 @@ export type FixtureOpts = {
   filePath: string
 }
 
-export type BackendStaticResponse = GenericStaticResponse<FixtureOpts, string>
+export type BackendStaticResponse = GenericStaticResponse<FixtureOpts, string, number> & {
+  // Millisecond timestamp for when the response should continue
+  continueResponseAt?: number
+}
 
 export const SERIALIZABLE_REQ_PROPS = [
   'headers',

--- a/packages/net-stubbing/lib/internal-types.ts
+++ b/packages/net-stubbing/lib/internal-types.ts
@@ -10,7 +10,7 @@ export type FixtureOpts = {
   filePath: string
 }
 
-export type BackendStaticResponse = GenericStaticResponse<FixtureOpts, string, number> & {
+export type BackendStaticResponse = GenericStaticResponse<FixtureOpts, string> & {
   // Millisecond timestamp for when the response should continue
   continueResponseAt?: number
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7661


### User facing changelog

- Added the capability to specify `delayMs` and `throttleKbps` when stubbing static responses using `cy.route2`.

### Additional details

- [x] decide if merging into #4176  or waiting for that to merge first 

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here --> https://github.com/cypress-io/cypress-documentation/pull/3144
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
