### PR TITLE
chore(CI): unparallelize server-unit and server-integration tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -596,7 +596,7 @@ jobs:
 
   server-unit-tests:
     <<: *defaults
-    parallelism: 2
+    parallelism: 1
     steps:
       - attach_workspace:
           at: ~/
@@ -609,7 +609,7 @@ jobs:
 
   server-integration-tests:
     <<: *defaults
-    parallelism: 2
+    parallelism: 1
     steps:
       - attach_workspace:
           at: ~/


### PR DESCRIPTION
we were running two instances of unit tests which were each running the entire test suite

