### PR TITLE
fix: Improve error message when binary not executable

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -29,7 +29,13 @@ yarn test-watch --scope cypress
 yarn test-debug --scope cypress
 ```
 
-This will take and compare snapshots of the CLI output. To update snapshots, see `snap-shot-it` instructions: https://github.com/bahmutov/snap-shot-it#advanced-use
+### Updating snaphots
+
+Prepend `SNAPSHOT_UPDATE=1` to any test command. See [`snap-shot-it` instructions](https://github.com/bahmutov/snap-shot-it#advanced-use) for more info.
+
+```bash
+SNAPSHOT_UPDATE=1 yarn test-unit --scope cypress
+```
 
 #### Type Linting
 

--- a/cli/__snapshots__/verify_spec.js
+++ b/cli/__snapshots__/verify_spec.js
@@ -10,6 +10,8 @@ Reasons this may happen:
 
 Please check that you have the appropriate user permissions.
 
+You can also try clearing the cache with \`cypress cache clear\` and reinstalling.
+
 ----------
 
 Platform: darwin (Foo-OsVersion)

--- a/cli/__snapshots__/verify_spec.js
+++ b/cli/__snapshots__/verify_spec.js
@@ -10,7 +10,7 @@ Reasons this may happen:
 
 Please check that you have the appropriate user permissions.
 
-You can also try clearing the cache with \`cypress cache clear\` and reinstalling.
+You can also try clearing the cache with 'cypress cache clear' and reinstalling.
 
 ----------
 

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -74,7 +74,7 @@ const binaryNotExecutable = (executable) => {
 
     Please check that you have the appropriate user permissions.
 
-    You can also try clearing the cache with \`cypress cache clear\` and reinstalling. 
+    You can also try clearing the cache with 'cypress cache clear' and reinstalling. 
   `,
   }
 }

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -73,6 +73,8 @@ const binaryNotExecutable = (executable) => {
     - the cypress npm package as 'root' or with 'sudo'
 
     Please check that you have the appropriate user permissions.
+
+    You can also try clearing the cache with \`cypress cache clear\` and reinstalling. 
   `,
   }
 }


### PR DESCRIPTION
- Closes #8397 

### User Changelog

-  The error message when the Cypress binary is not executable now recommends trying to clear cache and reinstall.

### Additional Details

### How has the user experience changed?

#### Before 

```
Error: Cypress cannot run because this binary file does not have executable permissions here:

/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress

Reasons this may happen:

- node was installed as 'root' or with 'sudo'
- the cypress npm package as 'root' or with 'sudo'

Please check that you have the appropriate user permissions.
```

#### After 

```
Error: Cypress cannot run because this binary file does not have executable permissions here:

/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress

Reasons this may happen:

- node was installed as 'root' or with 'sudo'
- the cypress npm package as 'root' or with 'sudo'

Please check that you have the appropriate user permissions.

You can also try clearing the cache with ‘cypress cache clear’ and reinstalling.
```