### PR TITLE
feat: automatically set CORS headers on stubbed responses

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -992,8 +992,8 @@ jobs:
           name: Run e2e example tests
           command: yarn test
           working_directory: npm/react/<<parameters.path>>
-  
-  
+
+
   npm-create-cypress-tests:
     <<: *defaults
     steps:
@@ -1002,8 +1002,8 @@ jobs:
       - run: yarn workspace create-cypress-tests build
       - run:
           name: Run unit test
-          command: yarn workspace create-cypress-tests test 
-          
+          command: yarn workspace create-cypress-tests test
+
   npm-eslint-plugin-dev:
     <<: *defaults
     steps:
@@ -1833,7 +1833,7 @@ linux-workflow: &linux-workflow
         path: examples/webpack-options
         requires:
           - npm-react
-    
+
     - npm-create-cypress-tests:
         requires:
           - build

--- a/packages/net-stubbing/lib/server/intercept-request.ts
+++ b/packages/net-stubbing/lib/server/intercept-request.ts
@@ -18,7 +18,12 @@ import {
   SERIALIZABLE_REQ_PROPS,
 } from '../types'
 import { getRouteForRequest } from './route-matching'
-import { sendStaticResponse, emit, setResponseFromFixture } from './util'
+import {
+  sendStaticResponse,
+  emit,
+  setResponseFromFixture,
+  setDefaultHeaders,
+} from './util'
 import CyServer from '@packages/server'
 
 const debug = Debug('cypress:net-stubbing:server:intercept-request')
@@ -46,7 +51,10 @@ export const InterceptRequest: RequestMiddleware = function () {
     requestId,
     route,
     continueRequest: this.next,
-    onResponse: this.onResponse,
+    onResponse: (incomingRes, resStream) => {
+      setDefaultHeaders(this.req, incomingRes)
+      this.onResponse(incomingRes, resStream)
+    },
     req: this.req,
     res: this.res,
   }

--- a/packages/net-stubbing/lib/server/util.ts
+++ b/packages/net-stubbing/lib/server/util.ts
@@ -17,6 +17,7 @@ import MimeTypes from 'mime-types'
 
 // TODO: move this into net-stubbing once cy.route is removed
 import { parseContentType } from '@packages/server/lib/controllers/xhrs'
+import { CypressIncomingRequest } from '@packages/proxy'
 
 const debug = Debug('cypress:net-stubbing:server:util')
 
@@ -81,6 +82,27 @@ const caseInsensitiveGet = function (obj, lowercaseProperty) {
       return obj[key]
     }
   }
