### PR TITLE
fix(net-stubbing): match cy.intercept(url) globs against url+path

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -60,6 +60,7 @@ describe('network stubbing', { retries: 2 }, function () {
             type: 'glob',
             value: url,
           },
+          matchUrlAgainstPath: true,
         },
         staticResponse: {
           body: 'bar',
@@ -68,7 +69,7 @@ describe('network stubbing', { retries: 2 }, function () {
       }
 
       const expectedRoute = {
-        options: { url },
+        options: { url, matchUrlAgainstPath: true },
         handler,
       }
 
@@ -87,12 +88,13 @@ describe('network stubbing', { retries: 2 }, function () {
             type: 'glob',
             value: url,
           },
+          matchUrlAgainstPath: true,
         },
         hasInterceptor: true,
       }
 
       const expectedRoute = {
-        options: { url },
+        options: { url, matchUrlAgainstPath: true },
         handler,
       }
 
@@ -124,7 +126,6 @@ describe('network stubbing', { retries: 2 }, function () {
           quuz: /(.*)quux/gi,
         },
         url: 'http://foo.invalid',
-        webSocket: false,
       }
 
       const expectedEvent = {
@@ -181,7 +182,6 @@ describe('network stubbing', { retries: 2 }, function () {
             type: 'glob',
             value: options.url,
           },
-          webSocket: options.webSocket,
         },
         hasInterceptor: true,
       }
@@ -1120,6 +1120,29 @@ describe('network stubbing', { retries: 2 }, function () {
           })
         })
         .wait('@foo')
+      })
+
+      // @see https://github.com/cypress-io/cypress/issues/9379
+      context('falls back to matching by path if plain string is passed', function () {
+        it('matches globs against path', function (done) {
+          cy.intercept('/foo/*', (req) => {
+            expect(req.url).to.include('/foo/1')
+            done()
+          })
+          .then(() => {
+            $.ajax({ url: '/foo/1', cache: true })
+          })
+        })
+
+        it('matches nested globs against path', function (done) {
+          cy.intercept('/foo/*/bar', (req) => {
+            expect(req.url).to.match(/\/foo\/1\/bar$/)
+            done()
+          })
+          .then(() => {
+            $.get({ url: '/foo/1/bar', cache: true })
+          })
+        })
       })
     })
 

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -406,6 +406,32 @@ describe('network stubbing', { retries: 2 }, function () {
             },
           })
         })
+
+        it('must set `url` with `matchUrlAgainstPath`', function (done) {
+          cy.on('fail', function (err) {
+            expect(err.message).to.include('`matchUrlAgainstPath` requires a `url` to be specified.')
+
+            done()
+          })
+
+          cy.intercept({
+            matchUrlAgainstPath: true,
+          })
+        })
+
+        it('must not set `path` with `matchUrlAgainstPath`', function (done) {
+          cy.on('fail', function (err) {
+            expect(err.message).to.include('`matchUrlAgainstPath` and `path` cannot both be set.')
+
+            done()
+          })
+
+          cy.intercept({
+            matchUrlAgainstPath: true,
+            path: '*',
+            url: '*',
+          })
+        })
       })
 
       context('with invalid handler', function () {

--- a/packages/driver/src/cy/net-stubbing/add-command.ts
+++ b/packages/driver/src/cy/net-stubbing/add-command.ts
@@ -67,7 +67,7 @@ function annotateMatcherOptionsTypes (options: RouteMatcherOptions) {
     }
   })
 
-  const noAnnotationRequiredFields = ['https', 'port', 'webSocket']
+  const noAnnotationRequiredFields: (keyof RouteMatcherOptions)[] = ['https', 'port', 'matchUrlAgainstPath']
 
   _.extend(ret, _.pick(options, noAnnotationRequiredFields))
 
@@ -113,8 +113,12 @@ function validateRouteMatcherOptions (routeMatcher: RouteMatcherOptions): { isVa
     }
   }
 
