### PR TITLE
fix: Alias name for `req.alias` containing a dot fail to intercept

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -2477,6 +2477,23 @@ describe('network stubbing', { retries: 2 }, function () {
 
         cy.wait('@netAlias').its('response.body').should('equal', 'my value')
       })
+
+      // https://github.com/cypress-io/cypress/issues/14444
+      it('can use dot in request alias', () => {
+        cy.intercept('/users', (req) => {
+          req.alias = 'get.url'
+          req.reply('foo')
+        })
+
+        cy.window().then((win) => {
+          const xhr = new win.XMLHttpRequest()
+
+          xhr.open('GET', '/users')
+          xhr.send()
+        })
+
+        cy.wait('@get.url')
+      })
     })
   })
 })

--- a/packages/driver/src/cy/commands/waiting.js
+++ b/packages/driver/src/cy/commands/waiting.js
@@ -100,11 +100,16 @@ module.exports = (Commands, Cypress, cy, state) => {
       _.keys(cy.state('aliases')).includes(str.slice(1))) {
         specifier = null
       } else {
-        // potentially request, response or index
+        // potentially request, response
         const allParts = _.split(str, '.')
+        const last = _.last(allParts)
 
-        str = _.join(_.dropRight(allParts, 1), '.')
-        specifier = _.last(allParts)
+        if (last === 'request' || last === 'response') {
+          str = _.join(_.dropRight(allParts, 1), '.')
+          specifier = _.last(allParts)
+        } else {
+          specifier = null
+        }
       }
 
       let aliasObj


### PR DESCRIPTION
TR-620
- Closes #14444

### User facing changelog

When there was a dot in `req.alias`, it failed. This PR fixes this problem. 

### Additional details
- Why was this change necessary? => adding dot for `req.alias` failed without reason. 
- What is affected by this change? => N/A
- Any implementation details to explain? => I only allowed the exception for `request` and `response`. 

### How has the user experience changed?

N/A

### Documentation problem. 

`request` and `response` are reserved. But it is not documented in [`cy.wait`](https://docs.cypress.io/api/commands/wait.html),  [`cy.intercept`](https://docs.cypress.io/api/commands/intercept.html#Comparison-to-cy-route), [`cy.route`](https://docs.cypress.io/api/commands/route.html#Syntax) docs. 

Only documentation I could find was [0.5.10 changelog](https://docs.cypress.io/guides/references/changelog.html#0-5-10). I think it should be added to avoid confusion. 

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? => Added a section above to get feedback. 
