### PR TITLE
fix: grab bitbucket PR environment variables

### DIFF
--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -165,6 +165,10 @@ const _providerCiParams = () => {
       'BITBUCKET_BUILD_NUMBER',
       'BITBUCKET_PARALLEL_STEP',
       'BITBUCKET_STEP_RUN_NUMBER',
+      // the PR variables are only set on pull request builds
+      'BITBUCKET_PR_ID',
+      'BITBUCKET_PR_DESTINATION_BRANCH',
+      'BITBUCKET_PR_DESTINATION_COMMIT',
     ]),
     buildkite: extract([
       'BUILDKITE_REPO',

--- a/packages/server/test/unit/ci_provider_spec.js
+++ b/packages/server/test/unit/ci_provider_spec.js
@@ -213,6 +213,61 @@ describe('lib/util/ci_provider', () => {
     })
   })
 
+  it('bitbucket pull request', () => {
+    resetEnv = mockedEnv({
+      CI: '1',
+
+      // build information
+      BITBUCKET_BUILD_NUMBER: 'bitbucketBuildNumber',
+      BITBUCKET_REPO_OWNER: 'bitbucketRepoOwner',
+      BITBUCKET_REPO_SLUG: 'bitbucketRepoSlug',
+      BITBUCKET_PARALLEL_STEP: 'bitbucketParallelStep',
+      BITBUCKET_STEP_RUN_NUMBER: 'bitbucketStepRunNumber',
+
+      // git information
+      BITBUCKET_COMMIT: 'bitbucketCommit',
+      BITBUCKET_BRANCH: 'bitbucketBranch',
+
+      // pull request info
+      BITBUCKET_PR_ID: 'bitbucketPrId',
+      BITBUCKET_PR_DESTINATION_BRANCH: 'bitbucketPrDestinationBranch',
+      BITBUCKET_PR_DESTINATION_COMMIT: 'bitbucketPrDestinationCommit',
+    }, { clear: true })
+
+    expectsName('bitbucket')
+    expectsCiParams({
+      bitbucketBuildNumber: 'bitbucketBuildNumber',
+      bitbucketRepoOwner: 'bitbucketRepoOwner',
+      bitbucketRepoSlug: 'bitbucketRepoSlug',
+      bitbucketParallelStep: 'bitbucketParallelStep',
+      bitbucketStepRunNumber: 'bitbucketStepRunNumber',
+      bitbucketPrId: 'bitbucketPrId',
+      bitbucketPrDestinationBranch: 'bitbucketPrDestinationBranch',
+      bitbucketPrDestinationCommit: 'bitbucketPrDestinationCommit',
+    })
+
+    expectsCommitParams({
+      sha: 'bitbucketCommit',
+      branch: 'bitbucketBranch',
+    })
+
+    expectsCommitDefaults({
+      sha: null,
+      branch: 'gitFoundBranch',
+    }, {
+      sha: 'bitbucketCommit',
+      branch: 'gitFoundBranch',
+    })
+
+    return expectsCommitDefaults({
+      sha: undefined,
+      branch: '',
+    }, {
+      sha: 'bitbucketCommit',
+      branch: 'bitbucketBranch',
+    })
+  })
+
   it('buildkite', () => {
     resetEnv = mockedEnv({
       BUILDKITE: 'true',


### PR DESCRIPTION
- Closes #15081

### User facing changelog

The test runner will send pull request information from Bitbucket pipelines. This information will be then visible in the Cypress Dashboard

### Additional details

We never collected these three pull request environment variables

### How has the user experience changed?

In the test runner nothing has changed, the Dashboard will display the PR number

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
