### PR TITLE
fix: Update error message for new error thrown when free plan limit exceeded

### DIFF
--- a/packages/server/__snapshots__/7_record_spec.js
+++ b/packages/server/__snapshots__/7_record_spec.js
@@ -1759,7 +1759,7 @@ https://on.cypress.io/dashboard/organizations/org-id-1234/billing
 exports['e2e record api interaction warnings create run warnings grace period - over tests limit warns when over test recordings 1'] = `
 You've exceeded the limit of test recordings under your free plan this month. The limit is 500 test recordings.
 
-Your plan is now in a grace period, which means you will have a full benefits of a paid plan until 2999-12-31. 
+Your plan is now in a grace period, which means you will have the full benefits of your current plan until 2999-12-31. 
 
 Please visit your billing to upgrade your plan.
 
@@ -1921,7 +1921,7 @@ https://on.cypress.io/dashboard/organizations/org-id-1234/billing
 exports['e2e record api interaction warnings create run warnings paid plan - over private tests limit warns when over private test recordings 1'] = `
 You've exceeded the limit of test recordings under your current billing plan this month. The limit is 500 private test recordings.
 
-Please visit your billing to upgrade your plan.
+To continue getting the full benefits of your current plan, please visit your billing to upgrade.
 
 https://on.cypress.io/dashboard/organizations/org-id-1234/billing
 
@@ -2001,7 +2001,7 @@ https://on.cypress.io/dashboard/organizations/org-id-1234/billing
 exports['e2e record api interaction warnings create run warnings paid plan - over tests limit warns when over test recordings 1'] = `
 You've exceeded the limit of test recordings under your current billing plan this month. The limit is 500 test recordings.
 
-Please visit your billing to upgrade your plan.
+To continue getting the full benefits of your current plan, please visit your billing to upgrade.
 
 https://on.cypress.io/dashboard/organizations/org-id-1234/billing
 
@@ -2430,7 +2430,7 @@ exports['e2e record passing passes 2'] = [
 exports['e2e record api interaction warnings create run warnings free plan - over tests limit v2 warns when over test recordings 1'] = `
 You've exceeded the limit of test recordings under your free billing plan this month. The limit is 500 test recordings.
 
-Please visit your billing to upgrade your plan.
+To continue getting the full benefits of your current plan, please visit your billing to upgrade.
 
 https://on.cypress.io/dashboard/organizations/org-id-1234/billing
 

--- a/packages/server/__snapshots__/7_record_spec.js
+++ b/packages/server/__snapshots__/7_record_spec.js
@@ -1759,7 +1759,9 @@ https://on.cypress.io/dashboard/organizations/org-id-1234/billing
 exports['e2e record api interaction warnings create run warnings grace period - over tests limit warns when over test recordings 1'] = `
 You've exceeded the limit of test recordings under your free plan this month. The limit is 500 test recordings.
 
-Your plan is now in a grace period, which means your tests will still be recorded until 2999-12-31. Please upgrade your plan to continue recording tests on the Cypress Dashboard in the future.
+Your plan is now in a grace period, which means you will have a full benefits of a paid plan until 2999-12-31. 
+
+Please visit your billing to upgrade your plan.
 
 https://on.cypress.io/dashboard/organizations/org-id-1234/billing
 
@@ -1917,9 +1919,9 @@ https://on.cypress.io/dashboard/organizations/org-id-1234/billing
 `
 
 exports['e2e record api interaction warnings create run warnings paid plan - over private tests limit warns when over private test recordings 1'] = `
-You've exceeded the limit of private test recordings under your current billing plan this month. The limit is 500 private test recordings.
+You've exceeded the limit of test recordings under your current billing plan this month. The limit is 500 private test recordings.
 
-To upgrade your account, please visit your billing to upgrade to another billing plan.
+Please visit your billing to upgrade your plan.
 
 https://on.cypress.io/dashboard/organizations/org-id-1234/billing
 
@@ -1999,7 +2001,7 @@ https://on.cypress.io/dashboard/organizations/org-id-1234/billing
 exports['e2e record api interaction warnings create run warnings paid plan - over tests limit warns when over test recordings 1'] = `
 You've exceeded the limit of test recordings under your current billing plan this month. The limit is 500 test recordings.
 
-To upgrade your account, please visit your billing to upgrade to another billing plan.
+Please visit your billing to upgrade your plan.
 
 https://on.cypress.io/dashboard/organizations/org-id-1234/billing
 
@@ -2424,3 +2426,83 @@ exports['e2e record passing passes 2'] = [
     }
   }
 ]
