### PR TITLE
fix: no tests found when onlySuite and uncaught error outside test

### DIFF
--- a/packages/driver/src/cypress/runner.js
+++ b/packages/driver/src/cypress/runner.js
@@ -1108,6 +1108,8 @@ const create = (specWindow, mocha, Cypress, cy) => {
       if (_uncaughtFn) {
         _runner.suite.suites = []
         _runner.suite.tests = []
+        // prevents .only on suite from hiding uncaught error
+        _runner.suite._onlySuites = []
 
         // create a runnable to associate for the failure
         mocha.createRootTest('An uncaught error was detected outside of a test', _uncaughtFn)

--- a/packages/runner/cypress/fixtures/errors/uncaught_onRunnable_spec.js
+++ b/packages/runner/cypress/fixtures/errors/uncaught_onRunnable_spec.js
@@ -1,0 +1,12 @@
+import './setup'
+
+describe.only('suite', ()=>{
+  it('t1', ()=>{
+    
+  })
+  it('t2', ()=>{
+    
+  })
+})
+
+throw new Error('my error')

--- a/packages/runner/cypress/integration/reporter.errors.spec.js
+++ b/packages/runner/cypress/integration/reporter.errors.spec.js
@@ -595,4 +595,11 @@ describe('errors ui', () => {
       method: 'cy.expect',
     })
   })
+
+  verify.it.only('uncaught error during onRunnable w/ onlySuite', {
+    file: 'uncaught_onRunnable_spec.js',
+    message: 'my error',
+    codeFrameText: `my error`,
+    column: 7,
+  })
 })

--- a/packages/runner/cypress/integration/reporter.errors.spec.js
+++ b/packages/runner/cypress/integration/reporter.errors.spec.js
@@ -596,7 +596,7 @@ describe('errors ui', () => {
     })
   })
 
-  verify.it.only('uncaught error during onRunnable w/ onlySuite', {
+  verify.it('uncaught error during onRunnable w/ onlySuite', {
     file: 'uncaught_onRunnable_spec.js',
     message: 'my error',
     codeFrameText: `my error`,


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #14455 

### User facing changelog
Fix bug causing an uncaught exception outside a suite with an `only` to not be displayed in the command log.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
