### PR TITLE
fix: ignore within subject when screenshotting the entire runner

### DIFF
--- a/packages/driver/cypress/integration/commands/screenshot_spec.js
+++ b/packages/driver/cypress/integration/commands/screenshot_spec.js
@@ -746,6 +746,17 @@ describe('src/cy/commands/screenshot', () => {
         })
       })
 
+      // https://github.com/cypress-io/cypress/issues/14253
+      it('ignores within subject when capturing the runner', () => {
+        cy.get('.short-element').within(() => {
+          cy.screenshot({ capture: 'runner' })
+        }).then(() => {
+          // the runner was captured
+          expect(Cypress.action.withArgs('cy:before:screenshot').args[0][1].appOnly).to.be.true
+          expect(Cypress.automation.withArgs('take:screenshot').args[0][1].capture).to.equal('viewport')
+        })
+      })
+
       it('coerces capture option into \'app\'', function () {
         Cypress.automation.withArgs('take:screenshot').resolves(this.serverResult)
 

--- a/packages/driver/src/cy/commands/screenshot.js
+++ b/packages/driver/src/cy/commands/screenshot.js
@@ -418,10 +418,15 @@ module.exports = function (Commands, Cypress, cy, state, config) {
         name = null
       }
 
-      const withinSubject = state('withinSubject')
+      // make sure when we capture the entire test runner
+      // we are not limited to "within" subject
+      // https://github.com/cypress-io/cypress/issues/14253
+      if (options.capture !== 'runner') {
+        const withinSubject = state('withinSubject')
 
-      if (withinSubject && $dom.isElement(withinSubject)) {
-        subject = withinSubject
+        if (withinSubject && $dom.isElement(withinSubject)) {
+          subject = withinSubject
+        }
       }
 
       // TODO: handle hook titles


### PR DESCRIPTION
- Closes #14253

### User facing changelog

The combination of `cy.within(() => cy.screenshot(name, {capture: 'runner'})` no longer captures the element and instead captures the test runner as expected.

### Additional details

We avoid surprising behavior

### How has the user experience changed?

Instead of the within element, we get the test runner screenshot


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
