### PR TITLE
fix: retries validation

### DIFF
--- a/packages/server/lib/util/validation.js
+++ b/packages/server/lib/util/validation.js
@@ -105,7 +105,7 @@ const isValidBrowserList = (key, browsers) => {
 
 const isValidRetriesConfig = (key, value) => {
   const optionalKeys = ['runMode', 'openMode']
-  const isValidRetryValue = (val) => _.isNull(val) || (_.isNumber(val) && val >= 0)
+  const isValidRetryValue = (val) => _.isNull(val) || (Number.isInteger(val) && val >= 0)
   const optionalKeysAreValid = (val, k) => optionalKeys.includes(k) && isValidRetryValue(val)
 
   if (isValidRetryValue(value)) {

--- a/packages/server/lib/util/validation.js
+++ b/packages/server/lib/util/validation.js
@@ -104,18 +104,19 @@ const isValidBrowserList = (key, browsers) => {
 }
 
 const isValidRetriesConfig = (key, value) => {
-  const isNullOrNumber = isOneOf([_.isNumber, _.isNull])
+  const optionalKeys = ['runMode', 'openMode']
+  const isValidRetryValue = (val) => _.isNull(val) || (_.isNumber(val) && val >= 0)
+  const optionalKeysAreValid = (val, k) => optionalKeys.includes(k) && isValidRetryValue(val)
 
-  if (
-    isNullOrNumber(value)
-    || (_.isEqual(_.keys(value), ['runMode', 'openMode']))
-      && isNullOrNumber(value.runMode)
-      && isNullOrNumber(value.openMode)
-  ) {
+  if (isValidRetryValue(value)) {
     return true
   }
 
-  return errMsg(key, value, 'a number or null or an object with keys "openMode" and "runMode" with values of numbers or nulls')
+  if (_.isObject(value) && _.every(value, optionalKeysAreValid)) {
+    return true
+  }
+
+  return errMsg(key, value, 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers or nulls')
 }
 
 const isValidFirefoxGcInterval = (key, value) => {

--- a/packages/server/test/unit/config_spec.js
+++ b/packages/server/test/unit/config_spec.js
@@ -690,6 +690,33 @@ describe('lib/config', () => {
         })
       })
 
+      context('retries', () => {
+        const retriesError = 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers or nulls'
+
+        // need to keep the const here or it'll get stripped by the build
+        // eslint-disable-next-line no-unused-vars
+        const cases = [
+          [{ retries: 3 }, 'when a number', true],
+          [{ retries: true }, 'when true', false],
+          [{ retries: false }, 'when false', false],
+          [{ retries: -1 }, 'with a negative number', false],
+          [{ retries: {} }, 'with an empty object', true],
+          [{ retries: null }, 'with null', true],
+          [{ retries: { runMode: 3 } }, 'when runMode is a positive number', true],
+          [{ retries: { runMode: -1 } }, 'when runMode is a negative number', false],
+          [{ retries: { openMode: 3 } }, 'when openMode is a positive number', true],
+          [{ retries: { openMode: -1 } }, 'when openMode is a negative number', false],
+          [{ retries: { openMode: 3, TypoRunMode: 3 } }, 'when there is an additional unknown key', false],
+          [{ retries: { openMode: 3, runMode: 3 } }, 'when both runMode and openMode are positive numbers', true],
+        ].forEach(([config, expectation, shouldPass]) => {
+          it(`${shouldPass ? 'passes' : 'fails'} ${expectation}`, function () {
+            this.setup(config)
+
+            return shouldPass ? this.expectValidationPasses() : this.expectValidationFails(retriesError)
+          })
+        })
+      })
+
       context('firefoxGcInterval', () => {
         it('passes if a number', function () {
           this.setup({ firefoxGcInterval: 1 })

--- a/packages/server/test/unit/config_spec.js
+++ b/packages/server/test/unit/config_spec.js
@@ -696,12 +696,13 @@ describe('lib/config', () => {
         // need to keep the const here or it'll get stripped by the build
         // eslint-disable-next-line no-unused-vars
         const cases = [
+          [{ retries: null }, 'with null', true],
           [{ retries: 3 }, 'when a number', true],
+          [{ retries: 3.2 }, 'when a float', false],
+          [{ retries: -1 }, 'with a negative number', false],
           [{ retries: true }, 'when true', false],
           [{ retries: false }, 'when false', false],
-          [{ retries: -1 }, 'with a negative number', false],
           [{ retries: {} }, 'with an empty object', true],
-          [{ retries: null }, 'with null', true],
           [{ retries: { runMode: 3 } }, 'when runMode is a positive number', true],
           [{ retries: { runMode: -1 } }, 'when runMode is a negative number', false],
           [{ retries: { openMode: 3 } }, 'when openMode is a positive number', true],


### PR DESCRIPTION
* Validation of retries config was being ignored completely due to `isNumberOrNull` returning an error message string and being checked for falsiness.
* Previously _both_ `runMode` and `openMode` were required when using the object signature. This fixes that.
* Previously we weren't guarding against negative numbers

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
