### PR TITLE
fix: each followed by contains correctly changes the scope.

### DIFF
--- a/packages/driver/cypress/integration/commands/connectors_spec.js
+++ b/packages/driver/cypress/integration/commands/connectors_spec.js
@@ -1932,6 +1932,13 @@ describe('src/cy/commands/connectors', () => {
         })
       })
 
+      // https://github.com/cypress-io/cypress/issues/4921
+      it('dual commands like contains() work after each()', () => {
+        cy.contains('New York')
+        cy.get('span').each(() => {})
+        cy.contains('New York')
+      })
+
       describe('errors', {
         defaultCommandTimeout: 100,
       }, () => {

--- a/packages/driver/src/cy/commands/connectors.js
+++ b/packages/driver/src/cy/commands/connectors.js
@@ -518,17 +518,22 @@ module.exports = function (Commands, Cypress, cy, state) {
       const next = state('current').get('next')
 
       if (next) {
-        const checkSubject = (newSubject, args) => {
+        const checkSubject = (newSubject, args, firstCall) => {
           if (state('current') !== next) {
             return
           }
 
-          // find the new subject and splice it out
-          // with our existing subject
-          const index = _.indexOf(args, newSubject)
+          // https://github.com/cypress-io/cypress/issues/4921
+          // When dual commands like contains() is used as the firstCall (cy.contains() style),
+          // we should not prepend subject.
+          if (!firstCall) {
+            // find the new subject and splice it out
+            // with our existing subject
+            const index = _.indexOf(args, newSubject)
 
-          if (index > -1) {
-            args.splice(index, 1, subject)
+            if (index > -1) {
+              args.splice(index, 1, subject)
+            }
           }
 
           return cy.removeListener('next:subject:prepared', checkSubject)

--- a/packages/driver/src/cypress/cy.js
+++ b/packages/driver/src/cypress/cy.js
@@ -656,7 +656,7 @@ const create = function (specWindow, Cypress, Cookies, state, config, log) {
 
     args.unshift(subject)
 
-    Cypress.action('cy:next:subject:prepared', subject, args)
+    Cypress.action('cy:next:subject:prepared', subject, args, firstCall)
 
     return args
   }


### PR DESCRIPTION
* Closes #4921

### User facing changelog
When dual commands like `cy.contains()` is used `each()`, it didn't work properly. This PR solves this problem.

### Additional details
#### Why was this change necessary?
Unexpected behavior of `each()` and `contains()`.

#### What is affected by this change? 
Nothing

#### Any implementation details to explain?
This problem happened because `each()` didn't care about whether the command is called first or not.

Because of that, the code A was interpreted like Code B.

```js
// code A
cy.contains('New York')
cy.get('span').each(() => {})
cy.contains('New York')
```

```js
// code B
cy.contains('New York')
cy.get('span').each(() => {}).contains('New York')
```

### How has the user experience changed?
N/A

### PR Tasks
* [x] Have tests been added/updated?
* [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
* [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
* [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
* [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?

