### PR TITLE
fix(route2): fixed the issue with not being able to await a request body when providing static response stub

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1804,6 +1804,13 @@ describe('network stubbing', { retries: 2 }, function () {
           $.post('/post-only', 'some body')
         }).wait('@foo').its('request.body').should('eq', 'changed')
       })
+
+      it('when static response body is provided', function () {
+        cy.route2('/post-only', { static: 'response' }).as('foo')
+        .then(() => {
+          $.post('/post-only', 'some body')
+        }).wait('@foo').its('request.body').should('eq', 'some body')
+      })
     })
 
     // @see https://github.com/cypress-io/cypress/issues/8536

--- a/packages/net-stubbing/lib/server/intercept-request.ts
+++ b/packages/net-stubbing/lib/server/intercept-request.ts
@@ -194,12 +194,6 @@ function _interceptRequest (state: NetStubbingState, request: BackendRequest, ro
     emit(socket, 'http:request:received', frame)
   }
 
-  if (route.staticResponse) {
-    emitReceived()
-
-    return sendStaticResponse(request.res, route.staticResponse, request.onResponse!)
-  }
-
   const ensureBody = (cb: () => void) => {
     if (frame.req.body) {
       return cb()
@@ -209,6 +203,15 @@ function _interceptRequest (state: NetStubbingState, request: BackendRequest, ro
       request.req.body = frame.req.body = reqBody.toString()
       cb()
     }))
+  }
+
+  if (route.staticResponse) {
+    const { staticResponse } = route
+
+    return ensureBody(() => {
+      emitReceived()
+      sendStaticResponse(request.res, staticResponse, request.onResponse!)
+    })
   }
 
   if (notificationOnly) {


### PR DESCRIPTION
### User facing changelog
Fixed an issue with not being able to await a request body when providing static response stub and using the `experimentalNetworkStubbing`.

### Additional details
* Why was this change necessary?

It's a bug fix.

* What is affected by this change?

experimentalNetworkStubbing

### How has the user experience changed?
N/A

### PR Tasks
* [x] Have tests been added/updated?

