### PR TITLE
fix: Expand logic for checking contentType when determining if content is HTML

### DIFF
--- a/packages/driver/cypress/integration/commands/navigation_spec.js
+++ b/packages/driver/cypress/integration/commands/navigation_spec.js
@@ -1726,6 +1726,11 @@ describe('src/cy/commands/navigation', () => {
         })
 
         cy.visit('https://google.com/foo')
+      })
+
+      // https://github.com/cypress-io/cypress/issues/8506
+      it('accepts text/html; + parameter as content-type', () => {
+        cy.visit('http://localhost:3500/html-content-type-with-charset-param')
       });
 
       // https://github.com/cypress-io/cypress/issues/3101
@@ -1733,7 +1738,7 @@ describe('src/cy/commands/navigation', () => {
         contentType: 'application/json',
         pathName: 'json-content-type',
       }, {
-        contentType: 'text/html; charset=utf-8,text/html',
+        contentType: 'text/image',
         pathName: 'invalid-content-type',
       }]
       .forEach(({ contentType, pathName }) => {

--- a/packages/driver/cypress/plugins/server.js
+++ b/packages/driver/cypress/plugins/server.js
@@ -97,8 +97,14 @@ const createApp = (port) => {
     return res.send({})
   })
 
+  app.get('/html-content-type-with-charset-param', (req, res) => {
+    res.setHeader('Content-Type', 'text/html;charset=utf-8')
+
+    return res.end('<html><head><title>Test</title></head><body><center>Hello</center></body></html>')
+  })
+
   app.get('/invalid-content-type', (req, res) => {
-    res.setHeader('Content-Type', 'text/html; charset=utf-8,text/html')
+    res.setHeader('Content-Type', 'text/image; charset=utf-8')
 
     return res.end('<html><head><title>Test</title></head><body><center>Hello</center></body></html>')
   })

--- a/packages/server/lib/server.js
+++ b/packages/server/lib/server.js
@@ -38,6 +38,7 @@ const templateEngine = require('./template_engine')
 
 const DEFAULT_DOMAIN_NAME = 'localhost'
 const fullyQualifiedRe = /^https?:\/\//
+const textHtmlContentTypeRe = /^text\/html/i
 
 const ALLOWED_PROXY_BYPASS_URLS = [
   '/',
@@ -71,7 +72,10 @@ const isResponseHtml = function (contentType, responseBuffer) {
   let body
 
   if (contentType) {
-    return contentType === 'text/html'
+    // want to match anything starting with 'text/html'
+    // including 'text/html;charset=utf-8' and 'Text/HTML'
+    // https://github.com/cypress-io/cypress/issues/8506
+    return textHtmlContentTypeRe.test(contentType)
   }
 
   body = _.invoke(responseBuffer, 'toString')


### PR DESCRIPTION
- close #8506 

### User facing changelog

- Using `cy.visit()` on sites with `content-type` of `text-html` followed by parameters will no longer throw an error about visiting a site with an invalid content-type.

### Additional Details

- Is this enough tests around this?
- Is this a stringent enough content-type test?

<img width="249" alt="Screen Shot 2020-11-02 at 3 15 51 PM" src="https://user-images.githubusercontent.com/1271364/97859100-801cbc00-1d2e-11eb-94d4-4692fcded119.png">


### PR Tasks

- [x] Added/updated tests
- [x] Tagged for release 

