### PR TITLE
fix: Show better error message during `cypress cache list` when no cache 

### DIFF
--- a/cli/__snapshots__/cli_spec.js
+++ b/cli/__snapshots__/cli_spec.js
@@ -451,3 +451,7 @@ exports['cli version and binary version with npm log warn'] = `
 Cypress package version: 1.2.3
 Cypress binary version: X.Y.Z
 `
+
+exports['prints explanation when no cache'] = `
+No binary cached versions were found.
+`

--- a/cli/__snapshots__/cli_spec.js
+++ b/cli/__snapshots__/cli_spec.js
@@ -453,5 +453,5 @@ Cypress binary version: X.Y.Z
 `
 
 exports['prints explanation when no cache'] = `
-No binary cached versions were found.
+No cached binary versions were found.
 `

--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -408,8 +408,14 @@ module.exports = {
           size: opts.size,
         })
 
-        return cache.list(opts.size).catch((e) => {
+        return cache.list(opts.size)
+        .catch({ code: 'ENOENT' }, () => {
+          logger.always('No binary cached versions were found.')
+          process.exit(0)
+        })
+        .catch((e) => {
           debug('cache list command failed with "%s"', e.message)
+
           util.logErrorExit1(e)
         })
       }

--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -410,7 +410,7 @@ module.exports = {
 
         return cache.list(opts.size)
         .catch({ code: 'ENOENT' }, () => {
-          logger.always('No binary cached versions were found.')
+          logger.always('No cached binary versions were found.')
           process.exit(0)
         })
         .catch((e) => {

--- a/cli/test/lib/cli_spec.js
+++ b/cli/test/lib/cli_spec.js
@@ -513,6 +513,20 @@ describe('cli', () => {
   })
 
   context('cypress cache list', () => {
+    it('prints explanation when no cache', (done) => {
+      const err = new Error()
+
+      err.code = 'ENOENT'
+
+      sinon.stub(cache, 'list').rejects(err)
+      this.exec('cache list')
+
+      process.exit.callsFake(() => {
+        snapshot('prints explanation when no cache', logger.print())
+        done()
+      })
+    })
+
     it('catches rejection and exits', (done) => {
       const err = new Error('cache list failed badly')
 


### PR DESCRIPTION
- Closes #6303 

### User facing changelog

- A clearer error is printed during `cypress cache list` when no cached versions are found.

### Additional Details

- Just trying to close an issue 🤷‍♀️ 

### How has the user experience changed?

#### Before

<img width="674" alt="Screen Shot 2020-10-29 at 5 18 26 PM" src="https://user-images.githubusercontent.com/1271364/97558655-cd391f00-1a0a-11eb-9fa0-b8dced014e72.png">


#### After

<img width="402" alt="Screen Shot 2020-10-29 at 5 18 15 PM" src="https://user-images.githubusercontent.com/1271364/97558676-d32f0000-1a0a-11eb-93b0-cb9916d0da2c.png">


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->

