### PR TITLE
fix: cy.task() can pass undefined as default argument.

### DIFF
--- a/packages/driver/cypress/integration/commands/task_spec.js
+++ b/packages/driver/cypress/integration/commands/task_spec.js
@@ -39,7 +39,7 @@ describe('src/cy/commands/task', () => {
     })
 
     it('returns the default value when no argument is given', () => {
-      cy.task('no:arg').should('eq', 'hello')
+      cy.task('arg:is:undefined').should('eq', 'arg was undefined')
     })
 
     describe('.log', () => {
@@ -209,7 +209,7 @@ describe('src/cy/commands/task', () => {
           expect(lastLog.get('error')).to.eq(err)
           expect(lastLog.get('state')).to.eq('failed')
 
-          expect(err.message).to.eq(`\`cy.task('bar')\` failed with the following error:\n\nThe task 'bar' was not handled in the plugins file. The following tasks are registered: return:arg, no:arg, wait, create:long:file\n\nFix this in your plugins file here:\n${Cypress.config('pluginsFile')}\n\nhttps://on.cypress.io/api/task`)
+          expect(err.message).to.eq(`\`cy.task('bar')\` failed with the following error:\n\nThe task 'bar' was not handled in the plugins file. The following tasks are registered: return:arg, arg:is:undefined, wait, create:long:file\n\nFix this in your plugins file here:\n${Cypress.config('pluginsFile')}\n\nhttps://on.cypress.io/api/task`)
 
           done()
         })

--- a/packages/driver/cypress/integration/commands/task_spec.js
+++ b/packages/driver/cypress/integration/commands/task_spec.js
@@ -38,6 +38,10 @@ describe('src/cy/commands/task', () => {
       cy.task('return:arg', 'works').should('eq', 'works')
     })
 
+    it('returns the default value when no argument is given', () => {
+      cy.task('no:arg').should('eq', 'hello')
+    })
+
     describe('.log', () => {
       beforeEach(function () {
         this.logs = []
@@ -205,7 +209,7 @@ describe('src/cy/commands/task', () => {
           expect(lastLog.get('error')).to.eq(err)
           expect(lastLog.get('state')).to.eq('failed')
 
-          expect(err.message).to.eq(`\`cy.task('bar')\` failed with the following error:\n\nThe task 'bar' was not handled in the plugins file. The following tasks are registered: return:arg, wait, create:long:file\n\nFix this in your plugins file here:\n${Cypress.config('pluginsFile')}\n\nhttps://on.cypress.io/api/task`)
+          expect(err.message).to.eq(`\`cy.task('bar')\` failed with the following error:\n\nThe task 'bar' was not handled in the plugins file. The following tasks are registered: return:arg, no:arg, wait, create:long:file\n\nFix this in your plugins file here:\n${Cypress.config('pluginsFile')}\n\nhttps://on.cypress.io/api/task`)
 
           done()
         })

--- a/packages/driver/cypress/plugins/index.js
+++ b/packages/driver/cypress/plugins/index.js
@@ -38,8 +38,12 @@ module.exports = (on) => {
     'return:arg' (arg) {
       return arg
     },
-    'no:arg' (arg = 'hello') {
-      return arg
+    'arg:is:undefined' (arg) {
+      if (arg === undefined) {
+        return 'arg was undefined'
+      }
+
+      throw new Error(`Expected arg to be undefined, but it was ${arg}`)
     },
     'wait' () {
       return Promise.delay(2000)

--- a/packages/driver/cypress/plugins/index.js
+++ b/packages/driver/cypress/plugins/index.js
@@ -38,6 +38,9 @@ module.exports = (on) => {
     'return:arg' (arg) {
       return arg
     },
+    'no:arg' (arg = 'hello') {
+      return arg
+    },
     'wait' () {
       return Promise.delay(2000)
     },

--- a/packages/server/lib/plugins/child/task.js
+++ b/packages/server/lib/plugins/child/task.js
@@ -32,7 +32,13 @@ const merge = (prevEvents, events) => {
 
 const wrap = (ipc, events, ids, args) => {
   const task = args[0]
-  const arg = args[1]
+  let arg = args[1]
+
+  // ipc converts undefined to null.
+  // we're restoring it.
+  if (arg && arg.__cypress_task_no_argument__) {
+    arg = undefined
+  }
 
   const invoke = (eventId, args = []) => {
     const handler = _.get(events, `${eventId}.handler.${task}`)

--- a/packages/server/lib/plugins/index.js
+++ b/packages/server/lib/plugins/index.js
@@ -119,6 +119,14 @@ const init = (config, options) => {
               invocationId,
             }
 
+            // no argument is passed for cy.task()
+            // This is necessary because undefined becomes null when it is sent through ipc.
+            if (args[1] === undefined) {
+              args[1] = {
+                __cypress_task_no_argument__: true,
+              }
+            }
+
             ipc.send('execute', registration.event, ids, args)
           })
         })


### PR DESCRIPTION
- Closes #5913

### User facing changelog

When we pass no argument to `cy.task`, it converted it to `null`, not `undefined`. This PR fixes this bug.

### Additional details

- Why was this change necessary? It's impossible to use default argument.
- What is affected by this change? N/A
- Any implementation details to explain? IPC converts `undefined` to `null`. To prevent this, we now pass an object with a special property when args is `undefined`.

### How has the user experience changed?

N/A

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
