### PR TITLE
fix: waiting on an alias when the cy.route command has been overwritten

### DIFF
--- a/packages/driver/cypress/integration/commands/waiting_spec.js
+++ b/packages/driver/cypress/integration/commands/waiting_spec.js
@@ -237,7 +237,7 @@ describe('src/cy/commands/waiting', () => {
       describe('errors', {
         defaultCommandTimeout: 100,
       }, () => {
-        it('throws when alias doesnt match a route', (done) => {
+        it('throws when alias does not match a route (DOM element)', (done) => {
           cy.on('fail', (err) => {
             expect(err.message).to.include('`cy.wait()` only accepts aliases for routes.\nThe alias: `b` did not match a route.')
             expect(err.docsUrl).to.eq('https://on.cypress.io/wait')
@@ -246,6 +246,17 @@ describe('src/cy/commands/waiting', () => {
           })
 
           cy.get('body').as('b').wait('@b')
+        })
+
+        it('throws when alias does not match a route (wrapped value)', (done) => {
+          cy.on('fail', (err) => {
+            expect(err.message).to.include('`cy.wait()` only accepts aliases for routes.\nThe alias: `b` did not match a route.')
+            expect(err.docsUrl).to.eq('https://on.cypress.io/wait')
+
+            done()
+          })
+
+          cy.wrap('my value').as('b').wait('@b')
         })
 
         it('throws when route is never resolved', {

--- a/packages/driver/cypress/integration/commands/xhr_spec.js
+++ b/packages/driver/cypress/integration/commands/xhr_spec.js
@@ -2808,4 +2808,46 @@ describe('src/cy/commands/xhr', () => {
       })
     })
   })
+
+  // @see https://github.com/cypress-io/cypress/issues/3890
+  context('overwrite cy.route', () => {
+    it('stores route as an alias', () => {
+      // sanity test before overwriting cy.route in the next test
+      cy
+      .server()
+      .route(/foo/, 'my value').as('getFoo')
+      .window().then((win) => {
+        win.$.get('foo')
+
+        return null
+      })
+      .wait('@getFoo').its('responseBody').should('equal', 'my value')
+    })
+
+    it('stores route as an alias after overwrite', () => {
+      let routeCalled
+
+      Cypress.Commands.overwrite('route', (route, ...args) => {
+        routeCalled = true
+
+        return cy.log(`cy.route ${args.join(' ')}`)
+        .then(() => {
+          return route(...args)
+        })
+      })
+
+      cy
+      .server()
+      .route(/foo/, 'my value').as('getFoo')
+      .window().then((win) => {
+        win.$.get('foo')
+
+        return null
+      })
+      .wait('@getFoo').its('responseBody').should('equal', 'my value')
+      .then(() => {
+        expect(routeCalled, 'route overwrite was called').to.be.true
+      })
+    })
+  })
 })

--- a/packages/driver/cypress/integration/commands/xhr_spec.js
+++ b/packages/driver/cypress/integration/commands/xhr_spec.js
@@ -2808,46 +2808,4 @@ describe('src/cy/commands/xhr', () => {
       })
     })
   })
-
-  // @see https://github.com/cypress-io/cypress/issues/3890
-  context('overwrite cy.route', () => {
-    it('stores route as an alias', () => {
-      // sanity test before overwriting cy.route in the next test
-      cy
-      .server()
-      .route(/foo/, 'my value').as('getFoo')
-      .window().then((win) => {
-        win.$.get('foo')
-
-        return null
-      })
-      .wait('@getFoo').its('responseBody').should('equal', 'my value')
-    })
-
-    it('stores route as an alias after overwrite', () => {
-      let routeCalled
-
-      Cypress.Commands.overwrite('route', (route, ...args) => {
-        routeCalled = true
-
-        return cy.log(`cy.route ${args.join(' ')}`)
-        .then(() => {
-          return route(...args)
-        })
-      })
-
-      cy
-      .server()
-      .route(/foo/, 'my value').as('getFoo')
-      .window().then((win) => {
-        win.$.get('foo')
-
-        return null
-      })
-      .wait('@getFoo').its('responseBody').should('equal', 'my value')
-      .then(() => {
-        expect(routeCalled, 'route overwrite was called').to.be.true
-      })
-    })
-  })
 })

