### PR TITLE
chore: fix mocha retries syntax in e2e test

### DIFF
--- a/packages/server/test/e2e/6_video_compression_spec.js
+++ b/packages/server/test/e2e/6_video_compression_spec.js
@@ -8,7 +8,7 @@ const NUM_TESTS = 40
 const MS_PER_TEST = 500
 const EXPECTED_DURATION_MS = NUM_TESTS * MS_PER_TEST
 
-describe('e2e video compression', { retries: 1 }, () => {
+describe('e2e video compression', () => {
   e2e.setup()
 
   return [

--- a/packages/server/test/e2e/7_record_spec.js
+++ b/packages/server/test/e2e/7_record_spec.js
@@ -537,8 +537,6 @@ describe('e2e record', () => {
     setup(routes)
 
     it('passes in parallel with group', function () {
-      this.retries(3)
-
       return Promise.all([
         e2e.exec(this, {
           key: 'f858a2bc-b469-4e48-be67-0876339ee7e1',

--- a/packages/server/test/e2e/7_record_spec.js
+++ b/packages/server/test/e2e/7_record_spec.js
@@ -537,6 +537,8 @@ describe('e2e record', () => {
     setup(routes)
 
     it('passes in parallel with group', function () {
+      this.retries(3)
+
       return Promise.all([
         e2e.exec(this, {
           key: 'f858a2bc-b469-4e48-be67-0876339ee7e1',


### PR DESCRIPTION
This was breaking the build. Mocha doesn't have support for Cypress's test retries syntax. doh.