### PR TITLE
fix: only modify js on AUT domain in proxy

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,8 +11,8 @@
 **/support/fixtures/*
 !**/support/fixtures/projects
 **/support/fixtures/projects/**/_fixtures/*
+**/support/fixtures/projects/**/static/*
 **/support/fixtures/projects/**/*.jsx
-**/support/fixtures/projects/**/jquery.js
 **/support/fixtures/projects/**/fail.js
 **/test/fixtures
 **/vendor

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -237,12 +237,13 @@ const PatchExpressSetHeader: ResponseMiddleware = function () {
 const SetInjectionLevel: ResponseMiddleware = function () {
   this.res.isInitial = this.req.cookies['__cypress.initial'] === 'true'
 
+  const isReqMatchOriginPolicy = reqMatchesOriginPolicy(this.req, this.getRemoteState())
   const getInjectionLevel = () => {
     if (this.incomingRes.headers['x-cypress-file-server-error'] && !this.res.isInitial) {
       return 'partial'
     }
 
-    if (!resContentTypeIs(this.incomingRes, 'text/html') || !reqMatchesOriginPolicy(this.req, this.getRemoteState())) {
+    if (!resContentTypeIs(this.incomingRes, 'text/html') || !isReqMatchOriginPolicy) {
       return false
     }
 
@@ -261,7 +262,7 @@ const SetInjectionLevel: ResponseMiddleware = function () {
     this.res.wantsInjection = getInjectionLevel()
   }
 
-  this.res.wantsSecurityRemoved = this.config.modifyObstructiveCode && (
+  this.res.wantsSecurityRemoved = this.config.modifyObstructiveCode && isReqMatchOriginPolicy && (
     (this.res.wantsInjection === 'full')
     || resContentTypeIsJavaScript(this.incomingRes)
   )

--- a/packages/server/test/e2e/7_proxying_spec.ts
+++ b/packages/server/test/e2e/7_proxying_spec.ts
@@ -1,0 +1,16 @@
+import e2e from '../support/helpers/e2e'
+
+describe('e2e proxying spec', () => {
+  e2e.setup({
+    servers: {
+      port: 7878,
+      static: true,
+      cors: true,
+      https: true,
+    },
+  })
+
+  e2e.it('integrity check', {
+    spec: 'proxying_spec.js',
+  })
+})

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/proxying_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/proxying_spec.js
@@ -1,0 +1,24 @@
+describe('proxying', () => {
+  // load a script that has obstructive code and would otherwise be modified by the proxy
+  // https://github.com/cypress-io/cypress/issues/8983
+  it('does not fail integrity check for cross-origin scripts', () => {
+    cy.visit('/index.html')
+    .then((win) => {
+      /**
+       * @type {Document}
+       */
+      const document = win.document
+      const script = document.createElement('script')
+
+      script.src = 'https://localhost:7878/static/simple_obstructive_code.js'
+      script.integrity = 'sha256-iVKZPZrzbe7YNdMKYWJ1+f74j5lD3gRFvGjqtLyji6A='
+      script.crossOrigin = 'anonymous'
+      document.head.append(script)
+
+      return new Promise((resolve, reject) => {
+        script.onload = resolve
+        script.onerror = () => reject(new Error('script failed to load, check the console. Possibly a failed integrity check'))
+      })
+    })
+  })
+})

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/plugins/index.js
@@ -8,6 +8,9 @@ const path = require('path')
 const Promise = require('bluebird')
 const { useFixedFirefoxResolution } = require('../../../utils')
 
+/**
+ * @type {Cypress.PluginConfig}
+ */
 module.exports = (on, config) => {
   let performance = {
     track: () => Promise.resolve(),

--- a/packages/server/test/support/fixtures/projects/e2e/static/simple_obstructive_code.js
+++ b/packages/server/test/support/fixtures/projects/e2e/static/simple_obstructive_code.js
@@ -1,0 +1,3 @@
+(function () {
+  if (top != self) {console.log('loaded!')}
+})()

--- a/packages/server/test/support/helpers/e2e.ts
+++ b/packages/server/test/support/helpers/e2e.ts
@@ -202,6 +202,10 @@ const startServer = function (obj) {
 
   app.use(morgan('dev'))
 
+  if (obj.cors) {
+    app.use(require('cors')())
+  }
+
   const s = obj.static
 
   if (s) {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->

- Closes #8983
- Closes #9049
- fix #8992 

NOTE: before this PR we were modifying frame busting code in ALL http javascript requests including cross-origin. This wasnt the case for https reqs until last release where all https went through the proxy. Now we will only modify js if it matches the AUT domain

### User facing changelog
Bug Fix: fix issue causing failed subresource integrity checks for external scripts
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
