### PR TITLE
fix: discriminate cypress run types

### DIFF
--- a/cli/types/cypress-npm-api.d.ts
+++ b/cli/types/cypress-npm-api.d.ts
@@ -264,6 +264,7 @@ declare namespace CypressCommandLine {
    * @see https://on.cypress.io/module-api
    */
   interface CypressRunResult {
+    status: 'finished'
     startedTestsAt: dateTimeISO
     endedTestsAt: dateTimeISO
     totalDuration: ms
@@ -294,7 +295,8 @@ declare namespace CypressCommandLine {
      * @example
       ```
       const result = await cypress.run()
-      if (result.failures) {
+      if (result.status === 'failed') {
+        console.error('failures %d', result.failures)
         console.error(result.message)
         process.exit(result.failures)
       }
@@ -302,6 +304,7 @@ declare namespace CypressCommandLine {
      *
   **/
   interface CypressFailedRunResult {
+    status: 'failed'
     failures: number
     message: string
   }
@@ -347,7 +350,11 @@ declare module 'cypress' {
      cypress.run({
        spec: 'cypress/integration/admin*-spec.js'
      }).then(results => {
-       // inspect results object
+       if (results.status === 'failed') {
+          // Cypress could not run
+        } else {
+          // inspect results object
+       }
      })
      ```
      */

--- a/cli/types/tests/cypress-npm-api-test.ts
+++ b/cli/types/tests/cypress-npm-api-test.ts
@@ -42,3 +42,13 @@ cypress.run({ config: runConfig })
 cypress.run({}).then((results) => {
   results as CypressCommandLine.CypressRunResult // $ExpectType CypressRunResult
 })
+
+// the caller can determine if Cypress ran or failed to launch
+cypress.run().then(results => {
+  if (results.status === 'failed') {
+    results // $ExpectType CypressFailedRunResult
+  } else {
+    results // $ExpectType CypressRunResult
+    results.status // $ExpectType "finished"
+  }
+})


### PR DESCRIPTION
closes #8580

Added a field to disambiguate the `cypress.run` result. 

Before:
<img width="882" alt="Screen Shot 2020-09-17 at 10 49 07 AM" src="https://user-images.githubusercontent.com/2212006/93488597-8b2da100-f8d4-11ea-9b45-e1ed646ee41f.png">

Now:
```js
// the caller can determine if Cypress ran or failed to launch
cypress.run().then(results => {
  if (results.status === 'failed') {
    results // $ExpectType CypressFailedRunResult
  } else {
    results // $ExpectType CypressRunResult
    results.status // $ExpectType "finished"
  }
})
``` 

Added tests, but will need to update the docs once this lands

## Why not a boolean?

I have tried using a simple boolean 

```
interface CypressFailedRunResult {
  failed: true
  ...
}

interface CypressRunResult {
  failed: false
  ...
}
```

But the user only could make it work without TS error if they did an explicit

```
cypress.run().then(results => {
  if (results.failed === true) {
    // handle failure
  }
})
// and NOT
cypress.run().then(results => {
  if (results.failed) {
    // handle failure
  }
})
```