### PR TITLE
fix(component-testing): bring back support for support files

### DIFF
--- a/npm/webpack-dev-server/package.json
+++ b/npm/webpack-dev-server/package.json
@@ -16,6 +16,7 @@
     "webpack-merge": "^5.4.0"
   },
   "devDependencies": {
+    "@types/webpack-dev-server": "^3.11.1",
     "webpack": "^4.44.2",
     "webpack-dev-server": "^3.11.0"
   },

--- a/npm/webpack-dev-server/src/loader.ts
+++ b/npm/webpack-dev-server/src/loader.ts
@@ -56,14 +56,14 @@ export default function loader () {
 
   var { init } = require(${JSON.stringify(require.resolve('./aut-runner'))})
 
-  var specLoaders = Object.values(allTheSpecs).reduce(
+  var scriptLoaders = Object.values(allTheSpecs).reduce(
     (accSpecLoaders, potentialSpecLoader) => {
       if (potentialSpecLoader.shouldLoad()) {
-        accSpecLoaders.push(potentialSpecLoader.load)
+        accSpecLoaders.push(potentialSpecLoader.load())
       }
       return accSpecLoaders
-  }, [loadSupport])
+  }, [loadSupport()])
 
-  init(specLoaders)
+  init(scriptLoaders)
   `
 }

--- a/npm/webpack-dev-server/src/loader.ts
+++ b/npm/webpack-dev-server/src/loader.ts
@@ -51,7 +51,7 @@ export default function loader (this: CypressCTWebpackContext) {
   const supportFileAbsolutePath = supportFile ? JSON.stringify(path.resolve(projectRoot, supportFile)) : undefined
 
   return `
-  var loadSupport = ${supportFile ? `() => import(${supportFileAbsolutePath})` : `() => Promise.resolve()`}
+  var loadSupportFile = ${supportFile ? `() => import(${supportFileAbsolutePath})` : `() => Promise.resolve()`}
   var allTheSpecs = ${buildSpecs(projectRoot, files)};
 
   var { init } = require(${JSON.stringify(require.resolve('./aut-runner'))})
@@ -62,7 +62,7 @@ export default function loader (this: CypressCTWebpackContext) {
         accSpecLoaders.push(specLoader.load)
       }
       return accSpecLoaders
-  }, [loadSupport])
+  }, [loadSupportFile])
 
   init(scriptLoaders)
   `

--- a/npm/webpack-dev-server/src/loader.ts
+++ b/npm/webpack-dev-server/src/loader.ts
@@ -50,8 +50,10 @@ function buildSpecs (projectRoot: string, files: Cypress.Cypress['spec'][] = [])
 export default function loader () {
   const { files, projectRoot, support } = this._cypress as CypressOptions
 
+  const supportFileAbsolutePath = JSON.stringify(path.resolve(projectRoot, support))
+
   return `
-  var loadSupport = ${support ? `() => import(${JSON.stringify(support)})` : `() => Promise.resolve()`}
+  var loadSupport = ${support ? `() => import(${supportFileAbsolutePath})` : `() => Promise.resolve()`}
   var allTheSpecs = ${buildSpecs(projectRoot, files)};
 
   var { init } = require(${JSON.stringify(require.resolve('./aut-runner'))})

