### PR TITLE
fix: Add retries to test config types

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2583,7 +2583,7 @@ declare namespace Cypress {
   }
 
   interface TestConfigOverrides extends Partial<Pick<ConfigOptions, 'baseUrl' | 'defaultCommandTimeout' | 'taskTimeout' | 'animationDistanceThreshold' | 'waitForAnimations' | 'viewportHeight' | 'viewportWidth' | 'requestTimeout' | 'execTimeout' | 'env' | 'responseTimeout'>> {
-    // retries?: number
+    retries?: Nullable<number | { runMode: Nullable<number>, openMode: Nullable<number> }>
     browser?: IsBrowserMatcher | IsBrowserMatcher[]
   }
 

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2582,8 +2582,7 @@ declare namespace Cypress {
     retries: Nullable<number | {runMode: Nullable<number>, openMode: Nullable<number>}>
   }
 
-  interface TestConfigOverrides extends Partial<Pick<ConfigOptions, 'baseUrl' | 'defaultCommandTimeout' | 'taskTimeout' | 'animationDistanceThreshold' | 'waitForAnimations' | 'viewportHeight' | 'viewportWidth' | 'requestTimeout' | 'execTimeout' | 'env' | 'responseTimeout'>> {
-    retries?: Nullable<number | { runMode: Nullable<number>, openMode: Nullable<number> }>
+  interface TestConfigOverrides extends Partial<Pick<ConfigOptions, 'baseUrl' | 'defaultCommandTimeout' | 'taskTimeout' | 'animationDistanceThreshold' | 'waitForAnimations' | 'viewportHeight' | 'viewportWidth' | 'requestTimeout' | 'execTimeout' | 'env' | 'responseTimeout' | 'retries'>> {
     browser?: IsBrowserMatcher | IsBrowserMatcher[]
   }
 

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -538,6 +538,22 @@ namespace CypressTestConfigOverridesTests {
     browser: {foo: 'bar'} // $ExpectError
   }, () => {})
 
+  it('test', {
+    retries: null
+  }, () => { })
+  it('test', {
+    retries: 3
+  }, () => { })
+  it('test', {
+    retries: {
+      runMode: 3,
+      openMode: null
+    }
+  }, () => { })
+  it('test', {
+    retries: { run: 3 } // $ExpectError
+  }, () => { })
+
   it.skip('test', {}, () => {})
   it.only('test', {}, () => {})
   xit('test', {}, () => {})


### PR DESCRIPTION
- close #8405 

### User Changelog

- Types have been added for `retries` passed within test configuration.

### Additional Details


### How has the user experience changed?

#### Before

<img width="374" alt="Screen Shot 2020-08-26 at 12 36 35 PM" src="https://user-images.githubusercontent.com/1271364/91267263-02ba5580-e799-11ea-86df-7a0e247b3c60.png">

#### After

Should no longer error

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?