### PR TITLE
fix: prevent custom command collisions with internal functions

### DIFF
--- a/packages/driver/cypress/integration/commands/commands_spec.js
+++ b/packages/driver/cypress/integration/commands/commands_spec.js
@@ -81,6 +81,18 @@ describe('src/cy/commands/commands', () => {
         expect($ce.get(0)).to.eq(ce.get(0))
       })
     })
+
+    context('errors', () => {
+      it('throws for reserved command names', (done) => {
+        cy.on('fail', (err) => {
+          expect(err.message).to.eq(`Cannot create custom command named: \`reset\`.\n\nThis command name is reserved internally by Cypress.`)
+
+          done()
+        })
+
+        Cypress.Commands.add('reset', () => {})
+      })
+    })
   })
 
   context('errors', () => {

--- a/packages/driver/src/cypress/commands.js
+++ b/packages/driver/src/cypress/commands.js
@@ -40,6 +40,11 @@ const builtInCommands = [
   require('../cy/net-stubbing').addCommand,
 ]
 
+const reservedCommandNames = [
+  'getAlias',
+  'reset',
+]
+
 const getTypeByPrevSubject = (prevSubject) => {
   if (prevSubject === 'optional') {
     return 'dual'
@@ -156,6 +161,14 @@ const create = (Cypress, cy, state, config) => {
       if (_.isFunction(options)) {
         fn = options
         options = {}
+      }
+
+      if (_.includes(reservedCommandNames, name)) {
+        $errUtils.throwErrByPath('miscellaneous.reserved_command', {
+          args: {
+            name,
+          },
+        })
       }
 
       const { prevSubject } = options

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -814,7 +814,7 @@ module.exports = {
       docsUrl: 'https://on.cypress.io/api',
     },
     invalid_overwrite: {
-      message: 'Cannot overwite command for: `{{name}}`. An existing command does not exist by that name.',
+      message: 'Cannot overwrite command for: `{{name}}`. An existing command does not exist by that name.',
       docsUrl: 'https://on.cypress.io/api',
     },
     invoking_child_without_parent (obj) {

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -864,6 +864,10 @@ module.exports = {
       This was never documented nor supported.
 
       Please go through the public function: ${cmd('state', '...')}`,
+    reserved_command: stripIndent`\
+      Cannot create custom command named: \`{{name}}\`.
+
+      This command name is reserved internally by Cypress.`,
     retry_timed_out: 'Timed out retrying: ',
   },
 


### PR DESCRIPTION
- Closes #6146

### User facing changelog

Adds & enforces "reserved" command names

### Additional details

The awesome ability to customize Cypress can sometimes be a drawback: it's easy to overwrite things we didn't mean to! This change prevents users' custom commands from interfering with internally-defined functions which should not be overwritten/modified.

### How has the user experience changed?

N/A

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