--- a/npm/webpack-dev-server/src/loader.ts
+++ b/npm/webpack-dev-server/src/loader.ts
@@ -59,10 +59,10 @@ export default function loader (this: CypressCTWebpackContext) {
   var scriptLoaders = Object.values(allTheSpecs).reduce(
     (accSpecLoaders, specLoader) => {
       if (specLoader.shouldLoad()) {
-        accSpecLoaders.push(specLoader.load())
+        accSpecLoaders.push(specLoader.load)
       }
       return accSpecLoaders
-  }, [loadSupport()])
+  }, [loadSupport])
 
   init(scriptLoaders)
   `

--- a/npm/webpack-dev-server/src/loader.ts
+++ b/npm/webpack-dev-server/src/loader.ts
@@ -16,9 +16,7 @@ const makeImport = (file: Cypress.Cypress['spec'], filename: string, chunkName: 
 
   return `"${filename}": {
     shouldLoad: () => document.location.pathname.includes(${JSON.stringify(file.relative)}),
-    load: () => {
-      return import(${JSON.stringify(path.resolve(projectRoot, file.relative))} ${magicComments})
-    },
+    load: () => import(${JSON.stringify(path.resolve(projectRoot, file.relative))} ${magicComments}),
     chunkName: "${chunkName}",
   }`
 }
@@ -59,9 +57,9 @@ export default function loader (this: CypressCTWebpackContext) {
   var { init } = require(${JSON.stringify(require.resolve('./aut-runner'))})
 
   var scriptLoaders = Object.values(allTheSpecs).reduce(
-    (accSpecLoaders, potentialSpecLoader) => {
-      if (potentialSpecLoader.shouldLoad()) {
-        accSpecLoaders.push(potentialSpecLoader.load)
+    (accSpecLoaders, specLoader) => {
+      if (specLoader.shouldLoad()) {
+        accSpecLoaders.push(specLoader.load())
       }
       return accSpecLoaders
   }, [loadSupport()])

--- a/npm/webpack-dev-server/src/loader.ts
+++ b/npm/webpack-dev-server/src/loader.ts
@@ -56,10 +56,14 @@ export default function loader () {
 
   var { init } = require(${JSON.stringify(require.resolve('./aut-runner'))})
 
-  var specLoaders = Object.keys(allTheSpecs)
-    .filter(key => allTheSpecs[key].shouldLoad())
-    .map((a) => () => allTheSpecs[a].load())
+  var specLoaders = Object.values(allTheSpecs).reduce(
+    (accSpecLoaders, potentialSpecLoader) => {
+      if (potentialSpecLoader.shouldLoad()) {
+        accSpecLoaders.push(potentialSpecLoader.load)
+      }
+      return accSpecLoaders
+  }, [loadSupport])
 
-  init([loadSupport, ...specLoaders])
+  init(specLoaders)
   `
 }

--- a/npm/webpack-dev-server/src/makeWebpackConfig.ts
+++ b/npm/webpack-dev-server/src/makeWebpackConfig.ts
@@ -35,6 +35,7 @@ export async function makeWebpackConfig (userWebpackConfig, config) {
         files,
         projectRoot,
         devServerEvents,
+        support,
       }),
     ],
   }

--- a/npm/webpack-dev-server/src/makeWebpackConfig.ts
+++ b/npm/webpack-dev-server/src/makeWebpackConfig.ts
@@ -1,7 +1,8 @@
 import { debug as debugFn } from 'debug'
 import * as path from 'path'
+import { Configuration } from 'webpack'
 import { merge } from 'webpack-merge'
-import CypressCTOptionsPlugin from './plugin'
+import CypressCTOptionsPlugin, { CypressCTOptionsPluginOptions } from './plugin'
 
 const debug = debugFn('cypress:webpack-dev-server:makeWebpackConfig')
 
@@ -9,8 +10,12 @@ const mergePublicPath = (baseValue, userValue = '/') => {
   return path.join(baseValue, userValue, '/')
 }
 
-export async function makeWebpackConfig (userWebpackConfig, config) {
-  const { projectRoot, webpackDevServerPublicPathRoute, files, support, devServerEvents } = config
+interface MakeWebpackConfigOptions extends CypressCTOptionsPluginOptions {
+  webpackDevServerPublicPathRoute: string
+}
+
+export async function makeWebpackConfig (userWebpackConfig: Configuration, options: MakeWebpackConfigOptions): Promise<Configuration> {
+  const { projectRoot, webpackDevServerPublicPathRoute, files, supportFile, devServerEvents } = options
 
   debug(`User passed in webpack config with values %o`, userWebpackConfig)
 
@@ -20,7 +25,7 @@ export async function makeWebpackConfig (userWebpackConfig, config) {
 
   debug(`New webpack entries %o`, files)
   debug(`Project root`, projectRoot)
-  debug(`Support files`, support)
+  debug(`Support file`, supportFile)
 
   const entry = path.resolve(__dirname, './browser.js')
 
@@ -35,12 +40,12 @@ export async function makeWebpackConfig (userWebpackConfig, config) {
         files,
         projectRoot,
         devServerEvents,
-        support,
+        supportFile,
       }),
     ],
   }
 
