### PR TITLE
fix: handle async errors when a cy chain isn't active

### DIFF
--- a/packages/server/test/e2e/6_uncaught_spec_errors_spec.js
+++ b/packages/server/test/e2e/6_uncaught_spec_errors_spec.js
@@ -30,6 +30,6 @@ describe('e2e uncaught errors', () => {
   e2e.it('failing5', {
     spec: 'caught_async_sync_test_spec.coffee',
     snapshot: true,
-    expectedExitCode: 4,
+    expectedExitCode: 6,
   })
 })

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/caught_async_sync_test_spec.coffee
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/caught_async_sync_test_spec.coffee
@@ -54,14 +54,55 @@ describe "foo", ->
     foo.bar()
 
   it "quux7 fails", (done) ->
-    ## no commands active, asynchronously emitted error
     setTimeout ->
       foo.bar()
     , 0
 
+  it "quux7b fails", (done) ->
+    window.top.setTimeout ->
+      foo.bar()
+    , 0
+
+  it "quux7c fails", (done) ->
+    setImmediate ->
+      foo.bar()
+
+  # bad, doesn't log to console, unlike Promiser unhandled rejections
+  it "quux7d fails", (done) ->
+    window.top.setImmediate ->
+      foo.bar()
+
+  # # bad, doesn't log to console, unlike Promiser unhandled rejections
+  # it "quux7d ii fails", (done) ->
+  #   cy.on "uncaught:exception", -> false
+  #   window.top.setImmediate ->
+  #     foo.bar()
+
+  it "quux7e fails", (done) ->
+    requestAnimationFrame ->
+      foo.bar()
+
+  it "quux7f fails", (done) ->
+    window.top.requestAnimationFrame ->
+      foo.bar()
+
+  # bad
   it "quux8 fails", (done) ->
-    ## no commands active, asynchronously emitted error
     Cypress.Promise.resolve()
+    .then ->
+      foo.bar()
+
+    return
+
+  it "quux8b fails", (done) ->
+    Promise.resolve()
+    .then ->
+      foo.bar()
+
+    return
+
+  it "quux8c fails", (done) ->
+    window.top.Promise.resolve()
     .then ->
       foo.bar()
 

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/caught_async_sync_test_spec.coffee
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/caught_async_sync_test_spec.coffee
@@ -52,3 +52,17 @@ describe "foo", ->
 
     ## no commands fail async handler should pass
     foo.bar()
+
+  it "quux7 fails", (done) ->
+    ## no commands active, asynchronously emitted error
+    setTimeout ->
+      foo.bar()
+    , 0
+
+  it "quux8 fails", (done) ->
+    ## no commands active, asynchronously emitted error
+    Cypress.Promise.resolve()
+    .then ->
+      foo.bar()
+
+    return


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes <!-- issue number here -->

### User facing changelog

<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
