### PR TITLE
build: correctly wait for jobs to pass before release

### DIFF
--- a/scripts/npm-release.js
+++ b/scripts/npm-release.js
@@ -148,7 +148,7 @@ const waitOnTests = async (names, packageInfo) => {
   console.log(`\nWaiting on the following CI jobs: ${jobs.join(', ')}`)
 
   return Promise.all(jobs.map((job) => {
-    waitForJobToPass(job)
+    return waitForJobToPass(job)
     .timeout(minutes(60))
     .then(() => {
       console.log(`${job} passed`)


### PR DESCRIPTION
Fix issue where releases would not properly wait on CI jobs to pass