### PR TITLE
chore: add option to disable command log

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -123,6 +123,7 @@ commands:
       - run:
           environment:
             CYPRESS_KONFIG_ENV: production
+            CYPRESS_NO_COMMANDLOG: 1
           command: |
             echo Current working directory is $PWD
             echo Total containers $CIRCLE_NODE_TOTAL

--- a/circle.yml
+++ b/circle.yml
@@ -123,7 +123,6 @@ commands:
       - run:
           environment:
             CYPRESS_KONFIG_ENV: production
-            CYPRESS_NO_COMMANDLOG: 1
           command: |
             echo Current working directory is $PWD
             echo Total containers $CIRCLE_NODE_TOTAL

--- a/packages/runner/cypress/integration/retries.ui.spec.js
+++ b/packages/runner/cypress/integration/retries.ui.spec.js
@@ -34,6 +34,7 @@ describe('runner/cypress retries.ui.spec', { viewportWidth: 600, viewportHeight:
     })
     .then(shouldHaveTestResults(2, 0))
 
+    cy.get('.test').should('have.length', 2)
     cy.percySnapshot()
   })
 

--- a/packages/runner/cypress/integration/runner.ui.spec.js
+++ b/packages/runner/cypress/integration/runner.ui.spec.js
@@ -341,5 +341,25 @@ describe('src/cypress/runner', () => {
         },
       })
     })
+
+    it('supports disabling command log reporter with env var NO_COMMANDLOG', () => {
+      runIsolatedCypress(() => {
+        it('foo', () => {
+          // simulate a page load, ensures reporter state event is properly stubbed
+          cy.then(() => Cypress.action('cy:collect:run:state'))
+          cy.visit('/')
+
+          // ensures runner doesn't wait for nonexist before:screenshot ack
+          cy.screenshot({
+            capture: 'runner',
+          })
+        })
+      },
+      {
+        config: { env: { NO_COMMANDLOG: '1' } },
+      })
+
+      cy.get('.reporter').should('not.exist')
+    })
   })
 })

--- a/packages/runner/cypress/integration/runner.ui.spec.js
+++ b/packages/runner/cypress/integration/runner.ui.spec.js
@@ -342,7 +342,7 @@ describe('src/cypress/runner', () => {
       })
     })
 
