### PR TITLE
fix: remove two annoying react warnings

### DIFF
--- a/packages/runner-ct/src/app/app.tsx
+++ b/packages/runner-ct/src/app/app.tsx
@@ -25,7 +25,6 @@ export interface ExtendedConfigOptions extends Cypress.ConfigOptions {
 }
 
 interface AppProps {
-  runMode: RunMode
   state: State;
   // eslint-disable-next-line
   eventManager: typeof EventManager
@@ -103,7 +102,6 @@ const App: React.FC<AppProps> = observer(
 )
 
 App.propTypes = {
-  runMode: PropTypes.oneOf<RunMode>(['single', 'multi']).isRequired,
   config: PropTypes.shape({
     browsers: PropTypes.arrayOf(PropTypes.shape({
       name: PropTypes.string.isRequired,

--- a/packages/runner-ct/src/specs/spec-file.tsx
+++ b/packages/runner-ct/src/specs/spec-file.tsx
@@ -26,7 +26,7 @@ export const SpecFile = observer(
         }
       >
         {state.runMode === 'single'
-          ? <input className="spec-list-radio" type="radio" checked={isActive} />
+          ? <input className="spec-list-radio" type="radio" checked={isActive} readOnly />
           : <i className={isActive ? 'fas fa-check-square active' : 'far fa-square'} />
         }
 


### PR DESCRIPTION
When we open compont testing we get the following warnings in the console:

```
@ The prop `runMode` is marked as required in `App`, but its value is `undefined`.
    in App (created by Container)
    in Container
@ Warning: Failed prop type: You provided a `checked` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultChecked`. Otherwise, set either `onChange` or `readOnly`.
    in input (created by SpecFile)
    in li (created by SpecFile)
    in SpecFile (created by SpecItem)
    in SpecItem (created by SpecsList)
    in ul (created by SpecsList)
    in div (created by SpecsList)
    in div (created by SpecsList)
    in SpecsList (created by App)
    in div (created by Pane)
    in Pane (created by SplitPane)
    in div (created by SplitPane)
    in SplitPane (created by App)
    in div (created by Pane)
    in Pane (created by SplitPane)
    in div (created by SplitPane)
    in SplitPane (created by App)
    in App (created by Container)
    in Container
```

This PR removes them