### PR TITLE
fix(cli): support to unset an env variable with an empty value

### DIFF
--- a/cli/lib/util.js
+++ b/cli/lib/util.js
@@ -464,24 +464,23 @@ const util = {
   getEnv (varName, trim) {
     la(is.unemptyString(varName), 'expected environment variable name, not', varName)
 
-    const envVar = process.env[varName]
-    const configVar = process.env[`npm_config_${varName}`]
-    const packageConfigVar = process.env[`npm_package_config_${varName}`]
+    const configVarName = `npm_config_${varName}`
+    const packageConfigVarName = `npm_package_config_${varName}`
 
     let result
 
-    if (envVar) {
+    if (process.env.hasOwnProperty(varName)) {
       debug(`Using ${varName} from environment variable`)
 
-      result = envVar
-    } else if (configVar) {
+      result = process.env[varName]
+    } else if (process.env.hasOwnProperty(configVarName)) {
       debug(`Using ${varName} from npm config`)
 
-      result = configVar
-    } else if (packageConfigVar) {
+      result = process.env[configVarName]
+    } else if (process.env.hasOwnProperty(packageConfigVarName)) {
       debug(`Using ${varName} from package.json config`)
 
-      result = packageConfigVar
+      result = process.env[packageConfigVarName]
     }
 
     // environment variables are often set double quotes to escape characters

--- a/cli/test/lib/util_spec.js
+++ b/cli/test/lib/util_spec.js
@@ -481,10 +481,22 @@ describe('util', () => {
       expect(util.getEnv('CYPRESS_FOO')).to.eql('bar')
     })
 
+    it('prefers env var over .npmrc config even if it\'s an empty string', () => {
+      process.env.CYPRESS_FOO = ''
+      process.env.npm_config_CYPRESS_FOO = 'baz'
+      expect(util.getEnv('CYPRESS_FOO')).to.eql('')
+    })
+
     it('prefers .npmrc config over package config', () => {
       process.env.npm_package_config_CYPRESS_FOO = 'baz'
       process.env.npm_config_CYPRESS_FOO = 'bloop'
       expect(util.getEnv('CYPRESS_FOO')).to.eql('bloop')
+    })
+
+    it('prefers .npmrc config over package config even if it\'s an empty string', () => {
+      process.env.npm_package_config_CYPRESS_FOO = 'baz'
+      process.env.npm_config_CYPRESS_FOO = ''
+      expect(util.getEnv('CYPRESS_FOO')).to.eql('')
     })
 
     it('throws on non-string name', () => {


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8488

### User facing changelog

<!--
Explain the change(s) for every user to read in our changelog.
-->

Support to override env variables with empty value, such as "CYPRESS_INSTALL_BINARY=".

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

Before: Cannot override the env of CYPRESS_INSTALL_BINARY to a *unset* status.
After: Can override the env of CYPRESS_INSTALL_BINARY to a *unset* status.

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
