### PR TITLE
fix: default component testing viewport

### DIFF
--- a/packages/server-ct/test/unit/project-ct.spec.ts
+++ b/packages/server-ct/test/unit/project-ct.spec.ts
@@ -11,3 +11,35 @@ describe('Project', () => {
     expect(typeof p.close).to.equal('function')
   })
 })
+
+describe('addComponentTestingUniqueDefaults', () => {
+  it('overrides e2e defaults if no user overrides provided', () => {
+    const expected = {
+      viewportHeight: 500,
+      viewportWidth: 500,
+    }
+    const p = new ProjectCt('foo')
+
+    const actual = p.addComponentTestingUniqueDefaults({
+      viewportHeight: 660,
+      viewportWidth: 1000,
+    })
+
+    expect(actual).to.eql(expected)
+  })
+
+  it('uses user configured values if provided', () => {
+    const expected = {
+      viewportHeight: 444,
+      viewportWidth: 444,
+    }
+    const p = new ProjectCt('foo')
+
+    const actual = p.addComponentTestingUniqueDefaults({
+      viewportHeight: 444,
+      viewportWidth: 444,
+    })
+
+    expect(actual).to.eql(expected)
+  })
+})


### PR DESCRIPTION
Use 500/500 by default for the viewport in component testing.

This is a little dirty. Ideally we will have a separate set of defaults for component testing, extends from a set of base defaults. I tried to do this but it's quite a big change to the existing server code, so this will do for now. The nice thing about this way is it only touches the CT code.