### PR TITLE
fix: inline element with visibile child now is considered visible

### DIFF
--- a/packages/driver/cypress/integration/dom/visibility_spec.ts
+++ b/packages/driver/cypress/integration/dom/visibility_spec.ts
@@ -310,6 +310,14 @@ describe('src/cypress/dom/visibility', () => {
 <span style="position: fixed; top: 40px; background: red;">covering the element with pointer-events: none</span>\
 `)
 
+      this.$parentDisplayInlineChildDisplayBlock = add(`\
+<div>
+  <span>
+    <label style="display: block;">display: block</label>
+  </span>
+</div>\
+`)
+
       this.$elOutOfParentBoundsToLeft = add(`\
 <div style='width: 100px; height: 100px; overflow: hidden; position: relative;'>
   <span style='position: absolute; left: -400px; top: 0px;'>position: absolute, out of bounds left</span>
@@ -735,6 +743,14 @@ describe('src/cypress/dom/visibility', () => {
       it('is visible if pointer-events: none and parent has position: fixed', function () {
         expect(this.$childPointerEventsNone.find('span')).to.be.visible
         expect(this.$childPointerEventsNone.find('span')).to.not.be.hidden
+      })
+    })
+
+    describe('css display', function () {
+      // https://github.com/cypress-io/cypress/issues/6183
+      it('parent is visible if display inline and child has display block', function () {
+        expect(this.$parentDisplayInlineChildDisplayBlock.find('span')).to.be.visible
+        expect(this.$parentDisplayInlineChildDisplayBlock.find('span')).to.not.be.hidden
       })
     })
 

--- a/packages/driver/src/dom/visibility.js
+++ b/packages/driver/src/dom/visibility.js
@@ -52,6 +52,11 @@ const isHidden = (el, name = 'isHidden()') => {
   // either its offsetHeight or offsetWidth is 0 because
   // it is impossible for the user to interact with this element
   if (elHasNoEffectiveWidthOrHeight($el)) {
+    // https://github.com/cypress-io/cypress/issues/6183
+    if (elHasDisplayInline($el)) {
+      return !elHasVisibleChild($el)
+    }
+
     return true // is hidden
   }
 
@@ -152,6 +157,10 @@ const elHasDisplayNone = ($el) => {
   return $el.css('display') === 'none'
 }
 
+const elHasDisplayInline = ($el) => {
+  return $el.css('display') === 'inline'
+}
+
 const elHasOverflowHidden = function ($el) {
   const cssOverflow = [$el.css('overflow'), $el.css('overflow-y'), $el.css('overflow-x')]
 
@@ -227,6 +236,12 @@ const elDescendentsHavePositionFixedOrAbsolute = function ($parent, $child) {
 
   return _.some($els.get(), (el) => {
     return fixedOrAbsoluteRe.test($jquery.wrap(el).css('position'))
+  })
+}
+
+const elHasVisibleChild = function ($el) {
+  return _.some($el.children(), (el) => {
+    return isVisible(el)
   })
 }
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #6183 

### User facing changelog

Fixes an issue where a `display: inline` parent would be considered hidden if it had a visible child who had `display: block`

### Additional details

~I do not think that implementing this fix is an appropriate course of action, see this comment in the original issue: https://github.com/cypress-io/cypress/issues/6183#issuecomment-666502078.~ Updated comment: https://github.com/cypress-io/cypress/pull/8130#issuecomment-673131654

I would like to have a discussion around this before we decide to merge these changes.

### How has the user experience changed?

Given the following test case (modified here so may not work exactly, but shows the general idea, actual test case can be seen in diff):

```javascript
const element = `
<div>
  <span>
    <label style="display: block;">display: block</label>
  </span>
</div>
`

it('parent is visible if display inline and child has display block', function () {
  expect(element.find('span')).to.be.visible
  expect(element.find('span')).to.not.be.hidden
})
```

Before:

![Screen Shot 2020-07-30 at 11 51 56 AM](https://user-images.githubusercontent.com/7033952/88945752-5f8b2480-d25c-11ea-8774-d94b477a3f1f.png)

After:

![Screen Shot 2020-07-30 at 11 51 15 AM](https://user-images.githubusercontent.com/7033952/88945759-631eab80-d25c-11ea-8e0e-bcf0954f8463.png)

Given the original test case from the issue:

```html
<html>
<body>
  <p>
    <span onmouseover="window.hover.style.display='block'" onmouseout="window.hover.style.display='none'">
      <label style="display: block">Hover me!</label>
    </span>
  </p>
  <p id="hover" style="display: none">
    Hovering!
  </p>
</body>
</html>
```

```javascript
it("should work", () => {
  cy.visit("index.html")
  cy.get("span").trigger("mouseover")
})
```

Before:

![](http://g.recordit.co/wM7K5ew7Hr.gif)

After:

![Screen Shot 2020-07-30 at 12 10 19 PM](https://user-images.githubusercontent.com/7033952/88946787-aaf20280-d25d-11ea-8166-f5dcb9f7479c.png)

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->