### PR TITLE
fix(studio): generate selectors before mouse events on click

### DIFF
--- a/packages/driver/cypress/fixtures/studio-selectors.html
+++ b/packages/driver/cypress/fixtures/studio-selectors.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <button data-cy="btn1" data-test="btn1" data-testid="btn1" id="btn1" class="btn1" type="button">data-cy</button>
+    <button data-test="btn2" data-testid="btn2" id="btn2" class="btn2" type="button">data-test</button>
+    <button data-testid="btn3" id="btn3" class="btn3" type="button">data-testid</button>
+    <button id="btn4" class="btn4" type="button">id</button>
+    <button class="btn5" type="button">class</button>
+    <button type="submit">attribute</button>
+    <button>nth-child</button>
+    <p>tag</p>
+  </body>
+</html>

--- a/packages/driver/cypress/fixtures/studio.html
+++ b/packages/driver/cypress/fixtures/studio.html
@@ -12,6 +12,8 @@
   <button class="interactive">changing button</button>
   <button class="interactive">another changing button</button>
   <button class="interactive">3rd changing button</button>
+  <button class="both">both</button>
+  <button class="both">another both</button>
   <button class="mdown">click adds class removed by mousedown</button>
   <button class="mdown">mdown</button>
   <script>
@@ -29,6 +31,16 @@
 
     btn3.addEventListener('mousedown', function() {
       btn3.classList.add('mousedown')
+    })
+
+    const both = document.getElementsByClassName('both')[0]
+
+    both.addEventListener('mouseover', function() {
+      both.classList.add('mouseover')
+    })
+
+    both.addEventListener('mousedown', function() {
+      both.classList.add('mousedown')
     })
 
     const mdown = document.getElementsByClassName('mdown')[0]

--- a/packages/driver/cypress/fixtures/studio.html
+++ b/packages/driver/cypress/fixtures/studio.html
@@ -2,5 +2,44 @@
 <html>
   <body>
     <button class="btn">button</button>
+    <input id="input-text" type="text" />
+    <input id="input-radio" type="radio" />
+    <input id="input-checkbox" type="checkbox" />
+    <select id="select">
+        <option value="0">0</option>
+        <option value="1">1</option>
+    </select>
+  <button class="interactive">changing button</button>
+  <button class="interactive">another changing button</button>
+  <button class="interactive">3rd changing button</button>
+  <button class="mdown">click adds class removed by mousedown</button>
+  <button class="mdown">mdown</button>
+  <script>
+    const btn1 = document.getElementsByClassName('interactive')[0]
+    const btn2 = document.getElementsByClassName('interactive')[1]
+    const btn3 = document.getElementsByClassName('interactive')[2]
+
+    btn1.addEventListener('mouseover', function() {
+      btn1.classList.add('mouseover')
+    })
+
+    btn2.addEventListener('mouseenter', function() {
+      btn2.classList.add('mouseenter')
+    })
+
+    btn3.addEventListener('mousedown', function() {
+      btn3.classList.add('mousedown')
+    })
+
+    const mdown = document.getElementsByClassName('mdown')[0]
+
+    mdown.addEventListener('mousedown', function() {
+      mdown.classList.remove('clicked')
+    })
+
+    mdown.addEventListener('click', function() {
+      mdown.classList.add('clicked')
+    })
+  </script>
   </body>
 </html>

--- a/packages/driver/cypress/fixtures/studio.html
+++ b/packages/driver/cypress/fixtures/studio.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <button class="btn">button</button>
+  </body>
+</html>

