### PR TITLE
fix: correctly wait for static delayMs w/ cy.intercept

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1041,6 +1041,29 @@ describe('network stubbing', { retries: 2 }, function () {
       })
     })
 
+    // @see https://github.com/cypress-io/cypress/issues/14446
+    it('should delay the same amount on every response', () => {
+      const delayMs = 250
+
+      const testDelay = () => {
+        const start = Date.now()
+
+        return $.get('/timeout').then((responseText) => {
+          expect(Date.now() - start).to.be.closeTo(delayMs, 50)
+          expect(responseText).to.eq('foo')
+        })
+      }
+
+      cy.intercept('/timeout', {
+        statusCode: 200,
+        body: 'foo',
+        delayMs,
+      }).as('get')
+      .then(() => testDelay()).wait('@get')
+      .then(() => testDelay()).wait('@get')
+      .then(() => testDelay()).wait('@get')
+    })
+
     context('body parsing', function () {
       it('automatically parses JSON request bodies', function () {
         const p = Promise.defer()

--- a/packages/driver/src/cy/net-stubbing/events/response-received.ts
+++ b/packages/driver/src/cy/net-stubbing/events/response-received.ts
@@ -97,8 +97,7 @@ export const onResponseReceived: HandlerFn<NetEventFrames.HttpResponseReceived> 
       return sendContinueFrame()
     },
     delay (delayMs) {
-      // reduce perceived delay by sending timestamp instead of offset
-      continueFrame.continueResponseAt = Date.now() + delayMs
+      continueFrame.delayMs = delayMs
 
       return this
     },

--- a/packages/driver/src/cy/net-stubbing/static-response-utils.ts
+++ b/packages/driver/src/cy/net-stubbing/static-response-utils.ts
@@ -88,7 +88,7 @@ function getFixtureOpts (fixture: string): FixtureOpts {
 }
 
 export function getBackendStaticResponse (staticResponse: Readonly<StaticResponse>): BackendStaticResponse {
-  const backendStaticResponse: BackendStaticResponse = _.omit(staticResponse, 'body', 'fixture', 'delayMs')
+  const backendStaticResponse: BackendStaticResponse = _.omit(staticResponse, 'body', 'fixture')
 
   if (staticResponse.fixture) {
     backendStaticResponse.fixture = getFixtureOpts(staticResponse.fixture)
@@ -101,10 +101,6 @@ export function getBackendStaticResponse (staticResponse: Readonly<StaticRespons
       backendStaticResponse.body = JSON.stringify(staticResponse.body)
       _.set(backendStaticResponse, 'headers.content-type', 'application/json')
     }
-  }
-
-  if (staticResponse.delayMs) {
-    backendStaticResponse.continueResponseAt = Date.now() + staticResponse.delayMs
   }
 
   return backendStaticResponse

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -292,12 +292,7 @@ export type RouteHandler = string | StaticResponse | RouteHandlerController | ob
 /**
  * Describes a response that will be sent back to the browser to fulfill the request.
  */
-export type StaticResponse = GenericStaticResponse<string, string | object> & {
-  /**
-   * Milliseconds to delay before the response is sent.
-   */
- delayMs?: number
-}
+export type StaticResponse = GenericStaticResponse<string, string | object>
 
 export interface GenericStaticResponse<Fixture, Body> {
   /**
@@ -328,6 +323,10 @@ export interface GenericStaticResponse<Fixture, Body> {
    * Kilobits per second to send 'body'.
    */
   throttleKbps?: number
+  /**
+   * Milliseconds to delay before the response is sent.
+   */
+   delayMs?: number
 }
 
 /**

--- a/packages/net-stubbing/lib/internal-types.ts
+++ b/packages/net-stubbing/lib/internal-types.ts
@@ -10,10 +10,7 @@ export type FixtureOpts = {
   filePath: string
 }
 
-export type BackendStaticResponse = GenericStaticResponse<FixtureOpts, string> & {
-  // Millisecond timestamp for when the response should continue
-  continueResponseAt?: number
-}
+export type BackendStaticResponse = GenericStaticResponse<FixtureOpts, string>
 
 export const SERIALIZABLE_REQ_PROPS = [
   'headers',
@@ -91,7 +88,7 @@ export declare namespace NetEventFrames {
     res?: CyHttpMessages.IncomingResponse
     staticResponse?: BackendStaticResponse
     // Millisecond timestamp for when the response should continue
-    continueResponseAt?: number
+    delayMs?: number
     throttleKbps?: number
     followRedirect?: boolean
   }

--- a/packages/net-stubbing/lib/server/intercept-response.ts
+++ b/packages/net-stubbing/lib/server/intercept-response.ts
@@ -103,13 +103,13 @@ export async function onResponseContinue (state: NetStubbingState, frame: NetEve
   debug('_onResponseContinue %o', { backendRequest: _.omit(backendRequest, 'res.body'), frame: _.omit(frame, 'res.body') })
 
   const throttleKbps = _.get(frame, 'staticResponse.throttleKbps') || frame.throttleKbps
-  const continueResponseAt = _.get(frame, 'staticResponse.continueResponseAt') || frame.continueResponseAt
+  const delayMs = _.get(frame, 'staticResponse.delayMs') || frame.delayMs
 
   if (frame.staticResponse) {
     // replacing response with a staticResponse
     await setResponseFromFixture(backendRequest.route.getFixture, frame.staticResponse)
 
-    const staticResponse = _.chain(frame.staticResponse).clone().assign({ continueResponseAt, throttleKbps }).value()
+    const staticResponse = _.chain(frame.staticResponse).clone().assign({ delayMs, throttleKbps }).value()
 
     return sendStaticResponse(backendRequest, staticResponse)
   }
@@ -117,7 +117,7 @@ export async function onResponseContinue (state: NetStubbingState, frame: NetEve
   // merge the changed response attributes with our response and continue
   _.assign(res, _.pick(frame.res, SERIALIZABLE_RES_PROPS))
 
-  const bodyStream = getBodyStream(res.body, { throttleKbps, continueResponseAt })
+  const bodyStream = getBodyStream(res.body, { throttleKbps, delayMs })
 
   return backendRequest.continueResponse!(bodyStream)
 }

--- a/packages/net-stubbing/lib/server/util.ts
+++ b/packages/net-stubbing/lib/server/util.ts
@@ -165,14 +165,13 @@ export function sendStaticResponse (backendRequest: Pick<BackendRequest, 'onErro
     body,
   })
 
-  const bodyStream = getBodyStream(body, _.pick(staticResponse, 'throttleKbps', 'continueResponseAt'))
+  const bodyStream = getBodyStream(body, _.pick(staticResponse, 'throttleKbps', 'delayMs'))
 
   onResponse!(incomingRes, bodyStream)
 }
 
-export function getBodyStream (body: Buffer | string | Readable | undefined, options: { continueResponseAt?: number, throttleKbps?: number }): Readable {
-  const { continueResponseAt, throttleKbps } = options
-  const delayMs = continueResponseAt ? _.max([continueResponseAt - Date.now(), 0]) : 0
+export function getBodyStream (body: Buffer | string | Readable | undefined, options: { delayMs?: number, throttleKbps?: number }): Readable {
+  const { delayMs, throttleKbps } = options
   const pt = new PassThrough()
 
   const sendBody = () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #14446 (programmatic delay)
- Closes #14511 (static delay argument)

### User facing changelog

Fixed an issue where using `delayMs` with `cy.intercept` did not wait for the expected amount of time when used in a `StaticResponse`.

### Additional details

- continueResponseAt was an attempt to be more time-accurate, but let's KISS, this works well enough. it will never be ms-accurate anyways

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
