### PR TITLE
fix: cy.visit() allows the URLs with double dots.

### DIFF
--- a/packages/driver/cypress/integration/cypress/location_spec.js
+++ b/packages/driver/cypress/integration/cypress/location_spec.js
@@ -426,5 +426,14 @@ describe('src/cypress/location', () => {
 
       expect(url).to.eq('http://localhost:3500/fixtures/sinon.html')
     })
+
+    // https://github.com/cypress-io/cypress/issues/5090
+    it('handles query param with two dots', function () {
+      let url = this.normalize('?foo=..')
+
+      url = Location.qualifyWithBaseUrl('http://localhost:3500/', url)
+
+      expect(url).to.eq('http://localhost:3500/?foo=..')
+    })
   })
 })

--- a/packages/driver/src/cypress/location.js
+++ b/packages/driver/src/cypress/location.js
@@ -145,18 +145,7 @@ class $Location {
   }
 
   static fullyQualifyUrl (url) {
-    if (this.isFullyQualifiedUrl(url)) {
-      return url
-    }
-
-    const existing = new UrlParse(window.location.href)
-
-    // always normalize against our existing origin
-    // as the baseUrl so that we do not accidentally
-    // have relative url's
-    url = new UrlParse(url, existing.origin)
-
-    return url.toString()
+    return new URL(url, window.location.origin).toString()
   }
 
   static mergeUrlWithParams (url, params) {
@@ -203,13 +192,7 @@ class $Location {
   }
 
   static qualifyWithBaseUrl (baseUrl, url) {
-    // if we have a root url and our url isnt full qualified
-    if (baseUrl && !this.isFullyQualifiedUrl(url)) {
-      // prepend the root url to it
-      url = this.join(baseUrl, url)
-    }
-
-    return this.fullyQualifyUrl(url)
+    return new URL(url, baseUrl).toString()
   }
 
   static isAbsoluteRelative (segment) {
@@ -234,24 +217,7 @@ class $Location {
   }
 
   static resolve (from, to) {
-    // if to is fully qualified then
-    // just return that
-    if (this.isFullyQualifiedUrl(to)) {
-      return to
-    }
-
-    // else take from and figure out if
-    // to is relative or absolute-relative
-
-    // if to is absolute relative '/foo'
-    if (this.isAbsoluteRelative(to)) {
-      // get origin from 'from'
-      const { origin } = this.create(from)
-
-      return this.join(origin, to)
-    }
-
-    return this.join(from, to)
+    return new URL(to, from).toString()
   }
 
   static create (remote) {

--- a/packages/driver/src/cypress/location.js
+++ b/packages/driver/src/cypress/location.js
@@ -145,7 +145,7 @@ class $Location {
   }
 
   static fullyQualifyUrl (url) {
-    return new URL(url, window.location.origin).toString()
+    return $Location.resolve(window.location.origin, url)
   }
 
   static mergeUrlWithParams (url, params) {
@@ -192,7 +192,7 @@ class $Location {
   }
 
   static qualifyWithBaseUrl (baseUrl, url) {
-    return new URL(url, baseUrl).toString()
+    return $Location.resolve(baseUrl, url)
   }
 
   static isAbsoluteRelative (segment) {

--- a/packages/driver/src/cypress/location.js
+++ b/packages/driver/src/cypress/location.js
@@ -129,6 +129,12 @@ class $Location {
   }
 
   static isUrlLike (url) {
+    // https://github.com/cypress-io/cypress/issues/5090
+    // In the case of a url like /?foo=..
+    if (/\.{2,}/.test(url)) {
+      return false
+    }
+
     // beta.cypress.io
     // aws.amazon.com/bucket/foo
     // foo.bar.co.uk

--- a/packages/driver/src/cypress/location.js
+++ b/packages/driver/src/cypress/location.js
@@ -145,7 +145,7 @@ class $Location {
   }
 
   static fullyQualifyUrl (url) {
-    return $Location.resolve(window.location.origin, url)
+    return this.resolve(window.location.origin, url)
   }
 
   static mergeUrlWithParams (url, params) {
@@ -192,7 +192,13 @@ class $Location {
   }
 
   static qualifyWithBaseUrl (baseUrl, url) {
-    return $Location.resolve(baseUrl, url)
+    // if we have a root url and our url isnt full qualified
+    if (baseUrl && !this.isFullyQualifiedUrl(url)) {
+      // prepend the root url to it
+      url = this.join(baseUrl, url)
+    }
+
+    return this.fullyQualifyUrl(url)
   }
 
   static isAbsoluteRelative (segment) {


### PR DESCRIPTION
- Closes #5090

Thanks, @ryan-snyder!

### User facing changelog

Allows cy.visit() to visit the URLs with `..` like `https://google.com?q=..` 

### Additional details

- Why was this change necessary? => Perfectly fine URL was not allowed.
- What is affected by this change? => N/A
- Any implementation details to explain? => When there are consecutive dots, it is not a valid URL. But `$Location.isUrlLike()` treats it's fine. Fixed that issue.

### How has the user experience changed?

N/A

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
