### PR TITLE
fix(component-testing): make content adjust to size of window

### DIFF
--- a/npm/react/cypress/component/viewport-spec.js
+++ b/npm/react/cypress/component/viewport-spec.js
@@ -20,4 +20,10 @@ describe('cy.viewport', () => {
       expect(window.innerHeight).to.eq(viewportHeight)
     })
   })
+
+  it('should make it scale down when overflowing', () => {
+    cy.viewport(20000, 200).should(() => {
+      expect(getComputedStyle(window.parent.document.querySelector('iframe').parentElement).transform).not.to.contain('matrix(1')
+    })
+  })
 })

--- a/npm/react/cypress/component/viewport-spec.jsx
+++ b/npm/react/cypress/component/viewport-spec.jsx
@@ -1,3 +1,6 @@
+import React from 'react'
+import { mount } from '@cypress/react'
+
 const viewportWidth = 200
 const viewportHeight = 100
 
@@ -22,7 +25,14 @@ describe('cy.viewport', () => {
   })
 
   it('should make it scale down when overflowing', () => {
-    cy.viewport(20000, 200).should(() => {
+    mount(<p>
+      Lorem, ipsum dolor sit amet consectetur adipisicing elit.
+      Incidunt necessitatibus quia quo obcaecati tempora numquam nobis
+      minima libero vel? Nam sequi iusto quod fugit vel rerum eligendi beatae voluptatibus numquam.
+    </p>)
+
+    expect(getComputedStyle(window.parent.document.querySelector('iframe').parentElement).transform).to.contain('matrix(1')
+    cy.viewport(2000, 200).should(() => {
       expect(getComputedStyle(window.parent.document.querySelector('iframe').parentElement).transform).not.to.contain('matrix(1')
     })
   })

--- a/packages/runner-ct/src/SpecList/spec-list.scss
+++ b/packages/runner-ct/src/SpecList/spec-list.scss
@@ -1,12 +1,11 @@
 .specs-list {
   font-family: "Muli", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 15px;
-  width: calc(100% - 41px);
+  width: calc(100% - 40px);
   height: calc(100% - 10px);
   display: flex;
   flex-direction: column;
   overflow: scroll;
-  border-right: 1px solid #CCC
 }
 
 .specs-list-scroll-container {

--- a/packages/runner-ct/src/SpecList/spec-list.scss
+++ b/packages/runner-ct/src/SpecList/spec-list.scss
@@ -1,11 +1,12 @@
 .specs-list {
   font-family: "Muli", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 15px;
-  width: 100%;
+  width: calc(100% - 41px);
   height: calc(100% - 10px);
   display: flex;
   flex-direction: column;
   overflow: scroll;
+  border-right: 1px solid #CCC
 }
 
 .specs-list-scroll-container {

--- a/packages/runner-ct/src/SpecList/spec-list.scss
+++ b/packages/runner-ct/src/SpecList/spec-list.scss
@@ -1,7 +1,7 @@
 .specs-list {
   font-family: "Muli", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 15px;
-  width: calc(100% - 40px);
+  width: 100%;
   height: calc(100% - 10px);
   display: flex;
   flex-direction: column;

--- a/packages/runner-ct/src/app/app.scss
+++ b/packages/runner-ct/src/app/app.scss
@@ -73,14 +73,16 @@ main.app-ct {
 }
 
 .runner-ct {
-  left: $specs-list-offset;
-
+  left: 0;
   header {
     position: static;
     top: unset;
     left: unset;
     right: unset;
     bottom: unset;
+  }
+  .size-container{
+    transform-origin: 0 0;
   }
 }
 

--- a/packages/runner-ct/src/app/app.scss
+++ b/packages/runner-ct/src/app/app.scss
@@ -74,6 +74,7 @@ main.app-ct {
 
 .runner-ct {
   left: 0;
+
   header {
     position: static;
     top: unset;

--- a/packages/runner-ct/src/app/app.tsx
+++ b/packages/runner-ct/src/app/app.tsx
@@ -23,207 +23,189 @@ import { findDOMNode } from 'react-dom'
 // TODO: figure out where the "source of truth" should be for
 // an internal options interface.
 export interface ExtendedConfigOptions extends Cypress.ConfigOptions {
-  projectName: string;
+  projectName: string
 }
 
 interface AppProps {
-  state: State;
-  // eslint-disable-next-line
-  eventManager: typeof EventManager;
-  config: ExtendedConfigOptions;
-  win?: Window
+  state: State
+  eventManager: typeof EventManager
+  config: ExtendedConfigOptions
 }
 
 const DEFAULT_LEFT_SIDE_OF_SPLITPANE_WIDTH = 355
 
-const App: React.FC<AppProps> = observer(function App (props: AppProps) {
-  const pluginRootContainer = React.useRef<null | HTMLDivElement>(null)
+const App: React.FC<AppProps> = observer(
+  function App (props: AppProps) {
+    const pluginRootContainer = React.useRef<null | HTMLDivElement>(null)
 
-  const { state, eventManager, config, win = window } = props
+    const { state, eventManager, config } = props
 
-  const [pluginsHeight, setPluginsHeight] = React.useState(500)
-  const [leftSideOfSplitPaneWidth, setLeftSideOfSplitPaneWidth] = React.useState(DEFAULT_LEFT_SIDE_OF_SPLITPANE_WIDTH)
-  const [isResizing, setIsResizing] = React.useState(false)
-  const [isSpecsListOpen, setIsSpecsListOpen] = React.useState(true)
-  const headerRef = React.useRef()
+    const [pluginsHeight, setPluginsHeight] = React.useState(500)
+    const [isResizing, setIsResizing] = React.useState(false)
+    const [isSpecsListOpen, setIsSpecsListOpen] = React.useState(true)
+    const [leftSideOfSplitPaneWidth, setLeftSideOfSplitPaneWidth] = React.useState(DEFAULT_LEFT_SIDE_OF_SPLITPANE_WIDTH)
+    const headerRef = React.useRef()
 
-  function monitorWindowResize () {
-    const $header = $(findDOMNode(headerRef.current))
+    function monitorWindowResize () {
+      const $header = $(findDOMNode(headerRef.current))
 
-    function onWindowResize () {
+      function onWindowResize () {
+        state.updateWindowDimensions({
+          windowWidth: window.innerWidth,
+          windowHeight: window.innerHeight,
+          reporterWidth: leftSideOfSplitPaneWidth,
+          headerHeight: $header.outerHeight(),
+        })
+      }
+
+      $(window)
+      .on('resize', onWindowResize)
+      .trigger('resize')
+    }
+
+    React.useEffect(() => {
+      if (pluginRootContainer.current) {
+        state.initializePlugins(config, pluginRootContainer.current)
+      }
+
+      monitorWindowResize()
+    }, [])
+
+    function onSplitPaneChange (newWidth: number) {
+      setLeftSideOfSplitPaneWidth(newWidth)
       state.updateWindowDimensions({
-        windowWidth: win.innerWidth,
-        windowHeight: win.innerHeight,
-        reporterWidth: leftSideOfSplitPaneWidth,
-        headerHeight: $header.outerHeight(),
+        reporterWidth: newWidth,
+        windowWidth: null,
+        windowHeight: null,
+        headerHeight: null,
       })
     }
 
-    $(win)
-    .on('resize', onWindowResize)
-    .trigger('resize')
-  }
-
-  React.useEffect(() => {
-    if (pluginRootContainer.current) {
-      state.initializePlugins(config, pluginRootContainer.current)
-    }
-
-    monitorWindowResize()
-  }, [])
-
-  function onSplitPaneChange (val) {
-    setLeftSideOfSplitPaneWidth(val)
-    monitorWindowResize()
-  }
-
-  return (
-    <>
-      <main className="app-ct">
-        <div
-          className={cs('specs-list-container', {
-            'specs-list-container__open': isSpecsListOpen,
-          })}
-        >
-          <nav>
-            <a
-              onClick={() => setIsSpecsListOpen(!isSpecsListOpen)}
-              id="menu-toggle"
-              className="menu-toggle"
-              aria-label="Open the menu"
-            >
-              <i className="fa fa-bars" aria-hidden="true" />
-            </a>
-          </nav>
-          <SpecList
-            specs={state.specs}
-            selectedSpecs={state.spec ? [state.spec.absolute] : []}
-            onSelectSpec={(spec) => state.setSingleSpec(spec)}
-          />
-        </div>
-        <div className="app-wrapper">
-          <SplitPane
-            split="vertical"
-            primary="first"
-            minSize={100}
-            // calculate maxSize of IFRAMES preview to not cover specs list and command log
-            maxSize={400}
-            defaultSize={DEFAULT_LEFT_SIDE_OF_SPLITPANE_WIDTH}
-            onDragStarted={() => setIsResizing(true)}
-            onDragFinished={() => setIsResizing(false)}
-            onChange={(val) => onSplitPaneChange(val)}
-            className={cs('reporter-pane', {
-              'is-reporter-resizing': isResizing,
-            })}
-          >
-            <div>
-              {state.spec && (
-                <Reporter
-                  runMode={state.runMode}
-                  runner={eventManager.reporterBus}
-                  spec={state.spec}
-                  allSpecs={state.multiSpecs}
-                  // @ts-ignore
-                  error={errorMessages.reporterError(
-                    state.scriptError,
-                    state.spec.relative,
-                  )}
-                  firefoxGcInterval={config.firefoxGcInterval}
-                  resetStatsOnSpecChange={state.runMode === 'single'}
-                  renderReporterHeader={(props) => (
-                    <ReporterHeader {...props} />
-                  )}
-                  experimentalStudioEnabled={false}
-                />
-              )}
-            </div>
+    return (
+      <>
+        <main className="app-ct">
+          <div className={cs('specs-list-container', { 'specs-list-container__open': isSpecsListOpen })}>
+            <nav>
+              <a onClick={() => setIsSpecsListOpen(!isSpecsListOpen)} id="menu-toggle"
+                className="menu-toggle" aria-label="Open the menu">
+                <i className="fa fa-bars" aria-hidden="true"/>
+              </a>
+            </nav>
+            <SpecList
+              specs={state.specs}
+              selectedSpecs={state.spec ? [state.spec.absolute] : []}
+              onSelectSpec={(spec) => state.setSingleSpec(spec)}
+            />
+          </div>
+          <div className="app-wrapper">
             <SplitPane
-              primary="second"
-              split="horizontal"
-              onChange={setPluginsHeight}
-              allowResize={state.isAnyDevtoolsPluginOpen}
+              split="vertical"
+              primary="first"
+              minSize={100}
+              // calculate maxSize of IFRAMES preview to not cover specs list and command log
+              maxSize={400}
+              defaultSize={355}
               onDragStarted={() => setIsResizing(true)}
               onDragFinished={() => setIsResizing(false)}
-              size={
-                state.isAnyDevtoolsPluginOpen
-                  ? pluginsHeight
-                  : // show the small not resize-able panel with buttons or nothing
-                  state.isAnyPluginToShow
-                    ? 30
-                    : 0
-              }
+              onChange={onSplitPaneChange}
+              className={cs('reporter-pane', { 'is-reporter-resizing': isResizing })}
             >
-              <div className="runner runner-ct container">
-                <Header {...props} ref={headerRef} />
-                <Iframes {...props} />
-                <Message state={state} />
+              <div>
+                {state.spec && (
+                  <Reporter
+                    runMode={state.runMode}
+                    runner={eventManager.reporterBus}
+                    spec={state.spec}
+                    allSpecs={state.multiSpecs}
+                    // @ts-ignore
+                    error={errorMessages.reporterError(state.scriptError, state.spec.relative)}
+                    firefoxGcInterval={config.firefoxGcInterval}
+                    resetStatsOnSpecChange={state.runMode === 'single'}
+                    renderReporterHeader={(props) => <ReporterHeader {...props} />}
+                    experimentalStudioEnabled={false}/>
+                )}
               </div>
-
-              <Hidden
-                type="layout"
-                hidden={!state.isAnyPluginToShow}
-                className="ct-plugins"
+              <SplitPane
+                primary="second"
+                split="horizontal"
+                onChange={setPluginsHeight}
+                allowResize={state.isAnyDevtoolsPluginOpen}
+                onDragStarted={() => setIsResizing(true)}
+                onDragFinished={() => setIsResizing(false)}
+                size={
+                  state.isAnyDevtoolsPluginOpen
+                    ? pluginsHeight
+                    // show the small not resize-able panel with buttons or nothing
+                    : state.isAnyPluginToShow ? 30 : 0
+                }
               >
-                <div className="ct-plugins-header">
-                  {state.plugins.map((plugin) => (
-                    <button
-                      key={plugin.name}
-                      onClick={() => state.openDevtoolsPlugin(plugin)}
-                      className={cs('ct-plugin-toggle-button', {
-                        'ct-plugin-toggle-button-selected':
-                          state.activePlugin === plugin.name,
-                      })}
-                    >
-                      {plugin.name}
-                    </button>
-                  ))}
-
-                  <button
-                    onClick={state.toggleDevtoolsPlugin}
-                    className={cs('ct-toggle-plugins-section-button ', {
-                      'ct-toggle-plugins-section-button-open':
-                        state.isAnyDevtoolsPluginOpen,
-                    })}
-                  >
-                    <i className="fas fa-chevron-up" />
-                  </button>
+                <div className="runner runner-ct container">
+                  <Header {...props} ref={headerRef}/>
+                  <Iframes {...props} />
+                  <Message state={state}/>
                 </div>
 
-                <Hidden
-                  type="layout"
-                  ref={pluginRootContainer}
-                  className="ct-devtools-container"
-                  // deal with jumps when inspecting element
-                  hidden={!state.isAnyDevtoolsPluginOpen}
-                  style={{ height: pluginsHeight - 30 }}
-                />
-              </Hidden>
+                <Hidden type="layout" hidden={!state.isAnyPluginToShow} className="ct-plugins">
+                  <div className="ct-plugins-header">
+                    {state.plugins.map((plugin) => (
+                      <button
+                        key={plugin.name}
+                        onClick={() => state.openDevtoolsPlugin(plugin)}
+                        className={cs('ct-plugin-toggle-button', {
+                          'ct-plugin-toggle-button-selected': state.activePlugin === plugin.name,
+                        })}
+                      >
+                        {plugin.name}
+                      </button>
+                    ))}
+
+                    <button
+                      onClick={state.toggleDevtoolsPlugin}
+                      className={cs('ct-toggle-plugins-section-button ', {
+                        'ct-toggle-plugins-section-button-open': state.isAnyDevtoolsPluginOpen,
+                      })}
+                    >
+                      <i className="fas fa-chevron-up"/>
+                    </button>
+                  </div>
+
+                  <Hidden
+                    type="layout"
+                    ref={pluginRootContainer}
+                    className="ct-devtools-container"
+                    // deal with jumps when inspecting element
+                    hidden={!state.isAnyDevtoolsPluginOpen}
+                    style={{ height: pluginsHeight - 30 }}
+                  />
+                </Hidden>
+              </SplitPane>
             </SplitPane>
-          </SplitPane>
-        </div>
-        {/* these pixels help ensure the browser has painted when taking a screenshot */}
-        <div className="screenshot-helper-pixels">
-          <div />
-          <div />
-          <div />
-          <div />
-          <div />
-          <div />
-        </div>
-      </main>
-    </>
-  )
-})
+          </div>
+          {/* these pixels help ensure the browser has painted when taking a screenshot */}
+          <div className='screenshot-helper-pixels'>
+            <div/>
+            <div/>
+            <div/>
+            <div/>
+            <div/>
+            <div/>
+          </div>
+        </main>
+      </>
+    )
+  },
+)
 
 App.propTypes = {
   config: PropTypes.shape({
-    browsers: PropTypes.arrayOf(
-      PropTypes.shape({
-        name: PropTypes.string.isRequired,
-        majorVersion: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        version: PropTypes.string.isRequired,
-      }),
-    ).isRequired,
+    browsers: PropTypes.arrayOf(PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      majorVersion: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+      ]),
+      version: PropTypes.string.isRequired,
+    })).isRequired,
     integrationFolder: PropTypes.string.isRequired,
     numTestsKeptInMemory: PropTypes.number.isRequired,
     projectName: PropTypes.string.isRequired,
@@ -239,7 +221,6 @@ App.propTypes = {
   //     on: PropTypes.func.isRequired,
   //   }).isRequired,
   // }).isRequired,
-  win: PropTypes.instanceOf(Window),
   state: PropTypes.instanceOf(State).isRequired,
 } as any // it is much easier to avoid types for prop-types using as any at the end
 

--- a/packages/runner-ct/src/app/app.tsx
+++ b/packages/runner-ct/src/app/app.tsx
@@ -33,6 +33,8 @@ interface AppProps {
 }
 
 const DEFAULT_LEFT_SIDE_OF_SPLITPANE_WIDTH = 355
+// needs to account for the left bar + the margins around the viewport
+const VIEWPORT_SIDE_MARGIN = 40 + 17
 
 const App: React.FC<AppProps> = observer(
   function App (props: AppProps) {
@@ -53,7 +55,7 @@ const App: React.FC<AppProps> = observer(
         state.updateWindowDimensions({
           windowWidth: window.innerWidth,
           windowHeight: window.innerHeight,
-          reporterWidth: leftSideOfSplitPaneWidth,
+          reporterWidth: leftSideOfSplitPaneWidth + VIEWPORT_SIDE_MARGIN,
           headerHeight: $header.outerHeight(),
         })
       }
@@ -74,7 +76,7 @@ const App: React.FC<AppProps> = observer(
     function onSplitPaneChange (newWidth: number) {
       setLeftSideOfSplitPaneWidth(newWidth)
       state.updateWindowDimensions({
-        reporterWidth: newWidth,
+        reporterWidth: newWidth + VIEWPORT_SIDE_MARGIN,
         windowWidth: null,
         windowHeight: null,
         headerHeight: null,

--- a/packages/runner-ct/src/app/app.tsx
+++ b/packages/runner-ct/src/app/app.tsx
@@ -50,7 +50,7 @@ const App: React.FC<AppProps> = observer(
       // I can't use forwardref in class based components
       // Header still is a class component
       // FIXME: use a forwardRef when available
-      const header = headerRef.current.refs.header
+      const header = headerRef.current.headerRef
 
       function onWindowResize () {
         state.updateWindowDimensions({

--- a/packages/runner-ct/src/app/app.tsx
+++ b/packages/runner-ct/src/app/app.tsx
@@ -3,7 +3,6 @@ import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import * as React from 'react'
 import { Reporter } from '@packages/reporter/src/main'
-import { $ } from '@packages/driver'
 
 import errorMessages from '../errors/error-messages'
 import State from '../lib/state'
@@ -17,7 +16,6 @@ import { ReporterHeader } from './ReporterHeader'
 import EventManager from '../lib/event-manager'
 import { Hidden } from '../lib/Hidden'
 import { SpecList } from '../SpecList'
-import { findDOMNode } from 'react-dom'
 
 // Cypress.ConfigOptions only appears to have internal options.
 // TODO: figure out where the "source of truth" should be for
@@ -46,23 +44,25 @@ const App: React.FC<AppProps> = observer(
     const [isResizing, setIsResizing] = React.useState(false)
     const [isSpecsListOpen, setIsSpecsListOpen] = React.useState(true)
     const [leftSideOfSplitPaneWidth, setLeftSideOfSplitPaneWidth] = React.useState(DEFAULT_LEFT_SIDE_OF_SPLITPANE_WIDTH)
-    const headerRef = React.useRef()
+    const headerRef = React.useRef(null)
 
     function monitorWindowResize () {
-      const $header = $(findDOMNode(headerRef.current))
+      // I can't use forwardref in class based components
+      // Header still is a class component
+      // FIXME: use a forwardRef when available
+      const header = headerRef.current.refs.header
 
       function onWindowResize () {
         state.updateWindowDimensions({
           windowWidth: window.innerWidth,
           windowHeight: window.innerHeight,
           reporterWidth: leftSideOfSplitPaneWidth + VIEWPORT_SIDE_MARGIN,
-          headerHeight: $header.outerHeight(),
+          headerHeight: header.offsetHeight || 0,
         })
       }
 
-      $(window)
-      .on('resize', onWindowResize)
-      .trigger('resize')
+      window.addEventListener('resize', onWindowResize)
+      window.dispatchEvent(new Event('resize'))
     }
 
     React.useEffect(() => {

--- a/packages/runner-ct/src/header/header.jsx
+++ b/packages/runner-ct/src/header/header.jsx
@@ -12,14 +12,16 @@ import selectorPlaygroundModel from '../selector-playground/selector-playground-
 
 @observer
 export default class Header extends Component {
-  @observable showingViewportMenu = false
+  headerRef = React.createRef()
+
+  @observable showingViewportMenu = false;
 
   render () {
     const { state, config } = this.props
 
     return (
       <header
-        ref='header'
+        ref={this.headerRef}
         className={cs({
           'showing-selector-playground': selectorPlaygroundModel.isOpen,
         })}
@@ -77,7 +79,7 @@ export default class Header extends Component {
   componentDidUpdate () {
     if (selectorPlaygroundModel.isOpen !== this.previousSelectorPlaygroundOpen) {
       this.props.state.updateWindowDimensions({
-        headerHeight: $(this.refs.header).outerHeight(),
+        headerHeight: this.headerRef.current.offsetHeight,
       })
 
       this.previousSelectorPlaygroundOpen = selectorPlaygroundModel.isOpen

--- a/packages/runner-ct/src/iframe/iframes.jsx
+++ b/packages/runner-ct/src/iframe/iframes.jsx
@@ -18,28 +18,36 @@ export function getSpecUrl ({ namespace, spec }, prefix = '') {
 
 @observer
 export default class Iframes extends Component {
-  _disposers = []
-  containerRef = null
+  _disposers = [];
+  containerRef = null;
 
   constructor (props) {
     super(props)
   }
 
   render () {
-    const { height, width, scriptError } = this.props.state
+    const {
+      height,
+      width,
+      scale,
+      scriptError,
+    } = this.props.state
 
     return (
-      <div className={cs('iframes-ct-container', { 'has-error': !!scriptError })}>
+      <div
+        className={cs('iframes-ct-container', { 'has-error': !!scriptError })}
+      >
         <div
-          ref={(container) => this.containerRef = container}
-          className='size-container'
+          ref={(container) => (this.containerRef = container)}
+          className="size-container"
           style={{
             height,
             width,
+            transform: `scale(${scale})`,
           }}
         />
         <ScriptError error={scriptError} />
-        <div className='cover' />
+        <div className="cover" />
       </div>
     )
   }
@@ -50,8 +58,16 @@ export default class Iframes extends Component {
     this.autIframe = new AutIframe(config)
 
     this.props.eventManager.on('visit:failed', this.autIframe.showVisitFailure)
-    this.props.eventManager.on('before:screenshot', this.autIframe.beforeScreenshot)
-    this.props.eventManager.on('after:screenshot', this.autIframe.afterScreenshot)
+    this.props.eventManager.on(
+      'before:screenshot',
+      this.autIframe.beforeScreenshot,
+    )
+
+    this.props.eventManager.on(
+      'after:screenshot',
+      this.autIframe.afterScreenshot,
+    )
+
     this.props.eventManager.on('script:error', this._setScriptError)
 
     // TODO: need to take headless mode into account
@@ -60,15 +76,26 @@ export default class Iframes extends Component {
       this._run(this.props.state.spec, config)
     })
 
-    this.props.eventManager.on('print:selector:elements:to:console', this._printSelectorElementsToConsole)
+    this.props.eventManager.on(
+      'print:selector:elements:to:console',
+      this._printSelectorElementsToConsole,
+    )
 
-    this._disposers.push(autorun(() => {
-      this.autIframe.toggleSelectorPlayground(selectorPlaygroundModel.isEnabled)
-    }))
+    this._disposers.push(
+      autorun(() => {
+        this.autIframe.toggleSelectorPlayground(
+          selectorPlaygroundModel.isEnabled,
+        )
+      }),
+    )
 
-    this._disposers.push(autorun(() => {
-      this.autIframe.toggleSelectorHighlight(selectorPlaygroundModel.isShowingHighlight)
-    }))
+    this._disposers.push(
+      autorun(() => {
+        this.autIframe.toggleSelectorHighlight(
+          selectorPlaygroundModel.isShowingHighlight,
+        )
+      }),
+    )
 
     this.props.eventManager.start(this.props.config)
 
@@ -91,18 +118,20 @@ export default class Iframes extends Component {
 
     this.iframeModel.listen()
 
-    this._disposers.push(autorun(() => {
-      const spec = this.props.state.spec
+    this._disposers.push(
+      autorun(() => {
+        const spec = this.props.state.spec
 
-      if (spec) {
-        this._run(spec, config)
-      }
-    }))
+        if (spec) {
+          this._run(spec, config)
+        }
+      }),
+    )
   }
 
   @action _setScriptError = (err) => {
     this.props.state.scriptError = err
-  }
+  };
 
   _run = (spec, config) => {
     config.spec = spec
@@ -116,16 +145,26 @@ export default class Iframes extends Component {
     const $autIframe = this._loadIframes(spec)
 
     // This is extremely required to not run test till devtools registered
-    when(() => this.props.state.readyToRunTests, () => {
-      window.Cypress.on('window:before:load', this.props.state.registerDevtools)
-      this.props.eventManager.initialize($autIframe, config)
-    })
-  }
+    when(
+      () => this.props.state.readyToRunTests,
+      () => {
+        window.Cypress.on(
+          'window:before:load',
+          this.props.state.registerDevtools,
+        )
+
+        this.props.eventManager.initialize($autIframe, config)
+      },
+    )
+  };
 
   // jQuery is a better fit for managing these iframes, since they need to get
   // wiped out and reset on re-runs and the snapshots are from dom we don't control
   _loadIframes (spec) {
-    const specSrc = getSpecUrl({ namespace: this.props.config.namespace, spec })
+    const specSrc = getSpecUrl({
+      namespace: this.props.config.namespace,
+      spec,
+    })
     const $container = $(this.containerRef).empty()
     const $autIframe = this.autIframe.create().appendTo($container)
 
@@ -148,16 +187,18 @@ export default class Iframes extends Component {
   }
 
   _toggleSnapshotHighlights = (snapshotProps) => {
-    this.props.state.snapshot.showingHighlights = !this.props.state.snapshot.showingHighlights
+    this.props.state.snapshot.showingHighlights = !this.props.state.snapshot
+    .showingHighlights
 
     if (this.props.state.snapshot.showingHighlights) {
-      const snapshot = snapshotProps.snapshots[this.props.state.snapshot.stateIndex]
+      const snapshot =
+        snapshotProps.snapshots[this.props.state.snapshot.stateIndex]
 
       this.autIframe.highlightEl(snapshot, snapshotProps)
     } else {
       this.autIframe.removeHighlights()
     }
-  }
+  };
 
   _changeSnapshotState = (snapshotProps, index) => {
     const snapshot = snapshotProps.snapshots[index]
@@ -170,7 +211,7 @@ export default class Iframes extends Component {
     } else {
       this.autIframe.removeHighlights()
     }
-  }
+  };
 
   componentDidUpdate () {
     const cb = this.props.state.callbackAfterUpdate
@@ -182,7 +223,7 @@ export default class Iframes extends Component {
 
   _printSelectorElementsToConsole = () => {
     this.autIframe.printSelectorElementsToConsole()
-  }
+  };
 
   componentWillUnmount () {
     this.props.eventManager.notifyRunningSpec(null)

--- a/packages/runner-ct/src/iframe/iframes.jsx
+++ b/packages/runner-ct/src/iframe/iframes.jsx
@@ -193,6 +193,6 @@ export default class Iframes extends Component {
   }
 
   getSizeContainer () {
-    return this.refs.container
+    return this.containerRef
   }
 }

--- a/packages/runner-ct/src/iframe/iframes.jsx
+++ b/packages/runner-ct/src/iframe/iframes.jsx
@@ -18,28 +18,21 @@ export function getSpecUrl ({ namespace, spec }, prefix = '') {
 
 @observer
 export default class Iframes extends Component {
-  _disposers = [];
-  containerRef = null;
+  _disposers = []
+  containerRef = null
 
   constructor (props) {
     super(props)
   }
 
   render () {
-    const {
-      height,
-      width,
-      scale,
-      scriptError,
-    } = this.props.state
+    const { height, width, scriptError, scale } = this.props.state
 
     return (
-      <div
-        className={cs('iframes-ct-container', { 'has-error': !!scriptError })}
-      >
+      <div className={cs('iframes-ct-container', { 'has-error': !!scriptError })}>
         <div
-          ref={(container) => (this.containerRef = container)}
-          className="size-container"
+          ref={(container) => this.containerRef = container}
+          className='size-container'
           style={{
             height,
             width,
@@ -47,7 +40,7 @@ export default class Iframes extends Component {
           }}
         />
         <ScriptError error={scriptError} />
-        <div className="cover" />
+        <div className='cover' />
       </div>
     )
   }
@@ -58,16 +51,8 @@ export default class Iframes extends Component {
     this.autIframe = new AutIframe(config)
 
     this.props.eventManager.on('visit:failed', this.autIframe.showVisitFailure)
-    this.props.eventManager.on(
-      'before:screenshot',
-      this.autIframe.beforeScreenshot,
-    )
-
-    this.props.eventManager.on(
-      'after:screenshot',
-      this.autIframe.afterScreenshot,
-    )
-
+    this.props.eventManager.on('before:screenshot', this.autIframe.beforeScreenshot)
+    this.props.eventManager.on('after:screenshot', this.autIframe.afterScreenshot)
     this.props.eventManager.on('script:error', this._setScriptError)
 
     // TODO: need to take headless mode into account
@@ -76,26 +61,15 @@ export default class Iframes extends Component {
       this._run(this.props.state.spec, config)
     })
 
-    this.props.eventManager.on(
-      'print:selector:elements:to:console',
-      this._printSelectorElementsToConsole,
-    )
+    this.props.eventManager.on('print:selector:elements:to:console', this._printSelectorElementsToConsole)
 
-    this._disposers.push(
-      autorun(() => {
-        this.autIframe.toggleSelectorPlayground(
-          selectorPlaygroundModel.isEnabled,
-        )
-      }),
-    )
+    this._disposers.push(autorun(() => {
+      this.autIframe.toggleSelectorPlayground(selectorPlaygroundModel.isEnabled)
+    }))
 
-    this._disposers.push(
-      autorun(() => {
-        this.autIframe.toggleSelectorHighlight(
-          selectorPlaygroundModel.isShowingHighlight,
-        )
-      }),
-    )
+    this._disposers.push(autorun(() => {
+      this.autIframe.toggleSelectorHighlight(selectorPlaygroundModel.isShowingHighlight)
+    }))
 
     this.props.eventManager.start(this.props.config)
 
@@ -118,20 +92,18 @@ export default class Iframes extends Component {
 
     this.iframeModel.listen()
 
-    this._disposers.push(
-      autorun(() => {
-        const spec = this.props.state.spec
+    this._disposers.push(autorun(() => {
+      const spec = this.props.state.spec
 
-        if (spec) {
-          this._run(spec, config)
-        }
-      }),
-    )
+      if (spec) {
+        this._run(spec, config)
+      }
+    }))
   }
 
   @action _setScriptError = (err) => {
     this.props.state.scriptError = err
-  };
+  }
 
   _run = (spec, config) => {
     config.spec = spec
@@ -145,26 +117,16 @@ export default class Iframes extends Component {
     const $autIframe = this._loadIframes(spec)
 
     // This is extremely required to not run test till devtools registered
-    when(
-      () => this.props.state.readyToRunTests,
-      () => {
-        window.Cypress.on(
-          'window:before:load',
-          this.props.state.registerDevtools,
-        )
-
-        this.props.eventManager.initialize($autIframe, config)
-      },
-    )
-  };
+    when(() => this.props.state.readyToRunTests, () => {
+      window.Cypress.on('window:before:load', this.props.state.registerDevtools)
+      this.props.eventManager.initialize($autIframe, config)
+    })
+  }
 
   // jQuery is a better fit for managing these iframes, since they need to get
   // wiped out and reset on re-runs and the snapshots are from dom we don't control
   _loadIframes (spec) {
-    const specSrc = getSpecUrl({
-      namespace: this.props.config.namespace,
-      spec,
-    })
+    const specSrc = getSpecUrl({ namespace: this.props.config.namespace, spec })
     const $container = $(this.containerRef).empty()
     const $autIframe = this.autIframe.create().appendTo($container)
 
@@ -187,18 +149,16 @@ export default class Iframes extends Component {
   }
 
   _toggleSnapshotHighlights = (snapshotProps) => {
-    this.props.state.snapshot.showingHighlights = !this.props.state.snapshot
-    .showingHighlights
+    this.props.state.snapshot.showingHighlights = !this.props.state.snapshot.showingHighlights
 
     if (this.props.state.snapshot.showingHighlights) {
-      const snapshot =
-        snapshotProps.snapshots[this.props.state.snapshot.stateIndex]
+      const snapshot = snapshotProps.snapshots[this.props.state.snapshot.stateIndex]
 
       this.autIframe.highlightEl(snapshot, snapshotProps)
     } else {
       this.autIframe.removeHighlights()
     }
-  };
+  }
 
   _changeSnapshotState = (snapshotProps, index) => {
     const snapshot = snapshotProps.snapshots[index]
@@ -211,7 +171,7 @@ export default class Iframes extends Component {
     } else {
       this.autIframe.removeHighlights()
     }
-  };
+  }
 
   componentDidUpdate () {
     const cb = this.props.state.callbackAfterUpdate
@@ -223,7 +183,7 @@ export default class Iframes extends Component {
 
   _printSelectorElementsToConsole = () => {
     this.autIframe.printSelectorElementsToConsole()
-  };
+  }
 
   componentWillUnmount () {
     this.props.eventManager.notifyRunningSpec(null)
@@ -234,6 +194,6 @@ export default class Iframes extends Component {
   }
 
   getSizeContainer () {
-    return this.containerRef
+    return this.refs.container
   }
 }

--- a/packages/runner-ct/src/iframe/iframes.scss
+++ b/packages/runner-ct/src/iframe/iframes.scss
@@ -1,9 +1,3 @@
-$cypress_blue: #3380FF;
-$hairline-color: $cypress_blue;
-$hairline-thickness: 1px;
-$hairline-size: min(60px, 80%);
-$hairline-offset: 15px;
-
 .iframes-ct-container {
   margin: 8px;
 }
@@ -11,31 +5,8 @@ $hairline-offset: 15px;
 .size-container {
   width: 100%;
   overflow: auto;
-  resize: both;
   background: none;
   box-shadow: none;
-
-  &:after, &:before {
-    content: "";
-    position: absolute;
-    background: $hairline-color;
-    opacity: .5;
-    padding: -2px;
-  }
-
-  &:after {
-    height: $hairline-size;
-    width: $hairline-thickness;
-    right: 0;
-    bottom: $hairline-offset;
-  }
-
-  &:before {
-    width: $hairline-size;
-    height: $hairline-thickness;
-    right: $hairline-offset;
-    bottom: 0;
-  }
 }
 
 .app-ct .runner {

--- a/packages/runner-ct/src/lib/state.ts
+++ b/packages/runner-ct/src/lib/state.ts
@@ -163,7 +163,15 @@ export default class State {
     }
   }
 
-  @action updateWindowDimensions ({ windowWidth, windowHeight, reporterWidth, headerHeight }) {
+  @action updateWindowDimensions ({
+    windowWidth, windowHeight, reporterWidth, headerHeight,
+  }:
+    {
+      windowWidth: number | null
+      windowHeight: number | null
+      reporterWidth: number | null
+      headerHeight: number | null
+    }) {
     if (windowWidth != null) this.windowWidth = windowWidth
 
     if (windowHeight != null) this.windowHeight = windowHeight


### PR DESCRIPTION
Makes the AUT adjust to the containing window when resizing.

<img width="1614" alt="Screen Shot 2021-02-02 at 4 49 41 PM" src="https://user-images.githubusercontent.com/5592465/106673429-320a9500-6577-11eb-94ba-86db041e53a3.png">

## To run the tests

When common build ready open npm/react and run `yarn cy:open`
On the last spec, `viewport_spec.js` the last test forces the window to be 2000px wide.
Try resizing the window and you will see the content adapt.

## Note

When we adjust the layout, we will need to adjust the calculation of the container width and height.

closes CT-231
