### PR TITLE
chore: Save yarn cache after installation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -448,6 +448,12 @@ jobs:
 
       - store-npm-logs
 
+      - save_cache:
+          name: Save yarn cache
+          key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Branch }}-deps-root-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache
+
       ## save entire folder as artifact for other jobs to run without reinstalling
       - persist_to_workspace:
           root: ~/


### PR DESCRIPTION
I figured out that `Restore yarn cache` always does nothing on the build and install script. This change should speed up the CI pipeline a little. 