### PR TITLE
fix(component-testing): ES6 import stubs test

### DIFF
--- a/npm/react/cypress/plugins/index.js
+++ b/npm/react/cypress/plugins/index.js
@@ -60,5 +60,3 @@ module.exports = (on, config) => {
 
   return config
 }
-
-module.exports = cypressPluginsFn

--- a/npm/vue/babel.config.json
+++ b/npm/vue/babel.config.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "@babel/plugin-transform-modules-commonjs"
+  ]
+}

--- a/npm/vue/cypress/component/advanced/mocking-imports/spec.js
+++ b/npm/vue/cypress/component/advanced/mocking-imports/spec.js
@@ -5,7 +5,7 @@ import * as GreetingModule from './greeting'
 
 describe('Mocking ES6 imports', () => {
   beforeEach(() => {
-    cy.viewport(300, 200)
+    // cy.viewport(300, 200)
   })
 
   it('shows real greeting without mocking', () => {

--- a/npm/vue/webpack.config.js
+++ b/npm/vue/webpack.config.js
@@ -28,6 +28,10 @@ module.exports = {
         test: /\.vue$/,
         loader: 'vue-loader',
       },
+      {
+        test: /\.js$/,
+        loader: 'babel-loader',
+      },
       // this will apply to both plain `.css` files
       // AND `<style>` blocks in `.vue` files
       {


### PR DESCRIPTION
This PR shows how to stub the import using 

```js
import * as GreetingModule from './greeting'

it("test", () => {
    cy.stub(GreetingModule, 'greeting').returns('Cypress').as('greeting')
})
```


# Documentation

> No idea where to write documentation, so let it be here until we will write the docs 

## Mocking imports 

> ⚠️ Anti-pattern: Mocking modules makes tests less confident and increase test complexity. It is mostly always possible to avoid mocking or mock values on a level lower than the whole module.

However, sometimes it can be required to mock es6 import in tests. In order to do this – it is required to process your modules to commonjs. The recommended way to achieve is output – [] babel plugin.

Add this to `babel.config.json`: 

```js 
{
  ...
  "env": {
    "TEST": {
      "plugins": [
        "@babel/plugin-transform-modules-commonjs"
      ]
    }
  }
}
```

> Make sure to not include this plugin for production build, because it will disable any es6 optimizations and tree-shaking.

And once cypress will run using `BABEL_ENV=TEST npx cypress open` it will be possible to stub any module using `cy.stub`:

```js
// some/module.js

export const exportOfModule = () => 'Value';
```

```js
// cypress spec.js

import { mount } from '@cypress/react'
import * as AnyModule from './some/module'

it("anytest", () => {
    cy.stub(AnyModule, 'exportOfModule').returns('Cypress')
    mount(<YourComponent />) // any calls of `exportOfModule` function will returns "Cypress" now 
})
```