### PR TITLE
fix: Fix selector TypeError when an assertion failed in afterEach

### DIFF
--- a/packages/driver/src/cypress/chai_jquery.js
+++ b/packages/driver/src/cypress/chai_jquery.js
@@ -53,7 +53,7 @@ const $chaiJquery = (chai, chaiUtils, callbacks = {}) => {
     try {
       // reset obj to wrapped
       const orig = ctx._obj
-      const selector = ctx._obj.selector
+      const selector = orig ? orig.selector : undefined
 
       ctx._obj = wrap(ctx)
 


### PR DESCRIPTION
* Closes #9207
* It might be related with #8277 because showing multiple errors can solve the root problem.

### User facing changelog
Fix selector TypeError when an assertion failed in afterEach

### Additional details
* Why was this change necessary? => Make code work even when assertions are used in `afterEach`.
* What is affected by this change? => N/A
* Any implementation details to explain? => N/A

### Note
Actually, I'm still not sure if this is the right direction. This PR is more of bringing back the buggy behavior before 5.3.0 to the current version than fixing the problem. 

When you check the issue, you can find that there are 2 problems:

1. The assertion failed in the `afterEach`, but it doesn't alarm and stop the test suite but goes on. 
1. Retry attempts are logged. (It's not a natural Cypress behavior.) 

### How has the user experience changed?
N/A

### PR Tasks
* [ ] Have tests been added/updated?
* [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->

