### PR TITLE
fix(desktop-gui): remember last browser used w/ non-default channel

### DIFF
--- a/packages/desktop-gui/cypress/fixtures/browsers.json
+++ b/packages/desktop-gui/cypress/fixtures/browsers.json
@@ -3,6 +3,7 @@
     "name": "chrome",
     "displayName": "Chrome",
     "family": "chromium",
+    "channel": "stable",
     "version": "50.0.2661.86",
     "path": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
     "majorVersion": "50"
@@ -11,6 +12,7 @@
     "name": "chromium",
     "displayName": "Chromium",
     "family": "chromium",
+    "channel": "stable",
     "version": "49.0.2609.0",
     "path": "/Users/bmann/Downloads/chrome-mac/Chromium.app/Contents/MacOS/Chromium",
     "majorVersion": "49"
@@ -19,6 +21,7 @@
     "name": "chrome",
     "displayName": "Canary",
     "family": "chromium",
+    "channel": "canary",
     "version": "48.0",
     "path": "/Users/bmann/Downloads/chrome-mac/Canary.app/Contents/MacOS/Canary",
     "majorVersion": "48"

--- a/packages/desktop-gui/cypress/fixtures/config.json
+++ b/packages/desktop-gui/cypress/fixtures/config.json
@@ -7,6 +7,7 @@
       "name": "chrome",
       "displayName": "Chrome",
       "family": "chromium",
+      "channel": "stable",
       "version": "78.0.3904.108",
       "path": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
       "majorVersion": "78"
@@ -15,6 +16,7 @@
       "name": "chromium",
       "displayName": "Chromium",
       "family": "chromium",
+      "channel": "stable",
       "version": "74.0.3729.0",
       "path": "/Applications/Chromium.app/Contents/MacOS/Chromium",
       "majorVersion": "74"
@@ -23,6 +25,7 @@
       "name": "chrome",
       "displayName": "Canary",
       "family": "chromium",
+      "channel": "canary",
       "version": "80.0.3977.4",
       "path": "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
       "majorVersion": "80"
@@ -31,6 +34,7 @@
       "name": "edge",
       "displayName": "Edge",
       "family": "chromium",
+      "channel": "stable",
       "version": "79.0.309.71",
       "path": "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
       "majorVersion": "79"
@@ -39,6 +43,7 @@
       "name": "edge",
       "displayName": "Edge Beta",
       "family": "chromium",
+      "channel": "beta",
       "version": "79.0.309.71",
       "path": "/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta",
       "majorVersion": "79"
@@ -47,6 +52,7 @@
       "name": "edge",
       "displayName": "Edge Canary",
       "family": "chromium",
+      "channel": "canary",
       "version": "79.0.309.71",
       "path": "/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary",
       "majorVersion": "79"
@@ -55,6 +61,7 @@
       "name": "edge",
       "displayName": "Edge Dev",
       "family": "chromium",
+      "channel": "dev",
       "version": "79.0.309.71",
       "path": "/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev",
       "majorVersion": "79"
@@ -63,6 +70,7 @@
       "name": "electron",
       "displayName": "Electron",
       "family": "chromium",
+      "channel": "stable",
       "version": "73.0.3683.121",
       "path": "",
       "majorVersion": "73",
@@ -72,6 +80,7 @@
       "name": "firefox",
       "displayName": "Firefox",
       "family": "firefox",
+      "channel": "stable",
       "version": "69.0.1",
       "path": "/Applications/Firefox/Contents/MacOS/Firefox",
       "majorVersion": "69"
