### PR TITLE
chore: Update assertion to be more explicit about element existence

### DIFF
--- a/npm/react/examples/nextjs/cypress/components/Page.spec.jsx
+++ b/npm/react/examples/nextjs/cypress/components/Page.spec.jsx
@@ -15,10 +15,7 @@ describe('NextJS page', () => {
   it('It doesn\'t run the `.getInitialProps()`', () => {
     mount(<IndexPage />)
 
-    cy.get('[data-testid="server-result"').should(
-      'not.contain',
-      '`.getInitialProps()` was called and passed props to this component',
-    )
+    cy.get('[data-testid="server-result"').should('not.exist')
   })
 
   it('Allows to manually mock the server side props', () => {


### PR DESCRIPTION
In Cypress 6.0 (`develop`), we fail the `cy.get()` is the element does not exist in the DOM instead of potentially falsely passing. See https://github.com/cypress-io/cypress/pull/9239