### PR TITLE
fix: scrollIntoView to work when scrolling is on the body

### DIFF
--- a/packages/driver/cypress/integration/commands/actions/scroll_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/scroll_spec.js
@@ -14,6 +14,8 @@ describe('src/cy/commands/actions/scroll', () => {
     const doc = cy.state('document')
 
     $(doc.body).empty().html(this.body)
+    $(doc.body).removeAttr('style')
+    $(doc.body.parentElement).removeAttr('style')
 
     cy.viewport(600, 200)
   })
@@ -641,6 +643,17 @@ describe('src/cy/commands/actions/scroll', () => {
 
       this.scrollBoth.scrollTop(0)
       this.scrollBoth.scrollLeft(0)
+    })
+
+    it('works with scroll on the body', () => {
+      const doc = cy.state('document')
+
+      $(doc.body).empty().html('<div style="height: 100vh;"><div style="height:2000px"></div><div id="bottom-content">Bottom Content</div></div>')
+      $(doc.body).css({ 'margin': 0, 'overflow-y': 'overlay' })
+      $(doc.body.parentElement).css({ 'overflow-y': 'overlay' })
+      cy.get('#bottom-content').scrollIntoView().then(() => {
+        expect(doc.body.scrollTop).to.be.above(1800)
+      })
     })
 
     it('does not change the subject', () => {

--- a/packages/driver/src/cy/commands/actions/scroll.js
+++ b/packages/driver/src/cy/commands/actions/scroll.js
@@ -11,7 +11,7 @@ const findScrollableParent = ($el, win) => {
 
   // if we're at the body, we just want to pass in
   // window into jQuery scrollTo
-  if ($parent.is('body,html') || $dom.isDocument($parent)) {
+  if ($parent.is('html') || $dom.isDocument($parent)) {
     return win
   }
 

--- a/packages/driver/src/dom/elements.ts
+++ b/packages/driver/src/dom/elements.ts
@@ -567,7 +567,8 @@ const isAttrType = function (el: HTMLInputElement, type: string) {
 }
 
 const isScrollOrAuto = (prop) => {
-  return prop === 'scroll' || prop === 'auto'
+  // overlay is non-standard but behaves the same as auto but with scrollbars drawn on top of content
+  return prop === 'scroll' || prop === 'auto' || prop === 'overlay'
 }
 
 const isAncestor = ($el, $maybeAncestor) => {


### PR DESCRIPTION
### User facing changelog
Fixes scrollIntoView to work when the body element is scrollable and when `overflow: overlay` is used.

### Additional details
When you have a body element that is scrollable, both cypress and jquery.scrollTo assume it is the window that is scrollable and try to scroll that. Since that is not scrollable, nothing happens and the command is useless.

Note - this fixes cypress but the test I added does not pass because jquery.scrollTo is broken.

### PR Tasks
* [x] Have tests been added/updated?
* [ ] Fix jquery.scrollTo and upgrade it

