### PR TITLE
fix(component-teting): Specs list selection spam

### DIFF
--- a/packages/reporter/src/main.tsx
+++ b/packages/reporter/src/main.tsx
@@ -33,6 +33,8 @@ type ReporterProps = {
   resetStatsOnSpecChange?: boolean
   renderReporterHeader?: (props: ReporterHeaderProps) => JSX.Element;
   spec: Cypress.Cypress['spec']
+  /** Used for component testing front-end */
+  specRunId?: string | null
 } & ({
   runMode: 'single',
 } | {
@@ -118,7 +120,7 @@ class Reporter extends Component<ReporterProps> {
 
     if (
       this.props.resetStatsOnSpecChange &&
-      this.props.spec.relative !== newProps.spec.relative
+      this.props.specRunId !== newProps.specRunId
     ) {
       runInAction('reporter:stats:reset', () => {
         this.props.statsStore.reset()

--- a/packages/runner-ct/package.json
+++ b/packages/runner-ct/package.json
@@ -26,6 +26,7 @@
     "koa": "^2.13.0",
     "lodash": "^4.17.20",
     "mocha": "^8.1.3",
+    "nanoid": "3.1.20",
     "react-split-pane": "^0.1.92"
   },
   "devDependencies": {

--- a/packages/runner-ct/src/app/app.tsx
+++ b/packages/runner-ct/src/app/app.tsx
@@ -59,6 +59,7 @@ const App: React.FC<AppProps> = observer(
                   runMode={state.runMode}
                   runner={eventManager.reporterBus}
                   spec={state.spec}
+                  specRunId={state.runId}
                   allSpecs={state.multiSpecs}
                   // @ts-ignore
                   autoScrollingEnabled={config.state.autoScrollingEnabled}

--- a/packages/runner-ct/src/lib/state.ts
+++ b/packages/runner-ct/src/lib/state.ts
@@ -1,5 +1,6 @@
 import { action, computed, observable } from 'mobx'
 import automation from './automation'
+import { nanoid } from 'nanoid'
 
 interface Defaults {
   messageTitle: string | null
@@ -84,9 +85,9 @@ export class State {
 
   @observable.ref scriptError = null
 
+  @observable runId: string | null = null
   @observable spec = _defaults.spec
   @observable specs = _defaults.specs
-  /** @type {"single" | "multi"} */
   @observable runMode: 'single' | 'multi' = 'single'
   @observable multiSpecs: Cypress.Cypress['spec'][] = [];
 
@@ -199,15 +200,19 @@ export class State {
   }
 
   @action setSingleSpec (spec) {
+    this.runId = nanoid()
+
     if (this.runMode === 'multi') {
       this.runMode = 'single'
       this.multiSpecs = []
     }
 
+    this.setSpec(null)
     this.setSpec(spec)
   }
 
   @action addSpecToMultiMode (newSpec: Cypress.Cypress['spec']) {
+    this.runId = nanoid()
     const isAlreadyRunningNewSpec = this.multiSpecs.some(
       (existingSpec) => existingSpec.relative === newSpec.relative,
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -24311,6 +24311,11 @@ nanoid@3.1.12:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
   integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
 
+nanoid@3.1.20:
+  version "3.1.20"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
+  integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
Fixes case when the user quickly selecting the same spec more and more. 

P.S. The `runId` state can be helpful for multi-specs as well