### PR TITLE
fix: Remove truncation of preprocessor errors

### DIFF
--- a/packages/server/__snapshots__/1_busted_support_file_spec.js
+++ b/packages/server/__snapshots__/1_busted_support_file_spec.js
@@ -34,6 +34,8 @@ Looked for and couldn't find the file at the following paths:
 [/foo/bar/.projects/busted-support-file/cypress/support/does/not/exist.ts]
 [/foo/bar/.projects/busted-support-file/cypress/support/does/not/exist.tsx]
  @ ./cypress/support/index.js 3:0-27
+ 
+      [stack trace lines]
 
 This occurred while Cypress was compiling and bundling your test code. This is usually caused by:
 

--- a/packages/server/__snapshots__/1_es_modules_spec.js
+++ b/packages/server/__snapshots__/1_es_modules_spec.js
@@ -95,6 +95,7 @@ SyntaxError: /foo/bar/.projects/e2e/lib/fail.js: Unexpected token (2:0)
 > 2 | 
     | ^
  @ ./cypress/integration/es_module_import_failing_spec.js 3:0-25
+      [stack trace lines]
 
 This occurred while Cypress was compiling and bundling your test code. This is usually caused by:
 

--- a/packages/server/__snapshots__/1_typescript_spec_support_spec.ts.js
+++ b/packages/server/__snapshots__/1_typescript_spec_support_spec.ts.js
@@ -96,6 +96,7 @@ You may need an additional loader to handle the result of these loaders.
 | // because it tests failing spec.
 > describe('fail', - > );
 |
+      [stack trace lines]
 
 This occurred while Cypress was compiling and bundling your test code. This is usually caused by:
 

--- a/packages/server/__snapshots__/5_stdout_spec.js
+++ b/packages/server/__snapshots__/5_stdout_spec.js
@@ -149,6 +149,7 @@ SyntaxError: /foo/bar/.projects/e2e/cypress/integration/stdout_exit_early_failin
 > 1 | +>
     |  ^
   2 |
+      [stack trace lines]
 
 This occurred while Cypress was compiling and bundling your test code. This is usually caused by:
 

--- a/packages/server/__snapshots__/7_record_spec.js
+++ b/packages/server/__snapshots__/7_record_spec.js
@@ -39,6 +39,8 @@ Looked for and couldn't find the file at the following paths:
 [/foo/bar/.projects/e2e/cypress/it/does/not/exist.ts]
 [/foo/bar/.projects/e2e/cypress/it/does/not/exist.tsx]
  @ ./cypress/integration/record_error_spec.js 3:0-31
+ 
+      [stack trace lines]
 
 This occurred while Cypress was compiling and bundling your test code. This is usually caused by:
 
@@ -991,6 +993,8 @@ Looked for and couldn't find the file at the following paths:
 [/foo/bar/.projects/e2e/cypress/it/does/not/exist.ts]
 [/foo/bar/.projects/e2e/cypress/it/does/not/exist.tsx]
  @ ./cypress/integration/record_error_spec.js 3:0-31
+ 
+      [stack trace lines]
 
 This occurred while Cypress was compiling and bundling your test code. This is usually caused by:
 

--- a/packages/server/lib/plugins/preprocessor.js
+++ b/packages/server/lib/plugins/preprocessor.js
@@ -9,9 +9,7 @@ const appData = require('../util/app_data')
 const plugins = require('../plugins')
 
 const errorMessage = function (err = {}) {
-  return (err.stack || err.annotated || err.message || err.toString())
-  .replace(/\n\s*at.*/g, '')
-  .replace(/From previous event:\n?/g, '')
+  return err.stack || err.annotated || err.message || err.toString()
 }
 
 const clientSideError = function (err) {

--- a/packages/server/test/unit/plugins/preprocessor_spec.js
+++ b/packages/server/test/unit/plugins/preprocessor_spec.js
@@ -185,8 +185,9 @@ describe('lib/plugins/preprocessor', () => {
       expect(preprocessor.errorMessage(err)).to.equal('message')
     })
 
-    it('removes stack lines', () => {
-      expect(preprocessor.errorMessage('foo\n  at what.ever (foo 23:30)\n baz\n    at where.ever (bar 1:5)')).to.equal('foo\n baz')
+    it('does not remove stack lines', () => {
+      expect(preprocessor.errorMessage('foo\n  at what.ever (foo 23:30)\n baz\n    at where.ever (bar 1:5)'))
+      .to.equal('foo\n  at what.ever (foo 23:30)\n baz\n    at where.ever (bar 1:5)')
     })
   })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Addresses [TR-667](https://cypress-io.atlassian.net/browse/TR-667)

### User facing changelog

- Cypress now displays the stack from errors thrown in the preprocessor.

### Additional details

We used to remove the stack from where there was a preprocessor error. I don't remember why. It may have been that we thought the error was overly verbose when we displayed it. But removing the stack makes it very difficult to debug a preprocessor, so it's better if we keep it and err on the side of it being verbose.

### How has the user experience changed?

Users now see the error stack when there's a preprocessor error.

**Before**

![Screen Shot 2021-02-23 at 3 43 19 PM](https://user-images.githubusercontent.com/1157043/108905814-29453600-75ee-11eb-8501-9f94cafb8751.png)

**After**

![Screen Shot 2021-02-23 at 3 45 13 PM](https://user-images.githubusercontent.com/1157043/108905834-2ea28080-75ee-11eb-9812-46ff827964ee.png)

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
