### PR TITLE
fix: viewport button hover styles

### DIFF
--- a/packages/runner/cypress/integration/runner.ui.spec.js
+++ b/packages/runner/cypress/integration/runner.ui.spec.js
@@ -310,6 +310,19 @@ describe('src/cypress/runner', () => {
     })
   })
 
+  describe('runner header', () => {
+    context('viewport dropdown', () => {
+      it('shows on click', () => {
+        runIsolatedCypress({})
+        cy.get('.viewport-menu').should('not.be.visible')
+        cy.get('.viewport-info button').click()
+        cy.get('.viewport-menu').should('be.visible')
+
+        cy.percySnapshot()
+      })
+    })
+  })
+
   describe('reporter interaction', () => {
     // https://github.com/cypress-io/cypress/issues/8621
     it('user can stop test execution', (done) => {

--- a/packages/runner/src/header/header.scss
+++ b/packages/runner/src/header/header.scss
@@ -425,7 +425,12 @@
       }
 
       &:hover {
+        background: none;
         color :#333;
+      }
+
+      &:focus {
+        background: none;
       }
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
Not sure when this happened and if the issue went out to any users

### Additional details
Fixes some messed up styling on the viewport menu button, since these files haven't been changed in a while my guess is the recent sass changes did something

### How has the user experience changed?
Before:
![ezgif-3-0a2eefcdaacf](https://user-images.githubusercontent.com/7033952/104408323-cca42500-5531-11eb-8fe1-63a7f5896a50.gif)

After:
![ezgif-3-abe4c02c784e](https://user-images.githubusercontent.com/7033952/104408344-d6c62380-5531-11eb-9433-23d53b2f7de6.gif)