### PR TITLE
fix(net-stubbing): fix waiting on responses with no-body status codes

### DIFF
--- a/packages/driver/cypress/plugins/server.js
+++ b/packages/driver/cypress/plugins/server.js
@@ -41,13 +41,17 @@ const createApp = (port) => {
     .send('<html><body>hello there</body></html>')
   })
 
-  app.get('/redirect', (req, res) => {
+  app.get('/status-code', (req, res) => {
+    res.sendStatus(req.query.code || 200)
+  })
+
+  app.all('/redirect', (req, res) => {
     if (req.query.chunked) {
       res.setHeader('transfer-encoding', 'chunked')
       res.removeHeader('content-length')
     }
 
-    res.statusCode = 301
+    res.statusCode = Number(req.query.code || 301)
     res.setHeader('Location', req.query.href)
     res.end()
   })

--- a/packages/net-stubbing/lib/server/intercept-request.ts
+++ b/packages/net-stubbing/lib/server/intercept-request.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import concatStream from 'concat-stream'
+import { concatStream } from '@packages/network'
 import Debug from 'debug'
 import url from 'url'
 

--- a/packages/net-stubbing/lib/server/intercept-response.ts
+++ b/packages/net-stubbing/lib/server/intercept-response.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash'
-import concatStream from 'concat-stream'
+import { concatStream, httpUtils } from '@packages/network'
 import Debug from 'debug'
-import { Readable } from 'stream'
+import { Readable, PassThrough } from 'stream'
 
 import {
   ResponseMiddleware,
@@ -65,17 +65,30 @@ export const InterceptResponse: ResponseMiddleware = function () {
 
   this.makeResStreamPlainText()
 
-  this.incomingResStream.pipe(concatStream((resBody) => {
-    res.body = resBody.toString()
+  new Promise((resolve) => {
+    if (httpUtils.responseMustHaveEmptyBody(this.req, this.incomingRes)) {
+      resolve('')
+    } else {
+      this.incomingResStream.pipe(concatStream((resBody) => {
+        resolve(resBody)
+      }))
+    }
+  })
+  .then((body) => {
+    const pt = this.incomingResStream = new PassThrough()
+
+    pt.end(body)
+
+    res.body = String(body)
     emitReceived()
-  }))
 
-  if (!backendRequest.waitForResponseContinue) {
-    this.next()
-  }
+    if (!backendRequest.waitForResponseContinue) {
+      this.next()
+    }
 
-  // this may get set back to `true` by another route
-  backendRequest.waitForResponseContinue = false
+    // this may get set back to `true` by another route
+    backendRequest.waitForResponseContinue = false
+  })
 }
 
 export async function onResponseContinue (state: NetStubbingState, frame: NetEventFrames.HttpResponseContinue) {

--- a/packages/net-stubbing/package.json
+++ b/packages/net-stubbing/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@types/mime-types": "2.1.0",
-    "concat-stream": "^2.0.0",
     "is-html": "^2.0.0",
     "lodash": "4.17.15",
     "mime-types": "2.1.27",

--- a/packages/network/lib/http-utils.ts
+++ b/packages/network/lib/http-utils.ts
@@ -7,5 +7,5 @@ import { IncomingMessage } from 'http'
 const NO_BODY_STATUS_CODES = [204, 304]
 
 export function responseMustHaveEmptyBody (req: IncomingMessage, res: IncomingMessage) {
-  return _.includes(NO_BODY_STATUS_CODES, res.statusCode) || req.method?.toLowerCase() === 'head'
+  return _.includes(NO_BODY_STATUS_CODES, res.statusCode) || (req.method && req.method.toLowerCase() === 'head')
 }

--- a/packages/network/lib/http-utils.ts
+++ b/packages/network/lib/http-utils.ts
@@ -7,5 +7,5 @@ import { IncomingMessage } from 'http'
 const NO_BODY_STATUS_CODES = [204, 304]
 
 export function responseMustHaveEmptyBody (req: IncomingMessage, res: IncomingMessage) {
-  return _.includes(NO_BODY_STATUS_CODES, res.statusCode) || _.invoke(req.method, 'toLowerCase') === 'head'
+  return _.includes(NO_BODY_STATUS_CODES, res.statusCode) || req.method?.toLowerCase() === 'head'
 }

--- a/packages/network/lib/http-utils.ts
+++ b/packages/network/lib/http-utils.ts
@@ -1,0 +1,11 @@
+import _ from 'lodash'
+import { IncomingMessage } from 'http'
+
+// https://github.com/cypress-io/cypress/issues/4298
+// https://tools.ietf.org/html/rfc7230#section-3.3.3
+// HEAD, 1xx, 204, and 304 responses should never contain anything after headers
+const NO_BODY_STATUS_CODES = [204, 304]
+
+export function responseMustHaveEmptyBody (req: IncomingMessage, res: IncomingMessage) {
+  return _.includes(NO_BODY_STATUS_CODES, res.statusCode) || _.invoke(req.method, 'toLowerCase') === 'head'
+}

--- a/packages/network/lib/index.ts
+++ b/packages/network/lib/index.ts
@@ -2,6 +2,7 @@ import agent from './agent'
 import * as blocked from './blocked'
 import * as connect from './connect'
 import * as cors from './cors'
+import * as httpUtils from './http-utils'
 import * as uri from './uri'
 
 export {
@@ -9,6 +10,7 @@ export {
   blocked,
   connect,
   cors,
+  httpUtils,
   uri,
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->

- Closes #8999
- Closes #8934 

### User facing changelog

- Fixed an issue where HTTP responses that cannot have a body (like HTTP 304 and HTTP 204) could not be awaited using `cy.intercept`.
- Fixed an issue where HTTP redirects could not be awaited using `cy.intercept` unless dynamically intercepted.

### Additional details

- tricky because internally, Node.js treats 304s differently from 204s
- also tricky because the fix for #4358 had to be maintained or else the 5 second timeout continues

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] test from RWA issue has been resolved https://github.com/cypress-io/cypress/pull/9097#issuecomment-736845181
- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
