### PR TITLE
fix: regeneratorRuntime error with cypress cache list --size option

### DIFF
--- a/cli/lib/tasks/get-folder-size.js
+++ b/cli/lib/tasks/get-folder-size.js
@@ -2,6 +2,8 @@ const fs = require('../fs')
 const { join } = require('path')
 const Bluebird = require('bluebird')
 
+require('regenerator-runtime/runtime')
+
 /**
  * Get the size of a folder or a file.
  *

--- a/cli/package.json
+++ b/cli/package.json
@@ -52,6 +52,7 @@
     "ospath": "^1.2.2",
     "pretty-bytes": "^5.3.0",
     "ramda": "~0.26.1",
+    "regenerator-runtime": "0.13.7",
     "request-progress": "^3.0.0",
     "supports-color": "^7.1.0",
     "tmp": "~0.2.1",


### PR DESCRIPTION
* Closes #8856
* TR-387

### User facing changelog
Fixed regenerator option.

### Additional details
* Why was this change necessary? => Command doesn't work.
* What is affected by this change? => N/A

### Any implementation details to explain? 
It seems that `@babel/preset-env` transpiles async await to regenerator. In this case, the tests are run in native (node 7.6.0+ supports native async/await) but the release transpiles them. That's why we need `regenerator-runtime`.

### How has the user experience changed?
N/A

### About the test.
I intentionally didn't add tests. As the cause of the problem is the difference between the dev and release environment. To test this, we might need to create a CircleCI job that runs the command, `npx cypress cache list --size`. But I guess it's too much.

### PR Tasks
* [N/A] Have tests been added/updated? => It's the difference between test and release differnece
* [ ] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
* [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
* [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
* [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?

