### PR TITLE
feat: send CI variables for CloudFresh

### DIFF
--- a/packages/server/__snapshots__/cypress_spec.js
+++ b/packages/server/__snapshots__/cypress_spec.js
@@ -68,6 +68,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 - codeshipBasic
 - codeshipPro
 - concourse
+- codeFresh
 - drone
 - githubActions
 - gitlab
@@ -104,6 +105,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 - codeshipBasic
 - codeshipPro
 - concourse
+- codeFresh
 - drone
 - githubActions
 - gitlab
@@ -141,6 +143,7 @@ The ciBuildId is automatically detected if you are running Cypress in any of the
 - codeshipBasic
 - codeshipPro
 - concourse
+- codeFresh
 - drone
 - githubActions
 - gitlab

--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -96,6 +96,7 @@ const CI_PROVIDERS = {
   'codeshipBasic': isCodeshipBasic,
   'codeshipPro': isCodeshipPro,
   'concourse': isConcourse,
+  cloudFresh: 'CF_BUILD_ID',
   'drone': 'DRONE',
   githubActions: 'GITHUB_ACTIONS',
   'gitlab': isGitlab,
@@ -217,6 +218,20 @@ const _providerCiParams = () => {
       'BUILD_PIPELINE_NAME',
       'BUILD_TEAM_NAME',
       'ATC_EXTERNAL_URL',
+    ]),
+    // https://codefresh.io/docs/docs/codefresh-yaml/variables/
+    cloudFresh: extract([
+      'CF_BUILD_ID',
+      'CF_BUILD_URL',
+      'CF_CURRENT_ATTEMPT',
+      'CF_STEP_NAME',
+      'CF_PIPELINE_NAME',
+      'CF_PIPELINE_TRIGGER_ID',
+      // variables added for pull requests
+      'CF_PULL_REQUEST_ID',
+      'CF_PULL_REQUEST_IS_FORK',
+      'CF_PULL_REQUEST_NUMBER',
+      'CF_PULL_REQUEST_TARGET',
     ]),
     drone: extract([
       'DRONE_JOB_NUMBER',
@@ -464,6 +479,12 @@ const _providerCommitParams = () => {
       authorEmail: env.CI_COMMITTER_EMAIL,
       // remoteOrigin: ???
       // defaultBranch: ???
+    },
+    cloudFresh: {
+      sha: env.CF_REVISION,
+      branch: env.CF_BRANCH,
+      message: env.CF_COMMIT_MESSAGE,
+      authorName: env.CF_COMMIT_AUTHOR,
     },
     drone: {
       sha: env.DRONE_COMMIT_SHA,

--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -96,7 +96,7 @@ const CI_PROVIDERS = {
   'codeshipBasic': isCodeshipBasic,
   'codeshipPro': isCodeshipPro,
   'concourse': isConcourse,
-  cloudFresh: 'CF_BUILD_ID',
+  codeFresh: 'CF_BUILD_ID',
   'drone': 'DRONE',
   githubActions: 'GITHUB_ACTIONS',
   'gitlab': isGitlab,

--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -220,7 +220,7 @@ const _providerCiParams = () => {
       'ATC_EXTERNAL_URL',
     ]),
     // https://codefresh.io/docs/docs/codefresh-yaml/variables/
-    cloudFresh: extract([
+    codeFresh: extract([
       'CF_BUILD_ID',
       'CF_BUILD_URL',
       'CF_CURRENT_ATTEMPT',
@@ -480,7 +480,7 @@ const _providerCommitParams = () => {
       // remoteOrigin: ???
       // defaultBranch: ???
     },
-    cloudFresh: {
+    codeFresh: {
       sha: env.CF_REVISION,
       branch: env.CF_BRANCH,
       message: env.CF_COMMIT_MESSAGE,

--- a/packages/server/test/unit/ci_provider_spec.js
+++ b/packages/server/test/unit/ci_provider_spec.js
@@ -458,6 +458,63 @@ describe('lib/util/ci_provider', () => {
     return expectsCommitParams(null)
   })
 
+  it('codeFresh', () => {
+    resetEnv = mockedEnv({
+      // build information
+      'CF_BUILD_ID': 'cfBuildId',
+      'CF_BUILD_URL': 'cfBuildUrl',
+      'CF_CURRENT_ATTEMPT': 'cfCurrentAttempt',
+      'CF_STEP_NAME': 'cfStepName',
+      'CF_PIPELINE_NAME': 'cfPipelineName',
+      'CF_PIPELINE_TRIGGER_ID': 'cfPipelineTriggerId',
+
+      // variables added for pull requests
+      'CF_PULL_REQUEST_ID': 'cfPullRequestId',
+      'CF_PULL_REQUEST_IS_FORK': 'cfPullRequestIsFork',
+      'CF_PULL_REQUEST_NUMBER': 'cfPullRequestNumber',
+      'CF_PULL_REQUEST_TARGET': 'cfPullRequestTarget',
+
+      // git information
+      CF_REVISION: 'cfRevision',
+      CF_BRANCH: 'cfBranch',
+      CF_COMMIT_MESSAGE: 'cfCommitMessage',
+      CF_COMMIT_AUTHOR: 'cfCommitAuthor',
+    }, { clear: true })
+
+    expectsName('cloudFlare')
+    expectsCiParams({
+      cfBuildId: 'cfBuildId',
+      cfBuildUrl: 'cfBuildUrl',
+      cfCurrentAttempt: 'cfCurrentAttempt',
+      cfStepName: 'cfStepName',
+      cfPipelineName: 'cfPipelineName',
+      cfPipelineTriggerId: 'cfPipelineTriggerId',
+    })
+
+    expectsCommitParams({
+      sha: 'cfRevision',
+      branch: 'cfBranch',
+      message: 'cfCommitMessage',
+      authorName: 'cfCommitAuthor',
+    })
+
+    expectsCommitDefaults({
+      sha: null,
+      branch: 'gitFoundBranch',
+    }, {
+      sha: 'bitbucketCommit',
+      branch: 'gitFoundBranch',
+    })
+
+    return expectsCommitDefaults({
+      sha: undefined,
+      branch: '',
+    }, {
+      sha: 'bitbucketCommit',
+      branch: 'bitbucketBranch',
+    })
+  })
+
   it('drone', () => {
     resetEnv = mockedEnv({
       DRONE: 'true',

--- a/packages/server/test/unit/ci_provider_spec.js
+++ b/packages/server/test/unit/ci_provider_spec.js
@@ -481,7 +481,7 @@ describe('lib/util/ci_provider', () => {
       CF_COMMIT_AUTHOR: 'cfCommitAuthor',
     }, { clear: true })
 
-    expectsName('cloudFlare')
+    expectsName('codeFresh')
     expectsCiParams({
       cfBuildId: 'cfBuildId',
       cfBuildUrl: 'cfBuildUrl',

--- a/packages/server/test/unit/ci_provider_spec.js
+++ b/packages/server/test/unit/ci_provider_spec.js
@@ -497,22 +497,6 @@ describe('lib/util/ci_provider', () => {
       message: 'cfCommitMessage',
       authorName: 'cfCommitAuthor',
     })
-
-    expectsCommitDefaults({
-      sha: null,
-      branch: 'gitFoundBranch',
-    }, {
-      sha: 'bitbucketCommit',
-      branch: 'gitFoundBranch',
-    })
-
-    return expectsCommitDefaults({
-      sha: undefined,
-      branch: '',
-    }, {
-      sha: 'bitbucketCommit',
-      branch: 'bitbucketBranch',
-    })
   })
 
   it('drone', () => {

--- a/packages/server/test/unit/ci_provider_spec.js
+++ b/packages/server/test/unit/ci_provider_spec.js
@@ -489,6 +489,11 @@ describe('lib/util/ci_provider', () => {
       cfStepName: 'cfStepName',
       cfPipelineName: 'cfPipelineName',
       cfPipelineTriggerId: 'cfPipelineTriggerId',
+      // pull request variables
+      cfPullRequestId: 'cfPullRequestId',
+      cfPullRequestIsFork: 'cfPullRequestIsFork',
+      cfPullRequestNumber: 'cfPullRequestNumber',
+      cfPullRequestTarget: 'cfPullRequestTarget',
     })
 
     expectsCommitParams({


### PR DESCRIPTION
- Closes #4609

### User facing changelog
Cypress extracts and sends CodeFresh CI default variables when using `--record` mode. The build number of the pull request information will be shown in the Dashboard. When using the parallel mode, the Dashboard will be able to automatically connect machines into the same build using the id.

### Additional details
Recording from the CodeFresh should have CI information

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
