### PR TITLE
fix(component-testing): start dev server event typings

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -23,6 +23,7 @@
     "@cypress/listr-verbose-renderer": "^0.4.1",
     "@cypress/request": "^2.88.5",
     "@cypress/xvfb": "^1.2.4",
+    "@types/node": "12.12.50",
     "@types/sinonjs__fake-timers": "^6.0.1",
     "@types/sizzle": "^2.3.2",
     "arch": "^2.1.2",

--- a/cli/types/cy-http.d.ts
+++ b/cli/types/cy-http.d.ts
@@ -1,0 +1,13 @@
+/**
+ * This file should be deleted as soon as the serever
+ * TODO: delete this file when ResolvedDevServerConfig.server is converted to closeServer
+ */
+
+/// <reference types="node" />
+import * as cyUtilsHttp from 'http'
+export = cyUtilsHttp
+/**
+ * namespace created to bridge nodeJs.http typings so that
+ * we can type http Server in CT
+ */
+export as namespace cyUtilsHttp

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -5142,9 +5142,9 @@ declare namespace Cypress {
   }
 
   interface ResolvedDevServerConfig {
-    port: number;
+    port: number
     // TODO: must improve this typing
-    server: any;
+    server: any
   } 
 
   interface PluginEvents {

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -5131,6 +5131,21 @@ declare namespace Cypress {
     tag?: string
   }
 
+  interface DevServerOptions {
+    specs: Cypress.Cypress['spec'][]
+    config: {
+      supportFile: string
+      projectRoot: string
+      webpackDevServerPublicPathRoute: string
+    }
+  }
+
+  interface ResolvedDevServerConfig {
+    port: number;
+    // TODO: must improve this typing
+    server: any;
+  } 
+
   interface PluginEvents {
     (action: 'after:run', fn: (results: CypressCommandLine.CypressRunResult | CypressCommandLine.CypressFailedRunResult) => void | Promise<void>): void
     (action: 'after:screenshot', fn: (details: ScreenshotDetails) => void | AfterScreenshotReturnObject | Promise<AfterScreenshotReturnObject>): void
@@ -5139,6 +5154,7 @@ declare namespace Cypress {
     (action: 'before:spec', fn: (spec: Spec) => void | Promise<void>): void
     (action: 'before:browser:launch', fn: (browser: Browser, browserLaunchOptions: BrowserLaunchOptions) => void | BrowserLaunchOptions | Promise<BrowserLaunchOptions>): void
     (action: 'file:preprocessor', fn: (file: FileObject) => string | Promise<string>): void
+    (action: 'dev-server:start', fn: (file: DevServerOptions) => Promise<ResolvedDevServerConfig>): void
     (action: 'task', tasks: Tasks): void
   }
 

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1,3 +1,4 @@
+/// <reference path="./cy-http.d.ts" />
 /// <reference path="./cypress-npm-api.d.ts" />
 
 declare namespace Cypress {
@@ -5132,9 +5133,9 @@ declare namespace Cypress {
   }
 
   interface DevServerOptions {
-    specs: Cypress.Cypress['spec'][]
+    specs: Spec[]
     config: {
-      supportFile: string
+      supportFile?: string
       projectRoot: string
       webpackDevServerPublicPathRoute: string
     },
@@ -5143,9 +5144,10 @@ declare namespace Cypress {
 
   interface ResolvedDevServerConfig {
     port: number
-    // TODO: must improve this typing
-    server: any
-  } 
+    // TODO: when removing server and replacing it by close Function,
+    // delete the cy-http.d.ts file. It's a hack.
+    server: cyUtilsHttp.Server
+  }
 
   interface PluginEvents {
     (action: 'after:run', fn: (results: CypressCommandLine.CypressRunResult | CypressCommandLine.CypressFailedRunResult) => void | Promise<void>): void

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -5137,7 +5137,8 @@ declare namespace Cypress {
       supportFile: string
       projectRoot: string
       webpackDevServerPublicPathRoute: string
-    }
+    },
+    devServerEvents: NodeJS.EventEmitter,
   }
 
   interface ResolvedDevServerConfig {

--- a/npm/react/cypress/plugins/index.js
+++ b/npm/react/cypress/plugins/index.js
@@ -55,6 +55,9 @@ const webpackConfig = {
   },
 }
 
+/**
+ * @type Cypress.PluginConfig
+ */
 module.exports = (on, config) => {
   on('dev-server:start', (options) => startDevServer({ options, webpackConfig }))
 

--- a/npm/react/package.json
+++ b/npm/react/package.json
@@ -49,7 +49,7 @@
     "@types/chalk": "2.2.0",
     "@types/inquirer": "7.3.1",
     "@types/mock-fs": "4.10.0",
-    "@types/node": "9.6.49",
+    "@types/node": "12.12.50",
     "@types/semver": "7.3.4",
     "arg": "4.1.3",
     "autoprefixer": "9.7.6",

--- a/npm/vue/cypress/plugins/index.js
+++ b/npm/vue/cypress/plugins/index.js
@@ -2,6 +2,9 @@
 const { startDevServer } = require('@cypress/webpack-dev-server')
 const webpackConfig = require('../../webpack.config')
 
+/**
+ * @type Cypress.PluginConfig
+ */
 module.exports = (on, config) => {
   require('@cypress/code-coverage/task')(on, config)
   on('dev-server:start', (options) => startDevServer({ options, webpackConfig }))

--- a/npm/webpack-dev-server/src/index.ts
+++ b/npm/webpack-dev-server/src/index.ts
@@ -5,16 +5,19 @@ import { Server } from 'http'
 import { start as createDevServer } from './startServer'
 const debug = debugFn('cypress:webpack-dev-server:webpack')
 
-interface Options {
+export interface DevServerOptions {
   specs: Cypress.Cypress['spec'][]
-  config: Record<string, string>
+  config: {
+    supportFile: string
+    projectRoot: string
+    webpackDevServerPublicPathRoute: string
+  }
   devServerEvents: EventEmitter
-  [key: string]: unknown
 }
 
 export interface StartDevServer {
   /* this is the Cypress options object */
-  options: Options
+  options: DevServerOptions
   /* support passing a path to the user's webpack config */
   webpackConfig?: Record<string, any>
 }

--- a/packages/runner-ct/cypress/plugins/index.js
+++ b/packages/runner-ct/cypress/plugins/index.js
@@ -2,10 +2,13 @@
 const { startDevServer } = require('@cypress/webpack-dev-server')
 const path = require('path')
 
+/**
+ * @type {Cypress.PluginConfig}
+ */
 module.exports = (on, config) => {
   on('dev-server:start', (options) => {
     // yarn tsc webpack.config.ts --esModuleInterop
-    const config = path.resolve(__dirname, '..', '..', 'webpack.config.js')
+    const config = path.resolve(__dirname, '../../webpack.config.js')
 
     return startDevServer({
       webpackConfig: require(config).default,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5663,11 +5663,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.50.tgz#e9b2e85fafc15f2a8aa8fdd41091b983da5fd6ee"
   integrity sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==
 
-"@types/node@9.6.49":
-  version "9.6.49"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.49.tgz#ab4df6e505db088882c8ce5417ae0bc8cbb7a8a6"
-  integrity sha512-YY0Okyn4QXC4ugJI+Kng5iWjK8A6eIHiQVaGIhJkyn0YL6Iqo0E0tBC8BuhvYcBK87vykBijM5FtMnCqaa5anA==
-
 "@types/node@^12.0.12":
   version "12.19.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.12.tgz#04793c2afa4ce833a9972e4c476432e30f9df47b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16127,10 +16127,10 @@ find-webpack@2.1.0:
     find-yarn-workspace-root "1.2.1"
     mocked-env "1.3.2"
 
-find-webpack@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/find-webpack/-/find-webpack-2.2.0.tgz#c67638517bf5966ebbeef25857020afd341197c0"
-  integrity sha512-eWdunKuIRRuyL141m0Jaz+RoSOT0jSLfxH3FXnjPTLaMUwjXhbAg82UaCjUZTiYTJ+knSLFGNlxAuVAI6JweDA==
+find-webpack@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/find-webpack/-/find-webpack-2.2.1.tgz#96e7b701a2d37c3500cae30d4dc59e14923ba460"
+  integrity sha512-OdDtn2AzQvu3l9U1TS5ALc7uTVcLK/yv3fhjo+Pz7yuv4hG3ANKnbkKnPIPZ5ofd9mpYe6wRf5g5H4X9Lx48vQ==
   dependencies:
     debug "4.1.1"
     find-yarn-workspace-root "1.2.1"


### PR DESCRIPTION
closes CT-252

Fixes and tightens the types of `dev-server:start`

I think it could use a bit of factoring to avoid repeating the type definitions.
This can be accomplished in a future PR.

<img width="627" alt="Screen Shot 2021-02-01 at 4 36 16 PM" src="https://user-images.githubusercontent.com/5592465/106526688-ab3cb600-64ab-11eb-916c-d4ec27765cb0.png">
