### PR TITLE
fix: copy other moment properties when wrapping with deprecated warning

### DIFF
--- a/packages/driver/cypress/integration/util/moment_spec.js
+++ b/packages/driver/cypress/integration/util/moment_spec.js
@@ -11,4 +11,18 @@ context('#moment', () => {
     expect(Cypress.moment.isDate()).to.be.false
     expect(Cypress.moment.isDate(new Date())).to.be.true
   })
+
+  it('logs deprecation warning when using duration', () => {
+    cy.stub(Cypress.utils, 'warning')
+
+    Cypress.moment.duration()
+    expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment()` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.')
+  })
+
+  it('logs deprecation warning when using isDate', () => {
+    cy.stub(Cypress.utils, 'warning')
+
+    Cypress.moment.isDate()
+    expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment()` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.')
+  })
 })

--- a/packages/driver/cypress/integration/util/moment_spec.js
+++ b/packages/driver/cypress/integration/util/moment_spec.js
@@ -5,4 +5,10 @@ context('#moment', () => {
     Cypress.moment()
     expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment()` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.')
   })
+
+  it('still has other moment properties', () => {
+    expect(Cypress.moment.duration).to.be.a('function')
+    expect(Cypress.moment.isDate()).to.be.false
+    expect(Cypress.moment.isDate(new Date())).to.be.true
+  })
 })

--- a/packages/driver/cypress/integration/util/moment_spec.js
+++ b/packages/driver/cypress/integration/util/moment_spec.js
@@ -3,7 +3,7 @@ context('#moment', () => {
     cy.stub(Cypress.utils, 'warning')
 
     Cypress.moment()
-    expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment()` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.')
+    expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.')
   })
 
   it('still has other moment properties', () => {
@@ -16,13 +16,13 @@ context('#moment', () => {
     cy.stub(Cypress.utils, 'warning')
 
     Cypress.moment.duration()
-    expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment()` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.')
+    expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.')
   })
 
   it('logs deprecation warning when using isDate', () => {
     cy.stub(Cypress.utils, 'warning')
 
     Cypress.moment.isDate()
-    expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment()` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.')
+    expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.')
   })
 })

--- a/packages/driver/src/cypress.js
+++ b/packages/driver/src/cypress.js
@@ -564,17 +564,25 @@ class $Cypress {
 }
 
 function wrapMoment (moment) {
-  function deprecatedMoment (...args) {
+  function deprecatedFunction (...args) {
     $errUtils.warnByPath('moment.deprecated')
 
     return moment.apply(moment, args)
   }
   // copy all existing properties from "moment" like "moment.duration"
   _.keys(moment).forEach((key) => {
-    deprecatedMoment[key] = moment[key]
+    const value = moment[key]
+
+    if (_.isFunction(value)) {
+      // recursively wrap any property that can be called by the user
+      // so that Cypress.moment.duration() shows deprecated message
+      deprecatedFunction[key] = wrapMoment(value)
+    } else {
+      deprecatedFunction[key] = value
+    }
   })
 
-  return deprecatedMoment
+  return deprecatedFunction
 }
 
 // attach to $Cypress to access

--- a/packages/driver/src/cypress.js
+++ b/packages/driver/src/cypress.js
@@ -564,11 +564,17 @@ class $Cypress {
 }
 
 function wrapMoment (moment) {
-  return function (...args) {
+  function deprecatedMoment (...args) {
     $errUtils.warnByPath('moment.deprecated')
 
     return moment.apply(moment, args)
   }
+  // copy all existing properties from "moment" like "moment.duration"
+  _.keys(moment).forEach((key) => {
+    deprecatedMoment[key] = moment[key]
+  })
+
+  return deprecatedMoment
 }
 
 // attach to $Cypress to access

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -871,7 +871,7 @@ module.exports = {
   },
 
   moment: {
-    deprecated: `\`Cypress.moment()\` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.`,
+    deprecated: `\`Cypress.moment\` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.`,
   },
 
   navigation: {


### PR DESCRIPTION
- for https://github.com/cypress-io/cypress/issues/8714
- builds on top of https://github.com/cypress-io/cypress/pull/9398 to copy the other moment properties

<img width="1278" alt="Screen Shot 2020-12-03 at 9 28 03 AM" src="https://user-images.githubusercontent.com/2212006/101042653-6ba92a80-354b-11eb-9be2-e67fcb568c51.png">

Otherwise our build is broken, and any user using these properties would be broken

<img width="1184" alt="Screen Shot 2020-12-03 at 9 36 23 AM" src="https://user-images.githubusercontent.com/2212006/101042683-7368cf00-354b-11eb-910b-0f38ae025d55.png">


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
