### PR TITLE
fix: add webpack-dev-server to peerDependencies, improve peerDependency error handling, fix index-template.html path

### DIFF
--- a/npm/webpack-dev-server/index.js
+++ b/npm/webpack-dev-server/index.js
@@ -1,1 +1,5 @@
+const { validatePeerDependencies } = require('./dist/errors')
+
+validatePeerDependencies()
+
 module.exports = require('./dist')

--- a/npm/webpack-dev-server/package.json
+++ b/npm/webpack-dev-server/package.json
@@ -25,7 +25,8 @@
   },
   "peerDependencies": {
     "html-webpack-plugin": "> 3",
-    "webpack": "> 4"
+    "webpack": "> 4",
+    "webpack-dev-server": "> 3"
   },
   "files": [
     "dist"

--- a/npm/webpack-dev-server/src/errors.ts
+++ b/npm/webpack-dev-server/src/errors.ts
@@ -1,0 +1,80 @@
+export interface MissingDependency {
+  prettyName: string
+  packageName: string
+}
+
+const peerDeps: MissingDependency[] = [
+  {
+    prettyName: 'Webpack Dev Server',
+    packageName: 'webpack-dev-server',
+  },
+  {
+    prettyName: 'Html Webpack Plugin',
+    packageName: 'html-webpack-plugin',
+  },
+  {
+    prettyName: 'Webpack',
+    packageName: 'webpack',
+  },
+]
+
+const makePrettyLibs = (libs) => {
+  return libs.reduce((acc, curr, idx) => {
+    acc.prettyNames.push(curr.prettyName)
+    acc.packageNames.push(curr.packageName)
+
+    if (idx >= libs.length) return acc
+
+    return {
+      prettyNames: acc.prettyNames.join(', '),
+      packageNames: acc.packageNames.join(' '),
+    }
+  }, { prettyNames: [], packageNames: [] })
+}
+
+export class MissingPeerDependency extends Error {
+  private libs: { prettyNames: string[], packageNames: string[] }
+
+  constructor (message,
+    libs: MissingDependency[]) {
+    const prettyLibs = makePrettyLibs(libs)
+
+    super(`${message} ${prettyLibs.prettyNames}`)
+    this.name = 'PeerDependencyMissing'
+    this.libs = prettyLibs
+
+    Object.setPrototypeOf(this, MissingPeerDependency.prototype)
+  }
+
+  get prettyMessage () {
+    return `❌ Missing ${this.libs.prettyNames}. Please install them with npm or yarn.
+
+    npm i ${this.libs.packageNames} -D
+    yarn add ${this.libs.packageNames} --dev
+
+    Updating webpack config is unnecessary
+`
+  }
+}
+
+export function validatePeerDependencies () {
+  const missingPeerDeps = peerDeps.filter((peerDep) => {
+    try {
+      require(peerDep.packageName)
+    } catch (err) {
+      return true
+    }
+
+    return false
+  })
+
+  if (missingPeerDeps.length) {
+    const error = new MissingPeerDependency(`@cypress/webpack-dev-server is missing peer dependencies`, missingPeerDeps)
+
+    console.error(error.prettyMessage) // eslint-disable-line
+
+    throw error
+  }
+
+  return true
+}


### PR DESCRIPTION
Fixing a crasher in `@cypress/webpack-dev-server`:
1. index-template.html wasn't being published which caused a failure
2. webpack-dev-server was not listed as a peer dependency. Webpack does not include it (CRA + Vue CLI do)
3. Error stack traces didn't clearly explain that peer dependencies were missing.

Cypress stack trace is very, very long (2-3 full page scrolls) so it's important that we have good runtime error handling.

![Screen Shot 2021-02-18 at 5 22 21 PM](https://user-images.githubusercontent.com/2801156/108430099-d98df580-720e-11eb-853a-8795e6a36d7c.png)