### PR TITLE
fix(component-testing): remove default export

### DIFF
--- a/npm/react/src/index.ts
+++ b/npm/react/src/index.ts
@@ -1,6 +1,3 @@
 export * from './mount'
 
 export * from './mountHook'
-
-/** @deprecated */
-export { default } from './mount'


### PR DESCRIPTION
Ensure the existing CT solutions is not broken by the new CT changes.

I tested it like this:

- in `npm/react` run `node ../../scripts/start.js --project ${PWD}` (e2e runner + CT plugin)
- in `npm/react` run `node ../../scripts/start.js --component-testing --project ${PWD}` (new CT runner)

I had to delete the export default, but this seems fine? It is marked for deprecation and this is basically a new major version (ideally CT goes out with 7.0).
