### PR TITLE
fix: Improve error message when .shadow() subject is not a shadow host

### DIFF
--- a/packages/driver/cypress/integration/commands/querying_shadow_dom_spec.js
+++ b/packages/driver/cypress/integration/commands/querying_shadow_dom_spec.js
@@ -134,6 +134,17 @@ describe('src/cy/commands/querying - shadow dom', () => {
       })
     })
 
+    it('has a custom error message if it cannot find a root', (done) => {
+      cy.on('fail', (err) => {
+        expect(err.message).to.equal(`Timed out retrying: Expected the subject to host a shadow root, but never found it.`)
+        expect(err.docsUrl).to.equal('https://on.cypress.io/shadow')
+
+        done()
+      })
+
+      cy.get('#non-shadow-element').shadow({ timeout: 0 })
+    })
+
     describe('.log', () => {
       beforeEach(function () {
         cy.on('log:added', (attrs, log) => {

--- a/packages/driver/src/cy/commands/querying.js
+++ b/packages/driver/src/cy/commands/querying.js
@@ -664,6 +664,16 @@ module.exports = (Commands, Cypress, cy, state) => {
 
         return cy.verifyUpcomingAssertions($el, options, {
           onRetry: getShadowRoots,
+          onFail (err) {
+            if (err.type !== 'existence') {
+              return
+            }
+
+            const { message, docsUrl } = $errUtils.cypressErrByPath('shadow.no_shadow_root')
+
+            err.message = message
+            err.docsUrl = docsUrl
+          },
         })
       }
 

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -904,7 +904,7 @@ module.exports = {
     `,
     hook_registered_late: stripIndent`\
     Cypress detected you registered a(n) \`{{hookTitle}}\` hook while a test was running (possibly a hook nested inside another hook). All hooks must be registered before a test begins executing.
-    
+
     Move the \`{{hookTitle}}\` into a suite callback or the global scope.
     `,
 
@@ -1475,6 +1475,13 @@ module.exports = {
           Pass \`secure: true\` to ${cmd('setCookie')} to set a cookie with \`sameSite: '{{value}}'\`.`,
         docsUrl: 'https://on.cypress.io/setcookie',
       }
+    },
+  },
+
+  shadow: {
+    no_shadow_root: {
+      message: 'Expected the subject to host a shadow root, but never found it.',
+      docsUrl: 'https://on.cypress.io/shadow',
     },
   },
 


### PR DESCRIPTION
- Closes #8530 

### User facing changelog

- Improved the error message when the subject provided to `.shadow()` is not a shadow host.


### How has the user experience changed?

**Before**

![Screen Shot 2020-09-09 at 4 35 18 PM](https://user-images.githubusercontent.com/1157043/92651246-d0d9e080-f2ba-11ea-8a03-8fe8071247ea.png)

**After**

![Screen Shot 2020-09-09 at 4 35 18 PM](https://user-images.githubusercontent.com/1157043/92651124-c7e90f00-f2ba-11ea-98af-55c005baee08.png)


### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
