### PR TITLE
build: use rollup to pack cypress/vue

### DIFF
--- a/npm/vue/package.json
+++ b/npm/vue/package.json
@@ -2,14 +2,14 @@
   "name": "@cypress/vue",
   "version": "0.0.0-development",
   "description": "Browser-based Component Testing for Vue.js with Cypress.io ✌️🌲",
-  "main": "dist/index.js",
+  "main": "dist/cypress-vue.cjs.js",
   "scripts": {
-    "build": "tsc",
+    "build": "rimraf dist && yarn rollup -c rollup.config.js",
     "build-prod": "yarn build",
     "cy:open": "node ../../scripts/cypress.js open-ct --project ${PWD}",
     "cy:run": "node ../../scripts/cypress.js run-ct --project ${PWD}",
     "test": "yarn cy:run",
-    "watch": "tsc -w"
+    "watch": "yarn build --watch --watch.exclude ./dist/**/*"
   },
   "dependencies": {
     "@vue/test-utils": "1.0.3",
@@ -22,6 +22,9 @@
     "@cypress/code-coverage": "3.8.1",
     "@cypress/webpack-dev-server": "0.0.0-development",
     "@intlify/vue-i18n-loader": "1.0.0",
+    "@rollup/plugin-commonjs": "^17.1.0",
+    "@rollup/plugin-json": "^4.1.0",
+    "@rollup/plugin-node-resolve": "^11.1.1",
     "@vue/cli-plugin-babel": "~4.4.0",
     "@vue/cli-service": "~4.4.0",
     "axios": "0.19.2",
@@ -33,6 +36,9 @@
     "eslint-plugin-vue": "^6.2.2",
     "find-webpack": "2.1.0",
     "mocha": "7.1.1",
+    "rollup": "^2.38.5",
+    "rollup-plugin-istanbul": "2.0.1",
+    "rollup-plugin-typescript2": "^0.29.0",
     "tailwindcss": "1.1.4",
     "typescript": "3.9.6",
     "vue": "2.6.11",
@@ -51,7 +57,8 @@
     "vue": "2.x"
   },
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "src/**/*.js"
   ],
   "engines": {
     "node": ">=8"
@@ -69,6 +76,8 @@
     "cypress",
     "vue"
   ],
+  "unpkg": "dist/cypress-vue.browser.js",
+  "module": "dist/cypress-vue.esm-bundler.js",
   "peerDependenciesMeta": {
     "@cypress/webpack-dev-server": {
       "optional": true

--- a/npm/vue/rollup.config.js
+++ b/npm/vue/rollup.config.js
@@ -1,0 +1,87 @@
+import ts from 'rollup-plugin-typescript2'
+import resolve from '@rollup/plugin-node-resolve'
+import commonjs from '@rollup/plugin-commonjs'
+import json from '@rollup/plugin-json'
+
+import pkg from './package.json'
+
+const banner = `
+/**
+ * ${pkg.name} v${pkg.version}
+ * (c) ${new Date().getFullYear()} Cypress.io
+ * Released under the MIT License
+ */
+`
+
+function createEntry (options) {
+  const {
+    format,
+    input,
+    isBrowser,
+  } = options
+
+  const config = {
+    input,
+    external: [
+      'vue',
+      '@vue/test-utils',
+      '@cypress/webpack-dev-server',
+    ],
+    plugins: [
+      resolve({ preferBuiltins: true }), commonjs(), json(),
+    ],
+    output: {
+      banner,
+      name: 'CypressVue',
+      file: pkg.unpkg,
+      format,
+      globals: {
+        vue: 'Vue',
+        '@vue/test-utils': 'VueTestUtils',
+      },
+      exports: 'auto',
+    },
+  }
+
+  if (input === 'src/index.ts') {
+    if (format === 'es') {
+      config.output.file = pkg.module
+      if (isBrowser) {
+        config.output.file = pkg.unpkg
+      }
+    }
+
+    if (format === 'cjs') {
+      config.output.file = pkg.main
+    }
+  } else {
+    config.output.file = input.replace(/^src\//, 'dist/')
+  }
+
+  console.log(`Building ${format}: ${config.output.file}`)
+
+  config.plugins.push(
+    ts({
+      check: format === 'es' && isBrowser,
+      tsconfigOverride: {
+        compilerOptions: {
+          declaration: format === 'es',
+          target: 'es5', // not sure what this should be?
+          module: format === 'cjs' ? 'es2015' : 'esnext',
+        },
+        exclude: ['tests'],
+      },
+    }),
+  )
+
+  return config
+}
+
+export default [
+  createEntry({ format: 'es', input: 'src/index.ts', isBrowser: false }),
+  createEntry({ format: 'es', input: 'src/index.ts', isBrowser: true }),
+  createEntry({ format: 'iife', input: 'src/index.ts', isBrowser: true }),
+  createEntry({ format: 'cjs', input: 'src/index.ts', isBrowser: false }),
+  createEntry({ format: 'cjs', input: 'src/support.js', isBrowser: false }),
+  createEntry({ format: 'cjs', input: 'src/plugins/webpack/index.js', isBrowser: false }),
+]

--- a/npm/vue/tsconfig.json
+++ b/npm/vue/tsconfig.json
@@ -28,7 +28,7 @@
 
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */

--- a/npm/vue/webpack.config.js
+++ b/npm/vue/webpack.config.js
@@ -4,6 +4,7 @@
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const path = require('path')
+const pkg = require('package.json')
 
 module.exports = {
   mode: 'development',
@@ -18,7 +19,7 @@ module.exports = {
     extensions: ['.js', '.json', '.vue'],
     alias: {
       // point at the built file
-      '@cypress/vue': path.join(__dirname, 'dist'),
+      '@cypress/vue': path.join(__dirname, pkg.main),
       vue: 'vue/dist/vue.esm.js',
     },
   },


### PR DESCRIPTION
Make `@cypress/vue` mount function accessible by vite dev server by bundling it in a esModule format using rollup

CT-269