### PR TITLE
fix(intercept): Fix matching routes to be in reverse order

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -2082,4 +2082,20 @@ describe('network stubbing', { retries: 2 }, function () {
       })
     })
   })
+
+  context('multiple matching routes', function () {
+    // https://github.com/cypress-io/cypress/issues/9302
+    it('uses the matching route defined last', function (done) {
+      const firstResponse = { foo: 'bar' }
+      const secondResponse = { hello: 'world' }
+
+      cy.intercept({ url: '*' }, firstResponse)
+      cy.intercept({ url: '*' }, secondResponse).then(() => {
+        $.get('/abc123').done((responseJson) => {
+          expect(responseJson).to.deep.eq(secondResponse)
+          done()
+        })
+      })
+    })
+  })
 })

--- a/packages/net-stubbing/lib/server/route-matching.ts
+++ b/packages/net-stubbing/lib/server/route-matching.ts
@@ -110,7 +110,13 @@ export function _getMatchableForRequest (req: CypressIncomingRequest) {
 export function getRouteForRequest (routes: BackendRoute[], req: CypressIncomingRequest, prevRoute?: BackendRoute) {
   const possibleRoutes = prevRoute ? routes.slice(_.findIndex(routes, prevRoute) + 1) : routes
 
-  return _.find(possibleRoutes, (route) => {
-    return _doesRouteMatch(route.routeMatcher, req)
-  })
+  for (let i = possibleRoutes.length - 1; i >= 0; i--) {
+    const route = possibleRoutes[i]
+
+    if (_doesRouteMatch(route.routeMatcher, req)) {
+      return route
+    }
+  }
+
+  return undefined
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->

- Closes #9302 

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->
Will make subsequent calls to `cy.intercept` for the same matching route override each other instead of using the route defined in the first call to `cy.intercept`.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Previously, when calling `cy.route` multiple times with route matchers that can match the same route, the last one was considered the match as seen here
https://github.com/cypress-io/cypress/blob/197f3097f7beaa09cd4dd1e2a0e9a39610f5ed69/packages/driver/src/cypress/server.js#L268-L277

Now, with the introduction of `cy.intercept` this behavior changed as seen here
https://github.com/cypress-io/cypress/blob/197f3097f7beaa09cd4dd1e2a0e9a39610f5ed69/packages/net-stubbing/lib/server/route-matching.ts#L110-L116

This PR changes the above to do the matching in reverse order to match the previous implementation of `cy.route`.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
No changes.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
