### PR TITLE
test: fix percy flake for 'loading tests' display

### DIFF
--- a/packages/reporter/cypress/integration/commands_spec.ts
+++ b/packages/reporter/cypress/integration/commands_spec.ts
@@ -44,13 +44,6 @@ describe('commands', () => {
   it('displays all the commands', () => {
     cy.get('.command').should('have.length', 9)
 
-    // ensure progress bar is no longer visible
-    // for snapshot
-    cy.contains('#in-progress')
-    .closest('.command')
-    .find('.command-progress span')
-    .should('not.be.visible')
-
     cy.percySnapshot()
   })
 

--- a/packages/reporter/cypress/integration/runnables_spec.ts
+++ b/packages/reporter/cypress/integration/runnables_spec.ts
@@ -44,6 +44,8 @@ describe('runnables', () => {
   it('displays loader when runnables have not yet loaded', () => {
     render()
     cy.contains('Your tests are loading...').should('be.visible')
+    // ensure the page is loaded before taking snapshot
+    cy.get('.focus-tests-text').should('be.visible')
     cy.percySnapshot()
   })
 

--- a/packages/reporter/cypress/support/index.ts
+++ b/packages/reporter/cypress/support/index.ts
@@ -1,4 +1,8 @@
 // @ts-ignore
 import installCustomPercyCommand from '@packages/ui-components/cypress/support/customPercyCommand'
 
-installCustomPercyCommand()
+installCustomPercyCommand({
+  elementOverrides: {
+    '.command-progress': true,
+  },
+})

--- a/packages/runner/cypress/integration/retries.ui.spec.js
+++ b/packages/runner/cypress/integration/retries.ui.spec.js
@@ -283,8 +283,8 @@ describe('runner/cypress retries.ui.spec', { viewportWidth: 600, viewportHeight:
       } }, { config: { retries: 1 } })
       .then(shouldHaveTestResults(0, 1, 0))
 
+      // ensure the page is loaded before taking snapshot
       cy.contains('skips this')
-
       cy.percySnapshot()
     })
   })


### PR DESCRIPTION
Add extra assertion to ensure page it loaded before taking Percy snapshot.

Percy flake: https://percy.io/cypress-io/cypress/builds-next/8146025/changed/463611682

<img width="936" alt="Screen Shot 2020-12-21 at 10 31 43 AM" src="https://user-images.githubusercontent.com/1271364/102738230-e52c7f80-4377-11eb-910c-f4b4ae1cb312.png">


