### PR TITLE
fix: Remove deprecated flag from types for cy.screenshot()

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1537,8 +1537,6 @@ declare namespace Cypress {
     route(options: Partial<RouteOptions>): Chainable<null>
 
     /**
-     * @deprecated Use `cy.intercept()` instead.
-     *
      * Take a screenshot of the application under test and the Cypress Command Log.
      *
      * @see https://on.cypress.io/screenshot


### PR DESCRIPTION
- close #9303 

TR-511

### User Changelog

`cy.screenshot()` types will no longer mistakenly display the command as deprecated.

### Additional details

- I could find a way to test that a command is deprecated/not.