### PR TITLE
fix(net-stubbing): do not fireChangeEvent for non-existing routes

### DIFF
--- a/packages/driver/src/cy/net-stubbing/events/request-received.ts
+++ b/packages/driver/src/cy/net-stubbing/events/request-received.ts
@@ -129,10 +129,6 @@ export const onRequestReceived: HandlerFn<NetEventFrames.HttpRequestReceived> = 
 
     continueSent = true
 
-    if (request) {
-      request.state = 'Intercepted'
-    }
-
     if (continueFrame) {
       // copy changeable attributes of userReq to req in frame
       // @ts-ignore
@@ -149,7 +145,10 @@ export const onRequestReceived: HandlerFn<NetEventFrames.HttpRequestReceived> = 
       emitNetEvent('http:request:continue', continueFrame)
     }
 
-    request.log.fireChangeEvent()
+    if (request) {
+      request.state = 'Intercepted'
+      request.log && request.log.fireChangeEvent()
+    }
   }
 
   if (!route) {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->

- Closes #9170 

### User facing changelog

- Fixed a race condition that could cause an unexpected "Cannot read property "fireChangeEvent" of undefined" error when using `cy.intercept`.

### Additional details

- if an intercepted request is received at the end of a test, it is possible for a race condition to occur where the server sends an `http:request:received` event that has no handler in the driver
- this was gracefully handled, but there were no tests around it, leading to this regression
- fixed, and also added tests for unexpected `http:response:received` and `http:request:complete`

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