-  if (_.has(routeMatcher, 'https') && !_.isBoolean(routeMatcher.https)) {
-    return err('`https` must be a boolean.')
+  const booleanProps = ['https', 'matchUrlAgainstPath']
+
+  for (const prop of booleanProps) {
+    if (_.has(routeMatcher, prop) && !_.isBoolean(routeMatcher[prop])) {
+      return err(`\`${prop}\` must be a boolean.`)
+    }
   }
 
   if (_.has(routeMatcher, 'port') && !isNumberMatcher(routeMatcher.port)) {
@@ -130,6 +134,16 @@ function validateRouteMatcherOptions (routeMatcher: RouteMatcherOptions): { isVa
       }
 
       knownFieldNames.push(k)
+    }
+  }
+
+  if (routeMatcher.matchUrlAgainstPath) {
+    if (!routeMatcher.url) {
+      return err('`matchUrlAgainstPath` requires a `url` to be specified.')
+    }
+
+    if (routeMatcher.path) {
+      return err('`matchUrlAgainstPath` and `path` cannot both be set.')
     }
   }
 
@@ -280,6 +294,7 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
         handler = arg2
 
         return {
+          matchUrlAgainstPath: true,
           method: matcher,
           url,
         }
@@ -288,6 +303,7 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
       if (isStringMatcher(matcher)) {
         // url, handler
         return {
+          matchUrlAgainstPath: true,
           url: matcher,
         }
       }

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -230,13 +230,9 @@ export interface RouteMap { [key: string]: Route }
  */
 export type RouteMatcher = StringMatcher | RouteMatcherOptions
 
-export interface RouteMatcherCompatOptions {
-  response?: string | object
-}
-
 export type RouteMatcherOptions = RouteMatcherOptionsGeneric<StringMatcher>
 
