### PR TITLE
feat: remove deprecated cy.route2 command

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -5,28 +5,6 @@ describe('network stubbing', { retries: 2 }, function () {
     cy.spy(Cypress.utils, 'warning')
   })
 
-  context('cy.route2()', function () {
-    it('emits a warning', function () {
-      cy.route2('*')
-      .then(() => expect(Cypress.utils.warning).to.be.calledWith('`cy.route2()` was renamed to `cy.intercept()` and will be removed in a future release. Please update usages of `cy.route2()` to use `cy.intercept()` instead.'))
-    })
-
-    it('calls through to cy.intercept()', function (done) {
-      cy.route2('*', 'hello world').then(() => {
-        $.get('/abc123').done((responseText, _, xhr) => {
-          expect(responseText).to.eq('hello world')
-
-          done()
-        })
-      })
-    })
-
-    it('can be used with cy.wait', function () {
-      cy.route2('*', 'hello world').as('foo')
-      .then(() => $.get('/abc123')).wait('@foo')
-    })
-  })
-
   context('cy.intercept()', function () {
     beforeEach(function () {
       // we don't use cy.spy() because it causes an infinite loop with logging events

--- a/packages/driver/src/cy/commands/querying.js
+++ b/packages/driver/src/cy/commands/querying.js
@@ -274,7 +274,7 @@ module.exports = (Commands, Cypress, cy, state) => {
             return requests
           }
 
-          if (['route2', 'intercept'].includes(command.get('name'))) {
+          if (command.get('name') === 'intercept') {
             const requests = getAliasedRequests(alias, state)
             // detect alias.all and alias.index
             const specifier = /\.(all|[\d]+)$/.exec(selector)

--- a/packages/driver/src/cy/commands/waiting.js
+++ b/packages/driver/src/cy/commands/waiting.js
@@ -157,7 +157,7 @@ module.exports = (Commands, Cypress, cy, state) => {
       }
 
       const isNetworkInterceptCommand = (command) => {
-        const commandsThatCreateNetworkIntercepts = ['route', 'route2', 'intercept']
+        const commandsThatCreateNetworkIntercepts = ['route', 'intercept']
         const commandName = command.get('name')
 
         return commandsThatCreateNetworkIntercepts.includes(commandName)

--- a/packages/driver/src/cy/net-stubbing/add-command.ts
+++ b/packages/driver/src/cy/net-stubbing/add-command.ts
@@ -278,13 +278,6 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
     return emitNetEvent('route:added', frame)
   }
 
-  function route2 (...args) {
-    $errUtils.warnByPath('net_stubbing.route2_renamed')
-
-    // @ts-ignore
-    return intercept.apply(undefined, args)
-  }
-
   function intercept (matcher: RouteMatcher, handler?: RouteHandler | StringMatcher, arg2?: RouteHandler) {
     function getMatcherOptions (): RouteMatcherOptions {
       if (_.isString(matcher) && $utils.isValidHttpMethod(matcher) && isStringMatcher(handler)) {
@@ -322,8 +315,5 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
     .then(() => null)
   }
 
-  Commands.addAll({
-    intercept,
-    route2,
-  })
+  Commands.addAll({ intercept })
 }

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -915,7 +915,6 @@ module.exports = {
   },
 
   net_stubbing: {
-    route2_renamed: `${cmd('route2')} was renamed to ${cmd('intercept')} and will be removed in a future release. Please update usages of ${cmd('route2')} to use ${cmd('intercept')} instead.`,
     invalid_static_response: ({ cmd, message, staticResponse }) => {
       return cyStripIndent(`\
         An invalid StaticResponse was supplied to \`${cmd}()\`. ${message}

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -395,14 +395,6 @@ declare global {
        */
       intercept(method: Method, url: RouteMatcher, response?: RouteHandler): Chainable<null>
       /**
-       * @deprecated Use `cy.intercept()` instead.
-       */
-      route2(url: RouteMatcher, response?: RouteHandler): Chainable<null>
-      /**
-       * @deprecated Use `cy.intercept()` instead.
-       */
-      route2(method: Method, url: RouteMatcher, response?: RouteHandler): Chainable<null>
-      /**
        * Wait for a specific request to complete.
        *
        * @see https://on.cypress.io/wait


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

BREAKING CHANGE

- Closes <!-- issue number here. e.g. "Closes #1234" -->

### User facing changelog

`cy.route2` was previously aliased to `cy.intercept`. Now the alias `cy.route2` has been removed. Please update usage of `cy.route2` to `cy.intercept`.

### Additional details

- was renamed in 6.0.0 to make the experimentalNetworkStubbing migration easier for users
- has been warning for a major release now so time to remove

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->https://github.com/cypress-io/cypress-documentation/pull/3517
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
