### PR TITLE
feat: take Firefox support out of beta

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2564,7 +2564,7 @@ declare namespace Cypress {
      */
     waitForAnimations: boolean
     /**
-     * Firefox-only: The number of tests that will run between forced garbage collections.
+     * Firefox version 79 and below only: The number of tests that will run between forced garbage collections.
      * If a number is supplied, it will apply to `run` mode and `open` mode.
      * Set the interval to `null` or 0 to disable forced garbage collections.
      * @default { runMode: 1, openMode: null }

--- a/packages/desktop-gui/cypress/integration/project_nav_spec.js
+++ b/packages/desktop-gui/cypress/integration/project_nav_spec.js
@@ -60,13 +60,6 @@ describe('Project Nav', function () {
       cy.percySnapshot()
     })
 
-    it('displays "Tests" page when switching to a beta browser', () => {
-      cy.get('.browsers .dropdown-chosen').click()
-      cy.contains('.browsers', 'beta').first().click()
-      cy.get('.list-as-table').should('be.visible')
-      cy.percySnapshot()
-    })
-
     describe('runs page', function () {
       beforeEach(function () {
         cy.fixture('runs').as('runs')
@@ -151,12 +144,7 @@ describe('Project Nav', function () {
           })
         })
 
-        it('shows beta text for firefox', function () {
-          cy.get('.browsers li').contains('Firefox')
-          .contains('beta')
-        })
-
-        it('shows info icon with tooltip for browsder with info', function () {
+        it('shows info icon with tooltip for browser with info', function () {
           const browserWithInfo = _.find(this.config.browsers, (b) => !!b.info)
 
           cy.get('.browsers-list .dropdown-chosen').click()

--- a/packages/desktop-gui/src/app/nav.scss
+++ b/packages/desktop-gui/src/app/nav.scss
@@ -261,14 +261,6 @@
   }
 }
 
-.dropdown .browser-beta {
-  font-size: 12px;
-  top: -5px;
-  position: relative;
-  margin-left: 4px;
-  color: #d8a10b;
-}
-
 .close-browser {
   .btn {
     padding: 6px 9px;

--- a/packages/desktop-gui/src/project-nav/browsers.jsx
+++ b/packages/desktop-gui/src/project-nav/browsers.jsx
@@ -74,7 +74,6 @@ export default class Browsers extends Component {
         {prefixText}{' '}
         {browser.displayName}{' '}
         {browser.majorVersion}
-        {browser.family === 'firefox' && <span className='browser-beta'>beta</span>}
         {this._info(browser)}
         {this._warn(browser)}
       </>

--- a/packages/driver/cypress/integration/util/firefox_forced_gc_spec.ts
+++ b/packages/driver/cypress/integration/util/firefox_forced_gc_spec.ts
@@ -84,6 +84,9 @@ describe('driver/src/util/firefox_forced_gc', () => {
         on: cy.stub().throws(),
         emit: cy.stub().throws(),
         isBrowser: cy.stub().throws(),
+        browser: {
+          majorVersion: 79,
+        },
         getFirefoxGcInterval: cy.stub().throws(),
         backend: cy.stub().throws(),
       }
@@ -109,6 +112,16 @@ describe('driver/src/util/firefox_forced_gc', () => {
 
     it('registers no event handlers if not in Firefox', () => {
       MockCypress.isBrowser.withArgs('firefox').returns(false)
+
+      install(MockCypress)
+
+      expect(MockCypress.on).to.not.be.called
+    })
+
+    // @see https://github.com/cypress-io/cypress/issues/8241
+    it('registers no event handlers if in Firefox >= 80', () => {
+      MockCypress.isBrowser.withArgs('firefox').returns(true)
+      MockCypress.browser.majorVersion = 80
 
       install(MockCypress)
 

--- a/packages/driver/src/util/firefox_forced_gc.ts
+++ b/packages/driver/src/util/firefox_forced_gc.ts
@@ -17,7 +17,9 @@ export function createIntervalGetter (config) {
 }
 
 export function install (Cypress: Cypress.Cypress & EventEmitter) {
-  if (!Cypress.isBrowser('firefox')) {
+  // the firefox GC issue was fixed in v80 so we can stop here
+  // @see https://github.com/cypress-io/cypress/issues/8241
+  if (!Cypress.isBrowser('firefox') || Cypress.browser.majorVersion >= 80) {
     return
   }
 

--- a/packages/launcher/__snapshots__/browsers_spec.ts.js
+++ b/packages/launcher/__snapshots__/browsers_spec.ts.js
@@ -35,7 +35,6 @@ exports['browsers returns the expected list of browsers 1'] = [
     "family": "firefox",
     "channel": "stable",
     "displayName": "Firefox",
-    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
     "binary": "firefox"
   },
@@ -44,7 +43,6 @@ exports['browsers returns the expected list of browsers 1'] = [
     "family": "firefox",
     "channel": "dev",
     "displayName": "Firefox Developer Edition",
-    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
     "binary": [
       "firefox-developer-edition",
@@ -56,7 +54,6 @@ exports['browsers returns the expected list of browsers 1'] = [
     "family": "firefox",
     "channel": "nightly",
     "displayName": "Firefox Nightly",
-    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
     "binary": [
       "firefox-nightly",

--- a/packages/launcher/__snapshots__/darwin_spec.ts.js
+++ b/packages/launcher/__snapshots__/darwin_spec.ts.js
@@ -59,7 +59,6 @@ exports['darwin browser detection detects browsers as expected 1'] = [
     "family": "firefox",
     "channel": "stable",
     "displayName": "Firefox",
-    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
     "binary": "firefox",
     "path": "/Applications/Firefox.app/Contents/MacOS/firefox-bin",
@@ -76,7 +75,6 @@ exports['darwin browser detection detects browsers as expected 1'] = [
     "family": "firefox",
     "channel": "dev",
     "displayName": "Firefox Developer Edition",
-    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
     "binary": [
       "firefox-developer-edition",
@@ -96,7 +94,6 @@ exports['darwin browser detection detects browsers as expected 1'] = [
     "family": "firefox",
     "channel": "nightly",
     "displayName": "Firefox Nightly",
-    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
     "binary": [
       "firefox-nightly",

--- a/packages/launcher/__snapshots__/windows_spec.ts.js
+++ b/packages/launcher/__snapshots__/windows_spec.ts.js
@@ -59,7 +59,6 @@ exports['windows browser detection detects browsers as expected 1'] = [
     "family": "firefox",
     "channel": "stable",
     "displayName": "Firefox",
-    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
     "binary": "firefox",
     "path": "C:/Program Files/Mozilla Firefox/firefox.exe",
@@ -76,7 +75,6 @@ exports['windows browser detection detects browsers as expected 1'] = [
     "family": "firefox",
     "channel": "dev",
     "displayName": "Firefox Developer Edition",
-    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
     "binary": [
       "firefox-developer-edition",
@@ -96,7 +94,6 @@ exports['windows browser detection detects browsers as expected 1'] = [
     "family": "firefox",
     "channel": "nightly",
     "displayName": "Firefox Nightly",
-    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
     "binary": [
       "firefox-nightly",
@@ -189,7 +186,6 @@ exports['windows browser detection detects local Firefox installs 1'] = [
     "family": "firefox",
     "channel": "stable",
     "displayName": "Firefox",
-    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
     "binary": "firefox",
     "path": "C:/Users/flotwig/AppData/Local/Mozilla Firefox/firefox.exe",
@@ -206,7 +202,6 @@ exports['windows browser detection detects local Firefox installs 1'] = [
     "family": "firefox",
     "channel": "dev",
     "displayName": "Firefox Developer Edition",
-    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
     "binary": [
       "firefox-developer-edition",
@@ -226,7 +221,6 @@ exports['windows browser detection detects local Firefox installs 1'] = [
     "family": "firefox",
     "channel": "nightly",
     "displayName": "Firefox Nightly",
-    "info": "Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).",
     "versionRegex": {},
     "binary": [
       "firefox-nightly",

--- a/packages/launcher/lib/browsers.ts
+++ b/packages/launcher/lib/browsers.ts
@@ -2,8 +2,6 @@ import { log } from './log'
 import * as cp from 'child_process'
 import { Browser, FoundBrowser } from './types'
 
-const firefoxInfo = 'Firefox support is currently in beta! You can help us continue to improve the Cypress + Firefox experience by [reporting any issues you find](https://on.cypress.io/new-issue).'
-
 /** list of the browsers we can detect and use by default */
 export const browsers: Browser[] = [
   {
@@ -36,7 +34,6 @@ export const browsers: Browser[] = [
     family: 'firefox',
     channel: 'stable',
     displayName: 'Firefox',
-    info: firefoxInfo,
     // Mozilla Firefox 70.0.1
     versionRegex: /^Mozilla Firefox ([^\sab]+)$/m,
     binary: 'firefox',
@@ -46,7 +43,6 @@ export const browsers: Browser[] = [
     family: 'firefox',
     channel: 'dev',
     displayName: 'Firefox Developer Edition',
-    info: firefoxInfo,
     // Mozilla Firefox 73.0b12
     versionRegex: /^Mozilla Firefox (\S+b\S*)$/m,
     // ubuntu PPAs install it as firefox
@@ -57,7 +53,6 @@ export const browsers: Browser[] = [
     family: 'firefox',
     channel: 'nightly',
     displayName: 'Firefox Nightly',
-    info: firefoxInfo,
     // Mozilla Firefox 74.0a1
     versionRegex: /^Mozilla Firefox (\S+a\S*)$/m,
     // ubuntu PPAs install it as firefox-trunk

--- a/packages/launcher/lib/detect.ts
+++ b/packages/launcher/lib/detect.ts
@@ -126,7 +126,19 @@ function checkOneBrowser (browser: Browser): Promise<boolean | FoundBrowser> {
   .then(pickBrowserProps)
   .then(tap(logBrowser))
   .then(setMajorVersion)
+  .then(maybeSetFirefoxWarning)
   .catch(failed)
+}
+
+export const firefoxGcWarning = 'This version of Firefox has a bug that causes excessive memory consumption and will cause your tests to run slowly. It is recommended to upgrade to Firefox 80 or newer. [Learn more.](https://docs.cypress.io/guides/references/configuration.html#firefoxGcInterval)'
+
+// @see https://github.com/cypress-io/cypress/issues/8241
+const maybeSetFirefoxWarning = (browser: FoundBrowser) => {
+  if (browser.family === 'firefox' && Number(browser.majorVersion) < 80) {
+    browser.warning = firefoxGcWarning
+  }
+
+  return browser
 }
 
 /** returns list of detected browsers */
@@ -190,6 +202,7 @@ export const detectByPath = (
   return helper
   .getVersionString(path)
   .then(detectBrowserByVersionString)
+  .then(maybeSetFirefoxWarning)
   .catch((err: NotDetectedAtPathError) => {
     if (err.notDetectedAtPath) {
       throw err

--- a/packages/launcher/test/unit/detect_spec.ts
+++ b/packages/launcher/test/unit/detect_spec.ts
@@ -1,5 +1,5 @@
 require('../spec_helper')
-import { detect, detectByPath, setMajorVersion } from '../../lib/detect'
+import { firefoxGcWarning, detect, detectByPath, setMajorVersion } from '../../lib/detect'
 import { goalBrowsers } from '../fixtures'
 import { expect } from 'chai'
 import { utils } from '../../lib/utils'
@@ -125,6 +125,20 @@ describe('browser detection', () => {
             path: '/Applications/My Shiny New Browser.app',
           }),
         )
+      })
+    })
+
+    // @see https://github.com/cypress-io/cypress/issues/8241
+    it('adds warnings to Firefox versions less than 80', async () => {
+      execa.withArgs('/good-firefox', ['--version'])
+      .resolves({ stdout: 'Mozilla Firefox 80.0' })
+
+      execa.withArgs('/bad-firefox', ['--version'])
+      .resolves({ stdout: 'Mozilla Firefox 79.1' })
+
+      expect(await detectByPath('/good-firefox')).to.not.have.property('warning')
+      expect(await detectByPath('/bad-firefox')).to.include({
+        warning: firefoxGcWarning,
       })
     })
   })

--- a/packages/launcher/test/unit/linux_spec.ts
+++ b/packages/launcher/test/unit/linux_spec.ts
@@ -4,7 +4,8 @@ import _ from 'lodash'
 import * as linuxHelper from '../../lib/linux'
 import 'chai-as-promised'
 import { log } from '../log'
-import { detect } from '../../lib/detect'
+import { detect, firefoxGcWarning } from '../../lib/detect'
+import { browsers } from '../../lib/browsers'
 import { goalBrowsers } from '../fixtures'
 import { expect } from 'chai'
 import { utils } from '../../lib/utils'
@@ -89,6 +90,18 @@ describe('linux browser detection', () => {
 
     // @ts-ignore
     return linuxHelper.detect(goal).then(checkBrowser)
+  })
+
+  // @see https://github.com/cypress-io/cypress/issues/8241
+  it('adds warnings to Firefox versions less than 80', async () => {
+    const goalFirefox = _.find(browsers, { binary: 'firefox' })
+
+    execa.withArgs('firefox', ['--version'])
+    .resolves({ stdout: 'Mozilla Firefox 79.1' })
+
+    expect((await detect([goalFirefox]))[0]).to.include({
+      warning: firefoxGcWarning,
+    })
   })
 
   // despite using detect(), this test is in linux/spec instead of detect_spec because it is

--- a/packages/server/__snapshots__/3_plugins_spec.js
+++ b/packages/server/__snapshots__/3_plugins_spec.js
@@ -142,7 +142,7 @@ Cypress supports the following browsers:
 - chromium
 - edge
 - electron
-- firefox (Cypress support in beta)
+- firefox
 
 You can also use a custom browser: https://on.cypress.io/customize-browsers
 

--- a/packages/server/__snapshots__/7_record_spec.js
+++ b/packages/server/__snapshots__/7_record_spec.js
@@ -782,7 +782,7 @@ Cypress supports the following browsers:
 - chromium
 - edge
 - electron
-- firefox (Cypress support in beta)
+- firefox
 
 You can also use a custom browser: https://on.cypress.io/customize-browsers
 

--- a/packages/server/__snapshots__/browsers_spec.js
+++ b/packages/server/__snapshots__/browsers_spec.js
@@ -8,7 +8,7 @@ Cypress supports the following browsers:
 - chromium
 - edge
 - electron
-- firefox (Cypress support in beta)
+- firefox
 
 You can also use a custom browser: https://on.cypress.io/customize-browsers
 
@@ -28,7 +28,7 @@ Cypress supports the following browsers:
 - chromium
 - edge
 - electron
-- firefox (Cypress support in beta)
+- firefox
 
 You can also use a custom browser: https://on.cypress.io/customize-browsers
 

--- a/packages/server/__snapshots__/chrome_spec.js
+++ b/packages/server/__snapshots__/chrome_spec.js
@@ -8,7 +8,7 @@ Cypress supports the following browsers:
 - chromium
 - edge
 - electron
-- firefox (Cypress support in beta)
+- firefox
 
 You can also use a custom browser: https://on.cypress.io/customize-browsers
 

--- a/packages/server/__snapshots__/cri-client_spec.ts.js
+++ b/packages/server/__snapshots__/cri-client_spec.ts.js
@@ -8,7 +8,7 @@ Cypress supports the following browsers:
 - chromium
 - edge
 - electron
-- firefox (Cypress support in beta)
+- firefox
 
 You can also use a custom browser: https://on.cypress.io/customize-browsers
 

--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -127,7 +127,7 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
         - chromium
         - edge
         - electron
-        - firefox (Cypress support in beta)
+        - firefox
 
         You can also use a custom browser: https://on.cypress.io/customize-browsers
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8241

### User facing changelog

- Firefox support is now out of beta!
- Updated `firefoxGcInterval` workaround to only apply to versions of Firefox older than 80. A warning will be presented if an older version is used.

### Additional details

New warning:

![image](https://user-images.githubusercontent.com/1151760/93255679-3ec55280-f768-11ea-8d9d-cf1b46ad3d23.png)

(note, the BrowserIcon for Custom Firefox is wrong (?)... not related to these changes)

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here --> https://github.com/cypress-io/cypress-documentation/pull/3168
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
