### PR TITLE
fix: Append number to manually-focused number-type input.

### DIFF
--- a/packages/driver/cypress/fixtures/issue-7170.html
+++ b/packages/driver/cypress/fixtures/issue-7170.html
@@ -1,0 +1,18 @@
+<html>
+<body>
+  <button onclick="onClick()">Show input</button>
+  <script>
+    function onClick() {
+      let input = document.createElement('input')
+      // The type has to be a `number` for the test to fail
+      input.type = 'number' 
+      input.value = 1
+
+      document.body.appendChild(input)
+
+      // The input needs to be forcibly focused for the test to fail
+      document.querySelector('input').focus() 
+    }
+  </script>
+</body>
+</html>

--- a/packages/driver/cypress/integration/issues/7170_spec.js
+++ b/packages/driver/cypress/integration/issues/7170_spec.js
@@ -1,0 +1,9 @@
+describe('issue 7170', () => {
+  it('can type in a number field correctly', () => {
+    cy.visit('fixtures/issue-7170.html')
+    cy.get('button').click()
+    cy.get('input')
+    .type('2')
+    .should('have.value', '12')
+  })
+})

--- a/packages/driver/src/dom/selection.ts
+++ b/packages/driver/src/dom/selection.ts
@@ -30,6 +30,13 @@ const _getSelectionBoundsFromInput = function (el) {
     }
   }
 
+  if (el.type === 'number') {
+    return {
+      start: el.value.length,
+      end: el.value.length,
+    }
+  }
+
   return {
     start: 0,
     end: 0,


### PR DESCRIPTION
- Closes #7170

### User facing changelog

When a number-type input field is manually focused, the number typed with `cy.type()` didn't append it but prepend it. This PR fixes this problem.

### Additional details

- Why was this change necessary? => Fix unexpected behavior.
- What is affected by this change? => N/A
- Any implementation details to explain? => When an input field is manually focused, `__Cypress_state__` is broken. So, we just return the length of the field as `pos`.

### How has the user experience changed?

N/A

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
