### PR TITLE
fix: use modern cli compile target, remove unneeded polyfills

### DIFF
--- a/cli/.babelrc
+++ b/cli/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": [["@babel/preset-env", { "targets": { "node": 10 }}]]
 }

--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -403,9 +403,15 @@ module.exports = {
       }
 
       if (command === 'list') {
-        cache.list(opts.size)
+        debug('cache command %o', {
+          command,
+          size: opts.size,
+        })
 
-        return
+        return cache.list(opts.size).catch((e) => {
+          debug('cache list command failed with "%s"', e.message)
+          util.logErrorExit1(e)
+        })
       }
 
       cache[command]()

--- a/cli/test/lib/cli_spec.js
+++ b/cli/test/lib/cli_spec.js
@@ -7,6 +7,7 @@ const logger = require(`${lib}/logger`)
 const info = require(`${lib}/exec/info`)
 const run = require(`${lib}/exec/run`)
 const open = require(`${lib}/exec/open`)
+const cache = require(`${lib}/tasks/cache`)
 const state = require(`${lib}/tasks/state`)
 const verify = require(`${lib}/tasks/verify`)
 const install = require(`${lib}/tasks/install`)
@@ -506,6 +507,20 @@ describe('cli', () => {
     it('calls info start', () => {
       this.exec('info')
       expect(info.start).to.have.been.calledWith()
+    })
+  })
+
+  context('cypress cache list', () => {
+    it('catches rejection and exits', (done) => {
+      const err = new Error('cache list failed badly')
+
+      sinon.stub(cache, 'list').rejects(err)
+      this.exec('cache list')
+
+      util.logErrorExit1.callsFake((e) => {
+        expect(e).to.eq(err)
+        done()
+      })
     })
   })
 })

--- a/cli/test/lib/cli_spec.js
+++ b/cli/test/lib/cli_spec.js
@@ -451,27 +451,29 @@ describe('cli', () => {
     })
   })
 
-  it('install calls install.start without forcing', () => {
-    sinon.stub(install, 'start').resolves()
-    this.exec('install')
-    expect(install.start).not.to.be.calledWith({ force: true })
-  })
+  context('cypress install', () => {
+    it('calls install.start without forcing', () => {
+      sinon.stub(install, 'start').resolves()
+      this.exec('install')
+      expect(install.start).not.to.be.calledWith({ force: true })
+    })
 
-  it('install calls install.start with force: true when passed', () => {
-    sinon.stub(install, 'start').resolves()
-    this.exec('install --force')
-    expect(install.start).to.be.calledWith({ force: true })
-  })
+    it('calls install.start with force: true when passed', () => {
+      sinon.stub(install, 'start').resolves()
+      this.exec('install --force')
+      expect(install.start).to.be.calledWith({ force: true })
+    })
 
-  it('install calls install.start + catches errors', (done) => {
-    const err = new Error('foo')
+    it('install calls install.start + catches errors', (done) => {
+      const err = new Error('foo')
 
-    sinon.stub(install, 'start').rejects(err)
-    this.exec('install')
+      sinon.stub(install, 'start').rejects(err)
+      this.exec('install')
 
-    util.logErrorExit1.callsFake((e) => {
-      expect(e).to.eq(err)
-      done()
+      util.logErrorExit1.callsFake((e) => {
+        expect(e).to.eq(err)
+        done()
+      })
     })
   })
 

--- a/packages/desktop-gui/package.json
+++ b/packages/desktop-gui/package.json
@@ -15,7 +15,6 @@
     "watch": "yarn build --watch --progress"
   },
   "devDependencies": {
-    "@babel/polyfill": "7.8.7",
     "@cypress/icons": "0.7.0",
     "@cypress/json-schemas": "5.35.0",
     "@cypress/react-tooltip": "0.5.3",

--- a/packages/desktop-gui/src/settings/configuration_spec.jsx
+++ b/packages/desktop-gui/src/settings/configuration_spec.jsx
@@ -1,4 +1,3 @@
-import 'regenerator-runtime/runtime'
 import Configuration from './configuration'
 import React from 'react'
 import { mount } from 'cypress-react-unit-test'

--- a/packages/desktop-gui/src/settings/file-preference_spec.jsx
+++ b/packages/desktop-gui/src/settings/file-preference_spec.jsx
@@ -1,4 +1,3 @@
-import 'regenerator-runtime/runtime'
 import FilePreference from './file-preference'
 import React from 'react'
 import { mount } from 'cypress-react-unit-test'

--- a/packages/desktop-gui/src/settings/settings_spec.jsx
+++ b/packages/desktop-gui/src/settings/settings_spec.jsx
@@ -1,5 +1,3 @@
-// prevents "regeneratorRuntime is not defined" error
-import 'regenerator-runtime/runtime'
 import React from 'react'
 import { mount } from 'cypress-react-unit-test'
 import Settings from './settings'

--- a/packages/desktop-gui/webpack.config.ts
+++ b/packages/desktop-gui/webpack.config.ts
@@ -6,7 +6,7 @@ import webpack from 'webpack'
 const config: webpack.Configuration = {
   ...getCommonConfig(),
   entry: {
-    app: [require.resolve('@babel/polyfill'), path.resolve(__dirname, 'src/main')],
+    app: path.resolve(__dirname, 'src/main'),
   },
   output: {
     path: path.resolve(__dirname, 'dist'),

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -42,7 +42,6 @@
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "regenerator-runtime": "0.13.7",
     "sinon": "7.5.0",
     "sinon-chai": "3.3.0",
     "snap-shot-core": "10.2.1",

--- a/packages/runner/src/main.jsx
+++ b/packages/runner/src/main.jsx
@@ -6,9 +6,6 @@ import { utils as driverUtils } from '@packages/driver'
 import State from './lib/state'
 import Container from './app/container'
 
-// to support async/await
-import 'regenerator-runtime/runtime'
-
 configure({ enforceActions: 'always' })
 
 const Runner = {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...

* Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
* Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
* Mark this PR as "Draft" if it is not ready for review.
-->
* Closes #8856 
* close #5799
* tell babel to target node >= 10 so we don't include polyfills we don't need like regeneratorRuntime
* remove unneeded polyfills in packages/desktop-gui and packages/runner

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->
Bug Fix: fix bug causing the `cypress cache list` command to error

### Additional details
<!-- Examples:

* Why was this change necessary?
* What is affected by this change?
* Any implementation details to explain?
-->

I have added running this command when we test Node versions too https://github.com/cypress-io/cypress-test-node-versions/pull/53

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

* [x] Have tests been added/updated?
* [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->

