### PR TITLE
feat(webpack-preprocessor): Allow specifying typescript path

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -287,6 +287,7 @@ commands:
     steps:
       - attach_workspace:
           at: ~/
+      - check-conditional-ci
       # make sure the binary and NPM package files are present
       - run: ls -l
       - run: ls -l cypress.zip cypress.tgz

--- a/npm/webpack-preprocessor/index.ts
+++ b/npm/webpack-preprocessor/index.ts
@@ -94,6 +94,7 @@ const quietErrorMessage = (err: Error) => {
 interface PreprocessorOptions {
   webpackOptions?: webpack.Configuration
   watchOptions?: Object
+  typescript?: string
   additionalEntries?: string[]
 }
 
@@ -201,9 +202,8 @@ const preprocessor: WebpackPreprocessor = (options: PreprocessorOptions = {}): F
     })
     .tap((opts) => {
       if (opts.devtool === false) {
-        // disable any overrides if
-        // we've explictly turned off sourcemaps
-        overrideSourceMaps(false)
+        // disable any overrides if we've explictly turned off sourcemaps
+        overrideSourceMaps(false, options.typescript)
 
         return
       }
@@ -212,14 +212,15 @@ const preprocessor: WebpackPreprocessor = (options: PreprocessorOptions = {}): F
 
       opts.devtool = 'inline-source-map'
 
-      // override typescript to always generate
-      // proper source maps
-      overrideSourceMaps(true)
+      // override typescript to always generate proper source maps
+      overrideSourceMaps(true, options.typescript)
     })
     .value() as any
 
     debug('webpackOptions: %o', webpackOptions)
     debug('watchOptions: %o', watchOptions)
+    if (options.typescript) debug('typescript: %s', options.typescript)
+
     debug(`input: ${filePath}`)
     debug(`output: ${outputPath}`)
 

--- a/npm/webpack-preprocessor/test/unit/index.spec.js
+++ b/npm/webpack-preprocessor/test/unit/index.spec.js
@@ -18,7 +18,7 @@ mockery.enable({
 mockery.registerMock('webpack', webpack)
 
 const preprocessor = require('../../index')
-const { getSourceMapOverride } = require('../../lib/typescript-overrides')
+const typescriptOverrides = require('../../lib/typescript-overrides')
 
 describe('webpack preprocessor', function () {
   beforeEach(function () {
@@ -152,13 +152,17 @@ describe('webpack preprocessor', function () {
       })
 
       describe('devtool', function () {
+        beforeEach((() => {
+          sinon.stub(typescriptOverrides, 'overrideSourceMaps')
+        }))
+
         it('enables inline source maps', function () {
           return this.run().then(() => {
             expect(webpack).to.be.calledWithMatch({
               devtool: 'inline-source-map',
             })
 
-            expect(getSourceMapOverride()).to.be.true
+            expect(typescriptOverrides.overrideSourceMaps).to.be.calledWith(true)
           })
         })
 
@@ -170,7 +174,7 @@ describe('webpack preprocessor', function () {
               devtool: false,
             })
 
-            expect(getSourceMapOverride()).to.be.false
+            expect(typescriptOverrides.overrideSourceMaps).to.be.calledWith(false)
           })
         })
 
@@ -182,7 +186,7 @@ describe('webpack preprocessor', function () {
               devtool: 'inline-source-map',
             })
 
-            expect(getSourceMapOverride()).to.be.true
+            expect(typescriptOverrides.overrideSourceMaps).to.be.calledWith(true)
           })
         })
       })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->

- Closes #8477

- Addresses [TR-450](https://cypress-io.atlassian.net/browse/TR-450)
- Addresses [TR-398](https://cypress-io.atlassian.net/browse/TR-398)

### User facing changelog

- Webpack preprocessor now allows passing the path to TypeScript via the `typescript` option.

### Additional details

When we run the default preprocessor and require typescript, it ends up requiring cypress's own version of typescript and not the user's. This prevents us from monkey-patching the correct version of typescript for source maps compatibility. 

We already search out the path to the user's typescript and pass it to the preprocessor. This utilizes that path to require typescript.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- N/A Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
