### PR TITLE
chore: Require dependency dashboard approval before raising PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,5 +31,5 @@
   "schedule": [
     "before 3am on the first day of the month"
   ],
-  "masterIssue": true
+  "dependencyDashboardApproval": true
 }


### PR DESCRIPTION
Renovate currently raises a PR for whatever dependency is next in its queue. This means that we have a [permanent PR](https://github.com/cypress-io/cypress/pull/8882) open for updating ‘types’, since it’s next in the queue. And if you close it, renovate just reopens it.

This PR makes it so that you have to manually approve (check) PRs from the [Dependency Dashboard issue](https://github.com/cypress-io/cypress/issues/3777) before they are opened. 