### PR TITLE
fix: set status property on the module API resolved object

### DIFF
--- a/cli/lib/cypress.js
+++ b/cli/lib/cypress.js
@@ -41,6 +41,7 @@ const cypressModuleApi = {
         .then((output) => {
           if (!output) {
             return {
+              status: 'failed',
               failures: failedTests,
               message: 'Could not find Cypress test run results',
             }

--- a/cli/test/lib/cypress_spec.js
+++ b/cli/test/lib/cypress_spec.js
@@ -68,6 +68,24 @@ describe('cypress', function () {
     })
   })
 
+  context('.run fails to write results file', function () {
+    it('resolves with error object', function () {
+      const outputPath = path.join(os.tmpdir(), 'cypress/monorepo/cypress_spec/output.json')
+
+      sinon.stub(tmp, 'fileAsync').resolves(outputPath)
+      sinon.stub(run, 'start').resolves(2)
+      sinon.stub(fs, 'readJsonAsync').withArgs(outputPath).resolves()
+
+      return cypress.run().then((result) => {
+        expect(result).to.deep.equal({
+          status: 'failed',
+          failures: 2,
+          message: 'Could not find Cypress test run results',
+        })
+      })
+    })
+  })
+
   context('.run', function () {
     let outputPath
 

--- a/packages/server/__snapshots__/5_spec_isolation_spec.js
+++ b/packages/server/__snapshots__/5_spec_isolation_spec.js
@@ -158,6 +158,7 @@ Although you have test retries enabled, we do not retry tests when \`before all\
 `
 
 exports['e2e spec_isolation fails [electron] 1'] = {
+  "stauts": "finished",
   "startedTestsAt": "2018-02-01T20:14:19.323Z",
   "endedTestsAt": "2018-02-01T20:14:19.323Z",
   "totalDuration": 5555,
@@ -2739,6 +2740,7 @@ exports['e2e spec_isolation failing with retries enabled [chrome] 1'] = {
 }
 
 exports['e2e spec_isolation failing with retries enabled [firefox] 1'] = {
+  "status": "finished",
   "startedTestsAt": "2018-02-01T20:14:19.323Z",
   "endedTestsAt": "2018-02-01T20:14:19.323Z",
   "totalDuration": 5555,

--- a/packages/server/__snapshots__/5_spec_isolation_spec.js
+++ b/packages/server/__snapshots__/5_spec_isolation_spec.js
@@ -158,7 +158,7 @@ Although you have test retries enabled, we do not retry tests when \`before all\
 `
 
 exports['e2e spec_isolation fails [electron] 1'] = {
-  "stauts": "finished",
+  "status": "finished",
   "startedTestsAt": "2018-02-01T20:14:19.323Z",
   "endedTestsAt": "2018-02-01T20:14:19.323Z",
   "totalDuration": 5555,

--- a/packages/server/__snapshots__/5_spec_isolation_spec.js
+++ b/packages/server/__snapshots__/5_spec_isolation_spec.js
@@ -721,6 +721,7 @@ exports['e2e spec_isolation fails [electron] 1'] = {
 }
 
 exports['e2e spec_isolation fails [chrome] 1'] = {
+  "status": "finished",
   "startedTestsAt": "2018-02-01T20:14:19.323Z",
   "endedTestsAt": "2018-02-01T20:14:19.323Z",
   "totalDuration": 5555,
@@ -1284,6 +1285,7 @@ exports['e2e spec_isolation fails [chrome] 1'] = {
 }
 
 exports['e2e spec_isolation fails [firefox] 1'] = {
+  "status": "finished",
   "startedTestsAt": "2018-02-01T20:14:19.323Z",
   "endedTestsAt": "2018-02-01T20:14:19.323Z",
   "totalDuration": 5555,
@@ -1847,6 +1849,7 @@ exports['e2e spec_isolation fails [firefox] 1'] = {
 }
 
 exports['e2e spec_isolation failing with retries enabled [electron] 1'] = {
+  "status": "finished",
   "startedTestsAt": "2018-02-01T20:14:19.323Z",
   "endedTestsAt": "2018-02-01T20:14:19.323Z",
   "totalDuration": 5555,
@@ -2291,6 +2294,7 @@ exports['e2e spec_isolation failing with retries enabled [electron] 1'] = {
 }
 
 exports['e2e spec_isolation failing with retries enabled [chrome] 1'] = {
+  "status": "finished",
   "startedTestsAt": "2018-02-01T20:14:19.323Z",
   "endedTestsAt": "2018-02-01T20:14:19.323Z",
   "totalDuration": 5555,

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1248,6 +1248,7 @@ module.exports = {
       beforeSpecRun,
     })
     .then((runs = []) => {
+      results.status = 'finished'
       results.startedTestsAt = getRun(_.first(runs), 'stats.wallClockStartedAt')
       results.endedTestsAt = getRun(_.last(runs), 'stats.wallClockEndedAt')
       results.totalDuration = sumByProp(runs, 'stats.wallClockDuration')


### PR DESCRIPTION
- Closes #8798

### User facing changelog

`cypress.run().then(results)` now has `status` property in the `results` object matching our CLI types ("failed" or "finished")


### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
  * [x] `cypress.run` resolves with `status: failed` when CLI cannot find results JSON file
  * [x] `cypress.run` resolves with `status: finished` test
- [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
