### PR TITLE
fix: Cookie interface expiry prop

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -5110,7 +5110,7 @@ declare namespace Cypress {
     domain: string
     httpOnly: boolean
     secure: boolean
-    expiry?: string
+    expiry?: number
     sameSite?: SameSiteStatus
   }
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8144

### User facing changelog

<!--
Explain the change(s) for every user to read in our changelog.
-->

Correct type for Cookie['expiry']
