### PR TITLE
fix(launcher): detect new Chrome 64-bit path on Windows

### DIFF
--- a/packages/launcher/__snapshots__/windows_spec.ts.js
+++ b/packages/launcher/__snapshots__/windows_spec.ts.js
@@ -176,3 +176,9 @@ exports['windows browser detection detects browsers as expected 1'] = [
     }
   }
 ]
+
+exports['windows browser detection detects new Chrome 64-bit app path 1'] = {
+  "name": "chrome",
+  "version": "4.4.4",
+  "path": "C:/Program Files/Google/Chrome/Application/chrome.exe"
+}

--- a/packages/launcher/lib/windows/index.ts
+++ b/packages/launcher/lib/windows/index.ts
@@ -9,9 +9,10 @@ import { Browser, FoundBrowser } from '../types'
 import { utils } from '../utils'
 
 function formFullAppPath (name: string) {
-  const prefix = 'C:/Program Files (x86)/Google/Chrome/Application'
-
-  return [normalize(join(prefix, `${name}.exe`))]
+  return [
+    `C:/Program Files (x86)/Google/Chrome/Application/${name}.exe`,
+    `C:/Program Files/Google/Chrome/Application/${name}.exe`,
+  ].map(normalize)
 }
 
 function formChromiumAppPath () {

--- a/packages/launcher/test/unit/windows_spec.ts
+++ b/packages/launcher/test/unit/windows_spec.ts
@@ -65,6 +65,14 @@ describe('windows browser detection', () => {
     snapshot(detected)
   })
 
+  // @see https://github.com/cypress-io/cypress/issues/8425
+  it('detects new Chrome 64-bit app path', async () => {
+    stubBrowser('C:/Program Files/Google/Chrome/Application/chrome.exe', '4.4.4')
+    const chrome = _.find(browsers, { name: 'chrome', channel: 'stable' })
+
+    snapshot(await windowsHelper.detect(chrome))
+  })
+
   context('#getVersionString', () => {
     it('runs wmic and returns output', async () => {
       stubBrowser('foo', 'bar')


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8425 

### User facing changelog

- Fixed an issue where Cypress would not detect newer 64-bit installations of Chrome on Windows.

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
