### PR TITLE
chore: Upgrade cypress-example-kitchensink to 1.12.0

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "chai": "3.5.0",
     "cross-env": "6.0.3",
-    "cypress-example-kitchensink": "1.11.2",
+    "cypress-example-kitchensink": "1.12.0",
     "gulp": "4.0.2",
     "gulp-clean": "0.4.0",
     "gulp-gh-pages": "0.6.0-6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9738,10 +9738,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress-example-kitchensink@1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/cypress-example-kitchensink/-/cypress-example-kitchensink-1.11.2.tgz#d5e29ab82c50db000c923b97dfddbc0303035a12"
-  integrity sha512-n2mqfFxXsrXaMDeL51q4BGbbfznKYGXU+LSsXHDWH40zNGSYRikSXHi+Vzw+r8K77NTlFQwfwcjWyzWPpRV4Hw==
+cypress-example-kitchensink@1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/cypress-example-kitchensink/-/cypress-example-kitchensink-1.12.0.tgz#d0286e105f7fb7076f784ce99e2423c51d794059"
+  integrity sha512-/FvkMdT8Q3DKwle+BpYLM3Rap8aI/DzLDomsE5ryQxNGAvOceoKMGtZAnaymhHtZZfvX6y+hPc9/vSx4ocWdSg==
   dependencies:
     npm-run-all "^4.1.2"
     serve "11.3.0"


### PR DESCRIPTION
Branched it correctly this time.