### PR TITLE
fix: webpack-preprocessor cleanseError handle Error type

### DIFF
--- a/npm/webpack-preprocessor/index.ts
+++ b/npm/webpack-preprocessor/index.ts
@@ -375,8 +375,8 @@ preprocessor.__reset = () => {
   bundles = {}
 }
 
-function cleanseError (err: string) {
-  return err.replace(/\n\s*at.*/g, '').replace(/From previous event:\n?/g, '')
+function cleanseError (err: Error) {
+  return err.message replace(/\n\s*at.*/g, '').replace(/From previous event:\n?/g, '')
 }
 
 export = preprocessor


### PR DESCRIPTION
Closes #8948 

### User facing changelog
- Fixes webpack-preprocessor throwing `TypeError: err.replace is not a function` instead of showing the real error

### Additional details
- I can't oversee whether my code fits all cases, it did the trick for me locally.

### How has the user experience changed?
Before:
![image](https://user-images.githubusercontent.com/1272512/96995036-d79c7a00-152d-11eb-9a65-c5f12a8768db.png)
After:
![image](https://user-images.githubusercontent.com/1272512/96995103-f6027580-152d-11eb-8367-c69b4673dddd.png)

### PR Tasks
- [ ] Have tests been added/updated?

