### PR TITLE
fix: NO_PROXY env var no longer be respected over npm_config_noproxy env var

### DIFF
--- a/packages/https-proxy/package.json
+++ b/packages/https-proxy/package.json
@@ -19,7 +19,7 @@
     "fs-extra": "8.1.0",
     "lodash": "4.17.19",
     "node-forge": "0.9.0",
-    "proxy-from-env": "1.1.0",
+    "proxy-from-env": "1.0.0",
     "semaphore": "1.1.0"
   },
   "devDependencies": {

--- a/packages/https-proxy/test/integration/proxy_spec.js
+++ b/packages/https-proxy/test/integration/proxy_spec.js
@@ -229,8 +229,13 @@ describe('Proxy', () => {
 
   context('with an upstream proxy', () => {
     beforeEach(function () {
+      // PROXY vars should override npm_config vars, so set them to cause failures if they are used
+      // @see https://github.com/cypress-io/cypress/pull/8295
+      process.env.npm_config_proxy = process.env.npm_config_https_proxy = 'http://erroneously-used-npm-proxy.invalid'
+      process.env.npm_config_noproxy = 'just,some,nonsense'
+
       process.env.NO_PROXY = ''
-      process.env.HTTP_PROXY = (process.env.HTTPS_PROXY = 'http://localhost:9001')
+      process.env.HTTP_PROXY = process.env.HTTPS_PROXY = 'http://localhost:9001'
 
       this.upstream = new DebugProxy({
         keepRequests: true,

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -18,7 +18,7 @@
     "concat-stream": "1.6.2",
     "debug": "4.1.1",
     "lodash": "4.17.19",
-    "proxy-from-env": "1.1.0"
+    "proxy-from-env": "1.0.0"
   },
   "devDependencies": {
     "@cypress/debugging-proxy": "2.0.1",

--- a/packages/network/test/unit/agent_spec.ts
+++ b/packages/network/test/unit/agent_spec.ts
@@ -74,6 +74,11 @@ describe('lib/agent', function () {
       context(testCase.name, function () {
         beforeEach(function () {
           if (testCase.proxyUrl) {
+            // PROXY vars should override npm_config vars, so set them to cause failures if they are used
+            // @see https://github.com/cypress-io/cypress/pull/8295
+            process.env.npm_config_proxy = process.env.npm_config_https_proxy = 'http://erroneously-used-npm-proxy.invalid'
+            process.env.npm_config_noproxy = 'just,some,nonsense'
+
             process.env.HTTP_PROXY = process.env.HTTPS_PROXY = testCase.proxyUrl
             process.env.NO_PROXY = ''
           }

--- a/packages/server/lib/util/proxy.ts
+++ b/packages/server/lib/util/proxy.ts
@@ -71,7 +71,7 @@ export const loadSystemProxySettings = () => {
   debug('found proxy environment variables %o', _.pick(process.env, [
     'NO_PROXY', 'HTTP_PROXY', 'HTTPS_PROXY',
     'no_proxy', 'http_proxy', 'https_proxy',
-    'npm_config_proxy', 'npm_config_https_proxy',
+    'npm_config_proxy', 'npm_config_https_proxy', 'npm_config_no_proxy',
   ]))
 
   ;['NO_PROXY', 'HTTP_PROXY', 'HTTPS_PROXY'].forEach(copyLowercaseEnvToUppercase)

--- a/packages/server/lib/util/proxy.ts
+++ b/packages/server/lib/util/proxy.ts
@@ -71,7 +71,7 @@ export const loadSystemProxySettings = () => {
   debug('found proxy environment variables %o', _.pick(process.env, [
     'NO_PROXY', 'HTTP_PROXY', 'HTTPS_PROXY',
     'no_proxy', 'http_proxy', 'https_proxy',
-    'npm_config_proxy', 'npm_config_https_proxy', 'npm_config_no_proxy',
+    'npm_config_proxy', 'npm_config_https_proxy', 'npm_config_noproxy',
   ]))
 
   ;['NO_PROXY', 'HTTP_PROXY', 'HTTPS_PROXY'].forEach(copyLowercaseEnvToUppercase)

--- a/yarn.lock
+++ b/yarn.lock
@@ -20448,7 +20448,12 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
 
-proxy-from-env@1.1.0, proxy-from-env@^1.0.0:
+proxy-from-env@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+  integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
+
+proxy-from-env@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==


### PR DESCRIPTION
- Close #8287 
- Revert #7900 

### User Facing Changelog

- We fixed a regression in 4.11.0 where the `NO_PROXY` environment variable would no longer be respected over `npm_config_noproxy` environment variables. This could have potentially caused issue for proxied requests.

### Additional Details

- It seems the original dep is not intending to change the behavior of the dep, so we'll have to do some further work if we want to update the dep. https://github.com/Rob--W/proxy-from-env/issues/13

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->