### PR TITLE
fix(component-testing): Update AUT coordinates when resizing

### DIFF
--- a/packages/runner-ct/src/app/app.tsx
+++ b/packages/runner-ct/src/app/app.tsx
@@ -1,11 +1,11 @@
 import cs from 'classnames'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useState } from 'react'
 import { Reporter } from '@packages/reporter/src/main'
 
 import errorMessages from '../errors/error-messages'
-import State, { RunMode } from '../lib/state'
+import State from '../lib/state'
 
 import { SpecsList } from '../specs/specs-list'
 import SplitPane from 'react-split-pane'
@@ -37,9 +37,19 @@ const App: React.FC<AppProps> = observer(
 
     const { state, eventManager, config } = props
     const [isReporterResizing, setIsReporterResizing] = React.useState(false)
+    const [containerRef, setContainerRef] = useState<HTMLDivElement | null>(null)
 
     // the viewport + padding left and right or fallback to default size
     const defaultIframeWidth = config.viewportWidth ? config.viewportWidth + 32 : 500
+
+    const onPaneSizeChange = () => {
+      if (!containerRef) {
+        // should never happen
+        return
+      }
+
+      props.state.updateDimensions(containerRef.offsetWidth)
+    }
 
     return (
       <>
@@ -51,6 +61,7 @@ const App: React.FC<AppProps> = observer(
           maxSize={windowSize.width - 400}
           defaultSize={defaultIframeWidth}
           onDragStarted={() => setIsReporterResizing(true)}
+          onChange={onPaneSizeChange}
           onDragFinished={() => setIsReporterResizing(false)}
           className={cs('reporter-pane', { 'is-reporter-resizing': isReporterResizing })}
         >
@@ -87,7 +98,11 @@ const App: React.FC<AppProps> = observer(
 
           <div className="runner runner-ct container">
             <Header {...props} />
-            <Iframes {...props} />
+            <Iframes
+              {...props}
+              containerRef={containerRef}
+              setContainerRef={setContainerRef}
+            />
             <Message state={state} />
           </div>
         </SplitPane>

--- a/packages/runner-ct/src/iframe/iframes.jsx
+++ b/packages/runner-ct/src/iframe/iframes.jsx
@@ -19,20 +19,26 @@ export function getSpecUrl ({ namespace, spec }, prefix = '') {
 @observer
 export default class Iframes extends Component {
   _disposers = []
+  maxWidth
+
+  constructor (props) {
+    super(props)
+    this.maxWidth = this.props.state.width
+  }
 
   render () {
-    const { width, height, scriptError } = this.props.state
+    const { height, scriptError } = this.props.state
 
     return (
       <div
         className={cs('iframes-ct-container', { 'has-error': !!scriptError })}
       >
         <div
-          ref='container'
+          ref={this.props.setContainerRef}
           className='size-container'
           style={{
             height,
-            width,
+            maxWidth: this.maxWidth,
           }}
         />
         <ScriptError error={scriptError} />
@@ -119,8 +125,8 @@ export default class Iframes extends Component {
   // wiped out and reset on re-runs and the snapshots are from dom we don't control
   _loadIframes (spec) {
     const specSrc = getSpecUrl({ namespace: this.props.config.namespace, spec })
-    const $container = $(this.refs.container).empty()
-    const $autIframe = this.autIframe.create(this.props.config).appendTo($container)
+    const $container = $(this.props.containerRef).empty()
+    const $autIframe = this.autIframe.create().appendTo($container)
 
     this.autIframe.showBlankContents()
 

--- a/packages/runner-ct/src/iframe/iframes.scss
+++ b/packages/runner-ct/src/iframe/iframes.scss
@@ -1,3 +1,7 @@
 .iframes-ct-container { 
   margin: 16px;
 }
+
+.size-container {
+  width: 100%;
+}

--- a/packages/runner-ct/src/lib/state.ts
+++ b/packages/runner-ct/src/lib/state.ts
@@ -33,8 +33,8 @@ const _defaults: Defaults = {
   messageControls: null,
   specSearchText: '',
 
-  width: 1000,
-  height: 660,
+  width: 500,
+  height: 500,
 
   reporterWidth: null,
 
@@ -160,9 +160,14 @@ export default class State {
     this.specSearchText = text
   }
 
-  @action updateDimensions (width, height) {
-    this.width = width
-    this.height = height
+  @action updateDimensions (width?: number, height?: number) {
+    if (width) {
+      this.width = width
+    }
+
+    if (height) {
+      this.height = height
+    }
   }
 
   @action updateWindowDimensions ({ windowWidth, windowHeight, reporterWidth, headerHeight }) {


### PR DESCRIPTION
Update the coordinates in the AUT viewport when resizing.

Video: http://g.recordit.co/3lsJu7wb6i.gif

NOTE: This is only set up for width right now. We could do something similar for height but it feels a little weird - a static height of 500 (or whatever) feels "right", somehow. It's a little more messy to deal with height, too - for width we can use the callback on `<SplitPane>`, but this won't work for height. We might need something like MutationObserver, if we choose to go down that route.

closes CT-192
