### PR TITLE
[POC] React devtools right in the test runner 

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
       "pre-commit": "lint-staged"
     }
   },
+  "dependencies": {
+    "react-devtools-inline": "4.8.2"
+  },
   "devDependencies": {
     "@cypress/bumpercar": "2.0.12",
     "@cypress/commit-message-install": "3.1.3",

--- a/packages/runner/src/iframe/iframe.scss
+++ b/packages/runner/src/iframe/iframe.scss
@@ -8,6 +8,37 @@
     }
   }
 
+  .devtools-container {
+    position: absolute;
+    bottom: 0;
+    max-height: 400px;
+    width: 100%;
+
+    & button {
+      background-color: unset;
+      border: unset;
+      border-radius: unset;
+      display: unset;
+      color: unset;
+      cursor: unset;
+      font-size: unset;
+      font-weight: unset;
+      line-height: unset;
+      padding: unset;
+      position: unset;
+      text-align: unset;
+      -ms-touch-action: unset;
+      touch-action: unset;
+      vertical-align: unset;
+      background-image: unset;
+      white-space: unset;
+      -webkit-user-select: unset;
+      -moz-user-select: unset;
+      -ms-user-select: unset;
+      user-select: unset;
+    }
+  }
+
   .size-container {
     width: 100%;
     height: 100%;

--- a/yarn.lock
+++ b/yarn.lock
@@ -20841,6 +20841,11 @@ react-clientside-effect@^1.2.2:
   dependencies:
     "@babel/runtime" "^7.0.0"
 
+react-devtools-inline@4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/react-devtools-inline/-/react-devtools-inline-4.8.2.tgz#f9d5dfc449542b5b8d8b74b9ad635a5271931948"
+  integrity sha512-ESK76a3kq8N5hwKbvtfYFbfnO/nFCWY3rvvY2q7fMuFkv8n2Y80ytfQvLpgIyQtejp6EzEEY6q2LK7pQ2+DPDg==
+
 "react-dom-15.6.1@npm:react-dom@15.6.1":
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"


### PR DESCRIPTION
# This is a proof of concept and the API will change

👀  Sneak peek 

<img width="1743" alt="Screenshot 2020-09-25 at 09 54 30" src="https://user-images.githubusercontent.com/16926049/94239726-e423b780-ff1a-11ea-9abe-dca402c2e947.png">

## Intro  

Thanks to the code sandbox and other online IDE react created specific dev tools that can run over an iframe. And because Cypress itself is fixing the cross-origin errors we can easily point dev tools to the application. 

**Works both for component and integration tests** 

## Reason

Our users love cypress because developer experience, and that it is actually possible with cypress to develop front-end through the tests. But if there are no framework-specific devtools – developers will open native chrome back to debug the application. I am sure this feature would be loved 🥰 

## Potential API 

This is not a final API, we need to make a new API. I think about adding a new event in plugins and creating plugins for each framework (vue, angular, react, etc) which will expose implemented devtools client for the integration

```js
const reactDevTools = require("@cypress/devtools/react");

module.exports((on, config) => {
  on('devtools:register', reactDevTools)
})
```

And for multiple devtools, this can be a rare case when somebody is using `apollo`.  It won't be a problem because we can store the devtools in a map with a unique name). 

```js
const reactDevTools = require("@cypress/devtools/react");
const apolloDevTools = require("@cypress/devtools/apollo");

module.exports((on, config) => {
  on('devtools:register', reactDevTools)
  on('devtools:register', apolloDevTools)
})
```

## UI

UI for dev tools could be a simple bottom accordion with a different tab for each dev tool. Something similar to https://codesandbox.io: 

![image](https://user-images.githubusercontent.com/16926049/94241488-61e8c280-ff1d-11ea-9ac2-49fda1ebec31.png)


## Problems 

There are 2 problems I see right now 

1. Devtools UX overridden by global styles (😢). This can be fixed by resetting all the styles inside the `devtools-container` or by removing global styles. 
 
![image](https://user-images.githubusercontent.com/16926049/94241636-8e044380-ff1d-11ea-8216-8fd79b9dfd47.png)

2. Devtools element highlighting not displayed correctly. For the number of absolute layout shift (`left` and `top`). This may require changing the layout and getting rid of `left` and `top` in favor of `flex` and `width`. **But this works nice for component testing** so it may have an easier solution. 

<img width="1744" alt="Screenshot 2020-09-25 at 09 18 13" src="https://user-images.githubusercontent.com/16926049/94241948-05d26e00-ff1e-11ea-9f6e-569370c21138.png">
