### PR TITLE
feat: Allow type() and click() to select an element inside contenteditable.

### DIFF
--- a/packages/driver/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_spec.js
@@ -1766,20 +1766,14 @@ describe('src/cy/commands/actions/type - #type', () => {
         cy.state('document').documentElement.focus()
         cy.get('div.item:first')
         .type('111')
-
-        cy.get('body').then(expectTextEndsWith('111'))
+        .then(expectTextEndsWith('111'))
       })
 
-      // TODO[breaking]: we should edit div.item:first text content instead of
-      // moving to the end of the host contenteditable. This will allow targeting
-      // specific elements to simplify testing rich editors
       it('can type in body[contenteditable]', () => {
         cy.state('document').body.setAttribute('contenteditable', true)
         cy.state('document').documentElement.focus()
         cy.get('div.item:first')
         .type('111')
-
-        cy.get('body')
         .then(expectTextEndsWith('111'))
       })
 

--- a/packages/driver/src/cy/actionability.js
+++ b/packages/driver/src/cy/actionability.js
@@ -4,6 +4,7 @@ const Promise = require('bluebird')
 const debug = require('debug')('cypress:driver:actionability')
 
 const $dom = require('../dom')
+const $elements = require('../dom/elements')
 const $errUtils = require('../cypress/error_utils')
 
 const delay = 50
@@ -360,8 +361,16 @@ const verify = function (cy, $el, options, callbacks) {
       }
 
       // pass our final object into onReady
-      const finalEl = $elAtCoords != null ? $elAtCoords : $el
       const finalCoords = getCoordinatesForEl(cy, $el, options)
+      let finalEl
+
+      // When a contenteditable element is selected, we don't go deeper,
+      // because it is treated as a rich text field to users.
+      if ($elements.hasContenteditableAttr($el.get(0))) {
+        finalEl = $el
+      } else {
+        finalEl = $elAtCoords != null ? $elAtCoords : $el
+      }
 
       return onReady(finalEl, finalCoords)
     }

--- a/packages/driver/src/dom/elements.ts
+++ b/packages/driver/src/dom/elements.ts
@@ -1309,6 +1309,12 @@ const findShadowRoots = (root: Node): Node[] => {
   return collectRoots(roots)
 }
 
+const hasContenteditableAttr = (el: HTMLElement) => {
+  const attr = tryCallNativeMethod(el, 'getAttribute', 'contenteditable')
+
+  return attr !== undefined && attr !== null && attr !== 'false'
+}
+
 export {
   elementFromPoint,
   isElement,
@@ -1372,4 +1378,5 @@ export {
   getParentNode,
   getAllParents,
   getShadowRoot,
+  hasContenteditableAttr,
 }


### PR DESCRIPTION
* Closes #2717 
* Closes #7721 
* It's the rework of #8529.

### User facing changelog
When `cy.type()` and `cy.click()` were used against an element inside `contenteditable`, it only worked with the root `contenteditable` element. With this PR, this behavior is fixed. Users can freely work with elements inside contenteditable. 

### Additional details
* Why was this change necessary? => To change things inside `contenteditable`, it is sometimes necessary to work with elements inside it. 
* What is affected by this change? => This is a breaking change. The behaviors of `type()` and `click()` changed slightly.
* Any implementation details to explain? => The change was a bit bigger than expected. I had to change the behavior of `runAllCheck` in `actionability.js` to ignore elements inside `contenteditable`. 

### How has the user experience changed?
```html
<div id="a" contenteditable="true"><span id="b">abc</span>def</div>
```

```js
cy.get('#a #b').type('123')
// => before: abcdef123
// => after: abc123def
```

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

* [x] Have tests been added/updated?
* [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
* [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? => Add this to 6.0 changes doc.

