### PR TITLE
feat(net-stubbing): allow waiting on network errors/forceNetworkError

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1839,13 +1839,7 @@ describe('network stubbing', { retries: 2 }, function () {
       it('doesn\'t fail test if network error occurs retrieving response and response is not intercepted', {
         // TODO: for some reason, this test is busted in FF
         browser: '!firefox',
-      }, function (done) {
-        cy.on('fail', (err) => {
-          // the test should have failed due to cy.wait, as opposed to because of a network error
-          expect(err.message).to.contain('Timed out retrying')
-          done()
-        })
-
+      }, function () {
         cy.intercept('/should-err', function (req) {
           req.reply()
         })
@@ -2147,6 +2141,17 @@ describe('network stubbing', { retries: 2 }, function () {
         cy.intercept('/foo').as('foo')
         cy.get('@foo').should('be.null')
       })
+    })
+
+    // @see https://github.com/cypress-io/cypress/issues/9062
+    it('can spy on a request using forceNetworkError', function () {
+      cy.intercept('/foo', { forceNetworkError: true })
+      .as('err')
+      .then(() => {
+        $.get('/foo')
+      })
+      .wait('@err').should('have.property', 'error')
+      .and('not.have.property', 'response')
     })
 
     context('with an intercepted request', function () {

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -2151,7 +2151,11 @@ describe('network stubbing', { retries: 2 }, function () {
         $.get('/foo')
       })
       .wait('@err').should('have.property', 'error')
-      .and('not.have.property', 'response')
+      .and('include', {
+        message: 'forceNetworkError called',
+        name: 'Error',
+      })
+      .get('@err').should('not.have.property', 'response')
     })
 
     context('with an intercepted request', function () {

--- a/packages/driver/src/cy/net-stubbing/wait-for-route.ts
+++ b/packages/driver/src/cy/net-stubbing/wait-for-route.ts
@@ -5,7 +5,7 @@ import {
 } from './types'
 import { getAliasedRequests } from './aliasing'
 
-const RESPONSE_WAITED_STATES: InterceptionState[] = ['ResponseIntercepted', 'Complete']
+const RESPONSE_WAITED_STATES: InterceptionState[] = ['ResponseIntercepted', 'Complete', 'Errored']
 
 function getPredicateForSpecifier (specifier: string): Partial<Interception> {
   if (specifier === 'request') {

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -193,6 +193,10 @@ export interface Interception {
   /* @internal */
   responseHandler?: HttpResponseInterceptor
   /**
+   * The error that occurred during this request.
+   */
+  error?: Error
+  /**
    * Was `cy.wait()` used to wait on the response to this request?
    * @internal
    */

--- a/packages/net-stubbing/lib/server/intercept-request.ts
+++ b/packages/net-stubbing/lib/server/intercept-request.ts
@@ -51,6 +51,7 @@ export const InterceptRequest: RequestMiddleware = function () {
     requestId,
     route,
     continueRequest: this.next,
+    onError: this.onError,
     onResponse: (incomingRes, resStream) => {
       setDefaultHeaders(this.req, incomingRes)
       this.onResponse(incomingRes, resStream)
@@ -109,7 +110,7 @@ function _interceptRequest (state: NetStubbingState, request: BackendRequest, ro
 
     return ensureBody(() => {
       emitReceived()
-      sendStaticResponse(request.res, staticResponse, request.onResponse!)
+      sendStaticResponse(request, staticResponse)
     })
   }
 
@@ -183,7 +184,7 @@ export async function onRequestContinue (state: NetStubbingState, frame: NetEven
   if (frame.staticResponse) {
     await setResponseFromFixture(backendRequest.route.getFixture, frame.staticResponse)
 
-    return sendStaticResponse(backendRequest.res, frame.staticResponse, backendRequest.onResponse!)
+    return sendStaticResponse(backendRequest, frame.staticResponse)
   }
 
   backendRequest.continueRequest()

--- a/packages/net-stubbing/lib/server/intercept-response.ts
+++ b/packages/net-stubbing/lib/server/intercept-response.ts
@@ -111,7 +111,7 @@ export async function onResponseContinue (state: NetStubbingState, frame: NetEve
 
     const staticResponse = _.chain(frame.staticResponse).clone().assign({ continueResponseAt, throttleKbps }).value()
 
-    return sendStaticResponse(res, staticResponse, backendRequest.onResponse!)
+    return sendStaticResponse(backendRequest, staticResponse)
   }
 
   // merge the changed response attributes with our response and continue

--- a/packages/net-stubbing/lib/server/types.ts
+++ b/packages/net-stubbing/lib/server/types.ts
@@ -25,6 +25,7 @@ export interface BackendRequest {
    * The route that matched this request.
    */
   route: BackendRoute
+  onError: (err: Error) => void
   /**
    * A callback that can be used to make the request go outbound.
    */

--- a/packages/net-stubbing/lib/server/util.ts
+++ b/packages/net-stubbing/lib/server/util.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import Debug from 'debug'
 import isHtml from 'is-html'
-import { ServerResponse, IncomingMessage } from 'http'
+import { IncomingMessage } from 'http'
 import {
   RouteMatcherOptionsGeneric,
   STRING_MATCHER_FIELDS,
@@ -11,7 +11,7 @@ import {
 import { Readable, PassThrough } from 'stream'
 import CyServer from '@packages/server'
 import { Socket } from 'net'
-import { GetFixtureFn } from './types'
+import { GetFixtureFn, BackendRequest } from './types'
 import ThrottleStream from 'throttle'
 import MimeTypes from 'mime-types'
 
@@ -142,17 +142,17 @@ export async function setResponseFromFixture (getFixtureFn: GetFixtureFn, static
 
 /**
  * Using an existing response object, send a response shaped by a StaticResponse object.
- * @param res Response object.
+ * @param backendRequest BackendRequest object.
  * @param staticResponse BackendStaticResponse object.
- * @param onResponse Will be called with the response metadata + body stream
- * @param resStream Optionally, provide a Readable stream to be used as the response body (overrides staticResponse.body)
  */
-export function sendStaticResponse (res: ServerResponse, staticResponse: BackendStaticResponse, onResponse: (incomingRes: IncomingMessage, stream: Readable) => void) {
-  if (staticResponse.forceNetworkError) {
-    res.connection.destroy()
-    res.destroy()
+export function sendStaticResponse (backendRequest: BackendRequest, staticResponse: BackendStaticResponse) {
+  const { onError, onResponse } = backendRequest
 
-    return
+  if (staticResponse.forceNetworkError) {
+    debug('forcing network error')
+    const err = new Error('forceNetworkError called')
+
+    return onError(err)
   }
 
   const statusCode = staticResponse.statusCode || 200
@@ -167,7 +167,7 @@ export function sendStaticResponse (res: ServerResponse, staticResponse: Backend
 
   const bodyStream = getBodyStream(body, _.pick(staticResponse, 'throttleKbps', 'continueResponseAt'))
 
-  onResponse(incomingRes, bodyStream)
+  onResponse!(incomingRes, bodyStream)
 }
 
 export function getBodyStream (body: Buffer | string | Readable | undefined, options: { continueResponseAt?: number, throttleKbps?: number }): Readable {


### PR DESCRIPTION
- Closes #9062

### User facing changelog

- Response errors from `forceNetworkError` can now be awaited using `cy.intercept` and `cy.wait`.

### Additional details

- will yield `interception.error` instead of `interception.response` when `cy.wait`ed

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->https://github.com/cypress-io/cypress-documentation/pull/3389
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
