### PR TITLE
fix: use app.whenReady and remove delay race for electron startup

### DIFF
--- a/packages/server/__snapshots__/spec_writer_spec.ts.js
+++ b/packages/server/__snapshots__/spec_writer_spec.ts.js
@@ -97,39 +97,6 @@ describe('top level suite', () => {
 
 `
 
-exports['lib/util/spec_writer #appendCommandsToTest can add commands to an existing test defined with it.only 1'] = `
-describe('top level suite', () => {
-  describe('inner suite with describe', () => {
-    it('test with it', () => {
-      cy.get('.btn').click()
-    })
-
-    specify('test with specify', () => {
-      cy.get('.btn').click()
-    })
-
-    // eslint-disable-next-line mocha/no-exclusive-tests
-    it.only('test with it.only', () => {
-      cy.get('.btn').click()
-      /* ==== Generated with Cypress Studio ==== */
-      cy.get('.input').type('typed text');
-      cy.get('.btn').click();
-      /* ==== End Cypress Studio ==== */
-    })
-  })
-
-  context('inner suite with context', () => {
-
-  })
-
-  // eslint-disable-next-line mocha/no-exclusive-tests
-  describe.only('inner suite with describe.only', () => {
-
-  })
-})
-
-`
-
 exports['lib/util/spec_writer #createNewTestInSuite can create a new test in a suite defined with describe 1'] = `
 describe('top level suite', () => {
   describe('inner suite with describe', () => {
@@ -197,41 +164,6 @@ describe('top level suite', () => {
   // eslint-disable-next-line mocha/no-exclusive-tests
   describe.only('inner suite with describe.only', () => {
 
-  })
-})
-
-`
-
-exports['lib/util/spec_writer #createNewTestInSuite can create a new test in a suite defined with describe.only 1'] = `
-describe('top level suite', () => {
-  describe('inner suite with describe', () => {
-    it('test with it', () => {
-      cy.get('.btn').click()
-    })
-
-    specify('test with specify', () => {
-      cy.get('.btn').click()
-    })
-
-    // eslint-disable-next-line mocha/no-exclusive-tests
-    it.only('test with it.only', () => {
-      cy.get('.btn').click()
-    })
-  })
-
-  context('inner suite with context', () => {
-
-  })
-
-  // eslint-disable-next-line mocha/no-exclusive-tests
-  describe.only('inner suite with describe.only', () => {
-    /* === Test Created with Cypress Studio === */
-    it('test added to describe.only', function() {
-      /* ==== Generated with Cypress Studio ==== */
-      cy.get('.input').type('typed text');
-      cy.get('.btn').click();
-      /* ==== End Cypress Studio ==== */
-    });
   })
 })
 

--- a/packages/server/lib/modes/interactive-e2e.js
+++ b/packages/server/lib/modes/interactive-e2e.js
@@ -3,7 +3,6 @@ const os = require('os')
 const EE = require('events')
 const { app } = require('electron')
 const image = require('electron').nativeImage
-const Promise = require('bluebird')
 const cyIcons = require('@cypress/icons')
 const electronApp = require('../util/electron-app')
 const savedState = require('../saved_state')
@@ -112,15 +111,11 @@ module.exports = {
     })
   },
 
-  run (options) {
+  async run (options) {
     electronApp.allowRendererProcessReuse()
 
-    return Promise.any([
-      app.whenReady(),
-      Promise.delay(500),
-    ])
-    .then(() => {
-      return this.ready(options)
-    })
+    await app.whenReady()
+
+    return this.ready(options)
   },
 }

--- a/packages/server/lib/modes/interactive-e2e.js
+++ b/packages/server/lib/modes/interactive-e2e.js
@@ -113,16 +113,10 @@ module.exports = {
   },
 
   run (options) {
-    const waitForReady = () => {
-      return new Promise((resolve, reject) => {
-        return app.on('ready', resolve)
-      })
-    }
-
     electronApp.allowRendererProcessReuse()
 
     return Promise.any([
-      waitForReady(),
+      app.whenReady(),
       Promise.delay(500),
     ])
     .then(() => {

--- a/packages/server/lib/modes/interactive-e2e.js
+++ b/packages/server/lib/modes/interactive-e2e.js
@@ -4,7 +4,6 @@ const EE = require('events')
 const { app } = require('electron')
 const image = require('electron').nativeImage
 const cyIcons = require('@cypress/icons')
-const electronApp = require('../util/electron-app')
 const savedState = require('../saved_state')
 const menu = require('../gui/menu')
 const Events = require('../gui/events')
@@ -112,8 +111,6 @@ module.exports = {
   },
 
   async run (options) {
-    electronApp.allowRendererProcessReuse()
-
     await app.whenReady()
 
     return this.ready(options)

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console, @cypress/dev/arrow-body-multiline-braces  */
 const _ = require('lodash')
+const { app } = require('electron')
 const la = require('lazy-ass')
 const pkg = require('@packages/root')
 const path = require('path')
@@ -27,7 +28,6 @@ const newlines = require('../util/newlines')
 const terminal = require('../util/terminal')
 const specsUtil = require('../util/specs')
 const humanTime = require('../util/human_time')
-const electronApp = require('../util/electron-app')
 const settings = require('../util/settings')
 const chromePolicyCheck = require('../util/chrome_policy_check')
 const experiments = require('../experiments')
@@ -1557,11 +1557,16 @@ module.exports = {
     })
   },
 
-  run (options) {
-    return electronApp
-    .waitForReady()
-    .then(() => {
-      return this.ready(options)
+  async run (options) {
+    // electron >= 5.0.0 will exit the app if all browserwindows are closed,
+    // this is obviously undesirable in run mode
+    // https://github.com/cypress-io/cypress/pull/4720#issuecomment-514316695
+    app.on('window-all-closed', () => {
+      debug('all BrowserWindows closed, not exiting')
     })
+
+    await app.whenReady()
+
+    return this.ready(options)
   },
 }

--- a/packages/server/lib/util/electron-app.js
+++ b/packages/server/lib/util/electron-app.js
@@ -8,53 +8,13 @@ const scale = () => {
   }
 }
 
-const allowRendererProcessReuse = () => {
-  const { app } = require('electron')
-
-  // @see https://github.com/electron/electron/issues/18397
-  // NOTE: in Electron 9, this can be removed, since it will be the new default
-  app.allowRendererProcessReuse = true
-}
-
-// NOTE: this function is only called in run mode
-const waitForReady = () => {
-  const debug = require('debug')('cypress:server:electron-app')
-
-  const Promise = require('bluebird')
-  const { app } = require('electron')
-
-  allowRendererProcessReuse()
-
-  // electron >= 5.0.0 will exit the app if all browserwindows are closed,
-  // this is obviously undesirable in run mode
-  // https://github.com/cypress-io/cypress/pull/4720#issuecomment-514316695
-  app.on('window-all-closed', () => {
-    debug('all BrowserWindows closed, not exiting')
-  })
-
-  const onReadyEvent = () => {
-    return new Promise((resolve) => {
-      app.on('ready', resolve)
-    })
-  }
-
-  return Promise.any([
-    onReadyEvent(),
-    Promise.delay(500),
-  ])
-}
-
 const isRunning = () => {
   // are we in the electron or the node process?
   return Boolean(process.versions && process.versions.electron)
 }
 
 module.exports = {
-  allowRendererProcessReuse,
-
   scale,
-
-  waitForReady,
 
   isRunning,
 }

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -124,7 +124,6 @@ describe('lib/cypress', () => {
     sinon.stub(videoCapture, 'start').resolves({})
     sinon.stub(plugins, 'init').resolves(undefined)
     sinon.stub(electronApp, 'isRunning').returns(true)
-    sinon.stub(electronApp, 'whenReady').resolves()
     sinon.stub(extension, 'setHostAndPath').resolves()
     sinon.stub(launcher, 'detect').resolves(TYPICAL_BROWSERS)
     sinon.stub(process, 'exit')

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -124,6 +124,7 @@ describe('lib/cypress', () => {
     sinon.stub(videoCapture, 'start').resolves({})
     sinon.stub(plugins, 'init').resolves(undefined)
     sinon.stub(electronApp, 'isRunning').returns(true)
+    sinon.stub(electronApp, 'whenReady').resolves()
     sinon.stub(extension, 'setHostAndPath').resolves()
     sinon.stub(launcher, 'detect').resolves(TYPICAL_BROWSERS)
     sinon.stub(process, 'exit')

--- a/packages/server/test/support/helpers/electron_stub.js
+++ b/packages/server/test/support/helpers/electron_stub.js
@@ -20,6 +20,7 @@ module.exports = {
       appendArgument () {},
     },
     disableHardwareAcceleration () {},
+    async whenReady () {},
   },
   systemPreferences: {
     isDarkMode () {},

--- a/packages/server/test/unit/modes/interactive_spec.js
+++ b/packages/server/test/unit/modes/interactive_spec.js
@@ -167,7 +167,7 @@ describe('gui/interactive', () => {
 
   context('.run', () => {
     beforeEach(() => {
-      sinon.stub(electron.app, 'on').withArgs('ready').yieldsAsync()
+      sinon.stub(electron.app, 'whenReady').resolves()
     })
 
     it('calls ready with options', () => {


### PR DESCRIPTION
This change fixes an issue that caused the startup to be delayed by 500ms.
We used `app.on('ready')` without checking `app.isReady()`, however the
'ready' event may already have fired at this point and thus we never
resolved the Promise waiting for it.
Using `app.whenReady` fixes this and now that Promise resolves before
the delay expires.

Related links:

https://www.electronjs.org/docs/api/app#event-ready
https://www.electronjs.org/docs/api/app#appwhenready

- Closes <!-- issue number here. e.g. "Closes #1234" -->

### User facing changelog

* Improved the startup time of `cypress open` and `cypress run`.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
