### PR TITLE
feat: deprecate experimentalFetchPolyfill

### DIFF
--- a/packages/server/lib/config_options.ts
+++ b/packages/server/lib/config_options.ts
@@ -289,5 +289,9 @@ export const breakingOptions = [
     name: 'experimentalShadowDomSupport',
     errorKey: 'EXPERIMENTAL_SHADOW_DOM_REMOVED',
     isWarning: true,
+  }, {
+    name: 'experimentalFetchPolyfill',
+    errorKey: 'EXPERIMENTAL_FETCH_POLYFILL_DEPRECATED',
+    isWarning: true,
   },
 ]

--- a/packages/server/lib/config_options.ts
+++ b/packages/server/lib/config_options.ts
@@ -71,7 +71,6 @@ export const options = [
     isExperimental: true,
   }, {
     name: 'experimentalFetchPolyfill',
-    defaultValue: false,
     validation: v.isBoolean,
     isExperimental: true,
   }, {
@@ -276,7 +275,18 @@ export const options = [
   },
 ]
 
-export const breakingOptions = [
+type BreakingOption = {
+  // Breaking config key
+  name: string
+  // Error or warning key
+  errorKey: string
+  // If this is a renamed config key, this is the new name
+  newName?: string
+  // Set to `true` to only throw a warning, not an error
+  isWarning?: boolean
+}
+
+export const breakingOptions: BreakingOption[] = [
   {
     name: 'blacklistHosts',
     errorKey: 'RENAMED_CONFIG_OPTION',

--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -905,7 +905,9 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
       return stripIndent`\
         The \`experimentalFetchPolyfill\` configuration option was deprecated in Cypress version \`6.0.0\`. It will be removed in a future release.
 
-        Consider using \`cy.http()\` to intercept fetch calls instead.`
+        Consider using \`cy.http()\` to intercept fetch calls instead.
+
+        https://on.cypress.io/http`
     case 'EXPERIMENTAL_NETWORK_STUBBING_REMOVED':
       return stripIndent`\
         The \`experimentalNetworkStubbing\` configuration option was removed in Cypress version \`6.0.0\`.

--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -901,6 +901,11 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
         The \`experimentalShadowDomSupport\` configuration option was removed in Cypress version \`5.2.0\`. It is no longer necessary when utilizing the \`includeShadowDom\` option.
 
         You can safely remove this option from your config.`
+    case 'EXPERIMENTAL_FETCH_POLYFILL_DEPRECATED':
+      return stripIndent`\
+        The \`experimentalFetchPolyfill\` configuration option was deprecated in Cypress version \`6.0.0\`. It will be removed in a future release.
+
+        Consider using \`cy.http()\` to intercept fetch calls instead.`
     case 'INCOMPATIBLE_PLUGIN_RETRIES':
       return stripIndent`\
       We've detected that the incompatible plugin \`cypress-plugin-retries\` is installed at \`${arg1}\`.

--- a/packages/server/test/e2e/0_fetch_polyfill_spec.js
+++ b/packages/server/test/e2e/0_fetch_polyfill_spec.js
@@ -141,6 +141,11 @@ describe('e2e fetch polyfill', () => {
     config: {
       experimentalFetchPolyfill: true,
     },
+    onRun: async (exec) => {
+      const { stdout } = await exec()
+
+      expect(stdout).to.include('The `experimentalFetchPolyfill` configuration option was deprecated in Cypress version `6.0.0`. It will be removed in a future release.')
+    },
   })
 })
 

--- a/packages/server/test/support/helpers/e2e.ts
+++ b/packages/server/test/support/helpers/e2e.ts
@@ -437,7 +437,7 @@ const e2e = {
 
       this.timeout(human('2 minutes'))
 
-      // Fixtures.remove()
+      Fixtures.remove()
 
       const s = this.servers
 

--- a/packages/server/test/support/helpers/e2e.ts
+++ b/packages/server/test/support/helpers/e2e.ts
@@ -437,7 +437,7 @@ const e2e = {
 
       this.timeout(human('2 minutes'))
 
-      Fixtures.remove()
+      // Fixtures.remove()
 
       const s = this.servers
 

--- a/packages/server/test/unit/config_spec.js
+++ b/packages/server/test/unit/config_spec.js
@@ -1166,7 +1166,6 @@ describe('lib/config', () => {
             env: {},
             execTimeout: { value: 60000, from: 'default' },
             experimentalComponentTesting: { value: false, from: 'default' },
-            experimentalFetchPolyfill: { value: false, from: 'default' },
             experimentalNetworkStubbing: { value: false, from: 'default' },
             experimentalSourceRewriting: { value: false, from: 'default' },
             fileServerFolder: { value: '', from: 'default' },
@@ -1244,7 +1243,6 @@ describe('lib/config', () => {
             defaultCommandTimeout: { value: 4000, from: 'default' },
             execTimeout: { value: 60000, from: 'default' },
             experimentalComponentTesting: { value: false, from: 'default' },
-            experimentalFetchPolyfill: { value: false, from: 'default' },
             experimentalNetworkStubbing: { value: false, from: 'default' },
             experimentalSourceRewriting: { value: false, from: 'default' },
             env: {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...


* Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
* Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
* Mark this PR as "Draft" if it is not ready for review.
-->
* Closes <!-- issue number here. e.g. "Closes #1234" -->

### User facing changelog
* Deprecated the `experimentalFetchPolyfill` experimental option. Consider using `cy.http()` to stub `fetch` requests instead.

### Additional details
<!-- Examples:


* Why was this change necessary?
* What is affected by this change?
* Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

#### After

<img width="1099" alt="Screen Shot 2020-11-18 at 12 44 18 PM" src="https://user-images.githubusercontent.com/1271364/99492368-d5e29c80-299b-11eb-921b-8a4fc8022998.png">


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

* [x] Have tests been added/updated?
* [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
* [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->https://github.com/cypress-io/cypress-documentation/pull/3330
* [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
* [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?

