### PR TITLE
fix: Capture env vars from AWS Code Build

### DIFF
--- a/packages/server/__snapshots__/cypress_spec.js
+++ b/packages/server/__snapshots__/cypress_spec.js
@@ -60,6 +60,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 
 - appveyor
 - azure
+- awsCodeBuild
 - bamboo
 - bitbucket
 - buildkite
@@ -95,6 +96,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 
 - appveyor
 - azure
+- awsCodeBuild
 - bamboo
 - bitbucket
 - buildkite
@@ -131,6 +133,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 
 - appveyor
 - azure
+- awsCodeBuild
 - bamboo
 - bitbucket
 - buildkite

--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -30,6 +30,12 @@ const isAzureCi = () => {
   return process.env.TF_BUILD && process.env.AZURE_HTTP_USER_AGENT
 }
 
+const isAWSCodeBuild = () => {
+  return _.some(process.env, (val, key) => {
+    return /^CODEBUILD_/.test(key)
+  })
+}
+
 const isBamboo = () => {
   return process.env.bamboo_buildNumber
 }
@@ -82,6 +88,7 @@ const isWercker = () => {
 const CI_PROVIDERS = {
   'appveyor': 'APPVEYOR',
   'azure': isAzureCi,
+  'awsCodeBuild': isAWSCodeBuild,
   'bamboo': isBamboo,
   'bitbucket': 'BITBUCKET_BUILD_NUMBER',
   'buildkite': 'BUILDKITE',
@@ -138,6 +145,13 @@ const _providerCiParams = () => {
       'BUILD_BUILDNUMBER',
       'BUILD_CONTAINERID',
       'BUILD_REPOSITORY_URI',
+    ]),
+    awsCodeBuild: extract([
+      'CODEBUILD_BUILD_ID',
+      'CODEBUILD_BUILD_NUMBER',
+      'CODEBUILD_RESOLVED_SOURCE_VERSION',
+      'CODEBUILD_SOURCE_REPO_URL',
+      'CODEBUILD_SOURCE_VERSION',
     ]),
     bamboo: extract([
       'bamboo_buildNumber',
@@ -373,6 +387,15 @@ const _providerCommitParams = () => {
       authorName: env.APPVEYOR_REPO_COMMIT_AUTHOR,
       authorEmail: env.APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL,
       // remoteOrigin: ???
+      // defaultBranch: ???
+    },
+    awsCodeBuild: {
+      sha: env.CODEBUILD_RESOLVED_SOURCE_VERSION,
+      // branch: ???,
+      // message: ???
+      // authorName: ???
+      // authorEmail: ???
+      remoteOrigin: env.CODEBUILD_SOURCE_REPO_URL,
       // defaultBranch: ???
     },
     azure: {

--- a/packages/server/test/unit/ci_provider_spec.js
+++ b/packages/server/test/unit/ci_provider_spec.js
@@ -114,6 +114,30 @@ describe('lib/util/ci_provider', () => {
     })
   })
 
+  it('awsCodeBuild', () => {
+    resetEnv = mockedEnv({
+      CODEBUILD_BUILD_ID: 'codebuild-demo-project:b1e6661e-e4f2-4156-9ab9-82a19EXAMPLE',
+      CODEBUILD_BUILD_NUMBER: '123',
+      CODEBUILD_RESOLVED_SOURCE_VERSION: 'commit',
+      CODEBUILD_SOURCE_REPO_URL: 'repositoryUrl',
+      CODEBUILD_SOURCE_VERSION: 'commitOrBranchOrTag',
+    }, { clear: true })
+
+    expectsName('awsCodeBuild')
+    expectsCiParams({
+      codebuildBuildId: 'codebuild-demo-project:b1e6661e-e4f2-4156-9ab9-82a19EXAMPLE',
+      codebuildBuildNumber: '123',
+      codebuildResolvedSourceVersion: 'commit',
+      codebuildSourceRepoUrl: 'repositoryUrl',
+      codebuildSourceVersion: 'commitOrBranchOrTag',
+    })
+
+    return expectsCommitParams({
+      sha: 'commit',
+      remoteOrigin: 'repositoryUrl',
+    })
+  })
+
   it('bamboo', () => {
     resetEnv = mockedEnv({
       'bamboo_buildNumber': 'bambooBuildNumber',


### PR DESCRIPTION
- Close #8101 

### User Changelog

- We now collect environment variables for AWS CodeBuild when recording to the Dashboard.

### Additional Details

AWS CodeBuild env vars: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/3046