### PR TITLE
fix: guard against non-string keys before showing an error

### DIFF
--- a/packages/server/lib/modes/record.js
+++ b/packages/server/lib/modes/record.js
@@ -404,6 +404,12 @@ const createRun = Promise.method((options = {}) => {
     switch (err.statusCode) {
       case 401:
         recordKey = keys.hide(recordKey)
+        if (!recordKey) {
+          // make sure the key is defined, otherwise the error
+          // printing logic substitutes the default value {}
+          // leading to "[object Object]" :)
+          recordKey = 'undefined'
+        }
 
         return errors.throw('DASHBOARD_RECORD_KEY_NOT_VALID', recordKey, projectId)
       case 402: {

--- a/packages/server/lib/modes/record.js
+++ b/packages/server/lib/modes/record.js
@@ -397,7 +397,7 @@ const createRun = Promise.method((options = {}) => {
       }
     })
   }).catch((err) => {
-    debug('failed creating run %o', {
+    debug('failed creating run with status %d %o', err.statusCode, {
       stack: err.stack,
     })
 

--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -238,6 +238,12 @@ module.exports = {
       project = undefined
     }
 
+    // if non-string key has been passed, set it to undefined
+    // https://github.com/cypress-io/cypress/issues/14571
+    if (typeof options.key !== 'string') {
+      delete options.key
+    }
+
     if (spec) {
       const resolvePath = (p) => {
         return path.resolve(options.cwd, p)

--- a/packages/server/lib/util/keys.js
+++ b/packages/server/lib/util/keys.js
@@ -3,6 +3,12 @@ const hide = (token) => {
     return
   }
 
+  if (typeof token !== 'string') {
+    // maybe somehow we passes key=true?
+    // https://github.com/cypress-io/cypress/issues/14571
+    return
+  }
+
   return [
     token.slice(0, 5),
     token.slice(-5),

--- a/packages/server/test/unit/args_spec.js
+++ b/packages/server/test/unit/args_spec.js
@@ -365,7 +365,7 @@ describe('lib/util/args', () => {
       this.obj = { config: { foo: 'bar' }, project: 'foo/bar' }
     })
 
-    it('rejects values which have an cooresponding underscore\'d key', function () {
+    it('rejects values which have an corresponding underscore\'d key', function () {
       expect(argsUtil.toArray(this.obj)).to.deep.eq([
         `--config=${JSON.stringify({ foo: 'bar' })}`,
         '--project=foo/bar',

--- a/packages/server/test/unit/util/keys_spec.ts
+++ b/packages/server/test/unit/util/keys_spec.ts
@@ -1,0 +1,20 @@
+import { hide } from '../../../lib/util/keys'
+import { expect } from 'chai'
+
+describe('util/keys', () => {
+  it('removes middle part of the string', () => {
+    const hidden = hide('12345-xxxx-abcde')
+
+    expect(hidden).to.equal('12345...abcde')
+  })
+
+  it('returns undefined for missing key', () => {
+    expect(hide()).to.be.undefined
+  })
+
+  // https://github.com/cypress-io/cypress/issues/14571
+  it('returns undefined for non-string argument', () => {
+    expect(hide(true)).to.be.undefined
+    expect(hide(1234)).to.be.undefined
+  })
+})


### PR DESCRIPTION
- Closes #14571

### User facing changelog

Cypress won't crash when running with the command
```
cypress run --record --key --parallel
```

### Additional details
The argument `--key` got value "--parallel" when parsing, and then later got cast to become "key: true". Later it crashes the test runner as we were trying to show an error message.

### How has the user experience changed?

You will see a good error message

<img width="854" alt="Screen Shot 2021-01-15 at 1 16 37 PM" src="https://user-images.githubusercontent.com/2212006/104763465-ec0aa000-5733-11eb-8b21-90a190cbdcbd.png">


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
