### PR TITLE
chore: add comprehensive error message if dev-server is not registered

### DIFF
--- a/packages/server/lib/plugins/dev-server.js
+++ b/packages/server/lib/plugins/dev-server.js
@@ -32,6 +32,11 @@ const API = {
   emitter: baseEmitter,
 
   start ({ specs, config }) {
+    if (!plugins.has('dev-server:start')) {
+      // TODO: add link to the documentation in the error message
+      throw new Error('It is required to register dev-server plugin that implements `dev-server:start` event for component testing.')
+    }
+
     return plugins.execute('dev-server:start', { specs, config })
   },
 


### PR DESCRIPTION
Fixes an issue if devserver not registered. 

> I tried to write a unit test for this, but project-ct is sooo complicated and it is required to mock dozens of functions to get to the state when `_initiPlugins` called. 