### PR TITLE
fix: Added types for runtime config.

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2624,11 +2624,11 @@ declare namespace Cypress {
      */
     blockHosts: null | string | string[]
     /**
-     * The browser Cypress is runnong on.
+     * The browser Cypress is running on.
      */
     browser: Browser
     /**
-     * The browsers Cypress can use.
+     * Available browsers found on your system.
      */
     browsers: Browser[]
     /**
@@ -2636,39 +2636,42 @@ declare namespace Cypress {
      */
     componentFolder: string
     /**
-     * Enables component testing.
+     * Whether component testing is enabled.
      */
     experimentalComponentTesting: boolean
-    /**
-     * Enables polyfill fetch.
-     */
-    experimentalFetchPolyfill: boolean
     /**
      * ???
      */
     hosts: null | string[]
     /**
-     * With this option enabled - Cypress will search through the response streams
-     * coming from your server on .html and .js files
-     * and replace code that matches some patterns.
+     * Whether Cypress was launched via 'cypress open' (interactive mode)
+     */
+    isInteractive: boolean
+    /**
+     * Whether Cypress will search for and replace
+     * obstructive JS code in .js or .html files.
      *
-     * @see https://docs.cypress.io/guides/references/configuration.html#modifyObstructiveCode
+     * @see https://on.cypress.io/configuration#modifyObstructiveCode
      */
     modifyObstructiveCode: boolean
     /**
-     * ???
+     * The platform Cypress is running on.
+     */
+    platform: 'linux' | 'darwin' | 'win32'
+    /**
+     * A unique ID for the project used for recording
      */
     projectId: null | string
     /**
-     * The path to the support folder
+     * Path to the support folder.
      */
     supportFolder: string
     /**
-     * Glob pattern for the test files.
+     * Glob pattern to determine what test files to load.
      */
     testFiles: string
     /**
-     * ???
+     * The user agent the browser sends in all request headers.
      */
     userAgent: null | string
     /**
@@ -2684,14 +2687,12 @@ declare namespace Cypress {
     cypressEnv: string
     integrationExampleName: string
     integrationExamplePath: string
-    isInteractive: boolean
     isNewProject: boolean
     isTextTerminal: boolean
     morgan: boolean
     namespace: string
     parentTestsFolder: string
     parentTestsFolderDisplay: string
-    platform: 'linux' | 'darwin' | 'win32'
     projectName: string
     projectRoot: string
     proxyUrl: string

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -281,7 +281,7 @@ declare namespace Cypress {
     // {defaultCommandTimeout: 10000, pageLoadTimeout: 30000, ...}
     ```
      */
-    config(): ResolvedConfigOptions
+    config(): ResolvedConfigOptions & RuntimeConfigOptions
     /**
      * Returns one configuration value.
      * @see https://on.cypress.io/config
@@ -2607,6 +2607,109 @@ declare namespace Cypress {
      * @default false
      */
     includeShadowDom: boolean
+  }
+
+  /**
+   * Options appended to config object on runtime.
+   */
+  interface RuntimeConfigOptions {
+    /**
+     * CPU architecture, from Node `os.arch()`
+     *
+     * @see https://nodejs.org/api/os.html#os_os_arch
+     */
+    arch: string
+    /**
+     * The list of hosts to be blocked
+     */
+    blockHosts: null | string | string[]
+    /**
+     * The browser Cypress is runnong on.
+     */
+    browser: Browser
+    /**
+     * The browsers Cypress can use.
+     */
+    browsers: Browser[]
+    /**
+     * Path to folder containing component test files.
+     */
+    componentFolder: string
+    /**
+     * Enables component testing.
+     */
+    experimentalComponentTesting: boolean
+    /**
+     * Enables polyfill fetch.
+     */
+    experimentalFetchPolyfill: boolean
+    /**
+     * ???
+     */
+    hosts: null | string[]
+    /**
+     * With this option enabled - Cypress will search through the response streams
+     * coming from your server on .html and .js files
+     * and replace code that matches some patterns.
+     *
+     * @see https://docs.cypress.io/guides/references/configuration.html#modifyObstructiveCode
+     */
+    modifyObstructiveCode: boolean
+    /**
+     * ???
+     */
+    projectId: null | string
+    /**
+     * The path to the support folder
+     */
+    supportFolder: string
+    /**
+     * Glob pattern for the test files.
+     */
+    testFiles: string
+    /**
+     * ???
+     */
+    userAgent: null | string
+    /**
+     * The Cypress version being used.
+     */
+    version: string
+
+    // Internal or Unlisted at server/lib/config_options
+    autoOpen: boolean
+    browserUrl: string
+    clientRoute: string
+    configFile: string
+    cypressEnv: string
+    integrationExampleName: string
+    integrationExamplePath: string
+    isInteractive: boolean
+    isNewProject: boolean
+    isTextTerminal: boolean
+    morgan: boolean
+    namespace: string
+    parentTestsFolder: string
+    parentTestsFolderDisplay: string
+    platform: 'linux' | 'darwin' | 'win32'
+    projectName: string
+    projectRoot: string
+    proxyUrl: string
+    report: boolean
+    reporterRoute: string
+    reporterUrl: string
+    socketId: null | string
+    socketIoCookie: string
+    socketIoRoute: string
+    spec: {
+      absolute: string
+      name: string
+      relative: string
+      specFilter: null | string
+      specType: 'integration' | 'component'
+    }
+    xhrRoute: string
+    xhrUrl: string
   }
 
   interface TestConfigOverrides extends Partial<Pick<ConfigOptions, 'animationDistanceThreshold' | 'baseUrl' | 'defaultCommandTimeout' | 'env' | 'execTimeout' | 'includeShadowDom' | 'requestTimeout' | 'responseTimeout' | 'retries' | 'scrollBehavior' | 'taskTimeout' | 'viewportHeight' | 'viewportWidth' | 'waitForAnimations'>> {

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2640,7 +2640,7 @@ declare namespace Cypress {
      */
     experimentalComponentTesting: boolean
     /**
-     * ???
+     * Hosts mappings to IP addresses.
      */
     hosts: null | string[]
     /**


### PR DESCRIPTION
- Closes #14392

### User facing changelog

Added types for config properties appended at runtime.

### Additional details
- Why was this change necessary? => Some runtime config properties are not defined in the type file. 
- What is affected by this change? => N/A

#### Any implementation details to explain? 

I got the list of runtime config properties with the code below:

```js
it('t', () => {
  console.log(Cypress.config())
})
```

And compared the list of options in `server/lib/config_options.ts`.

### How has the user experience changed?

N/A

### Questions

* I intentionally left some explanations for some properties as `???` because it's hard to guess or track the meaning of them.
* I intentionally grouped and left no explanation for internal or unlisted properties. 

### PR Tasks

I intentionally didn't add tests because config types are not tested in the `cli` tests.