### PR TITLE
fix(webpack-preprocessor): cleanseError compatability with error objects

### DIFF
--- a/npm/webpack-preprocessor/index.ts
+++ b/npm/webpack-preprocessor/index.ts
@@ -380,8 +380,11 @@ preprocessor.__reset = () => {
   bundles = {}
 }
 
-function cleanseError (err: string) {
-  return err.replace(/\n\s*at.*/g, '').replace(/From previous event:\n?/g, '')
+function cleanseError (err: string|Error) {
+  // Error can be either an Error object or a string
+  const message = typeof err == 'string' ? err : (err?.message ?? '');
+
+  return message.replace(/\n\s*at.*/g, '').replace(/From previous event:\n?/g, '');
 }
 
 export = preprocessor

--- a/npm/webpack-preprocessor/index.ts
+++ b/npm/webpack-preprocessor/index.ts
@@ -382,9 +382,9 @@ preprocessor.__reset = () => {
 
 function cleanseError (err: string|Error) {
   // Error can be either an Error object or a string
-  const message = typeof err == 'string' ? err : (err?.message ?? '');
+  const message = typeof err === 'string' ? err : (err?.message ?? '')
 
-  return message.replace(/\n\s*at.*/g, '').replace(/From previous event:\n?/g, '');
+  return message.replace(/\n\s*at.*/g, '').replace(/From previous event:\n?/g, '')
 }
 
 export = preprocessor

--- a/npm/webpack-preprocessor/package.json
+++ b/npm/webpack-preprocessor/package.json
@@ -70,7 +70,7 @@
     "@babel/core": "^7.0.1",
     "@babel/preset-env": "^7.0.0",
     "babel-loader": "^8.0.2",
-    "webpack": "^4.18.1"
+    "webpack": "^4.18.1||^5.0.0"
   },
   "files": [
     "dist"

--- a/npm/webpack-preprocessor/test/unit/index.spec.js
+++ b/npm/webpack-preprocessor/test/unit/index.spec.js
@@ -356,6 +356,26 @@ describe('webpack preprocessor', function () {
           expect(err.message).to.equal(`Webpack Compilation Error\n${errsNoStack.join('\n\n')}`)
         })
       })
+
+      it('it rejects with joined errors when a stats err with error object', function () {
+        const errs = [new Error('foo\nat Object.foo'), 'bar', new Error('baz')]
+        const errsNoStack = ['foo', 'bar', 'baz']
+
+        this.statsApi = {
+          hasErrors () {
+            return true
+          },
+          toJson () {
+            return { errors: errs }
+          },
+        }
+
+        this.compilerApi.run.yields(null, this.statsApi)
+
+        return this.run().catch((err) => {
+          expect(err.message).to.equal(`Webpack Compilation Error\n${errsNoStack.join('\n\n')}`)
+        })
+      })
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Cypress.io end to end testing tool",
   "private": true,
   "scripts": {


### PR DESCRIPTION
### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->
Using @cypress/webpack-preprocessor with webpack v5 causes plugin to crash when error is outputted as an Error object instead of the expected string.

### Additional details

This fixes an error in which errors outputted by webpack v5 are not strings but Error objects. This prevents any kind of error message being shown to the user, instead outputting an error from the webpack-preprocessor package.

### How has the user experience changed?

This results in the error message changing from this:

```
  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:      6.2.0                                                                            │
  │ Browser:      Chrome 87                                                                        │
  │ Specs:        1 found (bootstrap.ts)                                                           │
  │ Searched:     cypress/integration/bootstrap.ts                                                 │
  │ Experiments:  experimentalFetchPolyfill=true                                                   │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  bootstrap.ts                                                                    (1 of 1)

The following error was thrown by a plugin. We stopped running your tests because a plugin crashed. Please check your plugins file (`/Users/runner/work/kirei/kirei/cypress/plugins/index.js`)

TypeError: err.replace is not a function
    at cleanseError (/Users/runner/work/repo/repo/node_modules/@cypress/webpack-preprocessor/dist/index.js:272:16)
    at Array.map (<anonymous>)
    at handle (/Users/runner/work/repo/repo/node_modules/@cypress/webpack-preprocessor/dist/index.js:175:22)
    at finalCallback (/Users/runner/work/repo/repo/node_modules/webpack/lib/Compiler.js:388:32)
    at /Users/runner/work/repo/repo/node_modules/webpack/lib/Compiler.js:452:17
    at /Users/runner/work/repo/repo/node_modules/webpack/lib/HookWebpackError.js:69:3
Opening `/dev/tty` failed (6): Device not configured
    at Hook.eval [as callAsync] (eval at create (/Users/runner/work/repo/repo/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/Users/runner/work/repo/repo/node_modules/tapable/lib/Hook.js:18:14)
    at Cache.storeBuildDependencies (/Users/runner/work/repo/repo/node_modules/webpack/lib/Cache.js:122:37)
    at /Users/runner/work/repo/repo/node_modules/webpack/lib/Compiler.js:448:19
    at Hook.eval [as callAsync] (eval at create (/Users/runner/work/repo/repo/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/Users/runner/work/repo/repo/node_modules/tapable/lib/Hook.js:18:14)
    at /Users/runner/work/repo/repo/node_modules/webpack/lib/Compiler.js:445:23
    at Compiler.emitRecords (/Users/runner/work/repo/repo/node_modules/webpack/lib/Compiler.js:820:39)
    at /Users/runner/work/repo/repo/node_modules/webpack/lib/Compiler.js:437:11
    at /Users/runner/work/repo/repo/node_modules/webpack/lib/Compiler.js:802:14
    at Hook.eval [as callAsync] (eval at create (/Users/runner/work/repo/repo/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/Users/runner/work/repo/repo/node_modules/tapable/lib/Hook.js:18:14)
    at /Users/runner/work/repo/repo/node_modules/webpack/lib/Compiler.js:799:27
    at /Users/runner/work/repo/repo/node_modules/neo-async/async.js:2818:7
    at done (/Users/runner/work/repo/repo/node_modules/neo-async/async.js:3522:9)
    at Hook.eval [as callAsync] (eval at create (/Users/runner/work/repo/repo/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
```

To the more interesting and helpful:

```

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:      5.3.0                                                                            │
  │ Browser:      Electron 83 (headless)                                                           │
  │ Specs:        1 found (bootstrap.ts)                                                           │
  │ Searched:     cypress/integration/bootstrap.ts                                                 │
  │ Experiments:  experimentalFetchPolyfill=true                                                   │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  bootstrap.ts                                                                    (1 of 1)

Oops...we found an error preparing this test file:

  cypress/integration/bootstrap.ts

The error was:

Error: Webpack CompLooked for and couldn't find the file at the following paths:resolve 'element/src/queue' in '/e2e/cypress/integration/element'

This occurred while Cypress was compiling and bundling your test code. This is usually caused by:

- A missing file or dependency
- A syntax error in the file or one of its dependencies

Fix the error in your code and re-run your tests.
```

### PR Tasks

No tasks applicable.
