### PR TITLE
feat(cli): add --component to the version command

### DIFF
--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -1,3 +1,4 @@
+// @ts-check
 const _ = require('lodash')
 const R = require('ramda')
 const commander = require('commander')
@@ -160,16 +161,67 @@ function includesVersion (args) {
   )
 }
 
-function showVersions () {
+function showVersions (args) {
   debug('printing Cypress version')
+  debug('additional arguments %o', args)
 
-  return require('./exec/versions')
-  .getVersions()
-  .then((versions = {}) => {
+  const versionParser = commander.option(
+    '--component <package|binary|electron|node>', 'component to report version for',
+  )
+  .allowUnknownOption(true)
+  const parsed = versionParser.parse(args)
+  const parsedOptions = {
+    component: parsed.component,
+  }
+
+  debug('parsed version arguments %o', parsedOptions)
+
+  const reportAllVersions = (versions) => {
     logger.always('Cypress package version:', versions.package)
     logger.always('Cypress binary version:', versions.binary)
     logger.always('Electron version:', versions.electronVersion)
     logger.always('Bundled Node version:', versions.electronNodeVersion)
+  }
+
+  const reportComponentVersion = (componentName, versions) => {
+    const names = {
+      package: 'package',
+      binary: 'binary',
+      electron: 'electronVersion',
+      node: 'electronNodeVersion',
+    }
+
+    if (!names[componentName]) {
+      throw new Error(`Unknown component name "${componentName}"`)
+    }
+
+    const name = names[componentName]
+
+    if (!versions[name]) {
+      throw new Error(`Cannot find version for component "${componentName}" under property "${name}"`)
+    }
+
+    const version = versions[name]
+
+    logger.always(version)
+  }
+
+  const defaultVersions = {
+    package: undefined,
+    binary: undefined,
+    electronVersion: undefined,
+    electronNodeVersion: undefined,
+  }
+
+  return require('./exec/versions')
+  .getVersions()
+  .then((versions = defaultVersions) => {
+    if (parsedOptions.component) {
+      reportComponentVersion(parsedOptions.component, versions)
+    } else {
+      reportAllVersions(versions)
+    }
+
     process.exit(0)
   })
   .catch(util.logErrorExit1)
@@ -322,7 +374,9 @@ module.exports = {
     .option('-v, --version', text('version'))
     .command('version')
     .description(text('version'))
-    .action(showVersions)
+    .action(() => {
+      showVersions(args)
+    })
 
     addCypressRunCommand(program)
     .action((...fnArgs) => {
@@ -462,7 +516,7 @@ module.exports = {
       // and now does not understand top level options
       // .option('-v, --version').command('version')
       // so we have to manually catch '-v, --version'
-      return showVersions()
+      return showVersions(args)
     }
 
     debug('program parsing arguments')
@@ -471,6 +525,7 @@ module.exports = {
   },
 }
 
+// @ts-ignore
 if (!module.parent) {
   logger.error('This CLI module should be required from another Node module')
   logger.error('and not executed directly')


### PR DESCRIPTION
- Closes #9214

### User facing changelog

```
$ node ./bin/cypress version --help
Usage: cypress [options]

Options:
  --component <package|binary|electron|node>  component to report version for
  -h, --help                                  display help for command`
```

You can still report all versions like before. In this case, I am running this from the monorepo, in actual project these versions would have numbers

```
$ node ./bin/cypress version
Cypress package version: 0.0.0
Cypress binary version: not installed
Electron version: not found
Bundled Node version: not found
```

But with this PR you can grab just an individual version

```
$ node ./bin/cypress version --component package
0.0.0
$ node ./bin/cypress version --component electron
not found
```

etc.

### Additional details

When building Docker images, it would be nice to validate the Node version matches the bundled Node version for example

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/3339