+}
+
+const caseInsensitiveHas = function (obj, lowercaseProperty) {
+  for (let key of Object.keys(obj)) {
+    if (key.toLowerCase() === lowercaseProperty) {
+      return true
+    }
+  }
+
+  return false
+}
+
+export function setDefaultHeaders (req: CypressIncomingRequest, res: IncomingMessage) {
+  const setDefaultHeader = (lowercaseHeader: string, defaultValueFn: () => string) => {
+    if (!caseInsensitiveHas(res.headers, lowercaseHeader)) {
+      res.headers[lowercaseHeader] = defaultValueFn()
+    }
+  }
+
+  setDefaultHeader('access-control-allow-origin', () => caseInsensitiveGet(req.headers, 'origin') || '*')
+  setDefaultHeader('access-control-allow-credentials', _.constant('true'))
 }
 
 export async function setResponseFromFixture (getFixtureFn: GetFixtureFn, staticResponse: BackendStaticResponse) {

--- a/packages/proxy/lib/http/index.ts
+++ b/packages/proxy/lib/http/index.ts
@@ -40,6 +40,12 @@ type HttpMiddlewareCtx<T> = {
   deferSourceMapRewrite: (opts: { js: string, url: string }) => string
 } & T
 
+export const defaultMiddleware = {
+  [HttpStages.IncomingRequest]: RequestMiddleware,
+  [HttpStages.IncomingResponse]: ResponseMiddleware,
+  [HttpStages.Error]: ErrorMiddleware,
+}
+
 export type ServerCtx = Readonly<{
   config: CyServer.Config
   getFileServerToken: () => string
@@ -197,11 +203,7 @@ export class Http {
     this.request = opts.request
 
     if (typeof opts.middleware === 'undefined') {
-      this.middleware = {
-        [HttpStages.IncomingRequest]: RequestMiddleware,
-        [HttpStages.IncomingResponse]: ResponseMiddleware,
-        [HttpStages.Error]: ErrorMiddleware,
-      }
+      this.middleware = defaultMiddleware
     }
   }
 

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "build-prod": "tsc --project .",
     "clean-deps": "rm -rf node_modules",
-    "test": "yarn test-unit",
-    "test-unit": "mocha -r @packages/ts/register -r test/pretest.ts --reporter mocha-multi-reporters --reporter-options configFile=../../mocha-reporter-config.json --exit test/unit/**/*"
+    "run-mocha": "mocha -r @packages/ts/register -r test/pretest.ts --reporter mocha-multi-reporters --reporter-options configFile=../../mocha-reporter-config.json",
+    "test": "yarn run-mocha \"test/integration/*.spec.ts\" \"test/unit/**/*.spec.ts\"",
+    "test-integration": "yarn run-mocha \"test/integration/*.spec.ts\"",
+    "test-unit": "yarn run-mocha \"test/unit/**/*.spec.ts\""
   },
   "dependencies": {
     "bluebird": "3.5.3",
@@ -26,6 +28,9 @@
     "@cypress/request-promise": "4.2.6",
     "@cypress/sinon-chai": "2.9.0",
     "@types/express": "4.17.2",
+    "@types/supertest": "2.0.10",
+    "express": "4.17.1",
+    "supertest": "6.0.1",
     "typescript": "3.5.3"
   },
   "files": [

--- a/packages/proxy/test/integration/net-stubbing.spec.ts
+++ b/packages/proxy/test/integration/net-stubbing.spec.ts
@@ -1,0 +1,199 @@
+import { NetworkProxy } from '../../'
+import {
+  netStubbingState as _netStubbingState,
+  NetStubbingState,
+  onNetEvent,
+} from '@packages/net-stubbing'
+import { defaultMiddleware } from '../../lib/http'
+import express from 'express'
+import sinon from 'sinon'
+import { expect } from 'chai'
+import supertest from 'supertest'
+import { allowDestroy } from '@packages/network'
+import { EventEmitter } from 'events'
+
+const Request = require('@packages/server/lib/request')
+const getFixture = async () => {}
+
+context('network stubbing', () => {
+  let config
+  let remoteState
+  let netStubbingState: NetStubbingState
+  let app
+  let destinationApp
+  let server
+  let destinationPort
+  let socket
+
+  beforeEach((done) => {
+    config = {}
+    remoteState = {}
+    socket = new EventEmitter()
+    socket.toDriver = sinon.stub()
+    app = express()
+    netStubbingState = _netStubbingState()
+
+    const proxy = new NetworkProxy({
+      socket,
+      netStubbingState,
+      config,
+      middleware: defaultMiddleware,
+      getRemoteState: () => remoteState,
+      getFileServerToken: () => 'fake-token',
+      request: new Request(),
+    })
+
+    app.use((req, res, next) => {
+      req.proxiedUrl = req.url = req.url.slice(1)
+      req.cookies = {}
+      next()
+    })
+
+    app.use((req, res) => {
+      proxy.handleHttpRequest(req, res)
+    })
+
+    destinationApp = express()
+
+    destinationApp.get('/', (req, res) => res.send('it worked'))
+
+    server = allowDestroy(destinationApp.listen(() => {
+      destinationPort = server.address().port
+      done()
+    }))
+  })
+
+  afterEach(() => {
+    server.destroy()
+  })
+
+  it('can make a vanilla request', (done) => {
+    supertest(app)
+    .get(`/http://localhost:${destinationPort}`)
+    .expect('it worked', done)
+  })
+
+  it('does not add CORS headers to all responses', () => {
+    return supertest(app)
+    .get(`/http://localhost:${destinationPort}`)
+    .then((res) => {
+      expect(res.headers).to.not.have.property('access-control-allow-origin')
+    })
+  })
+
+  it('adds CORS headers to static stubs', () => {
+    netStubbingState.routes.push({
+      handlerId: '1',
+      routeMatcher: {
+        url: '*',
+      },
+      hasInterceptor: false,
+      staticResponse: {
+        body: 'foo',
+      },
+      getFixture: async () => {},
+    })
+
+    return supertest(app)
+    .get(`/http://localhost:${destinationPort}`)
+    .then((res) => {
+      expect(res.headers).to.include({
+        'access-control-allow-origin': '*',
+        'access-control-allow-credentials': 'true',
+      })
+
+      expect(res.text).to.eq('foo')
+    })
+  })
+
+  it('does not override CORS headers', () => {
+    netStubbingState.routes.push({
+      handlerId: '1',
+      routeMatcher: {
+        url: '*',
+      },
+      hasInterceptor: false,
+      staticResponse: {
+        body: 'foo',
+        headers: {
+          'access-control-allow-origin': 'something',
+        },
+      },
+      getFixture: async () => {},
+    })
+
+    return supertest(app)
+    .get(`/http://localhost:${destinationPort}`)
+    .then((res) => {
+      expect(res.headers).to.include({
+        'access-control-allow-origin': 'something',
+      })
+    })
+  })
+
+  it('uses Origin to set CORS header', () => {
+    netStubbingState.routes.push({
+      handlerId: '1',
+      routeMatcher: {
+        url: '*',
+      },
+      hasInterceptor: false,
+      staticResponse: {
+        body: 'foo',
+      },
+      getFixture: async () => {},
+    })
+
+    return supertest(app)
+    .get(`/http://localhost:${destinationPort}`)
+    .set('Origin', 'http://foo.com')
+    .then((res) => {
+      expect(res.headers).to.include({
+        'access-control-allow-origin': 'http://foo.com',
+      })
+    })
+  })
+
+  it('adds CORS headers to dynamically intercepted requests', () => {
+    netStubbingState.routes.push({
+      handlerId: '1',
+      routeMatcher: {
+        url: '*',
+      },
+      hasInterceptor: true,
+      getFixture,
+    })
+
+    socket.toDriver.callsFake((_, event, data) => {
+      if (event === 'http:request:received') {
+        onNetEvent({
+          eventName: 'http:request:continue',
+          frame: {
+            routeHandlerId: '1',
+            requestId: data.requestId,
+            req: data.req,
+            staticResponse: {
+              body: 'replaced',
+            },
+            hasResponseHandler: false,
+            tryNextRoute: false,
+          },
+          state: netStubbingState,
+          socket,
+          getFixture,
+          args: [],
+        })
+      }
+    })
+
+    return supertest(app)
+    .get(`/http://localhost:${destinationPort}`)
+    .then((res) => {
+      expect(res.headers).to.include({
+        'access-control-allow-origin': '*',
+      })
+
+      expect(res.text).to.eq('replaced')
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2818,9 +2818,9 @@
     "@types/yargs" "^13.0.0"
 
 "@jest/types@^26.3.0":
-  version "26.6.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.0.tgz#2c045f231bfd79d52514cda3fbc93ef46157fa6a"
-  integrity sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
@@ -5306,6 +5306,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookiejar@*":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
+  integrity sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==
+
 "@types/copy-webpack-plugin@5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@types/copy-webpack-plugin/-/copy-webpack-plugin-5.0.0.tgz#db7f9c9763b10b2af5c83f598fa9b5a13733b20b"
@@ -5815,6 +5820,21 @@
   integrity sha512-Yjye9VwMdYeXfS71ihueWRSxrruuXTwKCbzue4+5b2rjnQ//AtyM7myZ1BEhNhBQ/nL/RE7bdToUoLln2miKvg==
   dependencies:
     "@types/react" "*"
+
+"@types/superagent@*":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-4.1.10.tgz#5e2cc721edf58f64fe9b819f326ee74803adee86"
+  integrity sha512-xAgkb2CMWUMCyVc/3+7iQfOEBE75NvuZeezvmixbUw3nmENf2tCnQkW5yQLTYqvXUQ+R6EXxdqKKbal2zM5V/g==
+  dependencies:
+    "@types/cookiejar" "*"
+    "@types/node" "*"
+
+"@types/supertest@2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@types/supertest/-/supertest-2.0.10.tgz#630d79b4d82c73e043e43ff777a9ca98d457cab7"
+  integrity sha512-Xt8TbEyZTnD5Xulw95GLMOkmjGICrOQyJ2jqgkSjAUR3mm7pAIzSR0NFBaMcwlzVvlpCjNwbATcWWwjNiZiFrQ==
+  dependencies:
+    "@types/superagent" "*"
 
 "@types/tapable@*":
   version "1.0.6"
@@ -10944,7 +10964,7 @@ combine-source-map@^0.8.0, combine-source-map@~0.8.0:
     lodash.memoize "~3.0.3"
     source-map "~0.5.3"
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -11063,7 +11083,7 @@ component-emitter@1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
   integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
 
-component-emitter@^1.2.0, component-emitter@^1.2.1, component-emitter@~1.3.0:
+component-emitter@^1.2.0, component-emitter@^1.2.1, component-emitter@^1.3.0, component-emitter@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -11393,7 +11413,7 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
-cookiejar@^2.1.0:
+cookiejar@^2.1.0, cookiejar@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
   integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
@@ -15778,6 +15798,15 @@ form-data@^2.3.1, form-data@^2.5.0:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -15794,7 +15823,7 @@ formatio@1.1.1:
   dependencies:
     samsam "~1.1"
 
-formidable@^1.2.0:
+formidable@^1.2.0, formidable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.2.tgz#bf69aea2972982675f00865342b982986f6b8dd9"
   integrity sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==
@@ -26469,7 +26498,7 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.4.0, qs@^6.5.1:
+qs@^6.4.0, qs@^6.5.1, qs@^6.9.4:
   version "6.9.4"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
   integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
@@ -30627,6 +30656,23 @@ sumchecker@^3.0.1:
   dependencies:
     debug "^4.1.0"
 
+superagent@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-6.1.0.tgz#09f08807bc41108ef164cfb4be293cebd480f4a6"
+  integrity sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.2"
+    debug "^4.1.1"
+    fast-safe-stringify "^2.0.7"
+    form-data "^3.0.0"
+    formidable "^1.2.2"
+    methods "^1.1.2"
+    mime "^2.4.6"
+    qs "^6.9.4"
+    readable-stream "^3.6.0"
+    semver "^7.3.2"
+
 superagent@^3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
@@ -30657,6 +30703,14 @@ supertest@4.0.2:
   dependencies:
     methods "^1.1.2"
     superagent "^3.8.3"
+
+supertest@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.0.1.tgz#f6b54370de85c45d6557192c8d7df604ca2c9e18"
+  integrity sha512-8yDNdm+bbAN/jeDdXsRipbq9qMpVF7wRsbwLgsANHqdjPsCoecmlTuqEcLQMGpmojFBhxayZ0ckXmLXYq7e+0g==
+  dependencies:
+    methods "1.1.2"
+    superagent "6.1.0"
 
 supports-color@1.2.0:
   version "1.2.0"


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->

- Closes #9264 

### User facing changelog

- Responses stubbed from `cy.intercept` will now automatically set `Access-Control-Allow-Origin` and `Access-Control-Allow-Credentials` to permissive values unless explicitly overridden.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
