### PR TITLE
[internal] add retries to e2e/screenshot_spec

### DIFF
--- a/packages/server/test/e2e/5_screenshots_spec.js
+++ b/packages/server/test/e2e/5_screenshots_spec.js
@@ -65,6 +65,7 @@ describe('e2e screenshots', () => {
     spec: 'screenshots_spec.js',
     expectedExitCode: 5,
     snapshot: true,
+    retries: 1,
     timeout: 180000,
     onStdout: e2e.normalizeWebpackErrors,
     onRun (exec, browser) {

--- a/packages/server/test/support/helpers/e2e.ts
+++ b/packages/server/test/support/helpers/e2e.ts
@@ -303,6 +303,7 @@ const localItFn = function (title, opts = {}) {
   const DEFAULT_OPTIONS = {
     only: false,
     skip: false,
+    retries: null,
     browser: [],
     snapshot: false,
     spec: 'no spec name supplied!',
@@ -340,6 +341,10 @@ const localItFn = function (title, opts = {}) {
       }
 
       const originalTitle = this.test.parent.titlePath().concat(title).join(' / ')
+
+      if (options.retries) {
+        this.test.retries(options.retries)
+      }
 
       const ctx = this
 


### PR DESCRIPTION
This e2e test is flaky in firefox, should we try adding a retry?