### PR TITLE
fix: Revert Browser.setDownloadBehavior to Page.setDownloaderBehavior

### DIFF
--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -353,7 +353,7 @@ const _handleDownloads = async function (client, dir, automation) {
     })
   })
 
-  await client.send('Browser.setDownloadBehavior', {
+  await client.send('Page.setDownloadBehavior', {
     behavior: 'allow',
     downloadPath: dir,
   })

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -31,7 +31,7 @@ namespace CRI {
     'Page.navigate' |
     'Page.startScreencast' |
     'Page.screencastFrameAck' |
-    'Browser.setDownloadBehavior'
+    'Page.setDownloadBehavior'
 
   export type EventName =
     'Page.screencastFrame' |

--- a/packages/server/test/unit/browsers/chrome_spec.js
+++ b/packages/server/test/unit/browsers/chrome_spec.js
@@ -70,7 +70,7 @@ describe('lib/browsers/chrome', () => {
 
         expect(this.criClient.send).to.have.been.calledWith('Page.navigate')
         expect(this.criClient.send).to.have.been.calledWith('Page.enable')
-        expect(this.criClient.send).to.have.been.calledWith('Browser.setDownloadBehavior')
+        expect(this.criClient.send).to.have.been.calledWith('Page.setDownloadBehavior')
       })
     })
 


### PR DESCRIPTION


<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->


### User facing changelog

N/A - This fixes an issues that's only in `develop`

### Additional details

CDP has deprecated `Page.setDownloadBehavior` in favor of `Browser.setDownloaderBehavior`, but `Browser.setDownloadBehavior` isn't available in older versions of Chrome and will throw an error, whereas `Page.setDownloadBehavior` still works even in newer versions of Chrome.
