### PR TITLE
fix(perf): use JS to animate command progress bars

### DIFF
--- a/packages/reporter/cypress/integration/tests_spec.ts
+++ b/packages/reporter/cypress/integration/tests_spec.ts
@@ -196,7 +196,7 @@ describe('controls', function () {
           cy.get('.command-progress').should('be.visible')
         })
 
-        it('calculates correct width', function () {
+        it('calculates correct scale factor', function () {
           const { wallClockStartedAt } = this.runnables.suites[0].suites[0].tests[1].commands[0]
 
           // take the wallClockStartedAt of this command and add 2500 milliseconds to it
@@ -207,14 +207,15 @@ describe('controls', function () {
           cy.get('.runnable-active').click()
           cy.get('.command-progress > span').should(($span) => {
             expect($span.attr('style')).to.contain('animation-duration: 1500ms')
-            expect($span.attr('style')).to.contain('width: 37.5%')
+            expect($span.attr('style')).to.contain('transform: scaleX(0.375)')
 
-            // ensures that actual width hits 0 within default timeout
-            expect($span).to.have.css('width', '0px')
+            // ensures that actual scale factor hits 0 within default timeout
+            // this matrix is equivalent to scaleX(0)
+            expect($span).to.have.css('transform', 'matrix(0, 0, 0, 1, 0, 0)')
           })
         })
 
-        it('recalculates correct width after being closed', function () {
+        it('recalculates correct scale factor after being closed', function () {
           const { wallClockStartedAt } = this.runnables.suites[0].suites[0].tests[1].commands[0]
 
           // take the wallClockStartedAt of this command and add 1000 milliseconds to it
@@ -225,7 +226,7 @@ describe('controls', function () {
           cy.get('.runnable-active').click()
           cy.get('.command-progress > span').should(($span) => {
             expect($span.attr('style')).to.contain('animation-duration: 3000ms')
-            expect($span.attr('style')).to.contain('width: 75%')
+            expect($span.attr('style')).to.contain('transform: scaleX(0.75)')
           })
 
           // set the clock ahead as if time has passed
@@ -234,7 +235,7 @@ describe('controls', function () {
           cy.get('.runnable-active > .collapsible > .runnable-wrapper').click().click()
           cy.get('.command-progress > span').should(($span) => {
             expect($span.attr('style')).to.contain('animation-duration: 1000ms')
-            expect($span.attr('style')).to.contain('width: 25%')
+            expect($span.attr('style')).to.contain('transform: scaleX(0.25)')
           })
         })
       })

--- a/packages/reporter/src/commands/command.spec.tsx
+++ b/packages/reporter/src/commands/command.spec.tsx
@@ -315,7 +315,7 @@ describe('<Command />', () => {
         expect(component.find(Progress)).to.exist
       })
 
-      it('modifies the timer width based on time elapsed', () => {
+      it('modifies the timer scale factor based on time elapsed', () => {
         const initialDate = new Date(Date.now())
         const timeout = 1000
 
@@ -333,7 +333,7 @@ describe('<Command />', () => {
         const rootNode = component.getDOMNode()[0]
         const timerSpan = rootNode.children[0]
 
-        expect(timerSpan.style).to.have.property('width', '50%') // because we ticked half of the timeout
+        expect(timerSpan.style).to.have.property('transform', 'scaleX(0.5)') // because we ticked half of the timeout
       })
     })
   })

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -119,12 +119,12 @@ interface ProgressProps {
 const Progress = observer(({ model }: ProgressProps) => {
   const timeElapsed = Date.now() - new Date(model.wallClockStartedAt).getTime()
   const timeRemaining = model.timeout ? model.timeout - timeElapsed : 0
-  const percentageRemaining = timeRemaining / model.timeout * 100 || 0
+  const percentageRemaining = timeRemaining / model.timeout || 0
 
   // we add a key to the span to ensure a rerender and restart of the animation on change
   return (
     <div className='command-progress'>
-      <span style={{ animationDuration: `${timeRemaining}ms`, width: `${percentageRemaining}%` }} key={timeRemaining} />
+      <span style={{ animationDuration: `${timeRemaining}ms`, transform: `scaleX(${percentageRemaining})` }} key={timeRemaining} />
     </div>
   )
 })

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -274,10 +274,12 @@
       display: block;
       float: right;
       height: 100%;
+      width: 100%;
+      transform-origin: 0 0;
 
       @keyframes progress-bar {
         100% {
-          width: 0;
+          transform: scaleX(0);
         }
       }
     }


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8012

### User facing changelog

- Fixed a performance issue which led to CPU bottlenecking during Cypress runs.

### Additional details

- `<Progress>` element added in #7646 has a performance issue, the CSS animation on `width` causes repetitive Layout updates which leads to a serious performance regression: 
	* without Progress element:  
		 ![Pasted image](https://i.imgur.com/oQHns1t.png)
	* with Progress element:  
         ![Pasted image](https://i.imgur.com/wapT8wX.png)
	* performance issues were noted in the original PR but it was merged anyways
- animating `transform` instead of `width` fixes it:
	Commit SHA | Time to finish https://github.com/nphillipsworth/cypress-test-tiny/
	--- | ---
	public 4.8.0 build | 142066ms
	3f3e860fc | 172671ms
	f883590ef | 174939ms
	f305f8b10 | 153007ms
	dc075618b (from #7646) | 302152ms
	dc075618b without Progress element | 157521ms
	dc075618b using requestAnimationFrame | 182470ms
	dc075618b with transform (this PR) | **160454ms**
	6c6b23f88 | 323244ms
	4fb3f0b32 | 417179ms
	public 4.9.0 build | 310599ms

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
