### PR TITLE
chore(ci): fix binary upload version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ macBuildFilters: &macBuildFilters
     branches:
       only:
         - develop
-        - combine-artifact-steps
+        - fix-next-version
         - include-electron-node-version
 
 defaults: &defaults
@@ -36,7 +36,7 @@ testBinaryFirefox: &testBinaryFirefox
     branches:
       only:
         - develop
-        - combine-artifact-steps
+        - fix-next-version
   requires:
     - create-build-artifacts
 
@@ -479,7 +479,7 @@ commands:
           command: |
             node scripts/binary.js upload-unique-binary \
               --file cypress.zip \
-              --version $(node ./scripts/get-next-version.js)
+              --version $(node -p "require('./package.json').version")
       - run: cat binary-url.json
       - store-npm-logs
       - persist_to_workspace:
@@ -529,7 +529,7 @@ commands:
           command: |
             node scripts/binary.js upload-npm-package \
               --file cypress.tgz \
-              --version $(node ./scripts/get-next-version.js)
+              --version $(node -p "require('./package.json').version")
       - store-npm-logs
       - run: ls -l
       - run: cat npm-package-url.json
@@ -1152,7 +1152,7 @@ jobs:
       - run:
           name: Check current branch to persist artifacts
           command: |
-            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "combine-artifact-steps" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "fix-next-version" ]]; then
               echo "Not uploading artifacts or posting install comment for this branch."
               circleci-agent step halt
             fi
@@ -1833,7 +1833,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
-              - combine-artifact-steps
+              - fix-next-version
         requires:
           - build
     - test-kitchensink:
@@ -1851,7 +1851,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
-              - combine-artifact-steps
+              - fix-next-version
         requires:
           - build
     - create-build-artifacts:
@@ -1907,7 +1907,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
-              - combine-artifact-steps
+              - fix-next-version
         requires:
           - create-build-artifacts
     - test-npm-module-and-verify-binary:
@@ -1915,7 +1915,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
-              - combine-artifact-steps
+              - fix-next-version
         requires:
           - create-build-artifacts
     - test-binary-against-staging:
@@ -1924,7 +1924,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
-              - combine-artifact-steps
+              - fix-next-version
         requires:
           - create-build-artifacts
 
@@ -1949,7 +1949,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
-              - combine-artifact-steps
+              - fix-next-version
         requires:
           - create-build-artifacts
 
@@ -2012,7 +2012,7 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
-              - combine-artifact-steps
+              - fix-next-version
         requires:
           - darwin-create-build-artifacts
 
@@ -2024,7 +2024,7 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
-              - combine-artifact-steps
+              - fix-next-version
         requires:
           - darwin-create-build-artifacts
 


### PR DESCRIPTION
Before, darwin/linux download links for develop builds had the wrong version (check the URLs):

![image](https://user-images.githubusercontent.com/1151760/107567484-a4b1eb00-6bdd-11eb-8a03-2cdd5329ec68.png)
