### PR TITLE
chore: Add deprecated warnings to cy.route() and cy.server() in types

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1477,8 +1477,10 @@ declare namespace Cypress {
     root<E extends Node = HTMLHtmlElement>(options?: Partial<Loggable>): Chainable<JQuery<E>> // can't do better typing unless we ignore the `.within()` case
 
     /**
+     * Deprecated - use `cy.http()` instead.
+     * @deprecated
+     * 
      * Use `cy.route()` to manage the behavior of network requests.
-     *
      * @see https://on.cypress.io/route
      * @example
      *    cy.server()
@@ -1486,6 +1488,9 @@ declare namespace Cypress {
      */
     route(url: string | RegExp, response?: string | object): Chainable<null>
     /**
+     * Deprecated - use `cy.http()` instead.
+     * @deprecated
+     *
      * Spy or stub request with specific method and url.
      *
      * @see https://on.cypress.io/route
@@ -1496,6 +1501,9 @@ declare namespace Cypress {
      */
     route(method: string, url: string | RegExp, response?: string | object): Chainable<null>
     /**
+     * Deprecated - use `cy.http()` instead.
+     * @deprecated
+     *
      * Set a route by returning an object literal from a callback function.
      * Functions that return a Promise will automatically be awaited.
      *
@@ -1514,6 +1522,9 @@ declare namespace Cypress {
      */
     route(fn: () => RouteOptions): Chainable<null>
     /**
+     * Deprecated - use `cy.http()` instead.
+     * @deprecated
+     *
      * Spy or stub a given route.
      *
      * @see https://on.cypress.io/route
@@ -1530,6 +1541,9 @@ declare namespace Cypress {
     route(options: Partial<RouteOptions>): Chainable<null>
 
     /**
+     * Deprecated - use `cy.http()` instead.
+     * @deprecated
+     *
      * Take a screenshot of the application under test and the Cypress Command Log.
      *
      * @see https://on.cypress.io/screenshot
@@ -1581,6 +1595,9 @@ declare namespace Cypress {
     select(value: string | string[], options?: Partial<SelectOptions>): Chainable<Subject>
 
     /**
+     * Deprecated - use `cy.http()` instead.
+     * @deprecated
+     *
      * Start a server to begin routing responses to `cy.route()` and `cy.request()`.
      *
      * @example

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1477,8 +1477,7 @@ declare namespace Cypress {
     root<E extends Node = HTMLHtmlElement>(options?: Partial<Loggable>): Chainable<JQuery<E>> // can't do better typing unless we ignore the `.within()` case
 
     /**
-     * Deprecated - use `cy.http()` instead.
-     * @deprecated
+     * @deprecated Use `cy.http()` instead.
      * 
      * Use `cy.route()` to manage the behavior of network requests.
      * @see https://on.cypress.io/route
@@ -1488,8 +1487,7 @@ declare namespace Cypress {
      */
     route(url: string | RegExp, response?: string | object): Chainable<null>
     /**
-     * Deprecated - use `cy.http()` instead.
-     * @deprecated
+     * @deprecated Use `cy.http()` instead.
      *
      * Spy or stub request with specific method and url.
      *
@@ -1501,8 +1499,7 @@ declare namespace Cypress {
      */
     route(method: string, url: string | RegExp, response?: string | object): Chainable<null>
     /**
-     * Deprecated - use `cy.http()` instead.
-     * @deprecated
+     * @deprecated Use `cy.http()` instead.
      *
      * Set a route by returning an object literal from a callback function.
      * Functions that return a Promise will automatically be awaited.
@@ -1522,8 +1519,7 @@ declare namespace Cypress {
      */
     route(fn: () => RouteOptions): Chainable<null>
     /**
-     * Deprecated - use `cy.http()` instead.
-     * @deprecated
+     * @deprecated Use `cy.http()` instead.
      *
      * Spy or stub a given route.
      *
@@ -1541,8 +1537,7 @@ declare namespace Cypress {
     route(options: Partial<RouteOptions>): Chainable<null>
 
     /**
-     * Deprecated - use `cy.http()` instead.
-     * @deprecated
+     * @deprecated Use `cy.http()` instead.
      *
      * Take a screenshot of the application under test and the Cypress Command Log.
      *

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1478,7 +1478,7 @@ declare namespace Cypress {
 
     /**
      * @deprecated Use `cy.http()` instead.
-     * 
+     *
      * Use `cy.route()` to manage the behavior of network requests.
      * @see https://on.cypress.io/route
      * @example

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1590,8 +1590,7 @@ declare namespace Cypress {
     select(value: string | string[], options?: Partial<SelectOptions>): Chainable<Subject>
 
     /**
-     * Deprecated - use `cy.http()` instead.
-     * @deprecated
+     * @deprecated Use `cy.http()` instead.
      *
      * Start a server to begin routing responses to `cy.route()` and `cy.request()`.
      *


### PR DESCRIPTION
There was some discussion in our Issues Review meeting on how to improve deprecation warnings. One suggestion was to clearly mark the commands as deprecated in types.

### User Changelog

N/A

### Additiional Details

- This may be a pretty strict warning depending on how the user has their TS setup. We do sometimes get people opening issues that are like "Cypress is broken", when it's only a TypeScript rule that they don't realize they can disable. I dunno, I feel like without this people will have no idea we're planning to remove this next version, but maybe this is too aggressive with this release. 
- Maybe the deprecation wording could be clearer? I didn't feel like it was quite right to remove all examples/descriptions from the deprecated commands. Thoughts are welcome.
- I believe the deprecated command will show up with a strikethrough in some IDEs like below. Having a hard time thinking of how to even preview this 🤔 

![3497b11e-11f1-11e7-8c96-18882394310e](https://user-images.githubusercontent.com/1271364/99615057-1fd58c00-2a49-11eb-9525-4352574460a5.png)
