### PR TITLE
chore(tests): [fix flake] bump percy network-idle-timeout to fix flaky missing css in snapshots

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -14,6 +14,6 @@ agent:
 
     # let Percy wait for network to fetch static resources
     # like images and fonts to avoid missing icons
-    network-idle-timeout: 250 # ms
+    network-idle-timeout: 5000 # ms
     # assets that don't change could be cached
     cache-responses: true


### PR DESCRIPTION
- crank up percy config `network-idle-timoeut` to fix flaky test issues with css sometimes not loading

tested locally with dozens of runs, seems to solve it and not increase test duration much.

- fix #8402
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->


### User facing changelog
N/A
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

> NOTE: if we still see issues it may be because the `.percy.yml` config located in proj root isn't being used in some CI jobs, since it may be using a package as the working directory
