### PR TITLE
fix: use stdio for CDP instead of TCP

### DIFF
--- a/packages/launcher/lib/browsers.ts
+++ b/packages/launcher/lib/browsers.ts
@@ -97,6 +97,7 @@ export function launch (
   browser: FoundBrowser,
   url: string,
   args: string[] = [],
+  opts: { pipeStdio?: boolean } = {},
 ) {
   log('launching browser %o', { browser, url })
 
@@ -110,7 +111,15 @@ export function launch (
 
   log('spawning browser with args %o', { args })
 
-  const proc = cp.spawn(browser.path, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+  const stdio = ['ignore', 'pipe', 'pipe']
+
+  if (opts.pipeStdio) {
+    // also pipe stdio 3 and 4 for access to debugger protocol
+    stdio.push('pipe', 'pipe')
+  }
+
+  // @ts-ignore
+  const proc = cp.spawn(browser.path, args, { stdio })
 
   proc.stdout.on('data', (buf) => {
     log('%s stdout: %s', browser.name, String(buf).trim())

--- a/packages/server/__snapshots__/5_cdp_spec.ts.js
+++ b/packages/server/__snapshots__/5_cdp_spec.ts.js
@@ -60,3 +60,65 @@ Error: connect ECONNREFUSED 127.0.0.1:7777
 
 
 `
+
+exports['e2e cdp / with stdio transport / falls back to connecting via tcp when stdio cannot be connected'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      1 found (spec.ts)                                                                  │
+  │ Searched:   cypress/integration/spec.ts                                                        │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  spec.ts                                                                         (1 of 1)
+Warning: Cypress failed to connect to Chrome via stdio after 1 second. Falling back to TCP...
+
+
+  passes
+    ✓ passes
+
+
+  1 passing
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        1                                                                                │
+  │ Passing:      1                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     spec.ts                                                                          │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/spec.ts.mp4                         (X second)
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✔  spec.ts                                  XX:XX        1        1        -        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✔  All specs passed!                        XX:XX        1        1        -        -        -  
+
+
+`

--- a/packages/server/__snapshots__/5_cdp_spec.ts.js
+++ b/packages/server/__snapshots__/5_cdp_spec.ts.js
@@ -1,4 +1,4 @@
-exports['e2e cdp / handles disconnections as expected'] = `
+exports['e2e cdp / with TCP transport / handles disconnections as expected'] = `
 
 ====================================================================================================
 

--- a/packages/server/__snapshots__/5_cdp_spec.ts.js
+++ b/packages/server/__snapshots__/5_cdp_spec.ts.js
@@ -79,6 +79,7 @@ exports['e2e cdp / with stdio transport / falls back to connecting via tcp when 
                                                                                                     
   Running:  spec.ts                                                                         (1 of 1)
 Warning: Cypress failed to connect to Chrome via stdio after 1 second. Falling back to TCP...
+Connecting to Chrome via TCP was successful, continuing with tests.
 
 
   passes

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -278,10 +278,14 @@ const _connectToChromeRemoteInterface = function (browser, process, port, onErro
 
   return CriClient.create({ process }, onError)
   .timeout(stdioTimeoutMs)
-  .catch(Bluebird.TimeoutError, () => {
+  .catch(Bluebird.TimeoutError, async () => {
     errors.warning('CDP_STDIO_TIMEOUT', browser.displayName, stdioTimeoutMs)
 
-    return connectTcp()
+    const client = await connectTcp()
+
+    errors.warning('CDP_FALLBACK_SUCCEEDED', browser.displayName)
+
+    return client
   })
 }
 

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -37,7 +37,7 @@ type ChromePreferences = {
 }
 
 const staticCdpPort = Number(process.env.CYPRESS_REMOTE_DEBUGGING_PORT)
-const stdioTimeoutMs = Number(process.env.CYPRESS_CDP_TARGET_TIMEOUT) || 15000
+const stdioTimeoutMs = Number(process.env.CYPRESS_CDP_TARGET_TIMEOUT) || 60000
 
 const pathToExtension = extension.getPathToExtension()
 const pathToTheme = extension.getPathToTheme()

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -35,6 +35,8 @@ type ChromePreferences = {
   localState: object
 }
 
+const staticCdpPort = Number(process.env.CYPRESS_REMOTE_DEBUGGING_PORT)
+
 const pathToExtension = extension.getPathToExtension()
 const pathToTheme = extension.getPathToTheme()
 
@@ -173,9 +175,7 @@ const _writeChromePreferences = (userDir: string, originalPrefs: ChromePreferenc
 }
 
 const getRemoteDebuggingPort = async () => {
-  const port = Number(process.env.CYPRESS_REMOTE_DEBUGGING_PORT)
-
-  return port || utils.getPort()
+  return staticCdpPort || utils.getPort()
 }
 
 /**
@@ -243,12 +243,20 @@ const _disableRestorePagesPrompt = function (userDir) {
   .catch(() => { })
 }
 
-const supportsStdioCdp = (browser) => browser.majorVersion >= 72
+const useStdioCdp = (browser) => {
+  return (
+    // CDP via stdio doesn't seem to work in browsers older than 72
+    // @see https://github.com/cyrus-and/chrome-remote-interface/issues/381#issuecomment-445277683
+    browser.majorVersion >= 72
+    // allow users to force TCP by specifying a port in environment
+    && !staticCdpPort
+  )
+}
 
 // After the browser has been opened, we can connect to
 // its remote interface via a websocket.
 const _connectToChromeRemoteInterface = function (browser, process, port, onError) {
-  if (supportsStdioCdp(browser)) {
+  if (useStdioCdp(browser)) {
     return CriClient.create({ process }, onError)
   }
 
@@ -404,7 +412,7 @@ export = {
     args.push(`--remote-debugging-port=${port}`)
     args.push('--remote-debugging-address=127.0.0.1')
 
-    if (supportsStdioCdp(browser)) {
+    if (useStdioCdp(browser)) {
       args.push('--remote-debugging-pipe')
     }
 
@@ -464,7 +472,7 @@ export = {
     // start video recording and then
     // we will load the actual page
     const launchedBrowser = await utils.launch(browser, 'about:blank', args, {
-      pipeStdio: supportsStdioCdp(browser),
+      pipeStdio: useStdioCdp(browser),
     })
 
     la(launchedBrowser, 'did not get launched browser instance')

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -224,15 +224,14 @@ export const create = Bluebird.method((opts: CreateOpts, onAsynchronousError: Fu
     return new Promise<void>((resolve, reject) => {
       const isAboutBlank = (target) => target.type === 'page' && target.url === 'about:blank'
 
-      const attachToTarget = _.once(async ({ targetId }) => {
-        const result = await cri.send('Target.attachToTarget', {
+      const attachToTarget = _.once(({ targetId }) => {
+        cri.send('Target.attachToTarget', {
           targetId,
           flatten: true, // enable selecting via sessionId
+        }).then((result) => {
+          sessionId = result.sessionId
+          resolve()
         }).catch(reject)
-
-        sessionId = result.sessionId
-
-        resolve()
       })
 
       cri.send('Target.setDiscoverTargets', { discover: true })

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -1,6 +1,7 @@
 import Bluebird from 'bluebird'
 import debugModule from 'debug'
 import _ from 'lodash'
+import { ChildProcess } from 'child_process'
 
 const chromeRemoteInterface = require('chrome-remote-interface')
 const errors = require('../errors')
@@ -132,7 +133,12 @@ export { chromeRemoteInterface }
 
 type DeferredPromise = { resolve: Function, reject: Function }
 
-export const create = Bluebird.method((target: websocketUrl, onAsynchronousError: Function): Bluebird<CRIWrapper> => {
+type CreateOpts = {
+  target?: websocketUrl
+  process?: ChildProcess
+}
+
+export const create = Bluebird.method((opts: CreateOpts, onAsynchronousError: Function): Bluebird<CRIWrapper> => {
   const subscriptions: {eventName: CRI.EventName, cb: Function}[] = []
   let enqueuedCommands: {command: CRI.Command, params: any, p: DeferredPromise }[] = []
 
@@ -173,10 +179,10 @@ export const create = Bluebird.method((target: websocketUrl, onAsynchronousError
   const connect = () => {
     cri?.close()
 
-    debug('connecting %o', { target })
+    debug('connecting %o', opts)
 
     return chromeRemoteInterface({
-      target,
+      ...opts,
       local: true,
     })
     .then((newCri) => {

--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -851,6 +851,8 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
         There was an error reconnecting to the Chrome DevTools protocol. Please restart the browser.
 
         ${arg1.stack}`
+    case 'CDP_STDIO_ERROR':
+      return 'The connection between Cypress and Chrome has unexpectedly ended. Please restart the browser.'
     case 'CDP_RETRYING_CONNECTION':
       return `Failed to connect to Chrome, retrying in 1 second (attempt ${chalk.yellow(arg1)}/62)`
     case 'DEPRECATED_BEFORE_BROWSER_LAUNCH_ARGS':

--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -856,6 +856,8 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
       return 'The connection between Cypress and Chrome has unexpectedly ended. Please restart the browser.'
     case 'CDP_STDIO_TIMEOUT':
       return `Warning: Cypress failed to connect to ${arg1} via stdio after ${humanTime.long(arg2)}. Falling back to TCP...`
+    case 'CDP_FALLBACK_SUCCEEDED':
+      return `Connecting to ${arg1} via TCP was successful, continuing with tests.`
     case 'CDP_RETRYING_CONNECTION':
       return `Failed to connect to Chrome, retrying in 1 second (attempt ${chalk.yellow(arg1)}/62)`
     case 'DEPRECATED_BEFORE_BROWSER_LAUNCH_ARGS':

--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -5,6 +5,7 @@ const chalk = require('chalk')
 const AU = require('ansi_up')
 const Promise = require('bluebird')
 const { stripIndent } = require('./util/strip_indent')
+const humanTime = require('./util/human_time')
 
 const ansi_up = new AU.default
 
@@ -853,6 +854,8 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
         ${arg1.stack}`
     case 'CDP_STDIO_ERROR':
       return 'The connection between Cypress and Chrome has unexpectedly ended. Please restart the browser.'
+    case 'CDP_STDIO_TIMEOUT':
+      return `Warning: Cypress failed to connect to ${arg1} via stdio after ${humanTime.long(arg2)}. Falling back to TCP...`
     case 'CDP_RETRYING_CONNECTION':
       return `Failed to connect to Chrome, retrying in 1 second (attempt ${chalk.yellow(arg1)}/62)`
     case 'DEPRECATED_BEFORE_BROWSER_LAUNCH_ARGS':

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,7 +37,7 @@
     "chalk": "2.4.2",
     "check-more-types": "2.24.0",
     "chokidar": "3.2.2",
-    "chrome-remote-interface": "cypress-io/chrome-remote-interface#8146ca360bb68bfdabe3f031b71b612498c59745",
+    "chrome-remote-interface": "cypress-io/chrome-remote-interface#147192810f29951cd96c5e406495e9b4d740ba95",
     "cli-table3": "0.5.1",
     "coffeescript": "1.12.7",
     "color-string": "1.5.4",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,7 +37,7 @@
     "chalk": "2.4.2",
     "check-more-types": "2.24.0",
     "chokidar": "3.2.2",
-    "chrome-remote-interface": "0.28.2",
+    "chrome-remote-interface": "cypress-io/chrome-remote-interface#8146ca360bb68bfdabe3f031b71b612498c59745",
     "cli-table3": "0.5.1",
     "coffeescript": "1.12.7",
     "color-string": "1.5.4",

--- a/packages/server/test/e2e/5_cdp_spec.ts
+++ b/packages/server/test/e2e/5_cdp_spec.ts
@@ -48,5 +48,17 @@ describe('e2e cdp', function () {
       browser: 'chrome',
       expectedExitCode: 0,
     })
+
+    e2e.it('falls back to connecting via tcp when stdio cannot be connected', {
+      project: Fixtures.projectPath('remote-debugging-port-removed'),
+      processEnv: {
+        CY_REMOVE_PIPE: '1',
+        CYPRESS_CDP_TARGET_TIMEOUT: '1000',
+      },
+      spec: 'spec.ts',
+      browser: 'chrome',
+      expectedExitCode: 0,
+      snapshot: true,
+    })
   })
 })

--- a/packages/server/test/e2e/5_cdp_spec.ts
+++ b/packages/server/test/e2e/5_cdp_spec.ts
@@ -4,36 +4,49 @@ import Fixtures from '../support/helpers/fixtures'
 
 describe('e2e cdp', function () {
   e2e.setup()
-  let restoreEnv: Function
 
-  beforeEach(() => {
-    restoreEnv = mockedEnv({
-      CYPRESS_REMOTE_DEBUGGING_PORT: '7777',
+  context('with TCP transport', function () {
+    let restoreEnv: Function
+
+    beforeEach(() => {
+      restoreEnv = mockedEnv({
+        CYPRESS_REMOTE_DEBUGGING_PORT: '7777',
+      })
+    })
+
+    afterEach(() => {
+      restoreEnv()
+    })
+
+    // NOTE: this test takes almost a minute and is largely redundant with protocol_spec
+    e2e.it.skip('fails when remote debugging port cannot be connected to', {
+      project: Fixtures.projectPath('remote-debugging-port-removed'),
+      spec: 'spec.ts',
+      browser: 'chrome',
+      expectedExitCode: 1,
+    })
+
+    // https://github.com/cypress-io/cypress/issues/5685
+    e2e.it('handles disconnections as expected', {
+      project: Fixtures.projectPath('remote-debugging-disconnect'),
+      spec: 'spec.ts',
+      browser: 'chrome',
+      expectedExitCode: 1,
+      snapshot: true,
+      onStdout: (stdout) => {
+        // the location of this warning is non-deterministic
+        return stdout.replace('The automation client disconnected. Cannot continue running tests.\n', '')
+      },
     })
   })
 
-  afterEach(() => {
-    restoreEnv()
-  })
-
-  // NOTE: this test takes almost a minute and is largely redundant with protocol_spec
-  e2e.it.skip('fails when remote debugging port cannot be connected to', {
-    project: Fixtures.projectPath('remote-debugging-port-removed'),
-    spec: 'spec.ts',
-    browser: 'chrome',
-    expectedExitCode: 1,
-  })
-
-  // https://github.com/cypress-io/cypress/issues/5685
-  e2e.it('handles disconnections as expected', {
-    project: Fixtures.projectPath('remote-debugging-disconnect'),
-    spec: 'spec.ts',
-    browser: 'chrome',
-    expectedExitCode: 1,
-    snapshot: true,
-    onStdout: (stdout) => {
-      // the location of this warning is non-deterministic
-      return stdout.replace('The automation client disconnected. Cannot continue running tests.\n', '')
-    },
+  // @see https://github.com/cypress-io/cypress/pull/14348
+  context('with stdio transport', function () {
+    e2e.it('can run tests in chrome even with remote-debugging-port omitted', {
+      project: Fixtures.projectPath('remote-debugging-port-removed'),
+      spec: 'spec.ts',
+      browser: 'chrome',
+      expectedExitCode: 0,
+    })
   })
 })

--- a/packages/server/test/support/fixtures/projects/remote-debugging-port-removed/cypress/plugins.js
+++ b/packages/server/test/support/fixtures/projects/remote-debugging-port-removed/cypress/plugins.js
@@ -4,8 +4,10 @@ module.exports = (on) => {
   on('before:browser:launch', (browser = {}, options) => {
     la(browser.family === 'chromium', 'this test can only be run with a chromium-family browser')
 
-    // remove debugging port so that the browser connection fails
-    const newArgs = options.args.filter((arg) => !arg.startsWith('--remote-debugging-port='))
+    const cdpArg = process.env.CY_REMOVE_PIPE ? '--remote-debugging-pipe' : '--remote-debugging-port'
+
+    // remove debugging pipe or port so that the browser connection fails
+    const newArgs = options.args.filter((arg) => !arg.startsWith(cdpArg))
 
     la(newArgs.length === options.args.length - 1, 'exactly one argument should have been removed')
 

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -11,32 +11,39 @@ describe('lib/browsers/cri-client', function () {
     create: typeof create
   }
   let send: sinon.SinonStub
+  let sendRaw: sinon.SinonStub
+  let criStub: any
   let criImport: sinon.SinonStub
   let onError: sinon.SinonStub
-  let getClient: () => ReturnType<typeof create>
+  let getClient: (opts?: any) => ReturnType<typeof create>
 
   beforeEach(function () {
     sinon.stub(Bluebird, 'promisify').returnsArg(0)
 
     send = sinon.stub()
+    sendRaw = sinon.stub()
     onError = sinon.stub()
+
+    criStub = {
+      send,
+      sendRaw,
+      on: sinon.stub(),
+      close: sinon.stub(),
+      _notifier: new EventEmitter(),
+    }
 
     criImport = sinon.stub()
     .withArgs({
       target: DEBUGGER_URL,
       local: true,
     })
-    .resolves({
-      send,
-      close: sinon.stub(),
-      _notifier: new EventEmitter(),
-    })
+    .resolves(criStub)
 
     criClient = proxyquire('../lib/browsers/cri-client', {
       'chrome-remote-interface': criImport,
     })
 
-    getClient = () => criClient.create(DEBUGGER_URL, onError)
+    getClient = (opts = { target: DEBUGGER_URL }) => criClient.create(opts, onError)
   })
 
   context('.create', function () {
@@ -46,19 +53,65 @@ describe('lib/browsers/cri-client', function () {
       expect(client.send).to.be.instanceOf(Function)
     })
 
+    context('with process', function () {
+      let process: any
+
+      beforeEach(function () {
+        process = { /** stubbed */}
+
+        criImport.withArgs({
+          process,
+          local: true,
+        })
+        .resolves(criStub)
+      })
+
+      it('finds and attaches to target and persists sessionId', async function () {
+        const target = {
+          targetId: 'good',
+          type: 'page',
+          url: 'about:blank',
+        }
+
+        const otherTarget = {
+          targetId: 'bad',
+        }
+
+        send
+        .withArgs('Target.setDiscoverTargets').resolves()
+        .withArgs('Target.getTargets').resolves({ targetInfos: [otherTarget, target] })
+        .withArgs('Target.attachToTarget', { targetId: 'good', flatten: true }).resolves({ sessionId: 'session-1' })
+
+        sendRaw.resolves()
+
+        const client = await getClient({ process })
+
+        await client.send('Browser.getVersion')
+
+        expect(sendRaw).to.be.calledWith({
+          method: 'Browser.getVersion',
+          params: undefined,
+          sessionId: 'session-1',
+        })
+      })
+    })
+
     context('#send', function () {
-      it('calls cri.send with command and data', async function () {
-        send.resolves()
+      it('calls cri.sendRaw with command and data', async function () {
+        sendRaw.resolves()
         const client = await getClient()
 
         client.send('Browser.getVersion', { baz: 'quux' })
-        expect(send).to.be.calledWith('Browser.getVersion', { baz: 'quux' })
+        expect(sendRaw).to.be.calledWith({
+          method: 'Browser.getVersion',
+          params: { baz: 'quux' },
+        })
       })
 
-      it('rejects if cri.send rejects', async function () {
+      it('rejects if cri.sendRaw rejects', async function () {
         const err = new Error
 
-        send.rejects(err)
+        sendRaw.rejects(err)
         const client = await getClient()
 
         await expect(client.send('Browser.getVersion', { baz: 'quux' }))
@@ -74,14 +127,14 @@ describe('lib/browsers/cri-client', function () {
           it(`with '${msg}'`, async function () {
             const err = new Error(msg)
 
-            send.onFirstCall().rejects(err)
-            send.onSecondCall().resolves()
+            sendRaw.onFirstCall().rejects(err)
+            sendRaw.onSecondCall().resolves()
 
             const client = await getClient()
 
             await client.send('Browser.getVersion', { baz: 'quux' })
 
-            expect(send).to.be.calledTwice
+            expect(sendRaw).to.be.calledTwice
           })
         })
       })
@@ -90,7 +143,10 @@ describe('lib/browsers/cri-client', function () {
     context('#ensureMinimumProtocolVersion', function () {
       function withProtocolVersion (actual, test) {
         if (actual) {
-          send.withArgs('Browser.getVersion')
+          sendRaw.withArgs({
+            method: 'Browser.getVersion',
+            params: undefined,
+          })
           .resolves({ protocolVersion: actual })
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10374,9 +10374,9 @@ chrome-remote-interface@^0.25.7:
     commander "2.11.x"
     ws "3.3.x"
 
-chrome-remote-interface@cypress-io/chrome-remote-interface#8146ca360bb68bfdabe3f031b71b612498c59745:
+chrome-remote-interface@cypress-io/chrome-remote-interface#147192810f29951cd96c5e406495e9b4d740ba95:
   version "0.28.2"
-  resolved "https://codeload.github.com/cypress-io/chrome-remote-interface/tar.gz/8146ca360bb68bfdabe3f031b71b612498c59745"
+  resolved "https://codeload.github.com/cypress-io/chrome-remote-interface/tar.gz/147192810f29951cd96c5e406495e9b4d740ba95"
   dependencies:
     commander "2.11.x"
     ws "^7.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10366,14 +10366,6 @@ chrome-har-capturer@0.13.4:
     chrome-remote-interface "^0.25.7"
     commander "2.x.x"
 
-chrome-remote-interface@0.28.2:
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.28.2.tgz#6be3554d2c227ff07eb74baa7e5d4911da12a5a6"
-  integrity sha512-F7mjof7rWvRNsJqhVXuiFU/HWySCxTA9tzpLxUJxVfdLkljwFJ1aMp08AnwXRmmP7r12/doTDOMwaNhFCJsacw==
-  dependencies:
-    commander "2.11.x"
-    ws "^7.2.0"
-
 chrome-remote-interface@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.25.7.tgz#827e85fbef3cc561a9ef2404eb7eee355968c5bc"
@@ -10381,6 +10373,13 @@ chrome-remote-interface@^0.25.7:
   dependencies:
     commander "2.11.x"
     ws "3.3.x"
+
+chrome-remote-interface@cypress-io/chrome-remote-interface#8146ca360bb68bfdabe3f031b71b612498c59745:
+  version "0.28.2"
+  resolved "https://codeload.github.com/cypress-io/chrome-remote-interface/tar.gz/8146ca360bb68bfdabe3f031b71b612498c59745"
+  dependencies:
+    commander "2.11.x"
+    ws "^7.2.0"
 
 chrome-trace-event@^1.0.0, chrome-trace-event@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->
- TR-594
- Closes #6540
- Closes #7450
- Closes #8674
- Closes #8986

### User facing changelog

- Updated the CDP connection to attempt to use the stdio transport first with Chrome 72 and above, before falling back to using TCP. This should remediate issues causing sporadic 'Cypress failed to make a connection to the Chrome DevTools Protocol after retrying' errors.

### Additional details

- forked chrome-remote-interface to enable sessionId and stdio, see: https://github.com/cypress-io/chrome-remote-interface
	- upstream PRs: cyrus-and/chrome-remote-interface#440 cyrus-and/chrome-remote-interface#441
- using `CYPRESS_REMOTE_DEBUGGING_PORT` will force Cypress to use CDP in TCP mode
- warns and falls back to TCP if stdio cannot find a target after 60 seconds (default, can be configured with `CYPRESS_CDP_TARGET_TIMEOUT`)
	- i expect that some users wrap Cypress in a script that will sever stdio, but we'll see
- not removing TCP code yet since plugins rely on it/would potentially change our supported Chrome version

### How has the user experience changed?

- this warning: 
![image](https://user-images.githubusercontent.com/1151760/104245028-719ffe80-545b-11eb-81b8-ae326c91e928.png)
- `CYPRESS_CDP_TARGET_TIMEOUT` (undocumented, like `CYPRESS_REMOTE_DEBUGGING_PORT`, since it's just for testing purposes)


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
