### PR TITLE
fix: fix loading redirects with TE: chunked

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -411,6 +411,16 @@ describe('network stubbing', function () {
   })
 
   context('network handling', function () {
+    // @see https://github.com/cypress-io/cypress/issues/8497
+    it('can load transfer-encoding: chunked redirects', function () {
+      const url4 = 'http://localhost:3501/fixtures/generic.html'
+      const url3 = `http://localhost:3501/redirect?href=${encodeURIComponent(url4)}`
+      const url2 = `https://localhost:3502/redirect?chunked=1&href=${encodeURIComponent(url3)}`
+      const url1 = `https://localhost:3502/redirect?chunked=1&href=${encodeURIComponent(url2)}`
+
+      cy.visit(url1)
+    })
+
     context('can intercept against any domain', function () {
       beforeEach(function () {
         // reset origin

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -419,6 +419,7 @@ describe('network stubbing', function () {
       const url1 = `https://localhost:3502/redirect?chunked=1&href=${encodeURIComponent(url2)}`
 
       cy.visit(url1)
+      .location('href').should('eq', url4)
     })
 
     context('can intercept against any domain', function () {

--- a/packages/driver/cypress/plugins/server.js
+++ b/packages/driver/cypress/plugins/server.js
@@ -42,7 +42,14 @@ const createApp = (port) => {
   })
 
   app.get('/redirect', (req, res) => {
-    res.redirect(301, req.query.href)
+    if (req.query.chunked) {
+      res.setHeader('transfer-encoding', 'chunked')
+      res.removeHeader('content-length')
+    }
+
+    res.statusCode = 301
+    res.setHeader('Location', req.query.href)
+    res.end()
   })
 
   // allows us to serve the testrunner into an iframe for testing

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -299,6 +299,7 @@ const OmitProblematicHeaders: ResponseMiddleware = function () {
     'set-cookie',
     'x-frame-options',
     'content-length',
+    'transfer-encoding',
     'content-security-policy',
     'content-security-policy-report-only',
     'connection',


### PR DESCRIPTION
<!-- 
Thanks for contributing!
Read our contribution guidelines here: 
https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
-->

<!-- Example: "Closes #1234" -->

- Closes #8497 

### User facing changelog

- Fixed an issue where, with `experimentalNetworkStubbing` enabled, `cy.visit`s to URLs that redirect and set `Transfer-Encoding: chunked` would fail in Cypress with a "Parse Error".

### Additional details

- Cypress was setting the erroneous transfer-encoding header
- Still doesn't fix the case where the user has actually set both Content-Length and Transfer-Encoding: chunked - we cannot fix this case without modifying the HTTP parser, see https://github.com/nodejs/llhttp/issues/69

### How has the user experience changed?

<!--
Provide before and after examples of the change.
Screenshots or GIFs are preferred.
-->

### PR Tasks

<!-- 
These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. 
-->

- [x] Have tests been added/updated?
- [x] Has the original issue been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
