### PR TITLE
feat: rename delayMs to delay, deprecate delay

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1019,8 +1019,8 @@ describe('network stubbing', { retries: 2 }, function () {
     it('can delay and throttle a StaticResponse', function (done) {
       const payload = 'A'.repeat(10 * 1024)
       const throttleKbps = 10
-      const delayMs = 250
-      const expectedSeconds = payload.length / (1024 * throttleKbps) + delayMs / 1000
+      const delay = 250
+      const expectedSeconds = payload.length / (1024 * throttleKbps) + delay / 1000
 
       cy.intercept('/timeout', (req) => {
         this.start = Date.now()
@@ -1029,7 +1029,7 @@ describe('network stubbing', { retries: 2 }, function () {
           statusCode: 200,
           body: payload,
           throttleKbps,
-          delayMs,
+          delay,
         })
       }).then(() => {
         return $.get('/timeout').then((responseText) => {
@@ -1041,15 +1041,33 @@ describe('network stubbing', { retries: 2 }, function () {
       })
     })
 
+    it('can delay with deprecated delayMs param', function (done) {
+      const delay = 250
+
+      cy.intercept('/timeout', (req) => {
+        this.start = Date.now()
+
+        req.reply({
+          delay,
+        })
+      }).then(() => {
+        return $.get('/timeout').then((responseText) => {
+          expect(Date.now() - this.start).to.be.closeTo(250 + 100, 100)
+
+          done()
+        })
+      })
+    })
+
     // @see https://github.com/cypress-io/cypress/issues/14446
     it('should delay the same amount on every response', () => {
-      const delayMs = 250
+      const delay = 250
 
       const testDelay = () => {
         const start = Date.now()
 
         return $.get('/timeout').then((responseText) => {
-          expect(Date.now() - start).to.be.closeTo(delayMs, 50)
+          expect(Date.now() - start).to.be.closeTo(delay, 50)
           expect(responseText).to.eq('foo')
         })
       }
@@ -1057,7 +1075,7 @@ describe('network stubbing', { retries: 2 }, function () {
       cy.intercept('/timeout', {
         statusCode: 200,
         body: 'foo',
-        delayMs,
+        delay,
       }).as('get')
       .then(() => testDelay()).wait('@get')
       .then(() => testDelay()).wait('@get')
@@ -1634,15 +1652,15 @@ describe('network stubbing', { retries: 2 }, function () {
       const payload = 'A'.repeat(10 * 1024)
       const kbps = 20
       let expectedSeconds = payload.length / (1024 * kbps)
-      const delayMs = 500
+      const delay = 500
 
-      expectedSeconds += delayMs / 1000
+      expectedSeconds += delay / 1000
 
       cy.intercept('/timeout', (req) => {
         req.reply((res) => {
           this.start = Date.now()
 
-          res.throttle(kbps).delay(delayMs).send({
+          res.throttle(kbps).delay(delay).send({
             statusCode: 200,
             body: payload,
           })
@@ -1872,8 +1890,8 @@ describe('network stubbing', { retries: 2 }, function () {
       it('can delay and throttle', function (done) {
         const payload = 'A'.repeat(10 * 1024)
         const throttleKbps = 50
-        const delayMs = 50
-        const expectedSeconds = payload.length / (1024 * throttleKbps) + delayMs / 1000
+        const delay = 50
+        const expectedSeconds = payload.length / (1024 * throttleKbps) + delay / 1000
 
         cy.intercept('/timeout', (req) => {
           req.reply((res) => {
@@ -1884,7 +1902,7 @@ describe('network stubbing', { retries: 2 }, function () {
               statusCode: 200,
               body: payload,
               throttleKbps,
-              delayMs,
+              delay,
             })
           })
         }).then(() => {

--- a/packages/driver/src/cy/net-stubbing/events/response-received.ts
+++ b/packages/driver/src/cy/net-stubbing/events/response-received.ts
@@ -96,8 +96,8 @@ export const onResponseReceived: HandlerFn<NetEventFrames.HttpResponseReceived> 
 
       return sendContinueFrame()
     },
-    delay (delayMs) {
-      continueFrame.delayMs = delayMs
+    delay (delay) {
+      continueFrame.delay = delay
 
       return this
     },

--- a/packages/driver/src/cy/net-stubbing/static-response-utils.ts
+++ b/packages/driver/src/cy/net-stubbing/static-response-utils.ts
@@ -8,14 +8,14 @@ import {
 import $errUtils from '../../cypress/error_utils'
 
 // user-facing StaticResponse only
-export const STATIC_RESPONSE_KEYS: (keyof StaticResponse)[] = ['body', 'fixture', 'statusCode', 'headers', 'forceNetworkError', 'throttleKbps', 'delayMs']
+export const STATIC_RESPONSE_KEYS: (keyof StaticResponse)[] = ['body', 'fixture', 'statusCode', 'headers', 'forceNetworkError', 'throttleKbps', 'delay', 'delayMs']
 
 export function validateStaticResponse (cmd: string, staticResponse: StaticResponse): void {
   const err = (message) => {
     $errUtils.throwErrByPath('net_stubbing.invalid_static_response', { args: { cmd, message, staticResponse } })
   }
 
-  const { body, fixture, statusCode, headers, forceNetworkError, throttleKbps, delayMs } = staticResponse
+  const { body, fixture, statusCode, headers, forceNetworkError, throttleKbps, delay, delayMs } = staticResponse
 
   if (forceNetworkError && (body || statusCode || headers)) {
     err('`forceNetworkError`, if passed, must be the only option in the StaticResponse.')
@@ -43,8 +43,16 @@ export function validateStaticResponse (cmd: string, staticResponse: StaticRespo
     err('`throttleKbps` must be a finite, positive number.')
   }
 
+  if (delayMs && delay) {
+    err('`delayMs` and `delay` cannot both be set.')
+  }
+
   if (delayMs && (!_.isFinite(delayMs) || delayMs < 0)) {
     err('`delayMs` must be a finite, positive number.')
+  }
+
+  if (delay && (!_.isFinite(delay) || delay < 0)) {
+    err('`delay` must be a finite, positive number.')
   }
 }
 
@@ -88,7 +96,12 @@ function getFixtureOpts (fixture: string): FixtureOpts {
 }
 
 export function getBackendStaticResponse (staticResponse: Readonly<StaticResponse>): BackendStaticResponse {
-  const backendStaticResponse: BackendStaticResponse = _.omit(staticResponse, 'body', 'fixture')
+  const backendStaticResponse: BackendStaticResponse = _.omit(staticResponse, 'body', 'fixture', 'delayMs')
+
+  if (staticResponse.delayMs) {
+    // support deprecated `delayMs` usage
+    backendStaticResponse.delay = staticResponse.delayMs
+  }
 
   if (staticResponse.fixture) {
     backendStaticResponse.fixture = getFixtureOpts(staticResponse.fixture)

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -95,9 +95,9 @@ export namespace CyHttpMessages {
      */
     send(): void
     /**
-     * Wait for `delayMs` milliseconds before sending the response to the client.
+     * Wait for `delay` milliseconds before sending the response to the client.
      */
-    delay: (delayMs: number) => IncomingHttpResponse
+    delay: (delay: number) => IncomingHttpResponse
     /**
      * Serve the response at `throttleKbps` kilobytes per second.
      */
@@ -292,7 +292,13 @@ export type RouteHandler = string | StaticResponse | RouteHandlerController | ob
 /**
  * Describes a response that will be sent back to the browser to fulfill the request.
  */
-export type StaticResponse = GenericStaticResponse<string, string | object>
+export type StaticResponse = GenericStaticResponse<string, string | object> & {
+  /**
+   * Milliseconds to delay before the response is sent.
+   * @deprecated Use `delay` instead of `delayMs`.
+   */
+  delayMs?: number
+}
 
 export interface GenericStaticResponse<Fixture, Body> {
   /**
@@ -326,7 +332,7 @@ export interface GenericStaticResponse<Fixture, Body> {
   /**
    * Milliseconds to delay before the response is sent.
    */
-   delayMs?: number
+   delay?: number
 }
 
 /**

--- a/packages/net-stubbing/lib/internal-types.ts
+++ b/packages/net-stubbing/lib/internal-types.ts
@@ -88,7 +88,7 @@ export declare namespace NetEventFrames {
     res?: CyHttpMessages.IncomingResponse
     staticResponse?: BackendStaticResponse
     // Millisecond timestamp for when the response should continue
-    delayMs?: number
+    delay?: number
     throttleKbps?: number
     followRedirect?: boolean
   }

--- a/packages/net-stubbing/lib/server/intercept-response.ts
+++ b/packages/net-stubbing/lib/server/intercept-response.ts
@@ -103,13 +103,13 @@ export async function onResponseContinue (state: NetStubbingState, frame: NetEve
   debug('_onResponseContinue %o', { backendRequest: _.omit(backendRequest, 'res.body'), frame: _.omit(frame, 'res.body') })
 
   const throttleKbps = _.get(frame, 'staticResponse.throttleKbps') || frame.throttleKbps
-  const delayMs = _.get(frame, 'staticResponse.delayMs') || frame.delayMs
+  const delay = _.get(frame, 'staticResponse.delay') || frame.delay
 
   if (frame.staticResponse) {
     // replacing response with a staticResponse
     await setResponseFromFixture(backendRequest.route.getFixture, frame.staticResponse)
 
-    const staticResponse = _.chain(frame.staticResponse).clone().assign({ delayMs, throttleKbps }).value()
+    const staticResponse = _.chain(frame.staticResponse).clone().assign({ delay, throttleKbps }).value()
 
     return sendStaticResponse(backendRequest, staticResponse)
   }
@@ -117,7 +117,7 @@ export async function onResponseContinue (state: NetStubbingState, frame: NetEve
   // merge the changed response attributes with our response and continue
   _.assign(res, _.pick(frame.res, SERIALIZABLE_RES_PROPS))
 
-  const bodyStream = getBodyStream(res.body, { throttleKbps, delayMs })
+  const bodyStream = getBodyStream(res.body, { throttleKbps, delay })
 
   return backendRequest.continueResponse!(bodyStream)
 }

--- a/packages/net-stubbing/lib/server/util.ts
+++ b/packages/net-stubbing/lib/server/util.ts
@@ -165,13 +165,13 @@ export function sendStaticResponse (backendRequest: Pick<BackendRequest, 'onErro
     body,
   })
 
-  const bodyStream = getBodyStream(body, _.pick(staticResponse, 'throttleKbps', 'delayMs'))
+  const bodyStream = getBodyStream(body, _.pick(staticResponse, 'throttleKbps', 'delay'))
 
   onResponse!(incomingRes, bodyStream)
 }
 
-export function getBodyStream (body: Buffer | string | Readable | undefined, options: { delayMs?: number, throttleKbps?: number }): Readable {
-  const { delayMs, throttleKbps } = options
+export function getBodyStream (body: Buffer | string | Readable | undefined, options: { delay?: number, throttleKbps?: number }): Readable {
+  const { delay, throttleKbps } = options
   const pt = new PassThrough()
 
   const sendBody = () => {
@@ -195,7 +195,7 @@ export function getBodyStream (body: Buffer | string | Readable | undefined, opt
     return writable.end()
   }
 
-  delayMs ? setTimeout(sendBody, delayMs) : sendBody()
+  delay ? setTimeout(sendBody, delay) : sendBody()
 
   return pt
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- issue number here. e.g. "Closes #1234" -->

### User facing changelog

- The `delayMs` option for `StaticResponse`s used with `cy.intercept` has been renamed to `delay`.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here --> https://github.com/cypress-io/cypress-documentation/pull/3526
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
