### PR TITLE
Updating cli/package.json and circle.yml to require node 12 minimum

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1280,7 +1280,7 @@ jobs:
   test-npm-module-on-minimum-node-version:
     <<: *defaults
     docker:
-      - image: cypress/base:10.0.0
+      - image: cypress/base:12.0.0
     steps:
       - attach_workspace:
           at: ~/

--- a/cli/package.json
+++ b/cli/package.json
@@ -105,7 +105,7 @@
     "cypress": "bin/cypress"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "types": "types"
 }


### PR DESCRIPTION

- Closes #9545

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

Upgraded Cypress to require a minimum node version to 12.0.0

### Additional details

Node.10 is end of life April 2021


### How has the user experience changed?

Users are required to upgrade Node version from 10 to 12 in order to use Cypress

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
