### PR TITLE
fix: tests don't hang when there's an error in before() block.

### DIFF
--- a/packages/driver/src/cypress/runner.js
+++ b/packages/driver/src/cypress/runner.js
@@ -693,11 +693,19 @@ const _runnerListeners = (_runner, Cypress, _emissions, getTestById, getTest, se
       delete hook.ctx.currentTest
     }
 
-    // set the hook's id from the test because
-    // hooks do not have their own id, their
-    // commands need to grouped with the test
-    // and we can only associate them by this id
-    const test = getTestFromHookOrFindTest(hook)
+    let test = getTest()
+
+    // https://github.com/cypress-io/cypress/issues/9162
+    // In https://github.com/cypress-io/cypress/issues/8113, getTest() call was removed to handle skip() properly.
+    // But it caused tests to hang when there's a failure in before().
+    // That's why getTest() is revived and checks if the state is 'pending'.
+    if (!test || test.state === 'pending') {
+      // set the hook's id from the test because
+      // hooks do not have their own id, their
+      // commands need to grouped with the test
+      // and we can only associate them by this id
+      test = getTestFromHookOrFindTest(hook)
+    }
 
     if (!test) {
       // we couldn't find a test to run with this hook

--- a/packages/runner/cypress/fixtures/issues/issue-9162.js
+++ b/packages/runner/cypress/fixtures/issues/issue-9162.js
@@ -1,0 +1,9 @@
+describe('should not hang when an error is thrown in a before() block', () => {
+  before(() => {
+    expect(true).to.be.false
+  })
+
+  after(() => {})
+  it('has a test')
+  it('has another test')
+})

--- a/packages/runner/cypress/integration/issues/issue-9162.js
+++ b/packages/runner/cypress/integration/issues/issue-9162.js
@@ -1,0 +1,15 @@
+const helpers = require('../../support/helpers')
+
+const { createCypress } = helpers
+const { runIsolatedCypress } = createCypress()
+
+// https://github.com/cypress-io/cypress/issues/9162
+describe('issue 9162', () => {
+  beforeEach(function () {
+    return runIsolatedCypress(`cypress/fixtures/issues/issue-9162.js`)
+  })
+
+  it('tests does not hang even if there is a fail in before().', function () {
+    cy.contains('expected true to be false')
+  })
+})


### PR DESCRIPTION
- Closes #9162

### User facing changelog

Tests don't hang when there's an error in `before()` block.

### Additional details
- Why was this change necessary? => Test runner stopped when there's an error in `before()` block.
- What is affected by this change? => N/A
- Any implementation details to explain? => Revived the removed `getTest()` function and checks if the test is `pending`(skipped).

### How has the user experience changed?

N/A

### PR Tasks
- [x] Have tests been added/updated?
