### PR TITLE
fix: close selector playground on restart

### DIFF
--- a/packages/runner/cypress/integration/runner.ui.spec.js
+++ b/packages/runner/cypress/integration/runner.ui.spec.js
@@ -321,6 +321,28 @@ describe('src/cypress/runner', () => {
         cy.percySnapshot()
       })
     })
+
+    context('selector playground', () => {
+      it('shows on click', () => {
+        runIsolatedCypress({})
+
+        cy.get('.selector-playground').should('not.be.visible')
+        cy.get('.selector-playground-toggle').click()
+        cy.get('.selector-playground').should('be.visible')
+
+        cy.percySnapshot()
+      })
+
+      it('closes on restart', () => {
+        runIsolatedCypress({})
+
+        cy.get('.selector-playground-toggle').click()
+        cy.get('.selector-playground').should('be.visible')
+
+        cy.get('.restart').click()
+        cy.get('.selector-playground').should('not.be.visible')
+      })
+    })
   })
 
   describe('reporter interaction', () => {

--- a/packages/runner/src/lib/event-manager.js
+++ b/packages/runner/src/lib/event-manager.js
@@ -8,6 +8,7 @@ import { client, circularParser } from '@packages/socket/lib/browser'
 import automation from './automation'
 import logger from './logger'
 import studioRecorder from '../studio/studio-recorder'
+import selectorPlaygroundModel from '../selector-playground/selector-playground-model'
 
 import $Cypress, { $ } from '@packages/driver'
 
@@ -497,6 +498,7 @@ const eventManager = {
     Cypress.stop()
 
     studioRecorder.setInactive()
+    selectorPlaygroundModel.setOpen(false)
 
     return this._restart()
     .then(() => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #14689

### User facing changelog
Closes selector playground on restart

### Additional details
When launching into studio mode, having the selector playground open would interfere with events being properly recorded and created a poor user experience.

Since we disable the selector playground while tests are running and it gets into a weird state while tests are running (see below), I felt it made most sense to always close the selector playground on restart rather than only when launching into studio.

### How has the user experience changed?

**Without Studio**

Before

![ezgif-4-10caa938fc21](https://user-images.githubusercontent.com/7033952/106022272-a9ca5280-6093-11eb-95d0-44fd0cd8c765.gif)

After

![ezgif-4-514506332032](https://user-images.githubusercontent.com/7033952/106022286-ad5dd980-6093-11eb-9c36-671859ea76af.gif)

**Launching Studio**

Before

![ezgif-5-1357a88b762f](https://user-images.githubusercontent.com/7033952/105445670-82602980-5c3e-11eb-8e45-926177a95ad5.gif)

After

![ezgif-4-5b1825a8d31a](https://user-images.githubusercontent.com/7033952/106022250-a2a34480-6093-11eb-84b5-b30d3ad96f79.gif)

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
