### PR TITLE
chore: deprecate Cypress.moment()

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -166,7 +166,7 @@ declare namespace Cypress {
     /**
      * @deprecated Will be replaced in a future version.
      * Consider including your own datetime formatter in your tests.
-     * 
+     *
      * Cypress automatically includes moment.js and exposes it as Cypress.moment.
      *
      * @see https://on.cypress.io/moment

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -164,6 +164,9 @@ declare namespace Cypress {
      */
     minimatch: typeof Minimatch.minimatch
     /**
+     * @deprecated Will be replaced in a future version.
+     * Consider including your own datetime formatter in your tests.
+     * 
      * Cypress automatically includes moment.js and exposes it as Cypress.moment.
      *
      * @see https://on.cypress.io/moment

--- a/packages/driver/cypress/integration/util/moment_spec.js
+++ b/packages/driver/cypress/integration/util/moment_spec.js
@@ -1,0 +1,8 @@
+context('#moment', () => {
+  it('logs deprecation warning', () => {
+    cy.stub(Cypress.utils, 'warning')
+
+    Cypress.moment()
+    expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment()` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.')
+  })
+})

--- a/packages/driver/src/cypress.js
+++ b/packages/driver/src/cypress.js
@@ -563,6 +563,14 @@ class $Cypress {
   }
 }
 
+function wrapMoment (moment) {
+  return function (...args) {
+    $errUtils.warnByPath('moment.deprecated')
+
+    return moment.apply(moment, args)
+  }
+}
+
 // attach to $Cypress to access
 // all of the constructors
 // to enable users to monkeypatch
@@ -588,7 +596,7 @@ $Cypress.prototype.Screenshot = $Screenshot
 $Cypress.prototype.SelectorPlayground = $SelectorPlayground
 $Cypress.prototype.utils = $utils
 $Cypress.prototype._ = _
-$Cypress.prototype.moment = moment
+$Cypress.prototype.moment = wrapMoment(moment)
 $Cypress.prototype.Blob = blobUtil
 $Cypress.prototype.Promise = Promise
 $Cypress.prototype.minimatch = minimatch

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -870,6 +870,10 @@ module.exports = {
 
   },
 
+  moment: {
+    deprecated: `\`Cypress.moment()\` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.`,
+  },
+
   navigation: {
     cross_origin ({ message, originPolicy, configFile }) {
       return {


### PR DESCRIPTION
- Partially address #8714 
- TR-503

### User Changelog

*Deprecations*: `Cypress.moment()` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.

### Additional Details

- Moment is now legacy
- The thought is to move our library over to something like dayjs and make that available as a util in a future release, but I didn’t exactly want to promise this in the warning message as the future implementation. In the meantime, they could migrate to their own dep.

### How has the user experience changed?

#### After

<img width="989" alt="Screen Shot 2020-12-01 at 11 30 05 PM" src="https://user-images.githubusercontent.com/1271364/100771817-41614b00-342d-11eb-8945-ad944a762ce4.png">

<img width="234" alt="Screen Shot 2020-12-01 at 11 30 13 PM" src="https://user-images.githubusercontent.com/1271364/100771845-47572c00-342d-11eb-993a-bb99120e9a01.png">
