### PR TITLE
fix: Reporter shows the selector when it cannot find elements.

### DIFF
--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -127,6 +127,13 @@ describe('src/cy/commands/assertions', () => {
       }).should('deep.eq', { foo: 'baz' })
     })
 
+    // https://github.com/cypress-io/cypress/issues/5763
+    it('shows selector name used in the test when an element is not found', () => {
+      cy.get('it-should-not-exist').should('not.be.visible').then(function () {
+        expect(this.logs[1].get('message')).to.eq('expected **it-should-not-exist** not to be **visible**')
+      })
+    })
+
     describe('function argument', () => {
       it('waits until function is true', () => {
         const button = cy.$$('button:first')

--- a/packages/driver/src/cypress/chai_jquery.js
+++ b/packages/driver/src/cypress/chai_jquery.js
@@ -53,11 +53,15 @@ const $chaiJquery = (chai, chaiUtils, callbacks = {}) => {
     try {
       // reset obj to wrapped
       const orig = ctx._obj
+      const selector = ctx._obj.selector
 
       ctx._obj = wrap(ctx)
 
       if (ctx._obj.length === 0) {
-        ctx._obj = ctx._obj.selector
+        // From jQuery 3.x .selector API is deprecated. (https://api.jquery.com/selector/)
+        // Because of that, wrap() above removes selector property.
+        // That's why we're caching the value of selector above and using it here.
+        ctx._obj = selector
       }
 
       // apply the assertion


### PR DESCRIPTION
- Closes #5763

### User facing changelog

After Cypress 3.5.0, selector became `undefined` when no element is found. This error is fixed.

### Additional details

- Why was this change necessary? => Showing `undefined` is really unintuitive.
- What is affected by this change? => N/A
- Any implementation details to explain?

It happened because [`.selector` api is deprecated](https://api.jquery.com/selector/). That's why I cached the selector and used it instead.

### How has the user experience changed?

**Before:**
![image](https://user-images.githubusercontent.com/8130013/93564648-ff477200-f9c4-11ea-8ac5-b78f6fcc9649.png)

**After:**
![Screenshot from 2020-09-18 15-29-35](https://user-images.githubusercontent.com/8130013/93564682-125a4200-f9c5-11ea-9c3b-d3bcd0c443b7.png)


### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
