### PR TITLE
fix(driver): hide forced GC warning if using FF >= 80

### DIFF
--- a/packages/driver/cypress/integration/util/firefox_forced_gc_spec.ts
+++ b/packages/driver/cypress/integration/util/firefox_forced_gc_spec.ts
@@ -3,11 +3,15 @@ import { createIntervalGetter, install } from '../../../src/util/firefox_forced_
 describe('driver/src/util/firefox_forced_gc', () => {
   describe('#createIntervalGetter returns a function that', () => {
     const run = (configObj) => {
-      const configFn = (key) => {
-        return key ? configObj[key] : configObj
+      const fakeCypress = {
+        config: (key) => {
+          return key ? configObj[key] : configObj
+        },
+        browser: configObj.browser,
       }
 
-      return createIntervalGetter(configFn)()
+      // @ts-ignore
+      return createIntervalGetter(fakeCypress)()
     }
 
     it('returns undefined if not in Firefox', () => {
@@ -22,6 +26,7 @@ describe('driver/src/util/firefox_forced_gc', () => {
       expect(run({
         browser: {
           family: 'firefox',
+          majorVersion: 79,
         },
         firefoxGcInterval: 99,
       })).to.eq(99)
@@ -31,6 +36,7 @@ describe('driver/src/util/firefox_forced_gc', () => {
       expect(run({
         browser: {
           family: 'firefox',
+          majorVersion: 79,
         },
         firefoxGcInterval: null,
       })).to.eq(null)
@@ -40,6 +46,7 @@ describe('driver/src/util/firefox_forced_gc', () => {
       expect(run({
         browser: {
           family: 'firefox',
+          majorVersion: 79,
         },
         firefoxGcInterval: {
           runMode: 10,
@@ -53,6 +60,7 @@ describe('driver/src/util/firefox_forced_gc', () => {
       expect(run({
         browser: {
           family: 'firefox',
+          majorVersion: 79,
         },
         firefoxGcInterval: {
           runMode: 10,
@@ -67,10 +75,10 @@ describe('driver/src/util/firefox_forced_gc', () => {
       firefoxGcInterval: 5,
     }, () => {
       const real = Cypress.getFirefoxGcInterval
-      const fake = createIntervalGetter(Cypress.config)
+      const fake = createIntervalGetter(Cypress)
 
       // conditional, so it can pass in non-ff browsers
-      expect(real()).to.eq(fake()).and.eq(Cypress.isBrowser('firefox') ? 5 : undefined)
+      expect(real()).to.eq(fake()).and.eq(Cypress.isBrowser('firefox') && Cypress.browser.majorVersion < 80 ? 5 : undefined)
     })
   })
 
@@ -83,8 +91,8 @@ describe('driver/src/util/firefox_forced_gc', () => {
       MockCypress = {
         on: cy.stub().throws(),
         emit: cy.stub().throws(),
-        isBrowser: cy.stub().throws(),
         browser: {
+          family: 'firefox',
           majorVersion: 79,
         },
         getFirefoxGcInterval: cy.stub().throws(),
@@ -111,7 +119,7 @@ describe('driver/src/util/firefox_forced_gc', () => {
     }
 
     it('registers no event handlers if not in Firefox', () => {
-      MockCypress.isBrowser.withArgs('firefox').returns(false)
+      MockCypress.browser.family = 'chrome'
 
       install(MockCypress)
 
@@ -120,7 +128,6 @@ describe('driver/src/util/firefox_forced_gc', () => {
 
     // @see https://github.com/cypress-io/cypress/issues/8241
     it('registers no event handlers if in Firefox >= 80', () => {
-      MockCypress.isBrowser.withArgs('firefox').returns(true)
       MockCypress.browser.majorVersion = 80
 
       install(MockCypress)
@@ -129,7 +136,6 @@ describe('driver/src/util/firefox_forced_gc', () => {
     })
 
     it('triggers a forced GC correctly with interval = 1', () => {
-      MockCypress.isBrowser.withArgs('firefox').returns(true)
       MockCypress.getFirefoxGcInterval.returns(1)
 
       const forceGc = MockCypress.backend.withArgs('firefox:force:gc').resolves()
@@ -171,7 +177,6 @@ describe('driver/src/util/firefox_forced_gc', () => {
     })
 
     it('triggers a forced GC correctly with interval = 3', () => {
-      MockCypress.isBrowser.withArgs('firefox').returns(true)
       MockCypress.getFirefoxGcInterval.returns(3)
 
       const forceGc = MockCypress.backend.withArgs('firefox:force:gc').resolves()
@@ -204,7 +209,6 @@ describe('driver/src/util/firefox_forced_gc', () => {
     })
 
     it('does not trigger any forced GC with falsy interval', () => {
-      MockCypress.isBrowser.withArgs('firefox').returns(true)
       MockCypress.getFirefoxGcInterval.returns(false)
 
       const forceGc = MockCypress.backend.withArgs('firefox:force:gc').resolves()

--- a/packages/driver/src/cypress.js
+++ b/packages/driver/src/cypress.js
@@ -162,7 +162,7 @@ class $Cypress {
     this.state = $SetterGetter.create({})
     this.config = $SetterGetter.create(config)
     this.env = $SetterGetter.create(env)
-    this.getFirefoxGcInterval = $FirefoxForcedGc.createIntervalGetter(this.config)
+    this.getFirefoxGcInterval = $FirefoxForcedGc.createIntervalGetter(this)
     this.getTestRetries = function () {
       const testRetries = this.config('retries')
 

--- a/packages/driver/src/util/firefox_forced_gc.ts
+++ b/packages/driver/src/util/firefox_forced_gc.ts
@@ -1,25 +1,29 @@
-import { get, isNumber, isNull } from 'lodash'
+import { isNumber, isNull } from 'lodash'
 
-export function createIntervalGetter (config) {
+function usingFirefoxWithGcBug (browser: Cypress.Browser) {
+  // @see https://github.com/cypress-io/cypress/issues/8241
+  return browser.family === 'firefox' && browser.majorVersion < 80
+}
+
+export function createIntervalGetter (Cypress: Cypress.Cypress) {
   return () => {
-    if (get(config('browser'), 'family') !== 'firefox') {
+    if (!usingFirefoxWithGcBug(Cypress.browser)) {
       return undefined
     }
 
-    const intervals = config('firefoxGcInterval')
+    const intervals = Cypress.config('firefoxGcInterval')
 
     if (isNumber(intervals) || isNull(intervals)) {
       return intervals
     }
 
-    return intervals[config('isInteractive') ? 'openMode' : 'runMode']
+    // @ts-ignore
+    return intervals[Cypress.config('isInteractive') ? 'openMode' : 'runMode']
   }
 }
 
 export function install (Cypress: Cypress.Cypress & EventEmitter) {
-  // the firefox GC issue was fixed in v80 so we can stop here
-  // @see https://github.com/cypress-io/cypress/issues/8241
-  if (!Cypress.isBrowser('firefox') || Cypress.browser.majorVersion >= 80) {
+  if (!usingFirefoxWithGcBug(Cypress.browser)) {
     return
   }
 


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes <!-- issue number here -->

### User facing changelog

Fixed an issue where the forced garbage collection timer would still display in Firefox, even when using a version of Firefox newer than 80.

### Additional details

- follow-up on #8586 
- needed the intervalGetter to also return undefined

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
