### PR TITLE
fix: fix vue tests by using correct webpack config

### DIFF
--- a/npm/vue/cypress/component/advanced/i18n/spec.js
+++ b/npm/vue/cypress/component/advanced/i18n/spec.js
@@ -7,7 +7,8 @@ import { mount } from '@cypress/vue'
 import messages from './translations.json'
 
 function expectHelloWorldGreeting () {
-  cy.viewport(400, 200)
+  // TODO: Support this API!
+  // cy.viewport(400, 200)
   const allLocales = Cypress.vue.$i18n.availableLocales
 
   // ensure we don't strip locales

--- a/npm/vue/cypress/component/router-example/PizzaShop/router.js
+++ b/npm/vue/cypress/component/router-example/PizzaShop/router.js
@@ -1,8 +1,8 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
-import PizzaShop from './index'
-import Home from './Home'
-import Order from './Order'
+import PizzaShop from './index.vue'
+import Home from './Home.vue'
+import Order from './Order.vue'
 
 Vue.use(VueRouter)
 

--- a/npm/webpack-dev-server/src/startServer.ts
+++ b/npm/webpack-dev-server/src/startServer.ts
@@ -6,9 +6,14 @@ const debug = debugFn('cypress:webpack-dev-server:start')
 
 import { makeWebpackConfig } from './makeWebpackConfig'
 
-export async function start (userWebpackConfig = {}, { specs, config, devserverEvents }): Promise<WebpackDevServer> {
-  const foundConfig = fw.getWebpackOptions()
-  const webpackConfig = await makeWebpackConfig(foundConfig || userWebpackConfig, {
+export async function start (initialWebpackConfig, { specs, config, devserverEvents }): Promise<WebpackDevServer> {
+  if (initialWebpackConfig == null) {
+    debug('User did not pass in any webpack configuration')
+    // TODO: implement a method in find-webpack to return the path where it found the configuration
+    initialWebpackConfig = fw.getWebpackOptions()
+  }
+
+  const webpackConfig = await makeWebpackConfig(initialWebpackConfig, {
     files: specs,
     projectRoot: config.projectRoot,
     support: '',


### PR DESCRIPTION
Was not using the correct webpack config, I stole the fix from here:
https://github.com/cypress-io/cypress/pull/14287/files#diff-09d40ce97f8a517d6564d565aa9cf53bcaefaf37c3e5db9c5502412bacbbc5e9

The i18n spec still fails (among others) due to missing functionality like `cy.stub`, but at least some of the basic Vue specs now pass (previously the bundle was completely broken).

Test:

1. build latest webpack-dev-server with `yarn build` in `npm/webpack-dev-server`.
2. `cd packages/server-ct`
3. `NODE_OPTIONS=--max-http-header-size=1048576 node ../../scripts/start.js --component-testing --project ../../npm/vue`
4. Click first spec - it should work fine.