-  const mergedConfig = merge(userWebpackConfig, defaultWebpackConfig, dynamicWebpackConfig)
+  const mergedConfig = merge<Configuration>(userWebpackConfig, defaultWebpackConfig, dynamicWebpackConfig)
 
   mergedConfig.entry = entry
 

--- a/npm/webpack-dev-server/src/plugin.ts
+++ b/npm/webpack-dev-server/src/plugin.ts
@@ -7,26 +7,26 @@ import path from 'path'
 
 type UtimesSync = (path: PathLike, atime: string | number | Date, mtime: string | number | Date) => void
 
-export interface CypressOptions {
+export interface CypressCTOptionsPluginOptions {
   files: Cypress.Cypress['spec'][]
   projectRoot: string
-  support: string
+  supportFile: string
   devServerEvents?: EventEmitter
 }
 
-interface CypressCTWebpackContext extends compilation.Compilation {
-  _cypress: CypressOptions
+export interface CypressCTWebpackContext extends compilation.Compilation {
+  _cypress: CypressCTOptionsPluginOptions
 }
 
 export default class CypressCTOptionsPlugin implements Plugin {
   private files: Cypress.Cypress['spec'][] = []
-  private support: string
+  private supportFile: string
   private readonly projectRoot: string
   private readonly devServerEvents: EventEmitter
 
-  constructor (options: CypressOptions) {
+  constructor (options: CypressCTOptionsPluginOptions) {
     this.files = options.files
-    this.support = options.support
+    this.supportFile = options.supportFile
     this.projectRoot = options.projectRoot
     this.devServerEvents = options.devServerEvents
   }
@@ -35,7 +35,7 @@ export default class CypressCTOptionsPlugin implements Plugin {
     context._cypress = {
       files: this.files,
       projectRoot: this.projectRoot,
-      support: this.support,
+      supportFile: this.supportFile,
     }
   };
 

--- a/npm/webpack-dev-server/src/plugin.ts
+++ b/npm/webpack-dev-server/src/plugin.ts
@@ -7,9 +7,10 @@ import path from 'path'
 
 type UtimesSync = (path: PathLike, atime: string | number | Date, mtime: string | number | Date) => void
 
-interface CypressOptions {
-  files: any[]
+export interface CypressOptions {
+  files: Cypress.Cypress['spec'][]
   projectRoot: string
+  support: string
   devServerEvents?: EventEmitter
 }
 
@@ -18,12 +19,14 @@ interface CypressCTWebpackContext extends compilation.Compilation {
 }
 
 export default class CypressCTOptionsPlugin implements Plugin {
-  private files: string[] = []
+  private files: Cypress.Cypress['spec'][] = []
+  private support: string
   private readonly projectRoot: string
   private readonly devServerEvents: EventEmitter
 
   constructor (options: CypressOptions) {
     this.files = options.files
+    this.support = options.support
     this.projectRoot = options.projectRoot
     this.devServerEvents = options.devServerEvents
   }
@@ -32,6 +35,7 @@ export default class CypressCTOptionsPlugin implements Plugin {
     context._cypress = {
       files: this.files,
       projectRoot: this.projectRoot,
+      support: this.support,
     }
   };
 

--- a/npm/webpack-dev-server/src/startServer.ts
+++ b/npm/webpack-dev-server/src/startServer.ts
@@ -19,7 +19,7 @@ export async function start (initialWebpackConfig, { specs, config, devServerEve
     files: specs,
     projectRoot,
     webpackDevServerPublicPathRoute,
-    support: config.supportFile,
+    supportFile: config.supportFile,
     devServerEvents,
   })
 

--- a/npm/webpack-dev-server/src/startServer.ts
+++ b/npm/webpack-dev-server/src/startServer.ts
@@ -19,7 +19,7 @@ export async function start (initialWebpackConfig, { specs, config, devServerEve
     files: specs,
     projectRoot,
     webpackDevServerPublicPathRoute,
-    support: '',
+    support: config.supportFile,
     devServerEvents,
   })
 

--- a/packages/driver/cypress/integration/cypress/script_utils_spec.js
+++ b/packages/driver/cypress/integration/cypress/script_utils_spec.js
@@ -52,7 +52,7 @@ describe('src/cypress/script_utils', () => {
 
   context('#runPromises', () => {
     it('handles promises and doesnt try to fetch + eval manually', async () => {
-      const scriptsAsPromises = [Promise.resolve(), Promise.resolve()]
+      const scriptsAsPromises = [() => Promise.resolve(), () => Promise.resolve()]
       const result = await $scriptUtils.runScripts({}, scriptsAsPromises)
 
       expect(result).to.have.length(scriptsAsPromises.length)

--- a/packages/driver/src/cypress/script_utils.js
+++ b/packages/driver/src/cypress/script_utils.js
@@ -43,7 +43,7 @@ const runScripts = (specWindow, scripts) => {
     // NOTE: since in evalScripts, scripts are evaluated in order,
     // we chose to respect this constraint here too.
     // indeed _.each goes through the array in order
-    return scripts.reduce((prev, cur) => prev.then(cur), Promise.resolve())
+    return Bluebird.each(scripts, (script) => script())
   }
 
   return runScriptsFromUrls(specWindow, scripts)

--- a/packages/driver/src/cypress/script_utils.js
+++ b/packages/driver/src/cypress/script_utils.js
@@ -38,9 +38,9 @@ const runScriptsFromUrls = (specWindow, scripts) => {
 // Supports either scripts as objects or as async import functions
 const runScripts = (specWindow, scripts) => {
   // if scripts contains at least one promise
-  if (scripts.length && typeof scripts[0].then === 'function') {
+  if (scripts.length && typeof scripts[0] === 'function') {
     // merge the awaiting of the promises
-    return Bluebird.all(scripts)
+    return Bluebird.all(scripts.map((scriptLoader) => scriptLoader()))
   }
 
   return runScriptsFromUrls(specWindow, scripts)

--- a/packages/driver/src/cypress/script_utils.js
+++ b/packages/driver/src/cypress/script_utils.js
@@ -38,9 +38,9 @@ const runScriptsFromUrls = (specWindow, scripts) => {
 // Supports either scripts as objects or as async import functions
 const runScripts = (specWindow, scripts) => {
   // if scripts contains at least one promise
-  if (scripts.length && typeof scripts[0] === 'function') {
+  if (scripts.length && typeof scripts[0].then === 'function') {
     // merge the awaiting of the promises
-    return Bluebird.all(scripts.map((scriptLoader) => scriptLoader()))
+    return Bluebird.all(scripts)
   }
 
   return runScriptsFromUrls(specWindow, scripts)

--- a/packages/driver/src/cypress/script_utils.js
+++ b/packages/driver/src/cypress/script_utils.js
@@ -38,9 +38,9 @@ const runScriptsFromUrls = (specWindow, scripts) => {
 // Supports either scripts as objects or as async import functions
 const runScripts = (specWindow, scripts) => {
   // if scripts contains at least one promise
-  if (scripts.length && typeof scripts[0].then === 'function') {
+  if (scripts.length && typeof scripts[0] === 'function') {
     // merge the awaiting of the promises
-    return Bluebird.all(scripts)
+    return Bluebird.all(scripts.map((script) => script()))
   }
 
   return runScriptsFromUrls(specWindow, scripts)

--- a/packages/driver/src/cypress/script_utils.js
+++ b/packages/driver/src/cypress/script_utils.js
@@ -38,9 +38,12 @@ const runScriptsFromUrls = (specWindow, scripts) => {
 // Supports either scripts as objects or as async import functions
 const runScripts = (specWindow, scripts) => {
   // if scripts contains at least one promise
-  if (scripts.length && typeof scripts[0].then === 'function') {
-    // merge the awaiting of the promises
-    return Bluebird.all(scripts)
+  if (scripts.length && typeof scripts[0] === 'function') {
+    // chain the loading promises
+    // NOTE: since in evalScripts, scripts are evaluated in order,
+    // we chose to respect this constraint here too.
+    // indeed _.each goes through the array in order
+    return scripts.reduce((prev, cur) => prev.then(cur), Promise.resolve())
   }
 
   return runScriptsFromUrls(specWindow, scripts)

--- a/packages/driver/src/cypress/script_utils.js
+++ b/packages/driver/src/cypress/script_utils.js
@@ -38,9 +38,9 @@ const runScriptsFromUrls = (specWindow, scripts) => {
 // Supports either scripts as objects or as async import functions
 const runScripts = (specWindow, scripts) => {
   // if scripts contains at least one promise
-  if (scripts.length && typeof scripts[0] === 'function') {
+  if (scripts.length && typeof scripts[0].then === 'function') {
     // merge the awaiting of the promises
-    return Bluebird.all(scripts.map((script) => script()))
+    return Bluebird.all(scripts)
   }
 
   return runScriptsFromUrls(specWindow, scripts)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5282,6 +5282,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/connect-history-api-fallback@*":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.3.tgz#4772b79b8b53185f0f4c9deab09236baf76ee3b4"
+  integrity sha512-7SxFCd+FLlxCfwVwbyPxbR4khL9aNikJhrorw8nUIOqeuooc9gifBuDQOJw5kzN7i6i3vLn9G8Wde/4QDihpYw==
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/node" "*"
+
 "@types/connect@*":
   version "3.4.34"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.34.tgz#170a40223a6d666006d93ca128af2beb1d9b1901"
@@ -5350,7 +5358,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/express-serve-static-core@*":
+"@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18":
   version "4.17.18"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.18.tgz#8371e260f40e0e1ca0c116a9afcd9426fa094c40"
   integrity sha512-m4JTwx5RUBNZvky/JJ8swEJPKFd8si08pPF2PfizYjGZOKr/svUWPcoUmLow6MmPzhasphB7gSTINY67xn3JNA==
@@ -5358,6 +5366,16 @@
     "@types/node" "*"
     "@types/qs" "*"
     "@types/range-parser" "*"
+
+"@types/express@*":
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.11.tgz#debe3caa6f8e5fcda96b47bd54e2f40c4ee59545"
+  integrity sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.18"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
 
 "@types/express@4.17.2":
   version "4.17.2"
@@ -5439,7 +5457,16 @@
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
   integrity sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
 
-"@types/http-proxy@1.17.4":
+"@types/http-proxy-middleware@*":
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/@types/http-proxy-middleware/-/http-proxy-middleware-0.19.3.tgz#b2eb96fbc0f9ac7250b5d9c4c53aade049497d03"
+  integrity sha512-lnBTx6HCOUeIJMLbI/LaL5EmdKLhczJY5oeXZpX/cXE4rRqb3RmV7VcMpiEfYkmTjipv3h7IAyIINe4plEv7cA==
+  dependencies:
+    "@types/connect" "*"
+    "@types/http-proxy" "*"
+    "@types/node" "*"
+
+"@types/http-proxy@*", "@types/http-proxy@1.17.4":
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.4.tgz#e7c92e3dbe3e13aa799440ff42e6d3a17a9d045b"
   integrity sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==
@@ -5879,6 +5906,17 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
   integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
+
+"@types/webpack-dev-server@^3.11.1":
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/@types/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz#f8f4dac1da226d530bd15a1d5dc34b23ba766ccb"
+  integrity sha512-rIb+LtUkKnh7+oIJm3WiMJONd71Q0lZuqGLcSqhZ5qjN9gV/CNmZe7Bai+brnBPZ/KVYOsr+4bFLiNZwjBicLw==
+  dependencies:
+    "@types/connect-history-api-fallback" "*"
+    "@types/express" "*"
+    "@types/http-proxy-middleware" "*"
+    "@types/serve-static" "*"
+    "@types/webpack" "*"
 
 "@types/webpack-sources@*":
   version "2.1.0"


### PR DESCRIPTION
Made sure that support files are loaded in component testing mode.

Since we now accept to delegate the loading of the spec to a 3rd party we need to add the support script loading to this list of loads.

## How to test

Run the `server-ct/crossword` example and look at the `App.spec.js`. 
It uses a custom command "fillCrossword" that now works.

Closes CT-181

