### PR TITLE
chore: Deprecate experimentalShadowDomSupport flag and remove its usage

### DIFF
--- a/cli/schema/cypress.schema.json
+++ b/cli/schema/cypress.schema.json
@@ -239,11 +239,6 @@
       "default": false,
       "description": "Enables `cy.route2`, which can be used to dynamically intercept/stub/await any HTTP request or response (XHRs, fetch, beacons, etc.)"
     },
-    "experimentalShadowDomSupport": {
-      "type": "boolean",
-      "default": false,
-      "description": "Enables shadow DOM support. Adds the `cy.shadow()` command and the `ignoreShadowBoundaries` option to some DOM commands."
-    },
     "experimentalFetchPolyfill": {
       "type": "boolean",
       "default": false,

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1607,7 +1607,6 @@ declare namespace Cypress {
 
     /**
      * Traverse into an element's shadow root.
-     * Requires `experimentalShadowDomSupport: true` config option
      *
      * @example
      *    cy.get('my-component')
@@ -2582,12 +2581,6 @@ declare namespace Cypress {
      * @default false
      */
     experimentalNetworkStubbing: boolean
-    /**
-     * Enables shadow DOM support. Adds the `cy.shadow()` command and
-     * the `includeShadowDom` option to some DOM commands.
-     * @default false
-     */
-    experimentalShadowDomSupport: boolean
     /**
      * Number of times to retry a failed test.
      * If a number is set, tests will retry in both runMode and openMode.

--- a/packages/driver/cypress.json
+++ b/packages/driver/cypress.json
@@ -8,6 +8,5 @@
   "reporterOptions": {
     "configFile": "../../mocha-reporter-config.json"
   },
-  "experimentalNetworkStubbing": true,
-  "experimentalShadowDomSupport": true
+  "experimentalNetworkStubbing": true
 }

--- a/packages/driver/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/click_spec.js
@@ -3780,8 +3780,7 @@ describe('shadow dom', () => {
   })
 
   // https://github.com/cypress-io/cypress/issues/7679
-  it('does not hang when experimentalShadowDomSupport is false and clicking on custom element', () => {
-    Cypress.config('experimentalShadowDomSupport', false)
+  it('does not hang when clicking on custom element', () => {
     // needs some size or it's considered invisible and click will fail its prerequisites
     // so we make it display: block so its getClientRects() contains only a single
     cy.$$('#shadow-element-1').css({ display: 'block' })

--- a/packages/driver/cypress/integration/cypress/shadow_dom_utils_spec.ts
+++ b/packages/driver/cypress/integration/cypress/shadow_dom_utils_spec.ts
@@ -10,47 +10,29 @@ describe('src/cypress/shadow_dom_utils', () => {
       }
     })
 
-    describe('when experimental flag is false', () => {
-      beforeEach(() => {
-        CypressMock.config.withArgs('experimentalShadowDomSupport').returns(false)
-      })
+    it('returns true if command value is true', () => {
+      CypressMock.config.withArgs('includeShadowDom').returns(false)
 
-      it('returns false', () => {
-        CypressMock.config.withArgs('includeShadowDom').returns(true)
-
-        expect(resolveShadowDomInclusion(CypressMock, true)).to.be.false
-      })
+      expect(resolveShadowDomInclusion(CypressMock, true)).to.be.true
     })
 
-    describe('when experimental flag is true', () => {
-      beforeEach(() => {
-        CypressMock.config.withArgs('experimentalShadowDomSupport').returns(true)
-      })
+    it('returns false if command value is false', () => {
+      CypressMock.config.withArgs('includeShadowDom').returns(true)
 
-      it('returns true if command value is true', () => {
-        CypressMock.config.withArgs('includeShadowDom').returns(false)
+      expect(resolveShadowDomInclusion(CypressMock, false)).to.be.false
+    })
 
-        expect(resolveShadowDomInclusion(CypressMock, true)).to.be.true
-      })
-
-      it('returns false if command value is false', () => {
+    describe('when command value is undefined', () => {
+      it('returns true if config value is true', () => {
         CypressMock.config.withArgs('includeShadowDom').returns(true)
 
-        expect(resolveShadowDomInclusion(CypressMock, false)).to.be.false
+        expect(resolveShadowDomInclusion(CypressMock)).to.be.true
       })
 
-      describe('when command value is undefined', () => {
-        it('returns true if config value is true', () => {
-          CypressMock.config.withArgs('includeShadowDom').returns(true)
+      it('returns false if config value is false', () => {
+        CypressMock.config.withArgs('includeShadowDom').returns(false)
 
-          expect(resolveShadowDomInclusion(CypressMock)).to.be.true
-        })
-
-        it('returns false if config value is false', () => {
-          CypressMock.config.withArgs('includeShadowDom').returns(false)
-
-          expect(resolveShadowDomInclusion(CypressMock)).to.be.false
-        })
+        expect(resolveShadowDomInclusion(CypressMock)).to.be.false
       })
     })
   })

--- a/packages/driver/src/cy/commands/querying.js
+++ b/packages/driver/src/cy/commands/querying.js
@@ -623,60 +623,58 @@ module.exports = (Commands, Cypress, cy, state) => {
     },
   })
 
-  if (Cypress.config('experimentalShadowDomSupport')) {
-    Commands.add('shadow', { prevSubject: 'element' }, (subject, options) => {
-      const userOptions = options || {}
+  Commands.add('shadow', { prevSubject: 'element' }, (subject, options) => {
+    const userOptions = options || {}
 
-      options = _.defaults({}, userOptions, { log: true })
+    options = _.defaults({}, userOptions, { log: true })
 
-      const consoleProps = {
-        'Applied To': $dom.getElements(subject),
+    const consoleProps = {
+      'Applied To': $dom.getElements(subject),
+    }
+
+    if (options.log !== false) {
+      options._log = Cypress.log({
+        timeout: options.timeout,
+        consoleProps () {
+          return consoleProps
+        },
+      })
+    }
+
+    const setEl = ($el) => {
+      if (options.log === false) {
+        return
       }
 
-      if (options.log !== false) {
-        options._log = Cypress.log({
-          timeout: options.timeout,
-          consoleProps () {
-            return consoleProps
-          },
-        })
-      }
+      consoleProps.Yielded = $dom.getElements($el)
+      consoleProps.Elements = $el?.length
 
-      const setEl = ($el) => {
-        if (options.log === false) {
-          return
-        }
+      return options._log.set({ $el })
+    }
 
-        consoleProps.Yielded = $dom.getElements($el)
-        consoleProps.Elements = $el?.length
+    const getShadowRoots = () => {
+      // find all shadow roots of the subject(s), if any exist
+      const $el = subject
+      .map((i, node) => node.shadowRoot)
+      .filter((i, node) => node !== undefined && node !== null)
 
-        return options._log.set({ $el })
-      }
+      setEl($el)
 
-      const getShadowRoots = () => {
-        // find all shadow roots of the subject(s), if any exist
-        const $el = subject
-        .map((i, node) => node.shadowRoot)
-        .filter((i, node) => node !== undefined && node !== null)
+      return cy.verifyUpcomingAssertions($el, options, {
+        onRetry: getShadowRoots,
+        onFail (err) {
+          if (err.type !== 'existence') {
+            return
+          }
 
-        setEl($el)
+          const { message, docsUrl } = $errUtils.cypressErrByPath('shadow.no_shadow_root')
 
-        return cy.verifyUpcomingAssertions($el, options, {
-          onRetry: getShadowRoots,
-          onFail (err) {
-            if (err.type !== 'existence') {
-              return
-            }
+          err.message = message
+          err.docsUrl = docsUrl
+        },
+      })
+    }
 
-            const { message, docsUrl } = $errUtils.cypressErrByPath('shadow.no_shadow_root')
-
-            err.message = message
-            err.docsUrl = docsUrl
-          },
-        })
-      }
-
-      return getShadowRoots()
-    })
-  }
+    return getShadowRoots()
+  })
 }

--- a/packages/driver/src/cy/commands/traversals.js
+++ b/packages/driver/src/cy/commands/traversals.js
@@ -126,7 +126,6 @@ module.exports = (Commands, Cypress, cy) => {
       }
 
       const getEl = () => {
-        const shadowDomSupportEnabled = Cypress.config('experimentalShadowDomSupport')
         const includeShadowDom = resolveShadowDomInclusion(Cypress, userOptions.includeShadowDom)
         const optInShadowTraversal = optInShadowTraversals[traversal]
         const autoShadowTraversal = autoShadowTraversals[traversal]
@@ -138,7 +137,7 @@ module.exports = (Commands, Cypress, cy) => {
           return optInShadowTraversal(cy, subject, arg1, arg2)
         }
 
-        if (shadowDomSupportEnabled && autoShadowTraversal && $dom.isWithinShadowRoot(subject[0])) {
+        if (autoShadowTraversal && $dom.isWithinShadowRoot(subject[0])) {
           // if we detect the element is within a shadow root and we're using
           // .closest() or .parents(), automatically cross shadow boundaries
           return autoShadowTraversal(cy, subject, arg1, arg2)

--- a/packages/driver/src/cypress/shadow_dom_utils.ts
+++ b/packages/driver/src/cypress/shadow_dom_utils.ts
@@ -1,10 +1,8 @@
 /**
 * Order of preference for including shadow dom:
-* experimental flag > command-level > programmatic config > test-level > suite-level > cypress.json
+* command-level > programmatic config > test-level > suite-level > cypress.json
 */
 export const resolveShadowDomInclusion = (Cypress: Cypress.Cypress, commandValue?: boolean): boolean => {
-  if (!Cypress.config('experimentalShadowDomSupport')) return false
-
   if (commandValue != null) return commandValue
 
   return Cypress.config('includeShadowDom')

--- a/packages/server/__snapshots__/7_record_spec.js
+++ b/packages/server/__snapshots__/7_record_spec.js
@@ -1759,7 +1759,7 @@ https://on.cypress.io/dashboard/organizations/org-id-1234/billing
 exports['e2e record api interaction warnings create run warnings grace period - over tests limit warns when over test recordings 1'] = `
 You've exceeded the limit of test recordings under your free plan this month. The limit is 500 test recordings.
 
-Your plan is now in a grace period, which means you will have the full benefits of your current plan until 2999-12-31. 
+Your plan is now in a grace period, which means you will have the full benefits of your current plan until 2999-12-31.
 
 Please visit your billing to upgrade your plan.
 

--- a/packages/server/lib/config_options.ts
+++ b/packages/server/lib/config_options.ts
@@ -70,11 +70,6 @@ export const options = [
     validation: v.isBoolean,
     isExperimental: true,
   }, {
-    name: 'experimentalShadowDomSupport',
-    defaultValue: false,
-    validation: v.isBoolean,
-    isExperimental: true,
-  }, {
     name: 'experimentalFetchPolyfill',
     defaultValue: false,
     validation: v.isBoolean,
@@ -289,6 +284,10 @@ export const breakingOptions = [
   }, {
     name: 'experimentalGetCookiesSameSite',
     errorKey: 'EXPERIMENTAL_SAMESITE_REMOVED',
+    isWarning: true,
+  }, {
+    name: 'experimentalShadowDomSupport',
+    errorKey: 'EXPERIMENTAL_SHADOW_DOM_REMOVED',
     isWarning: true,
   }, {
     name: 'screenshotOnHeadlessFailure',

--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -756,8 +756,8 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
       return stripIndent`\
         You've exceeded the limit of test recordings under your free plan this month. ${arg1.usedTestsMessage}
 
-        Your plan is now in a grace period, which means you will have the full benefits of your current plan until ${arg1.gracePeriodMessage}. 
-        
+        Your plan is now in a grace period, which means you will have the full benefits of your current plan until ${arg1.gracePeriodMessage}.
+
         Please visit your billing to upgrade your plan.
 
         ${arg1.link}`
@@ -930,14 +930,19 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
         The \`experimentalGetCookiesSameSite\` configuration option was removed in Cypress version \`5.0.0\`. Yielding the \`sameSite\` property is now the default behavior of the \`cy.cookie\` commands.
 
         You can safely remove this option from your config.`
+    case 'EXPERIMENTAL_SHADOW_DOM_REMOVED':
+      return stripIndent`\
+        The \`experimentalShadowDomSupport\` configuration option was removed in Cypress version \`5.2.0\`. It is no longer necessary when utilizing the \`includeShadowDom\` option.
+
+        You can safely remove this option from your config.`
     case 'INCOMPATIBLE_PLUGIN_RETRIES':
       return stripIndent`\
       We've detected that the incompatible plugin \`cypress-plugin-retries\` is installed at \`${arg1}\`.
-      
+
       Test retries is now supported in Cypress version \`5.0.0\`.
 
       Remove the plugin from your dependencies to silence this warning.
-      
+
       https://on.cypress.io/test-retries
       `
     default:

--- a/packages/server/lib/experiments.ts
+++ b/packages/server/lib/experiments.ts
@@ -55,7 +55,6 @@ const _summaries: StringValues = {
   experimentalNetworkStubbing: 'Enables `cy.route2`, which can be used to dynamically intercept/stub/await any HTTP request or response (XHRs, fetch, beacons, etc.)',
   experimentalSourceRewriting: 'Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm.',
   experimentalFetchPolyfill: 'Polyfills `window.fetch` to enable Network spying and stubbing',
-  experimentalShadowDomSupport: 'Enables support for shadow DOM traversal, introduces the `shadow()` command and the `includeShadowDom` option to traversal commands.',
 }
 
 /**
@@ -72,7 +71,6 @@ const _names: StringValues = {
   experimentalComponentTesting: 'Component Testing',
   experimentalNetworkStubbing: 'Experimental network mocking',
   experimentalSourceRewriting: 'Improved source rewriting',
-  experimentalShadowDomSupport: 'Shadow DOM Support',
   experimentalFetchPolyfill: 'Fetch polyfill',
 }
 

--- a/packages/server/test/support/fixtures/projects/shadow-dom-global-inclusion/cypress.json
+++ b/packages/server/test/support/fixtures/projects/shadow-dom-global-inclusion/cypress.json
@@ -1,5 +1,4 @@
 {
-  "experimentalShadowDomSupport": true,
   "includeShadowDom": true,
   "pluginsFile": false,
   "supportFile": false

--- a/packages/server/test/unit/config_spec.js
+++ b/packages/server/test/unit/config_spec.js
@@ -1132,6 +1132,16 @@ describe('lib/config', () => {
       expect(warning).to.be.calledWith('EXPERIMENTAL_SAMESITE_REMOVED')
     })
 
+    it('warns if experimentalShadowDomSupport is passed', async function () {
+      const warning = sinon.spy(errors, 'warning')
+
+      await this.defaults('experimentalShadowDomSupport', true, {
+        experimentalShadowDomSupport: true,
+      })
+
+      expect(warning).to.be.calledWith('EXPERIMENTAL_SHADOW_DOM_REMOVED')
+    })
+
     describe('.resolved', () => {
       it('sets reporter and port to cli', () => {
         const obj = {
@@ -1158,7 +1168,6 @@ describe('lib/config', () => {
             experimentalComponentTesting: { value: false, from: 'default' },
             experimentalFetchPolyfill: { value: false, from: 'default' },
             experimentalNetworkStubbing: { value: false, from: 'default' },
-            experimentalShadowDomSupport: { value: false, from: 'default' },
             experimentalSourceRewriting: { value: false, from: 'default' },
             fileServerFolder: { value: '', from: 'default' },
             firefoxGcInterval: { value: { openMode: null, runMode: 1 }, from: 'default' },
@@ -1238,7 +1247,6 @@ describe('lib/config', () => {
             experimentalComponentTesting: { value: false, from: 'default' },
             experimentalFetchPolyfill: { value: false, from: 'default' },
             experimentalNetworkStubbing: { value: false, from: 'default' },
-            experimentalShadowDomSupport: { value: false, from: 'default' },
             experimentalSourceRewriting: { value: false, from: 'default' },
             env: {
               foo: {


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

### User facing changelog

- The `experimentalShadowDomSupport` flag is now deprecated and no longer necessary for testing the shadow DOM. Utilize the `includeShadowDom` option as needed to enable including shadow DOM elements in query results.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/3141#pullrequestreview-486196381
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [x] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
