### PR TITLE
feat(react): allow modifying the final preprocessorOptions for cra-v3

### DIFF
--- a/npm/react/docs/recipes.md
+++ b/npm/react/docs/recipes.md
@@ -32,6 +32,30 @@ See example repo [bahmutov/try-cra-with-unit-test](https://github.com/bahmutov/t
 
 **Tip:** `plugins/react-scripts` is just loading `plugins/cra-v3`.
 
+### With custom webpack preprocessor options
+
+To modify the `preprocessorOptions` that are passed into the `webpackPreprocessor` you can pass a function as `preprocessorOptionsFinal` option into the `react-scripts` plugin, e.g.
+
+```js
+// cypress/plugins/index.js
+module.exports = (on, config) => {
+  require('@cypress/react/plugins/react-scripts')(on, config, {
+      preprocessorOptionsFinal(preprocessorOptions) {
+          preprocessorOptions.webpackOptions.devtool = false
+
+          // IMPORTANT to return preprocessorOptions
+          return preprocessorOptions
+      },
+  })
+
+  // IMPORTANT to return the config object
+  // with the any changed environment variables
+  return config
+}
+```
+
+This would disable the source maps when the CRA app builds
+
 ## Next.js
 
 ```js

--- a/npm/react/plugins/cra-v3/file-preprocessor.js
+++ b/npm/react/plugins/cra-v3/file-preprocessor.js
@@ -29,7 +29,7 @@ const getWebpackPreprocessorOptions = (opts) => {
   return options
 }
 
-module.exports = (config) => {
+module.exports = (config, options = {}) => {
   debug('env object %o', config.env)
 
   const coverageIsDisabled =
@@ -64,7 +64,15 @@ module.exports = (config) => {
     // insert Babel plugin to mock named imports
     looseModules: true,
   }
-  const preprocessorOptions = getWebpackPreprocessorOptions(opts)
+  let preprocessorOptions = getWebpackPreprocessorOptions(opts)
+
+  if (
+    options.preprocessorOptionsFinal &&
+    typeof options.preprocessorOptionsFinal === 'function'
+  ) {
+    debug('preprocessorOptionsFinal callback found')
+    preprocessorOptions = options.preprocessorOptionsFinal(preprocessorOptions)
+  }
 
   debug('final webpack options %o', preprocessorOptions.webpackOptions)
 

--- a/npm/react/plugins/react-scripts/index.js
+++ b/npm/react/plugins/react-scripts/index.js
@@ -1,8 +1,8 @@
 const filePreprocessor = require('../cra-v3/file-preprocessor')
 
-module.exports = (on, config) => {
+module.exports = (on, config, options) => {
   require('@cypress/code-coverage/task')(on, config)
-  on('file:preprocessor', filePreprocessor(config))
+  on('file:preprocessor', filePreprocessor(config, options))
 
   // IMPORTANT to return the config object
   // with the any changed environment variables


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->
Inspired by Storybook's [webpackFinal](https://storybook.js.org/docs/react/configure/webpack) option, this allows passing a third parameter to the `react-scripts` function. If `preprocessorOptionsFinal` as function is given, it'll get called with the final `preprocessorOptions` to give user space a chance to modify things, like adjusting the webpack config, e.g.

```js
    reactScripts(on, config, {
        preprocessorOptionsFinal(preprocessorOptions) {
            preprocessorOptions.webpackOptions.devtool = false
            return preprocessorOptions
        },
    })
```

I suppose this would need some tests and/or documentation, just wanted to check if this might be a proper way to approach it

- Closes #9701 

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->
- Allows to modify the `cra-v3`'s react plugin `preprocessorOptions` before they get passed into `webpackPreprocessor`

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Transferred from https://github.com/cypress-io/cypress-react-unit-test/pull/557

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
   - Not sure if tests for the `@cypress/react` plugins already exist? Pointers would be appreciated
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
  - Not sure if `@cypress/react` documentation already exist in the documentation repo? Pointers would be appreciated. I've added a segment to the `recipes.md` instead
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
  - The `@cypress/react` plugins don't seem to have type definitions yet? Pointers would be appreciated
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
  - Doesn't seem to be necessary in this case?