### PR TITLE
fix(server): correctly redirect cy.visit when using HTTP POST

### DIFF
--- a/packages/server/__snapshots__/6_visit_spec.js
+++ b/packages/server/__snapshots__/6_visit_spec.js
@@ -35,16 +35,22 @@ exports['e2e visit / low response timeout / passes'] = `
       ✓ passes
     issue #309: request accept header not set
       ✓ sets accept header to text/html,*/*
+    can be redirected from initial POST
+      ✓ with status code 307
+      ✓ with status code 301
+      ✓ with status code 302
+      ✓ with status code 303
+      ✓ with status code 308
 
 
-  13 passing
+  18 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        13                                                                               │
-  │ Passing:      13                                                                               │
+  │ Tests:        18                                                                               │
+  │ Passing:      18                                                                               │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -68,9 +74,9 @@ exports['e2e visit / low response timeout / passes'] = `
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  visit_spec.coffee                        XX:XX       13       13        -        -        - │
+  │ ✔  visit_spec.coffee                        XX:XX       18       18        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX       13       13        -        -        -  
+    ✔  All specs passed!                        XX:XX       18       18        -        -        -  
 
 
 `

--- a/packages/server/lib/request.js
+++ b/packages/server/lib/request.js
@@ -602,6 +602,7 @@ module.exports = function (options = {}) {
 
       _.defaults(options, {
         headers: {},
+        followAllRedirects: true,
         onBeforeReqInit (fn) {
           return fn()
         },

--- a/packages/server/test/e2e/6_visit_spec.js
+++ b/packages/server/test/e2e/6_visit_spec.js
@@ -82,7 +82,7 @@ const onServer = function (app) {
   })
 
   // https://github.com/cypress-io/cypress/issues/5602
-  return app.get('/invalid-header-char', (req, res) => {
+  app.get('/invalid-header-char', (req, res) => {
     // express/node may interfere if we just use res.setHeader
     res.connection.write(
       `\
@@ -95,6 +95,23 @@ foo\
     )
 
     return res.connection.end()
+  })
+
+  app.post('/redirect-post', (req, res) => {
+    const code = Number(req.query.code)
+
+    if (!code) {
+      return res.end('no code supplied')
+    }
+
+    // 307 keeps the same HTTP method
+    const url = code === 307 ? '/post-only' : '/timeout'
+
+    res.redirect(code, url)
+  })
+
+  app.post('/post-only', (req, res) => {
+    res.end('<html>it posted</html>')
   })
 }
 

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/visit_spec.coffee
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/visit_spec.coffee
@@ -110,3 +110,27 @@ describe "visits", ->
 
           expect(headers.accept).to.eq("text/html,*/*")
           expect(headers.host).to.eq("localhost:3434")
+
+  # https://github.com/cypress-io/cypress/issues/8544
+  context "can be redirected from initial POST", ->
+    it "with status code 307", ->
+      # 307 is slightly different, the request method must not change
+      cy.visit({
+        url: "http://localhost:3434/redirect-post?code",
+        qs: {
+          code: 307
+        },
+        method: 'POST'
+      })
+      .contains('it posted')
+
+    [301, 302, 303, 308].forEach (code) ->
+      it "with status code #{code}", ->
+        cy.visit({
+          url: "http://localhost:3434/redirect-post?code",
+          qs: {
+            code
+          },
+          method: 'POST'
+        })
+        .contains('timeout: 0')


### PR DESCRIPTION
* Closes #8544

### User facing changelog
Fixed an issue where HTTP POST requests sent by `cy.visit` would fail if a HTTP redirect was received in the response.

### PR Tasks
* [x] Have tests been added/updated?
* [x] Has the original issue been tagged with a release in ZenHub?
* [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
* [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
* [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?

