### PR TITLE
test(component-testing): use Cypress in Vue tests

### DIFF
--- a/packages/server-ct/.eslintrc.json
+++ b/packages/server-ct/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "extends": [
+    "plugin:@cypress/dev/tests"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "rules": {
+    "no-undef": "off"
+  }
+}

--- a/packages/server-ct/example/src/components/HelloWorld.spec.js
+++ b/packages/server-ct/example/src/components/HelloWorld.spec.js
@@ -10,22 +10,24 @@ Vue.config.productionTip = false
 
 describe('hello', () => {
   it('works', async () => {
-    // window.Vue = Vue
-    // new Vue(HelloWorld).$mount('#root')
-    const wrapper = mount(HelloWorld, { attachTo: '#__cy_app' })
+    mount(HelloWorld, {
+      attachTo: '#__cy_app',
+      propsData: {
+        msg: 'Hello World!',
+      },
+    })
 
-    expect(wrapper.exists()).to.eq(true)
-    // const ret = await cy.get('h1')
-    // expect(ret.length).to.eq(1)
+    cy.get('h1').contains('Hello World!')
   })
 
   it('works again', async () => {
-    // window.Vue = Vue
-    // new Vue(HelloWorld).$mount('#root')
-    const wrapper = mount(HelloWorld, { attachTo: '#__cy_app' })
+    mount(HelloWorld, {
+      attachTo: '#__cy_app',
+      propsData: {
+        msg: 'Hello World!',
+      },
+    })
 
-    expect(wrapper.exists()).to.eq(true)
-    // const ret = await cy.get('h1')
-    // expect(ret.length).to.eq(1)
+    cy.get('h1').contains('Hello World!')
   })
 })

--- a/packages/server-ct/example/src/components/HelloWorld.spec.js
+++ b/packages/server-ct/example/src/components/HelloWorld.spec.js
@@ -1,17 +1,14 @@
 /* eslint-env mocha,chai,jest */
 
-// import '../main'
 import HelloWorld from './HelloWorld'
-import { mount } from '@vue/test-utils'
+import { mount } from '@cypress/vue'
 import Vue from 'vue'
-// import Vue from 'vue'
 
 Vue.config.productionTip = false
 
 describe('hello', () => {
-  it('works', async () => {
+  it('works!', () => {
     mount(HelloWorld, {
-      attachTo: '#__cy_app',
       propsData: {
         msg: 'Hello World!',
       },
@@ -20,14 +17,13 @@ describe('hello', () => {
     cy.get('h1').contains('Hello World!')
   })
 
-  it('works again', async () => {
+  it('works again', () => {
     mount(HelloWorld, {
-      attachTo: '#__cy_app',
       propsData: {
-        msg: 'Hello World!',
+        msg: 'Hello World Again!',
       },
     })
 
-    cy.get('h1').contains('Hello World!')
+    cy.get('h1').contains('Hello World Again!')
   })
 })

--- a/packages/server-ct/example/src/components/Prettiest.spec.js
+++ b/packages/server-ct/example/src/components/Prettiest.spec.js
@@ -8,9 +8,8 @@ import Vue from 'vue'
 Vue.config.productionTip = false
 
 describe('Prettiest', () => {
-  it('spec works', () => {
+  it('spec works!', () => {
     mount(HelloWorld, {
-      attachTo: '#__cy_app',
       propsData: {
         msg: 'Hello World!',
       },
@@ -21,7 +20,6 @@ describe('Prettiest', () => {
 
   it('spec works again', () => {
     mount(HelloWorld, {
-      attachTo: '#__cy_app',
       propsData: {
         msg: 'Hello World!',
       },

--- a/packages/server-ct/example/src/components/Prettiest.spec.js
+++ b/packages/server-ct/example/src/components/Prettiest.spec.js
@@ -2,30 +2,31 @@
 
 // import '../main'
 import HelloWorld from './HelloWorld'
-import { mount } from '@vue/test-utils'
+import { mount } from '@cypress/vue'
 import Vue from 'vue'
-// import Vue from 'vue'
 
 Vue.config.productionTip = false
 
 describe('Prettiest', () => {
-  it('spec works', async () => {
-    // window.Vue = Vue
-    // new Vue(HelloWorld).$mount('#root')
-    const wrapper = mount(HelloWorld, { attachTo: '#__cy_app' })
+  it('spec works', () => {
+    mount(HelloWorld, {
+      attachTo: '#__cy_app',
+      propsData: {
+        msg: 'Hello World!',
+      },
+    })
 
-    expect(wrapper.exists()).to.eq(true)
-    // const ret = await cy.get('h1')
-    // expect(ret.length).to.eq(1)
+    cy.get('h1').contains('Hello World!')
   })
 
-  it('works again', async () => {
-    // window.Vue = Vue
-    // new Vue(HelloWorld).$mount('#root')
-    const wrapper = mount(HelloWorld, { attachTo: '#__cy_app' })
+  it('spec works again', () => {
+    mount(HelloWorld, {
+      attachTo: '#__cy_app',
+      propsData: {
+        msg: 'Hello World!',
+      },
+    })
 
-    expect(wrapper.exists()).to.eq(true)
-    // const ret = await cy.get('h1')
-    // expect(ret.length).to.eq(1)
+    cy.get('h1').contains('Hello World!')
   })
 })

--- a/packages/server-ct/example/src/components/test/Pretty.spec.js
+++ b/packages/server-ct/example/src/components/test/Pretty.spec.js
@@ -10,7 +10,6 @@ Vue.config.productionTip = false
 describe('Pretty', () => {
   it('spec works', () => {
     mount(HelloWorld, {
-      attachTo: '#__cy_app',
       propsData: {
         msg: 'Hello World!',
       },

--- a/packages/server-ct/example/src/components/test/Pretty.spec.js
+++ b/packages/server-ct/example/src/components/test/Pretty.spec.js
@@ -2,30 +2,20 @@
 
 // import '../main'
 import HelloWorld from '../HelloWorld'
-import { mount } from '@vue/test-utils'
+import { mount } from '@cypress/vue'
 import Vue from 'vue'
-// import Vue from 'vue'
 
 Vue.config.productionTip = false
 
 describe('Pretty', () => {
-  it('spec works', async () => {
-    // window.Vue = Vue
-    // new Vue(HelloWorld).$mount('#root')
-    const wrapper = mount(HelloWorld, { attachTo: '#__cy_app' })
+  it('spec works', () => {
+    mount(HelloWorld, {
+      attachTo: '#__cy_app',
+      propsData: {
+        msg: 'Hello World!',
+      },
+    })
 
-    expect(wrapper.exists()).to.eq(true)
-    // const ret = await cy.get('h1')
-    // expect(ret.length).to.eq(1)
-  })
-
-  it('works again', async () => {
-    // window.Vue = Vue
-    // new Vue(HelloWorld).$mount('#root')
-    const wrapper = mount(HelloWorld, { attachTo: '#__cy_app' })
-
-    expect(wrapper.exists()).to.eq(true)
-    // const ret = await cy.get('h1')
-    // expect(ret.length).to.eq(1)
+    cy.get('h1').contains('Hello World!')
   })
 })


### PR DESCRIPTION
This targets spike/evergreen-bem: https://github.com/cypress-io/cypress/pull/9524.

I changed the component-testing example to use the Cypress testing API instead of using Vue Test Utils as per @JessicaSachs's recommendation as a good way to get my hands dirty.

Also the type definitions for `mount` in `@cypress/vue` appear to be incomplete, this can probably be fixed either here or in Vue Test Utils, but this doesn't seem like very important thing to do right now, so I left it as-is.