### PR TITLE
fix: cy.wait() works correctly when user aborted XHR.

### DIFF
--- a/packages/driver/cypress/fixtures/xhr-abort.html
+++ b/packages/driver/cypress/fixtures/xhr-abort.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <button id="btn" onclick="abortAndRequestAgain()">Abort and Request Again</button>
+    <script>
+      function abortAndRequestAgain() {
+        let xhr = new XMLHttpRequest();
+        xhr.open("GET", "https://jsonplaceholder.typicode.com/todos/1");
+        xhr.responseType = "json";
+        xhr.send();
+        xhr.abort();
+
+        xhr = new XMLHttpRequest();
+        xhr.open("GET", "https://jsonplaceholder.typicode.com/todos/1");
+        xhr.responseType = "json";
+        xhr.send();
+        xhr.onload = () => {
+          document.body.innerHTML += "<pre>" + JSON.stringify(xhr.response) + "</pre>";
+        };
+      }
+    </script>
+  </body>
+</html>

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -2225,6 +2225,15 @@ describe('network stubbing', { retries: 2 }, function () {
       .wait('@image').its('response.statusCode').should('eq', 304)
     })
 
+    // https://github.com/cypress-io/cypress/issues/9549
+    it('should handle aborted requests', () => {
+      cy.intercept('https://jsonplaceholder.typicode.com/todos/1').as('xhr')
+      cy.visit('fixtures/xhr-abort.html')
+      cy.get('#btn').click()
+      cy.get('pre').contains('delectus') // response body renders to page
+      cy.wait('@xhr')
+    })
+
     // @see https://github.com/cypress-io/cypress/issues/9306
     context('cy.get(alias)', function () {
       it('gets the latest Interception by alias', function () {

--- a/packages/driver/src/cy/net-stubbing/wait-for-route.ts
+++ b/packages/driver/src/cy/net-stubbing/wait-for-route.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import {
   Interception,
   InterceptionState,
@@ -7,37 +6,45 @@ import { getAliasedRequests } from './aliasing'
 
 const RESPONSE_WAITED_STATES: InterceptionState[] = ['ResponseIntercepted', 'Complete', 'Errored']
 
-function getPredicateForSpecifier (specifier: string): Partial<Interception> {
-  if (specifier === 'request') {
-    return { requestWaited: false }
-  }
-
-  // default to waiting on response
-  return { responseWaited: false }
-}
-
 export function waitForRoute (alias: string, state: Cypress.State, specifier: 'request' | 'response' | string): Interception | null {
   // 1. Create an array of known requests that have this alias.
   const candidateRequests = getAliasedRequests(alias, state)
 
-  // 2. Find the first request without responseWaited/requestWaited
-  const predicate = getPredicateForSpecifier(specifier)
-  const request = _.find(candidateRequests, predicate) as Interception | undefined
+  // 2. Find the requests without responseWaited/requestWaited
+  // We should not find only the first interception here,
+  // because there can be a list of interceptions with meaningful result
+  // when user calls xhr.abort();
+  // @see https://github.com/cypress-io/cypress/issues/9549
+  const requests = candidateRequests.filter((r) => {
+    if (specifier === 'request') {
+      return r.requestWaited === false
+    }
 
-  if (!request) {
+    return r.responseWaited === false
+  })
+
+  if (requests.length === 0) {
     return null
   }
 
   // 3. Determine if it's ready based on the specifier
-  request.requestWaited = true
+  // When request, return the first request.
   if (specifier === 'request') {
-    return request
+    requests[0].requestWaited = true
+
+    return requests[0]
   }
 
-  if (RESPONSE_WAITED_STATES.includes(request.state)) {
-    request.responseWaited = true
+  // When response, return the first request that has the wanted state.
+  for (let i = 0; i < requests.length; i++) {
+    const request = requests[i]
 
-    return request
+    if (RESPONSE_WAITED_STATES.includes(request.state)) {
+      request.requestWaited = true
+      request.responseWaited = true
+
+      return request
+    }
   }
 
   return null


### PR DESCRIPTION
- Closes #9549

### User facing changelog

`cy.wait()` falsely returns timeout when user aborted XHR. This PR fixes this issue.

### Additional details
- Why was this change necessary? => Cypress should handle aborting XHR.
- What is affected by this change? => N/A
- Any implementation details to explain? => Current code only checks the first request that matches the condition. But when user aborted XHR, there are multiple requests that match it and sometimes 2nd+ item tells us that the request has been done. So, I changed the code to fix this problem. 

### How has the user experience changed?

N/A

### PR Tasks
- [x] Have tests been added/updated?
