### PR TITLE
fix: Don't remove the "/" at the end when user passed it.

### DIFF
--- a/packages/driver/cypress/integration/cypress/location_spec.js
+++ b/packages/driver/cypress/integration/cypress/location_spec.js
@@ -456,5 +456,12 @@ describe('src/cypress/location', () => {
         })
       })
     })
+
+    // https://github.com/cypress-io/cypress/issues/9360
+    it('does not remove slash when user passed it.', () => {
+      const url = Location.qualifyWithBaseUrl('http://localhost:3500/', '/pageOne?param1=/param/')
+
+      expect(url).to.eq('http://localhost:3500/pageOne?param1=/param/')
+    })
   })
 })

--- a/packages/driver/src/cypress/location.js
+++ b/packages/driver/src/cypress/location.js
@@ -199,16 +199,20 @@ class $Location {
   static qualifyWithBaseUrl (baseUrl, url) {
     // if we have a root url and our url isnt full qualified
     if (baseUrl && !this.isFullyQualifiedUrl(url)) {
+      const urlEndsWithSlash = (url) => {
+        return url[url.length - 1] === '/'
+      }
+
       // https://github.com/cypress-io/cypress/issues/9360
       // When user passed the URL that ends with '/', then we should preserve it.
-      const isOriginalUrlEndsWithSlash = url[url.length - 1] === '/'
+      const originalUrlEndsWithSlash = urlEndsWithSlash(url)
 
       // prepend the root url to it
       url = this.join(baseUrl, url)
 
       // https://github.com/cypress-io/cypress/issues/2101
       // Has query param and ends with /
-      if (!isOriginalUrlEndsWithSlash && reQueryParam.test(url) && url[url.length - 1] === '/') {
+      if (!originalUrlEndsWithSlash && reQueryParam.test(url) && urlEndsWithSlash(url)) {
         url = url.substring(0, url.length - 1)
       }
     }

--- a/packages/driver/src/cypress/location.js
+++ b/packages/driver/src/cypress/location.js
@@ -199,12 +199,16 @@ class $Location {
   static qualifyWithBaseUrl (baseUrl, url) {
     // if we have a root url and our url isnt full qualified
     if (baseUrl && !this.isFullyQualifiedUrl(url)) {
+      // https://github.com/cypress-io/cypress/issues/9360
+      // When user passed the URL that ends with '/', then we should preserve it.
+      const isOriginalUrlEndsWithSlash = url[url.length - 1] === '/'
+
       // prepend the root url to it
       url = this.join(baseUrl, url)
 
       // https://github.com/cypress-io/cypress/issues/2101
       // Has query param and ends with /
-      if (reQueryParam.test(url) && url[url.length - 1] === '/') {
+      if (!isOriginalUrlEndsWithSlash && reQueryParam.test(url) && url[url.length - 1] === '/') {
         url = url.substring(0, url.length - 1)
       }
     }


### PR DESCRIPTION
* Closes #9360

### User facing changelog
Don't remove "/" at the end when user passed it.

### Additional details
* Why was this change necessary? => "/" at the end was removed even when user passed it.
* What is affected by this change? => N/A
* Any implementation details to explain? => N/A

### How has the user experience changed?
N/A

### PR Tasks
* [x] Have tests been added/updated?
* [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->

