### PR TITLE
fix(runner): `Cannot set property 'err' of undefined` on spec rerun due to file changes

### DIFF
--- a/packages/driver/src/cypress/runner.js
+++ b/packages/driver/src/cypress/runner.js
@@ -832,7 +832,6 @@ const create = (specWindow, mocha, Cypress, cy) => {
   }
 
   // hold onto the _runnables for faster lookup later
-  let _stopped = false
   let _test = null
   let _tests = []
   let _testsById = {}
@@ -932,8 +931,13 @@ const create = (specWindow, mocha, Cypress, cy) => {
 
       return _runner.run((failures) => {
         // if we happen to make it all the way through
-        // the run, then just set _stopped to true here
-        _stopped = true
+        // the run, then just set _runner.stopped to true here
+        _runner.stopped = true
+
+        // remove all the listeners
+        // so no more events fire
+        // since a test failure may 'leak' after a run completes
+        _runner.removeAllListeners()
 
         // TODO this functions is not correctly
         // synchronized with the 'end' event that
@@ -1183,11 +1187,11 @@ const create = (specWindow, mocha, Cypress, cy) => {
     },
 
     stop () {
-      if (_stopped) {
+      if (_runner.stopped) {
         return
       }
 
-      _stopped = true
+      _runner.stopped = true
 
       // abort the run
       _runner.abort()
@@ -1200,7 +1204,7 @@ const create = (specWindow, mocha, Cypress, cy) => {
 
       // remove all the listeners
       // so no more events fire
-      return _runner.removeAllListeners()
+      _runner.removeAllListeners()
     },
 
     getDisplayPropsForLog: $Log.getDisplayProps,

--- a/packages/runner/cypress/integration/reporter.hooks.spec.js
+++ b/packages/runner/cypress/integration/reporter.hooks.spec.js
@@ -120,6 +120,7 @@ describe('hooks', function () {
     })
   })
 
+  // https://github.com/cypress-io/cypress/issues/8189
   it('can fail in afterEach hook without associated test (due to run restart)', () => {
     runIsolatedCypress(() => {
       const top = window.parent

--- a/packages/runner/cypress/integration/reporter.hooks.spec.js
+++ b/packages/runner/cypress/integration/reporter.hooks.spec.js
@@ -121,7 +121,7 @@ describe('hooks', function () {
   })
 
   // https://github.com/cypress-io/cypress/issues/8189
-  it('can fail in afterEach hook without associated test (due to run restart)', () => {
+  it('can rerun without timeout error leaking into next run (due to run restart)', () => {
     runIsolatedCypress(() => {
       const top = window.parent
 

--- a/packages/runner/cypress/support/helpers.js
+++ b/packages/runner/cypress/support/helpers.js
@@ -188,9 +188,14 @@ function createCypress () {
             })
           })
 
-          cy.spy(cy.state('window').console, 'log').as('console_log')
-          cy.spy(cy.state('window').console, 'error').as('console_error')
-
+          // TODO: clean this up, sinon doesn't like wrapping things multiple times
+          // and this catches that error
+          try {
+            cy.spy(cy.state('window').console, 'log').as('console_log')
+            cy.spy(cy.state('window').console, 'error').as('console_error')
+          } catch (_e) {
+            // console was already wrapped, noop
+          }
           onInitializedListeners.forEach((fn) => fn(autCypress))
           onInitializedListeners = []
 


### PR DESCRIPTION
<!-- Example: "Closes #1234" -->


- fix #8189
### User facing changelog
- Bug Fix: fix `Cannot set property 'err' of undefined` error on spec rerun due to file changes
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details
- unregister mocha runner listeners after run completes to avoid timeout errors 'leaking'
- found a way to write a failing test this time :+1: 
- this didn't happen until recently because previously the error was still throwing but was caught due to being associated with the wrong test
<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->

