### PR TITLE
 feat(net-stubbing): rename cy.http to cy.intercept 

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1477,7 +1477,7 @@ declare namespace Cypress {
     root<E extends Node = HTMLHtmlElement>(options?: Partial<Loggable>): Chainable<JQuery<E>> // can't do better typing unless we ignore the `.within()` case
 
     /**
-     * @deprecated Use `cy.http()` instead.
+     * @deprecated Use `cy.intercept()` instead.
      *
      * Use `cy.route()` to manage the behavior of network requests.
      * @see https://on.cypress.io/route
@@ -1487,7 +1487,7 @@ declare namespace Cypress {
      */
     route(url: string | RegExp, response?: string | object): Chainable<null>
     /**
-     * @deprecated Use `cy.http()` instead.
+     * @deprecated Use `cy.intercept()` instead.
      *
      * Spy or stub request with specific method and url.
      *
@@ -1499,7 +1499,7 @@ declare namespace Cypress {
      */
     route(method: string, url: string | RegExp, response?: string | object): Chainable<null>
     /**
-     * @deprecated Use `cy.http()` instead.
+     * @deprecated Use `cy.intercept()` instead.
      *
      * Set a route by returning an object literal from a callback function.
      * Functions that return a Promise will automatically be awaited.
@@ -1519,7 +1519,7 @@ declare namespace Cypress {
      */
     route(fn: () => RouteOptions): Chainable<null>
     /**
-     * @deprecated Use `cy.http()` instead.
+     * @deprecated Use `cy.intercept()` instead.
      *
      * Spy or stub a given route.
      *
@@ -1537,7 +1537,7 @@ declare namespace Cypress {
     route(options: Partial<RouteOptions>): Chainable<null>
 
     /**
-     * @deprecated Use `cy.http()` instead.
+     * @deprecated Use `cy.intercept()` instead.
      *
      * Take a screenshot of the application under test and the Cypress Command Log.
      *
@@ -1590,7 +1590,7 @@ declare namespace Cypress {
     select(value: string | string[], options?: Partial<SelectOptions>): Chainable<Subject>
 
     /**
-     * @deprecated Use `cy.http()` instead.
+     * @deprecated Use `cy.intercept()` instead.
      *
      * Start a server to begin routing responses to `cy.route()` and `cy.request()`.
      *

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -240,7 +240,7 @@ describe('then', () => {
 
 cy.wait(['@foo', '@bar'])
   .then(([first, second]) => {
-    first // $ExpectType Request
+    first // $ExpectType Interception
   })
 
 cy.wait(1234) // $ExpectType Chainable<undefined>

--- a/packages/desktop-gui/cypress/integration/release_notes_spec.js
+++ b/packages/desktop-gui/cypress/integration/release_notes_spec.js
@@ -10,7 +10,7 @@ describe('Release Notes', () => {
 
     cy.fixture('user').then((theUser) => user = theUser)
     cy.fixture('release_notes').then((theReleaseNotes) => releaseNotes = theReleaseNotes)
-    cy.http('cypress-banner.jpg', { fixture: 'cypress-banner.jpg' })
+    cy.intercept('cypress-banner.jpg', { fixture: 'cypress-banner.jpg' })
 
     cy.visitIndex().then((win) => {
       ipc = win.App.ipc

--- a/packages/desktop-gui/cypress/support/index.js
+++ b/packages/desktop-gui/cypress/support/index.js
@@ -26,7 +26,7 @@ Cypress.Commands.add('visitIndex', (options = {}) => {
   // disable livereload within the Cypress-loaded desktop GUI. it doesn't fully
   // reload the app because the stubbed out ipc calls don't work after the first
   // time, so it ends up a useless white page
-  cy.http({ path: /livereload/ }, '')
+  cy.intercept({ path: /livereload/ }, '')
 
   cy.visit('/', options)
 })

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -8,10 +8,10 @@ describe('network stubbing', { retries: 2 }, function () {
   context('cy.route2()', function () {
     it('emits a warning', function () {
       cy.route2('*')
-      .then(() => expect(Cypress.utils.warning).to.be.calledWith('`cy.route2()` was renamed to `cy.http()` and will be removed in a future release. Please update usages of `cy.route2()` to use `cy.http()` instead.'))
+      .then(() => expect(Cypress.utils.warning).to.be.calledWith('`cy.route2()` was renamed to `cy.intercept()` and will be removed in a future release. Please update usages of `cy.route2()` to use `cy.intercept()` instead.'))
     })
 
-    it('calls through to cy.http()', function (done) {
+    it('calls through to cy.intercept()', function (done) {
       cy.route2('*', 'hello world').then(() => {
         $.get('/abc123').done((responseText, _, xhr) => {
           expect(responseText).to.eq('hello world')
@@ -27,14 +27,14 @@ describe('network stubbing', { retries: 2 }, function () {
     })
   })
 
-  context('cy.http()', function () {
+  context('cy.intercept()', function () {
     beforeEach(function () {
       // we don't use cy.spy() because it causes an infinite loop with logging events
       this.sandbox = sinon.createSandbox()
       this.emit = this.sandbox.spy(Cypress, 'emit').withArgs('backend:request', 'net', 'route:added')
 
       this.testRoute = function (options, handler, expectedEvent, expectedRoute) {
-        cy.http(options, handler).then(function () {
+        cy.intercept(options, handler).then(function () {
           const handlerId = _.findKey(state('routes'), { handler })
           const route = state('routes')[handlerId!]
 
@@ -196,7 +196,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
     // https://github.com/cypress-io/cypress/issues/8729
     it('resolve ambiguity between overloaded definitions', () => {
-      cy.http('POST', 'http://dummy.restapiexample.com/api/v1/create').as('create')
+      cy.intercept('POST', 'http://dummy.restapiexample.com/api/v1/create').as('create')
 
       cy.window().then((win) => {
         win.eval(
@@ -209,17 +209,17 @@ describe('network stubbing', { retries: 2 }, function () {
       cy.wait('@create')
     })
 
-    // TODO: implement warning in cy.http if appropriate
+    // TODO: implement warning in cy.intercept if appropriate
     // https://github.com/cypress-io/cypress/issues/2372
     it.skip('warns if a percent-encoded URL is used', function () {
-      cy.http('GET', '/foo%25bar').then(function () {
-        expect(Cypress.utils.warning).to.be.calledWith('A URL with percent-encoded characters was passed to cy.http(), but cy.http() expects a decoded URL.\n\nDid you mean to pass "/foo%bar"?')
+      cy.intercept('GET', '/foo%25bar').then(function () {
+        expect(Cypress.utils.warning).to.be.calledWith('A URL with percent-encoded characters was passed to cy.intercept(), but cy.intercept() expects a decoded URL.\n\nDid you mean to pass "/foo%bar"?')
       })
     })
 
     // NOTE: see todo on 'warns if a percent-encoded URL is used'
     it.skip('does not warn if an invalid percent-encoded URL is used', function () {
-      cy.http('GET', 'http://example.com/%E0%A4%A').then(function () {
+      cy.intercept('GET', 'http://example.com/%E0%A4%A').then(function () {
         expect(Cypress.utils.warning).to.not.be.called
       })
     })
@@ -237,7 +237,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('has name of route', function () {
-        cy.http('/foo', {}).then(function () {
+        cy.intercept('/foo', {}).then(function () {
           let lastLog
 
           lastLog = this.lastLog
@@ -247,7 +247,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('uses the wildcard URL', function () {
-        cy.http('*', {}).then(function () {
+        cy.intercept('*', {}).then(function () {
           let lastLog
 
           lastLog = this.lastLog
@@ -258,7 +258,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
       // TODO: implement log niceties
       it.skip('#consoleProps', function () {
-        cy.http('*', {
+        cy.intercept('*', {
           foo: 'bar',
         }).as('foo').then(function () {
           expect(this.lastLog.invoke('consoleProps')).to.deep.eq({
@@ -276,7 +276,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
       describe('numResponses', function () {
         it('is initially 0', function () {
-          cy.http(/foo/, {}).then(() => {
+          cy.intercept(/foo/, {}).then(() => {
             let lastLog
 
             lastLog = this.lastLog
@@ -286,13 +286,13 @@ describe('network stubbing', { retries: 2 }, function () {
         })
 
         it('is incremented to 2', function () {
-          cy.http(/foo/, {}).then(function () {
+          cy.intercept(/foo/, {}).then(function () {
             $.get('/foo')
           }).wrap(this).invoke('lastLog.get', 'numResponses').should('eq', 1)
         })
 
         it('is incremented for each matching request', function () {
-          cy.http(/foo/, {}).then(function () {
+          cy.intercept(/foo/, {}).then(function () {
             return Promise.all([$.get('/foo'), $.get('/foo'), $.get('/foo')])
           }).wrap(this).invoke('lastLog.get', 'numResponses').should('eq', 3)
         })
@@ -317,7 +317,7 @@ describe('network stubbing', { retries: 2 }, function () {
         })
 
         // @ts-ignore: should fail
-        cy.http({
+        cy.intercept({
           // @ts-ignore
           url: {},
         })
@@ -326,12 +326,12 @@ describe('network stubbing', { retries: 2 }, function () {
       // TODO: not currently implemented
       it.skip('fails when method is invalid', function (done) {
         cy.on('fail', function (err) {
-          expect(err.message).to.include('cy.http() was called with an invalid method: \'POSTS\'.')
+          expect(err.message).to.include('cy.intercept() was called with an invalid method: \'POSTS\'.')
 
           done()
         })
 
-        cy.http('post', '/foo', {})
+        cy.intercept('post', '/foo', {})
       })
 
       it('requires a url when given a response', function (done) {
@@ -341,18 +341,18 @@ describe('network stubbing', { retries: 2 }, function () {
           done()
         })
 
-        cy.http({})
+        cy.intercept({})
       })
 
       it('requires arguments', function (done) {
         cy.on('fail', function (err) {
-          expect(err.message).to.include('An invalid RouteMatcher was supplied to `cy.http()`. The RouteMatcher does not contain any keys. You must pass something to match on.')
+          expect(err.message).to.include('An invalid RouteMatcher was supplied to `cy.intercept()`. The RouteMatcher does not contain any keys. You must pass something to match on.')
 
           done()
         })
 
         // @ts-ignore - should fail
-        cy.http()
+        cy.intercept()
       })
 
       context('with invalid RouteMatcher', function () {
@@ -363,7 +363,7 @@ describe('network stubbing', { retries: 2 }, function () {
             done()
           })
 
-          cy.http({
+          cy.intercept({
             headers: {
               foo: 'bar',
               FOO: 'bar',
@@ -379,7 +379,7 @@ describe('network stubbing', { retries: 2 }, function () {
           })
 
           // @ts-ignore this is invalid on purpose
-          cy.http({
+          cy.intercept({
             headers: {
               good: 'string',
               fine: /regexp/,
@@ -403,7 +403,7 @@ describe('network stubbing', { retries: 2 }, function () {
             })
 
             // @ts-ignore - this should error
-            cy.http('/', handler)
+            cy.intercept('/', handler)
           })
         })
       })
@@ -447,7 +447,7 @@ describe('network stubbing', { retries: 2 }, function () {
             })
 
             // @ts-ignore - this should error
-            cy.http('/', handler)
+            cy.intercept('/', handler)
           })
         })
       })
@@ -473,7 +473,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('different origin (HTTP)', function () {
-        cy.http('/foo').as('foo')
+        cy.intercept('/foo').as('foo')
         .then(() => {
           $.get('http://baz.foobar.com:3501/foo')
         })
@@ -481,7 +481,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('different origin with response interception (HTTP)', function () {
-        cy.http('/xhr.html', (req) => {
+        cy.intercept('/xhr.html', (req) => {
           req.reply((res) => {
             expect(res.body).to.include('xhr fixture')
             res.body = 'replaced the body'
@@ -498,7 +498,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
       // @see https://github.com/cypress-io/cypress/issues/8487
       it('different origin (HTTPS)', function () {
-        cy.http('/foo', 'somethin').as('foo')
+        cy.intercept('/foo', 'somethin').as('foo')
         .then(() => {
           $.get('https://bar.foobar.com.invalid:3502/foo')
         })
@@ -506,7 +506,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('different origin with response interception (HTTPS)', function () {
-        cy.http('/xhr.html', (req) => {
+        cy.intercept('/xhr.html', (req) => {
           req.reply((res) => {
             expect(res.body).to.include('xhr fixture')
             res.body = 'replaced the body'
@@ -525,7 +525,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
   context('stubbing with static responses', function () {
     it('can stub a response with static body as string', function (done) {
-      cy.http({
+      cy.intercept({
         url: '*',
       }, 'hello world').then(() => {
         $.get('/abc123').done((responseText, _, xhr) => {
@@ -538,11 +538,11 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can stub a cy.visit with static body', function () {
-      cy.http('/foo', '<html>hello cruel world</html>').visit('/foo').document().should('contain.text', 'hello cruel world')
+      cy.intercept('/foo', '<html>hello cruel world</html>').visit('/foo').document().should('contain.text', 'hello cruel world')
     })
 
     it('can stub a response with an empty StaticResponse', function (done) {
-      cy.http('/', {}).then(() => {
+      cy.intercept('/', {}).then(() => {
         $.get('/').done((responseText, _, xhr) => {
           expect(xhr.status).to.eq(200)
           expect(responseText).to.eq('')
@@ -553,7 +553,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can stub a response with a network error', function (done) {
-      cy.http('/', {
+      cy.intercept('/', {
         forceNetworkError: true,
       }).then(() => {
         $.get('/').fail((xhr) => {
@@ -566,7 +566,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can use regular strings as response', function () {
-      cy.http('/foo', 'foo bar baz').as('getFoo').then(function (win) {
+      cy.intercept('/foo', 'foo bar baz').as('getFoo').then(function (win) {
         $.get('/foo')
       }).wait('@getFoo').then(function (res) {
         expect(res.response.body).to.eq('foo bar baz')
@@ -574,7 +574,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can stub requests with uncommon HTTP methods', function () {
-      cy.http('PROPFIND', '/foo', 'foo bar baz').as('getFoo').then(function (win) {
+      cy.intercept('PROPFIND', '/foo', 'foo bar baz').as('getFoo').then(function (win) {
         $.ajax({
           url: '/foo',
           method: 'PROPFIND',
@@ -587,7 +587,7 @@ describe('network stubbing', { retries: 2 }, function () {
     it('can stub a response with an array', function (done) {
       const response = ['foo', 'bar', { foo: 'baz' }]
 
-      cy.http({
+      cy.intercept({
         url: '*',
       }, response).then(() => {
         $.get('/abc123').done((responseJson, _, xhr) => {
@@ -602,7 +602,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
     // TODO: flaky - unable to reproduce outside of CI
     it('still works after a cy.visit', { retries: 2 }, function () {
-      cy.http(/foo/, {
+      cy.intercept(/foo/, {
         body: JSON.stringify({ foo: 'bar' }),
         headers: {
           'content-type': 'application/json',
@@ -633,7 +633,7 @@ describe('network stubbing', { retries: 2 }, function () {
       }
 
       it('with explicit StaticResponse', function (done) {
-        cy.http({
+        cy.intercept({
           url: '*',
         }, {
           body: [],
@@ -641,25 +641,25 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('with body shorthand', function (done) {
-        cy.http('*', []).then(assertEmptyArray(done))
+        cy.intercept('*', []).then(assertEmptyArray(done))
       })
 
       it('with method, url, res shorthand', function (done) {
-        cy.http('GET', '*', []).then(assertEmptyArray(done))
+        cy.intercept('GET', '*', []).then(assertEmptyArray(done))
       })
 
       it('in req.reply', function (done) {
-        cy.http('*', (req) => req.reply([])).then(assertEmptyArray(done))
+        cy.intercept('*', (req) => req.reply([])).then(assertEmptyArray(done))
       })
 
       it('in res.send', function (done) {
-        cy.http('*', (req) => req.reply((res) => res.send(200, []))).then(assertEmptyArray(done))
+        cy.intercept('*', (req) => req.reply((res) => res.send(200, []))).then(assertEmptyArray(done))
       })
     })
 
     context('fixtures', function () {
       it('can stub a response with a JSON object', function () {
-        cy.http({
+        cy.intercept({
           method: 'POST',
           url: '/test-xhr',
         }, {
@@ -670,7 +670,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('works with content-type override', function () {
-        cy.http({
+        cy.intercept({
           method: 'POST',
           url: '/test-xhr',
         }, {
@@ -684,7 +684,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('works if the JSON file has null content', function () {
-        cy.http({
+        cy.intercept({
           method: 'POST',
           url: '/test-xhr',
         }, {
@@ -698,7 +698,7 @@ describe('network stubbing', { retries: 2 }, function () {
       it('works with images', function () {
         cy.visit('/fixtures/img-embed.html')
         .contains('div', 'error loading image')
-        .http('non-existing-image.png', { fixture: 'media/cypress.png' })
+        .intercept('non-existing-image.png', { fixture: 'media/cypress.png' })
         .reload()
         .contains('div', 'it loaded')
       })
@@ -707,7 +707,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
   context('intercepting request', function () {
     it('receives the original request in handler', function (done) {
-      cy.http('/def456', function (req) {
+      cy.intercept('/def456', function (req) {
         req.reply({
           statusCode: 404,
         })
@@ -726,7 +726,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('receives the original request body in handler', function (done) {
-      cy.http('/aaa', function (req) {
+      cy.intercept('/aaa', function (req) {
         expect(req.body).to.eq('foo-bar-baz')
 
         done()
@@ -736,16 +736,16 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can modify original request body and have it passed to next handler', function (done) {
-      cy.http('/post-only', function (req) {
+      cy.intercept('/post-only', function (req) {
         expect(req.body).to.eq('foo-bar-baz')
         req.body = 'quuz'
       }).then(function () {
-        cy.http('/post-only', function (req) {
+        cy.intercept('/post-only', function (req) {
           expect(req.body).to.eq('quuz')
           req.body = 'quux'
         })
       }).then(function () {
-        cy.http('/post-only', function (req) {
+        cy.intercept('/post-only', function (req) {
           expect(req.body).to.eq('quux')
 
           done()
@@ -756,7 +756,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can modify a cy.visit before it goes out', function () {
-      cy.http('/dump-headers', function (req) {
+      cy.intercept('/dump-headers', function (req) {
         expect(req.headers['foo']).to.eq('bar')
 
         req.headers['foo'] = 'quux'
@@ -773,7 +773,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can modify the request URL and headers', function (done) {
-      cy.http('/does-not-exist', function (req) {
+      cy.intercept('/does-not-exist', function (req) {
         expect(req.headers['foo']).to.eq('bar')
         req.url = 'http://localhost:3500/dump-headers'
 
@@ -794,7 +794,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can modify the request method', function (done) {
-      cy.http('/dump-method', function (req) {
+      cy.intercept('/dump-method', function (req) {
         expect(req.method).to.eq('POST')
 
         req.method = 'PATCH'
@@ -810,7 +810,7 @@ describe('network stubbing', { retries: 2 }, function () {
     it('can modify the request body', function (done) {
       const body = '{"foo":"bar"}'
 
-      cy.http('/post-only', function (req) {
+      cy.intercept('/post-only', function (req) {
         expect(req.body).to.eq('quuz')
         req.headers['content-type'] = 'application/json'
 
@@ -827,7 +827,7 @@ describe('network stubbing', { retries: 2 }, function () {
     it('can add a body to a request that does not have one', function (done) {
       const body = '{"foo":"bar"}'
 
-      cy.http('/post-only', function (req) {
+      cy.intercept('/post-only', function (req) {
         expect(req.body).to.eq('')
         expect(req.method).to.eq('GET')
         req.method = 'POST'
@@ -844,7 +844,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can reply with a JSON fixture', function () {
-      cy.http({
+      cy.intercept({
         method: 'POST',
         url: '/test-xhr',
       }, (req) => {
@@ -862,7 +862,7 @@ describe('network stubbing', { retries: 2 }, function () {
       const delayMs = 250
       const expectedSeconds = payload.length / (1024 * throttleKbps) + delayMs / 1000
 
-      cy.http('/timeout', (req) => {
+      cy.intercept('/timeout', (req) => {
         this.start = Date.now()
 
         req.reply({
@@ -885,7 +885,7 @@ describe('network stubbing', { retries: 2 }, function () {
       it('automatically parses JSON request bodies', function () {
         const p = Promise.defer()
 
-        cy.http('/post-only', (req) => {
+        cy.intercept('/post-only', (req) => {
           expect(req.body).to.deep.eq({ foo: 'bar' })
 
           p.resolve()
@@ -908,7 +908,7 @@ describe('network stubbing', { retries: 2 }, function () {
       it('doesn\'t automatically parse JSON request bodies if content-type is wrong', function () {
         const p = Promise.defer()
 
-        cy.http('/post-only', (req) => {
+        cy.intercept('/post-only', (req) => {
           expect(req.body).to.deep.eq(JSON.stringify({ foo: 'bar' }))
 
           p.resolve()
@@ -927,7 +927,7 @@ describe('network stubbing', { retries: 2 }, function () {
       it('sets body to string if JSON is malformed', function () {
         const p = Promise.defer()
 
-        cy.http('/post-only', (req) => {
+        cy.intercept('/post-only', (req) => {
           expect(req.body).to.deep.eq('{ foo::: }')
 
           p.resolve()
@@ -947,19 +947,19 @@ describe('network stubbing', { retries: 2 }, function () {
 
     context('matches requests as expected', function () {
       it('handles querystrings as expected', function () {
-        cy.http({
+        cy.intercept({
           query: {
             foo: 'b*r',
             baz: /quu[x]/,
           },
         }).as('first')
-        .http({
+        .intercept({
           path: '/abc?foo=bar&baz=qu*x*',
         }).as('second')
-        .http({
+        .intercept({
           pathname: '/abc',
         }).as('third')
-        .http('*', 'it worked').as('final')
+        .intercept('*', 'it worked').as('final')
         .then(() => {
           return $.get('/abc?foo=bar&baz=quux')
         })
@@ -971,7 +971,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
       // @see https://github.com/cypress-io/cypress/issues/8921
       it('with case-insensitive header matching', function () {
-        cy.http({
+        cy.intercept({
           headers: {
             'X-some-Thing': 'foo',
           },
@@ -991,7 +991,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
     context('with StaticResponse shorthand', function () {
       it('req.reply(body)', function () {
-        cy.http('/foo', function (req) {
+        cy.intercept('/foo', function (req) {
           req.reply('baz')
         })
         .then(() => $.get('/foo'))
@@ -999,7 +999,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('req.reply(json)', function () {
-        cy.http('/foo', function (req) {
+        cy.intercept('/foo', function (req) {
           req.reply({ baz: 'quux' })
         })
         .then(() => $.getJSON('/foo'))
@@ -1007,7 +1007,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('req.reply(status)', function () {
-        cy.http('/foo', function (req) {
+        cy.intercept('/foo', function (req) {
           req.reply(777)
         })
         .then(() => {
@@ -1019,7 +1019,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('req.reply(status, body)', function () {
-        cy.http('/foo', function (req) {
+        cy.intercept('/foo', function (req) {
           req.reply(777, 'bar')
         })
         .then(() => {
@@ -1033,7 +1033,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('req.reply(status, json)', function () {
-        cy.http('/foo', function (req) {
+        cy.intercept('/foo', function (req) {
           req.reply(777, { bar: 'baz' })
         })
         .then(() => {
@@ -1047,7 +1047,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('req.reply(status, json, headers)', function () {
-        cy.http('/foo', function (req) {
+        cy.intercept('/foo', function (req) {
           req.reply(777, { bar: 'baz' }, { 'x-quux': 'quuz' })
         })
         .then(() => {
@@ -1063,7 +1063,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('can forceNetworkError', function (done) {
-        cy.http('/foo', function (req) {
+        cy.intercept('/foo', function (req) {
           req.reply({ forceNetworkError: true })
         })
         .then(() => {
@@ -1082,13 +1082,13 @@ describe('network stubbing', { retries: 2 }, function () {
 
     context('request handler chaining', function () {
       it('passes request through in order', function () {
-        cy.http('/dump-method', function (req) {
+        cy.intercept('/dump-method', function (req) {
           expect(req.method).to.eq('GET')
           req.method = 'POST'
-        }).http('/dump-method', function (req) {
+        }).intercept('/dump-method', function (req) {
           expect(req.method).to.eq('POST')
           req.method = 'PATCH'
-        }).http('/dump-method', function (req) {
+        }).intercept('/dump-method', function (req) {
           expect(req.method).to.eq('PATCH')
 
           req.reply()
@@ -1096,10 +1096,10 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('stops passing request through once req.reply called', function () {
-        cy.http('/dump-method', function (req) {
+        cy.intercept('/dump-method', function (req) {
           expect(req.method).to.eq('GET')
           req.method = 'POST'
-        }).http('/dump-method', function (req) {
+        }).intercept('/dump-method', function (req) {
           expect(req.method).to.eq('POST')
 
           req.reply()
@@ -1114,7 +1114,7 @@ describe('network stubbing', { retries: 2 }, function () {
           done()
         })
 
-        cy.http('/dump-method', function (req) {
+        cy.intercept('/dump-method', function (req) {
           req.reply()
 
           req.reply()
@@ -1127,7 +1127,7 @@ describe('network stubbing', { retries: 2 }, function () {
           done()
         })
 
-        cy.http('/dump-method', function (req) {
+        cy.intercept('/dump-method', function (req) {
           setTimeout(() => req.reply(), 50)
         }).visit('/dump-method')
       })
@@ -1138,7 +1138,7 @@ describe('network stubbing', { retries: 2 }, function () {
           done()
         })
 
-        cy.http('/dump-method', function (req) {
+        cy.intercept('/dump-method', function (req) {
           setTimeout(() => req.reply(), 50)
 
           return Promise.resolve()
@@ -1147,7 +1147,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
       it('fails test if an exception is thrown in req handler', function (done) {
         cy.on('fail', (err2) => {
-          expect(err2.message).to.contain('A request callback passed to `cy.http()` threw an error while intercepting a request')
+          expect(err2.message).to.contain('A request callback passed to `cy.intercept()` threw an error while intercepting a request')
           .and.contain(err.message)
 
           done()
@@ -1155,20 +1155,20 @@ describe('network stubbing', { retries: 2 }, function () {
 
         const err = new Error('bar')
 
-        cy.http('/foo', () => {
+        cy.intercept('/foo', () => {
           throw err
         }).visit('/foo')
       })
 
       it('fails test if req.reply is called with an invalid StaticResponse', function (done) {
         cy.on('fail', (err) => {
-          expect(err.message).to.contain('A request callback passed to `cy.http()` threw an error while intercepting a request')
+          expect(err.message).to.contain('A request callback passed to `cy.intercept()` threw an error while intercepting a request')
           .and.contain('must be a number between 100 and 999 (inclusive).')
 
           done()
         })
 
-        cy.http('/foo', (req) => {
+        cy.intercept('/foo', (req) => {
           req.reply({ statusCode: 1 })
         }).visit('/foo')
       })
@@ -1177,12 +1177,12 @@ describe('network stubbing', { retries: 2 }, function () {
         defaultCommandTimeout: 50,
       }, function (done) {
         cy.on('fail', (err) => {
-          expect(err.message).to.match(/^A request callback passed to `cy.http\(\)` timed out after returning a Promise that took more than the `defaultCommandTimeout` of `50ms` to resolve\./)
+          expect(err.message).to.match(/^A request callback passed to `cy.intercept\(\)` timed out after returning a Promise that took more than the `defaultCommandTimeout` of `50ms` to resolve\./)
 
           done()
         })
 
-        cy.http('/foo', () => {
+        cy.intercept('/foo', () => {
           return Promise.delay(200)
         }).visit('/foo')
       })
@@ -1191,7 +1191,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
   context('intercepting response', function () {
     it('receives the original response in handler', function (done) {
-      cy.http('/json-content-type', function (req) {
+      cy.intercept('/json-content-type', function (req) {
         req.reply(function (res) {
           expect(res.body).to.deep.eq({})
 
@@ -1208,7 +1208,7 @@ describe('network stubbing', { retries: 2 }, function () {
       const href = `/fixtures/generic.html?t=${Date.now()}`
       const url = `/redirect?href=${encodeURIComponent(href)}`
 
-      cy.http('/redirect', (req) => {
+      cy.intercept('/redirect', (req) => {
         req.reply((res) => {
           expect(res.statusCode).to.eq(301)
           expect(res.headers.location).to.eq(href)
@@ -1216,7 +1216,7 @@ describe('network stubbing', { retries: 2 }, function () {
         })
       })
       .as('redirect')
-      .http('/fixtures/generic.html').as('dest')
+      .intercept('/fixtures/generic.html').as('dest')
       .then(() => fetch(url))
       .wait('@redirect')
       .wait('@dest')
@@ -1227,7 +1227,7 @@ describe('network stubbing', { retries: 2 }, function () {
       const href = `/fixtures/generic.html?t=${Date.now()}`
       const url = `/redirect?href=${encodeURIComponent(href)}`
 
-      cy.http('/redirect', (req) => {
+      cy.intercept('/redirect', (req) => {
         req.followRedirect = true
         req.reply((res) => {
           expect(res.body).to.include('Some generic content')
@@ -1245,7 +1245,7 @@ describe('network stubbing', { retries: 2 }, function () {
       const url = `/fixtures/generic.html?t=${Date.now()}`
       let hits = 0
 
-      cy.http('/fixtures/generic.html', (req) => {
+      cy.intercept('/fixtures/generic.html', (req) => {
         req.reply((res) => {
           // the second time the request is sent, headers should have been passed
           // that result in Express serving a 304
@@ -1270,7 +1270,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can intercept a large proxy response', function (done) {
-      cy.http('/1mb', (req) => {
+      cy.intercept('/1mb', (req) => {
         req.reply((res) => {
           res.send()
         })
@@ -1285,7 +1285,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can delay a proxy response using res.delay', function (done) {
-      cy.http('/timeout', (req) => {
+      cy.intercept('/timeout', (req) => {
         req.reply((res) => {
           this.start = Date.now()
 
@@ -1303,7 +1303,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can \'delay\' a proxy response using Promise.delay', function (done) {
-      cy.http('/timeout', (req) => {
+      cy.intercept('/timeout', (req) => {
         req.reply((res) => {
           this.start = Date.now()
 
@@ -1323,7 +1323,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can throttle a proxy response using res.throttle', function (done) {
-      cy.http('/1mb', (req) => {
+      cy.intercept('/1mb', (req) => {
         // don't let gzip make response smaller and throw off the timing
         delete req.headers['accept-encoding']
 
@@ -1348,7 +1348,7 @@ describe('network stubbing', { retries: 2 }, function () {
       const kbps = 10
       const expectedSeconds = payload.length / (1024 * kbps)
 
-      cy.http('/timeout', (req) => {
+      cy.intercept('/timeout', (req) => {
         req.reply((res) => {
           this.start = Date.now()
 
@@ -1372,7 +1372,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
       expectedSeconds += delayMs / 1000
 
-      cy.http('/timeout', (req) => {
+      cy.intercept('/timeout', (req) => {
         req.reply((res) => {
           this.start = Date.now()
 
@@ -1392,7 +1392,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can reply with a JSON fixture', function () {
-      cy.http({
+      cy.intercept({
         method: 'POST',
         url: '/test-xhr',
       }, (req) => {
@@ -1415,7 +1415,7 @@ describe('network stubbing', { retries: 2 }, function () {
       it('automatically parses JSON response bodies', function () {
         const p = Promise.defer()
 
-        cy.http('/foo.bar.baz.json', (req) => {
+        cy.intercept('/foo.bar.baz.json', (req) => {
           req.reply((res) => {
             expect(res.body).to.deep.eq({ quux: 'quuz' })
             p.resolve()
@@ -1434,7 +1434,7 @@ describe('network stubbing', { retries: 2 }, function () {
       it('doesn\'t automatically parse JSON response bodies if content-type is wrong', function () {
         const p = Promise.defer()
 
-        cy.http('/json.txt', (req) => {
+        cy.intercept('/json.txt', (req) => {
           req.reply((res) => {
             expect(res.body).to.eq('{ "foo": "bar" }')
             p.resolve()
@@ -1453,7 +1453,7 @@ describe('network stubbing', { retries: 2 }, function () {
       it('sets body to string if JSON is malformed', function () {
         const p = Promise.defer()
 
-        cy.http('/invalid.json', (req) => {
+        cy.intercept('/invalid.json', (req) => {
           req.reply((res) => {
             expect(res.headers['content-type']).to.match(/^application\/json/)
             expect(res.body).to.eq('{ foo:::: }')
@@ -1469,7 +1469,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
     context('with StaticResponse', function () {
       it('res.send(body)', function () {
-        cy.http('/custom-headers', function (req) {
+        cy.intercept('/custom-headers', function (req) {
           req.reply((res) => {
             res.send('baz')
           })
@@ -1486,7 +1486,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('res.send(json)', function () {
-        cy.http('/custom-headers', function (req) {
+        cy.intercept('/custom-headers', function (req) {
           req.reply((res) => {
             res.send({ baz: 'quux' })
           })
@@ -1505,7 +1505,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('res.send(status)', function (done) {
-        cy.http('/custom-headers', function (req) {
+        cy.intercept('/custom-headers', function (req) {
           req.reply((res) => {
             res.send(777)
           })
@@ -1525,7 +1525,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('res.send(status, body)', function (done) {
-        cy.http('/custom-headers', function (req) {
+        cy.intercept('/custom-headers', function (req) {
           req.reply((res) => {
             res.send(777, 'bar')
           })
@@ -1544,7 +1544,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('res.send(status, json)', function (done) {
-        cy.http('/custom-headers', function (req) {
+        cy.intercept('/custom-headers', function (req) {
           req.reply((res) => {
             res.send(777, { bar: 'baz' })
           })
@@ -1564,7 +1564,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('res.send(status, json, headers)', function (done) {
-        cy.http('/custom-headers', function (req) {
+        cy.intercept('/custom-headers', function (req) {
           req.reply((res) => {
             res.send(777, { bar: 'baz' }, { 'x-quux': 'quuz' })
           })
@@ -1585,7 +1585,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('can forceNetworkError', function (done) {
-        cy.http('/foo', function (req) {
+        cy.intercept('/foo', function (req) {
           req.reply((res) => {
             res.send({ forceNetworkError: true })
           })
@@ -1609,7 +1609,7 @@ describe('network stubbing', { retries: 2 }, function () {
         const delayMs = 50
         const expectedSeconds = payload.length / (1024 * throttleKbps) + delayMs / 1000
 
-        cy.http('/timeout', (req) => {
+        cy.intercept('/timeout', (req) => {
           req.reply((res) => {
             this.start = Date.now()
 
@@ -1639,7 +1639,7 @@ describe('network stubbing', { retries: 2 }, function () {
           done()
         })
 
-        cy.http('/dump-method', function (req) {
+        cy.intercept('/dump-method', function (req) {
           req.reply(function (res) {
             res.send()
 
@@ -1658,7 +1658,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
         const err = new Error('bar')
 
-        cy.http('/foo', (req) => {
+        cy.intercept('/foo', (req) => {
           req.reply(() => {
             throw err
           })
@@ -1677,7 +1677,7 @@ describe('network stubbing', { retries: 2 }, function () {
           done()
         })
 
-        cy.http('/foo', (req) => {
+        cy.intercept('/foo', (req) => {
           req.reply((res) => {
             res.send({ statusCode: 1 })
           })
@@ -1696,7 +1696,7 @@ describe('network stubbing', { retries: 2 }, function () {
           done()
         })
 
-        cy.http('/should-err', function (req) {
+        cy.intercept('/should-err', function (req) {
           req.reply(() => {})
         }).then(function () {
           $.get('http://localhost:3333/should-err')
@@ -1713,7 +1713,7 @@ describe('network stubbing', { retries: 2 }, function () {
           done()
         })
 
-        cy.http('/should-err', function (req) {
+        cy.intercept('/should-err', function (req) {
           req.reply()
         })
         .as('err')
@@ -1742,7 +1742,7 @@ describe('network stubbing', { retries: 2 }, function () {
           done()
         })
 
-        cy.http('/timeout', (req) => {
+        cy.intercept('/timeout', (req) => {
           req.reply(() => {
             return Promise.delay(200)
           })
@@ -1759,7 +1759,7 @@ describe('network stubbing', { retries: 2 }, function () {
           done()
         })
 
-        cy.http('/timeout', (req) => {
+        cy.intercept('/timeout', (req) => {
           req.reply(_.noop)
         }).then(() => {
           $.get('/timeout?ms=50')
@@ -1770,7 +1770,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
   context('waiting and aliasing', function () {
     it('can wait on a single response using "alias"', function () {
-      cy.http('/foo', 'bar')
+      cy.intercept('/foo', 'bar')
       .as('foo.bar')
       .then(() => {
         $.get('/foo')
@@ -1784,7 +1784,7 @@ describe('network stubbing', { retries: 2 }, function () {
         done()
       })
 
-      cy.http('/foo', () => new Promise(_.noop))
+      cy.intercept('/foo', () => new Promise(_.noop))
       .as('foo.bar')
       .then(() => {
         $.get('/foo')
@@ -1793,7 +1793,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can wait on a single response using "alias.response"', function () {
-      cy.http('/foo', 'bar')
+      cy.intercept('/foo', 'bar')
       .as('foo.bar')
       .then(() => {
         $.get('/foo')
@@ -1807,7 +1807,7 @@ describe('network stubbing', { retries: 2 }, function () {
         done()
       })
 
-      cy.http('/foo', () => new Promise(_.noop))
+      cy.intercept('/foo', () => new Promise(_.noop))
       .as('foo.bar')
       .then(() => {
         $.get('/foo')
@@ -1816,7 +1816,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can wait on a single request using "alias.request"', function () {
-      cy.http('/foo')
+      cy.intercept('/foo')
       .as('foo.bar')
       .then(() => {
         $.get('/foo')
@@ -1830,13 +1830,13 @@ describe('network stubbing', { retries: 2 }, function () {
         done()
       })
 
-      cy.http('/foo')
+      cy.intercept('/foo')
       .as('foo.bar')
       .wait('@foo.bar.request', { timeout: 100 })
     })
 
     it('can incrementally wait on responses', function () {
-      cy.http('/foo', 'bar')
+      cy.intercept('/foo', 'bar')
       .as('foo.bar')
       .then(() => {
         $.get('/foo')
@@ -1854,7 +1854,7 @@ describe('network stubbing', { retries: 2 }, function () {
         done()
       })
 
-      cy.http('/foo', () => new Promise(_.noop))
+      cy.intercept('/foo', () => new Promise(_.noop))
       .as('foo.bar')
       .then(() => {
         $.get('/foo')
@@ -1865,7 +1865,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can incrementally wait on requests', function () {
-      cy.http('/foo', (req) => {
+      cy.intercept('/foo', (req) => {
         req.reply(_.noop) // only request will be received, no response
       })
       .as('foo.bar')
@@ -1885,7 +1885,7 @@ describe('network stubbing', { retries: 2 }, function () {
         done()
       })
 
-      cy.http('/foo', (req) => {
+      cy.intercept('/foo', (req) => {
         req.reply(_.noop) // only request will be received, no response
       })
       .as('foo.bar')
@@ -1897,7 +1897,7 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     it('can alias a route without stubbing it', function () {
-      cy.http(/fixtures\/app/).as('getFoo').then(function () {
+      cy.intercept(/fixtures\/app/).as('getFoo').then(function () {
         $.get('/fixtures/app.json')
       }).wait('@getFoo').then(function (res) {
         const log = cy.queue.logs({
@@ -1917,7 +1917,7 @@ describe('network stubbing', { retries: 2 }, function () {
 
     context('with an intercepted request', function () {
       it('can dynamically alias the request', function () {
-        cy.http('/foo', (req) => {
+        cy.intercept('/foo', (req) => {
           req.alias = 'fromInterceptor'
         })
         .then(() => {
@@ -1932,7 +1932,7 @@ describe('network stubbing', { retries: 2 }, function () {
           done()
         })
 
-        cy.http('/foo', (req) => {
+        cy.intercept('/foo', (req) => {
           req.alias = 'fromInterceptor'
         })
         .wait('@fromInterceptor', { timeout: 100 })
@@ -1944,7 +1944,7 @@ describe('network stubbing', { retries: 2 }, function () {
           done()
         })
 
-        cy.http('/foo', (req) => {
+        cy.intercept('/foo', (req) => {
           req.alias = 'fromInterceptor'
         })
         .as('fromAs')
@@ -1957,10 +1957,10 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('fulfills both dynamic aliases when two are defined', function () {
-        cy.http('/foo', (req) => {
+        cy.intercept('/foo', (req) => {
           req.alias = 'fromInterceptor'
         })
-        .http('/foo', (req) => {
+        .intercept('/foo', (req) => {
           expect(req.alias).to.be.undefined
           req.alias = 'fromInterceptor2'
         })
@@ -1975,14 +1975,14 @@ describe('network stubbing', { retries: 2 }, function () {
     // @see https://github.com/cypress-io/cypress/issues/8695
     context('yields request', function () {
       it('when not intercepted', function () {
-        cy.http('/post-only').as('foo')
+        cy.intercept('/post-only').as('foo')
         .then(() => {
           $.post('/post-only', 'some body')
         }).wait('@foo').its('request.body').should('eq', 'some body')
       })
 
       it('when intercepted', function () {
-        cy.http('/post-only', (req) => {
+        cy.intercept('/post-only', (req) => {
           req.body = 'changed'
         }).as('foo')
         .then(() => {
@@ -1991,7 +1991,7 @@ describe('network stubbing', { retries: 2 }, function () {
       })
 
       it('when static response body is provided', function () {
-        cy.http('/post-only', { static: 'response' }).as('foo')
+        cy.intercept('/post-only', { static: 'response' }).as('foo')
         .then(() => {
           $.post('/post-only', 'some body')
         }).wait('@foo').its('request.body').should('eq', 'some body')
@@ -2012,24 +2012,24 @@ describe('network stubbing', { retries: 2 }, function () {
       }
 
       it('when not stubbed', function (done) {
-        cy.http('/xml').as('foo')
+        cy.intercept('/xml').as('foo')
         .then(testResponse('<foo>bar</foo>', done))
       })
 
       it('when stubbed with StaticResponse', function (done) {
-        cy.http('/xml', 'something different')
+        cy.intercept('/xml', 'something different')
         .as('foo')
         .then(testResponse('something different', done))
       })
 
       it('when stubbed with req.reply', function (done) {
-        cy.http('/xml', (req) => req.reply('something different'))
+        cy.intercept('/xml', (req) => req.reply('something different'))
         .as('foo')
         .then(testResponse('something different', done))
       })
 
       it('when stubbed with res.send', function (done) {
-        cy.http('/xml', (req) => req.reply((res) => res.send('something different')))
+        cy.intercept('/xml', (req) => req.reply((res) => res.send('something different')))
         .as('foo')
         .then(testResponse('something different', done))
       })

--- a/packages/driver/cypress/integration/commands/xhr_spec.js
+++ b/packages/driver/cypress/integration/commands/xhr_spec.js
@@ -1086,7 +1086,7 @@ describe('src/cy/commands/xhr', () => {
 
       cy.server()
       .then(function () {
-        expect(Cypress.utils.warning).to.be.calledWithMatch(/^`cy\.server\(\)` has been deprecated and will be moved to a plugin in a future release\. Consider migrating to using `cy\.http\(\)` instead\./)
+        expect(Cypress.utils.warning).to.be.calledWithMatch(/^`cy\.server\(\)` has been deprecated and will be moved to a plugin in a future release\. Consider migrating to using `cy\.intercept\(\)` instead\./)
       })
     })
 
@@ -1275,7 +1275,7 @@ describe('src/cy/commands/xhr', () => {
 
       cy.route('*')
       .then(function () {
-        expect(Cypress.utils.warning).to.be.calledWithMatch(/^`cy\.route\(\)` has been deprecated and will be moved to a plugin in a future release\. Consider migrating to using `cy\.http\(\)` instead\./)
+        expect(Cypress.utils.warning).to.be.calledWithMatch(/^`cy\.route\(\)` has been deprecated and will be moved to a plugin in a future release\. Consider migrating to using `cy\.intercept\(\)` instead\./)
       })
     })
 

--- a/packages/driver/cypress/integration/cy/snapshot_spec.js
+++ b/packages/driver/cypress/integration/cy/snapshot_spec.js
@@ -112,7 +112,7 @@ describe('driver/src/cy/snapshots', () => {
     it('does not cause images to be requested multiple times', function () {
       let timesRequested = 0
 
-      cy.http('media/cypress.png', () => {
+      cy.intercept('media/cypress.png', () => {
         timesRequested++
       })
       .then(() => {

--- a/packages/driver/src/cy/commands/waiting.js
+++ b/packages/driver/src/cy/commands/waiting.js
@@ -162,7 +162,7 @@ module.exports = (Commands, Cypress, cy, state) => {
         log.set('referencesAlias', aliases)
       }
 
-      if (command && !['route', 'route2', 'http'].includes(command.get('name'))) {
+      if (command && !['route', 'route2', 'intercept'].includes(command.get('name'))) {
         $errUtils.throwErrByPath('wait.invalid_alias', {
           onFail: options._log,
           args: { alias },

--- a/packages/driver/src/cy/commands/waiting.js
+++ b/packages/driver/src/cy/commands/waiting.js
@@ -75,7 +75,7 @@ module.exports = (Commands, Cypress, cy, state) => {
 
       options.type = type
 
-      // check cy.http routes
+      // check cy.intercept routes
       const req = waitForRoute(alias, state, type)
 
       if (req) {
@@ -118,8 +118,8 @@ module.exports = (Commands, Cypress, cy, state) => {
       try {
         aliasObj = cy.getAlias(str, 'wait', log)
       } catch (err) {
-        // before cy.http, we could know when an alias did/did not exist, because they
-        // were declared synchronously. with cy.http, req.alias can be used to dynamically
+        // before cy.intercept, we could know when an alias did/did not exist, because they
+        // were declared synchronously. with cy.intercept, req.alias can be used to dynamically
         // create aliases, so we cannot know at wait-time if an alias exists or not
         if (!isDynamicAliasingPossible()) {
           throw err

--- a/packages/driver/src/cy/net-stubbing/add-command.ts
+++ b/packages/driver/src/cy/net-stubbing/add-command.ts
@@ -208,7 +208,7 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
         hasInterceptor = true
         break
       case _.isUndefined(handler):
-        // user is doing something like cy.http('foo').as('foo') to wait on a URL
+        // user is doing something like cy.intercept('foo').as('foo') to wait on a URL
         break
       case _.isString(handler):
         staticResponse = { body: <string>handler }
@@ -222,12 +222,12 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
           }
         }
 
-        validateStaticResponse('cy.http', <StaticResponse>handler)
+        validateStaticResponse('cy.intercept', <StaticResponse>handler)
 
         staticResponse = handler as StaticResponse
         break
       default:
-        return $errUtils.throwErrByPath('net_stubbing.http.invalid_handler', { args: { handler } })
+        return $errUtils.throwErrByPath('net_stubbing.intercept.invalid_handler', { args: { handler } })
     }
 
     const routeMatcher = annotateMatcherOptionsTypes(matcher)
@@ -267,10 +267,10 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
     $errUtils.warnByPath('net_stubbing.route2_renamed')
 
     // @ts-ignore
-    return http.apply(undefined, args)
+    return intercept.apply(undefined, args)
   }
 
-  function http (matcher: RouteMatcher, handler?: RouteHandler | StringMatcher, arg2?: RouteHandler) {
+  function intercept (matcher: RouteMatcher, handler?: RouteHandler | StringMatcher, arg2?: RouteHandler) {
     function getMatcherOptions (): RouteMatcherOptions {
       if (_.isString(matcher) && $utils.isValidHttpMethod(matcher) && isStringMatcher(handler)) {
         // method, url, handler
@@ -298,7 +298,7 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
     const { isValid, message } = validateRouteMatcherOptions(routeMatcherOptions)
 
     if (!isValid) {
-      $errUtils.throwErrByPath('net_stubbing.http.invalid_route_matcher', { args: { message, matcher: routeMatcherOptions } })
+      $errUtils.throwErrByPath('net_stubbing.intercept.invalid_route_matcher', { args: { message, matcher: routeMatcherOptions } })
     }
 
     return addRoute(routeMatcherOptions, handler as RouteHandler)
@@ -306,7 +306,7 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
   }
 
   Commands.addAll({
-    http,
+    intercept,
     route2,
   })
 }

--- a/packages/driver/src/cy/net-stubbing/events/index.ts
+++ b/packages/driver/src/cy/net-stubbing/events/index.ts
@@ -1,4 +1,4 @@
-import { Route, Request } from '../types'
+import { Route, Interception } from '../types'
 import { NetEventFrames } from '@packages/net-stubbing/lib/types'
 import { onRequestReceived } from './request-received'
 import { onResponseReceived } from './response-received'
@@ -6,7 +6,7 @@ import { onRequestComplete } from './request-complete'
 import Bluebird from 'bluebird'
 
 export type HandlerFn<Frame extends NetEventFrames.BaseHttp> = (Cypress: Cypress.Cypress, frame: Frame, opts: {
-  getRequest: (routeHandlerId: string, requestId: string) => Request | undefined
+  getRequest: (routeHandlerId: string, requestId: string) => Interception | undefined
   getRoute: (routeHandlerId: string) => Route | undefined
   emitNetEvent: (eventName: string, frame: any) => Promise<void>
   failCurrentTest: (err: Error) => void
@@ -25,7 +25,7 @@ export function registerEvents (Cypress: Cypress.Cypress) {
     return state('routes')[routeHandlerId]
   }
 
-  function getRequest (routeHandlerId: string, requestId: string): Request | undefined {
+  function getRequest (routeHandlerId: string, requestId: string): Interception | undefined {
     const route = getRoute(routeHandlerId)
 
     if (route) {

--- a/packages/driver/src/cy/net-stubbing/events/request-received.ts
+++ b/packages/driver/src/cy/net-stubbing/events/request-received.ts
@@ -2,7 +2,7 @@ import _ from 'lodash'
 
 import {
   Route,
-  Request,
+  Interception,
   CyHttpMessages,
   StaticResponse,
   SERIALIZABLE_REQ_PROPS,
@@ -19,7 +19,7 @@ import { HandlerFn } from './'
 import Bluebird from 'bluebird'
 
 export const onRequestReceived: HandlerFn<NetEventFrames.HttpRequestReceived> = (Cypress, frame, { getRoute, emitNetEvent }) => {
-  function getRequestLog (route: Route, request: Omit<Request, 'log'>) {
+  function getRequestLog (route: Route, request: Omit<Interception, 'log'>) {
     return Cypress.log({
       name: 'xhr',
       displayName: 'req',
@@ -52,7 +52,7 @@ export const onRequestReceived: HandlerFn<NetEventFrames.HttpRequestReceived> = 
 
   parseJsonBody(req)
 
-  const request: Partial<Request> = {
+  const request: Partial<Interception> = {
     id: requestId,
     request: req,
     state: 'Received',
@@ -156,11 +156,11 @@ export const onRequestReceived: HandlerFn<NetEventFrames.HttpRequestReceived> = 
     return sendContinueFrame()
   }
 
-  request.log = getRequestLog(route, request as Omit<Request, 'log'>)
+  request.log = getRequestLog(route, request as Omit<Interception, 'log'>)
 
   // TODO: this misnomer is a holdover from XHR, should be numRequests
   route.log.set('numResponses', (route.log.get('numResponses') || 0) + 1)
-  route.requests[requestId] = request as Request
+  route.requests[requestId] = request as Interception
 
   if (frame.notificationOnly) {
     return
@@ -212,7 +212,7 @@ export const onRequestReceived: HandlerFn<NetEventFrames.HttpRequestReceived> = 
     if (userReq.alias) {
       Cypress.state('aliasedRequests').push({
         alias: userReq.alias,
-        request: request as Request,
+        request: request as Interception,
       })
 
       delete userReq.alias

--- a/packages/driver/src/cy/net-stubbing/wait-for-route.ts
+++ b/packages/driver/src/cy/net-stubbing/wait-for-route.ts
@@ -22,7 +22,7 @@ export function waitForRoute (alias: string, state: Cypress.State, specifier: 'r
   const candidateRequests = _.filter(state('aliasedRequests'), { alias })
   .map(({ request }) => request)
 
-  // Now add route-level (cy.http(...).as()) aliased requests.
+  // Now add route-level (cy.intercept(...).as()) aliased requests.
   const route: Route = _.find(state('routes'), { alias })
 
   if (route) {

--- a/packages/driver/src/cy/net-stubbing/wait-for-route.ts
+++ b/packages/driver/src/cy/net-stubbing/wait-for-route.ts
@@ -1,13 +1,13 @@
 import _ from 'lodash'
 import {
-  Request,
+  Interception,
   Route,
-  RequestState,
+  InterceptionState,
 } from './types'
 
-const RESPONSE_WAITED_STATES: RequestState[] = ['ResponseIntercepted', 'Complete']
+const RESPONSE_WAITED_STATES: InterceptionState[] = ['ResponseIntercepted', 'Complete']
 
-function getPredicateForSpecifier (specifier: string): Partial<Request> {
+function getPredicateForSpecifier (specifier: string): Partial<Interception> {
   if (specifier === 'request') {
     return { requestWaited: false }
   }
@@ -16,7 +16,7 @@ function getPredicateForSpecifier (specifier: string): Partial<Request> {
   return { responseWaited: false }
 }
 
-export function waitForRoute (alias: string, state: Cypress.State, specifier: 'request' | 'response' | string): Request | null {
+export function waitForRoute (alias: string, state: Cypress.State, specifier: 'request' | 'response' | string): Interception | null {
   // 1. Create an array of known requests that have this alias.
   // Start with request-level (req.alias = '...') aliases that could be a match.
   const candidateRequests = _.filter(state('aliasedRequests'), { alias })
@@ -31,7 +31,7 @@ export function waitForRoute (alias: string, state: Cypress.State, specifier: 'r
 
   // 2. Find the first request without responseWaited/requestWaited
   const predicate = getPredicateForSpecifier(specifier)
-  const request = _.find(candidateRequests, predicate) as Request | undefined
+  const request = _.find(candidateRequests, predicate) as Interception | undefined
 
   if (!request) {
     return null

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -1196,7 +1196,7 @@ module.exports = {
   route: {
     deprecated: {
       message: `${cmd('route')} has been deprecated and will be moved to a plugin in a future release. Consider migrating to using ${cmd('intercept')} instead.`,
-      docsUrl: 'https://on.cypress.io/http',
+      docsUrl: 'https://on.cypress.io/intercept',
     },
     failed_prerequisites: {
       message: `${cmd('route')} cannot be invoked before starting the ${cmd('server')}`,
@@ -1391,7 +1391,7 @@ module.exports = {
   server: {
     deprecated: {
       message: `${cmd('server')} has been deprecated and will be moved to a plugin in a future release. Consider migrating to using ${cmd('intercept')} instead.`,
-      docsUrl: 'https://on.cypress.io/http',
+      docsUrl: 'https://on.cypress.io/intercept',
     },
     invalid_argument: {
       message: `${cmd('server')} accepts only an object literal as its argument.`,

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -909,23 +909,23 @@ module.exports = {
   },
 
   net_stubbing: {
-    route2_renamed: `${cmd('route2')} was renamed to ${cmd('http')} and will be removed in a future release. Please update usages of ${cmd('route2')} to use ${cmd('http')} instead.`,
+    route2_renamed: `${cmd('route2')} was renamed to ${cmd('intercept')} and will be removed in a future release. Please update usages of ${cmd('route2')} to use ${cmd('intercept')} instead.`,
     invalid_static_response: ({ cmd, message, staticResponse }) => {
       return cyStripIndent(`\
         An invalid StaticResponse was supplied to \`${cmd}()\`. ${message}
 
         You passed: ${format(staticResponse)}`, 8)
     },
-    http: {
+    intercept: {
       invalid_handler: ({ handler }) => {
         return stripIndent`\
-          ${cmd('http')}'s \`handler\` argument must be a String, StaticResponse, or HttpController function.
+          ${cmd('intercept')}'s \`handler\` argument must be a String, StaticResponse, or HttpController function.
 
           You passed: ${format(handler)}`
       },
       invalid_route_matcher: ({ message, matcher }) => {
         return stripIndent`\
-          An invalid RouteMatcher was supplied to ${cmd('http')}. ${message}
+          An invalid RouteMatcher was supplied to ${cmd('intercept')}. ${message}
 
           You passed: ${format(matcher)}`
       },
@@ -933,7 +933,7 @@ module.exports = {
     request_handling: {
       cb_failed: ({ err, req, route }) => {
         return cyStripIndent(`\
-          A request callback passed to ${cmd('http')} threw an error while intercepting a request:
+          A request callback passed to ${cmd('intercept')} threw an error while intercepting a request:
 
           ${err.message}
 
@@ -943,7 +943,7 @@ module.exports = {
       },
       cb_timeout: ({ timeout, req, route }) => {
         return cyStripIndent(`\
-          A request callback passed to ${cmd('http')} timed out after returning a Promise that took more than the \`defaultCommandTimeout\` of \`${timeout}ms\` to resolve.
+          A request callback passed to ${cmd('intercept')} timed out after returning a Promise that took more than the \`defaultCommandTimeout\` of \`${timeout}ms\` to resolve.
 
           If the request callback is expected to take longer than \`${timeout}ms\`, increase the configured \`defaultCommandTimeout\` value.
 
@@ -1195,7 +1195,7 @@ module.exports = {
 
   route: {
     deprecated: {
-      message: `${cmd('route')} has been deprecated and will be moved to a plugin in a future release. Consider migrating to using ${cmd('http')} instead.`,
+      message: `${cmd('route')} has been deprecated and will be moved to a plugin in a future release. Consider migrating to using ${cmd('intercept')} instead.`,
       docsUrl: 'https://on.cypress.io/http',
     },
     failed_prerequisites: {
@@ -1390,7 +1390,7 @@ module.exports = {
 
   server: {
     deprecated: {
-      message: `${cmd('server')} has been deprecated and will be moved to a plugin in a future release. Consider migrating to using ${cmd('http')} instead.`,
+      message: `${cmd('server')} has been deprecated and will be moved to a plugin in a future release. Consider migrating to using ${cmd('intercept')} instead.`,
       docsUrl: 'https://on.cypress.io/http',
     },
     invalid_argument: {

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -332,38 +332,38 @@ declare global {
   namespace Cypress {
     interface Chainable<Subject = any> {
       /**
-       * Use `cy.http()` to stub and intercept HTTP requests and responses.
+       * Use `cy.intercept()` to stub and intercept HTTP requests and responses.
        *
        * @see https://on.cypress.io/http
        * @example
-       *    cy.http('https://localhost:7777/users', [{id: 1, name: 'Pat'}])
+       *    cy.intercept('https://localhost:7777/users', [{id: 1, name: 'Pat'}])
        * @example
-       *    cy.http('https://localhost:7777/protected-endpoint', (req) => {
+       *    cy.intercept('https://localhost:7777/protected-endpoint', (req) => {
        *      req.headers['authorization'] = 'basic fooabc123'
        *    })
        * @example
-       *    cy.http('https://localhost:7777/some-response', (req) => {
+       *    cy.intercept('https://localhost:7777/some-response', (req) => {
        *      req.reply(res => {
        *        res.body = 'some new body'
        *      })
        *    })
        */
-      http(url: RouteMatcher, response?: RouteHandler): Chainable<null>
+      intercept(url: RouteMatcher, response?: RouteHandler): Chainable<null>
       /**
-       * Use `cy.http()` to stub and intercept HTTP requests and responses.
+       * Use `cy.intercept()` to stub and intercept HTTP requests and responses.
        *
        * @see https://on.cypress.io/http
        * @example
-       *    cy.http('GET', 'http://foo.com/fruits', ['apple', 'banana', 'cherry'])
+       *    cy.intercept('GET', 'http://foo.com/fruits', ['apple', 'banana', 'cherry'])
        */
-      http(method: Method, url: RouteMatcher, response?: RouteHandler): Chainable<null>
+      intercept(method: Method, url: RouteMatcher, response?: RouteHandler): Chainable<null>
       /**
-       * Deprecated - use `cy.http()` instead.
+       * Deprecated - use `cy.intercept()` instead.
        * @deprecated
        */
       route2(url: RouteMatcher, response?: RouteHandler): Chainable<null>
       /**
-       * Deprecated - use `cy.http()` instead.
+       * Deprecated - use `cy.intercept()` instead.
        * @deprecated
        */
       route2(method: Method, url: RouteMatcher, response?: RouteHandler): Chainable<null>

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -428,7 +428,7 @@ declare global {
       cy.visit('/dashboard')
 
       cy.wait(['@getUsers', '@getActivities', '@getComments'])
-        .then((intercepts) => {
+        .then((interceptions) => {
           // intercepts will now be an array of matching HTTP requests
         })
       ```

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -406,7 +406,7 @@ declare global {
       // without changing or stubbing its response
       cy.intercept('https://api.example.com/accounts/*').as('getAccount')
       cy.visit('/accounts/123')
-      cy.wait('@getAccount').then((intercepted) => {
+      cy.wait('@getAccount').then((interception) => {
         // we can now access the low level request
         // that contains the request body,
         // response body, status, etc

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -388,13 +388,11 @@ declare global {
        */
       intercept(method: Method, url: RouteMatcher, response?: RouteHandler): Chainable<null>
       /**
-       * Deprecated - use `cy.intercept()` instead.
-       * @deprecated
+       * @deprecated Use `cy.intercept()` instead.
        */
       route2(url: RouteMatcher, response?: RouteHandler): Chainable<null>
       /**
-       * Deprecated - use `cy.intercept()` instead.
-       * @deprecated
+       * @deprecated Use `cy.intercept()` instead.
        */
       route2(method: Method, url: RouteMatcher, response?: RouteHandler): Chainable<null>
       /**

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -178,7 +178,7 @@ export type NumberMatcher = number | number[]
 /**
  * Request/response cycle.
  */
-export interface Request {
+export interface Interception {
   id: string
   /* @internal */
   log: any
@@ -197,10 +197,10 @@ export interface Request {
    */
   responseWaited: boolean
   /* @internal */
-  state: RequestState
+  state: InterceptionState
 }
 
-export type RequestState =
+export type InterceptionState =
   'Received' |
   'Intercepted' |
   'ResponseReceived' |
@@ -214,7 +214,7 @@ export interface Route {
   options: RouteMatcherOptions
   handler: RouteHandler
   hitCount: number
-  requests: { [key: string]: Request }
+  requests: { [key: string]: Interception }
 }
 
 export interface RouteMap { [key: string]: Route }
@@ -413,7 +413,7 @@ declare global {
       })
       ```
       */
-      wait(alias: string, options?: Partial<WaitOptions>): Chainable<Request>
+      wait(alias: string, options?: Partial<WaitOptions>): Chainable<Interception>
       /**
        * Wait for list of requests to complete.
        *
@@ -433,7 +433,7 @@ declare global {
         })
       ```
       */
-      wait(alias: string[], options?: Partial<WaitOptions>): Chainable<Request[]>
+      wait(alias: string[], options?: Partial<WaitOptions>): Chainable<Interception[]>
     }
   }
 }

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -406,9 +406,9 @@ declare global {
       ```
       // Wait for the route aliased as 'getAccount' to respond
       // without changing or stubbing its response
-      cy.http('https://api.example.com/accounts/*').as('getAccount')
+      cy.intercept('https://api.example.com/accounts/*').as('getAccount')
       cy.visit('/accounts/123')
-      cy.wait('@getAccount').then((xhr) => {
+      cy.wait('@getAccount').then((intercepted) => {
         // we can now access the low level request
         // that contains the request body,
         // response body, status, etc
@@ -424,18 +424,14 @@ declare global {
        *
       ```
       // wait for 3 XHR requests to complete
-      cy.server()
-      cy.http('users/*').as('getUsers')
-      cy.http('activities/*').as('getActivities')
-      cy.http('comments/*').as('getComments')
+      cy.intercept('users/*').as('getUsers')
+      cy.intercept('activities/*').as('getActivities')
+      cy.intercept('comments/*').as('getComments')
       cy.visit('/dashboard')
 
       cy.wait(['@getUsers', '@getActivities', '@getComments'])
-        .then((xhrs) => {
-          // xhrs will now be an array of matching XHR's
-          // xhrs[0] <-- getUsers
-          // xhrs[1] <-- getActivities
-          // xhrs[2] <-- getComments
+        .then((intercepts) => {
+          // intercepts will now be an array of matching HTTP requests
         })
       ```
       */

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -364,7 +364,7 @@ declare global {
       /**
        * Use `cy.intercept()` to stub and intercept HTTP requests and responses.
        *
-       * @see https://on.cypress.io/http
+       * @see https://on.cypress.io/intercept
        * @example
        *    cy.intercept('https://localhost:7777/users', [{id: 1, name: 'Pat'}])
        * @example
@@ -382,7 +382,7 @@ declare global {
       /**
        * Use `cy.intercept()` to stub and intercept HTTP requests and responses.
        *
-       * @see https://on.cypress.io/http
+       * @see https://on.cypress.io/intercept
        * @example
        *    cy.intercept('GET', 'http://foo.com/fruits', ['apple', 'banana', 'cherry'])
        */

--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -903,8 +903,8 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
         You can safely remove this option from your config.`
     case 'EXPERIMENTAL_NETWORK_STUBBING_REMOVED':
       return stripIndent`\
-        The \`experimentalNetworkStubbing\` configuration option was removed in Cypress version \`6.0.0\`. 
-        It is no longer necessary for using \`cy.http()\` (formerly \`cy.route2()\`).
+        The \`experimentalNetworkStubbing\` configuration option was removed in Cypress version \`6.0.0\`.
+        It is no longer necessary for using \`cy.intercept()\` (formerly \`cy.route2()\`).
 
         You can safely remove this option from your config.`
     case 'INCOMPATIBLE_PLUGIN_RETRIES':
@@ -920,7 +920,7 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
     case 'INVALID_CONFIG_OPTION':
       return stripIndent`\
         ${arg1.map((arg) => `\`${arg}\` is not a valid configuration option`)}
-        
+
         https://on.cypress.io/configuration
         `
     default:


### PR DESCRIPTION
### User facing changelog

- Renamed the `cy.route2` command to `cy.intercept`.

### Additional details

- also updated types, tsdocs for "Interceptions"

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->https://github.com/cypress-io/cypress-documentation/pull/3340
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
