### PR TITLE
fix(server): CDP needs screencasts ack before sending more frames

### DIFF
--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -266,7 +266,10 @@ const _maybeRecordVideo = async function (client, options) {
   }
 
   debug('starting screencast')
-  client.on('Page.screencastFrame', options.onScreencastFrame)
+  client.on('Page.screencastFrame', (meta) => {
+    options.onScreencastFrame(meta)
+    client.send('Page.screencastFrameAck', { sessionId: meta.sessionId })
+  })
 
   await client.send('Page.startScreencast', {
     format: 'jpeg',

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -28,7 +28,8 @@ namespace CRI {
     'Page.bringToFront' |
     'Page.captureScreenshot' |
     'Page.navigate' |
-    'Page.startScreencast'
+    'Page.startScreencast' |
+    'Page.screencastFrameAck'
 
   export type EventName =
     'Page.screencastFrame'

--- a/packages/server/lib/browsers/electron.js
+++ b/packages/server/lib/browsers/electron.js
@@ -91,6 +91,7 @@ const _maybeRecordVideo = function (webContents, options) {
     webContents.debugger.on('message', (event, method, params) => {
       if (method === 'Page.screencastFrame') {
         onScreencastFrame(params)
+        webContents.debugger.sendCommand('Page.screencastFrameAck', { sessionId: params.sessionId })
       }
     })
 

--- a/packages/server/test/e2e/6_video_compression_spec.js
+++ b/packages/server/test/e2e/6_video_compression_spec.js
@@ -61,6 +61,7 @@ describe('e2e video compression', () => {
             const lastFrameFile = path.join(path.dirname(files[0]), 'lastFrame.jpg')
 
             await outputFinalFrameAsJpg(files[0], lastFrameFile)
+            // https://github.com/cypress-io/cypress/issues/9265
             // if video is seekable and not just one frozen frame, this file should exist
             await fs.stat(lastFrameFile).catch((err) => {
               throw new Error(`Expected video to have seekable ending frame, but it did not. The video may be corrupted.`)

--- a/packages/server/test/unit/browsers/chrome_spec.js
+++ b/packages/server/test/unit/browsers/chrome_spec.js
@@ -257,6 +257,7 @@ describe('lib/browsers/chrome', () => {
       return expect(chrome.open('chrome', 'http://', {}, this.automation)).to.be.rejectedWith('Cypress requires at least Chrome 64.')
     })
 
+    // https://github.com/cypress-io/cypress/issues/9265
     it('respond ACK after receiving new screenshot frame', function () {
       const frameMeta = { data: Buffer.from(''), sessionId: '1' }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...


* Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
* Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
* Mark this PR as "Draft" if it is not ready for review.
-->
* Closes #9265

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->
fix recorded videos only show a static frames.

### Additional details
<!-- Examples:


* Why was this change necessary?
* What is affected by this change?
* Any implementation details to explain?
-->
explained in https://github.com/cypress-io/cypress/issues/9265#issuecomment-732691175
chromium throttles frame rate with `Page.screencastFrameAck`

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

* [x] Have tests been added/updated?

