### PR TITLE
docs(contributing.md): remove "Testing" toc entry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,6 @@ Thanks for taking the time to contribute! :smile:
 - [Committing Code](#committing-code)
   - [Branches](#branches)
   - [Pull Requests](#pull-requests)
-  - [Testing](#testing)
   - [Dependencies](#dependencies)
 - [Reviewing Code](#reviewing-code)
   - [Some rules about Code Review](#Some-rules-about-Code-Review)


### PR DESCRIPTION
The Committing > Testing section was removed in https://github.com/cypress-io/cypress/commit/5842d1dffe32831dcfe2349b928f4386f47db980

Potential Contributors are now not confused anymore when nothing happens after clicking on "Testing" ;)
