### PR TITLE
chore: update wording of Cypress.moment deprecation to say 'removed' instead of 'replaced'

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -164,7 +164,7 @@ declare namespace Cypress {
      */
     minimatch: typeof Minimatch.minimatch
     /**
-     * @deprecated Will be replaced in a future version.
+     * @deprecated Will be removed in a future version.
      * Consider including your own datetime formatter in your tests.
      *
      * Cypress automatically includes moment.js and exposes it as Cypress.moment.

--- a/packages/driver/cypress/integration/util/moment_spec.js
+++ b/packages/driver/cypress/integration/util/moment_spec.js
@@ -3,7 +3,7 @@ context('#moment', () => {
     cy.stub(Cypress.utils, 'warning')
 
     Cypress.moment()
-    expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.')
+    expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment` has been deprecated and will be removed in a future release. Consider migrating to a different datetime formatter.')
   })
 
   it('still has other moment properties', () => {
@@ -16,13 +16,13 @@ context('#moment', () => {
     cy.stub(Cypress.utils, 'warning')
 
     Cypress.moment.duration()
-    expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.')
+    expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment` has been deprecated and will be removed in a future release. Consider migrating to a different datetime formatter.')
   })
 
   it('logs deprecation warning when using isDate', () => {
     cy.stub(Cypress.utils, 'warning')
 
     Cypress.moment.isDate()
-    expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.')
+    expect(Cypress.utils.warning).to.be.calledWith('`Cypress.moment` has been deprecated and will be removed in a future release. Consider migrating to a different datetime formatter.')
   })
 })

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -871,7 +871,7 @@ module.exports = {
   },
 
   moment: {
-    deprecated: `\`Cypress.moment\` has been deprecated and will be replaced in a future release. Consider migrating to a different datetime formatter.`,
+    deprecated: `\`Cypress.moment\` has been deprecated and will be removed in a future release. Consider migrating to a different datetime formatter.`,
   },
 
   navigation: {


### PR DESCRIPTION
While we may replace `Cypress.moment` in a future version with a comparable command, we’re not 100% sure about this. We feel it’s best to just inform people that it will be removed and they should find their own replacement for now.