### PR TITLE
fix(types): add tsdocs for cy.route2

### DIFF
--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -211,7 +211,37 @@ export type StringMatcher = GlobPattern | RegExp
 declare global {
   namespace Cypress {
     interface Chainable<Subject = any> {
+      /**
+       * Use `cy.route2()` to stub and intercept HTTP requests and responses.
+       *
+       * Note: this command is only available if you have set the `experimentalNetworkStubbing`
+       * configuration option to `true`.
+       *
+       * @see https://on.cypress.io/route2
+       * @example
+       *    cy.route2('https://localhost:7777/users', [{id: 1, name: 'Pat'}])
+       * @example
+       *    cy.route2('https://localhost:7777/protected-endpoint', (req) => {
+       *      req.headers['authorization'] = 'basic fooabc123'
+       *    })
+       * @example
+       *    cy.route2('https://localhost:7777/some-response', (req) => {
+       *      req.reply(res => {
+       *        res.body = 'some new body'
+       *      })
+       *    })
+       */
       route2(url: RouteMatcher, response?: RouteHandler): Chainable<null>
+      /**
+       * Use `cy.route2()` to stub and intercept HTTP requests and responses.
+       *
+       * Note: this command is only available if you have set the `experimentalNetworkStubbing`
+       * configuration option to `true`.
+       *
+       * @see https://on.cypress.io/route2
+       * @example
+       *    cy.route2('GET', 'http://foo.com/fruits', ['apple', 'banana', 'cherry'])
+       */
       route2(method: string, url: RouteMatcher, response?: RouteHandler): Chainable<null>
     }
   }


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

### User facing changelog

- Added missing type declarations for the `cy.route2` command.

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [na] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
