### PR TITLE
chore: Fix lint error due to .only rule change

### DIFF
--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/only_multiple_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/only_multiple_spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable
     mocha/no-exclusive-tests,
     mocha/no-global-tests,
-    no-only-tests/no-only-tests,
+    mocha/no-exclusive-tests,
 */
 it('t1', () => {})
 it('t2', () => {})

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/only_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/only_spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable
     mocha/no-exclusive-tests,
     mocha/no-global-tests,
-    no-only-tests/no-only-tests,
+    mocha/no-exclusive-tests,
 */
 it('t1', () => {})
 it('t2', () => {})


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->


### User facing changelog

N/A - internal only

### Additional details

The `.only` rule change in https://github.com/cypress-io/cypress/pull/14422 followed by the decaffeination in https://github.com/cypress-io/cypress/pull/14399 caused a couple lint errors only caught in `develop`. 


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->
N/A
