### PR TITLE
fix: Add autoEnd option to Cypress.Log Typescript definitions

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -5381,6 +5381,8 @@ declare namespace Cypress {
     /** Override *name* for display purposes only */
     displayName: string
     message: any
+    /** Set to false if you want to control the finishing of the command in the log yourself */
+    autoEnd: boolean
     /** Return an object that will be printed in the dev tools console */
     consoleProps(): ObjectLike
   }


### PR DESCRIPTION
Sorry if not respecting the contribution guidelines, but this is an issue/PR as I noticed the autoEnd option isn't in the typescript definitions for Cypress, and it was referenced in the webcast on Youtube by the Cypress team: https://www.youtube.com/watch?v=V-o8WzlwKmM

Tried adding it here with a sensible comment, does it look good?

EDIT: Unlazied myself and searched the issues and see that there's #9590 and actually also already a PR for this at #14220 but it seems like this PR is inactive? So I'll keep this up?

closes #9590 (though it doesn't address the lack of documentation)