### PR TITLE
fix: (driver) - Fix for introduced regression in cy.route 

### DIFF
--- a/packages/driver/cypress/integration/commands/xhr_spec.js
+++ b/packages/driver/cypress/integration/commands/xhr_spec.js
@@ -2158,10 +2158,12 @@ describe('src/cy/commands/xhr', () => {
           done()
         })
 
-        cy.route(/foo/, 'fx:NOT_EXISTING_FILE_FIXTURE')
+        cy.route(/foo/, 'fx:NOT_EXISTING_FILE_FIXTURE').as('stub')
         cy.window().then((win) => {
           win.$.get('/foo')
         })
+
+        cy.wait('@stub')
       })
     })
 

--- a/packages/driver/src/cy/commands/xhr.js
+++ b/packages/driver/src/cy/commands/xhr.js
@@ -471,15 +471,6 @@ module.exports = (Commands, Cypress, cy, state, config) => {
           })
         }
 
-        // look ahead to see if fixture exists
-        const fixturesRe = /^(fx:|fixture:)/
-
-        if (hasResponse && fixturesRe.test(options.response)) {
-          const fixtureName = options.response.replace(fixturesRe, '')
-
-          return cy.now('fixture', fixtureName).then(() => route())
-        }
-
         return route()
       }
 


### PR DESCRIPTION
Fix for introduced regression from https://github.com/cypress-io/cypress/pull/7983 in cy.route  fixture inside the route command

First of all I'm sorry for introduced regression. I didn't mean to and I hope you will forgive me :) I've decided to revert some of my changes related to load fixture in `cy.route`. The only thing I left is a improved error message in case when fixture doesn't exist.

- Closes #8181 

### User facing changelog

Revert the code that tries to load a fixture inside a cy.route command.

### Additional details

We don't need to try load a fixture inside a cy.route. Error message has been improved, but it will show up only when user waits for a stubbed route or returns a rejected promise from custom command.

In every other case, test will be not marked as failed (even when fixture has not been found).

### How has the user experience changed?

Previous behaviour of `cy.route` has been restored. Error message in case of missing fixture has been improved.

### PR Tasks

- [ x ] Have tests been added/updated?