-export interface RouteMatcherOptionsGeneric<S> extends RouteMatcherCompatOptions {
+export interface RouteMatcherOptionsGeneric<S> {
   /**
    * Match against the username and password used in HTTP Basic authentication.
    */
@@ -254,6 +250,11 @@ export interface RouteMatcherOptionsGeneric<S> extends RouteMatcherCompatOptions
    * If 'false', only HTTP requests will be matched.
    */
   https?: boolean
+  /**
+   * If `true`, will match the supplied `url` against incoming `path`s.
+   * Cannot be set without `url` or with `path`.
+   */
+  matchUrlAgainstPath?: boolean
   /**
    * Match against the request's HTTP method.
    * @default '*'

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -252,7 +252,7 @@ export interface RouteMatcherOptionsGeneric<S> {
   https?: boolean
   /**
    * If `true`, will match the supplied `url` against incoming `path`s.
-   * Cannot be set without `url` or with `path`.
+   * Requires a `url` argument. Cannot be used with a `path` argument.
    */
   matchUrlAgainstPath?: boolean
   /**

--- a/packages/net-stubbing/lib/server/driver-events.ts
+++ b/packages/net-stubbing/lib/server/driver-events.ts
@@ -62,7 +62,7 @@ export function _restoreMatcherOptionsTypes (options: AnnotatedRouteMatcherOptio
     _.set(ret, field, value)
   })
 
-  const noAnnotationRequiredFields = ['https', 'port', 'webSocket']
+  const noAnnotationRequiredFields: (keyof AnnotatedRouteMatcherOptions)[] = ['https', 'port', 'matchUrlAgainstPath']
 
   _.extend(ret, _.pick(options, noAnnotationRequiredFields))
 

--- a/packages/net-stubbing/lib/server/route-matching.ts
+++ b/packages/net-stubbing/lib/server/route-matching.ts
@@ -26,7 +26,17 @@ export function _doesRouteMatch (routeMatcher: RouteMatcherOptions, req: Cypress
     // for convenience, attempt to match `url` against `path`?
     const shouldTryMatchingPath = field === 'url' && routeMatcher.matchUrlAgainstPath
 
-    const stringMatch = (value: string, matcher: string) => value === matcher || minimatch(value, matcher, { matchBase: true }) || (field === 'url' && value.includes(matcher))
+    const stringMatch = (value: string, matcher: string) => {
+      return (
+        minimatch(value, matcher, { matchBase: true }) ||
+      (field === 'url' && (
+        // substring match
+        value.includes(matcher) ||
+        // be nice and match paths that are missing leading slashes
+        (value[0] === '/' && matcher[0] !== '/' && stringMatch(value, `/${matcher}`))
+      ))
+      )
+    }
 
     if (typeof value !== 'string') {
       value = String(value)

--- a/packages/net-stubbing/lib/server/route-matching.ts
+++ b/packages/net-stubbing/lib/server/route-matching.ts
@@ -28,13 +28,14 @@ export function _doesRouteMatch (routeMatcher: RouteMatcherOptions, req: Cypress
 
     const stringMatch = (value: string, matcher: string) => {
       return (
+        value === matcher ||
         minimatch(value, matcher, { matchBase: true }) ||
-      (field === 'url' && (
-        // substring match
-        value.includes(matcher) ||
-        // be nice and match paths that are missing leading slashes
-        (value[0] === '/' && matcher[0] !== '/' && stringMatch(value, `/${matcher}`))
-      ))
+        (field === 'url' && (
+          // substring match
+          value.includes(matcher) ||
+          // be nice and match paths that are missing leading slashes
+          (value[0] === '/' && matcher[0] !== '/' && stringMatch(value, `/${matcher}`))
+        ))
       )
     }
 

--- a/packages/net-stubbing/test/unit/route-matching-spec.ts
+++ b/packages/net-stubbing/test/unit/route-matching-spec.ts
@@ -121,6 +121,15 @@ describe('intercept-request', function () {
     })
 
     context('with matchUrlAgainstPath', function () {
+      it('false does not match globs against path', function () {
+        tryMatch({
+          proxiedUrl: 'http://foo.com/bar/a1',
+        }, {
+          matchUrlAgainstPath: false,
+          url: '/bar/*',
+        }, false)
+      })
+
       it('matches globs against path', function () {
         tryMatch({
           proxiedUrl: 'http://foo.com/bar/a1',

--- a/packages/net-stubbing/test/unit/route-matching-spec.ts
+++ b/packages/net-stubbing/test/unit/route-matching-spec.ts
@@ -52,6 +52,14 @@ describe('intercept-request', function () {
       expect(_doesRouteMatch(matcher, req as CypressIncomingRequest)).to.eq(expected)
     }
 
+    it('matches exact URL', function () {
+      tryMatch({
+        proxiedUrl: 'https://google.com/foo',
+      }, {
+        url: 'https://google.com/foo',
+      })
+    })
+
     it('matches on url as regexp', function () {
       tryMatch({
         proxiedUrl: 'https://google.com/foo',
@@ -163,6 +171,16 @@ describe('intercept-request', function () {
         }, {
           matchUrlAgainstPath: true,
           url: '/*/nested?k=*',
+        })
+      })
+
+      // @see https://github.com/cypress-io/cypress/issues/14256
+      it('matches when url has missing leading slash', function () {
+        tryMatch({
+          proxiedUrl: 'http://foo.com/services/api/agenda/Appointment?id=25',
+        }, {
+          matchUrlAgainstPath: true,
+          url: 'services/api/agenda/Appointment?id=**',
         })
       })
     })

--- a/packages/net-stubbing/test/unit/route-matching-spec.ts
+++ b/packages/net-stubbing/test/unit/route-matching-spec.ts
@@ -2,6 +2,7 @@ import {
   _doesRouteMatch,
   _getMatchableForRequest,
 } from '../../lib/server/route-matching'
+import { RouteMatcherOptions } from '../../lib/types'
 import { expect } from 'chai'
 import { CypressIncomingRequest } from '@packages/proxy'
 
