### PR TITLE
fix(webpack-preprocessor): fix webpack preprocessor potential race condition

### DIFF
--- a/npm/webpack-preprocessor/index.ts
+++ b/npm/webpack-preprocessor/index.ts
@@ -290,7 +290,11 @@ const preprocessor: WebpackPreprocessor = (options: PreprocessorOptions = {}): F
 
       // resolve with the outputPath so Cypress knows where to serve
       // the file from
-      latestBundle.resolve(outputPath)
+      // Seems to be a race condition where changing file before next tick
+      // does not cause build to rerun
+      Promise.delay(0).then(() => {
+        latestBundle.resolve(outputPath)
+      })
     }
 
     // this event is triggered when watching and a file is saved

--- a/npm/webpack-preprocessor/test/e2e/compilation.spec.js
+++ b/npm/webpack-preprocessor/test/e2e/compilation.spec.js
@@ -29,8 +29,6 @@ const createFile = ({ name = 'example_spec.js', shouldWatch = false } = {}) => {
   })
 }
 
-const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0))
-
 describe('webpack preprocessor - e2e', () => {
   let file
 
@@ -112,7 +110,6 @@ describe('webpack preprocessor - e2e', () => {
 
     await preprocessor()(file)
 
-    await nextTick()
     const _emit = sinon.spy(file, 'emit')
 
     await fs.outputFile(file.filePath, '{')
@@ -128,7 +125,6 @@ describe('webpack preprocessor - e2e', () => {
 
     expect(_emit).not.to.be.calledWith('rerun')
 
-    await nextTick()
     await fs.outputFile(file.filePath, 'console.log()')
 
     await retry(() => expect(_emit).calledWith('rerun'))

--- a/npm/webpack-preprocessor/test/e2e/compilation.spec.js
+++ b/npm/webpack-preprocessor/test/e2e/compilation.spec.js
@@ -29,6 +29,8 @@ const createFile = ({ name = 'example_spec.js', shouldWatch = false } = {}) => {
   })
 }
 
+const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0))
+
 describe('webpack preprocessor - e2e', () => {
   let file
 
@@ -105,11 +107,12 @@ describe('webpack preprocessor - e2e', () => {
     })
   })
 
-  xit('triggers rerun on syntax error', async () => {
+  it('triggers rerun on syntax error', async () => {
     file = createFile({ shouldWatch: true })
 
     await preprocessor()(file)
 
+    await nextTick()
     const _emit = sinon.spy(file, 'emit')
 
     await fs.outputFile(file.filePath, '{')
@@ -125,6 +128,7 @@ describe('webpack preprocessor - e2e', () => {
 
     expect(_emit).not.to.be.calledWith('rerun')
 
+    await nextTick()
     await fs.outputFile(file.filePath, 'console.log()')
 
     await retry(() => expect(_emit).calledWith('rerun'))


### PR DESCRIPTION
fixes potential race condition causing tests to flake


## Changelog
Bug Fix: [webpack-preprocessor] fix race condition causing file changes to occasionally not register