### PR TITLE
fix: add a trivial change to trigger semantic release

### DIFF
--- a/npm/webpack-dev-server/src/index.ts
+++ b/npm/webpack-dev-server/src/index.ts
@@ -14,18 +14,18 @@ export interface DevServerOptions {
   devServerEvents: EventEmitter
 }
 
-export interface StartDevServer {
-  /* this is the Cypress options object */
-  options: DevServerOptions
-  /* support passing a path to the user's webpack config */
-  webpackConfig?: Record<string, any>
-}
-
 type DoneCallback = () => unknown
 
 export interface ResolvedDevServerConfig {
   port: number
   close: (done?: DoneCallback) => void
+}
+
+export interface StartDevServer {
+  /* this is the Cypress options object */
+  options: DevServerOptions
+  /* support passing a path to the user's webpack config */
+  webpackConfig?: Record<string, any>
 }
 
 export async function startDevServer (startDevServerArgs: StartDevServer) {


### PR DESCRIPTION
Hopefully this will trigger it and verify if there was indeed a bug in npm earlier, or our config is incorrect.