### PR TITLE
feat(net-stubbing): add `followRedirect` to request interception

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -936,6 +936,22 @@ describe('network stubbing', function () {
       .wait('@dest')
     })
 
+    // @see https://github.com/cypress-io/cypress/issues/7967
+    it('can skip redirects via followRedirect', function () {
+      const href = `/fixtures/generic.html?t=${Date.now()}`
+      const url = `/redirect?href=${encodeURIComponent(href)}`
+
+      cy.route2('/redirect', (req) => {
+        req.followRedirect = true
+        req.reply((res) => {
+          expect(res.body).to.include('Some generic content')
+          expect(res.statusCode).to.eq(200)
+          res.send()
+        })
+      })
+      .then(() => fetch(url))
+    })
+
     it('intercepts cached responses as expected', {
       browser: '!firefox', // TODO: why does firefox behave differently? transparently returns cached response
     }, function () {

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -39,6 +39,11 @@ export namespace CyHttpMessages {
 
   export type IncomingRequest = BaseMessage & {
     responseTimeout?: number
+    /**
+     * Set if redirects should be followed when this request is made. By default, requests will
+     * not follow redirects before yielding the response (the 3xx redirect is yielded)
+     */
+    followRedirect?: boolean
   }
 
   export interface IncomingHttpRequest extends IncomingRequest {

--- a/packages/net-stubbing/lib/internal-types.ts
+++ b/packages/net-stubbing/lib/internal-types.ts
@@ -19,6 +19,7 @@ export const SERIALIZABLE_REQ_PROPS = [
   'method',
   'httpVersion',
   'responseTimeout',
+  'followRedirect',
 ]
 
 export const SERIALIZABLE_RES_PROPS = _.concat(
@@ -89,6 +90,7 @@ export declare namespace NetEventFrames {
     // Millisecond timestamp for when the response should continue
     continueResponseAt?: number
     throttleKbps?: number
+    followRedirect?: boolean
   }
 
   // fired when a response has been sent completely by the server to an intercepted request

--- a/packages/proxy/lib/http/request-middleware.ts
+++ b/packages/proxy/lib/http/request-middleware.ts
@@ -103,7 +103,7 @@ const SendRequestOutgoing: RequestMiddleware = function () {
   const requestOptions = {
     timeout: this.req.responseTimeout,
     strictSSL: false,
-    followRedirect: false,
+    followRedirect: this.req.followRedirect || false,
     retryIntervals: [0, 100, 200, 200],
     url: this.req.proxiedUrl,
   }

--- a/packages/proxy/lib/types.ts
+++ b/packages/proxy/lib/types.ts
@@ -10,6 +10,7 @@ export type CypressIncomingRequest = Request & {
   requestId: string
   body?: string
   responseTimeout?: number
+  followRedirect?: boolean
 }
 
 /**


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #7967 

### User facing changelog

Added a `followRedirect` option to request interception, to allow redirects to be followed before continuing to response interception.

### Additional details

- matches `followRedirect` option of `cy.request`
- may want to add a `redirects` array to `res` object

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? cypress-io/cypress-documentation#3132
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
