### PR TITLE
fix: Avoid looking up remote jquery instance if subject is not an element

### DIFF
--- a/packages/driver/src/cy/jquery.js
+++ b/packages/driver/src/cy/jquery.js
@@ -14,14 +14,16 @@ const create = function (state) {
 
   return {
     getRemotejQueryInstance (subject) {
-      const remoteJQuery = jquery()
-
       // we make assumptions that you cannot have
       // an array of mixed types, so we only look at
       // the first item (if there's an array)
       const firstSubject = $utils.unwrapFirst(subject)
 
-      if ($dom.isElement(firstSubject) && remoteJQueryisNotSameAsGlobal(remoteJQuery)) {
+      if (!$dom.isElement(firstSubject)) return
+
+      const remoteJQuery = jquery()
+
+      if (remoteJQueryisNotSameAsGlobal(remoteJQuery)) {
         const remoteSubject = remoteJQuery(subject)
 
         return remoteSubject


### PR DESCRIPTION
TR-244

Should fix [this flaky failure](https://app.circleci.com/pipelines/github/cypress-io/cypress/12876/workflows/15a6e1bb-66b4-4aba-a59e-fc34d993a826/jobs/421794).

The error originates from [this `cy.readFile().then` call](https://github.com/cypress-io/cypress-documentation/blob/develop/cypress/support/defaults.js#L48). We try to look up the remote jQuery instance from  even though the subject is not a dom element. This causes it to _sometimes_ fail with a cross-origin error in Firefox.

This prevents attempting to look up the remote jQuery instance in cases where the subject is not a dom element.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?

