### PR TITLE
fix: corrected coercion of config-file argument

### DIFF
--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -22,6 +22,10 @@ function unknownOption (flag, type = 'option') {
 }
 commander.Command.prototype.unknownOption = unknownOption
 
+const coerceFalseOrString = (arg) => {
+  return arg !== 'false' ? arg : false
+}
+
 const coerceFalse = (arg) => {
   return arg !== 'false'
 }
@@ -219,7 +223,7 @@ const castCypressRunOptions = (opts) => {
   // boolean arguments
   const result = R.evolve({
     port: coerceAnyStringToInt,
-    configFile: coerceFalse,
+    configFile: coerceFalseOrString,
   })(opts)
 
   return result

--- a/cli/test/lib/cypress_spec.js
+++ b/cli/test/lib/cypress_spec.js
@@ -207,6 +207,24 @@ describe('cypress', function () {
         })
       })
 
+      it('coerces --config-file false to boolean', async () => {
+        const args = 'cypress run --config-file false'.split(' ')
+        const options = await cypress.cli.parseRunArguments(args)
+
+        expect(options).to.deep.equal({
+          configFile: false,
+        })
+      })
+
+      it('coerces --config-file cypress.json to string', async () => {
+        const args = 'cypress run --config-file cypress.json'.split(' ')
+        const options = await cypress.cli.parseRunArguments(args)
+
+        expect(options).to.deep.equal({
+          configFile: 'cypress.json',
+        })
+      })
+
       it('parses config file false', async () => {
         const args = 'cypress run --config-file false'.split(' ')
         const options = await cypress.cli.parseRunArguments(args)


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

- Closes #8632 

### User facing changelog

Fixes an issue preventing users from passing the config-file argument when starting cypress through the Node module API.

### How has the user experience changed?

Passing the config-file argument when starting cypress through the Node module API now matches the behavior of starting cypress from the cli.

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
