### PR TITLE
fix: Add missing "waited" state to the driver

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1339,6 +1339,18 @@ describe('network stubbing', { retries: 2 }, function () {
       cy.contains('{"foo":1,"bar":{"baz":"cypress"}}')
     })
 
+    it('intercepts responses with no content', function () {
+      const url = '/status-204'
+
+      cy.route2(url)
+      .as('foo')
+      .then(() => fetch(url))
+      .wait('@foo')
+      .then((request) => {
+        expect(request.response.body).to.eq('')
+      })
+    })
+
     context('with StaticResponse', function () {
       it('res.send(body)', function () {
         cy.route2('/custom-headers', function (req) {

--- a/packages/driver/cypress/plugins/server.js
+++ b/packages/driver/cypress/plugins/server.js
@@ -129,6 +129,12 @@ const createApp = (port) => {
     return res.send(`<html><body>request headers:<br>${JSON.stringify(req.headers)}</body></html>`)
   })
 
+  app.get('/status-204', (req, res) => {
+    return res
+    .status(204)
+    .send('')
+  })
+
   app.get('/status-404', (req, res) => {
     return res
     .status(404)

--- a/packages/driver/src/cy/net-stubbing/wait-for-route.ts
+++ b/packages/driver/src/cy/net-stubbing/wait-for-route.ts
@@ -5,7 +5,7 @@ import {
   RequestState,
 } from './types'
 
-const RESPONSE_WAITED_STATES: RequestState[] = ['ResponseIntercepted', 'Complete']
+const RESPONSE_WAITED_STATES: RequestState[] = ['ResponseIntercepted', 'ResponseReceived', 'Complete']
 
 function getPredicateForSpecifier (specifier: string): Partial<Request> {
   if (specifier === 'request') {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...


* Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
* Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
* Mark this PR as "Draft" if it is not ready for review.
-->

This event was missing and therefore couldn't handle responses with empty body such as ones with a status code of 204 or 304.

* Closes #8999 

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->
Handle the "Received Response" event on the driver

### Additional details
<!-- Examples:


* Why was this change necessary?
* What is affected by this change?
* Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

* [x] Have tests been added/updated?
* [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
* [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
* [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
* [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?

