### PR TITLE
chore: fix the after pack to wait while files are being copied

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ macBuildFilters: &macBuildFilters
         - develop
         - v5.0-release
         - install-node-on-circleci-mac
+        - stop-before-code-sign
 
 defaults: &defaults
   parallelism: 1

--- a/scripts/after-pack-hook.js
+++ b/scripts/after-pack-hook.js
@@ -27,14 +27,14 @@ module.exports = async function (params) {
 
   console.log('copying node_modules to', outputFolder)
 
-  packages.forEach(async (packageNodeModules) => {
+  for await (const packageNodeModules of packages) {
     console.log('copying', packageNodeModules)
 
     const sourceFolder = join(params.packager.info._appDir, packageNodeModules)
     const destinationFolder = join(outputFolder, packageNodeModules)
 
     await fs.copy(sourceFolder, destinationFolder)
-  })
+  }
 
   console.log('all node_modules subfolders copied to', outputFolder)
 }


### PR DESCRIPTION
- closes #8299

Previously files were being copied, but the code signing did not wait and tried to code sign ffmpeg - too soon.