### PR TITLE
fix: Cannot set property response of undefined

### DIFF
--- a/packages/driver/src/cy/net-stubbing/events/response-received.ts
+++ b/packages/driver/src/cy/net-stubbing/events/response-received.ts
@@ -42,11 +42,12 @@ export const onResponseReceived: HandlerFn<NetEventFrames.HttpResponseReceived> 
     // copy changeable attributes of userRes to res in frame
     // if the user is setting a StaticResponse, use that instead
     // @ts-ignore
-    request.response = continueFrame.res = {
+    continueFrame.res = {
       ..._.pick(continueFrame.staticResponse || userRes, SERIALIZABLE_RES_PROPS),
     }
 
     if (request) {
+      request.response = continueFrame.res
       request.state = 'ResponseIntercepted'
     }
 


### PR DESCRIPTION
- Closes #8858 

### User facing changelog

Fix the flaky "Cannot set property response of undefined".

### Additional details
- Why was this change necessary? => This causes flaky failures. 
- What is affected by this change? => N/A
- Any implementation details to explain? => This failure happened because `request` is sometimes `undefined`. But `sendContinueFrame` assumes that `request` is always non-`undefined`. Fixed this problem. 

### How has the user experience changed?

N/A

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated? => How should I test this?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
