### PR TITLE
feat(component-testing): MVP layout for component-testing runner

### DIFF
--- a/packages/reporter/src/header/header.tsx
+++ b/packages/reporter/src/header/header.tsx
@@ -10,13 +10,13 @@ import Controls from './controls'
 import Stats from './stats'
 import { StatsStore } from './stats-store'
 
-interface Props {
+export interface ReporterHeaderProps {
   appState: AppState
   events?: Events
   statsStore: StatsStore
 }
 
-const Header = observer(({ appState, events = defaultEvents, statsStore }: Props) => (
+const Header = observer(({ appState, events = defaultEvents, statsStore }: ReporterHeaderProps) => (
   <header>
     <Tooltip placement='bottom' title={<p>View All Tests <span className='kbd'>F</span></p>} wrapperClassName='focus-tests' className='cy-tooltip'>
       <button onClick={() => events.emit('focus:tests')}>

--- a/packages/reporter/src/main.tsx
+++ b/packages/reporter/src/main.tsx
@@ -1,3 +1,4 @@
+/* global Cypress, JSX */
 import { action, runInAction } from 'mobx'
 import { observer } from 'mobx-react'
 import cs from 'classnames'
@@ -16,7 +17,7 @@ import scroller, { Scroller } from './lib/scroller'
 import statsStore, { StatsStore } from './header/stats-store'
 import shortcuts from './lib/shortcuts'
 
-import Header from './header/header'
+import Header, { ReporterHeaderProps } from './header/header'
 import Runnables from './runnables/runnables'
 
 type ReporterProps = {
@@ -29,6 +30,7 @@ type ReporterProps = {
   events: Events
   error?: RunnablesErrorModel
   resetStatsOnSpecChange?: boolean
+  renderReporterHeader?: (props: ReporterHeaderProps) => JSX.Element;
   spec: Cypress.Cypress['spec']
 } & ({
   runMode: 'single',
@@ -68,11 +70,20 @@ class Reporter extends Component<ReporterProps> {
   }
 
   render () {
-    const { appState, runMode, runnablesStore, scroller, error, events, statsStore } = this.props
+    const {
+      appState,
+      runMode,
+      runnablesStore,
+      scroller,
+      error,
+      events,
+      statsStore,
+      renderReporterHeader = (props) => <Header {...props}/>,
+    } = this.props
 
     return (
       <div className={cs('reporter', { multiSpecs: runMode === 'multi' })}>
-        <Header appState={appState} statsStore={statsStore} />
+        {renderReporterHeader({ appState, statsStore })}
         {this.props.runMode === 'single' ? (
           <Runnables
             appState={appState}

--- a/packages/runner-ct/src/app/BottomPane.jsx
+++ b/packages/runner-ct/src/app/BottomPane.jsx
@@ -1,9 +1,0 @@
-import * as React from 'react'
-
-export function BottomPane ({ children }) {
-  return (
-    <div className="ct-bottom-pane">
-      {children}
-    </div>
-  )
-}

--- a/packages/runner-ct/src/app/ReporterHeader.tsx
+++ b/packages/runner-ct/src/app/ReporterHeader.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+import { observer } from 'mobx-react'
+import { ReporterHeaderProps } from '@packages/reporter/src/header/header'
+import Stats from '@packages/reporter/src/header/stats'
+import Controls from '@packages/reporter/src/header/controls'
+
+export const ReporterHeader: React.FC<ReporterHeaderProps> = observer(
+  function ReporterHeader ({ statsStore, appState }) {
+    return (
+      <header>
+        <Stats stats={statsStore} />
+        <div className='spacer' />
+        <Controls appState={appState} />
+      </header>
+    )
+  },
+)

--- a/packages/runner-ct/src/app/app.scss
+++ b/packages/runner-ct/src/app/app.scss
@@ -9,14 +9,7 @@
     bottom: unset;
   }
 }
-
-.ct-bottom-pane { 
-  height: 100%;
-  .reporter { 
-    height: 100%;
-    width: 100%;
-  }
-}
+ 
 
 // styles for react-split-pane
 .Resizer {

--- a/packages/runner-ct/src/app/app.tsx
+++ b/packages/runner-ct/src/app/app.tsx
@@ -7,7 +7,7 @@ import { Reporter } from '@packages/reporter'
 import errorMessages from '../errors/error-messages'
 import State from '../lib/state'
 
-import SpecsList from '../specs/specs-list'
+import { SpecsList } from '../specs/specs-list'
 import SplitPane from 'react-split-pane'
 import Header from '../header/header'
 import Iframes from '../iframe/iframes'

--- a/packages/runner-ct/src/app/app.tsx
+++ b/packages/runner-ct/src/app/app.tsx
@@ -1,3 +1,4 @@
+import cs from 'classnames'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -23,6 +24,7 @@ interface AppProps {
 const App: React.FC<AppProps> = observer(
   function App (props: AppProps) {
     const { state, eventManager, config } = props
+    const [isReporterResizing, setIsReporterResizing] = React.useState(false)
 
     return (
       <>
@@ -31,9 +33,13 @@ const App: React.FC<AppProps> = observer(
           <SplitPane
             split="vertical"
             primary="second"
-            defaultSize={config.viewportWidth}
             minSize="20%"
             maxSize="80%"
+            // the viewport + padding left and right
+            defaultSize={config.viewportWidth ? config.viewportWidth + 32 : '20%'}
+            onDragStarted={() => setIsReporterResizing(true)}
+            onDragFinished={() => setIsReporterResizing(false)}
+            className={cs({ 'is-reporter-resizing': isReporterResizing })}
           >
             <div>
               {state.spec && (

--- a/packages/runner-ct/src/app/app.tsx
+++ b/packages/runner-ct/src/app/app.tsx
@@ -13,6 +13,7 @@ import Header from '../header/header'
 import Iframes from '../iframe/iframes'
 import Message from '../message/message'
 import './app.scss'
+import { ReporterHeader } from './ReporterHeader'
 
 interface AppProps {
   state: State;
@@ -53,6 +54,7 @@ const App: React.FC<AppProps> = observer(
                   error={errorMessages.reporterError(state.scriptError, state.spec.relative)}
                   firefoxGcInterval={config.firefoxGcInterval}
                   resetStatsOnSpecChange={state.runMode === 'single'}
+                  renderReporterHeader={(props) => <ReporterHeader {...props} />}
                 />
               )}
             </div>

--- a/packages/runner-ct/src/app/app.tsx
+++ b/packages/runner-ct/src/app/app.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 import { Reporter } from '@packages/reporter'
 
 import errorMessages from '../errors/error-messages'
-import util from '../lib/util'
 import State from '../lib/state'
 
 import SpecsList from '../specs/specs-list'
@@ -12,25 +11,31 @@ import SplitPane from 'react-split-pane'
 import Header from '../header/header'
 import Iframes from '../iframe/iframes'
 import Message from '../message/message'
-import { BottomPane } from './BottomPane'
 import './app.scss'
 
-const App = observer(
-  function App (props) {
+interface AppProps {
+  state: State;
+  // eslint-disable-next-line
+  eventManager: typeof import('../lib/event-manager').default
+  config: Cypress.ConfigOptions
+}
+
+const App: React.FC<AppProps> = observer(
+  function App (props: AppProps) {
     const { state, eventManager, config } = props
 
     return (
       <>
         <SplitPane split="vertical" minSize={250} defaultSize="20%" >
           <SpecsList state={state} />
-          <SplitPane split="horizontal" primary="second" defaultSize="60%" minSize="20%" maxSize="80%">
-            <div className="runner runner-ct container">
-              <Header {...props} />
-              <Iframes {...props} />
-              <Message state={state} />
-            </div>
-
-            <BottomPane>
+          <SplitPane
+            split="vertical"
+            primary="second"
+            defaultSize={config.viewportWidth}
+            minSize="20%"
+            maxSize="80%"
+          >
+            <div>
               {state.spec && (
                 <Reporter
                   runMode={state.runMode}
@@ -38,12 +43,19 @@ const App = observer(
                   spec={state.spec}
                   allSpecs={state.multiSpecs}
                   autoScrollingEnabled={config.state.autoScrollingEnabled}
+                  // @ts-ignore
                   error={errorMessages.reporterError(state.scriptError, state.spec.relative)}
                   firefoxGcInterval={config.firefoxGcInterval}
                   resetStatsOnSpecChange={state.runMode === 'single'}
                 />
               )}
-            </BottomPane>
+            </div>
+
+            <div className="runner runner-ct container">
+              <Header {...props} />
+              <Iframes {...props} />
+              <Message state={state} />
+            </div>
           </SplitPane>
         </SplitPane>
 
@@ -55,11 +67,6 @@ const App = observer(
     )
   },
 )
-
-App.defaultProps = {
-  window,
-  util,
-}
 
 App.propTypes = {
   runMode: PropTypes.oneOf(['single', 'multi']),
@@ -78,6 +85,7 @@ App.propTypes = {
     viewportHeight: PropTypes.number.isRequired,
     viewportWidth: PropTypes.number.isRequired,
   }).isRequired,
+  // @ts-expect-error
   eventManager: PropTypes.shape({
     notifyRunningSpec: PropTypes.func.isRequired,
     reporterBus: PropTypes.shape({

--- a/packages/runner-ct/src/app/app.tsx
+++ b/packages/runner-ct/src/app/app.tsx
@@ -30,7 +30,7 @@ const App: React.FC<AppProps> = observer(
     return (
       <>
         <SplitPane split="vertical" minSize={250} defaultSize="20%" >
-          <SpecsList state={state} />
+          <SpecsList state={state} config={config} />
           <SplitPane
             split="vertical"
             primary="second"

--- a/packages/runner-ct/src/header/header.jsx
+++ b/packages/runner-ct/src/header/header.jsx
@@ -8,7 +8,6 @@ import { $ } from '@packages/driver'
 import { configFileFormatted } from '../lib/config-file-formatted'
 import SelectorPlayground from '../selector-playground/selector-playground'
 import selectorPlaygroundModel from '../selector-playground/selector-playground-model'
-import { getSpecUrl } from '../iframe/iframes'
 
 @observer
 export default class Header extends Component {
@@ -16,7 +15,6 @@ export default class Header extends Component {
 
   render () {
     const { state, config } = this.props
-    const url = state.url.length ? state.url : getSpecUrl(config, window.location.origin)
 
     return (
       <header
@@ -41,17 +39,6 @@ export default class Header extends Component {
               <i aria-hidden="true" className='fas fa-crosshairs' />
             </button>
           </Tooltip>
-          <div
-            className={cs('url-container', {
-              'loading': state.isLoadingUrl,
-              'highlighted': state.highlightUrl,
-            })}
-          >
-            <input className='url' value={url} readOnly onClick={this._openUrl} />
-            <span className='loading-container'>
-              ...loading <i className='fas fa-spinner fa-pulse'></i>
-            </span>
-          </div>
         </div>
         <ul className='menu'>
           <li className={cs('viewport-info', { 'open': this.showingViewportMenu })}>
@@ -98,10 +85,6 @@ export default class Header extends Component {
 
   _togglePlaygroundOpen = () => {
     selectorPlaygroundModel.toggleOpen()
-  }
-
-  _openUrl = () => {
-    window.open(getSpecUrl(this.props.config, window.location.origin))
   }
 
   @action _toggleViewportMenu = () => {

--- a/packages/runner-ct/src/header/header.jsx
+++ b/packages/runner-ct/src/header/header.jsx
@@ -43,7 +43,7 @@ export default class Header extends Component {
         <ul className='menu'>
           <li className={cs('viewport-info', { 'open': this.showingViewportMenu })}>
             <button onClick={this._toggleViewportMenu}>
-              {state.width} <span className='the-x'>x</span> {state.height} <span className='viewport-scale'>({state.displayScale}%)</span>
+              {state.width} <span className='the-x'>x</span> {state.height}
               <i className='fas fa-fw fa-info-circle'></i>
             </button>
             <div className='viewport-menu'>

--- a/packages/runner-ct/src/lib/state.ts
+++ b/packages/runner-ct/src/lib/state.ts
@@ -88,7 +88,7 @@ export default class State {
   @observable spec = _defaults.spec
   @observable specs = _defaults.specs
   /** @type {"single" | "multi"} */
-  @observable runMode = 'single'
+  @observable runMode: 'single' | 'multi' = 'single'
   @observable multiSpecs: Cypress.Cypress['spec'][] = [];
 
   constructor ({

--- a/packages/runner-ct/src/lib/useWindowSize.ts
+++ b/packages/runner-ct/src/lib/useWindowSize.ts
@@ -1,0 +1,32 @@
+import * as React from 'react'
+
+export function useWindowSize () {
+  // Initialize state with undefined width/height so server and client renders match
+  // Learn more here: https://joshwcomeau.com/react/the-perils-of-rehydration/
+  const [windowSize, setWindowSize] = React.useState({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  })
+
+  React.useEffect(() => {
+    // Handler to call on window resize
+    function handleResize () {
+      // Set window width/height to state
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      })
+    }
+
+    // Add event listener
+    window.addEventListener('resize', handleResize)
+
+    // Call handler right away so state gets updated with initial window size
+    handleResize()
+
+    // Remove event listener on cleanup
+    return () => window.removeEventListener('resize', handleResize)
+  }, []) // Empty array ensures that effect is only run on mount
+
+  return windowSize
+}

--- a/packages/runner-ct/src/specs/specs-list.scss
+++ b/packages/runner-ct/src/specs/specs-list.scss
@@ -1,6 +1,9 @@
 .specs-list{
     font-family: "Muli", "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 15px;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
     header{
         height: 46px;
         padding: 0 12px;
@@ -9,25 +12,53 @@
         overflow: hidden;
         white-space: nowrap;
         border-bottom: 1px solid #DDD;
-        color: #999999;
     }
+
+    .specs-list-search-input-container {
+        margin: 16px;
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+
+        input { 
+            width: 100%;
+            max-width: 240px;
+            height: 32px;
+            border-radius: 16px;
+            border: 1px solid #E8E8EC;
+            padding-left: 16px;
+
+            // avoid default focus outline because of input border radius
+            &:focus {
+                outline: none;
+                box-shadow: 0px 0px 2px #0012ff;
+            }
+        }
+    }
+
+    .specs-list-scroll-container {
+        height: 0px;
+        flex: 1 1 auto;
+        overflow-y: auto;
+    }
+
     ul{
+
         margin-left: 10px;
         transition: all .5s;
-        overflow: hidden;
+
         &.group-hidden{
             display: none;
         }
         &.specs-list-container{
-            position: absolute;
-            left: 0;
-            right: 0;
-            top: 47px;
-            bottom: 0;
-            overflow-y: auto;
+            // position: absolute;
+            // left: 0;
+            // right: 0;
+            // top: 47px;
+            // bottom: 0;
+            // overflow-y: auto;
         }
         ul{
-            padding: 2px 0;
             color: #555555;
             margin: 0;
             position: relative;

--- a/packages/runner-ct/src/specs/specs-list.scss
+++ b/packages/runner-ct/src/specs/specs-list.scss
@@ -42,22 +42,14 @@
         overflow-y: auto;
     }
 
-    ul{
-
+    ul {
         margin-left: 10px;
         transition: all .5s;
 
         &.group-hidden{
             display: none;
         }
-        &.specs-list-container{
-            // position: absolute;
-            // left: 0;
-            // right: 0;
-            // top: 47px;
-            // bottom: 0;
-            // overflow-y: auto;
-        }
+
         ul{
             color: #555555;
             margin: 0;

--- a/packages/runner-ct/src/specs/specs-list.tsx
+++ b/packages/runner-ct/src/specs/specs-list.tsx
@@ -6,32 +6,43 @@ import { SpecItem } from './spec-item'
 
 interface SpecsListProps {
   state: State
+  config: Cypress.ConfigOptions
 }
 
 export const SpecsList: React.FC<SpecsListProps> = observer(
-  function SpecsList ({ state }) {
+  function SpecsList ({ state, config }) {
     const specGroups = state.filteredSpecs.length ? makeSpecHierarchy(state.filteredSpecs) : []
 
     return (
       <div className="specs-list">
         <header>
+          <h1>
+            { // @ts-expect-error config.project name is not typed
+              config.projectName ?? document.title ?? 'Cypress'
+            }
+          </h1>
+
+        </header>
+        <div className="specs-list-search-input-container">
           <input
             placeholder='Select tests to run...'
             value={state.specSearchText}
-            onChange={(e) => this.props.state.setSearchSpecText(e.currentTarget.value.toLowerCase())}
+            onChange={(e) => state.setSearchSpecText(e.currentTarget.value.toLowerCase())}
           />
-        </header>
-        <ul className="specs-list-container">{
-          specGroups.map((item) => {
-            { // The `active` prop here is used only to
-              // force repaint of the tree when selecting a spec
-              // It is not used for anything else than to patch react
-              // not comparing members of an object (this.props.state in this case)
-            }
+        </div>
+        <div className="specs-list-scroll-container">
+          <ul className="specs-list-container">{
+            specGroups.map((item) => {
+              { // The `active` prop here is used only to
+                // force repaint of the tree when selecting a spec
+                // It is not used for anything else than to patch react
+                // not comparing members of an object (state in this case)
+              }
 
-            return <SpecItem key={item.shortName} item={item} state={state} />
-          })}
-        </ul>
+              return <SpecItem key={item.shortName} item={item} state={state} />
+            })}
+          </ul>
+        </div>
       </div>
     )
   },

--- a/packages/runner-ct/src/specs/specs-list.tsx
+++ b/packages/runner-ct/src/specs/specs-list.tsx
@@ -1,5 +1,5 @@
+import * as React from 'react'
 import { observer } from 'mobx-react'
-import React, { Component } from 'react'
 import State from '../lib/state'
 import { makeSpecHierarchy } from './make-spec-hierarchy'
 import { SpecItem } from './spec-item'
@@ -8,11 +8,8 @@ interface SpecsListProps {
   state: State
 }
 
-@observer
-class SpecsList extends Component<SpecsListProps> {
-  render () {
-    const { state } = this.props
-
+export const SpecsList: React.FC<SpecsListProps> = observer(
+  function SpecsList ({ state }) {
     const specGroups = state.filteredSpecs.length ? makeSpecHierarchy(state.filteredSpecs) : []
 
     return (
@@ -37,7 +34,5 @@ class SpecsList extends Component<SpecsListProps> {
         </ul>
       </div>
     )
-  }
-}
-
-export default SpecsList
+  },
+)


### PR DESCRIPTION
This PR implements the layout design for runner-ct. 

How it looks now:
![image](https://user-images.githubusercontent.com/16926049/102996620-16e64780-452c-11eb-89da-72e0683f69bc.png)

List of changes:
- Move command log to the vertical panel
- Read default size of iframe panel from `config.viewportHeight`
- Fix iframe focus interception when resizing
- Remove back to tests button from command log
- Change design for specs list and search field

### Where tests?

I would love to write some tests and add percy snapshots, but e2e tests PR [is blocked](https://github.com/cypress-io/cypress/pull/14266)