### PR TITLE
feat: Place the caret at the start/end (all text elements) or clicked point (contenteditable only)

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2390,6 +2390,13 @@ declare namespace Cypress {
      * @default false
      */
     cmdKey: boolean
+    /**
+     * Where the caret should be placed when <input>, <textarea>, [contenteditable] elements are clicked.
+     * 'point' option can be only used with [contenteditable].
+     *
+     * @default 'end'
+     */
+    caretPosition: 'start' | 'end' | 'point'
   }
 
   interface ResolvedConfigOptions {

--- a/packages/driver/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/click_spec.js
@@ -886,7 +886,7 @@ describe('src/cy/commands/actions/click', () => {
       })
 
       // caretPositionFromPoint doesn't work on headless mode on Firefox.
-      if (Cypress.isBrowser('chrome') || Cypress.config('isInteractive', true)) {
+      if (Cypress.isBrowser('chrome')) {
         describe('point', () => {
           it('[contenteditable]', () => {
             cy.get('[contenteditable]:first')

--- a/packages/driver/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/click_spec.js
@@ -762,59 +762,157 @@ describe('src/cy/commands/actions/click', () => {
       cy.get('#table tr:first').click()
     })
 
-    it('places cursor at the end of input', () => {
-      cy.get('input:first').invoke('val', 'foobar').click().then(($el) => {
-        const el = $el.get(0)
+    describe('caret position', () => {
+      describe('end - default', () => {
+        it('input', () => {
+          cy.get('input:first').invoke('val', 'foobar').click().then(($el) => {
+            const el = $el.get(0)
 
-        expect(el.selectionStart).to.eql(6)
+            expect(el.selectionStart).to.eql(6)
+            expect(el.selectionEnd).to.eql(6)
+          })
 
-        expect(el.selectionEnd).to.eql(6)
+          cy.get('input:first').invoke('val', '').click().then(($el) => {
+            const el = $el.get(0)
+
+            expect(el.selectionStart).to.eql(0)
+            expect(el.selectionEnd).to.eql(0)
+          })
+        })
+
+        it('textarea', () => {
+          cy.get('textarea:first').invoke('val', 'foo\nbar\nbaz').click().then(($el) => {
+            const el = $el.get(0)
+
+            expect(el.selectionStart).to.eql(11)
+            expect(el.selectionEnd).to.eql(11)
+          })
+
+          cy.get('textarea:first').invoke('val', '').click().then(($el) => {
+            const el = $el.get(0)
+
+            expect(el.selectionStart).to.eql(0)
+            expect(el.selectionEnd).to.eql(0)
+          })
+        })
+
+        it('[contenteditable]', () => {
+          cy.get('[contenteditable]:first')
+          .invoke('html', '<div><br></div>').click()
+          .then(expectCaret(0))
+
+          cy.get('[contenteditable]:first')
+          .invoke('html', 'foo').click()
+          .then(expectCaret(3))
+
+          cy.get('[contenteditable]:first')
+          .invoke('html', '<div>foo</div>').click()
+          .then(expectCaret(3))
+
+          cy.get('[contenteditable]:first')
+          // firefox headless: prevent contenteditable from disappearing (dont set to empty)
+          .invoke('html', '<br>').click()
+          .then(expectCaret(0))
+        })
       })
 
-      cy.get('input:first').invoke('val', '').click().then(($el) => {
-        const el = $el.get(0)
+      describe('start', () => {
+        it('input', () => {
+          cy.get('input:first').invoke('val', 'foobar').click({
+            caretPosition: 'start',
+          }).then(($el) => {
+            const el = $el.get(0)
 
-        expect(el.selectionStart).to.eql(0)
+            expect(el.selectionStart).to.eql(0)
+            expect(el.selectionEnd).to.eql(0)
+          })
 
-        expect(el.selectionEnd).to.eql(0)
+          cy.get('input:first').invoke('val', '').click({
+            caretPosition: 'start',
+          }).then(($el) => {
+            const el = $el.get(0)
+
+            expect(el.selectionStart).to.eql(0)
+            expect(el.selectionEnd).to.eql(0)
+          })
+        })
+
+        it('textarea', () => {
+          cy.get('textarea:first').invoke('val', 'foo\nbar\nbaz').click({
+            caretPosition: 'start',
+          }).then(($el) => {
+            const el = $el.get(0)
+
+            expect(el.selectionStart).to.eql(0)
+            expect(el.selectionEnd).to.eql(0)
+          })
+
+          cy.get('textarea:first').invoke('val', '').click({
+            caretPosition: 'start',
+          }).then(($el) => {
+            const el = $el.get(0)
+
+            expect(el.selectionStart).to.eql(0)
+            expect(el.selectionEnd).to.eql(0)
+          })
+        })
+
+        it('[contenteditable]', () => {
+          cy.get('[contenteditable]:first')
+          .invoke('html', '<div><br></div>').click({
+            caretPosition: 'start',
+          })
+          .then(expectCaret(0))
+
+          cy.get('[contenteditable]:first')
+          .invoke('html', 'foo').click({
+            caretPosition: 'start',
+          })
+          .then(expectCaret(0))
+
+          cy.get('[contenteditable]:first')
+          .invoke('html', '<div>foo</div>').click({
+            caretPosition: 'start',
+          })
+          .then(expectCaret(0))
+
+          cy.get('[contenteditable]:first')
+          // firefox headless: prevent contenteditable from disappearing (dont set to empty)
+          .invoke('html', '<br>').click({
+            caretPosition: 'start',
+          })
+          .then(expectCaret(0))
+        })
       })
-    })
 
-    it('places cursor at the end of textarea', () => {
-      cy.get('textarea:first').invoke('val', 'foo\nbar\nbaz').click().then(($el) => {
-        const el = $el.get(0)
+      describe('point', () => {
+        it('[contenteditable]', () => {
+          cy.get('[contenteditable]:first')
+          .invoke('html', '<div><br></div>').click(15, 5, {
+            caretPosition: 'point',
+          })
+          .then(expectCaret(0))
 
-        expect(el.selectionStart).to.eql(11)
+          cy.get('[contenteditable]:first')
+          .invoke('html', 'foobar').click(15, 5, {
+            caretPosition: 'point',
+          })
+          .then(expectCaret(2))
 
-        expect(el.selectionEnd).to.eql(11)
+          cy.get('[contenteditable]:first')
+          .invoke('html', '<div>foobar</div>').click(15, 5, {
+            caretPosition: 'point',
+          })
+          .then(expectCaret(2))
+
+          cy.get('[contenteditable]:first')
+          // firefox headless: prevent contenteditable from disappearing (dont set to empty)
+          .invoke('html', '<br>').click(15, 5, {
+            caretPosition: 'point',
+          })
+          .then(expectCaret(0))
+        })
       })
-
-      cy.get('textarea:first').invoke('val', '').click().then(($el) => {
-        const el = $el.get(0)
-
-        expect(el.selectionStart).to.eql(0)
-
-        expect(el.selectionEnd).to.eql(0)
-      })
-    })
-
-    it('places cursor at the end of [contenteditable]', () => {
-      cy.get('[contenteditable]:first')
-      .invoke('html', '<div><br></div>').click()
-      .then(expectCaret(0))
-
-      cy.get('[contenteditable]:first')
-      .invoke('html', 'foo').click()
-      .then(expectCaret(3))
-
-      cy.get('[contenteditable]:first')
-      .invoke('html', '<div>foo</div>').click()
-      .then(expectCaret(3))
-
-      cy.get('[contenteditable]:first')
-      // firefox headless: prevent contenteditable from disappearing (dont set to empty)
-      .invoke('html', '<br>').click()
-      .then(expectCaret(0))
     })
 
     it('can click SVG elements', () => {

--- a/packages/driver/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/click_spec.js
@@ -885,34 +885,37 @@ describe('src/cy/commands/actions/click', () => {
         })
       })
 
-      describe('point', () => {
-        it('[contenteditable]', () => {
-          cy.get('[contenteditable]:first')
-          .invoke('html', '<div><br></div>').click(15, 5, {
-            caretPosition: 'point',
-          })
-          .then(expectCaret(0))
+      // caretPositionFromPoint doesn't work on headless mode on Firefox.
+      if (Cypress.isBrowser('chrome') || Cypress.config('isInteractive', true)) {
+        describe('point', () => {
+          it('[contenteditable]', () => {
+            cy.get('[contenteditable]:first')
+            .invoke('html', '<div><br></div>').click(15, 5, {
+              caretPosition: 'point',
+            })
+            .then(expectCaret(0))
 
-          cy.get('[contenteditable]:first')
-          .invoke('html', 'foobar').click(15, 5, {
-            caretPosition: 'point',
-          })
-          .then(expectCaret(2))
+            cy.get('[contenteditable]:first')
+            .invoke('html', 'foobar').click(15, 5, {
+              caretPosition: 'point',
+            })
+            .then(expectCaret(2))
 
-          cy.get('[contenteditable]:first')
-          .invoke('html', '<div>foobar</div>').click(15, 5, {
-            caretPosition: 'point',
-          })
-          .then(expectCaret(2))
+            cy.get('[contenteditable]:first')
+            .invoke('html', '<div>foobar</div>').click(15, 5, {
+              caretPosition: 'point',
+            })
+            .then(expectCaret(2))
 
-          cy.get('[contenteditable]:first')
-          // firefox headless: prevent contenteditable from disappearing (dont set to empty)
-          .invoke('html', '<br>').click(15, 5, {
-            caretPosition: 'point',
+            cy.get('[contenteditable]:first')
+            // firefox headless: prevent contenteditable from disappearing (dont set to empty)
+            .invoke('html', '<br>').click(15, 5, {
+              caretPosition: 'point',
+            })
+            .then(expectCaret(0))
           })
-          .then(expectCaret(0))
         })
-      })
+      }
     })
 
     it('can click SVG elements', () => {

--- a/packages/driver/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/click_spec.js
@@ -762,6 +762,7 @@ describe('src/cy/commands/actions/click', () => {
       cy.get('#table tr:first').click()
     })
 
+    // https://github.com/cypress-io/cypress/issues/7721
     describe('caret position', () => {
       describe('end - default', () => {
         it('input', () => {

--- a/packages/driver/src/cy/commands/actions/click.js
+++ b/packages/driver/src/cy/commands/actions/click.js
@@ -2,6 +2,7 @@ const _ = require('lodash')
 const $ = require('jquery')
 const Promise = require('bluebird')
 const $dom = require('../../../dom')
+const $elements = require('../../../dom/elements')
 const $utils = require('../../../cypress/utils')
 const $errUtils = require('../../../cypress/error_utils')
 const $actionability = require('../../actionability')
@@ -93,6 +94,15 @@ module.exports = (Commands, Cypress, cy, state, config) => {
     }
 
     const perform = (el) => {
+      if (options.caretPosition === 'point' && !$elements.isContentEditable(el)) {
+        $errUtils.throwErrByPath('click.caretPosition_point_is_only_for_contentEditable')
+      }
+
+      // caretPosition === 'point' doesn't work with Firefox headless mode.
+      if (options.caretPosition === 'point' && Cypress.isBrowser('firefox') && Cypress.config('isInteractive') === false) {
+        $errUtils.throwErrByPath('click.firefox_caretPosition_point_headless')
+      }
+
       let deltaOptions
       const $el = $dom.wrap(el)
 

--- a/packages/driver/src/cy/commands/actions/click.js
+++ b/packages/driver/src/cy/commands/actions/click.js
@@ -62,6 +62,7 @@ module.exports = (Commands, Cypress, cy, state, config) => {
       metaKey: false,
       commandKey: false,
       cmdKey: false,
+      caretPosition: 'end',
       ...defaultOptions,
     })
 
@@ -186,7 +187,7 @@ module.exports = (Commands, Cypress, cy, state, config) => {
 
           flagModifiers(true)
 
-          const onReadyProps = onReady(fromElViewport, forceEl)
+          const onReadyProps = onReady(fromElViewport, forceEl, options.caretPosition)
 
           flagModifiers(false)
 
@@ -236,8 +237,8 @@ module.exports = (Commands, Cypress, cy, state, config) => {
         subject,
         userOptions: options,
         positionOrX,
-        onReady (fromElViewport, forceEl) {
-          const clickEvents = mouse.click(fromElViewport, forceEl)
+        onReady (fromElViewport, forceEl, caretPosition) {
+          const clickEvents = mouse.click(fromElViewport, forceEl, {}, {}, caretPosition)
 
           return {
             clickEvents,

--- a/packages/driver/src/cy/mouse.js
+++ b/packages/driver/src/cy/mouse.js
@@ -151,7 +151,7 @@ const create = (state, keyboard, focused, Cypress) => {
     return !_.isEqual(xy(fromElViewport), xy(coords))
   }
 
-  const shouldMoveCursorToEndAfterMousedown = (el) => {
+  const shouldMoveCursorAfterMousedown = (el) => {
     const _debug = debug.extend(':shouldMoveCursorToEnd')
 
     _debug('shouldMoveToEnd?', el)
@@ -450,7 +450,7 @@ const create = (state, keyboard, focused, Cypress) => {
       }
     },
 
-    down (fromElViewport, forceEl, pointerEvtOptionsExtend = {}, mouseEvtOptionsExtend = {}) {
+    down (fromElViewport, forceEl, pointerEvtOptionsExtend = {}, mouseEvtOptionsExtend = {}, caretPosition = 'end') {
       const $previouslyFocused = focused.getFocused()
 
       const mouseDownPhase = mouse._downEvents(fromElViewport, forceEl, pointerEvtOptionsExtend, mouseEvtOptionsExtend)
@@ -483,9 +483,19 @@ const create = (state, keyboard, focused, Cypress) => {
         }
       }
 
-      if (shouldMoveCursorToEndAfterMousedown(el)) {
-        debug('moveSelectionToEnd due to click', el)
-        $selection.moveSelectionToEnd(el, { onlyIfEmptySelection: true })
+      if (shouldMoveCursorAfterMousedown(el)) {
+        debug('moveSelection to', caretPosition)
+        debug('moveSelection due to click', el)
+
+        if (caretPosition === 'start') {
+          $selection.moveSelectionToStart(el, { onlyIfEmptySelection: true })
+        } else if (caretPosition === 'end') {
+          $selection.moveSelectionToEnd(el, { onlyIfEmptySelection: true })
+        } else if (caretPosition === 'point') {
+          const { x, y } = getMouseCoords(state)
+
+          $selection.moveSelectionToPoint(state('window'), x, y)
+        }
       }
 
       return mouseDownPhase
@@ -524,10 +534,10 @@ const create = (state, keyboard, focused, Cypress) => {
     * if (notDetached(el1))
     *   sendClick(ancestorOf(el1, el2))
     */
-    click (fromElViewport, forceEl, pointerEvtOptionsExtend = {}, mouseEvtOptionsExtend = {}) {
+    click (fromElViewport, forceEl, pointerEvtOptionsExtend = {}, mouseEvtOptionsExtend = {}, caretPosition = 'end') {
       debug('mouse.click', { fromElViewport, forceEl })
 
-      const mouseDownPhase = mouse.down(fromElViewport, forceEl, pointerEvtOptionsExtend, mouseEvtOptionsExtend)
+      const mouseDownPhase = mouse.down(fromElViewport, forceEl, pointerEvtOptionsExtend, mouseEvtOptionsExtend, caretPosition)
 
       const skipMouseupEvent = mouseDownPhase.events.pointerdown.skipped || mouseDownPhase.events.pointerdown.preventedDefault
 

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -232,6 +232,14 @@ module.exports = {
       message: `${cmd('{{cmd}}')} cannot be called on a \`<select>\` element. Use ${cmd('select')} command instead to change the value.`,
       docsUrl: 'https://on.cypress.io/select',
     },
+    firefox_caretPosition_point_headless: {
+      message: `caretPosition: 'point' option doesn't work on Firefox headless mode. Skip this test with \`!Cypress.isBrowser('firefox')\` condition.`,
+      docsUrl: 'https://on.cypress.io/click',
+    },
+    caretPosition_point_is_only_for_contentEditable: {
+      message: `caretPosition: 'point' option must be only used with contenteditable fields`,
+      docsUrl: 'https://on.cypress.io/click',
+    },
   },
 
   clock: {

--- a/packages/driver/src/dom/selection.ts
+++ b/packages/driver/src/dom/selection.ts
@@ -616,7 +616,13 @@ const moveSelectionToPoint = function (contentWindow, clientX, clientY) {
   let doc = contentWindow.document
 
   if (doc.caretPositionFromPoint) { // For Firefox
-    range = doc.caretPositionFromPoint(clientX, clientY)
+    const { offsetNode, offset } = doc.caretPositionFromPoint(clientX, clientY)
+
+    // Range should be manually created
+    // because the return type of caretPositionFromPoint is CaretPosition.
+    range = doc.createRange()
+    range.setStart(offsetNode, offset)
+    range.setEnd(offsetNode, offset)
   } else if (doc.caretRangeFromPoint) { // For Chrome
     range = doc.caretRangeFromPoint(clientX, clientY)
   }

--- a/packages/driver/src/dom/selection.ts
+++ b/packages/driver/src/dom/selection.ts
@@ -610,6 +610,23 @@ const moveSelectionToEnd = _.curry(_moveSelectionTo)(false)
 
 const moveSelectionToStart = _.curry(_moveSelectionTo)(true)
 
+const moveSelectionToPoint = function (contentWindow, clientX, clientY) {
+  let range
+  let sel = contentWindow.getSelection()
+  let doc = contentWindow.document
+
+  if (doc.caretPositionFromPoint) { // For Firefox
+    range = doc.caretPositionFromPoint(clientX, clientY)
+  } else if (doc.caretRangeFromPoint) { // For Chrome
+    range = doc.caretRangeFromPoint(clientX, clientY)
+  }
+
+  range.collapse(true)
+
+  sel.removeAllRanges()
+  sel.addRange(range)
+}
+
 const replaceSelectionContents = function (el, key) {
   if ($elements.isContentEditable(el)) {
     _replaceSelectionContentsContentEditable(el, key)
@@ -740,6 +757,7 @@ export {
   deleteSelectionContents,
   moveSelectionToEnd,
   moveSelectionToStart,
+  moveSelectionToPoint,
   getCaretPosition,
   getHostContenteditable,
   moveCursorLeft,


### PR DESCRIPTION
* Closes #2717
* Closes #5721
* Closes #7721

### User facing changelog
Users can choose to place the caret at the start or end of the text elements(`<input>`, `<textarea>`)

When a contentdeditable element is clicked, the caret can be placed at the clicked point. 

### Additional details
* Why was this change necessary? => Some users wanted to test their contenteditable is edited correctly but it was impossible.
* What is affected by this change? => N/A
* Any implementation details to explain? => I used `caretPositionFromPoint` and `caretRangeFromPoint`. Because of that, it only works with `[contenteditable]`.

### How has the user experience changed?
N/A

### PR Tasks
* [x] Have tests been added/updated?
* [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
* [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? => coming soon...
* [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
* [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?

