### PR TITLE
fix: Cypress.dom.isJquery() returns only boolean results

### DIFF
--- a/packages/driver/cypress/integration/dom/jquery_spec.ts
+++ b/packages/driver/cypress/integration/dom/jquery_spec.ts
@@ -9,5 +9,16 @@ describe('src/dom/jquery', () => {
     it('is true for actual jquery instances', () => {
       expect(Cypress.dom.isJquery(Cypress.$(':first'))).to.be.true
     })
+
+    // https://github.com/cypress-io/cypress/issues/14278
+    it('does not return undefined', () => {
+      cy.visit('fixtures/dom.html')
+
+      cy.get('#dom').then(($el) => {
+        expect(Cypress.dom.isJquery($el[0])).to.eql(false)
+        // @ts-ignore
+        expect(Cypress.dom.isJquery()).to.eql(false)
+      })
+    })
   })
 })

--- a/packages/driver/src/dom/jquery.js
+++ b/packages/driver/src/dom/jquery.js
@@ -35,7 +35,7 @@ const isJquery = (obj) => {
   // as the jquery property of the window constructor
   // for actual jquery, it should be the version number
   // so we ensure that it is a string (rather than HTML element)
-  return hasJqueryProperty && typeof _.get(obj, 'constructor.prototype.jquery') === 'string'
+  return !!hasJqueryProperty && typeof _.get(obj, 'constructor.prototype.jquery') === 'string'
 }
 
 // doing a little jiggle wiggle here


### PR DESCRIPTION
- Closes #14278

### User facing changelog

`isJquery` returns only boolean results.

### Additional details
- Why was this change necessary? => `isJquery` sometimes returned `undefined`.
- What is affected by this change? => N/A
- Any implementation details to explain? => Simply added `!!`.

### How has the user experience changed?

Users will not get `undefined` results. 

### PR Tasks

- [x] Have tests been added/updated?
