### PR TITLE
fix: adding build-prod tasks to all of the npm dependencies that need artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ cli/visual-snapshots
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff
+.idea
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/**/usage.statistics.xml

--- a/npm/react/package.json
+++ b/npm/react/package.json
@@ -5,6 +5,7 @@
   "main": "dist",
   "scripts": {
     "build": "rimraf dist && yarn transpile && yarn transpile:bin && yarn build:dist-package",
+    "build-prod": "yarn build",
     "build:dist-package": "node scripts/prepareDistPackage.js && ncp ./plugins ./dist/plugins",
     "check:links": "find . -type f -name 'README.md' ! -path './node_modules/*' | xargs -L1 npx markdown-link-check --quiet",
     "cy:open": "node ../../scripts/cypress open",
@@ -131,7 +132,7 @@
   },
   "homepage": "https://on.cypress.io/component-testing",
   "author": "Gleb Bahmutov <gleb.bahmutov@gmail.com>",
-  "bugs": "https://github.com/cypress-io/cypress/issues/new?assignees=JessicaSachs&labels=experiment%3A+component+testing,npm%3A%20%40cypress%2Freact&template=bug-report.md",
+  "bugs": "https://github.com/cypress-io/cypress/issues/new?assignees=&labels=npm%3A%20%40cypress%2Freact&template=1-bug-report.md&title=",
   "keywords": [
     "react",
     "cypress",

--- a/npm/vue/package.json
+++ b/npm/vue/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
+    "build-prod": "yarn build",
     "build:watch": "tsc --watch",
     "cy:open": "node ../../scripts/cypress open",
     "cy:run": "node ../../scripts/cypress run",
@@ -66,7 +67,7 @@
   },
   "homepage": "https://on.cypress.io/component-testing",
   "author": "Gleb Bahmutov <gleb.bahmutov@gmail.com>",
-  "bugs": "https://github.com/cypress-io/cypress/issues/new?assignees=JessicaSachs&labels=experiment%3A+component+testing,npm%3A%20%40cypress%2Fvue&template=bug-report.md",
+  "bugs": "https://github.com/cypress-io/cypress/issues/new?assignees=&labels=npm%3A%20%40cypress%2Fvue&template=1-bug-report.md&title=",
   "keywords": [
     "cypress",
     "vue"

--- a/npm/webpack-preprocessor/package.json
+++ b/npm/webpack-preprocessor/package.json
@@ -83,7 +83,7 @@
   },
   "homepage": "https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor#readme",
   "author": "Chris Breiding <chris@cypress.io>",
-  "bugs": "https://github.com/cypress-io/cypress/issues/new?assignees=&labels=npm%3A %40cypress%2Fwebpack-preprocessor&template=bug-report.md",
+  "bugs": "https://github.com/cypress-io/cypress/issues/new?assignees=&labels=npm%3A%20%40cypress%2Fwebpack-preprocessor&template=1-bug-report.md&title=",
   "keywords": [
     "cypress",
     "cypress-plugin",

--- a/scripts/npm-release.js
+++ b/scripts/npm-release.js
@@ -148,7 +148,7 @@ const waitOnTests = async (names, packageInfo) => {
   console.log(`\nWaiting on the following CI jobs: ${jobs.join(', ')}`)
 
   return Promise.all(jobs.map((job) => {
-    waitForJobToPass(job)
+    return Promise.resolve(waitForJobToPass(job))
     .timeout(minutes(60))
     .then(() => {
       console.log(`${job} passed`)


### PR DESCRIPTION
There was a bug in the release process where:
1. a change was made where the `build-prod` task was run instead of the `build` task, so nothing was building
2. also we weren't waiting for the builds to pass before releasing

- Closes #9037 