### PR TITLE
fix: truncate screenshot filenames using byteLength

### DIFF
--- a/packages/server/__snapshots__/5_screenshots_spec.js
+++ b/packages/server/__snapshots__/5_screenshots_spec.js
@@ -147,11 +147,11 @@ Because this error occurred during a \`after each\` hook we are skipping the rem
   -  /XXX/XXX/XXX/cypress/screenshots/screenshots_spec.js/taking screenshots -- reall     (1000x660)
      y long test title aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa               
      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa               
-     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.png                                                          
+     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.png                           
   -  /XXX/XXX/XXX/cypress/screenshots/screenshots_spec.js/taking screenshots -- reall     (1000x660)
      y long test title aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa               
      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa               
-     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (1).png                                                      
+     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (1).png                           
 
 
   (Video)

--- a/packages/server/__snapshots__/5_screenshots_spec.js
+++ b/packages/server/__snapshots__/5_screenshots_spec.js
@@ -147,11 +147,11 @@ Because this error occurred during a \`after each\` hook we are skipping the rem
   -  /XXX/XXX/XXX/cypress/screenshots/screenshots_spec.js/taking screenshots -- reall     (1000x660)
      y long test title aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa               
      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa               
-     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.png                           
+     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.png                                        
   -  /XXX/XXX/XXX/cypress/screenshots/screenshots_spec.js/taking screenshots -- reall     (1000x660)
      y long test title aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa               
      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa               
-     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (1).png                           
+     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (1).png                                        
 
 
   (Video)

--- a/packages/server/lib/screenshots.js
+++ b/packages/server/lib/screenshots.js
@@ -309,6 +309,8 @@ const ensureSafePath = function (withoutExt, extension, num = 0) {
 
   const fullPath = [withoutExt, suffix].join('')
 
+  debug('ensureSafePath %o', { withoutExt, extension, num, maxSafeBytes, maxSafePrefixBytes })
+
   return fs.pathExists(fullPath)
   .then((found) => {
     if (found) {
@@ -319,6 +321,8 @@ const ensureSafePath = function (withoutExt, extension, num = 0) {
     return fs.outputFileAsync(fullPath, '')
     .then(() => fullPath)
     .catch((err) => {
+      debug('received error when testing path %o', { err, fullPath, maxSafePrefixBytes, maxSafeBytes })
+
       if (err.code === 'ENAMETOOLONG' && maxSafePrefixBytes >= MIN_PREFIX_BYTES) {
         maxSafeBytes -= 1
 

--- a/packages/server/lib/screenshots.js
+++ b/packages/server/lib/screenshots.js
@@ -21,7 +21,7 @@ let __ID__ = null
 // many filesystems limit filename length to 255 bytes/characters, so truncate the filename to
 // the smallest common denominator of safe filenames, which is 255 bytes. when ENAMETOOLONG
 // errors are encountered, `maxSafeBytes` will be decremented to at most `MIN_PREFIX_BYTES`, at
-// which point the latest ENAMTOOLONG error will be emitted.
+// which point the latest ENAMETOOLONG error will be emitted.
 // @see https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits
 let maxSafeBytes = Number(process.env.CYPRESS_MAX_SAFE_FILENAME_BYTES) || 254
 const MIN_PREFIX_BYTES = 64

--- a/packages/server/lib/screenshots.js
+++ b/packages/server/lib/screenshots.js
@@ -23,7 +23,7 @@ let __ID__ = null
 // errors are encountered, `maxSafeBytes` will be decremented to at most `MIN_PREFIX_BYTES`, at
 // which point the latest ENAMTOOLONG error will be emitted.
 // @see https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits
-let maxSafeBytes = 255
+let maxSafeBytes = Number(process.env.CYPRESS_MAX_SAFE_FILENAME_BYTES) || 254
 const MIN_PREFIX_BYTES = 64
 
 // TODO: when we parallelize these builds we'll need

--- a/packages/server/lib/screenshots.js
+++ b/packages/server/lib/screenshots.js
@@ -18,6 +18,14 @@ const pathSeparatorRe = /[\\\/]/g
 // internal id incrementor
 let __ID__ = null
 
+// many filesystems limit filename length to 255 bytes/characters, so truncate the filename to
+// the smallest common denominator of safe filenames, which is 255 bytes. when ENAMETOOLONG
+// errors are encountered, `maxSafeBytes` will be decremented to at most `MIN_PREFIX_BYTES`, at
+// which point the latest ENAMTOOLONG error will be emitted.
+// @see https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits
+let maxSafeBytes = 255
+const MIN_PREFIX_BYTES = 64
+
 // TODO: when we parallelize these builds we'll need
 // a semaphore to access the file system when we write
 // screenshots since its possible two screenshots with
@@ -288,17 +296,13 @@ const getDimensions = function (details) {
   return pick(details.image.bitmap)
 }
 
-const ensureUniquePath = function (withoutExt, extension, num = 0) {
+const ensureSafePath = function (withoutExt, extension, num = 0) {
   const suffix = `${num ? ` (${num})` : ''}.${extension}`
-  // many filesystems limit filename length to 255 bytes/characters, so truncate the filename to
-  // the smallest common denominator of safe filenames, which is 255 bytes
-  // @see https://github.com/cypress-io/cypress/issues/2403
-  // @see https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits
-  const maxSafeBytes = 255 - suffix.length
+  const maxSafePrefixBytes = maxSafeBytes - suffix.length
   const filenameBuf = Buffer.from(path.basename(withoutExt))
 
-  if (filenameBuf.byteLength > maxSafeBytes) {
-    const truncated = filenameBuf.slice(0, maxSafeBytes).toString()
+  if (filenameBuf.byteLength > maxSafePrefixBytes) {
+    const truncated = filenameBuf.slice(0, maxSafePrefixBytes).toString()
 
     withoutExt = path.join(path.dirname(withoutExt), truncated)
   }
@@ -308,10 +312,21 @@ const ensureUniquePath = function (withoutExt, extension, num = 0) {
   return fs.pathExists(fullPath)
   .then((found) => {
     if (found) {
-      return ensureUniquePath(withoutExt, extension, num + 1)
+      return ensureSafePath(withoutExt, extension, num + 1)
     }
 
-    return fullPath
+    // path does not exist, attempt to create it to check for an ENAMETOOLONG error
+    return fs.outputFileAsync(fullPath, '')
+    .then(() => fullPath)
+    .catch((err) => {
+      if (err.code === 'ENAMETOOLONG' && maxSafePrefixBytes >= MIN_PREFIX_BYTES) {
+        maxSafeBytes -= 1
+
+        return ensureSafePath(withoutExt, extension, num)
+      }
+
+      throw err
+    })
   })
 }
 
@@ -346,7 +361,7 @@ const getPath = function (data, ext, screenshotsFolder) {
 
   const withoutExt = path.join(screenshotsFolder, ...specNames, ...names)
 
-  return ensureUniquePath(withoutExt, ext)
+  return ensureSafePath(withoutExt, ext)
 }
 
 const getPathToScreenshot = function (data, details, screenshotsFolder) {

--- a/packages/server/test/support/helpers/e2e.ts
+++ b/packages/server/test/support/helpers/e2e.ts
@@ -697,6 +697,8 @@ const e2e = {
           LINES: 24,
         })
         .defaults({
+          // match CircleCI's filesystem limits, so screenshot names in snapshots match
+          CYPRESS_MAX_SAFE_FILENAME_BYTES: 242,
           FAKE_CWD_PATH: '/XXX/XXX/XXX',
           DEBUG_COLORS: '1',
           // prevent any Compression progress

--- a/packages/server/test/unit/screenshots_spec.js
+++ b/packages/server/test/unit/screenshots_spec.js
@@ -618,6 +618,24 @@ describe('lib/screenshots', () => {
       })
     })
 
+    // @see https://github.com/cypress-io/cypress/issues/2403
+    it('truncates long paths with unicode in them', async () => {
+      const fullPath = await screenshots.getPath({
+        titles: [
+          'WMED: [STORY] Тестовые сценарии для CI',
+          'Сценарии:',
+          'Сценарий 2: Создание обращения, создание медзаписи, привязка обращения к медзаписи',
+          '- Сценарий 2',
+        ],
+        testFailure: true,
+        specName: 'WMED_UAT_Scenarios_For_CI_spec.js',
+      }, 'png', '/jenkins-slave/workspace/test-wmed/qa/cypress/wmed_ci/cypress/screenshots/')
+
+      const basename = path.basename(fullPath)
+
+      expect(Buffer.from(basename).byteLength).to.be.lessThan(255)
+    })
+
     _.each([Infinity, 0 / 0, [], {}, 1, false], (value) => {
       it(`doesn't err and stringifies non-string test title: ${value}`, () => {
         return screenshots.getPath({
@@ -632,7 +650,7 @@ describe('lib/screenshots', () => {
       })
     })
 
-    return _.each([null, undefined], (value) => {
+    _.each([null, undefined], (value) => {
       it(`doesn't err and removes null/undefined test title: ${value}`, () => {
         return screenshots.getPath({
           specName: 'examples$/user/list.js',


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #2403

### User facing changelog

- Fixed an issue where screenshots could fail because of names that were too long for the filesystem to accept.

### Additional details

- now using bytes instead of characters to resize the string
- if an ENAMETOOLONG error is encountered, the string will be further downsized, down to a minimum of 64 bytes after which the error will still be thrown, like described in https://github.com/cypress-io/cypress/pull/2635#issuecomment-434839317

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
