### PR TITLE
fix(typedefs): Cypress.Commands.add can return Promises.

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -518,7 +518,7 @@ declare namespace Cypress {
     off: Actions
   }
 
-  type CanReturnChainable = void | Chainable
+  type CanReturnChainable = void | Chainable | Promise<unknown>
   type ThenReturn<S, R> =
     R extends void ? Chainable<S> :
     R extends R | undefined ? Chainable<S | Exclude<R, undefined>> :

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -76,6 +76,9 @@ namespace CypressCommandsTests {
   Cypress.Commands.add('newCommand', { prevSubject: true }, () => {
     return
   })
+  Cypress.Commands.add('newCommand', () => {
+    return new Promise((resolve) => {})
+  })
   Cypress.Commands.overwrite('newCommand', () => {
     return
   })


### PR DESCRIPTION
- Closes #7807

### User facing changelog

`Cypress.Commands.add` could only return `void` or `Chainable`. Now, `Promise` is added to the list.

### Additional details

- Why was this change necessary? TypeScript throws an error for valid code.
- What is affected by this change? N/A
- Any implementation details to explain? N/A

### How has the user experience changed?

N/A

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
