### PR TITLE
feat: support requiring cypress.json (WIP)

### DIFF
--- a/packages/desktop-gui/cypress/fixtures/config.json
+++ b/packages/desktop-gui/cypress/fixtures/config.json
@@ -117,7 +117,7 @@
   "clientRoute": "/__/",
   "clientUrl": "http://localhost:2020/__/",
   "clientUrlDisplay": "http://localhost:2020",
-  "commandTimeout": 4000,
+  "defaultCommandTimeout": 4000,
   "cypressHostUrl": "http://localhost:2020",
   "cypressEnv": "development",
   "env": {},
@@ -302,7 +302,7 @@
         }
       ]
     },
-    "commandTimeout": {
+    "defaultCommandTimeout": {
       "from": "default",
       "value": 4000
     },

--- a/packages/server/lib/util/settings.js
+++ b/packages/server/lib/util/settings.js
@@ -11,10 +11,6 @@ const { fs } = require('../util/fs')
 // settings at the same time something else
 // is potentially reading it
 
-const flattenCypress = (obj) => {
-  return obj.cypress ? obj.cypress : undefined
-}
-
 const maybeVerifyConfigFile = Promise.method((configFile) => {
   if (configFile === false) {
     return
@@ -22,39 +18,6 @@ const maybeVerifyConfigFile = Promise.method((configFile) => {
 
   return fs.statAsync(configFile)
 })
-
-const renameVisitToPageLoad = (obj) => {
-  const v = obj.visitTimeout
-
-  if (v) {
-    obj = _.omit(obj, 'visitTimeout')
-    obj.pageLoadTimeout = v
-
-    return obj
-  }
-}
-
-const renameCommandTimeout = (obj) => {
-  const c = obj.commandTimeout
-
-  if (c) {
-    obj = _.omit(obj, 'commandTimeout')
-    obj.defaultCommandTimeout = c
-
-    return obj
-  }
-}
-
-const renameSupportFolder = (obj) => {
-  const sf = obj.supportFolder
-
-  if (sf) {
-    obj = _.omit(obj, 'supportFolder')
-    obj.supportFile = sf
-
-    return obj
-  }
-}
 
 module.exports = {
   _pathToFile (projectRoot, file) {
@@ -83,14 +46,6 @@ module.exports = {
     .catch((err) => {
       return this._logWriteErr(file, err)
     })
-  },
-
-  _applyRewriteRules (obj = {}) {
-    return _.reduce([flattenCypress, renameVisitToPageLoad, renameCommandTimeout, renameSupportFolder], (memo, fn) => {
-      const ret = fn(memo)
-
-      return ret ? ret : memo
-    }, _.cloneDeep(obj))
   },
 
   configFile (options = {}) {
@@ -142,14 +97,8 @@ module.exports = {
 
     try {
       const json = fs.readJsonSync(file)
-      const changed = this._applyRewriteRules(json)
 
-      if (_.isEqual(json, changed)) {
-        return json
-      }
-
-      // else write the new reduced obj
-      return this._write(file, changed)
+      return json
     } catch (err) {
       if (err.code === 'ENOENT') {
         return this._write(file, {})

--- a/packages/server/lib/util/settings.js
+++ b/packages/server/lib/util/settings.js
@@ -96,11 +96,9 @@ module.exports = {
     const file = this.pathToConfigFile(projectRoot, options)
 
     try {
-      const json = fs.readJsonSync(file)
-
-      return json
+      return require(file)
     } catch (err) {
-      if (err.code === 'ENOENT') {
+      if (err.code === 'MODULE_NOT_FOUND') {
         return this._write(file, {})
       }
 

--- a/packages/server/test/unit/settings_spec.js
+++ b/packages/server/test/unit/settings_spec.js
@@ -7,13 +7,18 @@ const settings = require(`${root}lib/util/settings`)
 const projectRoot = process.cwd()
 
 describe('lib/settings', () => {
-  context('with no configFile option', () => {
-    beforeEach(function () {
-      this.setup = (obj = {}) => {
-        return fs.writeFileAsync('cypress.json', JSON.stringify(obj))
-      }
-    })
+  beforeEach(function () {
+    this.setup = (obj = {}) => {
+      return fs.writeFileAsync('cypress.json', JSON.stringify(obj))
+    }
 
+    // need to clear require cache because we load cypress.json via require.
+    Object.keys(require.cache).forEach((key) => {
+      delete require.cache[key]
+    })
+  })
+
+  context('with no configFile option', () => {
     afterEach(() => {
       return fs.removeAsync('cypress.json')
     })

--- a/packages/server/test/unit/settings_spec.js
+++ b/packages/server/test/unit/settings_spec.js
@@ -10,7 +10,7 @@ describe('lib/settings', () => {
   context('with no configFile option', () => {
     beforeEach(function () {
       this.setup = (obj = {}) => {
-        return fs.writeJsonAsync('cypress.json', obj)
+        return fs.writeFileAsync('cypress.json', JSON.stringify(obj))
       }
     })
 
@@ -85,9 +85,9 @@ describe('lib/settings', () => {
       })
 
       it('returns project id for project', function () {
-        return fs.writeJsonAsync(`${this.projectRoot}cypress.json`, {
+        return fs.writeFileAsync(`${this.projectRoot}cypress.json`, JSON.stringify({
           projectId: 'id-123',
-        })
+        }))
         .then(() => {
           return settings.id(this.projectRoot)
         }).then((id) => {
@@ -228,7 +228,7 @@ describe('lib/settings', () => {
     })
 
     it('.read returns from configFile', function () {
-      return fs.writeJsonAsync(path.join(this.projectRoot, this.options.configFile), { foo: 'bar' })
+      return fs.writeFileAsync(path.join(this.projectRoot, this.options.configFile), JSON.stringify({ foo: 'bar' }))
       .then(() => {
         return settings.read(this.projectRoot, this.options)
         .then((settings) => {

--- a/packages/server/test/unit/settings_spec.js
+++ b/packages/server/test/unit/settings_spec.js
@@ -75,9 +75,9 @@ describe('lib/settings', () => {
       })
 
       it('returns project id for project', function () {
-        return fs.writeFileAsync(`${this.projectRoot}cypress.json`, JSON.stringify({
+        return fs.writeJsonAsync(`${this.projectRoot}cypress.json`, {
           projectId: 'id-123',
-        }))
+        })
         .then(() => {
           return settings.id(this.projectRoot)
         }).then((id) => {
@@ -182,7 +182,7 @@ describe('lib/settings', () => {
     })
 
     it('.read returns from configFile', function () {
-      return fs.writeFileAsync(path.join(this.projectRoot, this.options.configFile), JSON.stringify({ foo: 'bar' }))
+      return fs.writeJsonAsync(path.join(this.projectRoot, this.options.configFile), { foo: 'bar' })
       .then(() => {
         return settings.read(this.projectRoot, this.options)
         .then((settings) => {

--- a/packages/server/test/unit/settings_spec.js
+++ b/packages/server/test/unit/settings_spec.js
@@ -18,21 +18,6 @@ describe('lib/settings', () => {
       return fs.removeAsync('cypress.json')
     })
 
-    context('nested cypress object', () => {
-      it('flattens object on read', function () {
-        return this.setup({ cypress: { foo: 'bar' } })
-        .then(() => {
-          return settings.read(projectRoot)
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ foo: 'bar' })
-
-          return fs.readJsonAsync('cypress.json')
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ foo: 'bar' })
-        })
-      })
-    })
-
     context('.readEnv', () => {
       afterEach(() => {
         return fs.removeAsync('cypress.env.json')
@@ -103,42 +88,6 @@ describe('lib/settings', () => {
           return settings.read(projectRoot)
         }).then((obj) => {
           expect(obj).to.deep.eq({ foo: 'bar' })
-        })
-      })
-
-      it('renames commandTimeout -> defaultCommandTimeout', function () {
-        return this.setup({ commandTimeout: 30000, foo: 'bar' })
-        .then(() => {
-          return settings.read(projectRoot)
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ defaultCommandTimeout: 30000, foo: 'bar' })
-        })
-      })
-
-      it('renames supportFolder -> supportFile', function () {
-        return this.setup({ supportFolder: 'foo', foo: 'bar' })
-        .then(() => {
-          return settings.read(projectRoot)
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ supportFile: 'foo', foo: 'bar' })
-        })
-      })
-
-      it('renames visitTimeout -> pageLoadTimeout', function () {
-        return this.setup({ visitTimeout: 30000, foo: 'bar' })
-        .then(() => {
-          return settings.read(projectRoot)
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ pageLoadTimeout: 30000, foo: 'bar' })
-        })
-      })
-
-      it('renames visitTimeout -> pageLoadTimeout on nested cypress obj', function () {
-        return this.setup({ cypress: { visitTimeout: 30000, foo: 'bar' } })
-        .then(() => {
-          return settings.read(projectRoot)
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ pageLoadTimeout: 30000, foo: 'bar' })
         })
       })
     })


### PR DESCRIPTION
### User facing changelog

- You may now write your config as `cypress.js` instead of `cypress.json`. `cypress.js` must confirm to the same API, for example:

```js
module.exports = {
  video: false
}
```

I also took this opportunity to remove some code used to avoid breaking changes pre 1.0. A few keys in `cypress.json` changed in the early days, and we had some code to handle this. The code actually auto migrated by rewriting the users' `cypress.json`, so it's safe to assume any of these users would have had their `cypress.json` config updated by this point.

Specifically:

- removed migration code for the `"cypress"` top level key in `cypress.json`. Support for this was dropped in [2016, pre 1.0](https://github.com/cypress-io/cypress/blame/d8bdd4a85d899fcd1deb2f9f5ed376790fbcb701/packages/server/test/unit/settings_spec.coffee#L19)
- removed migration code for `supportFolder`, `visitTimeout`, `commandTimeout`. [Breaking change as of 0.18](https://docs.cypress.io/guides/references/changelog.html#0-18-0).

Seems unlikely any pre 1.0 users (circa 2016) would be upgrading straight to 6.x, so I think it's fine to remove these now.

### Additional details

The eventual goal is outlined [in this ticket](https://cypress-io.atlassian.net/browse/CT-282). We need to support runner specific config files; JS is more flexible than JSON for this. The first step to supporting JS as well as JSON for configuration is to load it via `require` instead of `fs.readJson`.

### How has the user experience changed?

It is still the same.

### PR Tasks

N/A
