### PR TITLE
fix(react): link types from the correct directory

### DIFF
--- a/npm/react/package.json
+++ b/npm/react/package.json
@@ -107,11 +107,10 @@
   },
   "files": [
     "dist",
-    "lib",
     "support",
     "plugins"
   ],
-  "types": "lib",
+  "types": "dist",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### User facing changelog

Allows to use `import { mount } from '@cypress/react';` in TypeScript projects. 

### Additional details

Currently `types` filed in the `package.json` targets missing `lib` directory, which makes imports from `@cypress/react` invalid.