### PR TITLE
fix: updated cy.intercept to automatically parse more JSON MIME types

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1,4 +1,4 @@
-describe('network stubbing', { retries: 0 }, function () {
+describe('network stubbing', { retries: 2 }, function () {
   const { $, _, sinon, state, Promise } = Cypress
 
   beforeEach(function () {

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1091,6 +1091,7 @@ describe('network stubbing', { retries: 0 }, function () {
           const p = Promise.defer()
 
           cy.intercept('/post-only', (req) => {
+            expect(req.headers['content-type']).to.eq(contentType)
             expect(req.body).to.deep.eq({ foo: 'bar' })
 
             p.resolve()

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1,4 +1,4 @@
-describe('network stubbing', { retries: 2 }, function () {
+describe('network stubbing', { retries: 0 }, function () {
   const { $, _, sinon, state, Promise } = Cypress
 
   beforeEach(function () {
@@ -1083,27 +1083,32 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     context('body parsing', function () {
-      it('automatically parses JSON request bodies', function () {
-        const p = Promise.defer()
+      [
+        ['application/json', '{"foo":"bar"}'],
+        ['application/vnd.api+json', '{}'],
+      ].forEach(([contentType, expectedBody]) => {
+        it(`automatically parses ${contentType} request bodies`, function () {
+          const p = Promise.defer()
 
-        cy.intercept('/post-only', (req) => {
-          expect(req.body).to.deep.eq({ foo: 'bar' })
+          cy.intercept('/post-only', (req) => {
+            expect(req.body).to.deep.eq({ foo: 'bar' })
 
-          p.resolve()
-        }).as('post')
-        .then(() => {
-          return $.ajax({
-            url: '/post-only',
-            method: 'POST',
-            contentType: 'application/json',
-            data: JSON.stringify({ foo: 'bar' }),
+            p.resolve()
+          }).as('post')
+          .then(() => {
+            return $.ajax({
+              url: '/post-only',
+              method: 'POST',
+              contentType,
+              data: JSON.stringify({ foo: 'bar' }),
+            })
+          }).then((responseText) => {
+            expect(responseText).to.include(`request body:<br>${expectedBody}`)
+
+            return p
           })
-        }).then((responseText) => {
-          expect(responseText).to.include('request body:<br>{"foo":"bar"}')
-
-          return p
+          .wait('@post').its('request.body').should('deep.eq', { foo: 'bar' })
         })
-        .wait('@post').its('request.body').should('deep.eq', { foo: 'bar' })
       })
 
       it('doesn\'t automatically parse JSON request bodies if content-type is wrong', function () {
@@ -1696,23 +1701,29 @@ describe('network stubbing', { retries: 2 }, function () {
     })
 
     context('body parsing', function () {
-      it('automatically parses JSON response bodies', function () {
-        const p = Promise.defer()
+      [
+        'application/json',
+        'application/vnd.api+json',
+      ].forEach((contentType) => {
+        it(`automatically parses ${contentType} response bodies`, function () {
+          const p = Promise.defer()
 
-        cy.intercept('/foo.bar.baz.json', (req) => {
-          req.reply((res) => {
-            expect(res.body).to.deep.eq({ quux: 'quuz' })
-            p.resolve()
+          cy.intercept(`/json-content-type`, (req) => {
+            req.reply((res) => {
+              expect(res.headers['content-type']).to.eq(contentType)
+              expect(res.body).to.deep.eq({})
+              p.resolve()
+            })
+          }).as('get')
+          .then(() => {
+            return $.get(`/json-content-type?contentType=${encodeURIComponent(contentType)}`)
+          }).then((responseJson) => {
+            expect(responseJson).to.deep.eq({})
+
+            return p
           })
-        }).as('get')
-        .then(() => {
-          return $.get('/fixtures/foo.bar.baz.json')
-        }).then((responseJson) => {
-          expect(responseJson).to.deep.eq({ quux: 'quuz' })
-
-          return p
+          .wait('@get').its('response.body').should('deep.eq', {})
         })
-        .wait('@get').its('response.body').should('deep.eq', { quux: 'quuz' })
       })
 
       it('doesn\'t automatically parse JSON response bodies if content-type is wrong', function () {

--- a/packages/driver/cypress/plugins/server.js
+++ b/packages/driver/cypress/plugins/server.js
@@ -102,7 +102,9 @@ const createApp = (port) => {
   })
 
   app.get('/json-content-type', (req, res) => {
-    return res.send({})
+    res.setHeader('content-type', req.query.contentType || 'application/json')
+
+    return res.end('{}')
   })
 
   app.get('/html-content-type-with-charset-param', (req, res) => {

--- a/packages/driver/src/cy/net-stubbing/events/utils.ts
+++ b/packages/driver/src/cy/net-stubbing/events/utils.ts
@@ -4,7 +4,7 @@ import { CyHttpMessages } from '@packages/net-stubbing/lib/types'
 export function hasJsonContentType (headers: { [k: string]: string }) {
   const contentType = find(headers, (v, k) => /^content-type$/i.test(k))
 
-  return contentType && /^application\/json/i.test(contentType)
+  return contentType && /^application\/.*json/i.test(contentType)
 }
 
 export function parseJsonBody (message: CyHttpMessages.BaseMessage) {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #14763

### User facing changelog

- BREAKING CHANGE: Updated cy.intercept to automatically parse more JSON MIME types, including 'application/vnd.api+json'.
	- This may remove the need to `JSON.parse(req.body)` or `JSON.parse(res.body)` manually in tests.
	
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
