### PR TITLE
fix(launcher): detect Firefox installed in AppData on Windows

### DIFF
--- a/packages/launcher/__snapshots__/windows_spec.ts.js
+++ b/packages/launcher/__snapshots__/windows_spec.ts.js
@@ -192,8 +192,14 @@ exports['windows browser detection detects local Firefox installs 1'] = [
     "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
     "binary": "firefox",
+    "path": "C:/Users/flotwig/AppData/Local/Mozilla Firefox/firefox.exe",
     "version": "100",
-    "path": "C:/Users/flotwig/AppData/Local/Mozilla Firefox/firefox.exe"
+    "findAppParams": {
+      "appName": "Firefox.app",
+      "executable": "Contents/MacOS/firefox-bin",
+      "appId": "org.mozilla.firefox",
+      "versionProperty": "CFBundleShortVersionString"
+    }
   },
   {
     "name": "firefox",
@@ -206,8 +212,14 @@ exports['windows browser detection detects local Firefox installs 1'] = [
       "firefox-developer-edition",
       "firefox"
     ],
+    "path": "C:/Users/flotwig/AppData/Local/Firefox Developer Edition/firefox.exe",
     "version": "300",
-    "path": "C:/Users/flotwig/AppData/Local/Firefox Developer Edition/firefox.exe"
+    "findAppParams": {
+      "appName": "Firefox Developer Edition.app",
+      "executable": "Contents/MacOS/firefox-bin",
+      "appId": "org.mozilla.firefoxdeveloperedition",
+      "versionProperty": "CFBundleShortVersionString"
+    }
   },
   {
     "name": "firefox",
@@ -220,7 +232,13 @@ exports['windows browser detection detects local Firefox installs 1'] = [
       "firefox-nightly",
       "firefox-trunk"
     ],
+    "path": "C:/Users/flotwig/AppData/Local/Firefox Nightly/firefox.exe",
     "version": "200",
-    "path": "C:/Users/flotwig/AppData/Local/Firefox Nightly/firefox.exe"
+    "findAppParams": {
+      "appName": "Firefox Nightly.app",
+      "executable": "Contents/MacOS/firefox-bin",
+      "appId": "org.mozilla.nightly",
+      "versionProperty": "CFBundleShortVersionString"
+    }
   }
 ]

--- a/packages/launcher/__snapshots__/windows_spec.ts.js
+++ b/packages/launcher/__snapshots__/windows_spec.ts.js
@@ -182,3 +182,45 @@ exports['windows browser detection detects new Chrome 64-bit app path 1'] = {
   "version": "4.4.4",
   "path": "C:/Program Files/Google/Chrome/Application/chrome.exe"
 }
+
+exports['windows browser detection detects local Firefox installs 1'] = [
+  {
+    "name": "firefox",
+    "family": "firefox",
+    "channel": "stable",
+    "displayName": "Firefox",
+    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
+    "versionRegex": {},
+    "binary": "firefox",
+    "version": "100",
+    "path": "C:/Users/flotwig/AppData/Local/Mozilla Firefox/firefox.exe"
+  },
+  {
+    "name": "firefox",
+    "family": "firefox",
+    "channel": "dev",
+    "displayName": "Firefox Developer Edition",
+    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
+    "versionRegex": {},
+    "binary": [
+      "firefox-developer-edition",
+      "firefox"
+    ],
+    "version": "300",
+    "path": "C:/Users/flotwig/AppData/Local/Firefox Developer Edition/firefox.exe"
+  },
+  {
+    "name": "firefox",
+    "family": "firefox",
+    "channel": "nightly",
+    "displayName": "Firefox Nightly",
+    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
+    "versionRegex": {},
+    "binary": [
+      "firefox-nightly",
+      "firefox-trunk"
+    ],
+    "version": "200",
+    "path": "C:/Users/flotwig/AppData/Local/Firefox Nightly/firefox.exe"
+  }
+]

--- a/packages/launcher/lib/windows/index.ts
+++ b/packages/launcher/lib/windows/index.ts
@@ -42,6 +42,13 @@ function getFirefoxPaths (editionFolder) {
     .map((programFiles) => {
       return normalize(`C:/${programFiles}/${editionFolder}/firefox.exe`)
     })
+    .concat(normalize(join(
+      os.homedir(),
+      'AppData',
+      'Local',
+      editionFolder,
+      'firefox.exe',
+    )))
   }
 }
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8432 

### User facing changelog

- Fixed an issue where Cypress would not detect per-user Firefox installations on Windows.

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
