### PR TITLE
fix: do not coerce --ci-build-id parameter

### DIFF
--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -188,7 +188,11 @@ module.exports = {
     // to an object
     let options = minimist(argv, {
       alias,
+      // never cast the following CLI arguments
+      string: ['ci-build-id'],
     })
+
+    debug('parsed argv options %o', { options })
 
     const allowed = _.pick(argv, allowList)
 

--- a/packages/server/test/unit/args_spec.js
+++ b/packages/server/test/unit/args_spec.js
@@ -5,7 +5,6 @@ const os = require('os')
 const snapshot = require('snap-shot-it')
 const stripAnsi = require('strip-ansi')
 const minimist = require('minimist')
-const { expect } = require('chai')
 const argsUtil = require(`${root}lib/util/args`)
 const getWindowsProxyUtil = require(`${root}lib/util/get-windows-proxy`)
 

--- a/packages/server/test/unit/args_spec.js
+++ b/packages/server/test/unit/args_spec.js
@@ -4,6 +4,8 @@ const path = require('path')
 const os = require('os')
 const snapshot = require('snap-shot-it')
 const stripAnsi = require('strip-ansi')
+const minimist = require('minimist')
+const { expect } = require('chai')
 const argsUtil = require(`${root}lib/util/args`)
 const getWindowsProxyUtil = require(`${root}lib/util/get-windows-proxy`)
 
@@ -14,6 +16,43 @@ describe('lib/util/args', () => {
     this.setup = (...args) => {
       return argsUtil.toObject(args)
     }
+  })
+
+  context('minimist behavior', () => {
+    it('casts numbers by default', () => {
+      const options = minimist(['--ci-build-id', '1e100'])
+
+      expect(options).to.deep.equal({
+        _: [],
+        'ci-build-id': 1e+100,
+      })
+    })
+
+    it('does not cast strings if specified', () => {
+      const options = minimist(['--ci-build-id', '1e100'], {
+        string: ['ci-build-id'],
+      })
+
+      expect(options).to.deep.equal({
+        _: [],
+        'ci-build-id': '1e100',
+      })
+    })
+
+    it('does not cast alias strings if specified', () => {
+      const options = minimist(['--ciBuildId', '1e100'], {
+        string: ['ci-build-id'],
+        alias: {
+          'ci-build-id': 'ciBuildId',
+        },
+      })
+
+      expect(options).to.deep.equal({
+        _: [],
+        'ci-build-id': '1e100',
+        ciBuildId: '1e100',
+      })
+    })
   })
 
   context('--smoke-test', () => {
@@ -420,6 +459,18 @@ describe('lib/util/args', () => {
         invokedFromCli: true,
         config: this.config,
         spec: this.specs,
+      })
+    })
+
+    it('does not coerce --ci-build-id', function () {
+      const result = argsUtil.toObject(['--ci-build-id', '1e100'])
+
+      expect(result).to.deep.equal({
+        ciBuildId: '1e100',
+        cwd,
+        _: [],
+        invokedFromCli: false,
+        config: {},
       })
     })
   })


### PR DESCRIPTION
- Closes #8874

### User facing changelog

We were accidentally coercing `--ci-build-id` parameter from a string to a number, if the parameter contained just numbers and the `e` character.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
