### PR TITLE
fix: when quitting chrome exit the process

### DIFF
--- a/packages/server-ct/index.ts
+++ b/packages/server-ct/index.ts
@@ -27,7 +27,11 @@ export const start = async (projectRoot: string, args: Record<string, any>) => {
 
     return openProject.create(projectRoot, args, options)
     .then((project) => {
-      return openProject.launch(browser, spec)
+      return openProject.launch(browser, spec, {
+        onBrowserClose: () => {
+          process.exit()
+        },
+      })
     })
   })
 }

--- a/packages/server-ct/index.ts
+++ b/packages/server-ct/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+import chalk from 'chalk'
 import browsers from '@packages/server/lib/browsers'
 import openProject from '@packages/server/lib/open_project'
 
@@ -29,6 +31,8 @@ export const start = async (projectRoot: string, args: Record<string, any>) => {
     .then((project) => {
       return openProject.launch(browser, spec, {
         onBrowserClose: () => {
+          console.log(chalk.blue('BROWSER EXITED SAFELY'))
+          console.log(chalk.blue('COMPONENT TESTING STOPPED'))
           process.exit()
         },
       })


### PR DESCRIPTION
In component-testing when quitting the chrome instance, the process needs to exit.

## How to test?

- Start component testing
- Type Ctrl-Q to quit chrome

The process should exit normally