### PR TITLE
fix: Patch app-builder-lib to disable strict code sign verification 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ macBuildFilters: &macBuildFilters
         - develop
         - v5.0-release
         - install-node-on-circleci-mac
+        - issue-8299-mac-codesign
 
 defaults: &defaults
   parallelism: 1

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "docker": "./scripts/run-docker-local.sh",
     "effective:circle:config": "circleci config process circle.yml | sed /^#/d",
     "ensure-deps": "./scripts/ensure-dependencies.sh",
-    "postinstall": "yarn build",
+    "postinstall": "patch-package",
     "jscodeshift": "jscodeshift -t ./node_modules/js-codemod/transforms/arrow-function-arguments.js",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx,.json .",
     "lint-changed": "lint-changed",

--- a/patches/app-builder-lib+22.8.0.patch
+++ b/patches/app-builder-lib+22.8.0.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/app-builder-lib/out/macPackager.js b/node_modules/app-builder-lib/out/macPackager.js
+index fad3541..743001b 100644
+--- a/node_modules/app-builder-lib/out/macPackager.js
++++ b/node_modules/app-builder-lib/out/macPackager.js
+@@ -339,6 +339,7 @@ class MacPackager extends _platformPackager().PlatformPackager {
+     }
+ 
+     const signOptions = {
++      "strict-verify": false,
+       "identity-validation": false,
+       // https://github.com/electron-userland/electron-builder/issues/1699
+       // kext are signed by the chipset manufacturers. You need a special certificate (only available on request) from Apple to be able to sign kext.


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8299
