### PR TITLE
fix: do not assume valid file info in error stack line

### DIFF
--- a/packages/driver/cypress/fixtures/error-stack-with-http-links.txt
+++ b/packages/driver/cypress/fixtures/error-stack-with-http-links.txt
@@ -1,0 +1,27 @@
+ReferenceError: The following error originated from your application code, not from Cypress.
+
+  > b is not defined
+
+When Cypress detects uncaught errors originating from your application it will automatically fail the current test.
+
+This behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.
+    at http://localhost:8888/js/utils.js:9:3
+    at http://localhost:8888/js/utils.js:60:3
+From previous event:
+    at run (http://localhost:8888/__cypress/runner/cypress_runner.js:169474:21)
+    at $Cy.cy.<computed> [as visit] (http://localhost:8888/__cypress/runner/cypress_runner.js:169931:11)
+    at Context.runnable.fn (http://localhost:8888/__cypress/runner/cypress_runner.js:170155:21)
+    at callFn (http://localhost:8888/__cypress/runner/cypress_runner.js:104227:21)
+    at Test.../driver/node_modules/mocha/lib/runnable.js.Runnable.run (http://localhost:8888/__cypress/runner/cypress_runner.js:104214:7)
+    at http://localhost:8888/__cypress/runner/cypress_runner.js:175754:28
+From previous event:
+    at Object.onRunnableRun (http://localhost:8888/__cypress/runner/cypress_runner.js:175742:17)
+    at $Cypress.action (http://localhost:8888/__cypress/runner/cypress_runner.js:166291:28)
+    at Test.Runnable.run (http://localhost:8888/__cypress/runner/cypress_runner.js:174128:13)
+    at Runner.../driver/node_modules/mocha/lib/runner.js.Runner.runTest (http://localhost:8888/__cypress/runner/cypress_runner.js:104886:10)
+    at http://localhost:8888/__cypress/runner/cypress_runner.js:105012:12
+    at next (http://localhost:8888/__cypress/runner/cypress_runner.js:104795:14)
+    at http://localhost:8888/__cypress/runner/cypress_runner.js:104805:7
+    at next (http://localhost:8888/__cypress/runner/cypress_runner.js:104707:14)
+    at http://localhost:8888/__cypress/runner/cypress_runner.js:104773:5
+    at timeslice (http://localhost:8888/__cypress/runner/cypress_runner.js:98699:27)

--- a/packages/driver/cypress/integration/cypress/stack_utils_spec.js
+++ b/packages/driver/cypress/integration/cypress/stack_utils_spec.js
@@ -96,6 +96,33 @@ describe('driver/src/cypress/stack_utils', () => {
     })
   })
 
+  context('.getSourceStack when http links', () => {
+    it('does not have absolute files', () => {
+      const projectRoot = '/dev/app'
+
+      cy.fixture('error-stack-with-http-links.txt')
+      .then((stack) => {
+        return $stackUtils.getSourceStack(stack, projectRoot)
+      })
+      .its('parsed')
+      .then((parsed) => {
+        return Cypress._.find(parsed, { fileUrl: 'http://localhost:8888/js/utils.js' })
+      })
+      .then((errorLocation) => {
+        expect(errorLocation, 'does not have disk information').to.deep.equal({
+          absoluteFile: undefined,
+          column: 4,
+          fileUrl: 'http://localhost:8888/js/utils.js',
+          function: '<unknown>',
+          line: 9,
+          originalFile: 'http://localhost:8888/js/utils.js',
+          relativeFile: undefined,
+          whitespace: '    ',
+        })
+      })
+    })
+  })
+
   context('.getSourceStack', () => {
     let generatedStack
     const projectRoot = '/dev/app'

--- a/packages/driver/cypress/integration/cypress/stack_utils_spec.js
+++ b/packages/driver/cypress/integration/cypress/stack_utils_spec.js
@@ -1,5 +1,6 @@
 const $stackUtils = require('@packages/driver/src/cypress/stack_utils')
 const $sourceMapUtils = require('@packages/driver/src/cypress/source_map_utils')
+const { stripIndent } = require('common-tags')
 
 describe('driver/src/cypress/stack_utils', () => {
   context('.replacedStack', () => {
@@ -236,6 +237,87 @@ Error: spec iframe stack
 
     it('returns empty object if there\'s no stack', () => {
       expect($stackUtils.getSourceStack()).to.eql({})
+    })
+  })
+
+  context('.getSourceDetailsForFirstLine', () => {
+    it('parses good stack trace', () => {
+      const stack = stripIndent`
+        Error
+          at Suite.eval (http://localhost:8888/__cypress/tests?p=cypress/integration/spec.js:101:3)
+          at Object../cypress/integration/spec.js (http://localhost:8888/__cypress/tests?p=cypress/integration/spec.js:100:1)
+          at __webpack_require__ (http://localhost:8888/__cypress/tests?p=cypress/integration/spec.js:20:30)
+          at Object.0 (http://localhost:8888/__cypress/tests?p=cypress/integration/spec.js:119:18)
+          at __webpack_require__ (http://localhost:8888/__cypress/tests?p=cypress/integration/spec.js:20:30)
+          at eval (http://localhost:8888/__cypress/tests?p=cypress/integration/spec.js:84:18)
+          at eval (http://localhost:8888/__cypress/tests?p=cypress/integration/spec.js:87:10)
+          at eval (<anonymous>)
+      `
+      const projectRoot = '/Users/gleb/git/cypress-example-todomvc'
+      const details = $stackUtils.getSourceDetailsForFirstLine(stack, projectRoot)
+
+      expect(details.function, 'function name').to.equal('Suite.eval')
+      expect(details.fileUrl, 'file url').to.equal('http://localhost:8888/__cypress/tests?p=cypress/integration/spec.js')
+    })
+
+    it('parses anonymous eval line', () => {
+      const stack = stripIndent`
+        SyntaxError: The following error originated from your application code, not from Cypress.
+
+          > Identifier 'app' has already been declared
+
+        When Cypress detects uncaught errors originating from your application it will automatically fail the current test.
+
+        This behavior is configurable, and you can choose to turn this off by listening to the \`uncaught:exception\` event.
+        SyntaxError: The following error originated from your application code, not from Cypress.
+
+          > Identifier 'app' has already been declared
+
+        When Cypress detects uncaught errors originating from your application it will automatically fail the current test.
+
+        This behavior is configurable, and you can choose to turn this off by listening to the \`uncaught:exception\` event.
+            at <anonymous>:1:1
+            at run (http://localhost:8888/node_modules/react/dist/JSXTransformer.js:184:10)
+            at check (http://localhost:8888/node_modules/react/dist/JSXTransformer.js:238:9)
+            at result.<computed>.async (http://localhost:8888/node_modules/react/dist/JSXTransformer.js:273:9)
+            at XMLHttpRequest.xhr.onreadystatechange (http://localhost:8888/node_modules/react/dist/JSXTransformer.js:208:9)
+        From previous event:
+            at run (cypress:///../driver/src/cypress/cy.js:561:21)
+            at $Cy.cy.<computed> [as visit] (cypress:///../driver/src/cypress/cy.js:1018:11)
+            at Context.runnable.fn (cypress:///../driver/src/cypress/cy.js:1242:21)
+            at callFn (cypress:///../driver/node_modules/mocha/lib/runnable.js:395:21)
+            at Test.Runnable.run (cypress:///../driver/node_modules/mocha/lib/runnable.js:382:7)
+            at eval (cypress:///../driver/src/cypress/runner.js:1249:28)
+        From previous event:
+            at Object.onRunnableRun (cypress:///../driver/src/cypress/runner.js:1237:17)
+            at $Cypress.action (cypress:///../driver/src/cypress.js:397:28)
+            at Test.Runnable.run (cypress:///../driver/src/cypress/mocha.js:348:13)
+            at Runner.runTest (cypress:///../driver/node_modules/mocha/lib/runner.js:541:10)
+            at eval (cypress:///../driver/node_modules/mocha/lib/runner.js:667:12)
+            at next (cypress:///../driver/node_modules/mocha/lib/runner.js:450:14)
+            at eval (cypress:///../driver/node_modules/mocha/lib/runner.js:460:7)
+            at next (cypress:///../driver/node_modules/mocha/lib/runner.js:362:14)
+            at eval (cypress:///../driver/node_modules/mocha/lib/runner.js:428:5)
+            at timeslice (cypress:///../driver/node_modules/mocha/browser-entry.js:80:27)
+      `
+
+      cy.stub(console, 'warn')
+      const projectRoot = '/Users/gleb/git/cypress-example-todomvc'
+      const details = $stackUtils.getSourceDetailsForFirstLine(stack, projectRoot)
+
+      expect(details, 'minimal details').to.deep.equal({
+        absoluteFile: undefined,
+        column: 2,
+        fileUrl: undefined,
+        function: '<unknown>',
+        line: 1,
+        originalFile: undefined,
+        relativeFile: undefined,
+        whitespace: '    ',
+      })
+
+      /* eslint-disable-next-line no-console */
+      expect(console.warn).to.have.been.calledWith('Could not get the original source file from line "    at <anonymous>:1:1"')
     })
   })
 

--- a/packages/driver/cypress/integration/cypress/stack_utils_spec.js
+++ b/packages/driver/cypress/integration/cypress/stack_utils_spec.js
@@ -301,7 +301,6 @@ Error: spec iframe stack
             at timeslice (cypress:///../driver/node_modules/mocha/browser-entry.js:80:27)
       `
 
-      cy.stub(console, 'warn')
       const projectRoot = '/Users/gleb/git/cypress-example-todomvc'
       const details = $stackUtils.getSourceDetailsForFirstLine(stack, projectRoot)
 
@@ -315,9 +314,6 @@ Error: spec iframe stack
         relativeFile: undefined,
         whitespace: '    ',
       })
-
-      /* eslint-disable-next-line no-console */
-      expect(console.warn).to.have.been.calledWith('Could not get the original source file from line "    at <anonymous>:1:1"')
     })
   })
 

--- a/packages/driver/src/cypress/mocha.js
+++ b/packages/driver/src/cypress/mocha.js
@@ -111,8 +111,10 @@ function getInvocationDetails (specWindow, config) {
       stack = $stackUtils.stackWithLinesDroppedFromMarker(stack, '__cypress/tests', true)
     }
 
+    const details = $stackUtils.getSourceDetailsForFirstLine(stack, config('projectRoot'))
+
     return {
-      details: $stackUtils.getSourceDetailsForFirstLine(stack, config('projectRoot')),
+      details,
       stack,
     }
   }

--- a/packages/driver/src/cypress/stack_utils.js
+++ b/packages/driver/src/cypress/stack_utils.js
@@ -223,10 +223,7 @@ const getSourceDetailsForLine = (projectRoot, line) => {
 
   if (!originalFile) {
     // this is an edge case: could not parse the stack trace
-    // let's not warn about it, but at least allow the user
-    // to see the original error by being defensive about it
-    /* eslint-disable-next-line no-console */
-    console.warn(`Could not get the original source file from line "${line}"`)
+    // maybe there was some code that was evaluated in the browser?
   }
 
   const relativeFile = stripCustomProtocol(originalFile)

--- a/packages/driver/src/cypress/stack_utils.js
+++ b/packages/driver/src/cypress/stack_utils.js
@@ -203,6 +203,16 @@ const stripCustomProtocol = (filePath) => {
     return
   }
 
+  // if the file path (after all said and done)
+  // still starts with "http://" or "https://" then
+  // it is an URL and we have no idea how it maps
+  // to a physical file location on disk. Let it be.
+  const httpProtocolRegex = /^https?:\/\//
+
+  if (httpProtocolRegex.test(filePath)) {
+    return
+  }
+
   return filePath.replace(customProtocolRegex, '')
 }
 
@@ -318,7 +328,7 @@ const normalizedUserInvocationStack = (userInvocationStack) => {
   const stackLines = getStackLines(userInvocationStack)
   const winnowedStackLines = _.reject(stackLines, (line) => {
     // WARNING: STACK TRACE WILL BE DIFFERENT IN DEVELOPMENT vs PRODUCTOIN
-    // stacks in developemnt builds look like:
+    // stacks in development builds look like:
     //     at cypressErr (cypress:///../driver/src/cypress/error_utils.js:259:17)
     // stacks in prod builds look like:
     //     at cypressErr (http://localhost:3500/isolated-runner/cypress_runner.js:173123:17)

--- a/packages/driver/src/cypress/stack_utils.js
+++ b/packages/driver/src/cypress/stack_utils.js
@@ -226,7 +226,7 @@ const getSourceDetailsForLine = (projectRoot, line) => {
     // let's not warn about it, but at least allow the user
     // to see the original error by being defensive about it
     /* eslint-disable-next-line no-console */
-    console.warn('Could not get the original source file from line "%s"', line)
+    console.warn(`Could not get the original source file from line "${line}"`)
   }
 
   const relativeFile = stripCustomProtocol(originalFile)

--- a/packages/driver/src/cypress/stack_utils.js
+++ b/packages/driver/src/cypress/stack_utils.js
@@ -199,6 +199,10 @@ const parseLine = (line) => {
 }
 
 const stripCustomProtocol = (filePath) => {
+  if (!filePath) {
+    return
+  }
+
   return filePath.replace(customProtocolRegex, '')
 }
 
@@ -216,6 +220,15 @@ const getSourceDetailsForLine = (projectRoot, line) => {
 
   const sourceDetails = getSourceDetails(generatedDetails)
   const originalFile = sourceDetails.file
+
+  if (!originalFile) {
+    // this is an edge case: could not parse the stack trace
+    // let's not warn about it, but at least allow the user
+    // to see the original error by being defensive about it
+    /* eslint-disable-next-line no-console */
+    console.warn('Could not get the original source file from line "%s"', line)
+  }
+
   const relativeFile = stripCustomProtocol(originalFile)
 
   return {
@@ -223,7 +236,7 @@ const getSourceDetailsForLine = (projectRoot, line) => {
     fileUrl: generatedDetails.file,
     originalFile,
     relativeFile,
-    absoluteFile: path.join(projectRoot, relativeFile),
+    absoluteFile: relativeFile ? path.join(projectRoot, relativeFile) : undefined,
     line: sourceDetails.line,
     // adding 1 to column makes more sense for code frame and opening in editor
     column: sourceDetails.column + 1,

--- a/packages/reporter/cypress/fixtures/cy_command_failed_error.json
+++ b/packages/reporter/cypress/fixtures/cy_command_failed_error.json
@@ -1,0 +1,43 @@
+{
+  "name": "AssertionError",
+  "message": "Timed out retrying: Expected to find element: `.new-todo`, but never found it.",
+  "stack": "AssertionError: Timed out retrying: Expected to find element: `.new-todo`, but never found it.\n    at getInputBox (http://localhost:8888/__cypress/tests?p=cypress/integration/spec.js:130:13)\n    at Context.eval (http://localhost:8888/__cypress/tests?p=cypress/integration/spec.js:105:32)",
+  "sourceMappedStack": "AssertionError: Timed out retrying: Expected to find element: `.new-todo`, but never found it.\n    at getInputBox (webpack:///cypress/integration/test-utils.js:2:13)\n    at Context.eval (webpack:///cypress/integration/spec.js:7:5)",
+  "parsedStack": [
+    {
+      "message": "AssertionError: Timed out retrying: Expected to find element: `.new-todo`, but never found it.",
+      "whitespace": ""
+    },
+    {
+      "function": "getInputBox",
+      "fileUrl": "http://localhost:8888/__cypress/tests?p=cypress/integration/spec.js",
+      "originalFile": "webpack:///cypress/integration/test-utils.js",
+      "relativeFile": "cypress/integration/test-utils.js",
+      "absoluteFile": "/Users/gleb/git/cypress-example-todomvc/cypress/integration/test-utils.js",
+      "line": 2,
+      "column": 13,
+      "whitespace": "    "
+    },
+    {
+      "function": "Context.eval",
+      "fileUrl": "http://localhost:8888/__cypress/tests?p=cypress/integration/spec.js",
+      "originalFile": "webpack:///cypress/integration/spec.js",
+      "relativeFile": "cypress/integration/spec.js",
+      "absoluteFile": "/Users/gleb/git/cypress-example-todomvc/cypress/integration/spec.js",
+      "line": 7,
+      "column": 5,
+      "whitespace": "    "
+    }
+  ],
+  "docsUrl": "",
+  "templateType": "",
+  "codeFrame": {
+    "line": 2,
+    "column": 13,
+    "originalFile": "cypress/integration/test-utils.js",
+    "relativeFile": "cypress/integration/test-utils.js",
+    "absoluteFile": "/Users/gleb/git/cypress-example-todomvc/cypress/integration/test-utils.js",
+    "frame": "  1 | export const getInputBox = () => {\n> 2 |   return cy.get('.new-todo')\n    |             ^\n  3 | }\n  4 | ",
+    "language": "js"
+  }
+}

--- a/packages/reporter/cypress/fixtures/no_location_app_error.json
+++ b/packages/reporter/cypress/fixtures/no_location_app_error.json
@@ -1,0 +1,224 @@
+{
+  "name": "ReferenceError",
+  "message": "The following error originated from your application code, not from Cypress.\n\n  > b is not defined\n\nWhen Cypress detects uncaught errors originating from your application it will automatically fail the current test.\n\nThis behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.",
+  "stack": "ReferenceError: The following error originated from your application code, not from Cypress.\n\n  > b is not defined\n\nWhen Cypress detects uncaught errors originating from your application it will automatically fail the current test.\n\nThis behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.\n    at http://localhost:8888/js/utils.js:9:3\n    at http://localhost:8888/js/utils.js:60:3\nFrom previous event:\n    at run (cypress:///../driver/src/cypress/cy.js:561:21)\n    at $Cy.cy.<computed> [as visit] (cypress:///../driver/src/cypress/cy.js:1018:11)\n    at Context.runnable.fn (cypress:///../driver/src/cypress/cy.js:1242:21)\n    at callFn (cypress:///../driver/node_modules/mocha/lib/runnable.js:395:21)\n    at Test.Runnable.run (cypress:///../driver/node_modules/mocha/lib/runnable.js:382:7)\n    at eval (cypress:///../driver/src/cypress/runner.js:1249:28)\nFrom previous event:\n    at Object.onRunnableRun (cypress:///../driver/src/cypress/runner.js:1237:17)\n    at $Cypress.action (cypress:///../driver/src/cypress.js:397:28)\n    at Test.Runnable.run (cypress:///../driver/src/cypress/mocha.js:347:13)\n    at Runner.runTest (cypress:///../driver/node_modules/mocha/lib/runner.js:541:10)\n    at eval (cypress:///../driver/node_modules/mocha/lib/runner.js:667:12)\n    at next (cypress:///../driver/node_modules/mocha/lib/runner.js:450:14)\n    at eval (cypress:///../driver/node_modules/mocha/lib/runner.js:460:7)\n    at next (cypress:///../driver/node_modules/mocha/lib/runner.js:362:14)\n    at eval (cypress:///../driver/node_modules/mocha/lib/runner.js:428:5)\n    at timeslice (cypress:///../driver/node_modules/mocha/browser-entry.js:80:27)",
+  "sourceMappedStack": "ReferenceError: The following error originated from your application code, not from Cypress.\n\n    > b is not defined\n\nWhen Cypress detects uncaught errors originating from your application it will automatically fail the current test.\n\nThis behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.\n    at <unknown> (http://localhost:8888/js/utils.js:9:4)\n    at <unknown> (http://localhost:8888/js/utils.js:60:4)\nFrom previous event:\n    at run (cypress:///../driver/src/cypress/cy.js:561:22)\n    at $Cy.cy.<computed> [as visit] (cypress:///../driver/src/cypress/cy.js:1018:12)\n    at Context.runnable.fn (cypress:///../driver/src/cypress/cy.js:1242:22)\n    at callFn (cypress:///../driver/node_modules/mocha/lib/runnable.js:395:22)\n    at Test.Runnable.run (cypress:///../driver/node_modules/mocha/lib/runnable.js:382:8)\n    at eval (cypress:///../driver/src/cypress/runner.js:1249:29)\nFrom previous event:\n    at Object.onRunnableRun (cypress:///../driver/src/cypress/runner.js:1237:18)\n    at $Cypress.action (cypress:///../driver/src/cypress.js:397:29)\n    at Test.Runnable.run (cypress:///../driver/src/cypress/mocha.js:347:14)\n    at Runner.runTest (cypress:///../driver/node_modules/mocha/lib/runner.js:541:11)\n    at eval (cypress:///../driver/node_modules/mocha/lib/runner.js:667:13)\n    at next (cypress:///../driver/node_modules/mocha/lib/runner.js:450:15)\n    at eval (cypress:///../driver/node_modules/mocha/lib/runner.js:460:8)\n    at next (cypress:///../driver/node_modules/mocha/lib/runner.js:362:15)\n    at eval (cypress:///../driver/node_modules/mocha/lib/runner.js:428:6)\n    at timeslice (cypress:///../driver/node_modules/mocha/browser-entry.js:80:28)",
+  "parsedStack": [
+    {
+      "message": "ReferenceError: The following error originated from your application code, not from Cypress.",
+      "whitespace": ""
+    },
+    {
+      "message": "",
+      "whitespace": ""
+    },
+    {
+      "message": "  > b is not defined",
+      "whitespace": "  "
+    },
+    {
+      "message": "",
+      "whitespace": ""
+    },
+    {
+      "message": "When Cypress detects uncaught errors originating from your application it will automatically fail the current test.",
+      "whitespace": ""
+    },
+    {
+      "message": "",
+      "whitespace": ""
+    },
+    {
+      "message": "This behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.",
+      "whitespace": ""
+    },
+    {
+      "function": "<unknown>",
+      "fileUrl": "http://localhost:8888/js/utils.js",
+      "originalFile": "http://localhost:8888/js/utils.js",
+      "line": 9,
+      "column": 4,
+      "whitespace": "    "
+    },
+    {
+      "function": "<unknown>",
+      "fileUrl": "http://localhost:8888/js/utils.js",
+      "originalFile": "http://localhost:8888/js/utils.js",
+      "line": 60,
+      "column": 4,
+      "whitespace": "    "
+    },
+    {
+      "message": "From previous event:",
+      "whitespace": ""
+    },
+    {
+      "function": "run",
+      "fileUrl": "cypress:///../driver/src/cypress/cy.js",
+      "originalFile": "cypress:///../driver/src/cypress/cy.js",
+      "relativeFile": "../driver/src/cypress/cy.js",
+      "absoluteFile": "/Users/gleb/git/driver/src/cypress/cy.js",
+      "line": 561,
+      "column": 22,
+      "whitespace": "    "
+    },
+    {
+      "function": "$Cy.cy.<computed> [as visit]",
+      "fileUrl": "cypress:///../driver/src/cypress/cy.js",
+      "originalFile": "cypress:///../driver/src/cypress/cy.js",
+      "relativeFile": "../driver/src/cypress/cy.js",
+      "absoluteFile": "/Users/gleb/git/driver/src/cypress/cy.js",
+      "line": 1018,
+      "column": 12,
+      "whitespace": "    "
+    },
+    {
+      "function": "Context.runnable.fn",
+      "fileUrl": "cypress:///../driver/src/cypress/cy.js",
+      "originalFile": "cypress:///../driver/src/cypress/cy.js",
+      "relativeFile": "../driver/src/cypress/cy.js",
+      "absoluteFile": "/Users/gleb/git/driver/src/cypress/cy.js",
+      "line": 1242,
+      "column": 22,
+      "whitespace": "    "
+    },
+    {
+      "function": "callFn",
+      "fileUrl": "cypress:///../driver/node_modules/mocha/lib/runnable.js",
+      "originalFile": "cypress:///../driver/node_modules/mocha/lib/runnable.js",
+      "relativeFile": "../driver/node_modules/mocha/lib/runnable.js",
+      "absoluteFile": "/Users/gleb/git/driver/node_modules/mocha/lib/runnable.js",
+      "line": 395,
+      "column": 22,
+      "whitespace": "    "
+    },
+    {
+      "function": "Test.Runnable.run",
+      "fileUrl": "cypress:///../driver/node_modules/mocha/lib/runnable.js",
+      "originalFile": "cypress:///../driver/node_modules/mocha/lib/runnable.js",
+      "relativeFile": "../driver/node_modules/mocha/lib/runnable.js",
+      "absoluteFile": "/Users/gleb/git/driver/node_modules/mocha/lib/runnable.js",
+      "line": 382,
+      "column": 8,
+      "whitespace": "    "
+    },
+    {
+      "function": "eval",
+      "fileUrl": "cypress:///../driver/src/cypress/runner.js",
+      "originalFile": "cypress:///../driver/src/cypress/runner.js",
+      "relativeFile": "../driver/src/cypress/runner.js",
+      "absoluteFile": "/Users/gleb/git/driver/src/cypress/runner.js",
+      "line": 1249,
+      "column": 29,
+      "whitespace": "    "
+    },
+    {
+      "message": "From previous event:",
+      "whitespace": ""
+    },
+    {
+      "function": "Object.onRunnableRun",
+      "fileUrl": "cypress:///../driver/src/cypress/runner.js",
+      "originalFile": "cypress:///../driver/src/cypress/runner.js",
+      "relativeFile": "../driver/src/cypress/runner.js",
+      "absoluteFile": "/Users/gleb/git/driver/src/cypress/runner.js",
+      "line": 1237,
+      "column": 18,
+      "whitespace": "    "
+    },
+    {
+      "function": "$Cypress.action",
+      "fileUrl": "cypress:///../driver/src/cypress.js",
+      "originalFile": "cypress:///../driver/src/cypress.js",
+      "relativeFile": "../driver/src/cypress.js",
+      "absoluteFile": "/Users/gleb/git/driver/src/cypress.js",
+      "line": 397,
+      "column": 29,
+      "whitespace": "    "
+    },
+    {
+      "function": "Test.Runnable.run",
+      "fileUrl": "cypress:///../driver/src/cypress/mocha.js",
+      "originalFile": "cypress:///../driver/src/cypress/mocha.js",
+      "relativeFile": "../driver/src/cypress/mocha.js",
+      "absoluteFile": "/Users/gleb/git/driver/src/cypress/mocha.js",
+      "line": 347,
+      "column": 14,
+      "whitespace": "    "
+    },
+    {
+      "function": "Runner.runTest",
+      "fileUrl": "cypress:///../driver/node_modules/mocha/lib/runner.js",
+      "originalFile": "cypress:///../driver/node_modules/mocha/lib/runner.js",
+      "relativeFile": "../driver/node_modules/mocha/lib/runner.js",
+      "absoluteFile": "/Users/gleb/git/driver/node_modules/mocha/lib/runner.js",
+      "line": 541,
+      "column": 11,
+      "whitespace": "    "
+    },
+    {
+      "function": "eval",
+      "fileUrl": "cypress:///../driver/node_modules/mocha/lib/runner.js",
+      "originalFile": "cypress:///../driver/node_modules/mocha/lib/runner.js",
+      "relativeFile": "../driver/node_modules/mocha/lib/runner.js",
+      "absoluteFile": "/Users/gleb/git/driver/node_modules/mocha/lib/runner.js",
+      "line": 667,
+      "column": 13,
+      "whitespace": "    "
+    },
+    {
+      "function": "next",
+      "fileUrl": "cypress:///../driver/node_modules/mocha/lib/runner.js",
+      "originalFile": "cypress:///../driver/node_modules/mocha/lib/runner.js",
+      "relativeFile": "../driver/node_modules/mocha/lib/runner.js",
+      "absoluteFile": "/Users/gleb/git/driver/node_modules/mocha/lib/runner.js",
+      "line": 450,
+      "column": 15,
+      "whitespace": "    "
+    },
+    {
+      "function": "eval",
+      "fileUrl": "cypress:///../driver/node_modules/mocha/lib/runner.js",
+      "originalFile": "cypress:///../driver/node_modules/mocha/lib/runner.js",
+      "relativeFile": "../driver/node_modules/mocha/lib/runner.js",
+      "absoluteFile": "/Users/gleb/git/driver/node_modules/mocha/lib/runner.js",
+      "line": 460,
+      "column": 8,
+      "whitespace": "    "
+    },
+    {
+      "function": "next",
+      "fileUrl": "cypress:///../driver/node_modules/mocha/lib/runner.js",
+      "originalFile": "cypress:///../driver/node_modules/mocha/lib/runner.js",
+      "relativeFile": "../driver/node_modules/mocha/lib/runner.js",
+      "absoluteFile": "/Users/gleb/git/driver/node_modules/mocha/lib/runner.js",
+      "line": 362,
+      "column": 15,
+      "whitespace": "    "
+    },
+    {
+      "function": "eval",
+      "fileUrl": "cypress:///../driver/node_modules/mocha/lib/runner.js",
+      "originalFile": "cypress:///../driver/node_modules/mocha/lib/runner.js",
+      "relativeFile": "../driver/node_modules/mocha/lib/runner.js",
+      "absoluteFile": "/Users/gleb/git/driver/node_modules/mocha/lib/runner.js",
+      "line": 428,
+      "column": 6,
+      "whitespace": "    "
+    },
+    {
+      "function": "timeslice",
+      "fileUrl": "cypress:///../driver/node_modules/mocha/browser-entry.js",
+      "originalFile": "cypress:///../driver/node_modules/mocha/browser-entry.js",
+      "relativeFile": "../driver/node_modules/mocha/browser-entry.js",
+      "absoluteFile": "/Users/gleb/git/driver/node_modules/mocha/browser-entry.js",
+      "line": 80,
+      "column": 28,
+      "whitespace": "    "
+    }
+  ],
+  "docsUrl": [
+    "https://on.cypress.io/uncaught-exception-from-application"
+  ],
+  "templateType": ""
+}

--- a/packages/reporter/cypress/integration/test_errors_spec.js
+++ b/packages/reporter/cypress/integration/test_errors_spec.js
@@ -394,3 +394,49 @@ describe('test error without file info', function () {
     cy.contains('.err-stack-line', 'http://localhost:8888/js/utils.js:60:4')
   })
 })
+
+describe('test error with good file info', function () {
+  beforeEach(function () {
+    cy.fixture('runnables_error').as('runnablesErr')
+    cy.fixture('cy_command_failed_error').as('commandErr')
+
+    this.setError = function (err) {
+      this.runnablesErr.suites[0].tests[0].err = err
+
+      cy.get('.reporter').then(() => {
+        this.runner.emit('runnables:ready', this.runnablesErr)
+
+        this.runner.emit('reporter:start', {})
+      })
+    }
+
+    this.runner = new EventEmitter()
+
+    cy.visit('cypress/support/index.html').then((win) => {
+      win.render({
+        runner: this.runner,
+        spec: {
+          name: 'foo.js',
+          relative: 'relative/path/to/foo.js',
+          absolute: '/absolute/path/to/foo.js',
+        },
+        config: {
+          projectRoot: '/root',
+        },
+      })
+    })
+  })
+
+  it('has open IDE links', function () {
+    this.setError(this.commandErr)
+    cy.contains('View stack trace').click()
+    cy.get('.runnable-err-stack-trace').should('be.visible')
+    // both files should be visible as clickable
+    cy.get('.runnable-err-stack-trace .runnable-err-file-path').should('have.length', 2)
+    cy.contains('.runnable-err-stack-trace .runnable-err-file-path', 'test-utils.js:2:13')
+    cy.contains('.runnable-err-stack-trace .runnable-err-file-path', 'spec.js:7:5')
+
+    // the code frame also has the open file path
+    cy.contains('.test-err-code-frame .runnable-err-file-path', 'test-utils.js:2:13')
+  })
+})


### PR DESCRIPTION
* Closes #7915
* Closes #9106

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

### Additional details
* no more file open links for stack lines without `absoluteFile` property. So we don't even show "open" for `http:/...` (which does not work anyway)

### How has the user experience changed?
The original error that is causing the crash is shown, not our "cannot replace" error

![](https://user-images.githubusercontent.com/2212006/98039410-a99c1d00-1dec-11eb-9ee1-03195aaa1fd2.png)

Scripts without local file no longer have clickable links

![](https://user-images.githubusercontent.com/2212006/98271148-a1172400-1f5d-11eb-9e42-7a570de3d8d1.png)

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

* [x] Have tests been added/updated?
* [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->

