### PR TITLE
fix: within followed by should correctly changes the scope.

### DIFF
--- a/packages/driver/cypress/integration/commands/querying_spec.js
+++ b/packages/driver/cypress/integration/commands/querying_spec.js
@@ -355,6 +355,20 @@ describe('src/cy/commands/querying', () => {
       })
     })
 
+    // https://github.com/cypress-io/cypress/issues/4757
+    it('subject is restored after within() call', () => {
+      cy.get('#wrapper').within(() => {
+        cy.get('#upper').should('contain.text', 'New York')
+      })
+      .should('have.id', 'wrapper')
+    })
+
+    // https://github.com/cypress-io/cypress/issues/5183
+    it('contains() works after within() call', () => {
+      cy.get(`#wrapper`).within(() => cy.get(`#upper`)).should(`contain.text`, `New York`)
+      cy.contains(`button`, `button`).should(`exist`)
+    })
+
     describe('.log', () => {
       beforeEach(function () {
         this.logs = []

--- a/packages/driver/src/cy/commands/querying.js
+++ b/packages/driver/src/cy/commands/querying.js
@@ -575,6 +575,16 @@ module.exports = (Commands, Cypress, cy, state) => {
 
       state('withinSubject', subject)
 
+      const restoreCmdIndex = state('index') + 1
+
+      cy.queue.splice(restoreCmdIndex, 0, {
+        args: [subject],
+        name: 'within-restore',
+        fn: (subject) => subject,
+      })
+
+      state('index', restoreCmdIndex)
+
       fn.call(ctx, subject)
 
       const cleanup = () => cy.removeListener('command:start', setWithinSubject)

--- a/packages/driver/src/cy/commands/querying.js
+++ b/packages/driver/src/cy/commands/querying.js
@@ -575,6 +575,9 @@ module.exports = (Commands, Cypress, cy, state) => {
 
       state('withinSubject', subject)
 
+      // https://github.com/cypress-io/cypress/pull/8699
+      // An internal command is inserted to create a divider between
+      // commands inside within() callback and commands chained to it.
       const restoreCmdIndex = state('index') + 1
 
       cy.queue.splice(restoreCmdIndex, 0, {


### PR DESCRIPTION
* Closes #2106
* Closes #4672
* Closes #4757
* Closes #5183

These all 4 issues cover the same problem and this PR solves that.

### User facing changelog
When a command is chained after `cy.within()` and `cy.get()` is called inside it, the scope was permanently changed. This PR solves this problem. 

### Additional details
#### Why was this change necessary?
The command didn't work as the documentation says.

#### What is affected by this change?
Some codes that use this bug will be broken. Example below:

```html
<article class='post'>
    <h1>My Blog Post</h1>
</article>
```

```js
cy.get(`article`).within(() => cy.get(`h1`)).should(`have.text`, `My Blog Post`);
```

This should fail because the `article` has text `\n My Blog Post \n`.

#### Any implementation details to explain?
When running tests, Cypress queues commands and runs them later. 

```js
cy.get('article').within(() => {
  cy.get('h1').should('contain.text', 'Blog')
})
.should('have.class', 'post')
```

In the example above, Cypress creates a queue like below:

```
get('article')
within
should('have.class', 'post')
```

After running `within`, the queue becomes like below:

```
get('article')
within
get('h1', { withinSubject: 'article' })
should('contain.text', 'Blog')
should('have.class', 'post')
```

Because `within` inserts commands inside the callback to the queue after itself.

But the problem happens here. Because the code below generates the identical queue state.

```js
cy.get('article').within(() => {
  cy.get('h1').should('contain.text', 'Blog').should('have.class', 'post')
})
```

And Cypress interprets that the code is written in that way. That's why the code failed. 

The solution is to insert the divider between the commands like below:

```
get('article')
within
get('h1', { withinSubject: 'article' })
should('contain.text', 'Blog')
within-restore <= This is necessary.
should('have.class', 'post')
```

And this PR inserts that internal command to the queue. 

### How has the user experience changed?
N/A

### PR Tasks
* [x] Have tests been added/updated?
* [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
* [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
* [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
* [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?

