### PR TITLE
test: add extra assertions for flaky percy snapshots

### DIFF
--- a/packages/reporter/cypress/integration/runnables_spec.ts
+++ b/packages/reporter/cypress/integration/runnables_spec.ts
@@ -69,6 +69,7 @@ describe('runnables', () => {
     ] })
 
     // ensure the page is loaded before taking snapshot
+    cy.get('.focus-tests-text').should('be.visible')
     cy.contains('buzz').should('be.visible')
     cy.percySnapshot()
   })

--- a/packages/reporter/cypress/integration/test_errors_spec.ts
+++ b/packages/reporter/cypress/integration/test_errors_spec.ts
@@ -220,6 +220,8 @@ describe('test errors', () => {
         expect(content).not.to.contain('*fizz*')
       })
 
+      // ensure the page is loaded before taking snapshot
+      cy.get('.focus-tests-text').should('be.visible')
       cy.percySnapshot()
     })
 


### PR DESCRIPTION
Found in these percy snapshot: https://percy.io/cypress-io/cypress/builds-next/8499985/changed/483176550

Need to ensure the ‘Tests’ button is rendered before snapshotting.

<img width="969" alt="Screen Shot 2021-01-22 at 10 28 11 AM" src="https://user-images.githubusercontent.com/1271364/105444662-a6525800-5c9c-11eb-92a3-ec1c65b763fc.png">
