### PR TITLE
feat: Add option to --disable-dev-shm-usage by default in Chrome

### DIFF
--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -106,6 +106,10 @@ const DEFAULT_ARGS = [
   '--disable-breakpad',
   '--password-store=basic',
   '--use-mock-keychain',
+
+  // write shared memory files into '/tmp' instead of '/dev/shm'
+  // https://github.com/cypress-io/cypress/issues/5336
+  '--disable-dev-shm-usage',
 ]
 
 /**


### PR DESCRIPTION
- close #5336 
- TR-505

### User Changelog

We now pass `—disable-dev-shm-usage` to the Chrome browser flags by default. This will write shared memory files into `/tmp` instead of `/dev/shm`.

### Additional Details

- We have to recommend to users to pass this flag on their own *a lot* because they encounter Chrome crashing otherwise. Frequently this is an issue in docker, as noted in our docs:
	>In a Docker container, the default size of the /dev/shm shared memory space is 64MB. This is not typically enough to run Chrome and can cause the browser to crash. You can fix this by passing the `--disable-dev-shm-usage` flag to Chrome with the following workaround:
- Previously @flotwig had noted the fact that we don’t have Chrome headless browser support as a possible reasoning why this option was causing issues for us. https://github.com/cypress-io/cypress/issues/5336#issue-505290346 Opening PR again to see if we see the same failures. 
- Users will still be able to remove this flag in the future if necessary, which I feel would be a smaller use case (I think they would be isolated to running multiple Cypress instances on one container, which we don't recommend anyways). They may want to instead  to increase the shared memory size instead, which there is a flag for.
	```js
    module.exports = (on, config) => {
      on('before:browser:launch', (browser = {}, launchOptions) => {
        if (browser.family === 'chromium' && browser.name !== 'electron')  {
          launchOptions.args = launchOptions.args.filter(arg => arg !== '--disable-dev-shm-usage')
		  // launchOptions.args.push('--shm-size=1G') // maybe increase the shared memory size instead

          return launchOptions
        }
      })
    }
    ```

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->