### PR TITLE
fix: blow away AUT iframe when HMR triggers

### DIFF
--- a/npm/webpack-dev-server/src/aut-runner.ts
+++ b/npm/webpack-dev-server/src/aut-runner.ts
@@ -1,6 +1,6 @@
 /*eslint-env browser,mocha*/
 
-function appendTargetIfNotExists (id, tag = 'div', parent = document.body) {
+function appendTargetIfNotExists (id: string, tag = 'div', parent = document.body) {
   let node = document.getElementById(id)
 
   if (!node) {
@@ -15,7 +15,7 @@ function appendTargetIfNotExists (id, tag = 'div', parent = document.body) {
 }
 
 export function init (importPromises, parent = (window.opener || window.parent)) {
-  let Cypress = (window as any).Cypress = parent.Cypress
+  const Cypress = (window as any).Cypress = parent.Cypress
 
   if (!Cypress) {
     throw new Error('Tests cannot run without a reference to Cypress!')
@@ -28,4 +28,8 @@ export function init (importPromises, parent = (window.opener || window.parent))
 
     root.appendChild(appendTargetIfNotExists('__cy_app'))
   })
+
+  return {
+    onHMR: Cypress.onHMR,
+  }
 }

--- a/npm/webpack-dev-server/src/aut-runner.ts
+++ b/npm/webpack-dev-server/src/aut-runner.ts
@@ -30,6 +30,6 @@ export function init (importPromises, parent = (window.opener || window.parent))
   })
 
   return {
-    onHMR: Cypress.onHMR,
+    restartRunner: Cypress.restartRunner,
   }
 }

--- a/npm/webpack-dev-server/src/loader.ts
+++ b/npm/webpack-dev-server/src/loader.ts
@@ -1,10 +1,19 @@
+/* global Cypress */
+/// <reference types="cypress" />
+
 import * as path from 'path'
 
