### PR TITLE
fix: studio reloads with updated spec on save even when watchForFileChanges is false

### DIFF
--- a/packages/runner/src/lib/event-manager.js
+++ b/packages/runner/src/lib/event-manager.js
@@ -244,12 +244,9 @@ const eventManager = {
     })
 
     localBus.on('studio:save', (saveInfo) => {
-      ws.emit('studio:save', saveInfo, (success, autoReload) => {
+      ws.emit('studio:save', saveInfo, (success) => {
         if (!success) {
           reporterBus.emit('test:set:state', studioRecorder.saveError, _.noop)
-        } else if (!autoReload) {
-          studioRecorder.cancel()
-          rerun()
         }
       })
     })

--- a/packages/runner/src/lib/event-manager.js
+++ b/packages/runner/src/lib/event-manager.js
@@ -237,9 +237,12 @@ const eventManager = {
     })
 
     localBus.on('studio:save', (saveInfo) => {
-      ws.emit('studio:save', saveInfo, (success) => {
+      ws.emit('studio:save', saveInfo, (success, autoReload) => {
         if (!success) {
           reporterBus.emit('test:set:state', studioRecorder.saveError, _.noop)
+        } else if (!autoReload) {
+          studioRecorder.cancel()
+          rerun()
         }
       })
     })

--- a/packages/server/lib/socket.js
+++ b/packages/server/lib/socket.js
@@ -74,6 +74,8 @@ class Socket {
   }
 
   onStudioTestFileChange (filePath) {
+    // wait for the studio test file to be written to disk, then reload the test
+    // and remove the listener (since this handler is only invoked when watchForFileChanges is false)
     return this.onTestFileChange(filePath).then(() => {
       this.removeOnStudioTestFileChange()
     })
@@ -484,6 +486,8 @@ class Socket {
       })
 
       socket.on('studio:save', (saveInfo, cb) => {
+        // even if the user has turned off file watching
+        // we want to force a reload on save
         if (!config.watchForFileChanges) {
           preprocessor.emitter.on('file:updated', this.onStudioTestFileChange)
         }

--- a/packages/server/lib/socket.js
+++ b/packages/server/lib/socket.js
@@ -473,7 +473,9 @@ class Socket {
 
       socket.on('studio:save', (saveInfo, cb) => {
         studio.save(saveInfo)
-        .then(cb)
+        .then((success) => {
+          cb(success, config.watchForFileChanges)
+        })
       })
 
       reporterEvents.forEach((event) => {

--- a/packages/server/lib/socket.js
+++ b/packages/server/lib/socket.js
@@ -483,7 +483,7 @@ class Socket {
         .then((success) => {
           cb(success)
 
-          if (!config.watchForFileChanges) {
+          if (success && !config.watchForFileChanges) {
             preprocessor.emitter.on('file:updated', this.onStudioTestFileChange)
           }
         })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #14744

### User facing changelog
Fixes an issue where studio would not exit with configuration `"watchForFileChanges": false`

### Additional details
So I found it pretty difficult to write any tests for this that were effective so there are no tests included in this fix. I'd be open to adding unit/integration tests for `event-manager.js` but not sure what would be possible outside of that.

### How has the user experience changed?
Studio will always exit and the TR will rerun all tests regardless of what `watchForFileChanges` is set to

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
