### PR TITLE
fix: include event emitter types from cypress types

### DIFF
--- a/cli/types/cypress-global-vars.d.ts
+++ b/cli/types/cypress-global-vars.d.ts
@@ -1,5 +1,3 @@
-/// <reference path="./cypress-eventemitter.d.ts" />
-
 /**
  * Global variables `cy` added by Cypress with all API commands.
  * @see https://on.cypress.io/api

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -5195,7 +5195,7 @@ declare namespace Cypress {
       })
     ```
      */
-    (action: 'uncaught:exception', fn: (error: Error, runnable: Mocha.Runnable) => false | void): void
+    (action: 'uncaught:exception', fn: (error: Error, runnable: Mocha.Runnable) => false | void): Cypress
     /**
      * Fires when your app calls the global `window.confirm()` method.
      * Cypress will auto accept confirmations. Return `false` from this event and the confirmation will be canceled.
@@ -5208,7 +5208,7 @@ declare namespace Cypress {
     })
     ```
      */
-    (action: 'window:confirm', fn: ((text: string) => false | void) | SinonSpyAgent<sinon.SinonSpy> | SinonSpyAgent<sinon.SinonStub>): void
+    (action: 'window:confirm', fn: ((text: string) => false | void) | SinonSpyAgent<sinon.SinonSpy> | SinonSpyAgent<sinon.SinonStub>): Cypress
     /**
      * Fires when your app calls the global `window.alert()` method.
      * Cypress will auto accept alerts. You cannot change this behavior.
@@ -5225,91 +5225,117 @@ declare namespace Cypress {
     ```
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'window:alert', fn: ((text: string) => void) | SinonSpyAgent<sinon.SinonSpy> | SinonSpyAgent<sinon.SinonStub>): void
+    (action: 'window:alert', fn: ((text: string) => void) | SinonSpyAgent<sinon.SinonSpy> | SinonSpyAgent<sinon.SinonStub>): Cypress
     /**
-     * Fires as the page begins to load, but before any of your applications JavaScript has executed. This fires at the exact same time as `cy.visit()` `onBeforeLoad` callback. Useful to modify the window on a page transition.
+     * Fires as the page begins to load, but before any of your applications JavaScript has executed.
+     * This fires at the exact same time as `cy.visit()` `onBeforeLoad` callback.
+     * Useful to modify the window on a page transition.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'window:before:load', fn: (win: AUTWindow) => void): void
+    (action: 'window:before:load', fn: (win: AUTWindow) => void): Cypress
     /**
-     * Fires after all your resources have finished loading after a page transition. This fires at the exact same time as a `cy.visit()` `onLoad` callback.
+     * Fires after all your resources have finished loading after a page transition.
+     * This fires at the exact same time as a `cy.visit()` `onLoad` callback.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'window:load', fn: (win: AUTWindow) => void): void
+    (action: 'window:load', fn: (win: AUTWindow) => void): Cypress
     /**
-     * Fires when your application is about to navigate away. The real event object is provided to you. Your app may have set a `returnValue` on the event, which is useful to assert on.
+     * Fires when your application is about to navigate away.
+     * The real event object is provided to you.
+     * Your app may have set a `returnValue` on the event, which is useful to assert on.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'window:before:unload', fn: (event: BeforeUnloadEvent) => void): void
+    (action: 'window:before:unload', fn: (event: BeforeUnloadEvent) => void): Cypress
     /**
-     * Fires when your application is has unloaded and is navigating away. The real event object is provided to you. This event is not cancelable.
+     * Fires when your application is has unloaded and is navigating away.
+     * The real event object is provided to you. This event is not cancelable.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'window:unload', fn: (event: Event) => void): void
+    (action: 'window:unload', fn: (event: Event) => void): Cypress
     /**
      * Fires whenever Cypress detects that your application's URL has changed.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'url:changed', fn: (url: string) => void): void
+    (action: 'url:changed', fn: (url: string) => void): Cypress
     /**
-     * Fires when the test has failed. It is technically possible to prevent the test from actually failing by binding to this event and invoking an async `done` callback. However this is **strongly discouraged**. Tests should never legitimately fail. This event exists because it's extremely useful for debugging purposes.
+     * Fires when the test has failed. It is technically possible to prevent the test
+     * from actually failing by binding to this event and invoking an async `done` callback.
+     * However this is **strongly discouraged**. Tests should never legitimately fail.
+     *  This event exists because it's extremely useful for debugging purposes.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'fail', fn: (error: Error, mocha: Mocha.Runnable) => void): void
+    (action: 'fail', fn: (error: Error, mocha: Mocha.Runnable) => void): Cypress
     /**
-     * Fires whenever the viewport changes via a `cy.viewport()` or naturally when Cypress resets the viewport to the default between tests. Useful for debugging purposes.
+     * Fires whenever the viewport changes via a `cy.viewport()` or naturally when
+     * Cypress resets the viewport to the default between tests. Useful for debugging purposes.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'viewport:changed', fn: (viewport: Viewport) => void): void
+    (action: 'viewport:changed', fn: (viewport: Viewport) => void): Cypress
     /**
-     * Fires whenever **Cypress** is scrolling your application. This event is fired when Cypress is {% url 'waiting for and calculating actionability' interacting-with-elements %}. It will scroll to 'uncover' elements currently being covered. This event is extremely useful to debug why Cypress may think an element is not interactive.
+     * Fires whenever **Cypress** is scrolling your application.
+     * This event is fired when Cypress is {% url 'waiting for and calculating
+     * actionability' interacting-with-elements %}. It will scroll to 'uncover'
+     * elements currently being covered. This event is extremely useful to debug why
+     * Cypress may think an element is not interactive.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'scrolled', fn: ($el: JQuery) => void): void
+    (action: 'scrolled', fn: ($el: JQuery) => void): Cypress
     /**
-     * Fires when a cy command is first invoked and enqueued to be run later. Useful for debugging purposes if you're confused about the order in which commands will execute.
+     * Fires when a cy command is first invoked and enqueued to be run later.
+     * Useful for debugging purposes if you're confused about the order in which commands will execute.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'command:enqueued', fn: (command: EnqueuedCommand) => void): void
+    (action: 'command:enqueued', fn: (command: EnqueuedCommand) => void): Cypress
     /**
-     * Fires when cy begins actually running and executing your command. Useful for debugging and understanding how the command queue is async.
+     * Fires when cy begins actually running and executing your command.
+     * Useful for debugging and understanding how the command queue is async.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'command:start', fn: (command: CommandQueue) => void): void
+    (action: 'command:start', fn: (command: CommandQueue) => void): Cypress
     /**
-     * Fires when cy finishes running and executing your command. Useful for debugging and understanding how commands are handled.
+     * Fires when cy finishes running and executing your command.
+     * Useful for debugging and understanding how commands are handled.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'command:end', fn: (command: CommandQueue) => void): void
+    (action: 'command:end', fn: (command: CommandQueue) => void): Cypress
     /**
-     * Fires whenever a command begins its retrying routines. This is called on the trailing edge after Cypress has internally waited for the retry interval. Useful to understand **why** a command is retrying, and generally includes the actual error causing the retry to happen. When commands fail the final error is the one that actually bubbles up to fail the test. This event is essentially to debug why Cypress is failing.
+     * Fires whenever a command begins its retrying routines.
+     * This is called on the trailing edge after Cypress has internally
+     * waited for the retry interval. Useful to understand **why** a command is retrying,
+     * and generally includes the actual error causing the retry to happen.
+     * When commands fail the final error is the one that actually bubbles up to fail the test.
+     * This event is essentially to debug why Cypress is failing.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'command:retry', fn: (command: CommandQueue) => void): void
+    (action: 'command:retry', fn: (command: CommandQueue) => void): Cypress
     /**
-     * Fires whenever a command emits this event so it can be displayed in the Command Log. Useful to see how internal cypress commands utilize the {% url 'Cypress.log()' cypress-log %} API.
+     * Fires whenever a command emits this event so it can be displayed in the Command Log.
+     * Useful to see how internal cypress commands utilize the {% url 'Cypress.log()' cypress-log %} API.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'log:added', fn: (log: any, interactive: boolean) => void): void
+    (action: 'log:added', fn: (log: any, interactive: boolean) => void): Cypress
     /**
-     * Fires whenever a command's attributes changes. This event is debounced to prevent it from firing too quickly and too often. Useful to see how internal cypress commands utilize the {% url 'Cypress.log()' cypress-log %} API.
+     * Fires whenever a command's attributes changes.
+     * This event is debounced to prevent it from firing too quickly and too often.
+     * Useful to see how internal cypress commands utilize the {% url 'Cypress.log()' cypress-log %} API.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'log:changed', fn: (log: any, interactive: boolean) => void): void
+    (action: 'log:changed', fn: (log: any, interactive: boolean) => void): Cypress
     /**
      * Fires before the test and all **before** and **beforeEach** hooks run.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'test:before:run', fn: (attributes: ObjectLike, test: Mocha.Test) => void): void
+    (action: 'test:before:run', fn: (attributes: ObjectLike, test: Mocha.Test) => void): Cypress
     /**
-     * Fires before the test and all **before** and **beforeEach** hooks run. If a `Promise` is returned, it will be awaited before proceeding.
+     * Fires before the test and all **before** and **beforeEach** hooks run.
+     * If a `Promise` is returned, it will be awaited before proceeding.
      */
