### PR TITLE
fix: Support path aliases in plugins file

### DIFF
--- a/packages/server/lib/util/ts-node.js
+++ b/packages/server/lib/util/ts-node.js
@@ -27,6 +27,7 @@ const registerTsNode = (projectRoot, pluginsFile) => {
     debug('typescript path: %s', tsPath)
     debug('registering project TS with options %o', tsOptions)
 
+    require('tsconfig-paths/register')
     tsnode.register(tsOptions)
   } catch (err) {
     debug(`typescript doesn't exist. ts-node setup failed.`)

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -178,6 +178,7 @@
     "supertest-session": "4.0.0",
     "through2": "2.0.5",
     "ts-loader": "7.0.4",
+    "tsconfig-paths": "3.9.0",
     "webpack": "4.43.0",
     "ws": "5.2.2",
     "xvfb": "cypress-io/node-xvfb#22e3783c31d81ebe64d8c0df491ea00cdc74726a",

--- a/packages/server/test/e2e/1_typescript_spec_support_spec.ts
+++ b/packages/server/test/e2e/1_typescript_spec_support_spec.ts
@@ -29,6 +29,9 @@ describe('e2e typescript in spec and support file', function () {
     })
   })
 
+  // this covers spec/support files as well as the plugins file
+  // @see https://github.com/cypress-io/cypress/issues/7006
+  // @see https://github.com/cypress-io/cypress/issues/8555
   it('respects tsconfig paths', function () {
     return e2e.exec(this, {
       project: Fixtures.projectPath('ts-proj-with-paths'),

--- a/packages/server/test/support/fixtures/projects/ts-proj-with-paths/cypress.json
+++ b/packages/server/test/support/fixtures/projects/ts-proj-with-paths/cypress.json
@@ -1,4 +1,1 @@
-{
-  "supportFile": false,
-  "pluginsFile": false
-}
+{}

--- a/packages/server/test/support/fixtures/projects/ts-proj-with-paths/cypress/plugins/index.ts
+++ b/packages/server/test/support/fixtures/projects/ts-proj-with-paths/cypress/plugins/index.ts
@@ -1,0 +1,7 @@
+import { appName } from '@app/main'
+
+if (appName !== 'Best App Ever') {
+  throw new Error('Path alias not working properly in plugins file!')
+}
+
+export default () => {}

--- a/packages/server/test/support/fixtures/projects/ts-proj-with-paths/cypress/support/index.ts
+++ b/packages/server/test/support/fixtures/projects/ts-proj-with-paths/cypress/support/index.ts
@@ -1,0 +1,5 @@
+import { appName } from '@app/main'
+
+if (appName !== 'Best App Ever') {
+  throw new Error('Path alias not working properly in support file!')
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -24475,7 +24475,7 @@ tsconfig-paths-webpack-plugin@^3.3.0:
     enhanced-resolve "^4.0.0"
     tsconfig-paths "^3.4.0"
 
-tsconfig-paths@^3.4.0:
+tsconfig-paths@3.9.0, tsconfig-paths@^3.4.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
   integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8555

### User facing changelog

- Fixed an issue where using TypeScript path aliases in the plugins file would error

### How has the user experience changed?

Users can now use TypeScript path aliases or 3rd party code that relies on 3rd party path aliases in their plugins file without it erroring.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
