### PR TITLE
fix: Fix crashing due to rerunning on initial bundle of specs

### DIFF
--- a/packages/server/lib/controllers/spec.js
+++ b/packages/server/lib/controllers/spec.js
@@ -3,6 +3,26 @@ const Promise = require('bluebird')
 const errors = require('../errors')
 const preprocessor = require('../plugins/preprocessor')
 
+const ignoreECONNABORTED = () => {
+  // https://github.com/cypress-io/cypress/issues/1877
+  // now that we are properly catching errors from
+  // res.sendFile, sendFile will reject if the browser aborts
+  // its internal requests (as it shuts down) with
+  // ECONNABORTED. This happens because if a previous spec
+  // file is unable to be transpiled correctly, we immediately
+  // shut down the run, which closes the browser, triggering
+  // the browser to abort the request which would end up here
+  // and display two different errors.
+}
+
+const ignoreEPIPE = () => {
+  // 'write EPIPE' errors can occur if a spec is served and then rerun
+  // quickly because it's trying to send the spec file to a socket that
+  // has already been closed. this can be ignored because it means
+  // another version of the file has already been sent and will
+  // be loaded by the browser instead
+}
+
 module.exports = {
   handle (spec, req, res, config, next, onError) {
     debug('request for %o', { spec })
@@ -22,17 +42,12 @@ module.exports = {
       const sendFile = Promise.promisify(res.sendFile.bind(res))
 
       return sendFile(filePath)
-    }).catch({ code: 'ECONNABORTED' }, (err) => {
-      // https://github.com/cypress-io/cypress/issues/1877
-      // now that we are properly catching errors from
-      // res.sendFile, sendFile will reject if the browser aborts
-      // its internal requests (as it shuts down) with
-      // ECONNABORTED. This happens because if a previous spec
-      // file is unable to be transpiled correctly, we immediately
-      // shut down the run, which closes the browser, triggering
-      // the browser to abort the request which would end up here
-      // and display two different errors.
-    }).catch((err) => {
+    })
+    .catch({ code: 'ECONNABORTED' }, ignoreECONNABORTED)
+    .catch({ code: 'EPIPE' }, ignoreEPIPE)
+    .catch((err) => {
+      debug(`preprocessor error for spec '%s': %s`, spec, err.stack)
+
       if (!config.isTextTerminal) {
         return res.send(preprocessor.clientSideError(err))
       }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,7 +28,7 @@
     "@cypress/request": "2.88.5",
     "@cypress/request-promise": "4.2.6",
     "@cypress/webpack-batteries-included-preprocessor": "2.0.0",
-    "@cypress/webpack-preprocessor": "5.4.3",
+    "@cypress/webpack-preprocessor": "5.4.4",
     "@ffmpeg-installer/ffmpeg": "1.0.20",
     "ansi_up": "4.0.4",
     "black-hole-stream": "0.0.1",

--- a/packages/server/test/unit/spec_spec.js
+++ b/packages/server/test/unit/spec_spec.js
@@ -49,7 +49,6 @@ describe('lib/controllers/spec', () => {
     return this.handle(specName).then(() => {
       expect(this.res.send).to.be.called
       expect(this.res.send.firstCall.args[0]).to.include('(function')
-
       expect(this.res.send.firstCall.args[0]).to.include('Reason request failed')
     })
   })
@@ -60,7 +59,6 @@ describe('lib/controllers/spec', () => {
     return this.handle(specName, { isTextTerminal: true }).then(() => {
       expect(this.onError).to.be.called
       expect(this.onError.lastCall.args[0].message).to.include('Oops...we found an error preparing this test file')
-
       expect(this.onError.lastCall.args[0].message).to.include('Reason request failed')
     })
   })
@@ -72,8 +70,27 @@ describe('lib/controllers/spec', () => {
 
     return this.handle(specName).then(() => {
       expect(this.res.send.firstCall.args[0]).to.include('(function')
-
       expect(this.res.send.firstCall.args[0]).to.include('ENOENT')
     })
+  })
+
+  it('ignores ECONNABORTED errors', function () {
+    const sendFileErr = new Error('ECONNABORTED')
+
+    sendFileErr.code = 'ECONNABORTED'
+
+    this.res.sendFile.yields(sendFileErr)
+
+    return this.handle(specName) // should resolve, not error
+  })
+
+  it('ignores EPIPE errors', function () {
+    const sendFileErr = new Error('EPIPE')
+
+    sendFileErr.code = 'EPIPE'
+
+    this.res.sendFile.yields(sendFileErr)
+
+    return this.handle(specName) // should resolve, not error
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1823,10 +1823,10 @@
     debug "4.1.1"
     lodash "4.17.19"
 
-"@cypress/webpack-preprocessor@5.4.3":
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.4.3.tgz#16cd450f15a7e95523a4e4e48b7ced3e318c4957"
-  integrity sha512-WomyLH7mtCkRpN6unHUfZcX/tl8lfL3MqSniSvlg6wTtQLmlYM3VPDUQjZ4mywQ+TOE9TkSEQyVeJT7SRksxUg==
+"@cypress/webpack-preprocessor@5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.4.4.tgz#20adaa338799485aeb67227a9784991c420acd31"
+  integrity sha512-aNOS4J7vilVO6CgzYUnMCraZTCF+SvQtGTlG0HKdqbpI4+dzCWGRFpwpqiSsCb83m+WAP2gfuGQVaFTCM43JcA==
   dependencies:
     bluebird "3.7.1"
     debug "4.1.1"


### PR DESCRIPTION
### User facing changelog

N/A - this only affects unreleased 5.0 branch

### Additional details

The issue:
- webpack preprocessor emits ‘rerun’ for every file once it’s done bundling it. It does this even when it’s the first time the file is bundled. 
- When running 'All Specs', this results in ‘rerun’ getting called over and over in the runner and it re-requesting iframe/_all over and over.
- This loads the iframe and multiple specs over and over, eventually leading to an EPIPE error thrown by express sendFile, because the socket open for the file is now closed by the new version of the file being sent. (This and the previous items occur outside of 'All Specs', but are unlikely to cause the next item because it just happens once instead of being multiplied by the number of specs).
- The EPIPE error is obscured by the ERR_HTTP_HEADERS_SENT because we don’t properly separate sendFile errors from preprocessor errors.

Fixes:
- Prevent webpack preprocessor from emitting ‘rerun’ on the first bundle (addressed by bumping webpack preprocessor version).
- Ignore EPIPE errors from res.sendFile, so the spec controller doesn't try to send the file again with the EPIPE error, resulting in an ERR_HTTP_HEADERS_SENT error.


### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