-    (action: 'test:before:run:async', fn: (attributes: ObjectLike, test: Mocha.Test) => void | Promise<any>): void
+    (action: 'test:before:run:async', fn: (attributes: ObjectLike, test: Mocha.Test) => void | Promise<any>): Cypress
     /**
      * Fires after the test and all **afterEach** and **after** hooks run.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'test:after:run', fn: (attributes: ObjectLike, test: Mocha.Test) => void): void
+    (action: 'test:after:run', fn: (attributes: ObjectLike, test: Mocha.Test) => void): Cypress
   }
 
   // $CommandQueue from `command_queue.coffee` - a lot to type. Might be more useful if it was written in TS

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1,4 +1,5 @@
 /// <reference path="./cypress-npm-api.d.ts" />
+/// <reference path="./cypress-eventemitter.d.ts" />
 
 declare namespace Cypress {
   type FileContents = string | any[] | object

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -343,6 +343,16 @@ namespace CypressOnTests {
     error // $ExpectType Error
     runnable // $ExpectType Runnable
   })
+
+  // you can chain multiple callbacks
+  Cypress
+    .on('test:before:run', () => { })
+    .on('test:after:run', () => { })
+    .on('test:before:run:async', () => { })
+
+  cy
+    .on('window:before:load', () => { })
+    .on('command:start', () => { })
 }
 
 namespace CypressOnceTests {


### PR DESCRIPTION
- closes #14991 by adding including the event emitter definition where it is used first

### User facing changelog

Types no longer complain when you chain event listeners like

```js
Cypress
  .on('test:before:run', () => {
    console.log('before running a test')
  })
  .on('test:after:run', () => {
    console.log('after running a test')
  })
```

### Additional details

Notice the types returned `void` while the test happily runs. Also moved the emitter reference line into the file where it was used.

### How has the user experience changed?

No more type errors

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
