### PR TITLE
chore(ci): only run build system unit tests once

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -723,26 +723,6 @@ jobs:
           command: yarn type-check --ignore-progress
       - store-npm-logs
 
-  build-system-unit-tests:
-    <<: *defaults
-    parallelism: 1
-    steps:
-      - attach_workspace:
-          at: ~/
-      - check-conditional-ci
-      - install-required-node
-      - run:
-          name: Mocha tests
-          command: |
-            . ./scripts/load-nvm.sh
-            yarn test-mocha
-      # test binary build code
-      - run:
-          name: Test scripts
-          command: |
-            . ./scripts/load-nvm.sh
-            yarn test-scripts
-
   server-unit-tests:
     <<: *defaults
     parallelism: 1
@@ -1658,9 +1638,6 @@ linux-workflow: &linux-workflow
     - cli-visual-tests:
         requires:
           - build
-    - build-system-unit-tests:
-        requires:
-          - build
     - unit-tests:
         requires:
           - build
@@ -1962,13 +1939,6 @@ mac-workflow: &mac-workflow
         <<: *macBuildFilters
         requires:
           - darwin-build
-
-    - build-system-unit-tests:
-        name: darwin-build-system-unit-tests
-        executor: mac
-        requires:
-          - darwin-build
-        <<: *macBuildFilters
 
     # maybe run all unit tests?
 


### PR DESCRIPTION
This is getting run as part of `unit-tests` anyways:

https://github.com/cypress-io/cypress/blob/2891a511a386b8e6d2bdc4a45c92156514b511f0/circle.yml#L689-L690

So let's just run it once.