### PR TITLE
chore: Add workflow to create Jira issues

### DIFF
--- a/.github/workflows/jira-issue-sync.yml
+++ b/.github/workflows/jira-issue-sync.yml
@@ -1,4 +1,4 @@
-name: Create Internal Issue on Jira
+name: Create Internal Issue on Jira from Issue
 
 on:
   # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#issues
@@ -7,9 +7,10 @@ on:
     types: [labeled]
 
 jobs:
-  jira:
+  create-jira-issue-from-labeled-issue:
     runs-on: ubuntu-latest
     steps:
+      # https://github.com/atlassian/gajira-login
       - name: Jira login
         id: login
         uses: atlassian/gajira-login@master
@@ -18,6 +19,7 @@ jobs:
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 
+      # https://github.com/atlassian/gajira-create
       - name: Create TR Jira issue for internal-priority labels
         id: create_jira_internal_priority_issue
         if: github.event.label.name == 'internal-priority'
@@ -28,9 +30,11 @@ jobs:
           summary: |
             ${{ github.event.issue.title }}
           description: |
-            ${{ github.event.issue.body }}
-            ----
-            ${{ github.event.issue.html_url }}
+            Created via GitHub Action with 'internal-priority' label.
+          # Find all available fields JIRA_BASE_URL/rest/api/3/field
+          fields: '{"customfield_10032": "${{ github.event.issue.html_url }}"}'
+
+      # https://github.com/actions/github-script
       - name: Add comment to GitHub issue
         uses: actions/github-script@v3
         with:
@@ -41,4 +45,4 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: 'Internal Jira issue: [${{ steps.create_jira_internal_priority_issue.outputs.issue }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create_jira_internal_priority_issue.outputs.issue }})'
-            })
+            }) 

--- a/.github/workflows/jira-issues.yml
+++ b/.github/workflows/jira-issues.yml
@@ -1,0 +1,44 @@
+name: Create Internal Issue on Jira
+
+on:
+  # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#issues
+  # https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#issues
+  issues:
+    types: [labeled]
+
+jobs:
+  jira:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Jira login
+        id: login
+        uses: atlassian/gajira-login@master
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Create TR Jira issue for internal-priority labels
+        id: create_jira_internal_priority_issue
+        if: github.event.label.name == 'internal-priority'
+        uses: atlassian/gajira-create@master
+        with:
+          project: TR
+          issuetype: Bug
+          summary: |
+            ${{ github.event.issue.title }}
+          description: |
+            ${{ github.event.issue.body }}
+            ----
+            ${{ github.event.issue.html_url }}
+      - name: Add comment to GitHub issue
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Internal Jira issue: [${{ steps.create_jira_internal_priority_issue.outputs.issue }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create_jira_internal_priority_issue.outputs.issue }})'
+            })

--- a/.github/workflows/jira-pr-sync.yml
+++ b/.github/workflows/jira-pr-sync.yml
@@ -1,0 +1,49 @@
+name: Create Internal Issue on Jira from PR
+
+on:
+  # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
+  # https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#pull_request
+  pull_request:
+    types: [labeled]
+
+jobs:
+  create-jira-issue-from-labeled-pr:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/atlassian/gajira-login
+      - name: Jira login
+        id: login
+        uses: atlassian/gajira-login@master
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      # https://github.com/atlassian/gajira-create
+      - name: Create TR Jira issue for internal-priority labels
+        id: create_jira_internal_priority_issue
+        if: github.event.label.name == 'internal-priority'
+        uses: atlassian/gajira-create@master
+        with:
+          project: TR
+          issuetype: Bug
+          summary: |
+            ${{ github.event.pull_request.title }}
+          description: |
+            Created via GitHub Action with 'internal-priority' label.
+          # Find all available fields JIRA_BASE_URL/rest/api/3/field
+          fields: '{"customfield_10032": "${{ github.event.pull_request.html_url }}"}'
+
+
+      # https://github.com/actions/github-script
+      - name: Add comment to GitHub PR
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Internal Jira issue: [${{ steps.create_jira_internal_priority_issue.outputs.issue }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create_jira_internal_priority_issue.outputs.issue }})'
+            }) 


### PR DESCRIPTION
### Summary 

When a GitHub issue or PR is labeled 'internal-priority', a Jira issue will be created and a comment will be made on the original GitHub issue or PR linking to the Jira issue.

I tested this in this test repo: https://github.com/cypress-io/gh-actions-test

### Jira issue details when created

- Jira issue title will match title of GitHub issue/PR
- Jira summary will show note "Created via GitHub Action with 'internal-priority' label
- GitHub Link field will link to original issue/PR
- Reporter will be shown as Jennifer Shehane (it's using my Jira email)

<img width="582" alt="Screen Shot 2021-01-29 at 3 04 33 PM" src="https://user-images.githubusercontent.com/1271364/106252471-b641dd00-6244-11eb-80f9-f0d997c20496.png">


### Comment made on original issue/PR

<img width="566" alt="Screen Shot 2021-01-29 at 3 04 01 PM" src="https://user-images.githubusercontent.com/1271364/106252408-a4603a00-6244-11eb-954d-4aa2eda86b39.png">

### Caveats

- *(edited)* The GitHub Action will not work on forked PRs because the secrets needed to execute the workflow are not available on forked PRs.
- If you mark an issue/PR with the 'internal-priority' label multiple times, it will create multiple issues in Jira. Say you add label, remove label, re-add label. This would have created 2 Jira issues.
- No syncing of existing GitHub issue/PR to Jira after creation. Removing the 'internal-prioirty' label will not do anything. 
- This is running a 3rd party action on our repo, albeit from Atlasssian which is a verified action creator. 

### Optimizations

- We could add this workflow to other repos, so we could import Jira issues from the docs/docker repo, etc.
- I **think** I could probably add better syncing...with a lot more work....or with less work but making the issue titles look ugly with the Jira ID in it.
- I could fill in some extra fields on the Jira issue, but I couldn't come up with anything that relevant.