### PR TITLE
fix(css): Have spec searchbar extend 100% width

### DIFF
--- a/packages/desktop-gui/cypress/integration/specs_list_spec.js
+++ b/packages/desktop-gui/cypress/integration/specs_list_spec.js
@@ -481,6 +481,7 @@ describe('Specs List', function () {
           cy.get('.specs-list').should('not.exist')
 
           cy.get('.empty-well').should('contain', 'No specs match your search: "foobarbaz"')
+          cy.percySnapshot()
         })
 
         it('removes run all tests buttons if no results', function () {

--- a/packages/desktop-gui/src/specs/specs.scss
+++ b/packages/desktop-gui/src/specs/specs.scss
@@ -26,7 +26,7 @@ $max-nesting-level: 14;
     margin-right: 15px;
     display: inline-block;
     position: relative;
-    width: calc(100% - 160px);
+    width: 100%;
 
     label {
       position: absolute;


### PR DESCRIPTION
- Close #14830 

### User facing changelog

The specs search filter now extends the entire width of the header.

### Additional details

Added a snapshot for the searchbar

### How has the user experience changed?

#### Before

<img width="925" alt="Screen Shot 2021-02-05 at 11 02 00 AM" src="https://user-images.githubusercontent.com/1271364/106990304-5f875680-67a2-11eb-8452-1295f21d2686.png">


#### After

<img width="780" alt="Screen Shot 2021-02-05 at 11 01 24 AM" src="https://user-images.githubusercontent.com/1271364/106990317-6615ce00-67a2-11eb-99cf-57f0ed7b35ed.png">

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->