### PR TITLE
feat: Add timeout period to retry error message

### DIFF
--- a/packages/desktop-gui/cypress/fixtures/runs.json
+++ b/packages/desktop-gui/cypress/fixtures/runs.json
@@ -26,7 +26,7 @@
     "failedTests": [
       {
         "body": "function () {}",
-        "error": "Timed out retrying: cy.click() failed because this element is being covered by another element:",
+        "error": "Timed out retrying after 4000ms. cy.click() failed because this element is being covered by another element:",
         "id": "175e807c-ce85-5f94-938c-e2e30b090633",
         "instanceId": "d1609552-31b5-50c1-b307-c27c9553ccb8",
         "stack": "Error: Uncaught ReferenceError:\n    at Object.$Cypress.Utils._.cypressErr (http://localhost:2020/__cypress/static/js/cypress.js:4678:15)\n    at Object.$Cypress.Utils._.throwErr (http://localhost:2020/__cypress/static/js/cypress.js:4642:22)\n    at Object.$Cypress.Utils._.throwErrByPath (http://localhost:2020/__cypress/static/js/cypress.js:4670:21)",
@@ -53,7 +53,7 @@
       },
       {
         "body": "function () {}",
-        "error": "Timed out retrying: cy.click() failed because this element is being covered by another element:",
+        "error": "Timed out retrying after 4000ms. cy.click() failed because this element is being covered by another element:",
         "failedFromHookId": "h1",
         "id": "ef0d934e-a247-5e60-b801-3c5be5aa8796",
         "instanceId": "d1609552-31b5-50c1-b307-c27c9553ccb8",

--- a/packages/desktop-gui/cypress/fixtures/runs.json
+++ b/packages/desktop-gui/cypress/fixtures/runs.json
@@ -26,7 +26,7 @@
     "failedTests": [
       {
         "body": "function () {}",
-        "error": "Timed out retrying after 4000ms. cy.click() failed because this element is being covered by another element:",
+        "error": "Timed out retrying after 4000ms: cy.click() failed because this element is being covered by another element:",
         "id": "175e807c-ce85-5f94-938c-e2e30b090633",
         "instanceId": "d1609552-31b5-50c1-b307-c27c9553ccb8",
         "stack": "Error: Uncaught ReferenceError:\n    at Object.$Cypress.Utils._.cypressErr (http://localhost:2020/__cypress/static/js/cypress.js:4678:15)\n    at Object.$Cypress.Utils._.throwErr (http://localhost:2020/__cypress/static/js/cypress.js:4642:22)\n    at Object.$Cypress.Utils._.throwErrByPath (http://localhost:2020/__cypress/static/js/cypress.js:4670:21)",
@@ -53,7 +53,7 @@
       },
       {
         "body": "function () {}",
-        "error": "Timed out retrying after 4000ms. cy.click() failed because this element is being covered by another element:",
+        "error": "Timed out retrying after 4000ms: cy.click() failed because this element is being covered by another element:",
         "failedFromHookId": "h1",
         "id": "ef0d934e-a247-5e60-b801-3c5be5aa8796",
         "instanceId": "d1609552-31b5-50c1-b307-c27c9553ccb8",

--- a/packages/driver/cypress/integration/commands/actions/trigger_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/trigger_spec.js
@@ -1054,7 +1054,7 @@ describe('src/cy/commands/actions/trigger', () => {
       it('throws when provided invalid event type', function (done) {
         cy.on('fail', (err) => {
           expect(this.logs.length).to.eq(2)
-          expect(err.message).to.eq('Timed out retrying after 100ms. `cy.trigger()` `eventConstructor` option must be a valid event (e.g. \'MouseEvent\', \'KeyboardEvent\'). You passed: `FooEvent`')
+          expect(err.message).to.eq('Timed out retrying after 100ms: `cy.trigger()` `eventConstructor` option must be a valid event (e.g. \'MouseEvent\', \'KeyboardEvent\'). You passed: `FooEvent`')
 
           done()
         })

--- a/packages/driver/cypress/integration/commands/actions/trigger_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/trigger_spec.js
@@ -1054,7 +1054,7 @@ describe('src/cy/commands/actions/trigger', () => {
       it('throws when provided invalid event type', function (done) {
         cy.on('fail', (err) => {
           expect(this.logs.length).to.eq(2)
-          expect(err.message).to.eq('Timed out retrying: `cy.trigger()` `eventConstructor` option must be a valid event (e.g. \'MouseEvent\', \'KeyboardEvent\'). You passed: `FooEvent`')
+          expect(err.message).to.eq('Timed out retrying after 100ms. `cy.trigger()` `eventConstructor` option must be a valid event (e.g. \'MouseEvent\', \'KeyboardEvent\'). You passed: `FooEvent`')
 
           done()
         })

--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -490,7 +490,7 @@ describe('src/cy/commands/assertions', () => {
 
       it('throws when eventually times out', (done) => {
         cy.on('fail', (err) => {
-          expect(err.message).to.eq('Timed out retrying after 50ms. expected \'<button>\' to have class \'does-not-have-class\'')
+          expect(err.message).to.eq('Timed out retrying after 50ms: expected \'<button>\' to have class \'does-not-have-class\'')
 
           done()
         })

--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -490,7 +490,7 @@ describe('src/cy/commands/assertions', () => {
 
       it('throws when eventually times out', (done) => {
         cy.on('fail', (err) => {
-          expect(err.message).to.eq('Timed out retrying: expected \'<button>\' to have class \'does-not-have-class\'')
+          expect(err.message).to.eq('Timed out retrying after 50ms. expected \'<button>\' to have class \'does-not-have-class\'')
 
           done()
         })

--- a/packages/driver/cypress/integration/commands/connectors_spec.js
+++ b/packages/driver/cypress/integration/commands/connectors_spec.js
@@ -616,7 +616,7 @@ describe('src/cy/commands/connectors', () => {
             }
 
             cy.on('fail', (err) => {
-              expect(err.message).to.include('Timed out retrying after 100ms. `cy.invoke()` errored because the property: `foo` returned a `regexp` value instead of a function. `cy.invoke()` can only be used on properties that return callable functions.')
+              expect(err.message).to.include('Timed out retrying after 100ms: `cy.invoke()` errored because the property: `foo` returned a `regexp` value instead of a function. `cy.invoke()` can only be used on properties that return callable functions.')
               expect(err.message).to.include('`cy.invoke()` waited for the specified property `foo` to return a function, but it never did.')
               expect(err.message).to.include('If you want to assert on the property\'s value, then switch to use `cy.its()` and add an assertion such as:')
               expect(err.message).to.include('`cy.wrap({ foo: \'bar\' }).its(\'foo\').should(\'eq\', \'bar\')`')
@@ -636,7 +636,7 @@ describe('src/cy/commands/connectors', () => {
             }
 
             cy.on('fail', (err) => {
-              expect(err.message).to.include('Timed out retrying after 100ms. `cy.invoke()` errored because the property: `bar` returned a `string` value instead of a function. `cy.invoke()` can only be used on properties that return callable functions.')
+              expect(err.message).to.include('Timed out retrying after 100ms: `cy.invoke()` errored because the property: `bar` returned a `string` value instead of a function. `cy.invoke()` can only be used on properties that return callable functions.')
               expect(err.message).to.include('`cy.invoke()` waited for the specified property `bar` to return a function, but it never did.')
               expect(err.message).to.include('If you want to assert on the property\'s value, then switch to use `cy.its()` and add an assertion such as:')
               expect(err.message).to.include('`cy.wrap({ foo: \'bar\' }).its(\'foo\').should(\'eq\', \'bar\')`')
@@ -972,7 +972,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying after 100ms. `cy.invoke()` errored because the property: `foo` does not exist on your subject.')
+            expect(err.message).to.include('Timed out retrying after 100ms: `cy.invoke()` errored because the property: `foo` does not exist on your subject.')
             expect(err.message).to.include('`cy.invoke()` waited for the specified property `foo` to exist, but it never did.')
             expect(err.message).to.include('If you do not expect the property `foo` to exist, then add an assertion such as:')
             expect(err.message).to.include('`cy.wrap({ foo: \'bar\' }).its(\'quux\').should(\'not.exist\')`')
@@ -1019,9 +1019,9 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.eq('Timed out retrying after 100ms. expected \'foo\' to equal \'bar\'')
+            expect(err.message).to.eq('Timed out retrying after 100ms: expected \'foo\' to equal \'bar\'')
 
-            expect(lastLog.get('error').message).to.eq('Timed out retrying after 100ms. expected \'foo\' to equal \'bar\'')
+            expect(lastLog.get('error').message).to.eq('Timed out retrying after 100ms: expected \'foo\' to equal \'bar\'')
 
             done()
           })
@@ -1033,7 +1033,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying after 100ms. `cy.invoke()` errored because your subject is: `undefined`. You cannot invoke any functions such as `foo` on a `undefined` value.')
+            expect(err.message).to.include('Timed out retrying after 100ms: `cy.invoke()` errored because your subject is: `undefined`. You cannot invoke any functions such as `foo` on a `undefined` value.')
             expect(err.message).to.include('If you expect your subject to be `undefined`, then add an assertion such as:')
             expect(err.message).to.include('`cy.wrap(undefined).should(\'be.undefined\')`')
             expect(err.docsUrl).to.eq('https://on.cypress.io/invoke')
@@ -1049,7 +1049,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying after 100ms. `cy.invoke()` errored because the property: `foo` is not a function, and instead returned a `undefined` value.')
+            expect(err.message).to.include('Timed out retrying after 100ms: `cy.invoke()` errored because the property: `foo` is not a function, and instead returned a `undefined` value.')
             expect(err.message).to.include('`cy.invoke()` waited for the specified property `foo` to become a callable function, but it never did.')
             expect(err.message).to.include('If you expect the property `foo` to be `undefined`, then switch to use `cy.its()` and add an assertion such as:')
             expect(err.message).to.include('`cy.wrap({ foo: undefined }).its(\'foo\').should(\'be.undefined\')`')
@@ -1066,7 +1066,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying after 100ms. `cy.invoke()` errored because the property: `baz` does not exist on your subject.')
+            expect(err.message).to.include('Timed out retrying after 100ms: `cy.invoke()` errored because the property: `baz` does not exist on your subject.')
             expect(lastLog.get('error').message).to.include(err.message)
             expect(err.docsUrl).to.eq('https://on.cypress.io/invoke')
 
@@ -1522,7 +1522,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying after 100ms. `cy.its()` errored because the property: `foo` does not exist on your subject.')
+            expect(err.message).to.include('Timed out retrying after 100ms: `cy.its()` errored because the property: `foo` does not exist on your subject.')
             expect(err.message).to.include('`cy.its()` waited for the specified property `foo` to exist, but it never did.')
             expect(err.message).to.include('If you do not expect the property `foo` to exist, then add an assertion such as:')
             expect(err.message).to.include('`cy.wrap({ foo: \'bar\' }).its(\'quux\').should(\'not.exist\')`')
@@ -1539,7 +1539,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying after 100ms. `cy.its()` errored because the property: `foo` returned a `undefined` value.')
+            expect(err.message).to.include('Timed out retrying after 100ms: `cy.its()` errored because the property: `foo` returned a `undefined` value.')
             expect(err.message).to.include('`cy.its()` waited for the specified property `foo` to become accessible, but it never did.')
             expect(err.message).to.include('If you expect the property `foo` to be `undefined`, then add an assertion such as:')
             expect(err.message).to.include('`cy.wrap({ foo: undefined }).its(\'foo\').should(\'be.undefined\')`')
@@ -1556,7 +1556,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying after 100ms. `cy.its()` errored because the property: `foo` returned a `null` value.')
+            expect(err.message).to.include('Timed out retrying after 100ms: `cy.its()` errored because the property: `foo` returned a `null` value.')
             expect(err.message).to.include('`cy.its()` waited for the specified property `foo` to become accessible, but it never did.')
             expect(err.message).to.include('If you expect the property `foo` to be `null`, then add an assertion such as:')
             expect(err.message).to.include('`cy.wrap({ foo: null }).its(\'foo\').should(\'be.null\')`')
@@ -1573,7 +1573,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying after 100ms. `cy.its()` errored because the property: `b` does not exist on your subject.')
+            expect(err.message).to.include('Timed out retrying after 100ms: `cy.its()` errored because the property: `b` does not exist on your subject.')
             expect(err.message).to.include('`cy.its()` waited for the specified property `b` to exist, but it never did.')
             expect(err.message).to.include('If you do not expect the property `b` to exist, then add an assertion such as:')
             expect(err.message).to.include('`cy.wrap({ foo: \'bar\' }).its(\'quux\').should(\'not.exist\')`')
@@ -1590,7 +1590,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying after 100ms. `cy.its()` errored because the property: `a` returned a `undefined` value.')
+            expect(err.message).to.include('Timed out retrying after 100ms: `cy.its()` errored because the property: `a` returned a `undefined` value.')
             expect(err.message).to.include('`cy.its()` waited for the specified property `a` to become accessible, but it never did.')
             expect(err.message).to.include('If you expect the property `a` to be `undefined`, then add an assertion such as:')
             expect(err.message).to.include('`cy.wrap({ foo: undefined }).its(\'foo\').should(\'be.undefined\')`')
@@ -1628,7 +1628,7 @@ describe('src/cy/commands/connectors', () => {
 
         it('can handle getter that throws', (done) => {
           const spy = cy.spy((err) => {
-            expect(err.message).to.eq('Timed out retrying after 100ms. some getter error')
+            expect(err.message).to.eq('Timed out retrying after 100ms: some getter error')
 
             done()
           }).as('onFail')
@@ -1650,7 +1650,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying after 100ms. `cy.its()` errored because the property: `baz` does not exist on your subject.')
+            expect(err.message).to.include('Timed out retrying after 100ms: `cy.its()` errored because the property: `baz` does not exist on your subject.')
             expect(err.docsUrl).to.eq('https://on.cypress.io/its')
             expect(lastLog.get('error').message).to.include(err.message)
             expect(lastLog.get('error').message).to.include(err.message)
@@ -1670,7 +1670,7 @@ describe('src/cy/commands/connectors', () => {
         [null, undefined].forEach((val) => {
           it(`throws on traversed '${val}' subject`, (done) => {
             cy.on('fail', (err) => {
-              expect(err.message).to.include(`Timed out retrying after 100ms. \`cy.its()\` errored because the property: \`a\` returned a \`${val}\` value. The property: \`b\` does not exist on a \`${val}\` value.`)
+              expect(err.message).to.include(`Timed out retrying after 100ms: \`cy.its()\` errored because the property: \`a\` returned a \`${val}\` value. The property: \`b\` does not exist on a \`${val}\` value.`)
               expect(err.message).to.include('`cy.its()` waited for the specified property `b` to become accessible, but it never did.')
               expect(err.message).to.include('If you do not expect the property `b` to exist, then add an assertion such as:')
               expect(err.message).to.include(`\`cy.wrap({ foo: ${val} }).its('foo.baz').should('not.exist')\``)
@@ -1684,7 +1684,7 @@ describe('src/cy/commands/connectors', () => {
 
           it(`throws on initial '${val}' subject`, (done) => {
             cy.on('fail', (err) => {
-              expect(err.message).to.include(`Timed out retrying after 100ms. \`cy.its()\` errored because your subject is: \`${val}\`. You cannot access any properties such as \`foo\` on a \`${val}\` value.`)
+              expect(err.message).to.include(`Timed out retrying after 100ms: \`cy.its()\` errored because your subject is: \`${val}\`. You cannot access any properties such as \`foo\` on a \`${val}\` value.`)
               expect(err.message).to.include(`If you expect your subject to be \`${val}\`, then add an assertion such as:`)
               expect(err.message).to.include(`\`cy.wrap(${val}).should('be.${val}')\``)
               expect(err.docsUrl).to.eq('https://on.cypress.io/its')
@@ -1767,7 +1767,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying after 200ms. expected \'bar\' to equal \'baz\'')
+            expect(err.message).to.include('Timed out retrying after 200ms: expected \'bar\' to equal \'baz\'')
             expect(lastLog.get('error').message).to.include(err.message)
 
             done()

--- a/packages/driver/cypress/integration/commands/connectors_spec.js
+++ b/packages/driver/cypress/integration/commands/connectors_spec.js
@@ -616,7 +616,7 @@ describe('src/cy/commands/connectors', () => {
             }
 
             cy.on('fail', (err) => {
-              expect(err.message).to.include('Timed out retrying: `cy.invoke()` errored because the property: `foo` returned a `regexp` value instead of a function. `cy.invoke()` can only be used on properties that return callable functions.')
+              expect(err.message).to.include('Timed out retrying after 100ms. `cy.invoke()` errored because the property: `foo` returned a `regexp` value instead of a function. `cy.invoke()` can only be used on properties that return callable functions.')
               expect(err.message).to.include('`cy.invoke()` waited for the specified property `foo` to return a function, but it never did.')
               expect(err.message).to.include('If you want to assert on the property\'s value, then switch to use `cy.its()` and add an assertion such as:')
               expect(err.message).to.include('`cy.wrap({ foo: \'bar\' }).its(\'foo\').should(\'eq\', \'bar\')`')
@@ -636,7 +636,7 @@ describe('src/cy/commands/connectors', () => {
             }
 
             cy.on('fail', (err) => {
-              expect(err.message).to.include('Timed out retrying: `cy.invoke()` errored because the property: `bar` returned a `string` value instead of a function. `cy.invoke()` can only be used on properties that return callable functions.')
+              expect(err.message).to.include('Timed out retrying after 100ms. `cy.invoke()` errored because the property: `bar` returned a `string` value instead of a function. `cy.invoke()` can only be used on properties that return callable functions.')
               expect(err.message).to.include('`cy.invoke()` waited for the specified property `bar` to return a function, but it never did.')
               expect(err.message).to.include('If you want to assert on the property\'s value, then switch to use `cy.its()` and add an assertion such as:')
               expect(err.message).to.include('`cy.wrap({ foo: \'bar\' }).its(\'foo\').should(\'eq\', \'bar\')`')
@@ -972,7 +972,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying: `cy.invoke()` errored because the property: `foo` does not exist on your subject.')
+            expect(err.message).to.include('Timed out retrying after 100ms. `cy.invoke()` errored because the property: `foo` does not exist on your subject.')
             expect(err.message).to.include('`cy.invoke()` waited for the specified property `foo` to exist, but it never did.')
             expect(err.message).to.include('If you do not expect the property `foo` to exist, then add an assertion such as:')
             expect(err.message).to.include('`cy.wrap({ foo: \'bar\' }).its(\'quux\').should(\'not.exist\')`')
@@ -1019,9 +1019,9 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.eq('Timed out retrying: expected \'foo\' to equal \'bar\'')
+            expect(err.message).to.eq('Timed out retrying after 100ms. expected \'foo\' to equal \'bar\'')
 
-            expect(lastLog.get('error').message).to.eq('Timed out retrying: expected \'foo\' to equal \'bar\'')
+            expect(lastLog.get('error').message).to.eq('Timed out retrying after 100ms. expected \'foo\' to equal \'bar\'')
 
             done()
           })
@@ -1033,7 +1033,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying: `cy.invoke()` errored because your subject is: `undefined`. You cannot invoke any functions such as `foo` on a `undefined` value.')
+            expect(err.message).to.include('Timed out retrying after 100ms. `cy.invoke()` errored because your subject is: `undefined`. You cannot invoke any functions such as `foo` on a `undefined` value.')
             expect(err.message).to.include('If you expect your subject to be `undefined`, then add an assertion such as:')
             expect(err.message).to.include('`cy.wrap(undefined).should(\'be.undefined\')`')
             expect(err.docsUrl).to.eq('https://on.cypress.io/invoke')
@@ -1049,7 +1049,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying: `cy.invoke()` errored because the property: `foo` is not a function, and instead returned a `undefined` value.')
+            expect(err.message).to.include('Timed out retrying after 100ms. `cy.invoke()` errored because the property: `foo` is not a function, and instead returned a `undefined` value.')
             expect(err.message).to.include('`cy.invoke()` waited for the specified property `foo` to become a callable function, but it never did.')
             expect(err.message).to.include('If you expect the property `foo` to be `undefined`, then switch to use `cy.its()` and add an assertion such as:')
             expect(err.message).to.include('`cy.wrap({ foo: undefined }).its(\'foo\').should(\'be.undefined\')`')
@@ -1066,7 +1066,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying: `cy.invoke()` errored because the property: `baz` does not exist on your subject.')
+            expect(err.message).to.include('Timed out retrying after 100ms. `cy.invoke()` errored because the property: `baz` does not exist on your subject.')
             expect(lastLog.get('error').message).to.include(err.message)
             expect(err.docsUrl).to.eq('https://on.cypress.io/invoke')
 
@@ -1522,7 +1522,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying: `cy.its()` errored because the property: `foo` does not exist on your subject.')
+            expect(err.message).to.include('Timed out retrying after 100ms. `cy.its()` errored because the property: `foo` does not exist on your subject.')
             expect(err.message).to.include('`cy.its()` waited for the specified property `foo` to exist, but it never did.')
             expect(err.message).to.include('If you do not expect the property `foo` to exist, then add an assertion such as:')
             expect(err.message).to.include('`cy.wrap({ foo: \'bar\' }).its(\'quux\').should(\'not.exist\')`')
@@ -1539,7 +1539,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying: `cy.its()` errored because the property: `foo` returned a `undefined` value.')
+            expect(err.message).to.include('Timed out retrying after 100ms. `cy.its()` errored because the property: `foo` returned a `undefined` value.')
             expect(err.message).to.include('`cy.its()` waited for the specified property `foo` to become accessible, but it never did.')
             expect(err.message).to.include('If you expect the property `foo` to be `undefined`, then add an assertion such as:')
             expect(err.message).to.include('`cy.wrap({ foo: undefined }).its(\'foo\').should(\'be.undefined\')`')
@@ -1556,7 +1556,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying: `cy.its()` errored because the property: `foo` returned a `null` value.')
+            expect(err.message).to.include('Timed out retrying after 100ms. `cy.its()` errored because the property: `foo` returned a `null` value.')
             expect(err.message).to.include('`cy.its()` waited for the specified property `foo` to become accessible, but it never did.')
             expect(err.message).to.include('If you expect the property `foo` to be `null`, then add an assertion such as:')
             expect(err.message).to.include('`cy.wrap({ foo: null }).its(\'foo\').should(\'be.null\')`')
@@ -1573,7 +1573,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying: `cy.its()` errored because the property: `b` does not exist on your subject.')
+            expect(err.message).to.include('Timed out retrying after 100ms. `cy.its()` errored because the property: `b` does not exist on your subject.')
             expect(err.message).to.include('`cy.its()` waited for the specified property `b` to exist, but it never did.')
             expect(err.message).to.include('If you do not expect the property `b` to exist, then add an assertion such as:')
             expect(err.message).to.include('`cy.wrap({ foo: \'bar\' }).its(\'quux\').should(\'not.exist\')`')
@@ -1590,7 +1590,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying: `cy.its()` errored because the property: `a` returned a `undefined` value.')
+            expect(err.message).to.include('Timed out retrying after 100ms. `cy.its()` errored because the property: `a` returned a `undefined` value.')
             expect(err.message).to.include('`cy.its()` waited for the specified property `a` to become accessible, but it never did.')
             expect(err.message).to.include('If you expect the property `a` to be `undefined`, then add an assertion such as:')
             expect(err.message).to.include('`cy.wrap({ foo: undefined }).its(\'foo\').should(\'be.undefined\')`')
@@ -1628,7 +1628,7 @@ describe('src/cy/commands/connectors', () => {
 
         it('can handle getter that throws', (done) => {
           const spy = cy.spy((err) => {
-            expect(err.message).to.eq('Timed out retrying: some getter error')
+            expect(err.message).to.eq('Timed out retrying after 100ms. some getter error')
 
             done()
           }).as('onFail')
@@ -1650,7 +1650,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying: `cy.its()` errored because the property: `baz` does not exist on your subject.')
+            expect(err.message).to.include('Timed out retrying after 100ms. `cy.its()` errored because the property: `baz` does not exist on your subject.')
             expect(err.docsUrl).to.eq('https://on.cypress.io/its')
             expect(lastLog.get('error').message).to.include(err.message)
             expect(lastLog.get('error').message).to.include(err.message)
@@ -1670,7 +1670,7 @@ describe('src/cy/commands/connectors', () => {
         [null, undefined].forEach((val) => {
           it(`throws on traversed '${val}' subject`, (done) => {
             cy.on('fail', (err) => {
-              expect(err.message).to.include(`Timed out retrying: \`cy.its()\` errored because the property: \`a\` returned a \`${val}\` value. The property: \`b\` does not exist on a \`${val}\` value.`)
+              expect(err.message).to.include(`Timed out retrying after 100ms. \`cy.its()\` errored because the property: \`a\` returned a \`${val}\` value. The property: \`b\` does not exist on a \`${val}\` value.`)
               expect(err.message).to.include('`cy.its()` waited for the specified property `b` to become accessible, but it never did.')
               expect(err.message).to.include('If you do not expect the property `b` to exist, then add an assertion such as:')
               expect(err.message).to.include(`\`cy.wrap({ foo: ${val} }).its('foo.baz').should('not.exist')\``)
@@ -1684,7 +1684,7 @@ describe('src/cy/commands/connectors', () => {
 
           it(`throws on initial '${val}' subject`, (done) => {
             cy.on('fail', (err) => {
-              expect(err.message).to.include(`Timed out retrying: \`cy.its()\` errored because your subject is: \`${val}\`. You cannot access any properties such as \`foo\` on a \`${val}\` value.`)
+              expect(err.message).to.include(`Timed out retrying after 100ms. \`cy.its()\` errored because your subject is: \`${val}\`. You cannot access any properties such as \`foo\` on a \`${val}\` value.`)
               expect(err.message).to.include(`If you expect your subject to be \`${val}\`, then add an assertion such as:`)
               expect(err.message).to.include(`\`cy.wrap(${val}).should('be.${val}')\``)
               expect(err.docsUrl).to.eq('https://on.cypress.io/its')
@@ -1767,7 +1767,7 @@ describe('src/cy/commands/connectors', () => {
           cy.on('fail', (err) => {
             const { lastLog } = this
 
-            expect(err.message).to.include('Timed out retrying: expected \'bar\' to equal \'baz\'')
+            expect(err.message).to.include('Timed out retrying after 200ms. expected \'bar\' to equal \'baz\'')
             expect(lastLog.get('error').message).to.include(err.message)
 
             done()

--- a/packages/driver/cypress/integration/commands/files_spec.js
+++ b/packages/driver/cypress/integration/commands/files_spec.js
@@ -252,7 +252,7 @@ describe('src/cy/commands/files', () => {
           expect(lastLog.get('state')).to.eq('failed')
 
           expect(err.message).to.eq(stripIndent`
-            Timed out retrying after 50ms. \`cy.readFile(\"foo.json\")\` failed because the file does not exist at the following path:
+            Timed out retrying after 50ms: \`cy.readFile(\"foo.json\")\` failed because the file does not exist at the following path:
 
             \`/path/to/foo.json\``)
 
@@ -274,7 +274,7 @@ describe('src/cy/commands/files', () => {
           expect(lastLog.get('error')).to.eq(err)
           expect(lastLog.get('state')).to.eq('failed')
           expect(err.message).to.eq(stripIndent`\
-            Timed out retrying after 50ms. \`cy.readFile(\"foo.json\")\` failed because the file exists when expected not to exist at the following path:
+            Timed out retrying after 50ms: \`cy.readFile(\"foo.json\")\` failed because the file exists when expected not to exist at the following path:
 
             \`/path/to/foo.json\``)
 
@@ -297,7 +297,7 @@ describe('src/cy/commands/files', () => {
           expect(this.logs.length).to.eq(1)
           expect(lastLog.get('error')).to.eq(err)
           expect(lastLog.get('state')).to.eq('failed')
-          expect(err.message).to.eq('Timed out retrying after 50ms. expected \'foo\' to equal \'contents\'')
+          expect(err.message).to.eq('Timed out retrying after 50ms: expected \'foo\' to equal \'contents\'')
 
           done()
         })

--- a/packages/driver/cypress/integration/commands/files_spec.js
+++ b/packages/driver/cypress/integration/commands/files_spec.js
@@ -252,7 +252,7 @@ describe('src/cy/commands/files', () => {
           expect(lastLog.get('state')).to.eq('failed')
 
           expect(err.message).to.eq(stripIndent`
-            Timed out retrying: \`cy.readFile(\"foo.json\")\` failed because the file does not exist at the following path:
+            Timed out retrying after 50ms. \`cy.readFile(\"foo.json\")\` failed because the file does not exist at the following path:
 
             \`/path/to/foo.json\``)
 
@@ -274,7 +274,7 @@ describe('src/cy/commands/files', () => {
           expect(lastLog.get('error')).to.eq(err)
           expect(lastLog.get('state')).to.eq('failed')
           expect(err.message).to.eq(stripIndent`\
-            Timed out retrying: \`cy.readFile(\"foo.json\")\` failed because the file exists when expected not to exist at the following path:
+            Timed out retrying after 50ms. \`cy.readFile(\"foo.json\")\` failed because the file exists when expected not to exist at the following path:
 
             \`/path/to/foo.json\``)
 
@@ -297,7 +297,7 @@ describe('src/cy/commands/files', () => {
           expect(this.logs.length).to.eq(1)
           expect(lastLog.get('error')).to.eq(err)
           expect(lastLog.get('state')).to.eq('failed')
-          expect(err.message).to.eq('Timed out retrying: expected \'foo\' to equal \'contents\'')
+          expect(err.message).to.eq('Timed out retrying after 50ms. expected \'foo\' to equal \'contents\'')
 
           done()
         })

--- a/packages/driver/cypress/integration/commands/querying_shadow_dom_spec.js
+++ b/packages/driver/cypress/integration/commands/querying_shadow_dom_spec.js
@@ -191,7 +191,7 @@ describe('src/cy/commands/querying - shadow dom', () => {
 
     it('has a custom error message if it cannot find a root', (done) => {
       cy.on('fail', (err) => {
-        expect(err.message).to.equal(`Timed out retrying after 0ms. Expected the subject to host a shadow root, but never found it.`)
+        expect(err.message).to.equal(`Timed out retrying after 0ms: Expected the subject to host a shadow root, but never found it.`)
         expect(err.docsUrl).to.equal('https://on.cypress.io/shadow')
 
         done()

--- a/packages/driver/cypress/integration/commands/querying_shadow_dom_spec.js
+++ b/packages/driver/cypress/integration/commands/querying_shadow_dom_spec.js
@@ -191,7 +191,7 @@ describe('src/cy/commands/querying - shadow dom', () => {
 
     it('has a custom error message if it cannot find a root', (done) => {
       cy.on('fail', (err) => {
-        expect(err.message).to.equal(`Timed out retrying: Expected the subject to host a shadow root, but never found it.`)
+        expect(err.message).to.equal(`Timed out retrying after 0ms. Expected the subject to host a shadow root, but never found it.`)
         expect(err.docsUrl).to.equal('https://on.cypress.io/shadow')
 
         done()

--- a/packages/driver/src/cy/retries.js
+++ b/packages/driver/src/cy/retries.js
@@ -66,7 +66,9 @@ const create = (Cypress, state, timeout, clearTimeout, whenStable, finishAsserti
 
         ({ error, onFail } = options)
 
-        const prependMsg = $errUtils.errByPath('miscellaneous.retry_timed_out').message
+        const prependMsg = $errUtils.errByPath('miscellaneous.retry_timed_out', {
+          ms: options._runnableTimeout,
+        }).message
 
         const retryErrProps = $errUtils.modifyErrMsg(error, prependMsg, (msg1, msg2) => {
           return `${msg2}${msg1}`

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -820,7 +820,9 @@ module.exports = {
       docsUrl: 'https://on.cypress.io/cannot-execute-commands-outside-test',
     },
     private_custom_command_interface: 'You cannot use the undocumented private command interface: `{{method}}`',
-    retry_timed_out: 'Timed out retrying: ',
+    retry_timed_out ({ ms }) {
+      return `Timed out retrying ${ms}ms: `
+    },
   },
 
   mocha: {

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -821,7 +821,7 @@ module.exports = {
     },
     private_custom_command_interface: 'You cannot use the undocumented private command interface: `{{method}}`',
     retry_timed_out ({ ms }) {
-      return `Timed out retrying after ${ms}ms. `
+      return `Timed out retrying after ${ms}ms: `
     },
   },
 

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -821,7 +821,7 @@ module.exports = {
     },
     private_custom_command_interface: 'You cannot use the undocumented private command interface: `{{method}}`',
     retry_timed_out ({ ms }) {
-      return `Timed out retrying ${ms}ms: `
+      return `Timed out retrying after ${ms}ms. `
     },
   },
 

--- a/packages/runner/cypress/integration/reporter.errors.spec.js
+++ b/packages/runner/cypress/integration/reporter.errors.spec.js
@@ -67,13 +67,13 @@ describe('errors ui', () => {
     verify.it('failure', {
       file,
       column: 8,
-      message: 'Timed out retrying after 0ms. Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 0ms: Expected to find element: #does-not-exist, but never found it',
     })
 
     verify.it('chained failure', {
       file,
       column: 20,
-      message: 'Timed out retrying after 0ms. Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 0ms: Expected to find element: #does-not-exist, but never found it',
     })
   })
 
@@ -95,7 +95,7 @@ describe('errors ui', () => {
     verify.it('command failure', {
       file,
       column: 10,
-      message: 'Timed out retrying after 0ms. Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 0ms: Expected to find element: #does-not-exist, but never found it',
     })
   })
 
@@ -117,13 +117,13 @@ describe('errors ui', () => {
     verify.it('standard assertion failure', {
       file,
       column: 6,
-      message: 'Timed out retrying after 0ms. expected {} to have property \'foo\'',
+      message: 'Timed out retrying after 0ms: expected {} to have property \'foo\'',
     })
 
     verify.it('after multiple', {
       file,
       column: 6,
-      message: 'Timed out retrying after 0ms. expected \'foo\' to equal \'bar\'',
+      message: 'Timed out retrying after 0ms: expected \'foo\' to equal \'bar\'',
     })
 
     verify.it('after multiple callbacks exception', {
@@ -150,7 +150,7 @@ describe('errors ui', () => {
     verify.it('command failure after success', {
       file,
       column: 8,
-      message: 'Timed out retrying after 0ms. Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 0ms: Expected to find element: #does-not-exist, but never found it',
     })
   })
 
@@ -523,7 +523,7 @@ describe('errors ui', () => {
     verify.it('command failure', {
       file,
       column: 6,
-      message: 'Timed out retrying after 0ms. Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 0ms: Expected to find element: #does-not-exist, but never found it',
       codeFrameText: `add('failCommand'`,
     })
   })
@@ -546,7 +546,7 @@ describe('errors ui', () => {
     verify.it('command failure', {
       file,
       column: 8,
-      message: 'Timed out retrying after 0ms. Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 0ms: Expected to find element: #does-not-exist, but never found it',
     })
   })
 

--- a/packages/runner/cypress/integration/reporter.errors.spec.js
+++ b/packages/runner/cypress/integration/reporter.errors.spec.js
@@ -67,13 +67,13 @@ describe('errors ui', () => {
     verify.it('failure', {
       file,
       column: 8,
-      message: 'Timed out retrying after 4000ms. Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 0ms. Expected to find element: #does-not-exist, but never found it',
     })
 
     verify.it('chained failure', {
       file,
       column: 20,
-      message: 'Timed out retrying after 4000ms. Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 0ms. Expected to find element: #does-not-exist, but never found it',
     })
   })
 
@@ -95,7 +95,7 @@ describe('errors ui', () => {
     verify.it('command failure', {
       file,
       column: 10,
-      message: 'Timed out retrying after 4000ms. Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 0ms. Expected to find element: #does-not-exist, but never found it',
     })
   })
 
@@ -117,13 +117,13 @@ describe('errors ui', () => {
     verify.it('standard assertion failure', {
       file,
       column: 6,
-      message: 'Timed out retrying after 4000ms. expected {} to have property \'foo\'',
+      message: 'Timed out retrying after 0ms. expected {} to have property \'foo\'',
     })
 
     verify.it('after multiple', {
       file,
       column: 6,
-      message: 'Timed out retrying after 4000ms. expected \'foo\' to equal \'bar\'',
+      message: 'Timed out retrying after 0ms. expected \'foo\' to equal \'bar\'',
     })
 
     verify.it('after multiple callbacks exception', {
@@ -150,7 +150,7 @@ describe('errors ui', () => {
     verify.it('command failure after success', {
       file,
       column: 8,
-      message: 'Timed out retrying after 4000ms. Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 0ms. Expected to find element: #does-not-exist, but never found it',
     })
   })
 
@@ -523,7 +523,7 @@ describe('errors ui', () => {
     verify.it('command failure', {
       file,
       column: 6,
-      message: 'Timed out retrying after 4000ms. Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 0ms. Expected to find element: #does-not-exist, but never found it',
       codeFrameText: `add('failCommand'`,
     })
   })
@@ -546,7 +546,7 @@ describe('errors ui', () => {
     verify.it('command failure', {
       file,
       column: 8,
-      message: 'Timed out retrying after 4000ms. Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 0ms. Expected to find element: #does-not-exist, but never found it',
     })
   })
 

--- a/packages/runner/cypress/integration/reporter.errors.spec.js
+++ b/packages/runner/cypress/integration/reporter.errors.spec.js
@@ -67,13 +67,13 @@ describe('errors ui', () => {
     verify.it('failure', {
       file,
       column: 8,
-      message: 'Timed out retrying: Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 4000ms. Expected to find element: #does-not-exist, but never found it',
     })
 
     verify.it('chained failure', {
       file,
       column: 20,
-      message: 'Timed out retrying: Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 4000ms. Expected to find element: #does-not-exist, but never found it',
     })
   })
 
@@ -95,7 +95,7 @@ describe('errors ui', () => {
     verify.it('command failure', {
       file,
       column: 10,
-      message: 'Timed out retrying: Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 4000ms. Expected to find element: #does-not-exist, but never found it',
     })
   })
 
@@ -117,13 +117,13 @@ describe('errors ui', () => {
     verify.it('standard assertion failure', {
       file,
       column: 6,
-      message: 'Timed out retrying: expected {} to have property \'foo\'',
+      message: 'Timed out retrying after 4000ms. expected {} to have property \'foo\'',
     })
 
     verify.it('after multiple', {
       file,
       column: 6,
-      message: 'Timed out retrying: expected \'foo\' to equal \'bar\'',
+      message: 'Timed out retrying after 4000ms. expected \'foo\' to equal \'bar\'',
     })
 
     verify.it('after multiple callbacks exception', {
@@ -150,7 +150,7 @@ describe('errors ui', () => {
     verify.it('command failure after success', {
       file,
       column: 8,
-      message: 'Timed out retrying: Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 4000ms. Expected to find element: #does-not-exist, but never found it',
     })
   })
 
@@ -523,7 +523,7 @@ describe('errors ui', () => {
     verify.it('command failure', {
       file,
       column: 6,
-      message: 'Timed out retrying: Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 4000ms. Expected to find element: #does-not-exist, but never found it',
       codeFrameText: `add('failCommand'`,
     })
   })
@@ -546,7 +546,7 @@ describe('errors ui', () => {
     verify.it('command failure', {
       file,
       column: 8,
-      message: 'Timed out retrying: Expected to find element: #does-not-exist, but never found it',
+      message: 'Timed out retrying after 4000ms. Expected to find element: #does-not-exist, but never found it',
     })
   })
 

--- a/packages/server/__snapshots__/1_caught_uncaught_hook_errors_spec.js
+++ b/packages/server/__snapshots__/1_caught_uncaught_hook_errors_spec.js
@@ -41,7 +41,7 @@ exports['e2e caught and uncaught hooks errors / failing1'] = `
 
   1) s1a
        "before each" hook for "t2a":
-     AssertionError: Timed out retrying after XX:XX: Expected to find element: \`.does-not-exist\`, but never found it.
+     AssertionError: Timed out retrying after 100ms: Expected to find element: \`.does-not-exist\`, but never found it.
 
 Because this error occurred during a \`before each\` hook we are skipping the remaining tests in the current suite: \`s1a\`
       [stack trace lines]

--- a/packages/server/__snapshots__/1_caught_uncaught_hook_errors_spec.js
+++ b/packages/server/__snapshots__/1_caught_uncaught_hook_errors_spec.js
@@ -41,7 +41,7 @@ exports['e2e caught and uncaught hooks errors / failing1'] = `
 
   1) s1a
        "before each" hook for "t2a":
-     AssertionError: Timed out retrying after XX:XX. Expected to find element: \`.does-not-exist\`, but never found it.
+     AssertionError: Timed out retrying after XX:XX: Expected to find element: \`.does-not-exist\`, but never found it.
 
 Because this error occurred during a \`before each\` hook we are skipping the remaining tests in the current suite: \`s1a\`
       [stack trace lines]

--- a/packages/server/__snapshots__/1_caught_uncaught_hook_errors_spec.js
+++ b/packages/server/__snapshots__/1_caught_uncaught_hook_errors_spec.js
@@ -41,7 +41,7 @@ exports['e2e caught and uncaught hooks errors / failing1'] = `
 
   1) s1a
        "before each" hook for "t2a":
-     AssertionError: Timed out retrying: Expected to find element: \`.does-not-exist\`, but never found it.
+     AssertionError: Timed out retrying after XX:XX. Expected to find element: \`.does-not-exist\`, but never found it.
 
 Because this error occurred during a \`before each\` hook we are skipping the remaining tests in the current suite: \`s1a\`
       [stack trace lines]

--- a/packages/server/__snapshots__/3_config_spec.js
+++ b/packages/server/__snapshots__/3_config_spec.js
@@ -92,7 +92,7 @@ exports['e2e config applies defaultCommandTimeout globally 1'] = `
 
   1) short defaultCommandTimeout
        times out looking for a missing element:
-     AssertionError: Timed out retrying: Expected to find element: \`#bar\`, but never found it.
+     AssertionError: Timed out retrying after  XX:XX. Expected to find element: \`#bar\`, but never found it.
       [stack trace lines]
 
 

--- a/packages/server/__snapshots__/3_config_spec.js
+++ b/packages/server/__snapshots__/3_config_spec.js
@@ -92,7 +92,7 @@ exports['e2e config applies defaultCommandTimeout globally 1'] = `
 
   1) short defaultCommandTimeout
        times out looking for a missing element:
-     AssertionError: Timed out retrying after  XX:XX. Expected to find element: \`#bar\`, but never found it.
+     AssertionError: Timed out retrying after  XX:XX: Expected to find element: \`#bar\`, but never found it.
       [stack trace lines]
 
 

--- a/packages/server/__snapshots__/3_config_spec.js
+++ b/packages/server/__snapshots__/3_config_spec.js
@@ -92,7 +92,7 @@ exports['e2e config applies defaultCommandTimeout globally 1'] = `
 
   1) short defaultCommandTimeout
        times out looking for a missing element:
-     AssertionError: Timed out retrying after  XX:XX: Expected to find element: \`#bar\`, but never found it.
+     AssertionError: Timed out retrying after 1000ms: Expected to find element: \`#bar\`, but never found it.
       [stack trace lines]
 
 

--- a/packages/server/__snapshots__/3_issue_173_spec.ts.js
+++ b/packages/server/__snapshots__/3_issue_173_spec.ts.js
@@ -24,7 +24,7 @@ exports['e2e issue 173 / failing'] = `
   1 failing
 
   1) fails:
-     AssertionError: Timed out retrying after XX:XX: Expected to find element: \`element_does_not_exist\`, but never found it.
+     AssertionError: Timed out retrying after 200ms: Expected to find element: \`element_does_not_exist\`, but never found it.
       [stack trace lines]
 
 

--- a/packages/server/__snapshots__/3_issue_173_spec.ts.js
+++ b/packages/server/__snapshots__/3_issue_173_spec.ts.js
@@ -24,7 +24,7 @@ exports['e2e issue 173 / failing'] = `
   1 failing
 
   1) fails:
-     AssertionError: Timed out retrying after XX:XX. Expected to find element: \`element_does_not_exist\`, but never found it.
+     AssertionError: Timed out retrying after XX:XX: Expected to find element: \`element_does_not_exist\`, but never found it.
       [stack trace lines]
 
 

--- a/packages/server/__snapshots__/3_issue_173_spec.ts.js
+++ b/packages/server/__snapshots__/3_issue_173_spec.ts.js
@@ -24,7 +24,7 @@ exports['e2e issue 173 / failing'] = `
   1 failing
 
   1) fails:
-     AssertionError: Timed out retrying: Expected to find element: \`element_does_not_exist\`, but never found it.
+     AssertionError: Timed out retrying after XX:XX. Expected to find element: \`element_does_not_exist\`, but never found it.
       [stack trace lines]
 
 

--- a/packages/server/__snapshots__/5_spec_isolation_spec.js
+++ b/packages/server/__snapshots__/5_spec_isolation_spec.js
@@ -441,7 +441,7 @@ exports['e2e spec_isolation fails [electron] 1'] = {
           ],
           "state": "failed",
           "body": "function() {\n    return cy.wrap(true, {\n      timeout: 100\n    }).should(\"be.false\");\n  }",
-          "displayError": "AssertionError: Timed out retrying after XX:XX: expected true to be false\n      [stack trace lines]",
+          "displayError": "AssertionError: Timed out retrying after 100ms: expected true to be false\n      [stack trace lines]",
           "attempts": [
             {
               "state": "failed",
@@ -1005,7 +1005,7 @@ exports['e2e spec_isolation fails [chrome] 1'] = {
           ],
           "state": "failed",
           "body": "function() {\n    return cy.wrap(true, {\n      timeout: 100\n    }).should(\"be.false\");\n  }",
-          "displayError": "AssertionError: Timed out retrying after XX:XX: expected true to be false\n      [stack trace lines]",
+          "displayError": "AssertionError: Timed out retrying after 100ms: expected true to be false\n      [stack trace lines]",
           "attempts": [
             {
               "state": "failed",
@@ -1569,7 +1569,7 @@ exports['e2e spec_isolation fails [firefox] 1'] = {
           ],
           "state": "failed",
           "body": "function() {\n    return cy.wrap(true, {\n      timeout: 100\n    }).should(\"be.false\");\n  }",
-          "displayError": "AssertionError: Timed out retrying after XX:XX: expected true to be false\n      [stack trace lines]",
+          "displayError": "AssertionError: Timed out retrying after 100ms: expected true to be false\n      [stack trace lines]",
           "attempts": [
             {
               "state": "failed",

--- a/packages/server/__snapshots__/5_spec_isolation_spec.js
+++ b/packages/server/__snapshots__/5_spec_isolation_spec.js
@@ -441,13 +441,13 @@ exports['e2e spec_isolation fails [electron] 1'] = {
           ],
           "state": "failed",
           "body": "function() {\n    return cy.wrap(true, {\n      timeout: 100\n    }).should(\"be.false\");\n  }",
-          "displayError": "AssertionError: Timed out retrying: expected true to be false\n      [stack trace lines]",
+          "displayError": "AssertionError: Timed out retrying after XX:XX. expected true to be false\n      [stack trace lines]",
           "attempts": [
             {
               "state": "failed",
               "error": {
                 "name": "AssertionError",
-                "message": "Timed out retrying: expected true to be false",
+                "message": "Timed out retrying after 100ms. expected true to be false",
                 "stack": "[stack trace lines]",
                 "codeFrame": {
                   "line": 3,
@@ -1005,13 +1005,13 @@ exports['e2e spec_isolation fails [chrome] 1'] = {
           ],
           "state": "failed",
           "body": "function() {\n    return cy.wrap(true, {\n      timeout: 100\n    }).should(\"be.false\");\n  }",
-          "displayError": "AssertionError: Timed out retrying: expected true to be false\n      [stack trace lines]",
+          "displayError": "AssertionError: Timed out retrying after XX:XX. expected true to be false\n      [stack trace lines]",
           "attempts": [
             {
               "state": "failed",
               "error": {
                 "name": "AssertionError",
-                "message": "Timed out retrying: expected true to be false",
+                "message": "Timed out retrying after 100ms. expected true to be false",
                 "stack": "[stack trace lines]",
                 "codeFrame": {
                   "line": 3,
@@ -1569,13 +1569,13 @@ exports['e2e spec_isolation fails [firefox] 1'] = {
           ],
           "state": "failed",
           "body": "function() {\n    return cy.wrap(true, {\n      timeout: 100\n    }).should(\"be.false\");\n  }",
-          "displayError": "AssertionError: Timed out retrying: expected true to be false\n      [stack trace lines]",
+          "displayError": "AssertionError: Timed out retrying after XX:XX. expected true to be false\n      [stack trace lines]",
           "attempts": [
             {
               "state": "failed",
               "error": {
                 "name": "AssertionError",
-                "message": "Timed out retrying: expected true to be false",
+                "message": "Timed out retrying after 100ms. expected true to be false",
                 "stack": "[stack trace lines]",
                 "codeFrame": {
                   "line": 3,

--- a/packages/server/__snapshots__/5_spec_isolation_spec.js
+++ b/packages/server/__snapshots__/5_spec_isolation_spec.js
@@ -441,13 +441,13 @@ exports['e2e spec_isolation fails [electron] 1'] = {
           ],
           "state": "failed",
           "body": "function() {\n    return cy.wrap(true, {\n      timeout: 100\n    }).should(\"be.false\");\n  }",
-          "displayError": "AssertionError: Timed out retrying after XX:XX. expected true to be false\n      [stack trace lines]",
+          "displayError": "AssertionError: Timed out retrying after XX:XX: expected true to be false\n      [stack trace lines]",
           "attempts": [
             {
               "state": "failed",
               "error": {
                 "name": "AssertionError",
-                "message": "Timed out retrying after 100ms. expected true to be false",
+                "message": "Timed out retrying after 100ms: expected true to be false",
                 "stack": "[stack trace lines]",
                 "codeFrame": {
                   "line": 3,
@@ -1005,13 +1005,13 @@ exports['e2e spec_isolation fails [chrome] 1'] = {
           ],
           "state": "failed",
           "body": "function() {\n    return cy.wrap(true, {\n      timeout: 100\n    }).should(\"be.false\");\n  }",
-          "displayError": "AssertionError: Timed out retrying after XX:XX. expected true to be false\n      [stack trace lines]",
+          "displayError": "AssertionError: Timed out retrying after XX:XX: expected true to be false\n      [stack trace lines]",
           "attempts": [
             {
               "state": "failed",
               "error": {
                 "name": "AssertionError",
-                "message": "Timed out retrying after 100ms. expected true to be false",
+                "message": "Timed out retrying after 100ms: expected true to be false",
                 "stack": "[stack trace lines]",
                 "codeFrame": {
                   "line": 3,
@@ -1569,13 +1569,13 @@ exports['e2e spec_isolation fails [firefox] 1'] = {
           ],
           "state": "failed",
           "body": "function() {\n    return cy.wrap(true, {\n      timeout: 100\n    }).should(\"be.false\");\n  }",
-          "displayError": "AssertionError: Timed out retrying after XX:XX. expected true to be false\n      [stack trace lines]",
+          "displayError": "AssertionError: Timed out retrying after XX:XX: expected true to be false\n      [stack trace lines]",
           "attempts": [
             {
               "state": "failed",
               "error": {
                 "name": "AssertionError",
-                "message": "Timed out retrying after 100ms. expected true to be false",
+                "message": "Timed out retrying after 100ms: expected true to be false",
                 "stack": "[stack trace lines]",
                 "codeFrame": {
                   "line": 3,

--- a/packages/server/__snapshots__/5_stdout_spec.js
+++ b/packages/server/__snapshots__/5_stdout_spec.js
@@ -458,7 +458,7 @@ exports['e2e stdout / displays assertion errors'] = `
   2) assertion errors
        fails with assertion diff, with retries:
 
-      AssertionError: Timed out retrying after  XX:XX: expected [] to deeply equal [ 1, 2, 3 ]
+      Timed out retrying after  XX:XX
       + expected - actual
 
       -[]

--- a/packages/server/__snapshots__/5_stdout_spec.js
+++ b/packages/server/__snapshots__/5_stdout_spec.js
@@ -458,7 +458,7 @@ exports['e2e stdout / displays assertion errors'] = `
   2) assertion errors
        fails with assertion diff, with retries:
 
-      AssertionError: Timed out retrying after  XX:XX. expected [] to deeply equal [ 1, 2, 3 ]
+      AssertionError: Timed out retrying after  XX:XX: expected [] to deeply equal [ 1, 2, 3 ]
       + expected - actual
 
       -[]
@@ -473,7 +473,7 @@ exports['e2e stdout / displays assertion errors'] = `
 
   4) assertion errors
        fails with dom assertion without diff, with retries:
-     AssertionError: Timed out retrying after  XX:XX. expected '<body>' to have class 'foo'
+     AssertionError: Timed out retrying after  XX:XX: expected '<body>' to have class 'foo'
       [stack trace lines]
 
 

--- a/packages/server/__snapshots__/5_stdout_spec.js
+++ b/packages/server/__snapshots__/5_stdout_spec.js
@@ -1,3 +1,115 @@
+exports['e2e stdout / displays assertion errors'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      1 found (stdout_assertion_errors_spec.js)                                          │
+  │ Searched:   cypress/integration/stdout_assertion_errors_spec.js                                │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  stdout_assertion_errors_spec.js                                                 (1 of 1)
+
+
+  assertion errors
+    1) fails with assertion diff, no retries
+    2) fails with assertion diff, with retries
+    3) fails with dom assertion without diff, with retries
+    4) fails with dom assertion without diff, with retries
+
+
+  0 passing
+  4 failing
+
+  1) assertion errors
+       fails with assertion diff, no retries:
+
+      AssertionError: expected [] to deeply equal [ 1, 2, 3 ]
+      + expected - actual
+
+      -[]
+      +[ 1, 2, 3 ]
+      
+      [stack trace lines]
+
+  2) assertion errors
+       fails with assertion diff, with retries:
+
+      AssertionError: Timed out retrying after  XX:XX. expected [] to deeply equal [ 1, 2, 3 ]
+      + expected - actual
+
+      -[]
+      +[ 1, 2, 3 ]
+      
+      [stack trace lines]
+
+  3) assertion errors
+       fails with dom assertion without diff, with retries:
+     AssertionError: expected '<body>' to have class 'foo'
+      [stack trace lines]
+
+  4) assertion errors
+       fails with dom assertion without diff, with retries:
+     AssertionError: Timed out retrying after  XX:XX. expected '<body>' to have class 'foo'
+      [stack trace lines]
+
+
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        4                                                                                │
+  │ Passing:      0                                                                                │
+  │ Failing:      4                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  4                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     stdout_assertion_errors_spec.js                                                  │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Screenshots)
+
+  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
+     s -- fails with assertion diff, no retries (failed).png                                        
+  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
+     s -- fails with assertion diff, with retries (failed).png                                      
+  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
+     s -- fails with dom assertion without diff, with retries (failed).png                          
+  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
+     s -- fails with dom assertion without diff, with retries (failed) (1).png                      
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/stdout_assertion_errors_spec.js     (X second)
+                          .mp4                                                                      
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✖  stdout_assertion_errors_spec.js          XX:XX        4        -        4        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✖  1 of 1 failed (100%)                     XX:XX        4        -        4        -        -  
+
+
+`
+
 exports['e2e stdout displays errors from failures 1'] = `
 
 ====================================================================================================
@@ -193,78 +305,6 @@ Fix the error in your code and re-run your tests.
 
 `
 
-exports['e2e stdout does not duplicate suites or tests between visits 1'] = `
-
-====================================================================================================
-
-  (Run Starting)
-
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Cypress:    1.2.3                                                                              │
-  │ Browser:    FooBrowser 88                                                                      │
-  │ Specs:      1 found (stdout_passing_spec.coffee)                                               │
-  │ Searched:   cypress/integration/stdout_passing_spec.coffee                                     │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-────────────────────────────────────────────────────────────────────────────────────────────────────
-                                                                                                    
-  Running:  stdout_passing_spec.coffee                                                      (1 of 1)
-
-
-  stdout_passing_spec
-    file
-      ✓ visits file
-    google
-      ✓ visits google
-      ✓ google2
-    apple
-      ✓ apple1
-      ✓ visits apple
-    subdomains
-      ✓ cypress1
-      ✓ visits cypress
-      ✓ cypress3
-
-
-  8 passing
-
-
-  (Results)
-
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        8                                                                                │
-  │ Passing:      8                                                                                │
-  │ Failing:      0                                                                                │
-  │ Pending:      0                                                                                │
-  │ Skipped:      0                                                                                │
-  │ Screenshots:  0                                                                                │
-  │ Video:        true                                                                             │
-  │ Duration:     X seconds                                                                        │
-  │ Spec Ran:     stdout_passing_spec.coffee                                                       │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Video)
-
-  -  Started processing:  Compressing to 32 CRF                                                     
-  -  Finished processing: /XXX/XXX/XXX/cypress/videos/stdout_passing_spec.coffee.mp4      (X second)
-
-
-====================================================================================================
-
-  (Run Finished)
-
-
-       Spec                                              Tests  Passing  Failing  Pending  Skipped  
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  stdout_passing_spec.coffee               XX:XX        8        8        -        -        - │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        8        8        -        -        -  
-
-
-`
-
 exports['e2e stdout displays fullname of nested specfile 1'] = `
 
 ====================================================================================================
@@ -411,141 +451,6 @@ exports['e2e stdout displays fullname of nested specfile 1'] = `
   │    pecfile.js                                                                                  │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
     ✔  All specs passed!                        XX:XX        3        3        -        -        -  
-
-
-`
-
-exports['e2e stdout / displays assertion errors'] = `
-
-====================================================================================================
-
-  (Run Starting)
-
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Cypress:    1.2.3                                                                              │
-  │ Browser:    FooBrowser 88                                                                      │
-  │ Specs:      1 found (stdout_assertion_errors_spec.js)                                          │
-  │ Searched:   cypress/integration/stdout_assertion_errors_spec.js                                │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-────────────────────────────────────────────────────────────────────────────────────────────────────
-                                                                                                    
-  Running:  stdout_assertion_errors_spec.js                                                 (1 of 1)
-
-
-  assertion errors
-    1) fails with assertion diff, no retries
-    2) fails with assertion diff, with retries
-    3) fails with dom assertion without diff, with retries
-    4) fails with dom assertion without diff, with retries
-
-
-  0 passing
-  4 failing
-
-  1) assertion errors
-       fails with assertion diff, no retries:
-
-      AssertionError: expected [] to deeply equal [ 1, 2, 3 ]
-      + expected - actual
-
-      -[]
-      +[ 1, 2, 3 ]
-      
-      [stack trace lines]
-
-  2) assertion errors
-       fails with assertion diff, with retries:
-
-      Timed out retrying
-      + expected - actual
-
-      -[]
-      +[ 1, 2, 3 ]
-      
-      [stack trace lines]
-
-  3) assertion errors
-       fails with dom assertion without diff, with retries:
-     AssertionError: expected '<body>' to have class 'foo'
-      [stack trace lines]
-
-  4) assertion errors
-       fails with dom assertion without diff, with retries:
-     AssertionError: Timed out retrying: expected '<body>' to have class 'foo'
-      [stack trace lines]
-
-
-
-
-  (Results)
-
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        4                                                                                │
-  │ Passing:      0                                                                                │
-  │ Failing:      4                                                                                │
-  │ Pending:      0                                                                                │
-  │ Skipped:      0                                                                                │
-  │ Screenshots:  4                                                                                │
-  │ Video:        true                                                                             │
-  │ Duration:     X seconds                                                                        │
-  │ Spec Ran:     stdout_assertion_errors_spec.js                                                  │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
-     s -- fails with assertion diff, no retries (failed).png                                        
-  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
-     s -- fails with assertion diff, with retries (failed).png                                      
-  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
-     s -- fails with dom assertion without diff, with retries (failed).png                          
-  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
-     s -- fails with dom assertion without diff, with retries (failed) (1).png                      
-
-
-  (Video)
-
-  -  Started processing:  Compressing to 32 CRF                                                     
-  -  Finished processing: /XXX/XXX/XXX/cypress/videos/stdout_assertion_errors_spec.js     (X second)
-                          .mp4                                                                      
-
-
-====================================================================================================
-
-  (Run Finished)
-
-
-       Spec                                              Tests  Passing  Failing  Pending  Skipped  
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✖  stdout_assertion_errors_spec.js          XX:XX        4        -        4        -        - │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✖  1 of 1 failed (100%)                     XX:XX        4        -        4        -        -  
-
-
-`
-
-exports['e2e stdout respects quiet mode 1'] = `
-
-
-  stdout_passing_spec
-    file
-      ✓ visits file
-    google
-      ✓ visits google
-      ✓ google2
-    apple
-      ✓ apple1
-      ✓ visits apple
-    subdomains
-      ✓ cypress1
-      ✓ visits cypress
-      ✓ cypress3
-
-
-  8 passing
 
 
 `

--- a/packages/server/__snapshots__/5_stdout_spec.js
+++ b/packages/server/__snapshots__/5_stdout_spec.js
@@ -458,7 +458,7 @@ exports['e2e stdout / displays assertion errors'] = `
   2) assertion errors
        fails with assertion diff, with retries:
 
-      Timed out retrying after  XX:XX
+      Timed out retrying after 4000ms
       + expected - actual
 
       -[]
@@ -473,7 +473,7 @@ exports['e2e stdout / displays assertion errors'] = `
 
   4) assertion errors
        fails with dom assertion without diff, with retries:
-     AssertionError: Timed out retrying after  XX:XX: expected '<body>' to have class 'foo'
+     AssertionError: Timed out retrying after 4000ms: expected '<body>' to have class 'foo'
       [stack trace lines]
 
 

--- a/packages/server/__snapshots__/5_stdout_spec.js
+++ b/packages/server/__snapshots__/5_stdout_spec.js
@@ -1,115 +1,3 @@
-exports['e2e stdout / displays assertion errors'] = `
-
-====================================================================================================
-
-  (Run Starting)
-
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Cypress:    1.2.3                                                                              │
-  │ Browser:    FooBrowser 88                                                                      │
-  │ Specs:      1 found (stdout_assertion_errors_spec.js)                                          │
-  │ Searched:   cypress/integration/stdout_assertion_errors_spec.js                                │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-────────────────────────────────────────────────────────────────────────────────────────────────────
-                                                                                                    
-  Running:  stdout_assertion_errors_spec.js                                                 (1 of 1)
-
-
-  assertion errors
-    1) fails with assertion diff, no retries
-    2) fails with assertion diff, with retries
-    3) fails with dom assertion without diff, with retries
-    4) fails with dom assertion without diff, with retries
-
-
-  0 passing
-  4 failing
-
-  1) assertion errors
-       fails with assertion diff, no retries:
-
-      AssertionError: expected [] to deeply equal [ 1, 2, 3 ]
-      + expected - actual
-
-      -[]
-      +[ 1, 2, 3 ]
-      
-      [stack trace lines]
-
-  2) assertion errors
-       fails with assertion diff, with retries:
-
-      AssertionError: Timed out retrying after  XX:XX. expected [] to deeply equal [ 1, 2, 3 ]
-      + expected - actual
-
-      -[]
-      +[ 1, 2, 3 ]
-      
-      [stack trace lines]
-
-  3) assertion errors
-       fails with dom assertion without diff, with retries:
-     AssertionError: expected '<body>' to have class 'foo'
-      [stack trace lines]
-
-  4) assertion errors
-       fails with dom assertion without diff, with retries:
-     AssertionError: Timed out retrying after  XX:XX. expected '<body>' to have class 'foo'
-      [stack trace lines]
-
-
-
-
-  (Results)
-
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        4                                                                                │
-  │ Passing:      0                                                                                │
-  │ Failing:      4                                                                                │
-  │ Pending:      0                                                                                │
-  │ Skipped:      0                                                                                │
-  │ Screenshots:  4                                                                                │
-  │ Video:        true                                                                             │
-  │ Duration:     X seconds                                                                        │
-  │ Spec Ran:     stdout_assertion_errors_spec.js                                                  │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
-     s -- fails with assertion diff, no retries (failed).png                                        
-  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
-     s -- fails with assertion diff, with retries (failed).png                                      
-  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
-     s -- fails with dom assertion without diff, with retries (failed).png                          
-  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
-     s -- fails with dom assertion without diff, with retries (failed) (1).png                      
-
-
-  (Video)
-
-  -  Started processing:  Compressing to 32 CRF                                                     
-  -  Finished processing: /XXX/XXX/XXX/cypress/videos/stdout_assertion_errors_spec.js     (X second)
-                          .mp4                                                                      
-
-
-====================================================================================================
-
-  (Run Finished)
-
-
-       Spec                                              Tests  Passing  Failing  Pending  Skipped  
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✖  stdout_assertion_errors_spec.js          XX:XX        4        -        4        -        - │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✖  1 of 1 failed (100%)                     XX:XX        4        -        4        -        -  
-
-
-`
-
 exports['e2e stdout displays errors from failures 1'] = `
 
 ====================================================================================================
@@ -305,6 +193,78 @@ Fix the error in your code and re-run your tests.
 
 `
 
+exports['e2e stdout does not duplicate suites or tests between visits 1'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      1 found (stdout_passing_spec.coffee)                                               │
+  │ Searched:   cypress/integration/stdout_passing_spec.coffee                                     │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  stdout_passing_spec.coffee                                                      (1 of 1)
+
+
+  stdout_passing_spec
+    file
+      ✓ visits file
+    google
+      ✓ visits google
+      ✓ google2
+    apple
+      ✓ apple1
+      ✓ visits apple
+    subdomains
+      ✓ cypress1
+      ✓ visits cypress
+      ✓ cypress3
+
+
+  8 passing
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        8                                                                                │
+  │ Passing:      8                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     stdout_passing_spec.coffee                                                       │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/stdout_passing_spec.coffee.mp4      (X second)
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✔  stdout_passing_spec.coffee               XX:XX        8        8        -        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✔  All specs passed!                        XX:XX        8        8        -        -        -  
+
+
+`
+
 exports['e2e stdout displays fullname of nested specfile 1'] = `
 
 ====================================================================================================
@@ -451,6 +411,141 @@ exports['e2e stdout displays fullname of nested specfile 1'] = `
   │    pecfile.js                                                                                  │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
     ✔  All specs passed!                        XX:XX        3        3        -        -        -  
+
+
+`
+
+exports['e2e stdout / displays assertion errors'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      1 found (stdout_assertion_errors_spec.js)                                          │
+  │ Searched:   cypress/integration/stdout_assertion_errors_spec.js                                │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  stdout_assertion_errors_spec.js                                                 (1 of 1)
+
+
+  assertion errors
+    1) fails with assertion diff, no retries
+    2) fails with assertion diff, with retries
+    3) fails with dom assertion without diff, with retries
+    4) fails with dom assertion without diff, with retries
+
+
+  0 passing
+  4 failing
+
+  1) assertion errors
+       fails with assertion diff, no retries:
+
+      AssertionError: expected [] to deeply equal [ 1, 2, 3 ]
+      + expected - actual
+
+      -[]
+      +[ 1, 2, 3 ]
+      
+      [stack trace lines]
+
+  2) assertion errors
+       fails with assertion diff, with retries:
+
+      AssertionError: Timed out retrying after  XX:XX. expected [] to deeply equal [ 1, 2, 3 ]
+      + expected - actual
+
+      -[]
+      +[ 1, 2, 3 ]
+      
+      [stack trace lines]
+
+  3) assertion errors
+       fails with dom assertion without diff, with retries:
+     AssertionError: expected '<body>' to have class 'foo'
+      [stack trace lines]
+
+  4) assertion errors
+       fails with dom assertion without diff, with retries:
+     AssertionError: Timed out retrying after  XX:XX. expected '<body>' to have class 'foo'
+      [stack trace lines]
+
+
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        4                                                                                │
+  │ Passing:      0                                                                                │
+  │ Failing:      4                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  4                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     stdout_assertion_errors_spec.js                                                  │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Screenshots)
+
+  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
+     s -- fails with assertion diff, no retries (failed).png                                        
+  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
+     s -- fails with assertion diff, with retries (failed).png                                      
+  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
+     s -- fails with dom assertion without diff, with retries (failed).png                          
+  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors_spec.js/assertion error     (1280x720)
+     s -- fails with dom assertion without diff, with retries (failed) (1).png                      
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/stdout_assertion_errors_spec.js     (X second)
+                          .mp4                                                                      
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✖  stdout_assertion_errors_spec.js          XX:XX        4        -        4        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✖  1 of 1 failed (100%)                     XX:XX        4        -        4        -        -  
+
+
+`
+
+exports['e2e stdout respects quiet mode 1'] = `
+
+
+  stdout_passing_spec
+    file
+      ✓ visits file
+    google
+      ✓ visits google
+      ✓ google2
+    apple
+      ✓ apple1
+      ✓ visits apple
+    subdomains
+      ✓ cypress1
+      ✓ visits cypress
+      ✓ cypress3
+
+
+  8 passing
 
 
 `

--- a/packages/server/__snapshots__/6_web_security_spec.js
+++ b/packages/server/__snapshots__/6_web_security_spec.js
@@ -98,7 +98,7 @@ https://on.cypress.io/cross-origin-violation
 
   4) web security
        fails when doing a CORS request cross-origin:
-     AssertionError: Timed out retrying: Expected to find content: 'success!' but never did.
+     AssertionError: Timed out retrying after XX:XX. Expected to find content: 'success!' but never did.
       [stack trace lines]
 
 

--- a/packages/server/__snapshots__/6_web_security_spec.js
+++ b/packages/server/__snapshots__/6_web_security_spec.js
@@ -98,7 +98,7 @@ https://on.cypress.io/cross-origin-violation
 
   4) web security
        fails when doing a CORS request cross-origin:
-     AssertionError: Timed out retrying after XX:XX. Expected to find content: 'success!' but never did.
+     AssertionError: Timed out retrying after XX:XX: Expected to find content: 'success!' but never did.
       [stack trace lines]
 
 

--- a/packages/server/__snapshots__/6_web_security_spec.js
+++ b/packages/server/__snapshots__/6_web_security_spec.js
@@ -98,7 +98,7 @@ https://on.cypress.io/cross-origin-violation
 
   4) web security
        fails when doing a CORS request cross-origin:
-     AssertionError: Timed out retrying after XX:XX: Expected to find content: 'success!' but never did.
+     AssertionError: Timed out retrying after 500ms: Expected to find content: 'success!' but never did.
       [stack trace lines]
 
 

--- a/packages/server/test/support/helpers/e2e.ts
+++ b/packages/server/test/support/helpers/e2e.ts
@@ -43,6 +43,8 @@ const browserNameVersionRe = /(Browser\:\s+)(Custom |)(Electron|Chrome|Canary|Ch
 const availableBrowsersRe = /(Available browsers found on your system are:)([\s\S]+)/g
 const crossOriginErrorRe = /(Blocked a frame .* from accessing a cross-origin frame.*|Permission denied.*cross-origin object.*)/gm
 const whiteSpaceBetweenNewlines = /\n\s+\n/
+const retryDuration = /Timed out retrying after (\d+)ms/g
+const escapedRetryDuration = /TORA(\d+)/g
 
 export const STDOUT_DURATION_IN_TABLES_RE = /(\s+?)(\d+ms|\d+:\d+:?\d+)/g
 
@@ -154,8 +156,12 @@ const normalizeStdout = function (str, options: any = {}) {
   .replace(browserNameVersionRe, replaceBrowserName)
   // numbers in parenths
   .replace(/\s\(\d+([ms]|ms)\)/g, '')
+  // escape "Timed out retrying" messages
+  .replace(retryDuration, 'TORA$1')
   // 12:35 -> XX:XX
   .replace(STDOUT_DURATION_IN_TABLES_RE, replaceDurationInTables)
+  // restore "Timed out retrying" messages
+  .replace(escapedRetryDuration, 'Timed out retrying after $1ms')
   .replace(/(coffee|js)-\d{3}/g, '$1-456')
   // Cypress: 2.1.0 -> Cypress: 1.2.3
   .replace(/(Cypress\:\s+)(\d+\.\d+\.\d+)/g, replaceCypressVersion)


### PR DESCRIPTION
- Closes #5781

### User facing changelog

Retry timeout error message now contains timeout period.

### Additional details
- Why was this change necessary? => It wasn't clear how long the timeout was.
- What is affected by this change? => N/A
- Any implementation details to explain? => It simply shows the difference. 

### How has the user experience changed?

**Before:**

![Screenshot from 2020-11-09 16-11-04](https://user-images.githubusercontent.com/8130013/98510462-7e12aa00-22a6-11eb-877e-ea735cec5cbe.png)

**After:**

![Screenshot from 2020-11-09 16-09-56](https://user-images.githubusercontent.com/8130013/98510468-80750400-22a6-11eb-987e-b30bb6ff3dc4.png)

### Questions

I intentionally stopped the CI because there are some problems to solve. 

* Is error message OK? Maybe there might be better copy.
* Should we should the timeout period number every time? If it's the default, should we hide it?
* Maybe it's not an important information and just closing the issue might be the solution. 

Without these questions cleared, editing error messages in the tests is meaningless.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