+
+exports['e2e record api interaction warnings create run warnings free plan - over tests limit v2 warns when over test recordings 1'] = `
+You've exceeded the limit of test recordings under your free billing plan this month. The limit is 500 test recordings.
+
+Please visit your billing to upgrade your plan.
+
+https://on.cypress.io/dashboard/organizations/org-id-1234/billing
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      1 found (record_pass_spec.coffee)                                                  │
+  │ Searched:   cypress/integration/record_pass*                                                   │
+  │ Params:     Tag: false, Group: false, Parallel: false                                          │
+  │ Run URL:    https://dashboard.cypress.io/projects/cjvoj7/runs/12                               │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  record_pass_spec.coffee                                                         (1 of 1)
+  Estimated: 8 seconds
+
+
+  record pass
+    ✓ passes
+    - is pending
+
+
+  1 passing
+  1 pending
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        2                                                                                │
+  │ Passing:      1                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      1                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  1                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Estimated:    8 seconds                                                                        │
+  │ Spec Ran:     record_pass_spec.coffee                                                          │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Screenshots)
+
+  -  /XXX/XXX/XXX/cypress/screenshots/record_pass_spec.coffee/yay it passes.png           (202x1002)
+
+
+  (Uploading Results)
+
+  - Done Uploading (1/1) /foo/bar/.projects/e2e/cypress/screenshots/record_pass_spec.coffee/yay it passes.png
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✔  record_pass_spec.coffee                  XX:XX        2        1        -        1        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✔  All specs passed!                        XX:XX        2        1        -        1        -  
+
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                       
+  Recorded Run: https://dashboard.cypress.io/projects/cjvoj7/runs/12                                   
+
+
+`

--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -756,7 +756,7 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
       return stripIndent`\
         You've exceeded the limit of test recordings under your free plan this month. ${arg1.usedTestsMessage}
 
-        Your plan is now in a grace period, which means you will have a full benefits of a paid plan until ${arg1.gracePeriodMessage}. 
+        Your plan is now in a grace period, which means you will have the full benefits of your current plan until ${arg1.gracePeriodMessage}. 
         
         Please visit your billing to upgrade your plan.
 
@@ -765,14 +765,7 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
       return stripIndent`\
         You've exceeded the limit of test recordings under your ${arg1.planType} billing plan this month. ${arg1.usedTestsMessage}
 
-        Please visit your billing to upgrade your plan.
-
-        ${arg1.link}`
-    case 'FREE_PLAN_EXCEEDS_MONTHLY_TESTS_V2':
-      return stripIndent`\
-        You've exceeded the limit of test recordings under your free plan this month. ${arg1.usedTestsMessage}
-
-        Please visit your billing to upgrade your plan.
+        To continue getting the full benefits of your current plan, please visit your billing to upgrade.
 
         ${arg1.link}`
     case 'FREE_PLAN_IN_GRACE_PERIOD_PARALLEL_FEATURE':

--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -756,14 +756,23 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
       return stripIndent`\
         You've exceeded the limit of test recordings under your free plan this month. ${arg1.usedTestsMessage}
 
-        Your plan is now in a grace period, which means your tests will still be recorded until ${arg1.gracePeriodMessage}. Please upgrade your plan to continue recording tests on the Cypress Dashboard in the future.
+        Your plan is now in a grace period, which means you will have a full benefits of a paid plan until ${arg1.gracePeriodMessage}. 
+        
+        Please visit your billing to upgrade your plan.
 
         ${arg1.link}`
-    case 'PAID_PLAN_EXCEEDS_MONTHLY_TESTS':
+    case 'PLAN_EXCEEDS_MONTHLY_TESTS':
       return stripIndent`\
-        You've exceeded the limit of test recordings under your current billing plan this month. ${arg1.usedTestsMessage}
+        You've exceeded the limit of test recordings under your ${arg1.planType} billing plan this month. ${arg1.usedTestsMessage}
 
