### PR TITLE
fix(server): fix bug not allowing setCookie starting with `__Host-`

### DIFF
--- a/packages/driver/cypress/integration/commands/cookies_spec.js
+++ b/packages/driver/cypress/integration/commands/cookies_spec.js
@@ -8,12 +8,6 @@ describe('src/cy/commands/cookies', () => {
   })
 
   context('test:before:run:async', () => {
-    it('can test unstubbed, real server', () => {
-      Cypress.automation.restore()
-
-      cy.setCookie('foo', 'bar')
-    })
-
     it('clears cookies before each test run', () => {
       Cypress.automation
       .withArgs('get:cookies', { domain: 'localhost' })

--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -116,6 +116,11 @@ export const CdpAutomation = (sendDebuggerCommandFn: SendDebuggerCommand) => {
       }
     }
 
+    if (cookie.name.startsWith('__Host-')) {
+      setCookieRequest.url = `https://${cookie.domain}`
+      delete setCookieRequest.domain
+    }
+
     return setCookieRequest
   }
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- fix #8261 

### User facing changelog
Bug fix: fix issue causing `cy.setCookie()` to fail when the cookie name starts with `__Host-`
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

when trying to set a cookie with name starting with `__Host-`
before:
![image](https://user-images.githubusercontent.com/14625260/92527636-4e3b1d80-f1f5-11ea-8691-e6ea189e8e6c.png)

after:
![image](https://user-images.githubusercontent.com/14625260/92527606-44b1b580-f1f5-11ea-85a9-007207306bd2.png)

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->