--- a/packages/driver/cypress/integration/issues/3890_spec.js
+++ b/packages/driver/cypress/integration/issues/3890_spec.js
@@ -1,0 +1,63 @@
+// @see https://github.com/cypress-io/cypress/issues/3890
+const { $ } = Cypress
+
+describe('issue 3890 overwriting cy.route command', () => {
+  before(() => {
+    cy
+    .visit('/fixtures/jquery.html')
+    .then(function (win) {
+      const h = $(win.document.head)
+
+      h.find('script').remove()
+
+      this.head = h.prop('outerHTML')
+      this.body = win.document.body.outerHTML
+    })
+  })
+
+  beforeEach(function () {
+    const doc = cy.state('document')
+
+    $(doc.head).empty().html(this.head)
+    $(doc.body).empty().html(this.body)
+  })
+
+  it('stores route as an alias', () => {
+    // sanity test before overwriting cy.route in the next test
+    cy
+    .server()
+    .route(/foo/, 'my value').as('getFoo')
+    .window().then((win) => {
+      win.$.get('foo')
+
+      return null
+    })
+    .wait('@getFoo').its('responseBody').should('equal', 'my value')
+  })
+
+  it('stores route as an alias after overwrite', () => {
+    let routeCalled
+
+    Cypress.Commands.overwrite('route', (route, ...args) => {
+      routeCalled = true
+
+      return cy.log(`cy.route ${args.join(' ')}`)
+      .then(() => {
+        return route(...args)
+      })
+    })
+
+    cy
+    .server()
+    .route(/foo/, 'my value').as('getFoo')
+    .window().then((win) => {
+      win.$.get('foo')
+
+      return null
+    })
+    .wait('@getFoo').its('responseBody').should('equal', 'my value')
+    .then(() => {
+      expect(routeCalled, 'route overwrite was called').to.be.true
+    })
+  })
+})

--- a/packages/driver/src/cy/commands/waiting.js
+++ b/packages/driver/src/cy/commands/waiting.js
@@ -172,10 +172,18 @@ module.exports = (Commands, Cypress, cy, state) => {
       const isInterceptAlias = (alias) => Boolean(findInterceptAlias(alias))
 
       const isRouteAlias = (alias) => {
-        const routes = cy.state('aliasRequests') || {}
-        const routeAliases = _.keys(routes)
+        // has all aliases saved using cy.as() command
+        const aliases = cy.state('aliases') || {}
 
-        return _.includes(routeAliases, alias)
+        const aliasObject = aliases[alias]
+
+        if (!aliasObject) {
+          return false
+        }
+
+        // cy.route aliases have subject that has all XHR properties
+        // let's check one of them
+        return aliasObj.subject && Boolean(aliasObject.subject.xhrUrl)
       }
 
       if (command && !isNetworkInterceptCommand(command)) {

--- a/packages/driver/src/cy/commands/waiting.js
+++ b/packages/driver/src/cy/commands/waiting.js
@@ -171,8 +171,15 @@ module.exports = (Commands, Cypress, cy, state) => {
 
       const isInterceptAlias = (alias) => Boolean(findInterceptAlias(alias))
 
+      const isRouteAlias = (alias) => {
+        const routes = cy.state('aliasRequests') || {}
+        const routeAliases = _.keys(routes)
+
+        return _.includes(routeAliases, alias)
+      }
+
       if (command && !isNetworkInterceptCommand(command)) {
-        if (!isInterceptAlias(alias)) {
+        if (!isInterceptAlias(alias) && !isRouteAlias(alias)) {
           $errUtils.throwErrByPath('wait.invalid_alias', {
             onFail: options._log,
             args: { alias },


### PR DESCRIPTION
- Closes #3890

### User facing changelog

You can overwrite `cy.route` command and still wait on the alias

```js
Cypress.Commands.overwrite('route', (route, ...args) => {
  return cy.log(`cy.route ${args.join(' ')}`)
    .then(() => {
      return route(...args)
    })
})
cy.server()
  .route(/foo/, 'my value').as('getFoo')
// make request
cy.wait('@getFoo').its('responseBody').should('equal', 'my value')
```

### Additional details

As described in https://glebbahmutov.com/blog/cypress-intercept-problems/#the-intercept-was-registered-too-late sometimes we might need to log when the `cy.route` is defined. For that we need to overwrite the `cy.route` command. Now we can wait for the `cy.route` interception.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
