### PR TITLE
fix(route2): case-insensitively match headers

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -310,6 +310,7 @@ describe('network stubbing', function () {
 
         // @ts-ignore: should fail
         cy.route2({
+          // @ts-ignore
           url: {},
         })
       })
@@ -369,6 +370,7 @@ describe('network stubbing', function () {
             done()
           })
 
+          // @ts-ignore this is invalid on purpose
           cy.route2({
             headers: {
               good: 'string',

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -118,11 +118,11 @@ describe('network stubbing', function () {
             },
           },
           headers: {
-            'Accept-Language': {
+            'accept-language': {
               type: 'regex',
               value: '/hylian/i',
             },
-            'Content-Encoding': {
+            'content-encoding': {
               type: 'glob',
               value: options.headers['Content-Encoding'],
             },
@@ -344,6 +344,40 @@ describe('network stubbing', function () {
 
         // @ts-ignore - should fail
         cy.route2()
+      })
+
+      context('with invalid RouteMatcher', function () {
+        it('requires unique header names', function (done) {
+          cy.on('fail', function (err) {
+            expect(err.message).to.include('`FOO` was specified more than once in `headers`. Header fields can only be matched once (HTTP header field names are case-insensitive).')
+
+            done()
+          })
+
+          cy.route2({
+            headers: {
+              foo: 'bar',
+              FOO: 'bar',
+            },
+          })
+        })
+
+        it('requires StringMatcher header values', function (done) {
+          cy.on('fail', function (err) {
+            expect(err.message).to.include('`headers.wrong` must be a string or a regular expression.')
+
+            done()
+          })
+
+          cy.route2({
+            headers: {
+              good: 'string',
+              fine: /regexp/,
+              // @ts-ignore
+              wrong: 3,
+            },
+          })
+        })
       })
 
       context('with invalid handler', function () {
@@ -839,6 +873,25 @@ describe('network stubbing', function () {
         .wait('@second')
         .wait('@third')
         .wait('@final')
+      })
+
+      // @see https://github.com/cypress-io/cypress/issues/8921
+      it('with case-insensitive header matching', function () {
+        cy.route2({
+          headers: {
+            'X-some-Thing': 'foo',
+          },
+        })
+        .as('foo')
+        .then(() => {
+          $.get({
+            url: '/foo',
+            headers: {
+              'X-SOME-THING': 'foo',
+            },
+          })
+        })
+        .wait('@foo')
       })
     })
 

--- a/packages/driver/src/cy/net-stubbing/add-command.ts
+++ b/packages/driver/src/cy/net-stubbing/add-command.ts
@@ -23,6 +23,8 @@ import { registerEvents } from './events'
 import $errUtils from '../../cypress/error_utils'
 import $utils from '../../cypress/utils'
 
+const lowercaseFieldNames = (headers: { [fieldName: string]: any }) => _.mapKeys(headers, (v, k) => _.toLower(k))
+
 /**
  * Get all STRING_MATCHER_FIELDS paths plus any extra fields the user has added within
  * DICT_STRING_MATCHER_FIELDS objects
@@ -117,6 +119,18 @@ function validateRouteMatcherOptions (routeMatcher: RouteMatcherOptions): { isVa
 
   if (_.has(routeMatcher, 'port') && !isNumberMatcher(routeMatcher.port)) {
     return err('`port` must be a number or a list of numbers.')
+  }
+
+  if (_.has(routeMatcher, 'headers')) {
+    const knownFieldNames: string[] = []
+
+    for (const k in routeMatcher.headers) {
+      if (knownFieldNames.includes(k.toLowerCase())) {
+        return err(`\`${k}\` was specified more than once in \`headers\`. Header fields can only be matched once (HTTP header field names are case-insensitive).`)
+      }
+
+      knownFieldNames.push(k)
+    }
   }
 
   return { isValid: true }
@@ -216,10 +230,18 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
         return $errUtils.throwErrByPath('net_stubbing.route2.invalid_handler', { args: { handler } })
     }
 
+    const routeMatcher = annotateMatcherOptionsTypes(matcher)
+
+    if (routeMatcher.headers) {
+      // HTTP header names are case-insensitive, lowercase the matcher so it works as expected
+      // @see https://github.com/cypress-io/cypress/issues/8921
+      routeMatcher.headers = lowercaseFieldNames(routeMatcher.headers)
+    }
+
     const frame: NetEventFrames.AddRoute = {
       handlerId,
       hasInterceptor,
-      routeMatcher: annotateMatcherOptionsTypes(matcher),
+      routeMatcher,
     }
 
     if (staticResponse) {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->

- Closes #8921 

### User facing changelog

- Fixed an issue where `headers` field names passed to `cy.route2` would not case-insensitively match against the field names of incoming HTTP requests.

### Additional details

- see https://github.com/cypress-io/cypress/issues/8921#issuecomment-714525877
- also added test to ensure no duplicate field names are set

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
