### PR TITLE
fix: Remove fallback chainer assertion types

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -4908,16 +4908,6 @@ declare namespace Cypress {
      * @see https://on.cypress.io/assertions
      */
     (chainer: 'not.match', value: string): Chainable<Subject>
-
-    // fallback
-    /**
-     * Create an assertion. Assertions are automatically retried until they pass or time out.
-     * Ctrl+Space will invoke auto-complete in most editors.
-     * @see https://on.cypress.io/should
-     */
-    (chainers: string, value?: any): Chainable<Subject>
-    (chainers: string, value: any, match: any): Chainable<Subject>
-
     /**
      * Create an assertion. Assertions are automatically retried until they pass or time out.
      * Passing a function to `.should()` enables you to make multiple assertions on the yielded subject. This also gives you the opportunity to massage what you’d like to assert on.


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->

- Closes #8614 

### User facing changelog
Remove fallback chainers, to enable stricter type checking of chainer strings. If you are using custom chainers, please make sure you have correctly defined your type definitions by following this recipe https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/extending-cypress__chai-assertions

<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

### Additional details
N/A

### How has the user experience changed?

Previously `cy.get('.error').should('be.empyt')` would be valid typescript and the typo would only be caught at runtime, rather than by the IDE or at compile-time. After this change `'be.empyt'` is highlighted as an error.
    

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

-  ~~Have tests been added/updated?~~
I dont believe the type definitions have any tests that need to be updated?
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
