### PR TITLE
fix(typedefs): Add type for autoEnd on LogConfig.

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -5233,6 +5233,7 @@ declare namespace Cypress {
   interface LogConfig extends Timeoutable {
     /** The JQuery element for the command. This will highlight the command in the main window when debugging */
     $el: JQuery
+    autoEnd: boolean
     /** Allows the name of the command to be overwritten */
     name: string
     /** Override *name* for display purposes only */


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->

- Closes #9590

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->
Add type for autoEnd on LogConfig.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
I wanted to make a small contribution to Cypress and get the dev environment set up. The only change I made was adding the type.

#### Side notes about Cypress development:
After I made the change, I built the package and built the binary, and in my test project I pointed to the package in package.json and had to copy paste the binary into my cypress cache in order to successfully `yarn` on my test project, otherwise it would try to download the binary online and fail since the version didn't exist. 

I also had to downgrade my node version to avoid a build error in node-sass. 

### How has the user experience changed?
Now it doesn't produce a type error and shows autoEnd correctly typed. 
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
![image](https://user-images.githubusercontent.com/7061807/102514176-0708c800-4041-11eb-9c3f-e10f11de4303.png)

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