@@ -79,6 +88,7 @@
     {
       "name": "firefox",
       "displayName": "Firefox Developer Edition",
+      "channel": "dev",
       "family": "firefox",
       "version": "69.0.1",
       "path": "/Applications/Firefox Developer/Contents/MacOS/Firefox Developer",
@@ -87,6 +97,7 @@
     {
       "name": "firefox",
       "displayName": "Firefox Nightly",
+      "channel": "beta",
       "family": "firefox",
       "version": "69.0.1",
       "path": "/Applications/Firefox Nightly/Contents/MacOS/Firefox Nightly",
@@ -96,6 +107,7 @@
     {
       "name": "custom",
       "displayName": "Custom",
+      "channel": "dev",
       "family": "custom",
       "version": "4.3.2",
       "path": "/Applications/Custom/Contents/MacOS/Custom",

--- a/packages/desktop-gui/cypress/integration/project_nav_spec.js
+++ b/packages/desktop-gui/cypress/integration/project_nav_spec.js
@@ -215,7 +215,7 @@ describe('Project Nav', function () {
         })
 
         it('saves chosen browser in local storage', () => {
-          expect(localStorage.getItem('chosenBrowser')).to.eq('chromium')
+          expect(localStorage.getItem('chosenBrowser')).to.eq(JSON.stringify({ name: 'chromium', channel: 'stable' }))
         })
       })
 
@@ -318,8 +318,15 @@ describe('Project Nav', function () {
     })
 
     describe('local storage saved browser', function () {
+      // deliberately not the default 'chrome' browser
+      // @see https://github.com/cypress-io/cypress/issues/8281
+      const canaryJson = JSON.stringify({
+        name: 'chrome',
+        channel: 'canary',
+      })
+
       beforeEach(function () {
-        localStorage.setItem('chosenBrowser', 'chromium')
+        localStorage.setItem('chosenBrowser', canaryJson)
 
         this.openProject.resolve(this.config)
       })
@@ -330,13 +337,13 @@ describe('Project Nav', function () {
 
       it('displays local storage browser name in chosen', () => {
         cy.get('.browsers-list .dropdown-chosen')
-        .should('contain', 'Chromium')
+        .should('contain', 'Canary').and('not.contain', 'Edge')
       })
 
       it('displays local storage browser icon in chosen', () => {
         cy.get('.browsers-list .dropdown-chosen .browser-icon')
         .should('have.attr', 'src')
-        .and('include', './img/chromium')
+        .and('include', './img/chrome-canary')
       })
     })
 

--- a/packages/desktop-gui/cypress/integration/project_nav_spec.js
+++ b/packages/desktop-gui/cypress/integration/project_nav_spec.js
@@ -318,32 +318,42 @@ describe('Project Nav', function () {
     })
 
     describe('local storage saved browser', function () {
-      // deliberately not the default 'chrome' browser
-      // @see https://github.com/cypress-io/cypress/issues/8281
-      const canaryJson = JSON.stringify({
-        name: 'chrome',
-        channel: 'canary',
-      })
-
-      beforeEach(function () {
-        localStorage.setItem('chosenBrowser', canaryJson)
-
-        this.openProject.resolve(this.config)
-      })
-
       afterEach(() => {
         cy.clearLocalStorage()
       })
 
-      it('displays local storage browser name in chosen', () => {
+      it('displays chosen browser in localStorage', function () {
+        // deliberately not the default 'chrome' browser
+        // @see https://github.com/cypress-io/cypress/issues/8281
+        localStorage.setItem('chosenBrowser', JSON.stringify({
+          name: 'chrome',
+          channel: 'canary',
+        }))
+
+        this.openProject.resolve(this.config)
+
         cy.get('.browsers-list .dropdown-chosen')
         .should('contain', 'Canary').and('not.contain', 'Edge')
+        .get('.dropdown-chosen .browser-icon')
+        .should('have.attr', 'src').and('include', './img/chrome-canary')
       })
 
-      it('displays local storage browser icon in chosen', () => {
-        cy.get('.browsers-list .dropdown-chosen .browser-icon')
-        .should('have.attr', 'src')
-        .and('include', './img/chrome-canary')
+      it('displays chosen browser with old string-style id in localStorage', function () {
+        localStorage.setItem('chosenBrowser', 'chrome')
+
+        this.openProject.resolve(this.config)
+
+        cy.get('.browsers-list .dropdown-chosen')
+        .should('contain', 'Chrome')
+      })
+
+      it('displays default browser with null localStorage', function () {
+        localStorage.removeItem('chosenBrowser')
+
+        this.openProject.resolve(this.config)
+
+        cy.get('.browsers-list .dropdown-chosen')
+        .should('contain', this.config.browsers[0].displayName)
       })
     })
 

--- a/packages/desktop-gui/src/project-nav/browsers.jsx
+++ b/packages/desktop-gui/src/project-nav/browsers.jsx
@@ -77,7 +77,6 @@ export default class Browsers extends Component {
         {browser.family === 'firefox' && <span className='browser-beta'>beta</span>}
         {this._info(browser)}
         {this._warn(browser)}
-
       </>
     )
   }

--- a/packages/desktop-gui/src/project/project-model.js
+++ b/packages/desktop-gui/src/project/project-model.js
@@ -180,8 +180,10 @@ export default class Project {
         return this.setChosenBrowser(customBrowser, { save: false })
       }
 
-      if (localStorage.getItem('chosenBrowser')) {
-        return this.setChosenBrowserByName(localStorage.getItem('chosenBrowser'))
+      const ls = localStorage.getItem('chosenBrowser')
+
+      if (ls) {
+        return this.setChosenBrowserFromLocalStorage(ls)
       }
 
       return this.setChosenBrowser(this.defaultBrowser)
@@ -194,7 +196,7 @@ export default class Project {
     })
 
     if (save !== false) {
-      localStorage.setItem('chosenBrowser', browser.name)
+      localStorage.setItem('chosenBrowser', JSON.stringify(_.pick(browser, 'name', 'channel')))
     }
 
     browser.isChosen = true
@@ -250,8 +252,17 @@ export default class Project {
     this.apiError = err
   }
 
-  @action setChosenBrowserByName (name) {
-    const browser = _.find(this.browsers, { name }) || this.defaultBrowser
+  @action setChosenBrowserFromLocalStorage (ls) {
+    let filter = {}
+
+    try {
+      _.merge(filter, JSON.parse(ls))
+    } catch (err) {
+      // localStorage pre-dates JSON filter, assume "name"
+      filter.name = ls
+    }
+
+    const browser = _.find(this.browsers, filter) || this.defaultBrowser
 
     this.setChosenBrowser(browser)
   }


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8281 

### User facing changelog

- Fixed a bug where the "last used browser" would be incorrectly remembered in `cypress open` if a non-default-channel browser was selected.

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
