### PR TITLE
fix: Fix issue with cy.contains when scoped inside shadow root

### DIFF
--- a/packages/driver/cypress/fixtures/shadow-dom.html
+++ b/packages/driver/cypress/fixtures/shadow-dom.html
@@ -39,6 +39,11 @@
       <cy-test-element innerClass="inside-focusable" content="Inside Focusable"></cy-test-element>
     </div>
     <cy-test-element id="shadow-element-10" innerClass="inside-non-visible" content="Not Visible" style="display:block; transform-style: preserve-3d; backface-visibility: hidden; transform: rotateY(180deg);"></cy-test-element>
+    <cy-test-element id="shadow-element-11" content="
+      <span class='shadow-11-contains'>Find Me With cy.contains</span>
+      <span class='shadow-11-contains shadow-11-scope'>Find Me With cy.contains</span>
+      <span class='shadow-11-contains'>Find Me With cy.contains</span>
+    "></cy-test-element>
 
     <script type="text/javascript">
       if (window.customElements) {

--- a/packages/driver/cypress/integration/commands/querying_shadow_dom_spec.js
+++ b/packages/driver/cypress/integration/commands/querying_shadow_dom_spec.js
@@ -1,0 +1,183 @@
+const helpers = require('../../support/helpers')
+
+const { _ } = Cypress
+
+describe('src/cy/commands/querying - shadow dom', () => {
+  beforeEach(() => {
+    cy.visit('/fixtures/shadow-dom.html')
+  })
+
+  context('#within', () => {
+    it('finds element within shadow dom with includeShadowDom option', () => {
+      cy.get('#parent-of-shadow-container-0').within(() => {
+        cy
+        .get('p', { includeShadowDom: true })
+        .should('have.length', 1)
+        .should('have.text', 'Shadow Content 3')
+      })
+    })
+
+    it('when within subject is shadow root, finds element without needing includeShadowDom option', () => {
+      cy.get('#shadow-element-1').shadow().within(() => {
+        cy
+        .get('p')
+        .should('have.length', 1)
+        .should('have.text', 'Shadow Content 1')
+      })
+    })
+
+    it('when within subject is already in shadow dom, finds element without needing includeShadowDom option', () => {
+      cy.get('.shadow-8-nested-1', { includeShadowDom: true }).within(() => {
+        cy
+        .get('.shadow-8-nested-5')
+        .should('have.text', '8')
+      })
+    })
+  })
+
+  context('#get', () => {
+    it('finds elements within shadow roots', () => {
+      cy.get('.shadow-1', { includeShadowDom: true })
+      .should('have.text', 'Shadow Content 1')
+    })
+
+    it('finds shadow elements within shadow roots', () => {
+      cy.get('.shadow-5', { includeShadowDom: true })
+      .should('have.text', 'Shadow Content 5')
+    })
+
+    it('finds light elements within shadow slots', () => {
+      cy.get('.in-shadow-slot', { includeShadowDom: true })
+      .should('have.text', 'In Shadow Slot')
+    })
+
+    // TODO: enable once we support cross-boundary selectors nicely
+    it.skip('finds elements within shadow roots with cross-boundary selector', () => {
+      cy.get('#parent-of-shadow-container-0 .shadow-3', { includeShadowDom: true })
+      .should('have.text', 'Shadow Content 3')
+    })
+
+    it('finds elements outside shadow roots', () => {
+      cy.get('#non-shadow-element', { includeShadowDom: true })
+      .should('have.text', 'Non Shadow')
+    })
+
+    it('finds elements in and out of shadow roots', () => {
+      cy.get('.in-and-out', { includeShadowDom: true })
+      .should('have.length', 2)
+    })
+
+    // https://github.com/cypress-io/cypress/issues/7676
+    it('does not error when querySelectorAll is wrapped and snapshots are off', () => {
+      cy.visit('/fixtures/shadow-dom.html?wrap-qsa=true')
+      cy.get('.shadow-1', { includeShadowDom: true })
+    })
+  })
+
+  context('#contains', () => {
+
+  })
+
+  context('#shadow', () => {
+    it('returns an empty set if no shadow roots exist', () => {
+      cy.get('#non-shadow-element').shadow()
+      .should('not.exist')
+      .then(($root) => {
+        expect($root).to.be.null
+      })
+    })
+
+    it('returns the shadow root of an individual element', () => {
+      cy.get('#shadow-element-1').shadow()
+      .then(($roots) => {
+        expect($roots.length).to.eq(1)
+      })
+    })
+
+    it('returns a set of shadow roots for a set of elements', () => {
+      const $shadowElements = cy.$$('#shadow-element-1, #shadow-element-2')
+
+      cy.get('#shadow-element-1, #shadow-element-2').shadow()
+      .then(($roots) => {
+        expect($roots.length).to.eq(2)
+        expect($roots.get(0)).to.eq($shadowElements.get(0).shadowRoot)
+        expect($roots.get(1)).to.eq($shadowElements.get(1).shadowRoot)
+      })
+    })
+
+    it('retries until it can find a root', () => {
+      cy.on('command:retry', _.after(2, () => {
+        cy.$$('#non-shadow-element')[0].attachShadow({ mode: 'open' })
+      }))
+
+      cy.get('#non-shadow-element').shadow()
+      .then(($roots) => {
+        expect($roots.length).to.equal(1)
+      })
+    })
+
+    describe('.log', () => {
+      beforeEach(function () {
+        cy.on('log:added', (attrs, log) => {
+          this.lastLog = log
+        })
+
+        return null
+      })
+
+      it('logs immediately before resolving', (done) => {
+        cy.on('log:added', (attrs, log) => {
+          if (log.get('name') === 'shadow') {
+            expect(log.pick('state')).to.deep.eq({
+              state: 'pending',
+            })
+
+            done()
+          }
+        })
+
+        cy.get('#shadow-element-1').shadow()
+      })
+
+      it('snapshots after finding element', () => {
+        cy.get('#shadow-element-1').shadow()
+        .then(function () {
+          const { lastLog } = this
+
+          expect(lastLog.get('snapshots').length).to.eq(1)
+          expect(lastLog.get('snapshots')[0]).to.be.an('object')
+        })
+      })
+
+      it('has the $el', () => {
+        cy.get('#shadow-element-1').shadow()
+        .then(function ($el) {
+          const { lastLog } = this
+
+          expect(lastLog.get('$el').get(0)).to.eq($el.get(0))
+        })
+      })
+
+      it('#consoleProps', () => {
+        cy.get('#shadow-element-1').shadow()
+        .then(function ($el) {
+          expect(this.lastLog.invoke('consoleProps')).to.deep.eq({
+            'Applied To': helpers.getFirstSubjectByName('get').get(0),
+            Yielded: Cypress.dom.getElements($el),
+            Elements: $el.length,
+            Command: 'shadow',
+          })
+        })
+      })
+
+      it('can be turned off', () => {
+        cy.get('#shadow-element-1').shadow({ log: false })
+        .then(function () {
+          const { lastLog } = this
+
+          expect(lastLog.get('name')).to.eq('get')
+        })
+      })
+    })
+  })
+})

--- a/packages/driver/cypress/integration/commands/querying_shadow_dom_spec.js
+++ b/packages/driver/cypress/integration/commands/querying_shadow_dom_spec.js
@@ -75,7 +75,25 @@ describe('src/cy/commands/querying - shadow dom', () => {
   })
 
   context('#contains', () => {
+    it('finds element within shadow dom based on text content', () => {
+      cy
+      .contains('Shadow Content 1', { includeShadowDom: true })
+      .should('have.class', 'shadow-1')
+    })
 
+    it('finds element within shadow dom based on text content, scoped to selector', () => {
+      cy
+      .contains('.shadow-11-scope', 'Find Me With cy.contains', { includeShadowDom: true })
+      .should('have.length', 1)
+    })
+
+    it('finds element within shadow dom based when already past shadow root', () => {
+      cy
+      .get('#shadow-element-1')
+      .shadow()
+      .contains('Shadow Content 1')
+      .should('have.class', 'shadow-1')
+    })
   })
 
   context('#shadow', () => {

--- a/packages/driver/cypress/integration/commands/querying_spec.js
+++ b/packages/driver/cypress/integration/commands/querying_spec.js
@@ -1,8 +1,6 @@
 const { _, $ } = Cypress
 const { Promise } = Cypress
 
-const helpers = require('../../support/helpers')
-
 describe('src/cy/commands/querying', () => {
   beforeEach(() => {
     cy.visit('/fixtures/dom.html')
@@ -353,38 +351,6 @@ describe('src/cy/commands/querying', () => {
       cy.get('#button-text').within(() => {
         cy.get('button span').then(($span) => {
           expect($span.get(0)).to.eq(span.get(0))
-        })
-      })
-    })
-
-    describe('shadow dom', () => {
-      beforeEach(() => {
-        cy.visit('/fixtures/shadow-dom.html')
-      })
-
-      it('finds element within shadow dom with includeShadowDom option', () => {
-        cy.get('#parent-of-shadow-container-0').within(() => {
-          cy
-          .get('p', { includeShadowDom: true })
-          .should('have.length', 1)
-          .should('have.text', 'Shadow Content 3')
-        })
-      })
-
-      it('when within subject is shadow root, finds element without needing includeShadowDom option', () => {
-        cy.get('#shadow-element-1').shadow().within(() => {
-          cy
-          .get('p')
-          .should('have.length', 1)
-          .should('have.text', 'Shadow Content 1')
-        })
-      })
-
-      it('when within subject is already in shadow dom, finds element without needing includeShadowDom option', () => {
-        cy.get('.shadow-8-nested-1', { includeShadowDom: true }).within(() => {
-          cy
-          .get('.shadow-8-nested-5')
-          .should('have.text', '8')
         })
       })
     })
@@ -938,49 +904,6 @@ describe('src/cy/commands/querying', () => {
         cy
         .get('button:first').as('btn')
         .get('@btn').should('have.class', 'foo-bar-baz')
-      })
-    })
-
-    describe('includeShadowDom', () => {
-      beforeEach(() => {
-        cy.visit('/fixtures/shadow-dom.html')
-      })
-
-      it('finds elements within shadow roots', () => {
-        cy.get('.shadow-1', { includeShadowDom: true })
-        .should('have.text', 'Shadow Content 1')
-      })
-
-      it('finds shadow elements within shadow roots', () => {
-        cy.get('.shadow-5', { includeShadowDom: true })
-        .should('have.text', 'Shadow Content 5')
-      })
-
-      it('finds light elements within shadow slots', () => {
-        cy.get('.in-shadow-slot', { includeShadowDom: true })
-        .should('have.text', 'In Shadow Slot')
-      })
-
-      // TODO: enable once we support cross-boundary selectors nicely
-      it.skip('finds elements within shadow roots with cross-boundary selector', () => {
-        cy.get('#parent-of-shadow-container-0 .shadow-3', { includeShadowDom: true })
-        .should('have.text', 'Shadow Content 3')
-      })
-
-      it('finds elements outside shadow roots', () => {
-        cy.get('#non-shadow-element', { includeShadowDom: true })
-        .should('have.text', 'Non Shadow')
-      })
-
-      it('finds elements in and out of shadow roots', () => {
-        cy.get('.in-and-out', { includeShadowDom: true })
-        .should('have.length', 2)
-      })
-
-      // https://github.com/cypress-io/cypress/issues/7676
-      it('does not error when querySelectorAll is wrapped and snapshots are off', () => {
-        cy.visit('/fixtures/shadow-dom.html?wrap-qsa=true')
-        cy.get('.shadow-1', { includeShadowDom: true })
       })
     })
 
@@ -2396,113 +2319,6 @@ space
         }))
 
         cy.contains(/^does not contain asdfasdf at all$/)
-      })
-    })
-  })
-
-  context('#shadow', () => {
-    beforeEach(() => {
-      cy.visit('/fixtures/shadow-dom.html')
-    })
-
-    it('returns an empty set if no shadow roots exist', () => {
-      cy.get('#non-shadow-element').shadow()
-      .should('not.exist')
-      .then(($root) => {
-        expect($root).to.be.null
-      })
-    })
-
-    it('returns the shadow root of an individual element', () => {
-      cy.get('#shadow-element-1').shadow()
-      .then(($roots) => {
-        expect($roots.length).to.eq(1)
-      })
-    })
-
-    it('returns a set of shadow roots for a set of elements', () => {
-      const $shadowElements = cy.$$('#shadow-element-1, #shadow-element-2')
-
-      cy.get('#shadow-element-1, #shadow-element-2').shadow()
-      .then(($roots) => {
-        expect($roots.length).to.eq(2)
-        expect($roots.get(0)).to.eq($shadowElements.get(0).shadowRoot)
-        expect($roots.get(1)).to.eq($shadowElements.get(1).shadowRoot)
-      })
-    })
-
-    it('retries until it can find a root', () => {
-      cy.on('command:retry', _.after(2, () => {
-        cy.$$('#non-shadow-element')[0].attachShadow({ mode: 'open' })
-      }))
-
-      cy.get('#non-shadow-element').shadow()
-      .then(($roots) => {
-        expect($roots.length).to.equal(1)
-      })
-    })
-
-    describe('.log', () => {
-      beforeEach(function () {
-        cy.on('log:added', (attrs, log) => {
-          this.lastLog = log
-        })
-
-        return null
-      })
-
-      it('logs immediately before resolving', (done) => {
-        cy.on('log:added', (attrs, log) => {
-          if (log.get('name') === 'shadow') {
-            expect(log.pick('state')).to.deep.eq({
-              state: 'pending',
-            })
-
-            done()
-          }
-        })
-
-        cy.get('#shadow-element-1').shadow()
-      })
-
-      it('snapshots after finding element', () => {
-        cy.get('#shadow-element-1').shadow()
-        .then(function () {
-          const { lastLog } = this
-
-          expect(lastLog.get('snapshots').length).to.eq(1)
-          expect(lastLog.get('snapshots')[0]).to.be.an('object')
-        })
-      })
-
-      it('has the $el', () => {
-        cy.get('#shadow-element-1').shadow()
-        .then(function ($el) {
-          const { lastLog } = this
-
-          expect(lastLog.get('$el').get(0)).to.eq($el.get(0))
-        })
-      })
-
-      it('#consoleProps', () => {
-        cy.get('#shadow-element-1').shadow()
-        .then(function ($el) {
-          expect(this.lastLog.invoke('consoleProps')).to.deep.eq({
-            'Applied To': helpers.getFirstSubjectByName('get').get(0),
-            Yielded: Cypress.dom.getElements($el),
-            Elements: $el.length,
-            Command: 'shadow',
-          })
-        })
-      })
-
-      it('can be turned off', () => {
-        cy.get('#shadow-element-1').shadow({ log: false })
-        .then(function () {
-          const { lastLog } = this
-
-          expect(lastLog.get('name')).to.eq('get')
-        })
       })
     })
   })

