### PR TITLE
fix: hanging on error thrown in test:after:run

### DIFF
--- a/packages/driver/src/cypress/runner.js
+++ b/packages/driver/src/cypress/runner.js
@@ -63,7 +63,16 @@ const testAfterRun = (test, Cypress) => {
   test.clearTimeout()
   if (!fired(TEST_AFTER_RUN_EVENT, test)) {
     setWallClockDuration(test)
-    fire(TEST_AFTER_RUN_EVENT, test, Cypress)
+    try {
+      fire(TEST_AFTER_RUN_EVENT, test, Cypress)
+    } catch (e) {
+      // if the test:after:run listener throws it's likely spec code
+      // Since the test status has already been emitted this can't affect the test status.
+      // Let's just log the error to console
+      // TODO: revist when we handle uncaught exceptions/rejections between tests
+      // eslint-disable-next-line no-console
+      console.error(e)
+    }
 
     // perf loop only through
     // a tests OWN properties and not

--- a/packages/runner/cypress/integration/runner.mochaEvents.spec.js
+++ b/packages/runner/cypress/integration/runner.mochaEvents.spec.js
@@ -306,4 +306,25 @@ describe('src/cypress/runner', () => {
       })
     })
   })
+
+  describe('event listeners', () => {
+    // https://github.com/cypress-io/cypress/issues/8701
+    it('does not hang when error thrown in test:after:run', () => {
+      runIsolatedCypress(() => {
+        Cypress.on('test:after:run', (test) => {
+          throw new Error('I am throwing')
+        })
+
+        describe('page', { defaultCommandTimeout: 400 }, () => {
+          it('t1', { retries: 2 }, () => {
+            assert(false)
+          })
+
+          it('t2', () => {
+            assert(true)
+          })
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #2271 
- Closes #8701
- TR-300

### User facing changelog
Bug fix: fix bug causing run to hang on error thrown in `test:after:run` handler
<!--
Explain the change(s) for every user to read in our changelog.
-->

### Additional details

<!--
Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->

