### PR TITLE
fix(server): Fix 5.0 spec duration always reporting as 0ms

### DIFF
--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1295,7 +1295,7 @@ module.exports = {
         })),
       })
 
-      return writeOutput(outputPath, moduleAPIResults).return(moduleAPIResults)
+      return writeOutput(outputPath, moduleAPIResults).return(results)
     })
   },
 

--- a/packages/server/test/e2e/5_spec_isolation_spec.js
+++ b/packages/server/test/e2e/5_spec_isolation_spec.js
@@ -1,13 +1,14 @@
 // TODO: rename this file to 5_module_api_spec
 
 const path = require('path')
+const _ = require('lodash')
 const snapshot = require('snap-shot-it')
 const fs = require('../../lib/util/fs')
-const e2e = require('../support/helpers/e2e').default
+const { default: e2e, STDOUT_DURATION_IN_TABLES_RE } = require('../support/helpers/e2e')
 const Fixtures = require('../support/helpers/fixtures')
 const { expectCorrectModuleApiResult } = require('../support/helpers/resultsUtils')
 const e2ePath = Fixtures.projectPath('e2e')
-const it = e2e.it
+const { it } = e2e
 
 const outputPath = path.join(e2ePath, 'output.json')
 
@@ -26,8 +27,12 @@ describe('e2e spec_isolation', () => {
     outputPath,
     snapshot: false,
     expectedExitCode: 5,
-    async onRun (exec) {
-      await exec()
+    async onRun (execFn) {
+      const { stdout } = await execFn()
+
+      _.each(STDOUT_DURATION_IN_TABLES_RE.exec(stdout), (str) => {
+        expect(str.trim(), 'spec durations in tables should not be 0ms').not.eq('0ms')
+      })
 
       // now what we want to do is read in the outputPath
       // and snapshot it so its what we expect after normalizing it

--- a/packages/server/test/support/helpers/e2e.ts
+++ b/packages/server/test/support/helpers/e2e.ts
@@ -44,6 +44,8 @@ const availableBrowsersRe = /(Available browsers found on your system are:)([\s\
 const crossOriginErrorRe = /(Blocked a frame .* from accessing a cross-origin frame.*|Permission denied.*cross-origin object.*)/gm
 const whiteSpaceBetweenNewlines = /\n\s+\n/
 
+export const STDOUT_DURATION_IN_TABLES_RE = /(\s+?)(\d+ms|\d+:\d+:?\d+)/g
+
 // this captures an entire stack trace and replaces it with [stack trace lines]
 // so that the stdout can contain stack traces of different lengths
 // '@' will be present in firefox stack trace lines
@@ -91,8 +93,6 @@ const replaceCypressVersion = (str, p1, p2) => {
 // when swapping out the duration, ensure we pad the
 // full length of the duration so it doesn't shift content
 const replaceDurationInTables = (str, p1, p2) => {
-  expect(str, 'duration should always be greater than 0ms').not.contain(' 0ms')
-
   return _.padStart('XX:XX', p1.length + p2.length)
 }
 
@@ -155,7 +155,7 @@ const normalizeStdout = function (str, options: any = {}) {
   // numbers in parenths
   .replace(/\s\(\d+([ms]|ms)\)/g, '')
   // 12:35 -> XX:XX
-  .replace(/(\s+?)(\d+ms|\d+:\d+:?\d+)/g, replaceDurationInTables)
+  .replace(STDOUT_DURATION_IN_TABLES_RE, replaceDurationInTables)
   .replace(/(coffee|js)-\d{3}/g, '$1-456')
   // Cypress: 2.1.0 -> Cypress: 1.2.3
   .replace(/(Cypress\:\s+)(\d+\.\d+\.\d+)/g, replaceCypressVersion)

--- a/packages/server/test/support/helpers/e2e.ts
+++ b/packages/server/test/support/helpers/e2e.ts
@@ -91,6 +91,8 @@ const replaceCypressVersion = (str, p1, p2) => {
 // when swapping out the duration, ensure we pad the
 // full length of the duration so it doesn't shift content
 const replaceDurationInTables = (str, p1, p2) => {
+  expect(str, 'duration should always be greater than 0ms').not.contain(' 0ms')
+
   return _.padStart('XX:XX', p1.length + p2.length)
 }
 


### PR DESCRIPTION
**exists only in develop**
fixes bug introduced by #8148 causing spec durations to be printed as `0ms` in the final spec results.

fix #8309 (unreleased)

before:
![image](https://user-images.githubusercontent.com/14625260/90557885-337f0700-e169-11ea-813f-24ffa94ad486.png)

after:
![image](https://user-images.githubusercontent.com/14625260/90557917-41348c80-e169-11ea-8c93-c4f5e7e17092.png)
