### PR TITLE
fix(component-testing): hot replace of dependencies of specs in component testing mode

### DIFF
--- a/npm/webpack-dev-server/src/startServer.ts
+++ b/npm/webpack-dev-server/src/startServer.ts
@@ -26,5 +26,5 @@ export async function start (initialWebpackConfig, { specs, config, devserverEve
 
   debug('starting webpack dev server')
 
-  return new WebpackDevServer(compiler, { hot: true, noInfo: !debug.enabled })
+  return new WebpackDevServer(compiler, { hot: false, noInfo: !debug.enabled })
 }

--- a/npm/webpack-dev-server/src/startServer.ts
+++ b/npm/webpack-dev-server/src/startServer.ts
@@ -26,5 +26,5 @@ export async function start (initialWebpackConfig, { specs, config, devserverEve
 
   debug('starting webpack dev server')
 
-  return new WebpackDevServer(compiler, { hot: true })
+  return new WebpackDevServer(compiler, { hot: true, noInfo: !debug.enabled })
 }


### PR DESCRIPTION
makes test re-run after every save of the spec file or any of the dependencies

closes CT-182 

- [x] made the logs a little cleaner by making webpack dev server logs optional. It was impossible to choose which logs were output by the dev server. Now if you want the dev server logs ON use ` DEBUG=cypress:webpack-dev-server:start` before your start the test server

### Testing steps

1. `yarn install` on root
1. `yarn install` on `/packages/server-ct/crossword-examples`
1. move to `/packages/server-ct`
1. start `yarn cypress:open`
1. open Cell.spec.js in cypress
1. open Cell.vue in code and change something in the code of the component
1. save 

It should re-run the tests in cypress

[EDIT] This PR is a rebase of #14334 onto the branch with all tests passing.