### PR TITLE
feat(component-testing): Make cypress's folders to be transpiled by default via webpack-preprocessors

### DIFF
--- a/npm/react/package.json
+++ b/npm/react/package.json
@@ -19,7 +19,7 @@
     "babel-plugin-istanbul": "6.0.0",
     "debug": "4.3.1",
     "find-up": "5.0.0",
-    "find-webpack": "2.2.0",
+    "find-webpack": "2.2.1",
     "mime-types": "2.1.26",
     "semver": "7.3.2",
     "unfetch": "4.1.0"

--- a/npm/react/plugins/cra-v3/file-preprocessor.js
+++ b/npm/react/plugins/cra-v3/file-preprocessor.js
@@ -2,6 +2,7 @@
 const debug = require('debug')('@cypress/react')
 const findWebpack = require('find-webpack')
 const webpackPreprocessor = require('@cypress/webpack-preprocessor')
+const { getTranspileFolders } = require('../utils/get-transpile-folders')
 const { addImageRedirect } = require('../utils/add-image-redirect')
 
 const getWebpackPreprocessorOptions = (opts) => {
@@ -40,26 +41,9 @@ module.exports = (config) => {
   debug('fixtures folder', config.fixturesFolder)
   debug('integration test folder: %s', config.integrationFolder)
 
-  const additionalFolders = []
-
-  // user can disable folders, so check first
-  if (config.componentFolder) {
-    additionalFolders.push(config.componentFolder)
-  }
-
-  if (config.fixturesFolder) {
-    additionalFolders.push(config.fixturesFolder)
-  }
-
-  if (config.integrationFolder) {
-    additionalFolders.push(config.integrationFolder)
-  }
-
-  debug('additional folders: %o', additionalFolders)
-
   const opts = {
     reactScripts: true,
-    addFolderToTranspile: additionalFolders,
+    addFolderToTranspile: getTranspileFolders(config),
     coverage: !coverageIsDisabled,
     // insert Babel plugin to mock named imports
     looseModules: true,

--- a/npm/react/plugins/load-webpack/index.js
+++ b/npm/react/plugins/load-webpack/index.js
@@ -3,6 +3,7 @@ const path = require('path')
 const debug = require('debug')('@cypress/react')
 const webpackPreprocessor = require('@cypress/webpack-preprocessor')
 const findWebpack = require('find-webpack')
+const { getTranspileFolders } = require('../utils/get-transpile-folders')
 const { addImageRedirect } = require('../utils/add-image-redirect')
 
 module.exports = (on, config) => {
@@ -36,6 +37,7 @@ module.exports = (on, config) => {
 
   const opts = {
     reactScripts: true,
+    addFolderToTranspile: getTranspileFolders(config),
     coverage: !coverageIsDisabled,
     // insert Babel plugin to mock named imports
     looseModules: true,

--- a/npm/react/plugins/utils/get-transpile-folders.js
+++ b/npm/react/plugins/utils/get-transpile-folders.js
@@ -1,0 +1,17 @@
+// @ts-check
+function getTranspileFolders (config) {
+  const folders = []
+
+  // user can disable folders, so check first
+  if (config.componentFolder) {
+    folders.push(config.componentFolder)
+  }
+
+  if (config.fixturesFolder) {
+    folders.push(config.fixturesFolder)
+  }
+
+  return folders
+}
+
+module.exports = { getTranspileFolders }


### PR DESCRIPTION
- Closes #14601

### User facing changelog
Cypress folders are added to be transpiled by webpack for react/plugins/load-webpack by default

### Additional details
logic from `@cypress/react/plugins/cra-v3` reused

### How has the user experience changed?
no need to customise webpack config with cypress folders

### PR Tasks
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
