### PR TITLE
chore: add prod build task for webpack-preprocessor to fix the binary build

### DIFF
--- a/npm/webpack-preprocessor/package.json
+++ b/npm/webpack-preprocessor/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "ban": "ban",
     "build": "rm -rf dist && tsc",
+    "build-prod": "yarn build",
     "deps": "deps-ok && dependency-check --no-dev .",
     "license": "license-checker --production --onlyunknown --csv",
     "secure": "nsp check",


### PR DESCRIPTION
The binary build is broken in develop/master because the webpack-preprocessor dist folder isn't found... likely because it isn't being built.