### PR TITLE
fix: Added missing calledOnceWith & calledOnceWithExactly sinon matchers.

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@babel/cli": "7.8.4",
     "@babel/preset-env": "7.9.5",
-    "@cypress/sinon-chai": "1.1.0",
+    "@cypress/sinon-chai": "2.9.1",
     "@packages/root": "*",
     "@types/bluebird": "3.5.29",
     "@types/chai": "4.2.7",

--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -408,6 +408,48 @@ describe('src/cy/commands/assertions', () => {
       })
     })
 
+    // https://github.com/cypress-io/cypress/issues/9644
+    describe('calledOnceWith', () => {
+      it('be.calledOnceWith', () => {
+        const spy = cy.spy().as('spy')
+
+        setTimeout(() => {
+          spy({ bar: 'test' }, 1234)
+        }, 100)
+
+        cy.get('@spy').should(
+          'be.calledOnceWith',
+          {
+            bar: 'test',
+          },
+        )
+      })
+
+      it('be.calledOnceWithExactly', () => {
+        const spy = cy.spy().as('spy')
+
+        setTimeout(() => {
+          spy({ bar: 'test' })
+        }, 100)
+
+        cy.get('@spy').should(
+          'be.calledOnceWithExactly',
+          { bar: 'test' },
+        )
+
+        const spy2 = cy.spy().as('spy2')
+
+        setTimeout(() => {
+          spy2({ bar: 'test' }, 12345)
+        }, 100)
+
+        cy.get('@spy2').should(
+          'not.be.calledOnceWithExactly',
+          { bar: 'test' },
+        )
+      })
+    })
+
     describe('errors', {
       defaultCommandTimeout: 50,
     }, () => {

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@babel/code-frame": "7.8.3",
     "@cypress/bower-kendo-ui": "0.0.2",
-    "@cypress/sinon-chai": "1.1.0",
+    "@cypress/sinon-chai": "2.9.1",
     "@cypress/unique-selector": "0.4.2",
     "@cypress/webpack-preprocessor": "*",
     "@cypress/what-is-circular": "1.0.1",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@cypress/request": "2.88.5",
     "@cypress/request-promise": "4.2.6",
-    "@cypress/sinon-chai": "2.9.0",
+    "@cypress/sinon-chai": "2.9.1",
     "@types/express": "4.17.2",
     "@types/supertest": "2.0.10",
     "express": "4.17.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -124,7 +124,7 @@
     "@babel/preset-env": "7.9.0",
     "@cypress/debugging-proxy": "2.0.1",
     "@cypress/json-schemas": "5.35.1",
-    "@cypress/sinon-chai": "1.1.0",
+    "@cypress/sinon-chai": "2.9.1",
     "@ffprobe-installer/ffprobe": "1.1.0",
     "@packages/desktop-gui": "*",
     "@packages/electron": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2106,15 +2106,10 @@
     debug "4.1.1"
     lazy-ass "1.6.0"
 
-"@cypress/sinon-chai@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@cypress/sinon-chai/-/sinon-chai-1.1.0.tgz#35c73ee37c420920d3ef114420a2f11ca6e4f670"
-  integrity sha512-h0VrqzKI10+X8u4Z+ut/bVmgXNdz8cDTCW+sM5kwu85jgLhPAi8bEH0PMmZXNN2KwGhtIIrQUaIZ5Ap74TNqMg==
-
-"@cypress/sinon-chai@2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@cypress/sinon-chai/-/sinon-chai-2.9.0.tgz#ebd1ea59eb8ebe9f2283a85afad167ee57776199"
-  integrity sha512-6tPzu+wpPJzqxnQjvIwSy8mzTwok3SrxxxCFwUS22K+x/GxAzENHiPDpfVKYjFYhB66YHzvkkw3Vm+hFTJypKw==
+"@cypress/sinon-chai@2.9.1":
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/@cypress/sinon-chai/-/sinon-chai-2.9.1.tgz#1705c0341bc286740979b1b1cac89b7f5d34d6bc"
+  integrity sha512-qwFQ1urghF3mv7CFSDw/LEqIQP12qqKLuW7p6mXR92HP5fPNlgNiZVITWVsupDg7JpOEKfeRTVearo9mkk/5eg==
 
 "@cypress/unique-selector@0.4.2":
   version "0.4.2"


### PR DESCRIPTION
- Closes #9644 

### User facing changelog

Added missing calledOnceWith & calledOnceWithExactly sinon matchers.

### Additional details
- Why was this change necessary? => `calledOnceWith` and `calledOnceWithExactly` exist in sinon-chai and Cypress types, but they're not supported.
- What is affected by this change? => N/A
- Any implementation details to explain? => The problem was fixed at cypress-io/sinon-chai#46. This PR updates the dependency and added some tests for the missing matchers.

### How has the user experience changed?

```js
const foo = cy.spy().as("foo")

setTimeout(() => {
    foo({ bar: "test" })
}, 500)

cy.get("@foo").should(
  "be.calledOnceWith",
  Cypress.sinon.match({
    bar: "test",
  })
);
```

The code above now works. 

### PR Tasks

- [x] Have tests been added/updated?
