### PR TITLE
chore(tests): [internal] fix flake e2e screenshot spec (firefox)

### DIFF
--- a/packages/server/test/e2e/5_screenshots_spec.js
+++ b/packages/server/test/e2e/5_screenshots_spec.js
@@ -99,8 +99,8 @@ describe('e2e screenshots', () => {
           // make sure all of the values are unique
           expect(sizes).to.deep.eq(_.uniq(sizes))
 
-          // png1 should not be within 5k of png2
-          expect(sizes[0]).not.to.be.closeTo(sizes[1], 5000)
+          // png1 should not be within 3k of png2
+          expect(sizes[0]).not.to.be.closeTo(sizes[1], 3000)
         }).then(() => {
           return Promise.all([
             sizeOf(screenshot1),


### PR DESCRIPTION
decrease the range of this assertion to `3k`, noticed this has been flaking recently

```
// png1 should not be within 5k of png2
expect(sizes[0]).not.to.be.closeTo(sizes[1], 5000)
```

example failure: https://app.circleci.com/pipelines/github/cypress-io/cypress/13071/workflows/17e9ae2b-7337-4d6d-96e0-3e9f0a27795f/jobs/432341

