### PR TITLE
fix: Display email and message to go to onboarding when name undefined after login

### DIFF
--- a/packages/desktop-gui/src/auth/login-modal.jsx
+++ b/packages/desktop-gui/src/auth/login-modal.jsx
@@ -80,7 +80,12 @@ class LoginContent extends Component {
       <div className='modal-body login'>
         <BootstrapModal.Dismiss className='btn btn-link close'>x</BootstrapModal.Dismiss>
         <h1><i className='fas fa-check'></i> Login Successful</h1>
-        <p>You are now logged in{authStore.user ? ` as ${authStore.user.name}` : ''}.</p>
+        <p>You are now logged in{authStore.user ? ` as ${authStore.user.displayName}` : ''}.</p>
+        {
+          !authStore.user.name ?
+            <p>Please go to the <a onClick={this._openDashboardProfile}>Cypress Dashboard</a> to complete the onboarding steps.</p> :
+            null
+        }
         <div className='login-content'>
           <button
             className='btn btn-login btn-primary btn-wide'
@@ -113,6 +118,10 @@ class LoginContent extends Component {
         <a onClick={this._openAPIHelp}>Learn more</a>
       </div>
     )
+  }
+
+  _openDashboardProfile () {
+    ipc.externalOpen('https://on.cypress.io/dashboard/profile')
   }
 
   _openDashboard () {


### PR DESCRIPTION
- TR-565

### User Changelog

- After login, if a name is undefined on your profile, the Test Runner will show the profile’s email and link to instructions to update the name.

### Additional Details

### How has the user experience changed?

#### Before

<img width="683" alt="Screen Shot 2020-12-23 at 2 23 56 PM" src="https://user-images.githubusercontent.com/1271364/102974375-cf13f000-452c-11eb-87e4-b931381ce3ad.png">

#### After

<img width="683" alt="Screen Shot 2020-12-23 at 2 28 15 PM" src="https://user-images.githubusercontent.com/1271364/102974407-ddfaa280-452c-11eb-930c-ecec7654eb93.png">

### PR Tasks

<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->