### PR TITLE
fix: Don't fail when project root is on a read-only filesystem.

### DIFF
--- a/packages/server/lib/util/settings.js
+++ b/packages/server/lib/util/settings.js
@@ -124,6 +124,9 @@ module.exports = {
     }).catch({ code: 'EACCES' }, () => {
       // we cannot write due to folder permissions
       return errors.warning('FOLDER_NOT_WRITABLE', projectRoot)
+    }).catch({ code: 'EROFS' }, () => {
+      // we cannot write due to filesystem being read-only
+      return errors.warning('FOLDER_NOT_WRITABLE', projectRoot)
     }).catch((err) => {
       if (errors.isCypressErr(err)) {
         throw err


### PR DESCRIPTION
Enhances fix for #1281 to include warning instead of failing when project root is a read-only filesystem (original fix only considers file permissions).

### How has the user experience changed?
Before:
![image](https://user-images.githubusercontent.com/4606735/98380048-f75c9380-203f-11eb-860b-48353b1b73df.png)

After:
![image](https://user-images.githubusercontent.com/4606735/98380175-1fe48d80-2040-11eb-8526-600c9f4c155f.png)