--- a/packages/driver/src/cy/commands/querying.js
+++ b/packages/driver/src/cy/commands/querying.js
@@ -392,8 +392,6 @@ module.exports = (Commands, Cypress, cy, state) => {
     contains (subject, filter, text, options = {}) {
       let userOptions = options
 
-      const shadowDomEnabled = Cypress.config('experimentalShadowDomSupport')
-
       // nuke our subject if its present but not an element.
       // in these cases its either window or document but
       // we dont care.
@@ -401,7 +399,7 @@ module.exports = (Commands, Cypress, cy, state) => {
       // command since its behavior is identical to using it
       // as a parent command: cy.contains()
       // don't nuke if subject is a shadow root, is a document not an element
-      if (subject && !$dom.isElement(subject) && (shadowDomEnabled && !$elements.isShadowRoot(subject[0]))) {
+      if (subject && !$dom.isElement(subject) && !$elements.isShadowRoot(subject[0])) {
         subject = null
       }
 

--- a/packages/driver/src/cy/commands/querying.js
+++ b/packages/driver/src/cy/commands/querying.js
@@ -2,6 +2,7 @@ const _ = require('lodash')
 const Promise = require('bluebird')
 
 const $dom = require('../../dom')
+const $elements = require('../../dom/elements')
 const $errUtils = require('../../cypress/error_utils')
 
 module.exports = (Commands, Cypress, cy, state) => {
@@ -391,13 +392,16 @@ module.exports = (Commands, Cypress, cy, state) => {
     contains (subject, filter, text, options = {}) {
       let userOptions = options
 
+      const shadowDomEnabled = Cypress.config('experimentalShadowDomSupport')
+
       // nuke our subject if its present but not an element.
       // in these cases its either window or document but
       // we dont care.
       // we'll null out the subject so it will show up as a parent
       // command since its behavior is identical to using it
       // as a parent command: cy.contains()
-      if (subject && !$dom.isElement(subject)) {
+      // don't nuke if subject is a shadow root, is a document not an element
+      if (subject && !$dom.isElement(subject) && (shadowDomEnabled && !$elements.isShadowRoot(subject[0]))) {
         subject = null
       }
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8494

### User facing changelog

- Fixed an issue where using `cy.contains()` within a shadow root would not yield the correct element

### Additional details

In addition to fixing the issue, this adds a couple more tests to ensure `cy.contains()` works correctly when the element being queried is in the shadow dom

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
