### PR TITLE
fix: remove reference to this repository being outside of the cypress monorepo

### DIFF
--- a/npm/vue/.releaserc.js
+++ b/npm/vue/.releaserc.js
@@ -2,6 +2,6 @@ module.exports = {
   ...require('../../.releaserc.base'),
   branches: [
     '@cypress/vue@1.0.0',
-    { name: 'master', prerelease: 'alpha' },
+    { name: 'master', channel: 'latest', prerelease: 'alpha' },
   ],
 }


### PR DESCRIPTION
Need to publish to the latest tag. Also, remove the old notice because this is not on the bahmutov namespace anymore