### PR TITLE
fix(ui): Style of 'Waiting for browser login' button

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -770,7 +770,7 @@ jobs:
             PERCY_PARALLEL_TOTAL=1 \
             yarn percy exec -- \
             yarn cypress:run \
-              --spec cypress/integration/settings_spec.js,cypress/integration/specs_list_spec.js,cypress/integration/runs_list_spec.js
+              --spec cypress/integration/settings_spec.js,cypress/integration/specs_list_spec.js,cypress/integration/runs_list_spec.js,cypress/integration/login_spec.js
           working_directory: packages/desktop-gui
       - verify-mocha-results
       # we don't really need any artifacts - we are only interested in visual screenshots

--- a/packages/desktop-gui/cypress/integration/login_spec.js
+++ b/packages/desktop-gui/cypress/integration/login_spec.js
@@ -2,7 +2,7 @@ describe('Login', function () {
   beforeEach(function () {
     cy.fixture('user').as('user')
 
-    return cy.visitIndex().then(function (win) {
+    cy.visitIndex().then(function (win) {
       let start = win.App.start
 
       this.win = win
@@ -75,21 +75,26 @@ describe('Login', function () {
         })
       })
 
-      it('disables login button', () => {
+      it('shows spinner with Opening browser and disables button', () => {
         cy.get('@loginBtn').should('be.disabled')
-      })
+        .invoke('text').should('contain', 'Opening browser...')
 
-      it('shows spinner with Opening browser', () => {
-        cy.get('@loginBtn').invoke('text').should('contain', 'Opening browser...')
+        cy.percySnapshot()
       })
 
       context('on begin:auth', function () {
-        beforeEach(function () {
-          cy.get('@loginBtn')
-        })
+        it('when browser opened, shows spinner with Waiting...', function () {
+          this.onAuthMessageCb(null, {
+            name: '',
+            message: '',
+            stack: '',
+            browserOpened: true,
+          })
 
-        it('displays spinner with Opening browser... and disables button', function () {
-          cy.contains('Opening browser...').should('be.disabled')
+          cy.get('@loginBtn').should('be.disabled')
+          .invoke('text').should('contain', 'Waiting for browser login...')
+
+          cy.percySnapshot()
         })
 
         describe('on ipc begin:auth success', function () {

--- a/packages/desktop-gui/cypress/integration/login_spec.js
+++ b/packages/desktop-gui/cypress/integration/login_spec.js
@@ -50,6 +50,8 @@ describe('Login', function () {
 
     it('has dashboard login button', function () {
       cy.get('.login').contains('button', 'Log In to Dashboard')
+
+      cy.percySnapshot()
     })
 
     it('opens dashboard on clicking \'Cypress Dashboard\'', () => {
@@ -112,6 +114,8 @@ describe('Login', function () {
 
           it('displays username in success dialog', () => {
             cy.get('.modal').contains('Jane Lane')
+
+            cy.percySnapshot()
           })
 
           it('can close modal by clicking Continue', () => {
@@ -164,6 +168,8 @@ describe('Login', function () {
           it('displays error in ui', () => {
             cy.get('.alert-danger').should('be.visible')
             .contains('There\'s an error')
+
+            cy.percySnapshot()
           })
 
           it('login button should be enabled', () => {
@@ -182,6 +188,8 @@ describe('Login', function () {
           it('displays warning in ui', () => {
             cy.get('.warning').should('be.visible')
             .contains('some warning here')
+
+            cy.percySnapshot()
           })
 
           it('login button should be disabled', () => {
@@ -198,6 +206,8 @@ describe('Login', function () {
             cy.get('.login-content .btn-login')
             .should('be.disabled')
             .should('have.text', ' Could not open browser.')
+
+            cy.percySnapshot()
           })
 
           it('<pre> can be click-selected', function () {
@@ -257,6 +267,8 @@ describe('Login', function () {
       cy.contains('http://api.server')
 
       cy.contains('ECONNREFUSED')
+
+      cy.percySnapshot()
     })
 
     describe('trying again', function () {

--- a/packages/desktop-gui/src/auth/login-modal.jsx
+++ b/packages/desktop-gui/src/auth/login-modal.jsx
@@ -83,7 +83,7 @@ class LoginContent extends Component {
         <p>You are now logged in{authStore.user ? ` as ${authStore.user.name}` : ''}.</p>
         <div className='login-content'>
           <button
-            className='btn btn-login btn-black btn-block'
+            className='btn btn-login btn-primary btn-wide'
             onClick={close}
           >
             Continue

--- a/packages/desktop-gui/src/auth/login.scss
+++ b/packages/desktop-gui/src/auth/login.scss
@@ -48,7 +48,7 @@
   button {
     display: block;
     margin: 0 auto 1em;
-    width: 250px;
+    width: auto;
   }
 
   .message {


### PR DESCRIPTION
TR-238

### User Changelog

N/A - fixing prereleased UI

### Additional Details

- [x] *PENDING*: percy snapshots did not ask for review of new snapshots
- I added percy snapshots throughout the login spec for uniquely styled views
- I also changed the style of the 'Continue' button to match the new blue button styles (missed this in last UI PR)

### How has the user experience changed?

#### Before (Waiting button)

<img width="801" alt="Screen Shot 2020-08-13 at 1 26 21 PM" src="https://user-images.githubusercontent.com/1271364/90103721-fed60e80-dd68-11ea-9826-c4d37135580d.png">

#### After (Waiting button)

<img width="802" alt="Screen Shot 2020-08-13 at 1 24 15 PM" src="https://user-images.githubusercontent.com/1271364/90103744-0695b300-dd69-11ea-9c61-f239fffec823.png">

#### Before (Continue button)

<img width="802" alt="Screen Shot 2020-08-13 at 1 25 45 PM" src="https://user-images.githubusercontent.com/1271364/90103764-0d242a80-dd69-11ea-8eaa-788f75c23361.png">

#### After (Continue button)

<img width="804" alt="Screen Shot 2020-08-13 at 1 24 41 PM" src="https://user-images.githubusercontent.com/1271364/90103786-14e3cf00-dd69-11ea-98ea-9bfd2f7f0c1f.png">

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->