### PR TITLE
fix: Don't add / when baseUrl has param(s).

### DIFF
--- a/packages/driver/cypress/integration/cypress/location_spec.js
+++ b/packages/driver/cypress/integration/cypress/location_spec.js
@@ -435,5 +435,25 @@ describe('src/cypress/location', () => {
 
       expect(url).to.eq('http://localhost:3500/?foo=..')
     })
+
+    // https://github.com/cypress-io/cypress/issues/2101
+    describe('handles query param in baseUrl', () => {
+      const cases = [
+        'http://localhost:3500/?foo=bar',
+        'http://localhost:3500?foo=bar',
+        'http://localhost:3500/?foo',
+        'http://localhost:3500/?foo=bar&a=b',
+      ]
+
+      cases.forEach((c) => {
+        it(c, function () {
+          let url = this.normalize('')
+
+          url = Location.qualifyWithBaseUrl(c, '')
+
+          expect(url).to.eq(c)
+        })
+      })
+    })
   })
 })

--- a/packages/driver/cypress/integration/cypress/location_spec.js
+++ b/packages/driver/cypress/integration/cypress/location_spec.js
@@ -443,6 +443,7 @@ describe('src/cypress/location', () => {
         'http://localhost:3500?foo=bar',
         'http://localhost:3500/?foo',
         'http://localhost:3500/?foo=bar&a=b',
+        'http://localhost:3500/abcd?foo=bar',
       ]
 
       cases.forEach((c) => {

--- a/packages/driver/src/cypress/location.js
+++ b/packages/driver/src/cypress/location.js
@@ -14,6 +14,7 @@ const reHttp = /^https?:\/\//
 const reWww = /^www/
 const reFile = /^file:\/\//
 const reLocalHost = /^(localhost|0\.0\.0\.0|127\.0\.0\.1)/
+const reQueryParam = /\?[^/]+/
 
 class $Location {
   constructor (remote) {
@@ -196,6 +197,12 @@ class $Location {
     if (baseUrl && !this.isFullyQualifiedUrl(url)) {
       // prepend the root url to it
       url = this.join(baseUrl, url)
+
+      // https://github.com/cypress-io/cypress/issues/2101
+      // Has query param and ends with /
+      if (reQueryParam.test(url) && url[url.length - 1] === '/') {
+        url = url.substring(0, url.length - 1)
+      }
     }
 
     return this.fullyQualifyUrl(url)

--- a/packages/driver/src/cypress/location.js
+++ b/packages/driver/src/cypress/location.js
@@ -146,6 +146,10 @@ class $Location {
   }
 
   static fullyQualifyUrl (url) {
+    if (url.startsWith(window.location.origin)) {
+      return url
+    }
+
     return this.resolve(window.location.origin, url)
   }
 


### PR DESCRIPTION
- Closes #2101

Thanks, @ryan-snyder!
Note: I don't usually solve first-timers-only issues. But it's related with #5175. So, I fixed it. 

### User facing changelog

/ is not added when `baseUrl` has param(s)

### Additional details

- Why was this change necessary? Some people defines `baseUrl` with params. But Cypress adds `/` by default. 
- What is affected by this change? => N/A
- Any implementation details to explain? => N/A

### How has the user experience changed?

N/A

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
