### PR TITLE
fix: lower-cased HTTP methods can be used with cy.intercept.

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -209,6 +209,21 @@ describe('network stubbing', { retries: 2 }, function () {
       cy.wait('@create')
     })
 
+    // https://github.com/cypress-io/cypress/issues/9313
+    it('lower-cased method works', () => {
+      cy.intercept('post', 'http://dummy.restapiexample.com/api/v1/create').as('create')
+
+      cy.window().then((win) => {
+        win.eval(
+          `fetch("http://dummy.restapiexample.com/api/v1/create", {
+            method: 'post', // *GET, POST, PUT, DELETE, etc.
+          });`,
+        )
+      })
+
+      cy.wait('@create')
+    })
+
     // TODO: implement warning in cy.intercept if appropriate
     // https://github.com/cypress-io/cypress/issues/2372
     it.skip('warns if a percent-encoded URL is used', function () {

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -196,11 +196,11 @@ describe('network stubbing', { retries: 2 }, function () {
 
     // https://github.com/cypress-io/cypress/issues/8729
     it('resolve ambiguity between overloaded definitions', () => {
-      cy.intercept('POST', 'http://dummy.restapiexample.com/api/v1/create').as('create')
+      cy.intercept('POST', '/post-only').as('create')
 
       cy.window().then((win) => {
         win.eval(
-          `fetch("http://dummy.restapiexample.com/api/v1/create", {
+          `fetch("/post-only", {
             method: 'POST', // *GET, POST, PUT, DELETE, etc.
           });`,
         )
@@ -211,11 +211,14 @@ describe('network stubbing', { retries: 2 }, function () {
 
     // https://github.com/cypress-io/cypress/issues/9313
     it('lower-cased method works', () => {
-      cy.intercept('post', 'http://dummy.restapiexample.com/api/v1/create').as('create')
+      cy.intercept({
+        method: 'post',
+        url: '/post-only',
+      }).as('create')
 
       cy.window().then((win) => {
         win.eval(
-          `fetch("http://dummy.restapiexample.com/api/v1/create", {
+          `fetch("/post-only", {
             method: 'post', // *GET, POST, PUT, DELETE, etc.
           });`,
         )

--- a/packages/driver/src/cy/net-stubbing/add-command.ts
+++ b/packages/driver/src/cy/net-stubbing/add-command.ts
@@ -279,7 +279,7 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
         handler = arg2
 
         return {
-          method: matcher.toUpperCase(),
+          method: matcher,
           url,
         }
       }

--- a/packages/driver/src/cy/net-stubbing/add-command.ts
+++ b/packages/driver/src/cy/net-stubbing/add-command.ts
@@ -279,7 +279,7 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
         handler = arg2
 
         return {
-          method: matcher,
+          method: matcher.toUpperCase(),
           url,
         }
       }

--- a/packages/net-stubbing/lib/server/route-matching.ts
+++ b/packages/net-stubbing/lib/server/route-matching.ts
@@ -20,7 +20,7 @@ export function _doesRouteMatch (routeMatcher: RouteMatcherOptions, req: Cypress
 
   for (let i = 0; i < stringMatcherFields.length; i++) {
     const field = stringMatcherFields[i]
-    const matcher = _.get(routeMatcher, field)
+    let matcher = _.get(routeMatcher, field)
     let value = _.get(matchable, field, '')
 
     if (typeof value !== 'string') {
@@ -33,6 +33,13 @@ export function _doesRouteMatch (routeMatcher: RouteMatcherOptions, req: Cypress
       }
 
       continue
+    }
+
+    if (field === 'method') {
+      // case-insensitively match on method
+      // @see https://github.com/cypress-io/cypress/issues/9313
+      value = value.toLowerCase()
+      matcher = matcher.toLowerCase()
     }
 
     if (field === 'url') {


### PR DESCRIPTION
* Closes #9313 

### User facing changelog
Lower-cased HTTP methods can be used with cy.intercept. 

### Additional details
* Why was this change necessary? => `cy.intercept` only allowed upper-cased HTTP methods. 
* What is affected by this change? => N/A
* Any implementation details to explain? => N/A

### How has the user experience changed?
N/A

### PR Tasks
* [x] Have tests been added/updated?
* [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->

