### PR TITLE
fix(Component Testing): Broken links in docs

### DIFF
--- a/npm/react/README.md
+++ b/npm/react/README.md
@@ -432,15 +432,6 @@ Because finding and modifying Webpack settings while running this plugin is done
 DEBUG=@cypress/react,find-webpack
 ```
 
-## Migration guide
-
-### From v3 to v4
-
-The old v3 `main` branch is available as branch [v3](https://github.com/cypress-io/cypress-react-unit-test/tree/v3)
-
-- the `cy.mount` is now simply `import { mount } from '@cypress/react'`
-- the support file is simply `require('@cypress/react/support')`
-
 ## Related tools
 
 Same feature for unit testing components from other frameworks using Cypress

--- a/npm/react/README.md
+++ b/npm/react/README.md
@@ -386,8 +386,7 @@ const webpackOptions = {
 }
 ```
 
-<!--  TODO FIX THE LINK -->
-Keep your eye on issue [#156](https://github.com/bahmutov/cypress-react-unut-test/issues/156) for more information.
+Keep your eye on issue [#9663](https://github.com/cypress-io/cypress/issues/9663) for more information.
 
 </details>
 
@@ -403,7 +402,7 @@ See related issue [#141](https://github.com/bahmutov/cypress-react-unit-test/rea
 <details id="gatsby-not-supported">
   <summary>Gatsby.js projects not supported</summary>
 
-Currently, this project cannot find Webpack settings used by Gatsby.js, thus it cannot bundle specs and application code correctly. Keep an eye on [#307](https://github.com/bahmutov/@cypress/react/issues/307)
+Currently, this project cannot find Webpack settings used by Gatsby.js, thus it cannot bundle specs and application code correctly. Keep an eye on [#307](https://github.com/cypress-io/cypress/issues/9671)
 
 </details>
 
@@ -437,7 +436,7 @@ DEBUG=@cypress/react,find-webpack
 
 ### From v3 to v4
 
-The old v3 `main` branch is available as branch [v3](https://github.com/bahmutov/@cypress/react/tree/v3)
+The old v3 `main` branch is available as branch [v3](https://github.com/cypress-io/cypress-react-unit-test/tree/v3)
 
 - the `cy.mount` is now simply `import { mount } from '@cypress/react'`
 - the support file is simply `require('@cypress/react/support')`

--- a/npm/vue/README.md
+++ b/npm/vue/README.md
@@ -729,7 +729,7 @@ module.exports = (on, config) => {
 
 ## Test adapters for other frameworks
 
-- [@cypress/react](https://github.com/bahmutov/@cypress/react)
+- [@cypress/react](https://github.com/cypress-io/@cypress/react)
 - [cypress-cycle-unit-test](https://github.com/bahmutov/cypress-cycle-unit-test)
 - [cypress-svelte-unit-test](https://github.com/bahmutov/cypress-svelte-unit-test)
 - [cypress-angular-unit-test](https://github.com/bahmutov/cypress-angular-unit-test)
@@ -743,7 +743,7 @@ module.exports = (on, config) => {
 The Cypress.io Component Testing Team
 
 - [Jessica Sachs](https://github.com/jessicasachs) (Current Maintainer, [Vue Test Utils](https://github.com/vuejs/vue-test-utils) Maintainer)
-- [Gleb Bahmutov](https://github.com/bahmutov) (Original Author, Current Maintainer of [@cypress/react](https://github.com/bahmutov/@cypress/react))
+- [Gleb Bahmutov](https://github.com/bahmutov) (Original Author, Current Maintainer of [@cypress/react](https://github.com//cypress-io/@cypress/react))
 
 Support: if you find any problems with this module, [tweet](https://twitter.com/_jessicasachs) / [open issue](https://github.com/cypress-io/cypress/issues) on Github
 


### PR DESCRIPTION
This PR fixes a few broken links in the component testing docs. 

- Closes N/A

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
