### PR TITLE
fix: Fix querying shadow dom in cy.within

### DIFF
--- a/packages/driver/cypress/integration/commands/querying_spec.js
+++ b/packages/driver/cypress/integration/commands/querying_spec.js
@@ -357,6 +357,38 @@ describe('src/cy/commands/querying', () => {
       })
     })
 
+    describe('shadow dom', () => {
+      beforeEach(() => {
+        cy.visit('/fixtures/shadow-dom.html')
+      })
+
+      it('finds element within shadow dom with includeShadowDom option', () => {
+        cy.get('#parent-of-shadow-container-0').within(() => {
+          cy
+          .get('p', { includeShadowDom: true })
+          .should('have.length', 1)
+          .should('have.text', 'Shadow Content 3')
+        })
+      })
+
+      it('when within subject is shadow root, finds element without needing includeShadowDom option', () => {
+        cy.get('#shadow-element-1').shadow().within(() => {
+          cy
+          .get('p')
+          .should('have.length', 1)
+          .should('have.text', 'Shadow Content 1')
+        })
+      })
+
+      it('when within subject is already in shadow dom, finds element without needing includeShadowDom option', () => {
+        cy.get('.shadow-8-nested-1', { includeShadowDom: true }).within(() => {
+          cy
+          .get('.shadow-8-nested-5')
+          .should('have.text', '8')
+        })
+      })
+    })
+
     describe('.log', () => {
       beforeEach(function () {
         this.logs = []

--- a/packages/driver/src/cy/commands/querying.js
+++ b/packages/driver/src/cy/commands/querying.js
@@ -282,7 +282,7 @@ module.exports = (Commands, Cypress, cy, state) => {
           let scope = options.withinSubject
 
           if (options.includeShadowDom) {
-            const root = options.withinSubject || cy.state('document')
+            const root = options.withinSubject ? options.withinSubject[0] : cy.state('document')
             const elementsWithShadow = $dom.findAllShadowRoots(root)
 
             scope = elementsWithShadow.concat(root)
@@ -536,7 +536,7 @@ module.exports = (Commands, Cypress, cy, state) => {
     },
   })
 
-  Commands.addAll({ prevSubject: 'element' }, {
+  Commands.addAll({ prevSubject: ['element', 'document'] }, {
     within (subject, options, fn) {
       let userOptions = options
       const ctx = this


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8478

### User facing changelog

- Fixed an issue where querying the shadow in a `cy.within()` callback would throw the error 'root.getRootNode is not a function'

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
