### PR TITLE
fix: add exit management on run-ct cli comand

### DIFF
--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -428,6 +428,8 @@ module.exports = {
       debug('running Cypress run-ct')
       require('./exec/run')
       .start(util.parseOpts(opts), { isComponentTesting: true })
+      .then(util.exit)
+      .catch(util.logErrorExit1)
     })
 
     program

--- a/packages/runner-ct/cypress/component/RunnerCt.spec.tsx
+++ b/packages/runner-ct/cypress/component/RunnerCt.spec.tsx
@@ -42,30 +42,40 @@ describe('RunnerCt', () => {
     cy.percySnapshot()
   })
 
-  it('toggles specs list drawer using shortcut', () => {
-    cy.viewport(1000, 500)
-    const state = new State({
-      reporterWidth: 500,
-      spec: null,
-      specs: [{ relative: '/test.js', absolute: 'root/test.js', name: 'test.js' }],
+  context('keyboard shortcuts', () => {
+    beforeEach(() => {
+      cy.viewport(1000, 500)
+      const state = new State({
+        reporterWidth: 500,
+        spec: null,
+        specs: [{ relative: '/test.js', absolute: 'root/test.js', name: 'test.js' }],
+      })
+
+      mount(
+        <App
+          state={state}
+          // @ts-ignore - this is difficult to stub. Real one breaks things.
+          eventManager={new FakeEventManager()}
+          config={{ projectName: 'Project', env: {} }}
+        />,
+      )
+
+      cy.window().then((win) => win.focus())
     })
 
-    mount(
-      <App
-        state={state}
-        // @ts-ignore - this is difficult to stub. Real one breaks things.
-        eventManager={new FakeEventManager()}
-        config={{ projectName: 'Project', env: {} }}
-      />,
-    )
+    it('toggles specs list drawer using shortcut', () => {
+      cy.realPress(['Meta', 'B'])
+      cy.wait(400) // can not wait for this animation automatically :(
+      assertSpecsListIs('closed')
 
-    cy.window().then((win) => win.focus())
-    cy.realPress(['Meta', 'B'])
-    cy.wait(400) // can not wait for this animation automatically :(
-    assertSpecsListIs('closed')
+      cy.realPress(['Meta', 'B'])
+      assertSpecsListIs('open')
+    })
 
-    cy.realPress(['Meta', 'B'])
-    assertSpecsListIs('open')
+    it('focuses the search field on "/"', () => {
+      cy.realPress('/')
+      cy.get('input[placeholder="Find spec..."]').should('be.focused')
+    })
   })
 
   context('specs-list resizing', () => {

--- a/packages/runner-ct/cypress/component/RunnerCt.spec.tsx
+++ b/packages/runner-ct/cypress/component/RunnerCt.spec.tsx
@@ -1,7 +1,7 @@
 /// <reference types="@percy/cypress" />
 import React from 'react'
 import { mount } from '@cypress/react'
-import App from '../../src/app/app'
+import App from '../../src/app/RunnerCt'
 import State from '../../src/lib/state'
 import '@packages/runner/src/main.scss'
 
@@ -12,7 +12,7 @@ class FakeEventManager {
   notifyRunningSpec = () => { }
 }
 
-describe('App', () => {
+describe('RunnerCt', () => {
   function assertSpecsListIs (state: 'closed' | 'open') {
     // for some reason should("not.be.visible") doesn't work here so ensure that specs list was outside of screen
     cy.get('[data-cy=specs-list]').then(([el]) => {
@@ -97,7 +97,7 @@ describe('App', () => {
 
       cy.get('[data-cy=resizer]').trigger('mouseup', 'center')
 
-      cy.get('[data-cy=specs-list-resize-box').should('have.css', 'width', '425px')
+      cy.get('[data-cy=specs-list-resize-box').should('have.css', 'width', '429px')
     })
 
     it('restore specs list width after closing and reopen', () => {
@@ -107,14 +107,14 @@ describe('App', () => {
       })
 
       cy.get('[data-cy=resizer]').trigger('mouseup', 'center')
-      cy.get('[data-cy=specs-list-resize-box').should('have.css', 'width', '475px')
+      cy.get('[data-cy=specs-list-resize-box').should('have.css', 'width', '479px')
 
       cy.get('[aria-label="Open the menu"').click()
       assertSpecsListIs('closed')
 
       cy.get('[aria-label="Open the menu"').click()
 
-      cy.get('[data-cy=specs-list-resize-box').should('have.css', 'width', '475px')
+      cy.get('[data-cy=specs-list-resize-box').should('have.css', 'width', '479px')
     })
   })
 })

--- a/packages/runner-ct/cypress/component/SpecList/SpecList.spec.tsx
+++ b/packages/runner-ct/cypress/component/SpecList/SpecList.spec.tsx
@@ -135,10 +135,7 @@ describe('SpecList', () => {
       />,
     )
 
-    cy.window().then((win) => win.focus())
-
-    cy.realPress('/')
-    cy.get('input[placeholder="Find spec..."]').should('be.focused')
+    cy.get('input[placeholder="Find spec..."]').focus()
 
     cy.realPress('ArrowDown')
     cy.realPress('ArrowDown')


### PR DESCRIPTION
closes CT-264

## To test

- open nom/react
- change the contents of cypress.json with 
```json
{
  "viewportWidth": 400,
  "viewportHeight": 400,
  "video": false,
  "projectId": "z9dxah",
  "testFiles": "**/hello-world-spec.{js,jsx,ts,tsx}",
  "env": {
    "reactDevtools": true,
    "cypress-react-selector": {
      "root": "#cypress-root"
    }
  },
  "ignoreTestFiles": [
    "**/__snapshots__/*",
    "**/__image_snapshots__/*"
  ],
  "experimentalComponentTesting": true,
  "experimentalFetchPolyfill": true
}
```
- run yarn cy:run
- the run should fail