### PR TITLE
fix: cy.contains() works with regexes that use single quotes.

### DIFF
--- a/packages/driver/cypress/integration/commands/querying_spec.js
+++ b/packages/driver/cypress/integration/commands/querying_spec.js
@@ -1801,6 +1801,12 @@ describe('src/cy/commands/querying', () => {
       cy.contains('DOES NOT CONTAIN THIS!')
     })
 
+    // https://github.com/cypress-io/cypress/issues/8626
+    it(`works correctly with ' character inside Regexp.`, () => {
+      $(`<button>'</button>`).appendTo($('body'))
+      cy.contains(/\'/)
+    })
+
     describe('should(\'not.exist\')', () => {
       it('returns null when no content exists', () => {
         cy.contains('alksjdflkasjdflkajsdf').should('not.exist').then(($el) => {

--- a/packages/driver/src/dom/elements.ts
+++ b/packages/driver/src/dom/elements.ts
@@ -1116,8 +1116,13 @@ const getContainsSelector = (text, filter = '', options: {
   $expr['cy-contains'] = cyContainsSelector
 
   const selectors = _.map(filters, (filter) => {
+    // https://github.com/cypress-io/cypress/issues/8626
+    // Sizzle cannot parse when \' is used inside [attribute~='value'] selector.
+    // We need to use other type of quote characters.
+    const textToFind = escapedText.includes(`\'`) ? `"${escapedText}"` : `'${escapedText}'`
+
     // use custom cy-contains selector that is registered above
-    return `${filter}:not(script,style):cy-contains('${escapedText}'), ${filter}[type='submit'][value~='${escapedText}']`
+    return `${filter}:not(script,style):cy-contains(${textToFind}), ${filter}[type='submit'][value~=${textToFind}]`
   })
 
   return selectors.join()


### PR DESCRIPTION
- Closes #8626

### User facing changelog

cy.contains() won't throw an error when single quote is used inside its argument regex.

### Additional details
- Why was this change necessary? => Let Cypress not throw an error when a regex is used with single quote in cy.contains.
- What is affected by this change? => N/A
- Any implementation details to explain? => Sizzle cannot parse it. So, I used double quotes when single quotes are used inside cy.contains regex.

### How has the user experience changed?

N/A

### PR Tasks

- [x] Have tests been added/updated?
