### PR TITLE
fix: Add autoEnd option to Cypress.Log Typescript definitions (#15076)

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -5424,6 +5424,8 @@ declare namespace Cypress {
     /** Override *name* for display purposes only */
     displayName: string
     message: any
+    /** Set to false if you want to control the finishing of the command in the log yourself */
+    autoEnd: boolean
     /** Return an object that will be printed in the dev tools console */
     consoleProps(): ObjectLike
   }


### PR DESCRIPTION
- closes #9590
- by mistake was first merged into `master` branch, this is a cherry-pick into develop