### PR TITLE
chore: Update setMajorVersion to not modify browser on call

### DIFF
--- a/packages/launcher/lib/detect.ts
+++ b/packages/launcher/lib/detect.ts
@@ -22,23 +22,24 @@ type HasVersion = {
   name: string
 }
 
-// TODO: make this function NOT change its argument
 export const setMajorVersion = <T extends HasVersion>(browser: T): T => {
+  let majorVersion = browser.majorVersion
+
   if (browser.version) {
-    browser.majorVersion = browser.version.split('.')[0]
+    majorVersion = browser.version.split('.')[0]
     log(
       'browser %s version %s major version %s',
       browser.name,
       browser.version,
-      browser.majorVersion,
+      majorVersion,
     )
 
-    if (browser.majorVersion) {
-      browser.majorVersion = parseInt(browser.majorVersion)
+    if (majorVersion) {
+      majorVersion = parseInt(majorVersion)
     }
   }
 
-  return browser
+  return extend({}, browser, { majorVersion })
 }
 
 type PlatformHelper = {
@@ -125,7 +126,7 @@ function checkOneBrowser (browser: Browser): Promise<boolean | FoundBrowser> {
   .then(merge(browser))
   .then(pickBrowserProps)
   .then(tap(logBrowser))
-  .then(setMajorVersion)
+  .then((browser) => setMajorVersion(browser))
   .then(maybeSetFirefoxWarning)
   .catch(failed)
 }
@@ -185,7 +186,7 @@ export const detectByPath = (
 
     const regexExec = browser.versionRegex.exec(stdout) as Array<string>
 
-    const parsedBrowser = {
+    let parsedBrowser = {
       name: browser.name,
       displayName: `Custom ${browser.displayName}`,
       info: `Loaded from ${path}`,
@@ -194,7 +195,7 @@ export const detectByPath = (
       version: regexExec[1],
     }
 
-    setMajorVersion(parsedBrowser)
+    parsedBrowser = setMajorVersion(parsedBrowser)
 
     return extend({}, browser, parsedBrowser)
   }

--- a/packages/launcher/test/unit/detect_spec.ts
+++ b/packages/launcher/test/unit/detect_spec.ts
@@ -44,9 +44,10 @@ describe('browser detection', () => {
       version: '11.22.33',
     }
 
-    setMajorVersion(foundBrowser)
+    const res = setMajorVersion(foundBrowser)
+
     // @ts-ignore
-    expect(foundBrowser.majorVersion, 'major version was converted to number').to.equal(11)
+    expect(res.majorVersion, 'major version was converted to number').to.equal(11)
   })
 
   context('#detectByPath', () => {


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

* Closes <!-- issue number here -->

### User facing changelog
N/A

### Additional details
* Why was this change necessary?

It's considered bad practice to modify the parameters of a function in that call. In order to purify the function call, we should create a new object instead.

* Any implementation details to explain?

Chose to create a new object instead of just returning the version and setting it due to some typing difficulties with FoundBrowser

<!--
Examples:

* Why was this change necessary?
* What is affected by this change?
* Any implementation details to explain?
-->

### How has the user experience changed?
N/A
<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

* [x] Have tests been added/updated?

