### PR TITLE
fix: include project folder when reporting no specs found

### DIFF
--- a/packages/server/__snapshots__/5_specs_spec.js
+++ b/packages/server/__snapshots__/5_specs_spec.js
@@ -14,7 +14,7 @@ We searched for any files matching this glob pattern:
 
 cypress/integration/cypress/integration/**notfound**
 
-With respect to the project root folder:
+Relative to the project root folder:
 
 /foo/bar/.projects/e2e
 

--- a/packages/server/__snapshots__/5_specs_spec.js
+++ b/packages/server/__snapshots__/5_specs_spec.js
@@ -14,4 +14,8 @@ We searched for any files matching this glob pattern:
 
 cypress/integration/cypress/integration/**notfound**
 
+With respect to the project root folder:
+
+/foo/bar/.projects/e2e
+
 `

--- a/packages/server/__snapshots__/7_record_spec.js
+++ b/packages/server/__snapshots__/7_record_spec.js
@@ -799,7 +799,7 @@ We searched for any files matching this glob pattern:
 
 cypress/integration/notfound/**
 
-With respect to the project root folder:
+Relative to the project root folder:
 
 /foo/bar/.projects/e2e
 

--- a/packages/server/__snapshots__/7_record_spec.js
+++ b/packages/server/__snapshots__/7_record_spec.js
@@ -799,6 +799,10 @@ We searched for any files matching this glob pattern:
 
 cypress/integration/notfound/**
 
+With respect to the project root folder:
+
+/foo/bar/.projects/e2e
+
 `
 
 exports['e2e record recordKey warns but does not exit when is forked pr 1'] = `

--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -497,6 +497,7 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
         Error writing to: ${chalk.blue(filePath)}
 
         ${chalk.yellow(err)}`
+
     case 'NO_SPECS_FOUND':
       // no glob provided, searched all specs
       if (!arg2) {
@@ -513,7 +514,11 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
 
         We searched for any files matching this glob pattern:
 
-        ${chalk.blue(arg2)}`
+        ${chalk.blue(arg2)}
+
+        With respect to the project root folder:
+
+        ${chalk.blue(arg1)}`
 
     case 'RENDERER_CRASHED':
       return stripIndent`\

--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -516,7 +516,7 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
 
         ${chalk.blue(arg2)}
 
-        With respect to the project root folder:
+        Relative to the project root folder:
 
         ${chalk.blue(arg1)}`
 

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1476,7 +1476,13 @@ module.exports = {
           }
 
           if (!specs.length) {
-            errors.throw('NO_SPECS_FOUND', config.integrationFolder, specPattern)
+            // did we use the spec pattern?
+            if (specPattern) {
+              errors.throw('NO_SPECS_FOUND', projectRoot, specPattern)
+            } else {
+              // else we looked in the integration folder
+              errors.throw('NO_SPECS_FOUND', config.integrationFolder, specPattern)
+            }
           }
 
           if (browser.family === 'chromium') {

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -854,32 +854,40 @@ describe('lib/cypress', () => {
       })
     })
 
-    it('logs error and exits when spec file was specified and does not exist', function () {
-      return cypress.start([`--run-project=${this.todosPath}`, '--spec=path/to/spec'])
-      .then(() => {
-        this.expectExitWithErr('NO_SPECS_FOUND', 'path/to/spec')
-        this.expectExitWithErr('NO_SPECS_FOUND', 'We searched for any files matching this glob pattern:')
+    describe('no specs found', function () {
+      it('logs error and exits when spec file was specified and does not exist', function () {
+        return cypress.start([`--run-project=${this.todosPath}`, '--spec=path/to/spec'])
+        .then(() => {
+          // includes the search spec
+          this.expectExitWithErr('NO_SPECS_FOUND', 'path/to/spec')
+          this.expectExitWithErr('NO_SPECS_FOUND', 'We searched for any files matching this glob pattern:')
+          // includes the project path
+          this.expectExitWithErr('NO_SPECS_FOUND', this.todosPath)
+        })
       })
-    })
 
-    it('logs error and exits when spec absolute file was specified and does not exist', function () {
-      return cypress.start([
-        `--run-project=${this.todosPath}`,
-        `--spec=${this.todosPath}/tests/path/to/spec`,
-      ])
-      .then(() => {
-        this.expectExitWithErr('NO_SPECS_FOUND', 'tests/path/to/spec')
+      it('logs error and exits when spec absolute file was specified and does not exist', function () {
+        return cypress.start([
+          `--run-project=${this.todosPath}`,
+          `--spec=${this.todosPath}/tests/path/to/spec`,
+        ])
+        .then(() => {
+          // includes path to the spec
+          this.expectExitWithErr('NO_SPECS_FOUND', 'tests/path/to/spec')
+          // includes folder name
+          this.expectExitWithErr('NO_SPECS_FOUND', this.todosPath)
+        })
       })
-    })
 
-    it('logs error and exits when no specs were found at all', function () {
-      return cypress.start([
-        `--run-project=${this.todosPath}`,
-        '--config=integrationFolder=cypress/specs',
-      ])
-      .then(() => {
-        this.expectExitWithErr('NO_SPECS_FOUND', 'We searched for any files inside of this folder:')
-        this.expectExitWithErr('NO_SPECS_FOUND', 'cypress/specs')
+      it('logs error and exits when no specs were found at all', function () {
+        return cypress.start([
+          `--run-project=${this.todosPath}`,
+          '--config=integrationFolder=cypress/specs',
+        ])
+        .then(() => {
+          this.expectExitWithErr('NO_SPECS_FOUND', 'We searched for any files inside of this folder:')
+          this.expectExitWithErr('NO_SPECS_FOUND', 'cypress/specs')
+        })
       })
     })
 


### PR DESCRIPTION
- Closes #14532

### User facing changelog

When using `--spec` or `cypress.run({ spec: ... })` parameter, the error message will now show the project folder, helping debug the "specs not found" error

### Additional details

I had the same problem as the reported issue. I always forgot if `--spec <path>` is relative to the integration folder or to the project root folder. Including the folder used in the error message will help a lot.

### How has the user experience changed?

Imagine you ran `cypress run --spec my-spec.js` in the project folder "/projects/my-folder", and there is no `my-spec.js`

Before:

```
Can't run because no spec files were found.

We searched for any files matching this glob pattern:

my-spec.js
```

After

```
Can't run because no spec files were found.

We searched for any files matching this glob pattern:

my-spec.js

With respect to the project root folder:

/projects/my-folder
```


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
