### PR TITLE
chore: Fix flaky webpack-preprocessor test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -851,12 +851,14 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - checkout
+      - run: yarn
       - run:
           name: Build
           command: yarn workspace @cypress/webpack-preprocessor build
       - run:
           name: Run tests
-          command: yarn workspace @cypress/webpack-preprocessor test
+          command: DEBUG=cypress:webpack yarn workspace @cypress/webpack-preprocessor test
       - run:
           name: Test babelrc
           command: yarn test

--- a/npm/webpack-preprocessor/test/e2e/compilation.spec.js
+++ b/npm/webpack-preprocessor/test/e2e/compilation.spec.js
@@ -127,7 +127,7 @@ describe('webpack preprocessor - e2e', () => {
 
     await fs.outputFile(file.filePath, 'console.log()')
 
-    await retry(() => expect(_emit).calledWith('rerun'), 2000)
+    await retry(() => expect(_emit).calledWith('rerun'), 20000)
   })
 })
 

--- a/npm/webpack-preprocessor/test/e2e/compilation.spec.js
+++ b/npm/webpack-preprocessor/test/e2e/compilation.spec.js
@@ -133,9 +133,14 @@ describe('webpack preprocessor - e2e', () => {
 
 function retry (fn, timeout = 1000) {
   let timedOut = false
+  let count = 0
 
   setTimeout(() => timedOut = true, timeout)
   const tryFn = () => {
+    count++
+    // eslint-disable-next-line
+    console.log('Try ', count)
+
     return Bluebird.try(() => {
       return fn()
     })

--- a/npm/webpack-preprocessor/test/e2e/compilation.spec.js
+++ b/npm/webpack-preprocessor/test/e2e/compilation.spec.js
@@ -107,10 +107,9 @@ describe('webpack preprocessor - e2e', () => {
 
   xit('triggers rerun on syntax error', async () => {
     file = createFile({ shouldWatch: true })
+    const _emit = sinon.spy(file, 'emit')
 
     await preprocessor()(file)
-
-    const _emit = sinon.spy(file, 'emit')
 
     await fs.outputFile(file.filePath, '{')
 
@@ -118,8 +117,9 @@ describe('webpack preprocessor - e2e', () => {
   })
 
   it('does not call rerun on initial build, but on subsequent builds', async () => {
-    file = createFile({ shouldWatch: true })
     const _emit = sinon.spy(file, 'emit')
+
+    file = createFile({ shouldWatch: true })
 
     await preprocessor()(file)
 

--- a/npm/webpack-preprocessor/test/e2e/compilation.spec.js
+++ b/npm/webpack-preprocessor/test/e2e/compilation.spec.js
@@ -105,7 +105,8 @@ describe('webpack preprocessor - e2e', () => {
     })
   })
 
-  xit('triggers rerun on syntax error', async () => {
+  // eslint-disable-next-line
+  it.skip('triggers rerun on syntax error', async () => {
     file = createFile({ shouldWatch: true })
     const _emit = sinon.spy(file, 'emit')
 

--- a/npm/webpack-preprocessor/test/e2e/compilation.spec.js
+++ b/npm/webpack-preprocessor/test/e2e/compilation.spec.js
@@ -127,7 +127,7 @@ describe('webpack preprocessor - e2e', () => {
 
     await fs.outputFile(file.filePath, 'console.log()')
 
-    await retry(() => expect(_emit).calledWith('rerun'))
+    await retry(() => expect(_emit).calledWith('rerun'), 2000)
   })
 })
 


### PR DESCRIPTION
I figured out that for clean builds it sometimes required 1.1second to run this specific test. Increase the timeout should remove flakiness 