### PR TITLE
chore: fix flake in reporter percy snapshots

### DIFF
--- a/packages/reporter/cypress/integration/forced_gc_spec.ts
+++ b/packages/reporter/cypress/integration/forced_gc_spec.ts
@@ -105,6 +105,9 @@ describe('forced gc', () => {
       cy.get('.forced-gc-warning').should('be.visible')
       cy.contains('GC Duration: 0.00')
       cy.contains('Running GC...')
+
+      // ensure the page is loaded before taking snapshot
+      cy.contains('test 4').should('be.visible')
       cy.percySnapshot()
     })
 

--- a/packages/reporter/cypress/integration/header_spec.ts
+++ b/packages/reporter/cypress/integration/header_spec.ts
@@ -74,6 +74,9 @@ describe('header', () => {
       cy.get('.passed .num').should('have.text', '2')
       cy.get('.failed .num').should('have.text', '3')
       cy.get('.pending .num').should('have.text', '1')
+
+      // ensure the page is loaded before taking snapshot
+      cy.contains('test 4').should('be.visible')
       cy.percySnapshot()
     })
 

--- a/packages/reporter/cypress/integration/runnables_spec.ts
+++ b/packages/reporter/cypress/integration/runnables_spec.ts
@@ -50,6 +50,9 @@ describe('runnables', () => {
   it('displays runnables when they load', () => {
     start()
     cy.get('.runnable').should('have.length', 9)
+
+    // ensure the page is loaded before taking snapshot
+    cy.contains('test 4').should('be.visible')
     cy.percySnapshot()
   })
 

--- a/packages/reporter/cypress/integration/spec_title_spec.ts
+++ b/packages/reporter/cypress/integration/spec_title_spec.ts
@@ -28,6 +28,9 @@ describe('spec title', () => {
     })
 
     cy.get('.runnable-header').should('have.text', 'All Specs')
+
+    // ensure the page is loaded before taking snapshot
+    cy.get('.focus-tests-text').should('be.visible')
     cy.percySnapshot()
   })
 
@@ -40,6 +43,9 @@ describe('spec title', () => {
     })
 
     cy.contains('.runnable-header', 'Specs matching "cof"')
+
+    // ensure the page is loaded before taking snapshot
+    cy.get('.focus-tests-text').should('be.visible')
     cy.percySnapshot()
   })
 
@@ -54,6 +60,9 @@ describe('spec title', () => {
 
     it('displays relative spec path', () => {
       cy.get('.runnable-header').find('a').should('have.text', 'relative/path/to/foo.js')
+
+      // ensure the page is loaded before taking snapshot
+      cy.get('.focus-tests-text').should('be.visible')
       cy.percySnapshot()
     })
 

--- a/packages/reporter/cypress/integration/suites_spec.ts
+++ b/packages/reporter/cypress/integration/suites_spec.ts
@@ -34,6 +34,8 @@ describe('suites', () => {
     .closest('.runnable')
     .should('have.class', 'suite')
 
+    // ensure the page is loaded before taking snapshot
+    cy.contains('test 4').should('be.visible')
     cy.percySnapshot()
   })
 

--- a/packages/reporter/cypress/integration/test_errors_spec.ts
+++ b/packages/reporter/cypress/integration/test_errors_spec.ts
@@ -238,6 +238,8 @@ describe('test errors', () => {
       .get('.test-err-code-frame')
       .should('be.visible')
 
+      // ensure the page is loaded before taking snapshot
+      cy.get('.focus-tests-text').should('be.visible')
       cy.percySnapshot()
     })
 

--- a/packages/reporter/src/header/header.tsx
+++ b/packages/reporter/src/header/header.tsx
@@ -21,7 +21,7 @@ const Header = observer(({ appState, events = defaultEvents, statsStore }: Props
     <Tooltip placement='bottom' title={<p>View All Tests <span className='kbd'>F</span></p>} wrapperClassName='focus-tests' className='cy-tooltip'>
       <button onClick={() => events.emit('focus:tests')}>
         <i className='fas fa-chevron-left'></i>
-        <span>Tests</span>
+        <span className='focus-tests-text'>Tests</span>
       </button>
     </Tooltip>
     <Stats stats={statsStore} />


### PR DESCRIPTION
### User Changelog
N/A

### Additional details
I've been frequently seeing flake in the new percy snapshots for the reporter where the UI is not done loading (like shown below). This PR aims to address that flake.

![](https://user-images.githubusercontent.com/1271364/100856918-6780fc80-34ba-11eb-917e-5e6014eb30c3.png)
![](https://user-images.githubusercontent.com/1271364/100856937-6c45b080-34ba-11eb-830a-cfefc9329aa9.png)

