### PR TITLE
feat: Support body option in RouteMatcher

### DIFF
--- a/packages/driver/cypress/fixtures/route-body.html
+++ b/packages/driver/cypress/fixtures/route-body.html
@@ -1,0 +1,27 @@
+<html>
+<body>
+  <div id="a"></div>
+  <div id="b"></div>
+</body>
+<script>
+  fetch('/api/v1/create', {
+    method: 'POST',
+    body: '123456',
+  })
+  .then(res => res.text()) 
+  .then(data => {
+    const a = document.getElementById('a')
+    a.innerText = data
+  })
+
+  fetch('/api/v1/test', {
+    method: 'post',
+    body: 'asdfg'
+  })
+  .then(res => res.text()) 
+  .then(data => {
+    const b = document.getElementById('b')
+    b.innerText = data
+  })
+</script>
+</html>

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -202,6 +202,23 @@ describe('network stubbing', function () {
       })
     })
 
+    it('body option', () => {
+      cy.route2({
+        url: '/api/v1/create',
+        body: '1234',
+      }, 'numbers')
+
+      cy.route2({
+        url: '/api/v1/test',
+        body: /[as]+/,
+      }, 'alphabet')
+
+      cy.visit('fixtures/route-body.html')
+
+      cy.get('#a').should('have.text', 'numbers')
+      cy.get('#b').should('have.text', 'alphabet')
+    })
+
     context('logging', function () {
       beforeEach(function () {
         this.logs = []

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -231,6 +231,10 @@ export interface RouteMatcherOptionsGeneric<S> extends RouteMatcherCompatOptions
    */
   auth?: { username: S, password: S }
   /**
+   * Match against the request body content.
+   */
+  body?: S
+  /**
    * Match against HTTP headers on the request.
    */
   headers?: DictMatcher<S>

--- a/packages/net-stubbing/lib/internal-types.ts
+++ b/packages/net-stubbing/lib/internal-types.ts
@@ -33,7 +33,7 @@ export const SERIALIZABLE_RES_PROPS = _.concat(
 
 export const DICT_STRING_MATCHER_FIELDS = ['headers', 'query']
 
-export const STRING_MATCHER_FIELDS = ['auth.username', 'auth.password', 'hostname', 'method', 'path', 'pathname', 'url']
+export const STRING_MATCHER_FIELDS = ['auth.username', 'auth.password', 'body', 'hostname', 'method', 'path', 'pathname', 'url']
 
 /**
  * Serializable `StringMatcher` type.

--- a/packages/net-stubbing/lib/server/intercept-request.ts
+++ b/packages/net-stubbing/lib/server/intercept-request.ts
@@ -52,7 +52,7 @@ export function _doesRouteMatch (routeMatcher: RouteMatcherOptions, req: Cypress
       continue
     }
 
-    if (field === 'url') {
+    if (field === 'url' || field === 'body') {
       if (value.includes(matcher)) {
         continue
       }
@@ -120,6 +120,8 @@ export function _getMatchableForRequest (req: CypressIncomingRequest) {
   if (!matchable.port) {
     matchable.port = matchable.https ? 443 : 80
   }
+
+  matchable.body = req.rawBody
 
   return matchable
 }

--- a/packages/net-stubbing/test/unit/intercept-request-spec.ts
+++ b/packages/net-stubbing/test/unit/intercept-request-spec.ts
@@ -25,6 +25,7 @@ describe('intercept-request', function () {
           username: 'foo',
           password: 'bar',
         },
+        body: undefined,
         method: req.method,
         headers: req.headers,
         hostname: 'google.com',
@@ -135,6 +136,42 @@ describe('intercept-request', function () {
       expect(_doesRouteMatch({
         url: '*',
       }, req)).to.be.true
+    })
+
+    context('body RouteMatcher option', function () {
+      it('type: string', function () {
+        const req = {
+          headers: {},
+          method: 'POST',
+          proxiedUrl: '/abc',
+          rawBody: '1234567890',
+        } as unknown as CypressIncomingRequest
+
+        expect(_doesRouteMatch({
+          body: '1234',
+        }, req)).to.be.true
+
+        expect(_doesRouteMatch({
+          body: '777',
+        }, req)).to.be.false
+      })
+
+      it('type: RegExp', function () {
+        const req = {
+          headers: {},
+          method: 'POST',
+          proxiedUrl: '/abc',
+          rawBody: '1234567890',
+        } as unknown as CypressIncomingRequest
+
+        expect(_doesRouteMatch({
+          body: /\d+/,
+        }, req)).to.be.true
+
+        expect(_doesRouteMatch({
+          body: /^[123]+$/,
+        }, req)).to.be.false
+      })
     })
   })
 })

--- a/packages/proxy/lib/types.ts
+++ b/packages/proxy/lib/types.ts
@@ -9,6 +9,7 @@ export type CypressIncomingRequest = Request & {
   abort: () => void
   requestId: string
   body?: string
+  rawBody: string
   responseTimeout?: number
   followRedirect?: boolean
 }

--- a/packages/server/lib/server.js
+++ b/packages/server/lib/server.js
@@ -131,6 +131,13 @@ class Server {
     const { morgan, clientRoute } = config
     const app = express()
 
+    app.use(function (req, res, next) {
+      req.pipe(concatStream((reqBody) => {
+        req.rawBody = reqBody.toString()
+        next()
+      }))
+    })
+
     // set the cypress config from the cypress.json file
     app.set('view engine', 'html')
 


### PR DESCRIPTION
#8560

### User facing changelog

You can easily match the content of request body with the `body` option in `RouteMatcher`. 

### Additional details
- Why was this change necessary? => It was too complicated to match the request body. 
- What is affected by this change? => N/A
- Any implementation details to explain? => Request body is saved at `rawBody` and used it inside `_doesRouteMatch`.

### How has the user experience changed?

Before:

```js
const p = Cypress.Promise.defer()

cy.route2({
  url: "http://localhost:3000/graphql",
  method: "POST"
}, (req) => {
  if (req.body.includes('searchShippingTemplate')) {
    p.resolve() // resolve the deferred promise
  }
})
// ... do some more Cypress stuff here ...
cy.wrap(p)
```

After:

```js
cy.route2({
  url: "http://localhost:3000/graphql",
  method: "POST",
  body: 'searchShippingTemplate',
})
// ... do some more Cypress stuff here ...
```

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? => coming soon...
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
