### PR TITLE
fix: prevent cy.type from losing focus from element on blur

### DIFF
--- a/packages/driver/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_spec.js
@@ -2041,6 +2041,16 @@ describe('src/cy/commands/actions/type - #type', () => {
         })
       })
 
+      // https://github.com/cypress-io/cypress/issues/5480
+      it('does NOT follow focus if target is blurred without another receiving focus', () => {
+        cy.$$('input:first').keydown(_.after(4, function () {
+          this.blur()
+        }))
+
+        cy.get('input:first').type('foobar')
+        .should('have.value', 'foobar')
+      })
+
       it('follows focus into date input', () => {
         cy.$$('input:first').on('input', _.after(3, _.once((e) => {
           cy.$$('input[type=date]:first').focus()


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->

- Closes #5480
_however, there are unlreated behaviors to the original being mentioned in that issue, which are not fixed_

### User facing changelog
Bug fix: fix issue causing cy.type to not type the entire string into the target element (regression from 3.5.0)
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

### Additional details

- this prevents issues with page loads / framework rerenders sometimes causing focus to be lost by an element mid-type, causing characters to be typed into the body instead of the input.
- not a breaking change since this only affects typing when element is blurred mid-type, and cy.type will still follow focus mid-type unless the new element is `body` or `null` (element was blurred, no new element was focused)
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
