### PR TITLE
fix: 5.0 runner hangs on nested hook

### DIFF
--- a/packages/driver/src/cypress/runner.js
+++ b/packages/driver/src/cypress/runner.js
@@ -1010,12 +1010,15 @@ const create = (specWindow, mocha, Cypress, cy) => {
   }
 
   const maybeHandleRetry = (runnable, err) => {
+    if (!err) return
+
     const r = runnable
     const isHook = r.type === 'hook'
     const isTest = r.type === 'test'
     const test = getTest() || getTestFromHook(runnable, getTestById)
-    const isBeforeEachHook = isHook && !!r.hookName.match(/before each/)
-    const isAfterEachHook = isHook && !!r.hookName.match(/after each/)
+    const hookName = isHook && getHookName(r)
+    const isBeforeEachHook = isHook && !!hookName.match(/before each/)
+    const isAfterEachHook = isHook && !!hookName.match(/after each/)
     const retryAbleRunnable = isTest || isBeforeEachHook || isAfterEachHook
     const willRetry = (test._currentRetry < test._retries) && retryAbleRunnable
 
@@ -1196,8 +1199,8 @@ const create = (specWindow, mocha, Cypress, cy) => {
 
       const isHook = runnable.type === 'hook'
 
-      const isAfterEachHook = isHook && runnable.hookName.match(/after each/)
-      const isBeforeEachHook = isHook && runnable.hookName.match(/before each/)
+      const isAfterEachHook = isHook && hookName.match(/after each/)
+      const isBeforeEachHook = isHook && hookName.match(/before each/)
 
       // if we've been told to skip hooks at a certain nested level
       // this happens if we're handling a runnable that is going to retry due to failing in a hook

--- a/packages/runner/cypress/integration/e2e/issue-8350.js
+++ b/packages/runner/cypress/integration/e2e/issue-8350.js
@@ -1,0 +1,19 @@
+const { createCypress } = require('../support/helpers')
+const { runIsolatedCypress } = createCypress()
+
+describe('issue-8350', () => {
+  it('does not hang on nested hook', () => {
+    runIsolatedCypress(() => {
+      before(() => {
+        beforeEach(() => {
+        })
+      })
+
+      describe('ae inside be', () => {
+        it('t1', () => {
+          //
+        })
+      })
+    })
+  })
+})

--- a/packages/runner/cypress/integration/issues/issue-8350.js
+++ b/packages/runner/cypress/integration/issues/issue-8350.js
@@ -1,4 +1,4 @@
-const { createCypress } = require('../support/helpers')
+const { createCypress } = require('../../support/helpers')
 const { runIsolatedCypress } = createCypress()
 
 // https://github.com/cypress-io/cypress/issues/8350

--- a/packages/runner/cypress/integration/issues/issue-8350.js
+++ b/packages/runner/cypress/integration/issues/issue-8350.js
@@ -1,6 +1,7 @@
 const { createCypress } = require('../support/helpers')
 const { runIsolatedCypress } = createCypress()
 
+// https://github.com/cypress-io/cypress/issues/8350
 describe('issue-8350', () => {
   it('does not hang on nested hook', () => {
     runIsolatedCypress(() => {

--- a/packages/runner/cypress/integration/issues/issue-8350.js
+++ b/packages/runner/cypress/integration/issues/issue-8350.js
@@ -10,7 +10,7 @@ describe('issue-8350', () => {
         })
       })
 
-      describe('ae inside be', () => {
+      describe('s1', () => {
         it('t1', () => {
           //
         })

--- a/packages/runner/cypress/support/helpers.js
+++ b/packages/runner/cypress/support/helpers.js
@@ -237,11 +237,6 @@ function createCypress (defaultOptions = {}) {
             if (testsInOwnFile) return
 
             generateMochaTestsForWin(specWindow, mochaTestsOrFile)
-            specWindow.before = () => {}
-            specWindow.beforeEach = () => {}
-            specWindow.afterEach = () => {}
-            specWindow.after = () => {}
-            specWindow.describe = () => {}
           })
 
           cy.stub(autCypress, 'run').snapshot(enableStubSnapshots).log(false).callsFake(runIsolatedCypress)


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8350

### User facing changelog
- Bug fix: fix issue causing tests to hang when spec code includes nested hook declarations
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details
- an uncaught error was being thrown inbetween the runnable.next() calls, causing the runner to never progress to the next runnable
- we never intended for hooks to be nested since it provides no real use case. However some users have written nested hooks and it's a simple fix for this regression that occurred in 5.0
- NOTE: we should probably error when we detect a nested hook was declared (leads to reporter issues as well). However that is more of a change than this PR which fixes a bug introduced in 5.0. Most users are accidentally writing nested hooks which can lead to performance problems, especially when nesting `each` hooks inside of `each` hooks:
```js
// this is bad, and will register a new afterEach hook for every test
beforeEach(()=>{
  // setup...
  afterEach(()=>{
  // tear down...
  })
})
```
<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
