### PR TITLE
fix: afterEach running after test stopped in ui

### DIFF
--- a/packages/driver/src/cypress/runner.js
+++ b/packages/driver/src/cypress/runner.js
@@ -1143,7 +1143,7 @@ const create = (specWindow, mocha, Cypress, cy) => {
 
       // if there's no test, this is likely a rouge before/after hook
       // that should not have run, so skip this runnable
-      if (!test) {
+      if (!test || _runner.stopped) {
         return _next()
       }
 

--- a/packages/runner/cypress/integration/runner.ui.spec.js
+++ b/packages/runner/cypress/integration/runner.ui.spec.js
@@ -317,6 +317,7 @@ describe('src/cypress/runner', () => {
   })
 
   describe('reporter interaction', () => {
+    // https://github.com/cypress-io/cypress/issues/8621
     it('user can stop test execution', (done) => {
       runIsolatedCypress(() => {
         // eslint-disable-next-line mocha/handle-done-callback

--- a/packages/runner/cypress/integration/runner.ui.spec.js
+++ b/packages/runner/cypress/integration/runner.ui.spec.js
@@ -315,4 +315,30 @@ describe('src/cypress/runner', () => {
       })
     })
   })
+
+  describe('reporter interaction', () => {
+    it('user can stop test execution', (done) => {
+      runIsolatedCypress(() => {
+        // eslint-disable-next-line mocha/handle-done-callback
+        it('test stops while running', (done) => {
+          cy.timeout(200)
+          cy.get('.not-exist')
+          setTimeout(() => {
+            cy.$$('button.stop', parent.document).click()
+          }, 100)
+        })
+
+        afterEach(function () {
+          this.currentTest.err = new Error('ran aftereach')
+        })
+      }, {
+        onBeforeRun ({ autCypress }) {
+          autCypress.on('test:after:run', (arg) => {
+            expect(arg.err.message).not.contain('aftereach')
+            done()
+          })
+        },
+      })
+    })
+  })
 })


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8621

### User facing changelog
fixed bug causing after/afterEach hooks to run after a run is manually stopped in openMode
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
