### PR TITLE
fix: clear() and type('{selectall}{del}') behavior difference.

### DIFF
--- a/packages/driver/cypress/fixtures/dom.html
+++ b/packages/driver/cypress/fixtures/dom.html
@@ -650,6 +650,10 @@
         iframe:<br>
         <iframe id="iframe" src="/fixtures/generic.html"></iframe>
       </div>
+      <div id="does-not-wrap-input">Text</div>
+      <div id="input-wrap">
+        <input style="width:100%" />
+      </div>
       <div>
         Cross domain iframe:<br>
         <iframe id="iframe-cross-domain" src="http://localhost:3501/fixtures/generic.html"></iframe>

--- a/packages/driver/cypress/integration/commands/actions/clear_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/clear_spec.js
@@ -297,14 +297,24 @@ describe('src/cy/commands/actions/type - #clear', () => {
       cy.on('fail', (err) => {
         expect(err.message).to.include('`cy.clear()` failed because it requires a valid clearable element.')
         expect(err.message).to.include('The element cleared was:')
-        expect(err.message).to.include('`<div id="dom">...</div>`')
+        expect(err.message).to.include('`<div id="does-not-wrap-input">Text</div>`')
         expect(err.message).to.include(`A clearable element matches one of the following selectors:`)
         expect(err.docsUrl).to.equal('https://on.cypress.io/clear')
 
         done()
       })
 
-      cy.get('div').clear()
+      cy.get('#does-not-wrap-input').clear()
+    })
+
+    it('throws center hidden error if the element is too high', (done) => {
+      cy.on('fail', (err) => {
+        expect(err.message).to.include('`cy.clear()` failed because the center of this element is hidden from view')
+
+        done()
+      })
+
+      cy.get('#dom').clear()
     })
 
     it('throws on an input radio', (done) => {


### PR DESCRIPTION
- Closes #8447

### User facing changelog

`clear()` and `type('{selectall}{del}')` behave differently when they were used against elements that contain text inputs.

### Additional details
- Why was this change necessary? => They didn't follow the documentation.
- What is affected by this change? => If an element is big and its center is outside the viewport, it would now return "center hidden" error, rather than "invalid element".
- Any implementation details to explain? => If the given element is not a text input, it now checks the actionability and uses the `$elToClick` just like `cy.type()`. 

### How has the user experience changed?

N/A

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?