### PR TITLE
chore: Remove default labels in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: "🐛 Bug report"
 about: Report a bug found while using Cypress
 title: ''
-labels: 'type: bug'
+labels: ''
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -2,7 +2,7 @@
 name: "✨ Feature"
 about: Suggest a feature or enhancement to improve Cypress
 title: ''
-labels: 'type: feature'
+labels: ''
 assignees: ''
 ---
 


### PR DESCRIPTION
I’m not sure what I was thinking adding default labels to the issue templates. This is definitely not in line with our triaging workflow.