### PR TITLE
fix: hanging due to deep clone on mocha runnable object in server/reporter

### DIFF
--- a/packages/server/lib/reporter.js
+++ b/packages/server/lib/reporter.js
@@ -131,6 +131,17 @@ const toMochaProps = (testProps) => {
   })
 }
 
+const toAttemptProps = (runnable) => {
+  return _.pick(runnable, [
+    'err',
+    'state',
+    'timings',
+    'failedFromHookId',
+    'wallClockStartedAt',
+    'wallClockDuration',
+  ])
+}
+
 const mergeRunnable = (eventName) => {
   return (function (testProps, runnables) {
     toMochaProps(testProps)
@@ -143,7 +154,7 @@ const mergeRunnable = (eventName) => {
         const prevAttempts = runnable.prevAttempts || []
 
         delete runnable.prevAttempts
-        const prevAttempt = _.cloneDeep(runnable)
+        const prevAttempt = toAttemptProps(runnable)
 
         delete runnable.failedFromHookId
         delete runnable.err

--- a/packages/server/test/e2e/3_retries_spec.ts
+++ b/packages/server/test/e2e/3_retries_spec.ts
@@ -12,6 +12,10 @@ describe('retries', () => {
     snapshot: true,
   })
 
+  it('completes a run of many retries in a reasonable time', {
+    spec: 'hanging_retries_spec.js',
+  })
+
   it('warns about retries plugin', {
     project: Fixtures.projectPath('plugin-retries'),
     spec: 'main.spec.js',

--- a/packages/server/test/e2e/3_retries_spec.ts
+++ b/packages/server/test/e2e/3_retries_spec.ts
@@ -14,6 +14,7 @@ describe('retries', () => {
 
   it('completes a run of many retries in a reasonable time', {
     spec: 'hanging_retries_spec.js',
+    expectedExitCode: 10,
   })
 
   it('warns about retries plugin', {

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/hanging_retries_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/hanging_retries_spec.js
@@ -1,0 +1,7 @@
+describe('page', { retries: 4 }, () => {
+  for (let i = 0; i < 10; i++) {
+    it(`test ${i}`, () => {
+      expect(true).to.be.false
+    })
+  }
+})


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
-->

- Closes #9040
### User facing changelog
Bug Fix: fix issue causing runs with retries enabled to hang
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

### Additional details
we were deep cloning a mocha runnable object, which recursed through runnable.parent and growed exponentially with every test
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->

