### PR TITLE
fix: Pass flag to disable backgrounding occluded windows for Chrome

### DIFF
--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -55,6 +55,7 @@ const DEFAULT_ARGS = [
   '--disable-background-timer-throttling',
   '--disable-renderer-backgrounding',
   '--disable-renderer-throttling',
+  '--disable-backgrounding-occluded-windows',
   '--disable-restore-session-state',
   '--disable-translate',
   '--disable-new-profile-management',


### PR DESCRIPTION
Close https://github.com/cypress-io/cypress/issues/9604

### User Changelog

We now pass `--disable-backgrounding-occluded-windows` as a default flag to Chrome to prevent backgrounding rendering when the Cypress window is occluded. 

### Additional Details

- How to test 🤔
- Chrome’s / Occlusion Tracking may potentially cause issues for people when they are running their app in cypress open and pull up other windows while it’s running. Chromium will essentially throttle resources like they do for hidden tabs when they determine the window is not being interacted with/hidden by another window: https://docs.google.com/document/d/1tPuJE0Vws7oskjjqrawNfMkwFtGxyHV33yQagiplVfY/edit
- Chromium themselves has a note about how this flag should be passed in order to have deterministic tests. 
	>Disable backgrounding renders for occluded windows. Done for tests to avoid nondeterministic behavior. https://source.chromium.org/chromium/chromium/src/+/master:content/public/common/content_switches.cc;l=81