### PR TITLE
fix(route2): always have .response present on cy.route2.wait

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -446,8 +446,7 @@ describe('network stubbing', function () {
       cy.route2('/foo', 'foo bar baz').as('getFoo').then(function (win) {
         $.get('/foo')
       }).wait('@getFoo').then(function (res) {
-        // TODO: determine if response bodies should be eagerly loaded for statically-defined routes
-        // expect(res.response.body).to.eq('foo bar baz')
+        expect(res.response.body).to.eq('foo bar baz')
       })
     })
 
@@ -458,8 +457,7 @@ describe('network stubbing', function () {
           method: 'PROPFIND',
         })
       }).wait('@getFoo').then(function (res) {
-        // TODO: determine if response bodies should be eagerly loaded for statically-defined routes
-        // expect(res.response.body).to.eq('foo bar baz')
+        expect(res.response.body).to.eq('foo bar baz')
       })
     })
 
@@ -1577,21 +1575,55 @@ describe('network stubbing', function () {
       cy.route2(/fixtures\/app/).as('getFoo').then(function () {
         $.get('/fixtures/app.json')
       }).wait('@getFoo').then(function (res) {
-        let log
-
-        log = cy.queue.logs({
+        const log = cy.queue.logs({
           displayName: 'req',
         })[0]
 
         expect(log.get('alias')).to.eq('getFoo')
 
-        // TODO: determine if response bodies should be eagerly loaded for statically-defined routes
-        // expect(res.responseBody).to.deep.eq({
-        //   some: 'json',
-        //   foo: {
-        //     bar: 'baz',
-        //   },
-        // })
+        expect(JSON.parse(res.response.body as string)).to.deep.eq({
+          some: 'json',
+          foo: {
+            bar: 'baz',
+          },
+        })
+      })
+    })
+
+    // @see https://github.com/cypress-io/cypress/issues/8536
+    context('yields response', function () {
+      const testResponse = (expectedBody, done) => {
+        return () => {
+          $.get('/xml')
+
+          cy.wait('@foo').then((request) => {
+            expect(request.response.body).to.eq(expectedBody)
+            done()
+          })
+        }
+      }
+
+      it('when not stubbed', function (done) {
+        cy.route2('/xml').as('foo')
+        .then(testResponse('<foo>bar</foo>', done))
+      })
+
+      it('when stubbed with StaticResponse', function (done) {
+        cy.route2('/xml', 'something different')
+        .as('foo')
+        .then(testResponse('something different', done))
+      })
+
+      it('when stubbed with req.reply', function (done) {
+        cy.route2('/xml', (req) => req.reply('something different'))
+        .as('foo')
+        .then(testResponse('something different', done))
+      })
+
+      it('when stubbed with res.send', function (done) {
+        cy.route2('/xml', (req) => req.reply((res) => res.send('something different')))
+        .as('foo')
+        .then(testResponse('something different', done))
       })
     })
 

--- a/packages/driver/src/cy/net-stubbing/events/response-received.ts
+++ b/packages/driver/src/cy/net-stubbing/events/response-received.ts
@@ -24,6 +24,13 @@ export const onResponseReceived: HandlerFn<NetEventFrames.HttpResponseReceived> 
 
   if (request) {
     request.state = 'ResponseReceived'
+
+    if (!request.responseHandler) {
+      // this is notification-only, update the request with the response attributes and end
+      request.response = res
+
+      return
+    }
   }
 
   const continueFrame: NetEventFrames.HttpResponseContinue = {
@@ -32,10 +39,11 @@ export const onResponseReceived: HandlerFn<NetEventFrames.HttpResponseReceived> 
   }
 
   const sendContinueFrame = () => {
-    // copy changeable attributes of userReq to req in frame
+    // copy changeable attributes of userRes to res in frame
+    // if the user is setting a StaticResponse, use that instead
     // @ts-ignore
     request.response = continueFrame.res = {
-      ..._.pick(userRes, SERIALIZABLE_RES_PROPS),
+      ..._.pick(continueFrame.staticResponse || userRes, SERIALIZABLE_RES_PROPS),
     }
 
     if (request) {

--- a/packages/net-stubbing/lib/server/intercept-error.ts
+++ b/packages/net-stubbing/lib/server/intercept-error.ts
@@ -11,14 +11,14 @@ export const InterceptError: ErrorMiddleware = function () {
   const backendRequest = this.netStubbingState.requests[this.req.requestId]
 
   if (!backendRequest) {
-    // either the original request was not intercepted, or there's nothing for the driver to do with this response
+    // the original request was not intercepted, nothing to do
     return this.next()
   }
 
   debug('intercepting error %o', { req: this.req, backendRequest })
 
   // this may get set back to `true` by another route
-  backendRequest.sendResponseToDriver = false
+  backendRequest.waitForResponseContinue = false
   backendRequest.continueResponse = this.next
 
   const frame: NetEventFrames.HttpRequestComplete = {

--- a/packages/net-stubbing/lib/server/intercept-request.ts
+++ b/packages/net-stubbing/lib/server/intercept-request.ts
@@ -254,7 +254,7 @@ export async function onRequestContinue (state: NetStubbingState, frame: NetEven
   }
 
   if (frame.hasResponseHandler) {
-    backendRequest.sendResponseToDriver = true
+    backendRequest.waitForResponseContinue = true
   }
 
   if (frame.tryNextRoute) {

--- a/packages/net-stubbing/lib/server/intercept-response.ts
+++ b/packages/net-stubbing/lib/server/intercept-response.ts
@@ -28,13 +28,10 @@ export const InterceptResponse: ResponseMiddleware = function () {
 
   debug('InterceptResponse %o', { req: _.pick(this.req, 'url'), backendRequest })
 
-  if (!backendRequest || !backendRequest.sendResponseToDriver) {
-    // either the original request was not intercepted, or there's nothing for the driver to do with this response
+  if (!backendRequest) {
+    // original request was not intercepted, nothing to do
     return this.next()
   }
-
-  // this may get set back to `true` by another route
-  backendRequest.sendResponseToDriver = false
 
   backendRequest.incomingRes = this.incomingRes
 
@@ -72,6 +69,13 @@ export const InterceptResponse: ResponseMiddleware = function () {
     res.body = resBody.toString()
     emitReceived()
   }))
+
+  if (!backendRequest.waitForResponseContinue) {
+    this.next()
+  }
+
+  // this may get set back to `true` by another route
+  backendRequest.waitForResponseContinue = false
 }
 
 export async function onResponseContinue (state: NetStubbingState, frame: NetEventFrames.HttpResponseContinue) {

--- a/packages/net-stubbing/lib/server/types.ts
+++ b/packages/net-stubbing/lib/server/types.ts
@@ -38,9 +38,9 @@ export interface BackendRequest {
   res: CypressOutgoingResponse
   incomingRes?: IncomingMessage
   /**
-   * Should the response go to the driver, or should it be allowed to continue?
+   * Should we wait for the driver to allow the response to continue?
    */
-  sendResponseToDriver?: boolean
+  waitForResponseContinue?: boolean
 }
 
 export interface NetStubbingState {


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8536

### User facing changelog

Fixed an issue where objects yielded by `cy.wait`ing on `cy.route2` aliases would not have the `response` property if the `response` was not intercepted.

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
