### PR TITLE
chore: fighting some visual flake

### DIFF
--- a/packages/desktop-gui/cypress/integration/settings_spec.js
+++ b/packages/desktop-gui/cypress/integration/settings_spec.js
@@ -479,6 +479,7 @@ describe('Settings', () => {
           this.getRecordKeys.resolve([])
 
           cy.logOut()
+          cy.animationsFinished()
         })
 
         it('shows message that user must be logged in to view record keys', () => {

--- a/packages/desktop-gui/cypress/support/index.js
+++ b/packages/desktop-gui/cypress/support/index.js
@@ -67,3 +67,7 @@ Cypress.Commands.add('setAppStore', (options = {}) => {
     win.AppStore.set(options)
   })
 })
+
+Cypress.Commands.add('animationsFinished', () => {
+  cy.get('.rc-collapse-anim').should('not.exist')
+})

--- a/packages/runner/cypress/integration/retries.ui.spec.js
+++ b/packages/runner/cypress/integration/retries.ui.spec.js
@@ -55,6 +55,7 @@ describe('runner/cypress retries.ui.spec', { viewportWidth: 600, viewportHeight:
     }, { config: { retries: 2 } })
     .then(shouldHaveTestResults(1, 1))
 
+    cy.get('.runnable-err-print').should('be.visible')
     cy.percySnapshot()
   })
 


### PR DESCRIPTION
Noticed a little bit of visual flake in https://github.com/cypress-io/cypress/pull/15117
https://percy.io/cypress-io/cypress/builds/8878688/changed/503718844

- ensure animation has finished when logging out
![Screen Shot 2021-02-16 at 7 39 03 PM](https://user-images.githubusercontent.com/2212006/108141802-6cedec00-7092-11eb-8339-0d2f42fe92c3.png)

- ensure the error message is shown
![Screen Shot 2021-02-16 at 8 07 17 PM](https://user-images.githubusercontent.com/2212006/108142132-28168500-7093-11eb-85cc-ce5717566eab.png)
