### PR TITLE
test: Add more percy snapshots throughout Desktop GUI tests

### DIFF
--- a/packages/desktop-gui/cypress/integration/error_message_spec.js
+++ b/packages/desktop-gui/cypress/integration/error_message_spec.js
@@ -52,6 +52,8 @@ describe('Error Message', function () {
 
     cy.get('.error')
     .should('contain', this.err.message)
+
+    cy.percySnapshot()
   })
 
   it('displays error message with html escaped', function () {
@@ -90,6 +92,8 @@ describe('Error Message', function () {
 
     cy.get('.error')
     .and('contain', this.longErrMessage)
+
+    cy.percySnapshot()
   })
 
   it('re-opens project on click of \'Try again\' button', function () {
@@ -149,6 +153,7 @@ describe('Error Message', function () {
     cy.get('details.stacktrace').should('not.have.attr', 'open')
     cy.get('details.stacktrace').click().should('have.attr', 'open')
     cy.get('details.stacktrace').should('contain', 'bar')
+    cy.percySnapshot()
   })
 
   it('doesn\'t show error stack trace if not provided', function () {

--- a/packages/desktop-gui/cypress/integration/global_mode_spec.js
+++ b/packages/desktop-gui/cypress/integration/global_mode_spec.js
@@ -64,6 +64,7 @@ describe('Global Mode', function () {
 
   it('shows notice about using Cypress locally', () => {
     cy.contains('versioning Cypress per project')
+    cy.percySnapshot()
   })
 
   it('opens link to docs on click \'installing...\'', () => {

--- a/packages/desktop-gui/cypress/integration/nav_spec.js
+++ b/packages/desktop-gui/cypress/integration/nav_spec.js
@@ -70,6 +70,7 @@ describe('Navigation', function () {
       cy.contains('Jane Lane').click()
 
       cy.contains('Log Out').should('be.visible')
+      cy.percySnapshot()
     })
 
     describe('logging out', function () {
@@ -95,6 +96,7 @@ describe('Navigation', function () {
 
       it('shows global error', () => {
         cy.get('.global-error').should('be.visible')
+        cy.percySnapshot()
       })
 
       it('displays error message', function () {

--- a/packages/desktop-gui/cypress/integration/project_nav_spec.js
+++ b/packages/desktop-gui/cypress/integration/project_nav_spec.js
@@ -152,6 +152,8 @@ describe('Project Nav', function () {
 
           cy.get('.cy-tooltip')
           .should('contain', browserWithInfo.info)
+
+          cy.percySnapshot()
         })
 
         it('does not display stop button', () => {
@@ -215,11 +217,15 @@ describe('Project Nav', function () {
         it('displays browser icon as spinner', () => {
           cy.get('.browsers-list .dropdown-chosen').find('i')
           .should('have.class', 'fas fa-sync-alt fa-spin')
+
+          cy.percySnapshot()
         })
 
         it('disables browser dropdown', () => {
           cy.get('.browsers-list .dropdown-chosen')
           .should('have.class', 'disabled')
+
+          cy.percySnapshot()
         })
       })
 
@@ -375,6 +381,8 @@ describe('Project Nav', function () {
       it('displays no dropdown btn', () => {
         cy.get('.browsers-list')
         .find('.dropdown-toggle').should('not.be.visible')
+
+        cy.percySnapshot()
       })
     })
 
@@ -402,6 +410,8 @@ describe('Project Nav', function () {
         cy.get('.cy-tooltip a').click().then(function () {
           expect(this.ipc.externalOpen).to.be.calledWith('https://on.cypress.io/bad-browser-policy')
         })
+
+        cy.percySnapshot()
       })
     })
 
@@ -466,6 +476,7 @@ describe('Project Nav', function () {
     it('main nav does not block project nav when long project name pushes it to multiple lines', () => {
       cy.viewport(400, 400)
       cy.get('.project-nav').should('be.visible')
+      cy.percySnapshot()
     })
   })
 })

--- a/packages/desktop-gui/cypress/integration/projects_list_spec.js
+++ b/packages/desktop-gui/cypress/integration/projects_list_spec.js
@@ -50,6 +50,8 @@ describe('Projects List', function () {
       cy.get('.projects-list .loader').then(() => {
         expect(this.ipc.getProjects).to.be.called
       })
+
+      cy.percySnapshot()
     })
 
     describe('when loaded', function () {
@@ -59,6 +61,7 @@ describe('Projects List', function () {
 
       it('displays projects', function () {
         cy.get('.projects-list li').should('have.length', this.projects.length)
+        cy.percySnapshot()
       })
 
       it('displays project name and path', function () {
@@ -237,6 +240,7 @@ describe('Projects List', function () {
         cy.get('.alert').should('contain', 'Failed to get project statuses')
 
         cy.get('.projects-list li').should('have.length', this.projects.length)
+        cy.percySnapshot()
       })
 
       it('does not display api errors', function () {

--- a/packages/desktop-gui/cypress/integration/runs_list_spec.js
+++ b/packages/desktop-gui/cypress/integration/runs_list_spec.js
@@ -105,6 +105,7 @@ describe('Runs List', function () {
 
         it('displays build num', function () {
           cy.get('@secondRunRow').contains(`#${this.runs[1].buildNumber}`)
+          cy.percySnapshot()
         })
 
         it('displays commit info', function () {
@@ -179,6 +180,7 @@ describe('Runs List', function () {
             .trigger('mouseover')
 
             cy.get('.cy-tooltip').contains('Parallelization was disabled for this run')
+            cy.percySnapshot()
           })
         })
       })
@@ -199,6 +201,7 @@ describe('Runs List', function () {
         cy.contains('Cannot connect to API server')
         cy.contains('http://api.server')
         cy.contains('ECONNREFUSED')
+        cy.percySnapshot()
       })
 
       describe('trying again', function () {
@@ -308,6 +311,8 @@ describe('Runs List', function () {
       cy.contains('button', 'Log In to Dashboard').click().then(function () {
         expect(this.ipc.beginAuth).to.be.calledOnce
       })
+
+      cy.percySnapshot()
     })
 
     it('clicking Log In to Dashboard passes utm code', () => {
@@ -437,6 +442,7 @@ describe('Runs List', function () {
         this.ipcError({ statusCode: 403 })
 
         cy.contains('Request access')
+        cy.percySnapshot()
       })
 
       it('displays "need to set up" message', function () {
@@ -556,6 +562,7 @@ describe('Runs List', function () {
 
             it('shows success message', () => {
               cy.contains('Request sent')
+              cy.percySnapshot()
             })
 
             it('persists request state (until app is reloaded at least)', function () {
@@ -611,6 +618,7 @@ describe('Runs List', function () {
 
               it('enables button', () => {
                 cy.get('@requestAccessBtn').should('not.be.disabled')
+                cy.percySnapshot()
               })
 
               it('shows "Request access" text', () => {
@@ -678,6 +686,7 @@ describe('Runs List', function () {
 
       it('displays timed out message', () => {
         cy.contains('timed out')
+        cy.percySnapshot()
       })
     })
 
@@ -692,6 +701,7 @@ describe('Runs List', function () {
 
       it('displays empty message', () => {
         cy.contains('Runs cannot be displayed')
+        cy.percySnapshot()
       })
     })
 
@@ -741,6 +751,7 @@ describe('Runs List', function () {
         .contains('.btn', 'Set up project').click()
 
         cy.contains('To record your first')
+        cy.percySnapshot()
       })
     })
 
@@ -755,8 +766,8 @@ describe('Runs List', function () {
 
       it('displays unexpected error message', function () {
         cy.contains('unexpected error')
-
         cy.contains('"no runs": "for you"')
+        cy.percySnapshot()
       })
     })
 

--- a/packages/desktop-gui/cypress/integration/settings_spec.js
+++ b/packages/desktop-gui/cypress/integration/settings_spec.js
@@ -375,6 +375,7 @@ describe('Settings', () => {
 
     it('displays project id section', function () {
       cy.contains(this.config.projectId)
+      cy.percySnapshot()
     })
 
     it('shows tooltip on hover of copy to clipboard', () => {
@@ -433,6 +434,8 @@ describe('Settings', () => {
           cy.get('.loading-record-keys').should('not.exist')
           cy.get('.settings-record-key')
           .contains(`cypress run --record --key ${this.keys[0].id}`)
+
+          cy.percySnapshot()
         })
 
         it('shows tooltip on hover of copy to clipboard', () => {
@@ -461,6 +464,7 @@ describe('Settings', () => {
 
         it('displays empty message', () => {
           cy.get('.settings-record-key .empty-well').should('contain', 'This project has no record keys')
+          cy.percySnapshot()
         })
 
         it('opens dashboard project settings when clicking \'Dashboard\'', () => {
@@ -479,6 +483,7 @@ describe('Settings', () => {
 
         it('shows message that user must be logged in to view record keys', () => {
           cy.get('.empty-well').should('contain', 'must be logged in')
+          cy.percySnapshot()
         })
 
         it('opens login modal after clicking \'Log In\'', () => {
@@ -565,6 +570,8 @@ describe('Settings', () => {
       .should('contain', 'bundled with Cypress')
       .should('not.contain', systemNodePath)
       .should('not.contain', systemNodeVersion)
+
+      cy.percySnapshot()
     })
 
     it('with custom node displays path to custom node', function () {
@@ -578,48 +585,6 @@ describe('Settings', () => {
       .should('contain', systemNodePath)
       .should('contain', systemNodeVersion)
       .should('not.contain', bundledNodeVersion)
-    })
-  })
-
-  describe('errors', () => {
-    beforeEach(function () {
-      this.err = {
-        title: 'Foo Title',
-        message: 'Port \'2020\' is already in use.',
-        name: 'Error',
-        port: 2020,
-        portInUse: true,
-        stack: '[object Object]↵  at Object.API.get (/Users/jennifer/Dev/Projects/cypress-app/lib/errors.coffee:55:15)↵  at Object.wrapper [as get] (/Users/jennifer/Dev/Projects/cypress-app/node_modules/lodash/lodash.js:4414:19)↵  at Server.portInUseErr (/Users/jennifer/Dev/Projects/cypress-app/lib/server.coffee:58:16)↵  at Server.onError (/Users/jennifer/Dev/Projects/cypress-app/lib/server.coffee:86:19)↵  at Server.g (events.js:273:16)↵  at emitOne (events.js:90:13)↵  at Server.emit (events.js:182:7)↵  at emitErrorNT (net.js:1253:8)↵  at _combinedTickCallback (internal/process/next_tick.js:74:11)↵  at process._tickDomainCallback (internal/process/next_tick.js:122:9)↵From previous event:↵    at fn (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:57919:14)↵    at Object.appIpc [as ipc] (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:57939:10)↵    at openProject (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:59135:24)↵    at new Project (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:58848:34)↵    at ReactCompositeComponentMixin._constructComponentWithoutOwner (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:44052:27)↵    at ReactCompositeComponentMixin._constructComponent (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:44034:21)↵    at ReactCompositeComponentMixin.mountComponent (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:43953:21)↵    at Object.ReactReconciler.mountComponent (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:51315:35)↵    at ReactCompositeComponentMixin.performInitialMount (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:44129:34)↵    at ReactCompositeComponentMixin.mountComponent (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:44016:21)↵    at Object.ReactReconciler.mountComponent (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:51315:35)↵    at ReactDOMComponent.ReactMultiChild.Mixin._mountChildAtIndex (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:50247:40)↵    at ReactDOMComponent.ReactMultiChild.Mixin._updateChildren (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:50163:43)↵    at ReactDOMComponent.ReactMultiChild.Mixin.updateChildren (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:50123:12)↵    at ReactDOMComponent.Mixin._updateDOMChildren (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:45742:12)↵    at ReactDOMComponent.Mixin.updateComponent (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:45571:10)↵    at ReactDOMComponent.Mixin.receiveComponent (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:45527:10)↵    at Object.ReactReconciler.receiveComponent (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:51396:22)↵    at ReactCompositeComponentMixin._updateRenderedComponent (file:///Users/jennifer/Dev/Projects/cypress-core-desktop-gui/dist/app.js:44547:23)',
-        type: 'PORT_IN_USE_SHORT',
-      }
-
-      this.config.resolved.baseUrl.value = 'http://localhost:7777'
-
-      this.projectStatuses[0].id = this.config.projectId
-      this.getProjectStatus.resolve(this.projectStatuses[0])
-      this.openProject.resolve(this.config)
-      this.goToSettings()
-      openConfiguration()
-
-      cy.contains('http://localhost:7777').then(() => {
-        this.ipc.openProject.onCall(1).rejects(this.err)
-
-        this.ipc.onConfigChanged.yield()
-      })
-    })
-
-    it('displays errors', () => {
-      cy.contains('Foo Title')
-    })
-
-    it('displays config after error is fixed', function () {
-      cy.contains('Foo Title').then(() => {
-        this.ipc.openProject.onCall(1).resolves(this.config)
-
-        this.ipc.onConfigChanged.yield()
-      })
-
-      cy.contains('Configuration')
     })
   })
 
@@ -657,6 +622,7 @@ describe('Settings', () => {
       cy.get('.settings-proxy tr:nth-child(1) > td > code').should('contain', 'http://foo-bar.baz')
 
       cy.get('.settings-proxy tr:nth-child(2) > td > code').should('contain', 'a, b, c, d')
+      cy.percySnapshot()
     })
 
     it('with environment proxy settings indicates proxy and the source', () => {
@@ -848,6 +814,7 @@ describe('Settings', () => {
         .closest('li').should('have.class', 'is-selected')
 
         cy.wrap(this.ipc.setUserEditor).should('be.calledWith', availableEditors[0])
+        cy.percySnapshot()
       })
     })
 
@@ -893,6 +860,7 @@ describe('Settings', () => {
 
     it('displays errors', () => {
       cy.contains(errorText)
+      cy.percySnapshot()
     })
 
     it('displays config after error is fixed', function () {

--- a/packages/desktop-gui/cypress/integration/setup_project_modal_spec.js
+++ b/packages/desktop-gui/cypress/integration/setup_project_modal_spec.js
@@ -64,6 +64,7 @@ describe('Connect to Dashboard', function () {
 
       it('clicking link opens setup project window', () => {
         cy.get('.modal').should('be.visible')
+        cy.percySnapshot()
       })
 
       it('submit button is disabled', () => {
@@ -146,6 +147,8 @@ describe('Connect to Dashboard', function () {
           cy.get('.organizations-select__menu').should('be.visible')
           cy.get('.organizations-select__option')
           .should('have.length', this.orgs.length)
+
+          cy.percySnapshot()
         })
 
         it('selects personal org by default', function () {
@@ -170,6 +173,8 @@ describe('Connect to Dashboard', function () {
 
           cy.get('.privacy-radio').should('be.visible')
           .find('input').should('not.be.checked')
+
+          cy.percySnapshot()
         })
       })
 
@@ -219,6 +224,7 @@ describe('Connect to Dashboard', function () {
           cy.get('.empty-select-orgs').should('be.visible')
           cy.get('.organizations-select').should('not.be.visible')
           cy.get('.privacy-radio').should('not.be.visible')
+          cy.percySnapshot()
         })
 
         it('opens dashboard organizations when \'create org\' is clicked', () => {
@@ -475,6 +481,7 @@ describe('Connect to Dashboard', function () {
         })
 
         cy.contains('"system": "down"')
+        cy.percySnapshot()
       })
     })
 

--- a/packages/desktop-gui/cypress/integration/specs_list_spec.js
+++ b/packages/desktop-gui/cypress/integration/specs_list_spec.js
@@ -44,6 +44,7 @@ describe('Specs List', function () {
 
     it('displays empty message', () => {
       cy.contains('No files found')
+      cy.percySnapshot()
     })
 
     it('displays integration test folder path', function () {
@@ -103,6 +104,7 @@ describe('Specs List', function () {
 
     it('displays modal', () => {
       cy.contains('.modal', 'To help you get started').should('be.visible')
+      cy.percySnapshot()
     })
 
     it('displays the scaffolded files', () => {
@@ -227,6 +229,7 @@ describe('Specs List', function () {
             cy.get('@allSpecs').find('i').should('have.class', 'fa-dot-circle')
 
             cy.get('@allSpecs').find('i').should('not.have.class', 'fa-play')
+            cy.percySnapshot()
           })
 
           it('sets spec as active', () => {
@@ -771,6 +774,7 @@ describe('Specs List', function () {
 
     it('displays when spec is hovered over', function () {
       cy.get('@button').invoke('show').should('be.visible')
+      cy.percySnapshot()
     })
 
     describe('opens files', function () {

--- a/packages/desktop-gui/cypress/integration/warning_message_spec.js
+++ b/packages/desktop-gui/cypress/integration/warning_message_spec.js
@@ -108,6 +108,8 @@ describe('Warning Message', function () {
     .then(function () {
       expect(this.ipc.externalOpen).to.be.calledWith('http://example.com/')
     })
+
+    cy.percySnapshot()
   })
 
   it('does not try to open non-links', function () {
@@ -154,6 +156,7 @@ describe('Warning Message', function () {
 
     it('shows retry button', function () {
       cy.contains('Try Again')
+      cy.percySnapshot()
     })
 
     it('pings baseUrl and disables retry button when clicked', function () {
@@ -215,6 +218,8 @@ describe('Warning Message', function () {
 
       cy.get('.alert-warning').its('1')
       .should('contain', 'Other message')
+
+      cy.percySnapshot()
     })
 
     it('can dismiss the warnings', function () {


### PR DESCRIPTION
I want to have a baseline of percy snapshots to compare against the large CSS changes in https://github.com/cypress-io/cypress/pull/9061