### PR TITLE
fix: should(`have.value`) regression

### DIFF
--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -1908,6 +1908,20 @@ describe('src/cy/commands/assertions', () => {
           expect($els).to.include.value('foo')
         }).should('contain.value', 'oo2')
       })
+
+      // https://github.com/cypress-io/cypress/issues/14359
+      it('shows undefined correctly', (done) => {
+        cy.on('log:added', (attrs, log) => {
+          if (attrs.name === 'assert') {
+            cy.removeAllListeners('log:added')
+            expect(log.get('message')).to.eq('expected **undefined** to have value **somevalue**')
+
+            done()
+          }
+        })
+
+        cy.wrap(undefined).should('have.value', 'somevalue')
+      })
     })
 
     context('descendants', () => {

--- a/packages/driver/src/cypress/chai_jquery.js
+++ b/packages/driver/src/cypress/chai_jquery.js
@@ -191,7 +191,7 @@ const $chaiJquery = (chai, chaiUtils, callbacks = {}) => {
 
     // some elements return a number for the .value property
     // in this case, we don't want to cast the expected value to a string
-    if (!$elements.isValueNumberTypeElement($el[0])) {
+    if ($el[0] && !$elements.isValueNumberTypeElement($el[0])) {
       value = maybeCastNumberToString(value)
     }
 


### PR DESCRIPTION
- Closes #14359

### User facing changelog

`cy.wrap(undefined).should('have.value', 'somevalue')` didn't show correct error message caused by #7621.

### Additional details
- Why was this change necessary? => Because it didn't show the correct message.
- What is affected by this change? => N/A
- Any implementation details to explain? => I didn't handle the case when `$el[0]` is `undefined`. 

### How has the user experience changed?

`cy.wrap(undefined).should('have.value', 'somevalue')` shows the error like before.

### PR Tasks

- [x] Have tests been added/updated?