-const makeImport = (file, fileKey, chunkName, projectRoot) => {
+/**
+ * @param {ComponentSpec} file spec to create import string from.
+ * @param {string} filename name of the spec file - this is the same as file.name
+ * @param {string} chunkName webpack chunk name. eg: 'spec-0'
+ * @param {string} projectRoot absolute path to the project root. eg: /Users/<username>/my-app
+ */
+const makeImport = (file: Cypress.Cypress['spec'], filename: string, chunkName: string, projectRoot: string) => {
   // If we want to rename the chunks, we can use this
   const magicComments = chunkName ? `/* webpackChunkName: "${chunkName}" */` : ''
 
-  return `"${fileKey}": {
+  return `"${filename}": {
     shouldLoad: () => document.location.pathname.includes(${JSON.stringify(file.relative)}),
     load: () => {
       return import(${JSON.stringify(path.resolve(projectRoot, file.relative), null, 2)} ${magicComments})
@@ -13,8 +22,23 @@ const makeImport = (file, fileKey, chunkName, projectRoot) => {
   }`
 }
 
-function buildSpecs (files, projectRoot) {
-  if (!files || !Array.isArray(files)) return `{}`
+/**
+ * Creates a object maping a spec file to an object mapping
+ * the spec name to the result of `makeImport`.
+ *
+ * @returns {Record<string, ReturnType<makeImport>}
+ * {
+ *   "App.spec.js": {
+ *     shouldLoad: () => document.location.pathname.includes("cypress/component/App.spec.js"),
+ *     load: () => {
+ *       return import("/Users/projects/my-app/cypress/component/App.spec.js" \/* webpackChunkName: "spec-0" *\/)
+ *     },
+ *     chunkName: "spec-0"
+ *   }
+ * }
+ */
+function buildSpecs (projectRoot: string, files: Cypress.Cypress['spec'][] = []): string {
+  if (!Array.isArray(files)) return `{}`
 
   return `{${files.map((f, i) => {
     return makeImport(f, f.name, `spec-${i}`, projectRoot)
@@ -22,15 +46,15 @@ function buildSpecs (files, projectRoot) {
 }
 
 // Runs the tests inside the iframe
-export default function loader () {
-  const { files, projectRoot } = this._cypress
+export default async function loader (): Promise<string> {
+  const { files, projectRoot } = this._cypress as { files: Cypress.Cypress['spec'][], projectRoot: string }
 
   return `
-  var allTheSpecs = ${buildSpecs(files, projectRoot)};
+  var allTheSpecs = ${buildSpecs(projectRoot, files)};
 
   const { init } = require(${JSON.stringify(require.resolve('./aut-runner'))})
 
-  init(Object.keys(allTheSpecs)
+  const { onHMR } = init(Object.keys(allTheSpecs)
     .filter(key => allTheSpecs[key].shouldLoad())
     .map(a => allTheSpecs[a].load())
   )

--- a/npm/webpack-dev-server/src/loader.ts
+++ b/npm/webpack-dev-server/src/loader.ts
@@ -46,7 +46,7 @@ function buildSpecs (projectRoot: string, files: Cypress.Cypress['spec'][] = [])
 }
 
 // Runs the tests inside the iframe
-export default async function loader (): Promise<string> {
+export default function loader () {
   const { files, projectRoot } = this._cypress as { files: Cypress.Cypress['spec'][], projectRoot: string }
 
   return `
@@ -54,9 +54,13 @@ export default async function loader (): Promise<string> {
 
   const { init } = require(${JSON.stringify(require.resolve('./aut-runner'))})
 
-  const { onHMR } = init(Object.keys(allTheSpecs)
+  const { restartRunner } = init(Object.keys(allTheSpecs)
     .filter(key => allTheSpecs[key].shouldLoad())
     .map(a => allTheSpecs[a].load())
   )
+
+  if (module.hot) {
+    restartRunner()
+  }
   `
 }

--- a/packages/driver/src/cypress.js
+++ b/packages/driver/src/cypress.js
@@ -167,20 +167,18 @@ class $Cypress {
     return this.runner.run(fn)
   }
 
-  // Callback to execute when module.hot is called in component testing
+  // Method to manually re-execute Runner (usually within $autIframe)
+  // used mainly by Component Testing
   restartRunner () {
-    if (!window.parent.Cypress || !window.parent.Cypress.$autIframe) {
-      throw Error('Cannot re-run spec without Cypress or Cypress.$autIframe')
+    if (!window.top.Cypress) {
+      throw Error('Cannot re-run spec without Cypress')
     }
 
-    const $autIframe = window.parent.Cypress.$autIframe[0]
     // MobX state is only available on the Runner instance
     // which is attached to the top level `window`
-    const state = $autIframe.ownerDocument.defaultView.Runner.state
-
-    // avoid endless restart loop by checking if not in a loading state.
-    if (!state.isLoading) {
-      window.parent.Cypress.$autIframe[0].ownerDocument.defaultView.Runner.emit('restart')
+    // We avoid infinite restart loop by checking if not in a loading state.
+    if (!window.top.Runner.state.isLoading) {
+      window.top.Runner.emit('restart')
     }
   }
 

--- a/packages/driver/src/cypress.js
+++ b/packages/driver/src/cypress.js
@@ -168,9 +168,9 @@ class $Cypress {
   }
 
   // Callback to execute when module.hot is called in component testing
-  onHMR () {
+  restartRunner () {
     if (!window.parent.Cypress || !window.parent.Cypress.$autIframe[0]) {
-      throw Error('Cannot re-run spec without Cypress or Cypress.$aucIframe')
+      throw Error('Cannot re-run spec without Cypress or Cypress.$autIframe')
     }
 
     const $autIframe = window.parent.Cypress.$autIframe[0]

--- a/packages/driver/src/cypress.js
+++ b/packages/driver/src/cypress.js
@@ -167,6 +167,21 @@ class $Cypress {
     return this.runner.run(fn)
   }
 
+  // Callback to execute when module.hot is called in component testing
+  onHMR () {
+    if (!window.parent.Cypress || !window.parent.Cypress.$autIframe[0]) {
+      throw Error('Cannot re-run spec without Cypress or Cypress.$aucIframe')
+    }
+
+    const $autIframe = window.parent.Cypress.$autIframe[0]
+    const state = $autIframe.ownerDocument.defaultView.Runner.state
+
+    // avoid endless restart loop by checking if not in a loading state.
+    if (!state.isLoading) {
+      window.parent.Cypress.$autIframe[0].ownerDocument.defaultView.Runner.emit('restart')
+    }
+  }
+
   // onSpecWindow is called as the spec window
   // is being served but BEFORE any of the actual
   // specs or support files have been downloaded

--- a/packages/driver/src/cypress.js
+++ b/packages/driver/src/cypress.js
@@ -169,11 +169,13 @@ class $Cypress {
 
   // Callback to execute when module.hot is called in component testing
   restartRunner () {
-    if (!window.parent.Cypress || !window.parent.Cypress.$autIframe[0]) {
+    if (!window.parent.Cypress || !window.parent.Cypress.$autIframe) {
       throw Error('Cannot re-run spec without Cypress or Cypress.$autIframe')
     }
 
     const $autIframe = window.parent.Cypress.$autIframe[0]
+    // MobX state is only available on the Runner instance
+    // which is attached to the top level `window`
     const state = $autIframe.ownerDocument.defaultView.Runner.state
 
     // avoid endless restart loop by checking if not in a loading state.

--- a/packages/runner-ct/src/main.jsx
+++ b/packages/runner-ct/src/main.jsx
@@ -2,6 +2,7 @@ import { autorun, action, configure } from 'mobx'
 import React from 'react'
 import { render } from 'react-dom'
 import { utils as driverUtils } from '@packages/driver'
+import defaultEvents from '@packages/reporter/src/lib/events'
 
 import State from './lib/state'
 import Container from './app/container'
@@ -13,6 +14,10 @@ import 'regenerator-runtime/runtime'
 configure({ enforceActions: 'always' })
 
 const Runner = {
+  emit (evt, ...args) {
+    defaultEvents.emit(evt, ...args)
+  },
+
   start (el, base64Config) {
     action('started', () => {
       const config = JSON.parse(driverUtils.decodeBase64Unicode(base64Config))

--- a/packages/server-ct/crossword-example/cypress/component/RenderFn.spec.js
+++ b/packages/server-ct/crossword-example/cypress/component/RenderFn.spec.js
@@ -1,0 +1,11 @@
+import Foo from '@/components/Foo'
+import { mount } from '@cypress/vue'
+
+describe('Foo', () => {
+  it('works', () => {
+    mount(Foo)
+    cy.get('h3').contains('Count is: 0')
+    cy.get('button').contains('Increment').click()
+    cy.get('h3').contains('Count is: 1')
+  })
+})

--- a/packages/server-ct/crossword-example/cypress/component/RenderFn.spec.js
+++ b/packages/server-ct/crossword-example/cypress/component/RenderFn.spec.js
@@ -1,9 +1,9 @@
-import Foo from '@/components/Foo'
+import RenderFn from '@/components/RenderFn'
 import { mount } from '@cypress/vue'
 
 describe('Foo', () => {
   it('works', () => {
-    mount(Foo)
+    mount(RenderFn)
     cy.get('h3').contains('Count is: 0')
     cy.get('button').contains('Increment').click()
     cy.get('h3').contains('Count is: 1')

--- a/packages/server-ct/crossword-example/src/components/RenderFn.js
+++ b/packages/server-ct/crossword-example/src/components/RenderFn.js
@@ -1,0 +1,22 @@
+export default {
+  data () {
+    return {
+      count: 0,
+    }
+  },
+  methods: {
+    inc () {
+      this.count += 1
+    },
+  },
+  render (h) {
+    const btn = h('button', {
+      on: {
+        click: this.inc,
+      },
+    }, 'Increment')
+    const display = h('h3', {}, `Count is: ${this.count}`)
+
+    return h('div', [btn, display])
+  },
+}


### PR DESCRIPTION
Testing:

1. make sure you build the latest webpack-dev-server by going to `npm/webpack-dev-server` and running `yarn build`.
2. Go to `packages/server-ct`
3. run `yarn cypress:open`

Currently `.vue` files do not trigger HMR for some reason - I need to look into this. But you can edit `RenderFn.js` and `RenderFn.spec.js` and watch the test re-run. Note is is entirely blowing away the AUT iframe by emitting a `restart` event, ensuring no state is preserved between tests.