### PR TITLE
feat(cy.intercept): add `times` option to `RouteMatcher`

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1565,10 +1565,10 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
           const third = sinon.stub()
 
           cy
-          .intercept({ url: '/foo*', times: 3 }, 'fourth')
-          .intercept({ url: '/foo*', times: 2 }, third)
-          .intercept({ url: '/foo*', times: 2 }, 'second')
-          .intercept({ url: '/foo*', times: 1 }, 'first')
+          .intercept({ url: '/foo*', times: 3 }, 'fourth').as('4')
+          .intercept({ url: '/foo*', times: 2 }, third).as('3')
+          .intercept({ url: '/foo*', times: 2 }, 'second').as('2')
+          .intercept({ url: '/foo*', times: 1 }, 'first').as('1')
           .then(async () => {
             const expectGet = (expected) => $.get('/foo').then((res) => expect(res).to.eq(expected))
 
@@ -1582,7 +1582,18 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
             ], expectGet)
 
             expect(third).to.be.calledTwice
+
+            // now that matches are exhausted, it should fall through
+            await $.get('/foo').catch((xhr) => {
+              expect(xhr).to.include({
+                status: 404,
+              })
+            })
           })
+          .get('@1.all').should('have.length', 1)
+          .get('@2.all').should('have.length', 2)
+          .get('@3.all').should('have.length', 2)
+          .get('@4.all').should('have.length', 3)
         })
       })
     })

--- a/packages/driver/src/cy/net-stubbing/add-command.ts
+++ b/packages/driver/src/cy/net-stubbing/add-command.ts
@@ -130,6 +130,10 @@ function validateRouteMatcherOptions (routeMatcher: RouteMatcherOptions): { isVa
     return err('`port` must be a number or a list of numbers.')
   }
 
+  if (_.has(routeMatcher, 'times') && (!_.isInteger(routeMatcher.times) || Number(routeMatcher.times) <= 0)) {
+    return err('`times` must be a positive integer.')
+  }
+
   if (_.has(routeMatcher, 'headers')) {
     const knownFieldNames: string[] = []
 

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -365,6 +365,10 @@ export interface RouteMatcherOptionsGeneric<S> {
    */
   query?: DictMatcher<S>
   /**
+   * If set, this `RouteMatcher` will only match the first `times` requests.
+   */
+  times?: number
+  /**
    * Match against the full request URL.
    * If a string is passed, it will be used as a substring match,
    * not an equality match.

--- a/packages/net-stubbing/lib/internal-types.ts
+++ b/packages/net-stubbing/lib/internal-types.ts
@@ -31,7 +31,7 @@ export const SERIALIZABLE_RES_PROPS = _.concat(
   'throttleKbps',
 )
 
-export const PLAIN_FIELDS: (keyof RouteMatcherOptionsGeneric<any>)[] = ['https', 'port', 'middleware']
+export const PLAIN_FIELDS: (keyof RouteMatcherOptionsGeneric<any>)[] = ['https', 'port', 'middleware', 'times']
 
 export const DICT_STRING_MATCHER_FIELDS: (keyof RouteMatcherOptionsGeneric<any>)[] = ['headers', 'query']
 

--- a/packages/net-stubbing/lib/server/driver-events.ts
+++ b/packages/net-stubbing/lib/server/driver-events.ts
@@ -35,6 +35,7 @@ async function onRouteAdded (state: NetStubbingState, getFixture: GetFixtureFn, 
     staticResponse: options.staticResponse,
     routeMatcher,
     getFixture,
+    matches: 0,
   }
 
   state.routes.push(route)

--- a/packages/net-stubbing/lib/server/intercepted-request.ts
+++ b/packages/net-stubbing/lib/server/intercepted-request.ts
@@ -175,7 +175,7 @@ export class InterceptedRequest {
         }
       }
 
-      for (const { subscriptions, immediateStaticResponse } of this.subscriptionsByRoute) {
+      for (const { routeId, subscriptions, immediateStaticResponse } of this.subscriptionsByRoute) {
         for (const subscription of subscriptions) {
           await handleSubscription(subscription)
 
@@ -184,10 +184,20 @@ export class InterceptedRequest {
           }
         }
 
-        if (eventName === 'before:request' && immediateStaticResponse) {
-          sendStaticResponse(this, immediateStaticResponse)
+        if (eventName === 'before:request') {
+          const route = this.matchingRoutes.find(({ id }) => id === routeId) as BackendRoute
 
-          return data
+          route.matches++
+
+          if (route.routeMatcher.times && route.matches >= route.routeMatcher.times) {
+            route.disabled = true
+          }
+
+          if (immediateStaticResponse) {
+            sendStaticResponse(this, immediateStaticResponse)
+
+            return data
+          }
         }
       }
     }

--- a/packages/net-stubbing/lib/server/route-matching.ts
+++ b/packages/net-stubbing/lib/server/route-matching.ts
@@ -133,7 +133,7 @@ export function getRouteForRequest (routes: BackendRoute[], req: CypressIncoming
   const possibleRoutes = prevRoute ? orderedRoutes.slice(_.findIndex(orderedRoutes, prevRoute) + 1) : orderedRoutes
 
   for (const route of possibleRoutes) {
-    if (_doesRouteMatch(route.routeMatcher, req)) {
+    if (!route.disabled && _doesRouteMatch(route.routeMatcher, req)) {
       return route
     }
   }

--- a/packages/net-stubbing/lib/server/types.ts
+++ b/packages/net-stubbing/lib/server/types.ts
@@ -14,6 +14,8 @@ export interface BackendRoute {
   hasInterceptor: boolean
   staticResponse?: BackendStaticResponse
   getFixture: GetFixtureFn
+  matches: number
+  disabled?: boolean
 }
 
 export interface NetStubbingState {

--- a/packages/net-stubbing/test/unit/intercepted-request-spec.ts
+++ b/packages/net-stubbing/test/unit/intercepted-request-spec.ts
@@ -19,11 +19,13 @@ describe('InterceptedRequest', () => {
           {
             id: '1',
             hasInterceptor: true,
+            routeMatcher: {},
           },
           // @ts-ignore
           {
             id: '2',
             hasInterceptor: true,
+            routeMatcher: {},
           },
         ],
       })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #8531
- Closes #4460

### User facing changelog

- Added a `times` option to `cy.intercept`'s `RouteMatcher`. `times` specifies the number of times that a particular `cy.intercept` should be applied.

### Additional details

### How has the user experience changed?

New API:

```js
// this example will cause 1 request to `/temporary-error` to receive a network
// error. subsequent requests will not match this RouteMatcher.
cy.intercept('/temporary-error', { times: 1 }, { forceNetworkError: true })
```

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->https://github.com/cypress-io/cypress-documentation/pull/3910
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