-    it('supports disabling command log reporter with env var NO_COMMANDLOG', () => {
+    it('supports disabling command log reporter with env var NO_COMMAND_LOG', () => {
       runIsolatedCypress(() => {
         it('foo', () => {
           // simulate a page load, ensures reporter state event is properly stubbed
@@ -356,7 +356,7 @@ describe('src/cypress/runner', () => {
         })
       },
       {
-        config: { env: { NO_COMMANDLOG: '1' } },
+        config: { env: { NO_COMMAND_LOG: '1' } },
       })
 
       cy.get('.reporter').should('not.exist')

--- a/packages/runner/src/app/app.jsx
+++ b/packages/runner/src/app/app.jsx
@@ -26,6 +26,8 @@ class App extends Component {
      */
     const spec = this.props.config.spec
 
+    const disableCommandLog = this.props.config.env && this.props.config.env.NO_COMMANDLOG
+
     return (
       <div className={cs({
         'is-reporter-resizing': this.isReporterResizing,
@@ -34,15 +36,15 @@ class App extends Component {
         <div
           ref='reporterWrap'
           className='reporter-wrap'
-          style={{ width: this.props.state.reporterWidth }}
+          style={{ width: disableCommandLog ? 0 : this.props.state.reporterWidth }}
         >
-          <Reporter
+          {Boolean(disableCommandLog) || <Reporter
             runner={this.props.eventManager.reporterBus}
             spec={spec}
             autoScrollingEnabled={this.props.config.state.autoScrollingEnabled}
             error={errorMessages.reporterError(this.props.state.scriptError, spec.relative)}
             firefoxGcInterval={this.props.config.firefoxGcInterval}
-          />
+          />}
         </div>
         <div
           ref='container'

--- a/packages/runner/src/app/app.jsx
+++ b/packages/runner/src/app/app.jsx
@@ -26,7 +26,7 @@ class App extends Component {
      */
     const spec = this.props.config.spec
 
-    const NO_COMMANDLOG = this.props.config.env && this.props.config.env.NO_COMMANDLOG
+    const NO_COMMAND_LOG = this.props.config.env && this.props.config.env.NO_COMMAND_LOG
 
     return (
       <div className={cs({
@@ -38,7 +38,7 @@ class App extends Component {
           className='reporter-wrap'
           style={{ width: this.props.state.reporterWidth }}
         >
-          {Boolean(NO_COMMANDLOG) || <Reporter
+          {Boolean(NO_COMMAND_LOG) || <Reporter
             runner={this.props.eventManager.reporterBus}
             spec={spec}
             autoScrollingEnabled={this.props.config.state.autoScrollingEnabled}

--- a/packages/runner/src/app/app.jsx
+++ b/packages/runner/src/app/app.jsx
@@ -26,7 +26,7 @@ class App extends Component {
      */
     const spec = this.props.config.spec
 
-    const disableCommandLog = this.props.config.env && this.props.config.env.NO_COMMANDLOG
+    const NO_COMMANDLOG = this.props.config.env && this.props.config.env.NO_COMMANDLOG
 
     return (
       <div className={cs({
@@ -36,9 +36,9 @@ class App extends Component {
         <div
           ref='reporterWrap'
           className='reporter-wrap'
-          style={{ width: disableCommandLog ? 0 : this.props.state.reporterWidth }}
+          style={{ width: this.props.state.reporterWidth }}
         >
-          {Boolean(disableCommandLog) || <Reporter
+          {Boolean(NO_COMMANDLOG) || <Reporter
             runner={this.props.eventManager.reporterBus}
             spec={spec}
             autoScrollingEnabled={this.props.config.state.autoScrollingEnabled}

--- a/packages/runner/src/lib/event-manager.js
+++ b/packages/runner/src/lib/event-manager.js
@@ -292,7 +292,7 @@ const eventManager = {
     })
 
     Cypress.on('collect:run:state', () => {
-      if (Cypress.env('NO_COMMANDLOG')) {
+      if (Cypress.env('NO_COMMAND_LOG')) {
         return Promise.resolve()
       }
 
@@ -319,7 +319,7 @@ const eventManager = {
         cb()
       }
 
-      if (Cypress.env('NO_COMMANDLOG')) {
+      if (Cypress.env('NO_COMMAND_LOG')) {
         return beforeThenCb()
       }
 

--- a/packages/runner/src/lib/event-manager.js
+++ b/packages/runner/src/lib/event-manager.js
@@ -292,6 +292,10 @@ const eventManager = {
     })
 
     Cypress.on('collect:run:state', () => {
+      if (Cypress.env('NO_COMMANDLOG')) {
+        return Promise.resolve()
+      }
+
       return new Promise((resolve) => {
         reporterBus.emit('reporter:collect:run:state', resolve)
       })
@@ -313,6 +317,10 @@ const eventManager = {
       const beforeThenCb = () => {
         localBus.emit('before:screenshot', config)
         cb()
+      }
+
+      if (Cypress.env('NO_COMMANDLOG')) {
+        return beforeThenCb()
       }
 
       const wait = !config.appOnly && config.waitForCommandSynchronization

--- a/packages/runner/src/main.jsx
+++ b/packages/runner/src/main.jsx
@@ -16,7 +16,9 @@ const Runner = {
     action('started', () => {
       const config = JSON.parse(driverUtils.decodeBase64Unicode(base64Config))
 
-      const state = new State((config.state || {}).reporterWidth)
+      const NO_COMMANDLOG = config.env && config.env.NO_COMMANDLOG
+
+      const state = new State(NO_COMMANDLOG ? 0 : (config.state || {}).reporterWidth)
 
       Runner.state = state
       Runner.configureMobx = configure

--- a/packages/runner/src/main.jsx
+++ b/packages/runner/src/main.jsx
@@ -16,9 +16,9 @@ const Runner = {
     action('started', () => {
       const config = JSON.parse(driverUtils.decodeBase64Unicode(base64Config))
 
-      const NO_COMMANDLOG = config.env && config.env.NO_COMMANDLOG
+      const NO_COMMAND_LOG = config.env && config.env.NO_COMMAND_LOG
 
-      const state = new State(NO_COMMANDLOG ? 0 : (config.state || {}).reporterWidth)
+      const state = new State(NO_COMMAND_LOG ? 0 : (config.state || {}).reporterWidth)
 
       Runner.state = state
       Runner.configureMobx = configure


### PR DESCRIPTION
TR-361

Add env var for debugging performance issues related to command log rendering
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes N/A

### User facing changelog
misc: added environment variable `CYPRESS_NO_COMMAND_LOG` for disabling the rendering of the Command Log.
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks
- [x] add tests
- [x] remove circle.yml changes
<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
