### PR TITLE
fix: negated assertions passing w/o existence check

### DIFF
--- a/packages/desktop-gui/cypress/integration/error_message_spec.js
+++ b/packages/desktop-gui/cypress/integration/error_message_spec.js
@@ -164,7 +164,7 @@ describe('Error Message', function () {
     this.start()
 
     cy.get('.error')
-    cy.get('details.stacktrace > summary').should('not.be.visible')
+    cy.get('details.stacktrace > summary').should('not.exist')
   })
 
   it('shows abbreviated error details if only one line', function () {

--- a/packages/desktop-gui/cypress/integration/project_nav_spec.js
+++ b/packages/desktop-gui/cypress/integration/project_nav_spec.js
@@ -294,7 +294,7 @@ describe('Project Nav', function () {
           })
 
           it('hides close browser button', () => {
-            cy.get('.close-browser').should('not.be.visible')
+            cy.get('.close-browser').should('not.exist')
           })
 
           it('re-enables browser dropdown', () => {

--- a/packages/desktop-gui/cypress/integration/project_nav_spec.js
+++ b/packages/desktop-gui/cypress/integration/project_nav_spec.js
@@ -44,7 +44,7 @@ describe('Project Nav', function () {
     })
 
     it('displays projects nav', function () {
-      cy.get('.empty').should('not.be.visible')
+      cy.get('.empty').should('not.exist')
 
       cy.get('.navbar-default')
     })
@@ -380,7 +380,7 @@ describe('Project Nav', function () {
 
       it('displays no dropdown btn', () => {
         cy.get('.browsers-list')
-        .find('.dropdown-toggle').should('not.be.visible')
+        .find('.dropdown-toggle').should('not.exist')
 
         cy.percySnapshot()
       })

--- a/packages/desktop-gui/cypress/integration/setup_project_modal_spec.js
+++ b/packages/desktop-gui/cypress/integration/setup_project_modal_spec.js
@@ -142,7 +142,7 @@ describe('Connect to Dashboard', function () {
         })
 
         it('lists organizations to assign to project', function () {
-          cy.get('.empty-select-orgs').should('not.be.visible')
+          cy.get('.empty-select-orgs').should('not.exist')
           cy.get('.organizations-select__dropdown-indicator').click()
           cy.get('.organizations-select__menu').should('be.visible')
           cy.get('.organizations-select__option')
@@ -185,7 +185,7 @@ describe('Connect to Dashboard', function () {
         })
 
         it('lists organizations to assign to project', function () {
-          cy.get('.empty-select-orgs').should('not.be.visible')
+          cy.get('.empty-select-orgs').should('not.exist')
           cy.get('.organizations-select__dropdown-indicator').click()
           cy.get('.organizations-select__menu').should('be.visible')
           cy.get('.organizations-select__option')
@@ -222,8 +222,8 @@ describe('Connect to Dashboard', function () {
 
         it('displays empty message', () => {
           cy.get('.empty-select-orgs').should('be.visible')
-          cy.get('.organizations-select').should('not.be.visible')
-          cy.get('.privacy-radio').should('not.be.visible')
+          cy.get('.organizations-select').should('not.exist')
+          cy.get('.privacy-radio').should('not.exist')
           cy.percySnapshot()
         })
 
@@ -436,7 +436,7 @@ describe('Connect to Dashboard', function () {
         })
 
         it('closes modal', () => {
-          cy.get('.modal').should('not.be.visible')
+          cy.get('.modal').should('not.exist')
         })
 
         it('updates localStorage projects cache', () => {

--- a/packages/desktop-gui/cypress/integration/setup_project_modal_spec.js
+++ b/packages/desktop-gui/cypress/integration/setup_project_modal_spec.js
@@ -223,7 +223,7 @@ describe('Connect to Dashboard', function () {
         it('displays empty message', () => {
           cy.get('.empty-select-orgs').should('be.visible')
           cy.get('.organizations-select').should('not.exist')
-          cy.get('.privacy-radio').should('not.exist')
+          cy.get('.privacy-radio').should('not.be.visible')
           cy.percySnapshot()
         })
 

--- a/packages/desktop-gui/cypress/integration/specs_list_spec.js
+++ b/packages/desktop-gui/cypress/integration/specs_list_spec.js
@@ -857,7 +857,7 @@ describe('Specs List', function () {
 
         it('closes modal when cancel is clicked', function () {
           cy.contains('Cancel').click()
-          cy.contains('Set preference and open file').should('not.be.visible')
+          cy.contains('Set preference and open file').should('not.exist')
         })
 
         describe('when editor is not selected', function () {
@@ -905,7 +905,7 @@ describe('Specs List', function () {
           })
 
           it('closes modal', function () {
-            cy.contains('Set preference and open file').should('not.be.visible')
+            cy.contains('Set preference and open file').should('not.exist')
           })
 
           it('sets user editor', function () {

--- a/packages/desktop-gui/cypress/integration/update_modal_spec.js
+++ b/packages/desktop-gui/cypress/integration/update_modal_spec.js
@@ -69,7 +69,7 @@ describe('Update Modal', () => {
       cy.get('.footer .version').click()
       cy.get('.modal').find('.close').click()
 
-      cy.get('.modal').should('not.be.visible')
+      cy.get('.modal').should('not.exist')
     })
   })
 

--- a/packages/desktop-gui/cypress/integration/warning_message_spec.js
+++ b/packages/desktop-gui/cypress/integration/warning_message_spec.js
@@ -183,7 +183,7 @@ describe('Warning Message', function () {
         this.pingBaseUrl.resolve()
       })
 
-      cy.get('.alert-warning').should('not.be.visible')
+      cy.get('.alert-warning').should('not.exist')
     })
 
     it('shows real error if one results from pinging baseUrl', function () {
@@ -239,8 +239,7 @@ describe('Warning Message', function () {
 
       cy.get('.alert-warning .close').click()
       cy.get('.alert-warning')
-      .should('not.contain', 'Some warning')
-      .should('not.contain', 'Other message')
+      .should('not.exist')
     })
   })
 })

--- a/packages/desktop-gui/src/settings/file-preference_spec.jsx
+++ b/packages/desktop-gui/src/settings/file-preference_spec.jsx
@@ -32,14 +32,14 @@ describe('FilePreference', () => {
       { alias: 'FilePreference', stylesheets: '/__root/dist/app.css' },
     )
 
-    cy.get('.file-preference').should('not.be.visible')
+    cy.get('.file-preference').should('not.exist')
     cy.log('**Opening file preferences**')
     cy.contains('File Opener Preference').click()
     cy.get('.file-preference').should('be.visible')
     cy.get('.loading-editors').should('be.visible')
 
     cy.log('**Editors loaded**')
-    cy.get('.loading-editors').should('not.be.visible')
+    cy.get('.loading-editors').should('not.exist')
     cy.contains('Visual Studio Code').closest('li').should('have.class', 'is-selected')
   })
 })

--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -127,13 +127,6 @@ describe('src/cy/commands/assertions', () => {
       }).should('deep.eq', { foo: 'baz' })
     })
 
-    // https://github.com/cypress-io/cypress/issues/5763
-    it('shows selector name used in the test when an element is not found', () => {
-      cy.get('it-should-not-exist').should('not.be.visible').then(function () {
-        expect(this.logs[1].get('message')).to.eq('expected **it-should-not-exist** not to be **visible**')
-      })
-    })
-
     describe('function argument', () => {
       it('waits until function is true', () => {
         const button = cy.$$('button:first')
@@ -1160,6 +1153,19 @@ describe('src/cy/commands/assertions', () => {
         cy.noop('foobar').should('contain', 'oob')
       })
 
+      it('fails not.contain for non-existent DOM', function (done) {
+        cy.timeout(100)
+        cy.on('fail', ({ message }) => {
+          expect(message)
+          .include('.non-existent')
+          .include('but never found it')
+
+          done()
+        })
+
+        cy.get('.non-existent').should('not.contain', 'foo')
+      })
+
       // https://github.com/cypress-io/cypress/issues/3549
       it('is true when DOM el and not jQuery el contains text', () => {
         cy.get('div').then(($el) => {
@@ -1240,11 +1246,91 @@ describe('src/cy/commands/assertions', () => {
       it('jquery wrapping els and selectors, not changing subject', () => {
         cy.wrap(cy.$$('<div></div>').appendTo('body')).should('not.be.visible')
         cy.wrap(cy.$$('<div></div>')).should('not.exist')
-        cy.wrap(cy.$$('<div></div>').appendTo('body')).should('not.be.visible').should('exist')
-        cy.wrap(cy.$$('.non-existent')).should('not.be.visible').should('not.exist')
+        cy.wrap(cy.$$('<div></div>').appendTo('body')).should('exist')
         cy.wrap(cy.$$('.non-existent')).should('not.exist')
+      })
 
-        cy.wrap(cy.$$('.non-existent')).should('not.be.visible').should('not.exist')
+      describe('does not pass not.visible for non-dom', function () {
+        beforeEach(function () {
+          return Cypress.config('defaultCommandTimeout', 50)
+        })
+
+        it('undefined', function (done) {
+          let spy
+
+          spy = cy.spy(function (err) {
+            expect(err.message).to.contain('attempted to make')
+
+            return done()
+          }).as('onFail')
+
+          cy.on('fail', spy)
+
+          return cy.wrap().should('not.be.visible')
+        })
+
+        it('null', function (done) {
+          let spy
+
+          spy = cy.spy(function (err) {
+            expect(err.message).to.contain('attempted to make')
+
+            return done()
+          }).as('onFail')
+
+          cy.on('fail', spy)
+
+          return cy.wrap(null).should('not.be.visible')
+        })
+
+        it('[]', function (done) {
+          let spy
+
+          spy = cy.spy(function (err) {
+            expect(err.message).to.contain('attempted to make')
+
+            return done()
+          }).as('onFail')
+
+          cy.on('fail', spy)
+
+          return cy.wrap([]).should('not.be.visible')
+        })
+
+        it('{}', function (done) {
+          let spy
+
+          spy = cy.spy(function (err) {
+            expect(err.message).to.contain('attempted to make')
+
+            return done()
+          }).as('onFail')
+
+          cy.on('fail', spy)
+
+          return cy.wrap({}).should('not.be.visible')
+        })
+
+        it('fails not.visible for detached DOM', function (done) {
+          cy.on('fail', (err) => {
+            expect(err.message).include('detached')
+            done()
+          })
+
+          cy.get('<div></div>').should('not.be.visible')
+        })
+
+        it('fails not.visible for non-existent DOM', function (done) {
+          cy.on('fail', (err) => {
+            // prints selector on failure
+            // https://github.com/cypress-io/cypress/issues/5763
+            expect(err.message).include('.non-existent')
+            expect(err.message).include('Expected to find')
+            done()
+          })
+
+          cy.get('.non-existent', { timeout: 10 }).should('not.visible')
+        })
       })
     })
 
@@ -2721,12 +2807,12 @@ describe('src/cy/commands/assertions', () => {
   context('cross-origin iframe', () => {
     it(`doesn't throw when iframe exists`, () => {
       cy.visit('fixtures/cross_origin.html')
-      cy.get('.foo').should('not.be.visible')
+      cy.get('.foo').should('not.exist')
     })
 
     it(`doesn't throw when iframe with name attribute exists`, () => {
       cy.visit('fixtures/cross_origin_name.html')
-      cy.get('.foo').should('not.be.visible')
+      cy.get('.foo').should('not.exist')
     })
   })
 })

--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -1153,7 +1153,8 @@ describe('src/cy/commands/assertions', () => {
         cy.noop('foobar').should('contain', 'oob')
       })
 
-      it('fails not.contain for non-existent DOM', function (done) {
+      // https://github.com/cypress-io/cypress/issues/205
+      it('fails existence check on not.contain for non-existent DOM', function (done) {
         cy.timeout(100)
         cy.on('fail', ({ message }) => {
           expect(message)
@@ -1250,6 +1251,7 @@ describe('src/cy/commands/assertions', () => {
         cy.wrap(cy.$$('.non-existent')).should('not.exist')
       })
 
+      // https://github.com/cypress-io/cypress/issues/205
       describe('does not pass not.visible for non-dom', function () {
         beforeEach(function () {
           return Cypress.config('defaultCommandTimeout', 50)

--- a/packages/driver/cypress/integration/e2e/focus_blur_spec.js
+++ b/packages/driver/cypress/integration/e2e/focus_blur_spec.js
@@ -722,10 +722,10 @@ describe('intercept blur methods correctly', () => {
 
       expect(stub).not.called
 
-      cy.get('no-focus-1').should('not.be.visible')
-      cy.get('no-focus-2').should('not.be.visible')
-      cy.get('no-focus-3').should('not.be.visible')
-      cy.get('no-focus-4').should('not.be.visible')
+      cy.get('#no-focus-1').should('not.be.visible')
+      cy.get('#no-focus-2').should('not.be.visible')
+      cy.get('#no-focus-3').should('not.be.visible')
+      cy.get('#no-focus-4').should('not.be.visible')
     })
   })
 

--- a/packages/driver/src/cy/chai.js
+++ b/packages/driver/src/cy/chai.js
@@ -265,7 +265,7 @@ chai.use((chai, u) => {
       return (function (text) {
         let obj = this._obj
 
-        if (!($dom.isJquery(obj) || $dom.isElement(obj))) {
+        if (!($dom.isElement(obj))) {
           return _super.apply(this, arguments)
         }
 

--- a/packages/driver/src/cy/ensures.js
+++ b/packages/driver/src/cy/ensures.js
@@ -172,8 +172,11 @@ const create = (state, expect) => {
 
   const ensureAttached = (subject, name, onFail) => {
     if ($dom.isDetached(subject)) {
-      const cmd = name ?? state('current').get('name')
-      const prev = state('current').get('prev').get('name')
+      const current = state('current')
+
+      const cmd = name ?? current.get('name')
+
+      const prev = current.get('prev') ? current.get('prev').get('name') : current.get('name')
       const node = $dom.stringify(subject)
 
       return $errUtils.throwErrByPath('subject.not_attached', {

--- a/packages/driver/src/cypress/chai_jquery.js
+++ b/packages/driver/src/cypress/chai_jquery.js
@@ -36,11 +36,12 @@ const $chaiJquery = (chai, chaiUtils, callbacks = {}) => {
   const { inspect, flag } = chaiUtils
 
   const assertDom = (ctx, method, ...args) => {
-    if (!$dom.isDom(ctx._obj)) {
+    if (!$dom.isDom(ctx._obj) && !$dom.isJquery(ctx._obj)) {
       try {
         // always fail the assertion
         // if we aren't a DOM like object
-        return ctx.assert(false, ...args)
+        // depends on the "negate" flag
+        return ctx.assert(!!ctx.__flags.negate, ...args)
       } catch (err) {
         return callbacks.onInvalid(method, ctx._obj)
       }
@@ -62,6 +63,9 @@ const $chaiJquery = (chai, chaiUtils, callbacks = {}) => {
         // Because of that, wrap() above removes selector property.
         // That's why we're caching the value of selector above and using it here.
         ctx._obj = selector
+        // if no element found, fail the existence check
+        // depends on the negate flag
+        ctx.assert(!!ctx.__flags.negate, ...args)
       }
 
       // apply the assertion

--- a/packages/reporter/cypress/integration/test_errors_spec.js
+++ b/packages/reporter/cypress/integration/test_errors_spec.js
@@ -317,7 +317,7 @@ describe('test errors', function () {
 
       cy
       .get('.test-err-code-frame')
-      .should('not.be.visible')
+      .should('not.exist')
     })
 
     it('use correct language class', function () {

--- a/packages/reporter/cypress/support/utils.js
+++ b/packages/reporter/cypress/support/utils.js
@@ -110,7 +110,7 @@ export const itHandlesFileOpening = (selector, file, stackTrace = false) => {
       })
 
       it('closes modal', function () {
-        cy.contains('Set preference and open file').should('not.be.visible')
+        cy.contains('Set preference and open file').should('not.exist')
       })
 
       it('emits set:user:editor', function () {

--- a/packages/runner/cypress/integration/retries.ui.spec.js
+++ b/packages/runner/cypress/integration/retries.ui.spec.js
@@ -147,7 +147,7 @@ describe('runner/cypress retries.ui.spec', { viewportWidth: 600, viewportHeight:
       cy.get(attemptTag(3)).parentsUntil('.collapsible').last().parent().within(() => {
         cy.get('.instruments-container').should('contain', 'Spies / Stubs (2)')
         cy.get('.instruments-container').should('contain', 'Routes (2)')
-        cy.get('.runnable-err').should('not.contain', 'AssertionError')
+        cy.get('.runnable-err').should('not.exist')
       })
     })
 

--- a/packages/ui-components/cypress/integration/file-opener_spec.jsx
+++ b/packages/ui-components/cypress/integration/file-opener_spec.jsx
@@ -99,7 +99,7 @@ describe('<FileOpener />', () => {
       cy.get('.file-opener').click()
       cy.contains('Sublime Text').click()
       cy.contains('Cancel').click()
-      cy.contains('Set preference and open file').should('not.be.visible')
+      cy.contains('Set preference and open file').should('not.exist')
     })
 
     it('initially has no editors chosen', () => {
@@ -173,7 +173,7 @@ describe('<FileOpener />', () => {
       cy.get('.file-opener').click()
       cy.contains('Sublime Text').click()
       cy.get('.submit').click()
-      cy.contains('Set preference and open file').should('not.be.visible')
+      cy.contains('Set preference and open file').should('not.exist')
     })
   })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->

- fix #205

- Docs PR: https://github.com/cypress-io/cypress-documentation/pull/1375

reboot of #3268 
### User facing changelog
BREAKING: bug fix: negated assertions on element assertions no longer pass when an element cannot be found in the DOM
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

### Additional details

fixes a bug where this would be a passing assertion:
```js
expect({}).to.not.have.html('')
// or
cy.get('does-not-exist').should('not.contain', 'foo')
```
 (which should fail telling user `{}` is not a dom node), but our technique to "force" a failing assertion was not taking account whether the negation flag was set

<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