@@ -41,100 +42,120 @@ describe('intercept-request', function () {
   })
 
   context('._doesRouteMatch', function () {
-    it('matches on url as regexp', function () {
-      const req = {
-        headers: {
-          quuz: 'quux',
-        },
+    const tryMatch = (req: Partial<CypressIncomingRequest>, matcher: RouteMatcherOptions, expected = true) => {
+      req = {
         method: 'GET',
+        headers: {},
+        ...req,
+      }
+
+      expect(_doesRouteMatch(matcher, req as CypressIncomingRequest)).to.eq(expected)
+    }
+
+    it('matches on url as regexp', function () {
+      tryMatch({
         proxiedUrl: 'https://google.com/foo',
-      } as unknown as CypressIncomingRequest
-
-      const matched = _doesRouteMatch({
+      }, {
         url: /foo/,
-      }, req)
-
-      expect(matched).to.be.true
+      })
     })
 
     it('matches on a null matcher', function () {
-      const req = {
-        headers: {
-          quuz: 'quux',
-        },
-        method: 'GET',
+      tryMatch({
         proxiedUrl: 'https://google.com/asdf?1234=a',
-      } as unknown as CypressIncomingRequest
-
-      const matched = _doesRouteMatch({}, req)
-
-      expect(matched).to.be.true
+      }, {})
     })
 
     it('matches on auth matcher', function () {
-      const req = {
+      tryMatch({
         headers: {
           authorization: 'basic Zm9vOmJhcg==',
         },
-        method: 'GET',
         proxiedUrl: 'https://google.com/asdf?1234=a',
-      } as unknown as CypressIncomingRequest
-
-      const matched = _doesRouteMatch({
+      }, {
         auth: {
           username: /^Fo[aob]$/i,
           password: /.*/,
         },
-      }, req)
-
-      expect(matched).to.be.true
+      })
     })
 
     it('doesn\'t match on a partial match', function () {
-      const req = {
+      tryMatch({
         headers: {
           authorization: 'basic Zm9vOmJhcg==',
         },
-        method: 'GET',
         proxiedUrl: 'https://google.com/asdf?1234=a',
-      } as unknown as CypressIncomingRequest
-
-      const matched = _doesRouteMatch({
+      }, {
         auth: {
           username: /^Fo[aob]$/i,
           password: /.*/,
         },
         method: 'POST',
-      }, req)
-
-      expect(matched).to.be.false
+      }, false)
     })
 
     it('handles querystrings as expected', function () {
       const req = {
-        headers: {},
-        method: 'GET',
         proxiedUrl: '/abc?foo=bar&baz=quux',
-      } as unknown as CypressIncomingRequest
+      }
 
-      expect(_doesRouteMatch({
+      tryMatch(req, {
         query: {
           foo: 'b*r',
           baz: /quu[x]/,
         },
-      }, req)).to.be.true
+      })
 
-      expect(_doesRouteMatch({
+      tryMatch(req, {
         path: '/abc?foo=bar&baz=qu*x',
-      }, req)).to.be.true
+      })
 
-      expect(_doesRouteMatch({
+      tryMatch(req, {
         pathname: '/abc',
-      }, req)).to.be.true
+      })
 
-      expect(_doesRouteMatch({
+      tryMatch(req, {
         url: '*',
-      }, req)).to.be.true
+      })
+    })
+
+    context('with matchUrlAgainstPath', function () {
+      it('matches globs against path', function () {
+        tryMatch({
+          proxiedUrl: 'http://foo.com/bar/a1',
+        }, {
+          matchUrlAgainstPath: true,
+          url: '/bar/*',
+        })
+      })
+
+      it('matches nested glob against path', function () {
+        tryMatch({
+          proxiedUrl: 'http://foo.com/bar/a1/foo',
+        }, {
+          matchUrlAgainstPath: true,
+          url: '/bar/*/foo',
+        })
+      })
+
+      it('fails to match with missing queryparams', function () {
+        tryMatch({
+          proxiedUrl: 'http://foo.com/foo/nested?k=v',
+        }, {
+          matchUrlAgainstPath: true,
+          url: '/*/nested',
+        }, false)
+      })
+
+      it('can glob-match against queryparams', function () {
+        tryMatch({
+          proxiedUrl: 'http://foo.com/foo/nested?k=v',
+        }, {
+          matchUrlAgainstPath: true,
+          url: '/*/nested?k=*',
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
- Closes #9379 
- Closes #14256

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

### Additional details

- adds a `matchUrlAgainstPath` property to RouteMatcher
	- allows differentiating `cy.intercept(url)` from `cy.intercept({ url })` or `cy.intercept({ path })`
	- also follows old `cy.route` behavior by applying a `/` prefix to un-prefixed `url` values that are being matched against a path - old behavior: https://github.com/cypress-io/cypress/blob/ad194de98ffbbcdf687aa7c6c64b1cc1f6690a94/packages/driver/src/cypress/server.js#L296-L301

### How has the user experience changed?

now works as described in https://github.com/cypress-io/cypress/issues/9379#issuecomment-742004697

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->https://github.com/cypress-io/cypress-documentation/pull/3424
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
