### PR TITLE
feat(ct): Add the ct flag to the cypress cli and wire it to component testing

### DIFF
--- a/cli/__snapshots__/cli_spec.js
+++ b/cli/__snapshots__/cli_spec.js
@@ -35,6 +35,7 @@ exports['shows help for open --foo 1'] = `
     -P, --project <project-path>     path to the project
     --dev                            runs cypress in development and bypasses
                                      binary check
+    -ct, --component-testing         Cypress Component Testing mode (alpha)
     -h, --help                       display help for command
   -------
   stderr:

--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -400,6 +400,7 @@ module.exports = {
     .option('-p, --port <port>', text('port'))
     .option('-P, --project <project-path>', text('project'))
     .option('--dev', text('dev'), coerceFalse)
+    .option('-ct, --component-testing', 'Cypress Component Testing mode (alpha)')
     .action((opts) => {
       debug('opening Cypress')
       require('./exec/open')

--- a/cli/lib/exec/open.js
+++ b/cli/lib/exec/open.js
@@ -35,6 +35,10 @@ module.exports = {
       args.push('--project', options.project)
     }
 
+    if (options.componentTesting) {
+      args.push('--componentTesting', options.componentTesting)
+    }
+
     debug('opening from options %j', options)
     debug('command line arguments %j', args)
 

--- a/cli/lib/util.js
+++ b/cli/lib/util.js
@@ -197,6 +197,7 @@ const parseOpts = (opts) => {
     'cacheClear',
     'cachePrune',
     'ciBuildId',
+    'componentTesting',
     'config',
     'configFile',
     'cypressVersion',


### PR DESCRIPTION
In the main `bem` branch, only the `server` package understands the flag component-testing.
For end users to access it we add a flag to the cli, that will pass it down to the server package in production.

Use with `cypress open --component-testing` to open the window.

There is a shortcut `cypress open -ct`