### PR TITLE
fix: (cy.intercept()) intercept-request body buffer encoding problem for multipart/form-data

### DIFF
--- a/packages/net-stubbing/lib/server/intercept-request.ts
+++ b/packages/net-stubbing/lib/server/intercept-request.ts
@@ -110,7 +110,8 @@ function _interceptRequest (state: NetStubbingState, request: BackendRequest, ro
     }
 
     request.req.pipe(concatStream((reqBody) => {
-      const isMultipart = frame.req.headers['content-type']?.includes('multipart/form-data')
+      const contentType = frame.req.headers['content-type']
+      const isMultipart = contentType && contentType.includes('multipart/form-data')
 
       request.req.body = frame.req.body = isMultipart ? reqBody : reqBody.toString()
       cb()

--- a/packages/net-stubbing/lib/server/intercept-request.ts
+++ b/packages/net-stubbing/lib/server/intercept-request.ts
@@ -110,7 +110,7 @@ function _interceptRequest (state: NetStubbingState, request: BackendRequest, ro
     }
 
     request.req.pipe(concatStream((reqBody) => {
-      request.req.body = frame.req.body = reqBody.toString()
+      request.req.body = reqBody.byteLength ? reqBody : undefined
       cb()
     }))
   }

--- a/packages/net-stubbing/lib/server/intercept-request.ts
+++ b/packages/net-stubbing/lib/server/intercept-request.ts
@@ -110,7 +110,9 @@ function _interceptRequest (state: NetStubbingState, request: BackendRequest, ro
     }
 
     request.req.pipe(concatStream((reqBody) => {
-      request.req.body = frame.req.body = reqBody
+      const isMultipart = frame.req.headers['content-type']?.includes('multipart/form-data')
+
+      request.req.body = frame.req.body = isMultipart ? reqBody : reqBody.toString()
       cb()
     }))
   }

--- a/packages/net-stubbing/lib/server/intercept-request.ts
+++ b/packages/net-stubbing/lib/server/intercept-request.ts
@@ -110,7 +110,7 @@ function _interceptRequest (state: NetStubbingState, request: BackendRequest, ro
     }
 
     request.req.pipe(concatStream((reqBody) => {
-      request.req.body = reqBody.byteLength ? reqBody : undefined
+      request.req.body = frame.req.body = reqBody
       cb()
     }))
   }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->

- Closes #9359 

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->
We fixed an issue with `cy.intercept()` where multipart/form-data was wrongly encoded by the internal proxy, thus resulting in differences between the `content-length` header and the actual byte length of the request body buffer, which led to `Unexpected end of multipart data` errors on the backend service where the request was pointing to. Fixes #9359. 

### Additional details
#### Why was this change necessary?
This change is necessary because otherwise it is not possible to use `cy.intercept()` on multipart/form-data file upload requests. 
For a more technical answer please read my [comment](https://github.com/cypress-io/cypress/issues/9359#issuecomment-747354545) on the issue.

#### What is affected by this change?
The `InterceptRequest` middleware and internal proxy are affected by these changes.

### How has the user experience changed?
The usage of cypress for the user has not changed.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->