### PR TITLE
fix(types): add scrollBehavior type to allowed TestConfig options

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2592,7 +2592,7 @@ declare namespace Cypress {
     includeShadowDom: boolean
   }
 
-  interface TestConfigOverrides extends Partial<Pick<ConfigOptions, 'baseUrl' | 'defaultCommandTimeout' | 'taskTimeout' | 'animationDistanceThreshold' | 'waitForAnimations' | 'viewportHeight' | 'viewportWidth' | 'requestTimeout' | 'execTimeout' | 'env' | 'responseTimeout' | 'retries' | 'includeShadowDom'>> {
+  interface TestConfigOverrides extends Partial<Pick<ConfigOptions, 'animationDistanceThreshold' | 'baseUrl' | 'defaultCommandTimeout' | 'env' | 'execTimeout' | 'includeShadowDom' | 'requestTimeout' | 'responseTimeout' | 'retries' | 'scrollBehavior' | 'taskTimeout' | 'viewportHeight' | 'viewportWidth' |  'waitForAnimations'>> {
     browser?: IsBrowserMatcher | IsBrowserMatcher[]
   }
 

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -538,13 +538,27 @@ namespace CypressDomTests {
 namespace CypressTestConfigOverridesTests {
   // set config on a per-test basis
   it('test', {
+    animationDistanceThreshold: 10,
+    baseUrl: 'www.foobar.com',
+    defaultCommandTimeout: 6000,
+    env: {},
+    execTimeout: 6000,
+    includeShadowDom: true,
+    requestTimeout: 6000,
+    responseTimeout: 6000,
+    scrollBehavior: 'center',
+    taskTimeout: 6000,
+    viewportHeight: 200,
+    viewportWidth: 200,
+    waitForAnimations: false
+  }, () => { })
+  it('test', {
     browser: {name: 'firefox'}
   }, () => {})
   it('test', {
     browser: [{name: 'firefox'}, {name: 'chrome'}]
   }, () => {})
   it('test', {
-    baseUrl: 'www.foobar.com',
     browser: 'firefox'
   }, () => {})
   it('test', {


### PR DESCRIPTION
- Close #9643 

### User Facing Changelog

- `scrollBehavior` is now an allowed type when passed as test configuration.

### Additional Details

- I alphabetized the types in the code 🤓

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
