### PR TITLE
fix: use net-stubbing.d.ts in triple-slash reference

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -9,6 +9,6 @@ types/minimatch
 types/sinon
 types/sinon-chai
 # copied from net-stubbing package on build
-types/net-stubbing.ts
+types/net-stubbing.d.ts
 # ignore CLI output build folder
 build

--- a/cli/package.json
+++ b/cli/package.json
@@ -98,8 +98,7 @@
     "bin",
     "lib",
     "index.js",
-    "types/**/*.d.ts",
-    "types/net-stubbing.ts"
+    "types/**/*.d.ts"
   ],
   "bin": {
     "cypress": "bin/cypress"

--- a/cli/scripts/post-install.js
+++ b/cli/scripts/post-install.js
@@ -71,4 +71,4 @@ shell.sed('-i', 'from \'sinon\';', 'from \'../sinon\';', sinonChaiFilename)
 
 // copy experimental network stubbing type definitions
 // so users can import: `import 'cypress/types/net-stubbing'`
-shell.cp(resolvePkg('@packages/net-stubbing/lib/external-types.ts'), 'types/net-stubbing.ts')
+shell.cp(resolvePkg('@packages/net-stubbing/lib/external-types.ts'), 'types/net-stubbing.d.ts')

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -27,7 +27,7 @@
 // hmm, how to load it better?
 /// <reference path="./cypress-npm-api.d.ts" />
 
-/// <reference path="./net-stubbing.ts" />
+/// <reference path="./net-stubbing.d.ts" />
 /// <reference path="./cypress.d.ts" />
 /// <reference path="./cypress-global-vars.d.ts" />
 /// <reference path="./cypress-type-helpers.d.ts" />


### PR DESCRIPTION
### User facing changelog

fix compiler error with custom rootDir that was caused by net-stubbing.ts reference

### Additional details

When referencing a .ts file (vs. .d.ts) file, an import of cypress in a TypeScript project with a custom rootDir will lead to this error:

```
error TS6059: File
'<snip>/foo/node_modules/cypress/types/net-stubbing.ts' is not under 'rootDir' '<snip>foo/bar'.
'rootDir' is expected to contain all source files.
```

Using a .d.ts file is in line with the other references in index.d.ts and fixes this compiler error.

### How has the user experience changed?

no compiler error when importing cypress in a TypeScript project with a custom rootDir
