### PR TITLE
fix(net-stubbing): route HTTPS traffic through net-stubbing interceptors

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -400,6 +400,32 @@ describe('network stubbing', function () {
     })
   })
 
+  context('network handling', function () {
+    context('can intercept against any domain', function () {
+      beforeEach(function () {
+        // reset origin
+        cy.visit('http://localhost:3500/fixtures/generic.html')
+      })
+
+      it('different origin (HTTP)', function () {
+        cy.route2('/foo').as('foo')
+        .then(() => {
+          $.get('http://baz.foobar.com:3501/foo')
+        })
+        .wait('@foo')
+      })
+
+      // @see https://github.com/cypress-io/cypress/issues/8487
+      it('different origin (HTTPS)', function () {
+        cy.route2('/foo', 'somethin').as('foo')
+        .then(() => {
+          $.get('https://bar.foobar.com:3502/foo')
+        })
+        .wait('@foo')
+      })
+    })
+  })
+
   context('stubbing with static responses', function () {
     it('can stub a response with static body as string', function (done) {
       cy.route2({

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -415,13 +415,45 @@ describe('network stubbing', function () {
         .wait('@foo')
       })
 
+      it('different origin with response interception (HTTP)', function () {
+        cy.route2('/xhr.html', (req) => {
+          req.reply((res) => {
+            expect(res.body).to.include('xhr fixture')
+            res.body = 'replaced the body'
+          })
+        }).as('foo')
+        .then(() => {
+          return $.get('http://baz.foobar.com:3501/fixtures/xhr.html')
+          .then((responseText) => {
+            expect(responseText).to.eq('replaced the body')
+          })
+        })
+        .wait('@foo').its('response.body').should('eq', 'replaced the body')
+      })
+
       // @see https://github.com/cypress-io/cypress/issues/8487
       it('different origin (HTTPS)', function () {
         cy.route2('/foo', 'somethin').as('foo')
         .then(() => {
-          $.get('https://bar.foobar.com:3502/foo')
+          $.get('https://bar.foobar.com.invalid:3502/foo')
         })
         .wait('@foo')
+      })
+
+      it('different origin with response interception (HTTPS)', function () {
+        cy.route2('/xhr.html', (req) => {
+          req.reply((res) => {
+            expect(res.body).to.include('xhr fixture')
+            res.body = 'replaced the body'
+          })
+        }).as('foo')
+        .then(() => {
+          return $.get('https://bar.foobar.com:3502/fixtures/xhr.html')
+          .then((responseText) => {
+            expect(responseText).to.eq('replaced the body')
+          })
+        })
+        .wait('@foo').its('response.body').should('eq', 'replaced the body')
       })
     })
   })

--- a/packages/driver/cypress/plugins/server.js
+++ b/packages/driver/cypress/plugins/server.js
@@ -3,15 +3,16 @@ const auth = require('basic-auth')
 const bodyParser = require('body-parser')
 const express = require('express')
 const http = require('http')
+const httpsProxy = require('@packages/https-proxy')
 const path = require('path')
 const Promise = require('bluebird')
 
 const PATH_TO_SERVER_PKG = path.dirname(require.resolve('@packages/server'))
-const ports = [3500, 3501]
+const httpPorts = [3500, 3501]
+const httpsPort = 3502
 
-ports.forEach((port) => {
+const createApp = (port) => {
   const app = express()
-  const server = http.Server(app)
 
   app.set('port', port)
 
@@ -131,8 +132,23 @@ ports.forEach((port) => {
 
   app.use(require('errorhandler')())
 
+  return app
+}
+
+httpPorts.forEach((port) => {
+  const app = createApp(port)
+  const server = http.Server(app)
+
   return server.listen(app.get('port'), () => {
     // eslint-disable-next-line no-console
     return console.log('Express server listening on port', app.get('port'))
   })
+})
+
+const httpsApp = createApp(httpsPort)
+const httpsServer = httpsProxy.httpsServer(httpsApp)
+
+httpsServer.listen(httpsPort, () => {
+  // eslint-disable-next-line no-console
+  return console.log('Express server listening on port', httpsPort, '(HTTPS)')
 })

--- a/packages/net-stubbing/lib/server/index.ts
+++ b/packages/net-stubbing/lib/server/index.ts
@@ -8,6 +8,8 @@ export { InterceptResponse } from './intercept-response'
 
 export { NetStubbingState } from './types'
 
+export { isHostInterceptable } from './is-host-interceptable'
+
 import { state } from './state'
 
 export const netStubbingState = state

--- a/packages/net-stubbing/lib/server/is-host-interceptable.ts
+++ b/packages/net-stubbing/lib/server/is-host-interceptable.ts
@@ -1,0 +1,60 @@
+import { NetStubbingState } from './types'
+import { URL } from 'url'
+import minimatch from 'minimatch'
+
+/**
+ * Returns `true` if there is any chance that a request for `host` could match a route defined in `state`.
+ * @param host `hostname:port`
+ */
+export function isHostInterceptable (host: string, { routes }: Pick<NetStubbingState, 'routes'>) {
+  const [hostname, portStr] = host.split(':')
+  const port = Number(portStr)
+
+  for (const { routeMatcher } of routes) {
+    if (routeMatcher.port) {
+      if (Array.isArray(routeMatcher.port) && !routeMatcher.port.includes(port)) {
+        continue // excluded by port list mismatch
+      }
+
+      if (!Array.isArray(routeMatcher.port) && routeMatcher.port !== port) {
+        continue // excluded by port mismatch
+      }
+    }
+
+    if (!routeMatcher.hostname && !routeMatcher.url) {
+      return true // route has no constraints on host, could match
+    }
+
+    if (routeMatcher.hostname) {
+      if (routeMatcher.hostname instanceof RegExp && routeMatcher.hostname.test(hostname)) {
+        return true // hostname RegExp is a match
+      }
+
+      if (routeMatcher.hostname === hostname) {
+        return true // hostname is an exact match
+      }
+    }
+
+    if (routeMatcher.url) {
+      if (routeMatcher.url instanceof RegExp) {
+        return true // possible that the RegExp could match a URL
+      }
+
+      if (host.includes(routeMatcher.url)) {
+        return true // possible for substring to match
+      }
+
+      try {
+        const url = new URL(routeMatcher.url)
+
+        if (minimatch(host, url.host) || minimatch(hostname, url.hostname)) {
+          return true // host could match
+        }
+      } catch (e) {
+        return true // invalid URL, so partial URL, could possibly match
+      }
+    }
+  }
+
+  return false // ruled out all possibilities for a match
+}

--- a/packages/net-stubbing/test/unit/is-host-interceptable-spec.ts
+++ b/packages/net-stubbing/test/unit/is-host-interceptable-spec.ts
@@ -1,0 +1,123 @@
+import {
+  isHostInterceptable,
+} from '../../lib/server/is-host-interceptable'
+import { expect } from 'chai'
+import { RouteMatcherOptions } from '../../lib/types'
+
+const testMatchers = (host: string, matchers: RouteMatcherOptions[], expected: boolean) => {
+  const routes = matchers.map((routeMatcher) => {
+    return { routeMatcher }
+  })
+
+  // @ts-ignore
+  expect(isHostInterceptable(host, { routes })).to.eq(expected)
+}
+
+describe('is host interceptable?', () => {
+  it('returns false if no routes set', () => {
+    testMatchers('foo.com:123', [], false)
+  })
+
+  it('returns false if host mismatch', () => {
+    testMatchers('foo.com:123', [
+      {
+        hostname: 'bar.com',
+      },
+    ], false)
+  })
+
+  it('returns true if matcher doesn\'t constrain host or port', () => {
+    testMatchers('foo.com:123', [{}], true)
+    testMatchers('foo.com:123', [{
+      pathname: 'foo',
+    }], true)
+  })
+
+  it('returns true if host equals', () => {
+    testMatchers('foo.com:123', [
+      {
+        hostname: 'foo.com',
+      },
+    ], true)
+  })
+
+  it('returns true if host matches regex', () => {
+    testMatchers('foo.com:123', [
+      {
+        hostname: /foo/,
+      },
+    ], true)
+  })
+
+  it('returns false if port mismatch', () => {
+    testMatchers('foo.com:123', [
+      {
+        port: 456,
+      },
+    ], false)
+  })
+
+  it('returns true if port equals', () => {
+    testMatchers('foo.com:123', [
+      {
+        port: 123,
+      },
+    ], true)
+  })
+
+  it('returns true if port in list', () => {
+    testMatchers('foo.com:123', [
+      {
+        port: [123],
+      },
+    ], true)
+  })
+
+  it('returns true if url is a RegExp', () => {
+    testMatchers('foo.com:123', [
+      {
+        url: /anything-is-possible/,
+      },
+    ], true)
+  })
+
+  it('returns true if url has same hostname', () => {
+    testMatchers('foo.com:123', [
+      {
+        url: 'http://foo.com:123/anything/really',
+      },
+    ], true)
+  })
+
+  it('returns true if url is a fragment glob', () => {
+    testMatchers('foo.com:123', [
+      {
+        url: '/foo',
+      },
+    ], true)
+  })
+
+  it('returns true if url domain matches', () => {
+    testMatchers('foo.com:80', [
+      {
+        url: 'http://foo.com',
+      },
+    ], true)
+  })
+
+  it('returns true if url domain glob matches', () => {
+    testMatchers('foobar.com:80', [
+      {
+        url: 'http://foo*ar.com',
+      },
+    ], true)
+  })
+
+  it('returns false if url domain glob does not match', () => {
+    testMatchers('foobar.com:80', [
+      {
+        url: 'http://bar*ar.com',
+      },
+    ], false)
+  })
+})


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8487

### User facing changelog

Fixed an issue where routes defined with `cy.route2` would not match against HTTPS requests to a different origin.

### Additional details

- only affected HTTPS requests - all HTTP requests are proxied already
- makes an attempt to optimize which HTTPS requests are proxied. some will still be transparently proxied. only potentially-interceptable connections will be proxied through the Cy proxy layer, and thus through the net-stubbing code
	- check `is-host-interceptable.ts` for implementation

### How has the user experience changed?

Users can now use `cy.route2` to spy and stub on any URL, anywhere :smile: 

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
