### PR TITLE
fix: Fix Cypress.dom.isVisible() regression caused by "position: fixed"

### DIFF
--- a/packages/driver/cypress/fixtures/issue-8998.html
+++ b/packages/driver/cypress/fixtures/issue-8998.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+<style>
+  .option-wrap {
+    position: fixed;
+  }
+
+  .option-list {
+    height: 100px;
+    overflow: scroll;
+  }
+</style>
+</head>
+<body>
+  <div class="option-wrap">
+    <div class="option-list">
+      <div class="option">Option 1</div>
+      <div class="option">Option 2</div>
+      <div class="option">Option 3</div>
+      <div class="option">Option 4</div>
+      <div class="option">Option 5</div>
+      <div class="option">Option 6</div>
+      <div class="option">Option 7</div>
+      <div class="option">Option 8</div>
+      <div class="option">Option 9</div>
+      <div class="option">Option 10</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/packages/driver/cypress/integration/issues/8998_spec.js
+++ b/packages/driver/cypress/integration/issues/8998_spec.js
@@ -1,4 +1,5 @@
-it('t', () => {
+// https://github.com/cypress-io/cypress/issues/8998
+it('issue 8998', () => {
   cy.visit('fixtures/issue-8998.html')
   cy.get('.option').then((el) => {
     const x = Cypress.dom.isVisible(el[8])

--- a/packages/driver/cypress/integration/issues/8998_spec.js
+++ b/packages/driver/cypress/integration/issues/8998_spec.js
@@ -1,0 +1,8 @@
+it('t', () => {
+  cy.visit('fixtures/issue-8998.html')
+  cy.get('.option').then((el) => {
+    const x = Cypress.dom.isVisible(el[8])
+
+    expect(x).to.be.false
+  })
+})

--- a/packages/driver/src/dom/visibility.js
+++ b/packages/driver/src/dom/visibility.js
@@ -267,11 +267,21 @@ const elIsNotElementFromPoint = function ($el) {
   // if the element at point is not a descendent
   // of our $el then we know it's being covered or its
   // not visible
+  if ($elements.isDescendent($el, $elAtPoint)) {
+    return false
+  }
 
   // we also check if the element at point is a
   // parent since pointer-events: none
   // will cause elAtCenterPoint to fall through to parent
-  return !($elements.isDescendent($el, $elAtPoint) || ($elAtPoint && $elements.isAncestor($el, $elAtPoint)))
+  if (
+    ($el.css('pointer-events') === 'none' || $el.parent().css('pointer-events') === 'none') &&
+    ($elAtPoint && $elements.isAncestor($el, $elAtPoint))
+  ) {
+    return false
+  }
+
+  return true
 }
 
 const elIsOutOfBoundsOfAncestorsOverflow = function ($el, $ancestor = $elements.getParent($el)) {


### PR DESCRIPTION
* Closes #8998
* Closes #9031 

### User facing changelog
Fix Cypress.dom.isVisible() regression caused by "position: fixed"

### Additional details
* Why was this change necessary? => When Cypress.dom.isVisible() is used with an ancestor element with "position: fixed", it causes a regression.
* What is affected by this change? => N/A
* Any implementation details to explain? => I only check `pointer-events: none` for the element to be tested and its parent element because of the performance. Looping to the body can be bad for performance. 

### How has the user experience changed?
Regression resolved. 

### PR Tasks
* [x] Have tests been added/updated?