--- a/packages/runner/cypress/integration/studio.record.spec.js
+++ b/packages/runner/cypress/integration/studio.record.spec.js
@@ -82,7 +82,6 @@ describe('studio record', () => {
     it('uses the selector for an element before it changes from mousedown', () => {
       // this is a very specific example to illustrate why we must
       // track mousedown and not only mouseover
-
       runCypressStudio()
       .then(() => {
         getFrame().find('.mdown').first().click().should('have.class', 'clicked')

--- a/packages/runner/cypress/integration/studio.record.spec.js
+++ b/packages/runner/cypress/integration/studio.record.spec.js
@@ -3,7 +3,7 @@ const helpers = require('../support/helpers')
 const { createCypress } = helpers
 const { runIsolatedCypress } = createCypress({ config: { experimentalStudio: true } })
 
-const runCypressStudio = () => {
+const runCypressStudio = (visitUrl = 'http://localhost:3500/fixtures/studio.html') => {
   return runIsolatedCypress('cypress/fixtures/studio/basic_spec.js', {
     config: {
       env: {
@@ -13,7 +13,7 @@ const runCypressStudio = () => {
     state: {
       studioTestId: 'r3',
     },
-    visitUrl: 'http://localhost:3500/fixtures/studio.html',
+    visitUrl,
   })
 }
 
@@ -40,14 +40,219 @@ const verifyCommandLog = (index, { selector, name, message }) => {
 }
 
 describe('studio record', () => {
-  it('records click event', () => {
-    runCypressStudio()
-    .then(() => {
-      getFrame().find('.btn').click({ force: true })
+  context('click', () => {
+    it('records click event', () => {
+      runCypressStudio()
+      .then(() => {
+        getFrame().find('.btn').click()
 
-      verifyCommandLog(1, {
-        selector: '.btn',
-        name: 'click',
+        verifyCommandLog(1, {
+          selector: '.btn',
+          name: 'click',
+        })
+      })
+    })
+
+    // https://github.com/cypress-io/cypress/issues/14658
+    it('uses the selector for an element before it changes from mouse events', () => {
+      runCypressStudio()
+      .then(() => {
+        getFrame().find('.interactive').eq(0).click().should('have.class', 'mouseover')
+        getFrame().find('.interactive').eq(1).click().should('have.class', 'mouseenter')
+        getFrame().find('.interactive').eq(2).click().should('have.class', 'mousedown')
+
+        verifyCommandLog(1, {
+          selector: ':nth-child(6)',
+          name: 'click',
+        })
+
+        verifyCommandLog(2, {
+          selector: ':nth-child(7)',
+          name: 'click',
+        })
+
+        verifyCommandLog(3, {
+          selector: ':nth-child(8)',
+          name: 'click',
+        })
+      })
+    })
+
+    // https://github.com/cypress-io/cypress/issues/14658
+    it('uses the selector for an element before it changes from mousedown', () => {
+      // this is a very specific example to illustrate why we must
+      // track mousedown and not only mouseover
+
+      runCypressStudio()
+      .then(() => {
+        getFrame().find('.mdown').first().click().should('have.class', 'clicked')
+        getFrame().find('.mdown').first().click()
+
+        verifyCommandLog(1, {
+          selector: ':nth-child(9)',
+          name: 'click',
+        })
+
+        verifyCommandLog(2, {
+          selector: '.clicked',
+          name: 'click',
+        })
+      })
+    })
+  })
+
+  context('type', () => {
+    it('records type event', () => {
+      runCypressStudio()
+      .then(() => {
+        getFrame().find('#input-text').type('this was typed')
+
+        verifyCommandLog(1, {
+          selector: '#input-text',
+          name: 'type',
+          message: 'this was typed',
+        })
+      })
+    })
+
+    it('records special characters', () => {
+      runCypressStudio()
+      .then(() => {
+        getFrame().find('#input-text').type('this was typed{enter}')
+
+        verifyCommandLog(1, {
+          selector: '#input-text',
+          name: 'type',
+          message: 'this was typed{enter}',
+        })
+      })
+    })
+  })
+
+  context('check and uncheck', () => {
+    it('records checks for radio buttons', () => {
+      runCypressStudio()
+      .then(() => {
+        getFrame().find('#input-radio').click()
+
+        verifyCommandLog(1, {
+          selector: '#input-radio',
+          name: 'check',
+        })
+      })
+    })
+
+    it('records checks and unchecks for checkboxes', () => {
+      runCypressStudio()
+      .then(() => {
+        getFrame().find('#input-checkbox').click()
+
+        verifyCommandLog(1, {
+          selector: '#input-checkbox',
+          name: 'check',
+        })
+
+        getFrame().find('#input-checkbox').click()
+
+        verifyCommandLog(2, {
+          selector: '#input-checkbox',
+          name: 'uncheck',
+        })
+      })
+    })
+  })
+
+  context('select', () => {
+    it('records select events', () => {
+      runCypressStudio()
+      .then(() => {
+        getFrame().find('#select').select('1')
+
+        // we check the 3rd log since cypress issues a click event
+        // on the option - this does not happen from a real user
+        verifyCommandLog(3, {
+          selector: '#select',
+          name: 'select',
+          message: '1',
+        })
+      })
+    })
+  })
+
+  context('selectors', () => {
+    it('generates unique selectors for each element with priority', () => {
+      runCypressStudio('http://localhost:3500/fixtures/studio-selectors.html')
+      .then(() => {
+        getFrame().find('button').click({ multiple: true })
+        getFrame().find('p').click()
+
+        verifyCommandLog(1, {
+          selector: '[data-cy=btn1]',
+          name: 'click',
+        })
+
+        verifyCommandLog(2, {
+          selector: '[data-test=btn2]',
+          name: 'click',
+        })
+
+        verifyCommandLog(3, {
+          selector: '[data-testid=btn3]',
+          name: 'click',
+        })
+
+        verifyCommandLog(4, {
+          selector: '#btn4',
+          name: 'click',
+        })
+
+        verifyCommandLog(5, {
+          selector: '.btn5',
+          name: 'click',
+        })
+
+        verifyCommandLog(6, {
+          selector: '[type="submit"]',
+          name: 'click',
+        })
+
+        verifyCommandLog(7, {
+          selector: ':nth-child(7)',
+          name: 'click',
+        })
+
+        verifyCommandLog(8, {
+          selector: 'p',
+          name: 'click',
+        })
+      })
+    })
+  })
+
+  context('command log', () => {
+    it('will remove command on button click', () => {
+      runCypressStudio()
+      .then(() => {
+        getFrame().find('.btn').click().click()
+
+        verifyCommandLog(1, {
+          selector: '.btn',
+          name: 'click',
+        })
+
+        verifyCommandLog(2, {
+          selector: '.btn',
+          name: 'click',
+        })
+
+        getParentCommand(2).find('.studio-command-remove').click()
+
+        verifyCommandLog(1, {
+          selector: '.btn',
+          name: 'click',
+        })
+
+        cy.get('.reporter').find('.hook-studio').find('.command-number').contains('2').should('not.exist')
       })
     })
   })

--- a/packages/runner/cypress/integration/studio.record.spec.js
+++ b/packages/runner/cypress/integration/studio.record.spec.js
@@ -79,8 +79,21 @@ describe('studio record', () => {
     })
 
     // https://github.com/cypress-io/cypress/issues/14658
+    it('uses the original selector for an element with both mouseover and mousedown handlers', () => {
+      runCypressStudio()
+      .then(() => {
+        getFrame().find('.both').first().click().should('have.class', 'mouseover').should('have.class', 'mousedown')
+
+        verifyCommandLog(1, {
+          selector: ':nth-child(9)',
+          name: 'click',
+        })
+      })
+    })
+
+    // https://github.com/cypress-io/cypress/issues/14658
     it('uses the selector for an element before it changes from mousedown', () => {
-      // this is a very specific example to illustrate why we must
+      // this is a very unique example to illustrate why we must
       // track mousedown and not only mouseover
       runCypressStudio()
       .then(() => {
@@ -88,7 +101,7 @@ describe('studio record', () => {
         getFrame().find('.mdown').first().click()
 
         verifyCommandLog(1, {
-          selector: ':nth-child(9)',
+          selector: ':nth-child(11)',
           name: 'click',
         })
 

--- a/packages/runner/cypress/integration/studio.record.spec.js
+++ b/packages/runner/cypress/integration/studio.record.spec.js
@@ -1,0 +1,54 @@
+const helpers = require('../support/helpers')
+
+const { createCypress } = helpers
+const { runIsolatedCypress } = createCypress({ config: { experimentalStudio: true } })
+
+const runCypressStudio = () => {
+  return runIsolatedCypress('cypress/fixtures/studio/basic_spec.js', {
+    config: {
+      env: {
+        INTERNAL_E2E_TESTS: 1,
+      },
+    },
+    state: {
+      studioTestId: 'r3',
+    },
+    visitUrl: 'http://localhost:3500/fixtures/studio.html',
+  })
+}
+
+const getFrame = () => {
+  return cy.get('.aut-iframe').its('0.contentDocument').its('body').should('not.be.undefined').then(cy.wrap)
+}
+
+const getParentCommand = (index) => {
+  return cy.get('.reporter').find('.hook-studio').find('.command-number').contains(index).closest('.command')
+}
+
+const getChildCommand = (index) => {
+  return getParentCommand(index).next('.command')
+}
+
+const verifyCommandLog = (index, { selector, name, message }) => {
+  getParentCommand(index).find('.command-message').should('have.text', selector)
+
+  getChildCommand(index).find('.command-method').should('have.text', name)
+
+  if (message) {
+    getChildCommand(index).find('.command-message').should('have.text', message)
+  }
+}
+
+describe('studio record', () => {
+  it('records click event', () => {
+    runCypressStudio()
+    .then(() => {
+      getFrame().find('.btn').click({ force: true })
+
+      verifyCommandLog(1, {
+        selector: '.btn',
+        name: 'click',
+      })
+    })
+  })
+})

--- a/packages/runner/src/header/header.scss
+++ b/packages/runner/src/header/header.scss
@@ -397,10 +397,6 @@
       }
     }
 
-    .available-commands {
-      padding: 10px;
-    }
-
     .studio-controls {
       display: flex;
       margin-left: auto;

--- a/packages/runner/src/studio/studio-recorder.js
+++ b/packages/runner/src/studio/studio-recorder.js
@@ -36,8 +36,8 @@ export class StudioRecorder {
   @observable isLoading = false
   @observable isActive = false
   @observable url = null
-  @observable _hasStarted = false
   @observable isFailed = false
+  @observable _hasStarted = false
 
   fileDetails = null
   _currentId = 1
@@ -227,6 +227,8 @@ export class StudioRecorder {
         passive: true,
       })
     })
+
+    this._clearPreviousMouseEvent()
   }
 
   removeListeners = () => {
@@ -243,6 +245,8 @@ export class StudioRecorder {
         capture: true,
       })
     })
+
+    this._clearPreviousMouseEvent()
   }
 
   _trustEvent = (event) => {

--- a/packages/server/__snapshots__/3_studio_spec.ts.js
+++ b/packages/server/__snapshots__/3_studio_spec.ts.js
@@ -84,8 +84,6 @@ describe('extends test', () => {
     cy.get('.input-checkbox', { log: false }).click({ log: false })
     cy.get('.input-checkbox', { log: false }).click({ log: false })
     cy.get('.select', { log: false }).select('1', { log: false })
-    cy.get('button', { log: false }).click({ log: false, multiple: true })
-    cy.get('p', { log: false }).click({ log: false })
 
     verifyCommandLog(1, {
       selector: '.link',
@@ -129,46 +127,6 @@ describe('extends test', () => {
       message: '1',
     })
 
-    verifyCommandLog(9, {
-      selector: '[data-cy=btn1]',
-      name: 'click',
-    })
-
-    verifyCommandLog(10, {
-      selector: '[data-test=btn2]',
-      name: 'click',
-    })
-
-    verifyCommandLog(11, {
-      selector: '[data-testid=btn3]',
-      name: 'click',
-    })
-
-    verifyCommandLog(12, {
-      selector: '#btn4',
-      name: 'click',
-    })
-
-    verifyCommandLog(13, {
-      selector: '.btn5',
-      name: 'click',
-    })
-
-    verifyCommandLog(14, {
-      selector: '[type="submit"]',
-      name: 'click',
-    })
-
-    verifyCommandLog(15, {
-      selector: ':nth-child(12)',
-      name: 'click',
-    })
-
-    verifyCommandLog(16, {
-      selector: 'p',
-      name: 'click',
-    })
-
     saveStudio()
     /* ==== Generated with Cypress Studio ==== */
     cy.get('.link').click();
@@ -179,14 +137,6 @@ describe('extends test', () => {
     cy.get('.select').click();
     cy.get('[value="1"]').click();
     cy.get('.select').select('1');
-    cy.get('[data-cy=btn1]').click();
-    cy.get('[data-test=btn2]').click();
-    cy.get('[data-testid=btn3]').click();
-    cy.get('#btn4').click();
-    cy.get('.btn5').click();
-    cy.get('[type="submit"]').click();
-    cy.get(':nth-child(12)').click();
-    cy.get('p').click();
     /* ==== End Cypress Studio ==== */
   })
 })

--- a/packages/server/test/support/fixtures/projects/studio/cypress/integration/extend.spec.js
+++ b/packages/server/test/support/fixtures/projects/studio/cypress/integration/extend.spec.js
@@ -18,8 +18,6 @@ describe('extends test', () => {
     cy.get('.input-checkbox', { log: false }).click({ log: false })
     cy.get('.input-checkbox', { log: false }).click({ log: false })
     cy.get('.select', { log: false }).select('1', { log: false })
-    cy.get('button', { log: false }).click({ log: false, multiple: true })
-    cy.get('p', { log: false }).click({ log: false })
 
     verifyCommandLog(1, {
       selector: '.link',
@@ -61,46 +59,6 @@ describe('extends test', () => {
       selector: '.select',
       name: 'select',
       message: '1',
-    })
-
-    verifyCommandLog(9, {
-      selector: '[data-cy=btn1]',
-      name: 'click',
-    })
-
-    verifyCommandLog(10, {
-      selector: '[data-test=btn2]',
-      name: 'click',
-    })
-
-    verifyCommandLog(11, {
-      selector: '[data-testid=btn3]',
-      name: 'click',
-    })
-
-    verifyCommandLog(12, {
-      selector: '#btn4',
-      name: 'click',
-    })
-
-    verifyCommandLog(13, {
-      selector: '.btn5',
-      name: 'click',
-    })
-
-    verifyCommandLog(14, {
-      selector: '[type="submit"]',
-      name: 'click',
-    })
-
-    verifyCommandLog(15, {
-      selector: ':nth-child(12)',
-      name: 'click',
-    })
-
-    verifyCommandLog(16, {
-      selector: 'p',
-      name: 'click',
     })
 
     saveStudio()

--- a/packages/server/test/support/fixtures/projects/studio/index.html
+++ b/packages/server/test/support/fixtures/projects/studio/index.html
@@ -8,13 +8,5 @@
       <option value="0">0</option>
       <option value="1">1</option>
   </select>
-  <button data-cy="btn1" data-test="btn1" data-testid="btn1" id="btn1" class="btn1" type="button">data-cy</button>
-  <button data-test="btn2" data-testid="btn2" id="btn2" class="btn2" type="button">data-test</button>
-  <button data-testid="btn3" id="btn3" class="btn3" type="button">data-testid</button>
-  <button id="btn4" class="btn4" type="button">id</button>
-  <button class="btn5" type="button">class</button>
-  <button type="submit">attribute</button>
-  <button>nth-child</button>
-  <p>tag</p>
 </body>
 </html>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #14658

### User facing changelog
Fixes a bug where Studio might generate invalid selectors for click events

### Additional details
Since events such as mouseover and mousedown might trigger changes in state within an application, we need to record the state of an element before these events occur in order to generate a working selector. Since `cy.click()` simulates these mouse events before clicking, we know that the application state will change properly with these generated selectors.

Also added a bunch of additional studio tests in the runner and simplified the e2e test content since the selectors are tested in the isolated runner now.

Tiny change to some misplaced padding in the "Available Commands" link, too.

Note: this could cause some small changes that I don't feel are worth addressing now - for example if an input adds a class on hover and the user hovers, then clicks, then types; the click and type events may technically have different selectors, resulting in 2 commands being added to the studio log rather than one (the two will still work correctly, one is just unnecessary).

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