-        To upgrade your account, please visit your billing to upgrade to another billing plan.
+        Please visit your billing to upgrade your plan.
+
+        ${arg1.link}`
+    case 'FREE_PLAN_EXCEEDS_MONTHLY_TESTS_V2':
+      return stripIndent`\
+        You've exceeded the limit of test recordings under your free plan this month. ${arg1.usedTestsMessage}
+
+        Please visit your billing to upgrade your plan.
 
         ${arg1.link}`
     case 'FREE_PLAN_IN_GRACE_PERIOD_PARALLEL_FEATURE':

--- a/packages/server/lib/modes/record.js
+++ b/packages/server/lib/modes/record.js
@@ -384,13 +384,21 @@ const createRun = Promise.method((options = {}) => {
             gracePeriodMessage: gracePeriodMessage(warning.gracePeriodEnds),
             link: billingLink(warning.orgId),
           })
+        case 'FREE_PLAN_EXCEEDS_MONTHLY_TESTS_V2':
+          return errors.warning('PLAN_EXCEEDS_MONTHLY_TESTS', {
+            planType: 'free',
+            usedTestsMessage: usedTestsMessage(warning.limit, 'test'),
+            link: billingLink(warning.orgId),
+          })
         case 'PAID_PLAN_EXCEEDS_MONTHLY_PRIVATE_TESTS':
-          return errors.warning('PAID_PLAN_EXCEEDS_MONTHLY_PRIVATE_TESTS', {
+          return errors.warning('PLAN_EXCEEDS_MONTHLY_TESTS', {
+            planType: 'current',
             usedTestsMessage: usedTestsMessage(warning.limit, 'private test'),
             link: billingLink(warning.orgId),
           })
         case 'PAID_PLAN_EXCEEDS_MONTHLY_TESTS':
-          return errors.warning('PAID_PLAN_EXCEEDS_MONTHLY_TESTS', {
+          return errors.warning('PLAN_EXCEEDS_MONTHLY_TESTS', {
+            planType: 'current',
             usedTestsMessage: usedTestsMessage(warning.limit, 'test'),
             link: billingLink(warning.orgId),
           })

--- a/packages/server/test/e2e/7_record_spec.js
+++ b/packages/server/test/e2e/7_record_spec.js
@@ -1668,6 +1668,45 @@ describe('e2e record', () => {
         })
       })
 
+      describe('free plan - over tests limit v2', () => {
+        const routes = defaultRoutes.slice()
+
+        routes[0] = {
+          method: 'post',
+          url: '/runs',
+          req: 'postRunRequest@2.2.0',
+          resSchema: 'postRunResponse@2.2.0',
+          res (req, res) {
+            return res.status(200).json({
+              runId,
+              groupId,
+              machineId,
+              runUrl,
+              tags,
+              warnings: [{
+                name: 'FreePlanExceedsMonthlyTests',
+                message: 'Warning from Cypress Dashboard: Organization with free plan has exceeded monthly test recordings limit.',
+                code: 'FREE_PLAN_EXCEEDS_MONTHLY_TESTS_V2',
+                used: 700,
+                limit: 500,
+                orgId: 'org-id-1234',
+              }],
+            })
+          },
+        }
+
+        setup(routes)
+
+        it('warns when over test recordings', function () {
+          return e2e.exec(this, {
+            key: 'f858a2bc-b469-4e48-be67-0876339ee7e1',
+            spec: 'record_pass*',
+            record: true,
+            snapshot: true,
+          })
+        })
+      })
+
       describe('unknown warning', () => {
         const routes = defaultRoutes.slice()
 


### PR DESCRIPTION
- TR-292
- Addresses new error in #4021 

### User Changelog

- `cypress run` when recording will no longer exit and stop recording when exceeding the number of test recordings on a free plan. The stdout will instead display a warning message. 

### Additional Details

- I decided not to be explicit about the consequences of exceeding the free limit, as I don’t think we should hard code this into the Test Runner so that we have flexibility to change this on the API side. (Meaning, I am not explicitly saying that parallelization is disabled now).
- I also tweaked the existing language of exceeding plans in general.

### How has the user experience changed?

#### Before

**Free plans exceeds monthly limit**

![65aee43f-16d5-4d4a-91b9-e965e67c4504](https://user-images.githubusercontent.com/1271364/91272714-28982800-e7a2-11ea-99e6-645906151740.png)

**Paid plan exceeds monthly limit**

>You've exceeded the limit of test recordings under your current billing plan this month. The limit is 500 test recordings.
>
>To upgrade your account, please visit your billing to upgrade to another billing plan.
>
>https://on.cypress.io/dashboard/organizations/org-id-1234/billing

**Free plan in grace period exceeds monthly limit**

>You've exceeded the limit of test recordings under your free billing plan this month. The limit is 500 private test recordings.
>
>Your plan is now in a grace period, which means your tests will still be recorded until 2999-12-31. Please upgrade your plan to continue recording tests on the Cypress Dashboard in the future.
>
>https://on.cypress.io/dashboard/organizations/org-id-1234/billing


#### After

**Free plans exceeds monthly limit**

<img width="999" alt="Screen Shot 2020-08-26 at 1 42 25 PM" src="https://user-images.githubusercontent.com/1271364/91272689-1ddd9300-e7a2-11ea-8120-0525f17842ff.png">


**Paid plan exceeds monthly limit**

<img width="1063" alt="Screen Shot 2020-08-26 at 1 42 06 PM" src="https://user-images.githubusercontent.com/1271364/91272728-3188f980-e7a2-11ea-8e24-55e6defcf867.png">



**Free plan in grace period exceeds monthly limit**
<img width="958" alt="Screen Shot 2020-08-26 at 1 41 45 PM" src="https://user-images.githubusercontent.com/1271364/91272751-3e0d5200-e7a2-11ea-9a4b-2bcaa6adb48b.png">

