### PR TITLE
chore: Create webpack5 release channel for webpack prepocessor

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -2,5 +2,6 @@ module.exports = {
   ...require('./.releaserc.base'),
   branches: [
     'master',
+    { name: 'chore/webpack-5', channel: 'channel-webpack5' },
   ],
 }

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -2,6 +2,6 @@ module.exports = {
   ...require('./.releaserc.base'),
   branches: [
     'master',
-    { name: 'chore/webpack-5', channel: 'channel-webpack5' },
+    { name: 'chore/webpack-5', channel: 'channel-next' },
   ],
 }


### PR DESCRIPTION
Make a semantic release channel to publish prerelease version of webpack-preprocessor that supports webpack v5 #8929