### PR TITLE
fix: Handle non-error empty objects from release notes service

### DIFF
--- a/packages/desktop-gui/cypress/integration/release_notes_spec.js
+++ b/packages/desktop-gui/cypress/integration/release_notes_spec.js
@@ -43,6 +43,15 @@ describe('Release Notes', () => {
     cy.contains('Update to Version 1.2.3').should('be.visible')
   })
 
+  it('shows update instructions if release notes does not include title or content', () => {
+    // if this hasn't been released on on.cypress.io yet, it will use the default redirect
+    // and not a 404 error, which returns an empty object
+    // also protects against the data not being correct in any case
+    getReleaseNotes.resolve({})
+    cy.get('.update-notice').contains('Learn more').click()
+    cy.contains('Update to Version 1.2.3').should('be.visible')
+  })
+
   it('shows update instructions if getting release notes errors', () => {
     getReleaseNotes.reject(new Error('something went wrong'))
     cy.get('.update-notice').contains('Learn more').click()

--- a/packages/desktop-gui/src/update/updates.js
+++ b/packages/desktop-gui/src/update/updates.js
@@ -42,10 +42,17 @@ export const getReleaseNotes = (version) => {
 
   ipc.getReleaseNotes(version)
   .then((releaseNotes) => {
+    if (!releaseNotes || !releaseNotes.title || !releaseNotes.content) {
+      updateStore.setReleaseNotes(undefined)
+      updateStore.setState(updateStore.SHOW_INSTRUCTIONS)
+
+      return
+    }
+
     updateStore.setReleaseNotes(releaseNotes)
-    updateStore.setState(releaseNotes ? updateStore.SHOW_RELEASE_NOTES : updateStore.SHOW_INSTRUCTIONS)
+    updateStore.setState(updateStore.SHOW_RELEASE_NOTES)
   })
-  .catch((err) => {
+  .catch(() => {
     updateStore.setReleaseNotes(undefined)
     updateStore.setState(updateStore.SHOW_INSTRUCTIONS)
   })


### PR DESCRIPTION

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

N/A - only an issue in `develop` 

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

I made a false assumption that `on.cypress.io` would return 404 for a non-supported path (e.g. `/release-notes/1.2.3`), which will happen if the in-app release notes feature is released before the new version of `on.cypress.io` is deployed (seems likely to happen). In reality, it tries to redirect to the docs and returns an empty object. In that case, the desktop gui would think there were release notes when there weren't and display a release notes modal with `undefined` instead of going straight to the update instructions.


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Before:

![Screen Shot 2020-11-09 at 10 17 26 AM](https://user-images.githubusercontent.com/1157043/98559588-cadd8d00-2274-11eb-9a13-9f5995727337.png)


After:

![Screen Shot 2020-11-09 at 10 18 20 AM](https://user-images.githubusercontent.com/1157043/98559674-e779c500-2274-11eb-962b-ca61841e59d0.png)



### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- N/A Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
