### PR TITLE
fix: missing index-template.html from package.json deps for webpack-dev-server

### DIFF
--- a/npm/webpack-dev-server/package.json
+++ b/npm/webpack-dev-server/package.json
@@ -29,7 +29,8 @@
     "webpack-dev-server": "> 3"
   },
   "files": [
-    "dist"
+    "dist",
+    "index-template.html"
   ],
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Missing index-template.html was failing the build.
