### PR TITLE
build: fix linting checks for .only

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,8 @@
     "@cypress/dev"
   ],
   "extends": [
-    "plugin:@cypress/dev/general"
+    "plugin:@cypress/dev/general",
+    "plugin:@cypress/dev/tests"
   ],
   "rules": {
     "prefer-spread": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,13 +1,11 @@
 {
   "plugins": [
-    "@cypress/dev",
-    "no-only-tests"
+    "@cypress/dev"
   ],
   "extends": [
     "plugin:@cypress/dev/general"
   ],
   "rules": {
-    "no-only-tests/no-only-tests": "warn",
     "prefer-spread": "off",
     "prefer-rest-params": "off"
   },

--- a/__snapshots__/mocha-snapshot-spec.js
+++ b/__snapshots__/mocha-snapshot-spec.js
@@ -1,4 +1,4 @@
-exports['captures mocha output 1'] = `
+exports['mocha snapshot captures mocha output 1'] = `
 
   command: npm run test-mocha
   code: 0

--- a/circle.yml
+++ b/circle.yml
@@ -439,6 +439,12 @@ jobs:
             . ./scripts/load-nvm.sh
             yarn check-terminal
 
+      - run:
+          name: Stop .only
+          command: |
+            . ./scripts/load-nvm.sh
+            yarn stop-only-all
+
       - restore_cache:
           name: Restore yarn cache
           key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-deps-root-{{ checksum "yarn.lock" }}

--- a/circle.yml
+++ b/circle.yml
@@ -485,7 +485,7 @@ jobs:
           command: |
             . ./scripts/load-nvm.sh
             git clean -df
-            yarn lint --max-warnings=0
+            yarn lint
       - run:
           name: cypress info (dev)
           command: node cli/bin/cypress info --dev

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "set-next-ci-version": "node ./scripts/binary.js setNextVersion",
     "prestart": "yarn ensure-deps",
     "start": "node $(yarn bin cypress) open --dev --global",
+    "stop-only": "npx stop-only --skip .cy,.publish,.projects,node_modules,dist,dist-test,fixtures,lib,bower_components,src --exclude e2e.ts,cypress-tests.ts",
+    "stop-only-all": "yarn stop-only --folder packages",
     "pretest": "yarn ensure-deps",
     "test": "yarn lerna exec yarn test --scope cypress --scope \"'@packages/{electron,extension,https-proxy,launcher,net-stubbing,network,proxy,rewriter,runner,socket}'\"",
     "test-debug": "lerna exec yarn test-debug --ignore \"'@packages/{desktop-gui,driver,root,static,web-config}'\"",
@@ -185,6 +187,7 @@
     "sinon": "7.3.2",
     "snap-shot-it": "7.9.3",
     "start-server-and-test": "1.10.8",
+    "stop-only": "3.0.1",
     "strip-ansi": "4.0.0",
     "term-to-html": "1.2.0",
     "terminal-banner": "1.1.0",
@@ -235,6 +238,7 @@
   },
   "lint-staged": {
     "*.coffee": [
+      "yarn stop-only --folder",
       "git add"
     ],
     "*.{js,jsx,ts,tsx,json,eslintrc}": [

--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
     "eslint-plugin-cypress": "2.11.1",
     "eslint-plugin-json-format": "2.0.0",
     "eslint-plugin-mocha": "6.1.0",
-    "eslint-plugin-no-only-tests": "^2.4.0",
     "eslint-plugin-react": "7.18.3",
     "execa": "4.0.0",
     "execa-wrap": "1.4.0",
@@ -239,7 +238,7 @@
       "git add"
     ],
     "*.{js,jsx,ts,tsx,json,eslintrc}": [
-      "eslint --fix --max-warnings=0",
+      "eslint --fix",
       "git add"
     ]
   },

--- a/packages/server/test/support/helpers/e2e.ts
+++ b/packages/server/test/support/helpers/e2e.ts
@@ -270,7 +270,7 @@ const getMochaItFn = function (only, skip, browser, specifiedBrowser) {
   }
 
   if (only) {
-    // eslint-disable-next-line no-only-tests/no-only-tests
+    // eslint-disable-next-line mocha/no-exclusive-tests
     return it.only
   }
 

--- a/packages/ui-components/cypress/integration/editor-picker_spec.jsx
+++ b/packages/ui-components/cypress/integration/editor-picker_spec.jsx
@@ -52,8 +52,8 @@ describe('<EditorPicker />', () => {
     cy.get('input[type="radio"]').should('not.be.checked')
   })
 
-  // this doesn't work currently because the tooltip renders in the spec
-  // iframe and not the AUT iframe. need to switch to cypress-react-unit-test
+  // NOTE: this doesn't work currently because the tooltip renders in the spec
+  // iframe and not the AUT iframe. need to switch to @cypress/react
   // or something similar to get this to work
   it.skip('shows info circle with desciption tooltip when specified', () => {
     cy.render(render, <EditorPicker {...defaultProps} />)

--- a/packages/ui-components/cypress/integration/select_spec.jsx
+++ b/packages/ui-components/cypress/integration/select_spec.jsx
@@ -121,7 +121,7 @@ describe('<Select />', () => {
       })
     })
 
-    // requires native event tab support
+    // NOTE: requires native event tab support
     // cypress-plugin-tab does not mimic the behavior of tabbing in this context exactly as the browser does
     it.skip('tabbing moves focus to the next element with a tabIndex', () => {
       cy.render(render, (

--- a/scripts/mocha-snapshot-spec.js
+++ b/scripts/mocha-snapshot-spec.js
@@ -13,8 +13,10 @@ function normalize (s) {
 }
 
 /* eslint-env mocha */
-it('captures mocha output', () => {
-  return execa('npm', ['run', 'test-mocha'])
-  .then(normalize)
-  .then(snapshot)
+describe('mocha snapshot', () => {
+  it('captures mocha output', () => {
+    return execa('npm', ['run', 'test-mocha'])
+    .then(normalize)
+    .then(snapshot)
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -14372,11 +14372,6 @@ eslint-plugin-mocha@^8.0.0:
     eslint-utils "^2.1.0"
     ramda "^0.27.1"
 
-eslint-plugin-no-only-tests@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz#7d565434aa7d16ccc7eea957c391d98f827332ca"
-  integrity sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==
-
 eslint-plugin-promise@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz#845fd8b2260ad8f82564c1222fce44ad71d9418a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14859,6 +14859,19 @@ execa@0.10.0, execa@^0.10.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.11.0.tgz#0b3c71daf9b9159c252a863cd981af1b4410d97a"
+  integrity sha512-k5AR22vCt1DcfeiRixW46U5tMLtBg44ssdJM9PiXw3D8Bn5qyxFCSnKY/eR22y+ctFDGPqafpaXg2G4Emyua4A==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@0.8.0, execa@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
@@ -30550,6 +30563,15 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+stop-only@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/stop-only/-/stop-only-3.0.1.tgz#480176c2712d59373eff6accc8de5fbff960c2ee"
+  integrity sha512-B38Y/K0QbnAbE3llvP4WkjzdN4QkgAHMLC/FxQyPMOC/X6SLrGjRsqFiebkrt6fqQnD9jdp8QpMIdQWMuUYEhA==
+  dependencies:
+    debug "4.1.1"
+    execa "0.11.0"
+    minimist "1.2.0"
 
 stream-browserify@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Updates the way that we check for `.only` locally using eslint-plugin-mocha, removes an unneeded plugin and some of the changes introduced in #9624

Setting the error level to `warn` combined with `max-warnings=0` was causing a bunch of issues for completely unrelated warnings - this fixes that