### PR TITLE
chore: Fix Response type.

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -5250,7 +5250,8 @@ declare namespace Cypress {
     duration: number
     headers: { [key: string]: string }
     isOkStatusCode: boolean
-    redirectedToUrl: string
+    redirects?: string[]
+    redirectedToUrl?: string
     requestHeaders: { [key: string]: string }
     status: number
     statusText: string

--- a/cli/types/tests/kitchen-sink.ts
+++ b/cli/types/tests/kitchen-sink.ts
@@ -84,6 +84,10 @@ cy.request({
   url: "http://localhost:3000/myressource",
   method: "POST",
   body: {}
+}).then((resp) => {
+  resp // $ExpectType Response
+  resp.redirectedToUrl // $ExpectType string | undefined
+  resp.redirects // $ExpectTyep string[] | undefined
 })
 
 // specify query parameters


### PR DESCRIPTION
- Closes #9120 

### User facing changelog

Added the type of `redirects` and changed `redirectedToUrl` optional. 

### Additional details
- Why was this change necessary? => `redirects` was missing and `redirectedToUrl` was wrong.
- What is affected by this change? => N/A
- Any implementation details to explain?

The following code told me that the type of `redirects` is `string[]`.

https://github.com/cypress-io/cypress/blob/91b900958b4b97ff4cb67450c768fe8408acc370/packages/server/lib/request.js#L727

I checked the code below and learned that `redirectedToUrl` isn't removed. It was optional. 

https://github.com/cypress-io/cypress/blob/91b900958b4b97ff4cb67450c768fe8408acc370/packages/server/lib/request.js#L748-L761

### How has the user experience changed?

N/A

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Add/Update tests.
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->