### PR TITLE
fix(net-stubbing): fix cy.get(alias) with cy.intercept()

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -2080,6 +2080,75 @@ describe('network stubbing', { retries: 2 }, function () {
       .wait('@image').its('response.statusCode').should('eq', 304)
     })
 
+    // @see https://github.com/cypress-io/cypress/issues/9306
+    context('cy.get(alias)', function () {
+      it('gets the latest Interception by alias', function () {
+        cy.intercept('/foo', { bar: 'baz' }).as('alias')
+        .then(() => {
+          $.get('/foo')
+          $.get('/foo')
+        })
+        .wait('@alias').wait('@alias').then((interception) => {
+          cy.get('@alias').then((interception2) => {
+            expect(interception).to.not.be.null
+            expect(interception).to.eq(interception2)
+          })
+        })
+      })
+
+      it('gets all aliased Interceptions by alias.all', function () {
+        cy.intercept('/foo', { bar: 'baz' }).as('alias')
+        .then(() => {
+          $.get('/foo')
+          $.get('/foo')
+        })
+        .wait('@alias').wait('@alias')
+
+        cy.get('@alias.all').then((interceptions) => {
+          expect(interceptions).to.have.length(2)
+        })
+      })
+
+      it('gets indexed Interception by alias.number', function () {
+        let interception
+
+        cy.intercept('/foo', { bar: 'baz' }).as('alias')
+        .then(() => {
+          $.get('/foo')
+          $.get('/foo')
+        })
+        .wait('@alias').then((_interception) => {
+          interception = _interception
+        }).wait('@alias')
+
+        cy.get('@alias.0').then((interception2) => {
+          expect(interception).to.not.be.null
+          expect(interception).to.eq(interception2)
+        })
+      })
+
+      it('gets per-request aliased Interceptions', function () {
+        cy.intercept('/foo', (req) => {
+          req.alias = 'alias'
+          req.reply({ bar: 'baz' })
+        })
+        .then(() => {
+          $.get('/foo')
+        })
+        .wait('@alias').then((interception) => {
+          cy.get('@alias').then((interception2) => {
+            expect(interception).to.not.be.null
+            expect(interception).to.eq(interception2)
+          })
+        })
+      })
+
+      it('yields null when no requests have been made', function () {
+        cy.intercept('/foo').as('foo')
+        cy.get('@foo').should('be.null')
+      })
+    })
+
     context('with an intercepted request', function () {
       it('can dynamically alias the request', function () {
         cy.intercept('/foo', (req) => {

--- a/packages/driver/src/cy/commands/querying.js
+++ b/packages/driver/src/cy/commands/querying.js
@@ -179,9 +179,7 @@ module.exports = (Commands, Cypress, cy, state) => {
       try {
         aliasObj = cy.getAlias(toSelect)
       } catch (err) {
-        // before cy.intercept, we could know when an alias did/did not exist, because they
-        // were declared synchronously. with cy.intercept, req.alias can be used to dynamically
-        // create aliases, so we cannot know at wait-time if an alias exists or not
+        // possibly this is a dynamic alias, check to see if there is a request
         const alias = toSelect.slice(1)
         const [request] = getAliasedRequests(alias, state)
 
@@ -196,7 +194,6 @@ module.exports = (Commands, Cypress, cy, state) => {
       }
 
       if (!aliasObj && isDynamicAliasingPossible(state)) {
-        // possibly this is a dynamic alias, check to see if there is a request
         const requests = getAliasedRequests(toSelect, state)
 
         if (requests.length) {

--- a/packages/driver/src/cy/commands/querying.js
+++ b/packages/driver/src/cy/commands/querying.js
@@ -276,6 +276,7 @@ module.exports = (Commands, Cypress, cy, state) => {
 
           if (['route2', 'intercept'].includes(command.get('name'))) {
             const requests = getAliasedRequests(alias, state)
+            // detect alias.all and alias.index
             const specifier = /\.(all|[\d]+)$/.exec(selector)
 
             if (specifier) {

--- a/packages/driver/src/cy/commands/waiting.js
+++ b/packages/driver/src/cy/commands/waiting.js
@@ -1,6 +1,7 @@
 const _ = require('lodash')
 const Promise = require('bluebird')
-const { waitForRoute } = require('../net-stubbing')
+const { waitForRoute } = require('../net-stubbing/wait-for-route')
+const { isDynamicAliasingPossible } = require('../net-stubbing/aliasing')
 const ordinal = require('ordinal')
 
 const $errUtils = require('../../cypress/error_utils')
@@ -24,13 +25,6 @@ const throwErr = (arg) => {
 }
 
 module.exports = (Commands, Cypress, cy, state) => {
-  const isDynamicAliasingPossible = () => {
-    // dynamic aliasing is possible if a route with dynamic interception has been defined
-    return _.find(state('routes'), (route) => {
-      return _.isFunction(route.handler)
-    })
-  }
-
   let userOptions = null
 
   const waitNumber = (subject, ms, options) => {
@@ -121,7 +115,7 @@ module.exports = (Commands, Cypress, cy, state) => {
         // before cy.intercept, we could know when an alias did/did not exist, because they
         // were declared synchronously. with cy.intercept, req.alias can be used to dynamically
         // create aliases, so we cannot know at wait-time if an alias exists or not
-        if (!isDynamicAliasingPossible()) {
+        if (!isDynamicAliasingPossible(state)) {
           throw err
         }
 

--- a/packages/driver/src/cy/net-stubbing/add-command.ts
+++ b/packages/driver/src/cy/net-stubbing/add-command.ts
@@ -254,6 +254,7 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
       handler,
       hitCount: 0,
       requests: {},
+      command: state('current'),
     }
 
     if (alias) {

--- a/packages/driver/src/cy/net-stubbing/aliasing.ts
+++ b/packages/driver/src/cy/net-stubbing/aliasing.ts
@@ -1,0 +1,27 @@
+import _ from 'lodash'
+import {
+  Interception,
+  Route,
+} from './types'
+
+export function isDynamicAliasingPossible (state: Cypress.State) {
+  // dynamic aliasing is possible if a route with dynamic interception has been defined
+  return _.find(state('routes'), (route) => {
+    return _.isFunction(route.handler)
+  })
+}
+
+export function getAliasedRequests (alias: string, state: Cypress.State): Interception[] {
+  // Start with request-level (req.alias = '...') aliases that could be a match.
+  const requests = _.filter(state('aliasedRequests'), { alias })
+  .map(({ request }) => request)
+
+  // Now add route-level (cy.intercept(...).as()) aliased requests.
+  const route: Route = _.find(state('routes'), { alias })
+
+  if (route) {
+    Array.prototype.push.apply(requests, _.values(route.requests))
+  }
+
+  return requests
+}

--- a/packages/driver/src/cy/net-stubbing/events/request-received.ts
+++ b/packages/driver/src/cy/net-stubbing/events/request-received.ts
@@ -54,6 +54,7 @@ export const onRequestReceived: HandlerFn<NetEventFrames.HttpRequestReceived> = 
 
   const request: Partial<Interception> = {
     id: requestId,
+    routeHandlerId: frame.routeHandlerId,
     request: req,
     state: 'Received',
     requestWaited: false,

--- a/packages/driver/src/cy/net-stubbing/events/request-received.ts
+++ b/packages/driver/src/cy/net-stubbing/events/request-received.ts
@@ -54,7 +54,7 @@ export const onRequestReceived: HandlerFn<NetEventFrames.HttpRequestReceived> = 
 
   const request: Partial<Interception> = {
     id: requestId,
-    routeHandlerId: frame.routeHandlerId,
+    routeHandlerId,
     request: req,
     state: 'Received',
     requestWaited: false,

--- a/packages/driver/src/cy/net-stubbing/wait-for-route.ts
+++ b/packages/driver/src/cy/net-stubbing/wait-for-route.ts
@@ -18,7 +18,6 @@ function getPredicateForSpecifier (specifier: string): Partial<Interception> {
 
 export function waitForRoute (alias: string, state: Cypress.State, specifier: 'request' | 'response' | string): Interception | null {
   // 1. Create an array of known requests that have this alias.
-  // Start with request-level (req.alias = '...') aliases that could be a match.
   const candidateRequests = getAliasedRequests(alias, state)
 
   // 2. Find the first request without responseWaited/requestWaited

--- a/packages/driver/src/cy/net-stubbing/wait-for-route.ts
+++ b/packages/driver/src/cy/net-stubbing/wait-for-route.ts
@@ -1,9 +1,9 @@
 import _ from 'lodash'
 import {
   Interception,
-  Route,
   InterceptionState,
 } from './types'
+import { getAliasedRequests } from './aliasing'
 
 const RESPONSE_WAITED_STATES: InterceptionState[] = ['ResponseIntercepted', 'Complete']
 
@@ -19,15 +19,7 @@ function getPredicateForSpecifier (specifier: string): Partial<Interception> {
 export function waitForRoute (alias: string, state: Cypress.State, specifier: 'request' | 'response' | string): Interception | null {
   // 1. Create an array of known requests that have this alias.
   // Start with request-level (req.alias = '...') aliases that could be a match.
-  const candidateRequests = _.filter(state('aliasedRequests'), { alias })
-  .map(({ request }) => request)
-
-  // Now add route-level (cy.intercept(...).as()) aliased requests.
-  const route: Route = _.find(state('routes'), { alias })
-
-  if (route) {
-    Array.prototype.push.apply(candidateRequests, _.values(route.requests))
-  }
+  const candidateRequests = getAliasedRequests(alias, state)
 
   // 2. Find the first request without responseWaited/requestWaited
   const predicate = getPredicateForSpecifier(specifier)

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -180,6 +180,7 @@ export type NumberMatcher = number | number[]
  */
 export interface Interception {
   id: string
+  routeHandlerId: string
   /* @internal */
   log: any
   request: CyHttpMessages.IncomingRequest
@@ -215,6 +216,7 @@ export interface Route {
   handler: RouteHandler
   hitCount: number
   requests: { [key: string]: Interception }
+  command: any
 }
 
 export interface RouteMap { [key: string]: Route }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->

- Closes #9306 
### User facing changelog

- Fixed an issue where using `cy.get` for an alias of `cy.intercept` would always yield null.

### Additional details

- added explicit support for `cy.get('@alias')`, `@alias.all`, and `@alias.[index]`

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
