### PR TITLE
feat: use require to support config via cypress.js

### DIFF
--- a/packages/server/lib/util/settings.js
+++ b/packages/server/lib/util/settings.js
@@ -140,7 +140,14 @@ module.exports = {
 
     const file = this.pathToConfigFile(projectRoot, options)
 
-    return fs.readJsonAsync(file)
+    const requireAsync = (file) => {
+      return Promise.try(() => require(file))
+    }
+
+    return requireAsync(file)
+    .catch({ code: 'MODULE_NOT_FOUND' }, () => {
+      return this._write(file, {})
+    })
     .catch({ code: 'ENOENT' }, () => {
       return this._write(file, {})
     }).then((json = {}) => {

--- a/packages/server/test/e2e/6_visit_spec.js
+++ b/packages/server/test/e2e/6_visit_spec.js
@@ -5,14 +5,7 @@ const https = require('https')
 const useragent = require('express-useragent')
 const { allowDestroy } = require('@packages/network')
 const e2e = require('../support/helpers/e2e').default
-
-function clearCypressJsonCache () {
-  Object.keys(require.cache).forEach((key) => {
-    if (key.includes('cypress.json')) {
-      delete require.cache[key]
-    }
-  })
-}
+const { clearCypressJsonCache } = require('../specUtils')
 
 // create an HTTPS server that forces TLSv1
 const startTlsV1Server = (port) => {

--- a/packages/server/test/e2e/6_visit_spec.js
+++ b/packages/server/test/e2e/6_visit_spec.js
@@ -6,6 +6,14 @@ const useragent = require('express-useragent')
 const { allowDestroy } = require('@packages/network')
 const e2e = require('../support/helpers/e2e').default
 
+function clearCypressJsonCache () {
+  Object.keys(require.cache).forEach((key) => {
+    if (key.includes('cypress.json')) {
+      delete require.cache[key]
+    }
+  })
+}
+
 // create an HTTPS server that forces TLSv1
 const startTlsV1Server = (port) => {
   return Bluebird.fromCallback((cb) => {
@@ -116,6 +124,10 @@ foo\
 }
 
 describe('e2e visit', () => {
+  beforeEach(() => {
+    clearCypressJsonCache()
+  })
+
   context('low response timeout', () => {
     e2e.setup({
       settings: {

--- a/packages/server/test/e2e/6_web_security_spec.js
+++ b/packages/server/test/e2e/6_web_security_spec.js
@@ -1,4 +1,5 @@
 const e2e = require('../support/helpers/e2e').default
+const { clearCypressJsonCache } = require('../specUtils')
 
 const onServer = function (app) {
   app.get('/link', (req, res) => {
@@ -47,14 +48,6 @@ const onServer = function (app) {
       })
       .catch(err => document.write(err.message))
     </script>`)
-  })
-}
-
-function clearCypressJsonCache () {
-  Object.keys(require.cache).forEach((key) => {
-    if (key.includes('cypress.json')) {
-      delete require.cache[key]
-    }
   })
 }
 

--- a/packages/server/test/e2e/6_web_security_spec.js
+++ b/packages/server/test/e2e/6_web_security_spec.js
@@ -50,7 +50,19 @@ const onServer = function (app) {
   })
 }
 
+function clearCypressJsonCache () {
+  Object.keys(require.cache).forEach((key) => {
+    if (key.includes('cypress.json')) {
+      delete require.cache[key]
+    }
+  })
+}
+
 describe('e2e web security', () => {
+  beforeEach(() => {
+    clearCypressJsonCache()
+  })
+
   e2e.setup({
     servers: [{
       port: 4466,

--- a/packages/server/test/e2e/7_record_spec.js
+++ b/packages/server/test/e2e/7_record_spec.js
@@ -164,6 +164,14 @@ const onServer = (routes) => {
   })
 }
 
+function clearCypressJsonCache () {
+  Object.keys(require.cache).forEach((key) => {
+    if (key.includes('cypress.json')) {
+      delete require.cache[key]
+    }
+  })
+}
+
 const setup = (routes, settings = {}) => {
   return e2e.setup({
     settings: _.extend({
@@ -744,6 +752,10 @@ describe('e2e record', () => {
     })
 
     describe('create run 500', () => {
+      beforeEach(() => {
+        clearCypressJsonCache()
+      })
+
       const routes = [{
         method: 'post',
         url: '/runs',

--- a/packages/server/test/e2e/7_record_spec.js
+++ b/packages/server/test/e2e/7_record_spec.js
@@ -11,6 +11,7 @@ const { expectRunsToHaveCorrectTimings } = require('../support/helpers/resultsUt
 const postRunResponseWithWarnings = jsonSchemas.getExample('postRunResponse')('2.2.0')
 const postRunResponse = _.assign({}, postRunResponseWithWarnings, { warnings: [] })
 const postRunInstanceResponse = jsonSchemas.getExample('postRunInstanceResponse')('2.1.0')
+const { clearCypressJsonCache } = require('../specUtils')
 
 const e2ePath = Fixtures.projectPath('e2e')
 const outputPath = path.join(e2ePath, 'output.json')
@@ -161,14 +162,6 @@ const onServer = (routes) => {
         route.resSchema,
       ))
     })
-  })
-}
-
-function clearCypressJsonCache () {
-  Object.keys(require.cache).forEach((key) => {
-    if (key.includes('cypress.json')) {
-      delete require.cache[key]
-    }
   })
 }
 

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -654,8 +654,6 @@ describe('lib/cypress', () => {
     })
 
     it('scaffolds out fixtures + files if they do not exist', function () {
-      clearCypressJsonCache()
-
       return config.get(this.pristinePath)
       .then((cfg) => {
         return fs.statAsync(cfg.fixturesFolder)
@@ -672,7 +670,6 @@ describe('lib/cypress', () => {
     })
 
     it('scaffolds out support + files if they do not exist', function () {
-      clearCypressJsonCache()
       const supportFolder = path.join(this.pristinePath, 'cypress/support')
 
       return config.get(this.pristinePath)
@@ -1265,13 +1262,12 @@ describe('lib/cypress', () => {
     describe('--env', () => {
       beforeEach(() => {
         process.env = _.omit(process.env, 'CYPRESS_DEBUG')
+        clearCypressJsonCache()
 
         return runMode.listenForProjectEnd.resolves({ stats: { failures: 0 } })
       })
 
       it('can set specific environment variables', function () {
-        clearCypressJsonCache()
-
         return cypress.start([
           `--run-project=${this.todosPath}`,
           '--video=false',
@@ -1291,8 +1287,6 @@ describe('lib/cypress', () => {
       })
 
       it('parses environment variables with empty values', function () {
-        clearCypressJsonCache()
-
         return cypress.start([
           `--run-project=${this.todosPath}`,
           '--video=false',
@@ -1934,11 +1928,11 @@ describe('lib/cypress', () => {
 
     describe('--config-file', () => {
       beforeEach(function () {
+        clearCypressJsonCache()
         this.open = sinon.stub(ServerE2E.prototype, 'open').resolves([])
       })
 
       it('reads config from a custom config file', function () {
-        clearCypressJsonCache()
         const filename = 'foo.bar.baz.asdf.quux.json'
 
         fs.writeFileAsync(

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -47,6 +47,7 @@ const system = require(`${root}lib/util/system`)
 const appData = require(`${root}lib/util/app_data`)
 const electronApp = require('../../lib/util/electron-app')
 const savedState = require(`${root}lib/saved_state`)
+const { clearCypressJsonCache } = require('../specUtils')
 
 const TYPICAL_BROWSERS = [
   {
@@ -100,14 +101,6 @@ const snapshotConsoleLogs = function (name) {
   process.chdir(previousCwd)
 
   return snapshot(name, stripAnsi(args))
-}
-
-function clearCypressJsonCache () {
-  Object.keys(require.cache).forEach((key) => {
-    if (key.includes('cypress.json')) {
-      delete require.cache[key]
-    }
-  })
 }
 
 describe('lib/cypress', () => {

--- a/packages/server/test/specUtils.ts
+++ b/packages/server/test/specUtils.ts
@@ -46,3 +46,11 @@ export const getFs = () => {
 
   return recurse({ root: mockfs.getMockRoot() }, -1).root
 }
+
+export const clearCypressJsonCache = () => {
+  Object.keys(require.cache).forEach((key) => {
+    if (key.includes('cypress.json')) {
+      delete require.cache[key]
+    }
+  })
+}

--- a/packages/server/test/unit/settings_spec.js
+++ b/packages/server/test/unit/settings_spec.js
@@ -6,7 +6,19 @@ const settings = require(`${root}lib/util/settings`)
 
 const projectRoot = process.cwd()
 
+function clearCypressJsonCache () {
+  Object.keys(require.cache).forEach((key) => {
+    if (key.includes('cypress.json')) {
+      delete require.cache[key]
+    }
+  })
+}
+
 describe('lib/settings', () => {
+  beforeEach(function () {
+    clearCypressJsonCache()
+  })
+
   context('with no configFile option', () => {
     beforeEach(function () {
       this.setup = (obj = {}) => {

--- a/packages/server/test/unit/settings_spec.js
+++ b/packages/server/test/unit/settings_spec.js
@@ -3,16 +3,9 @@ require('../spec_helper')
 const path = require('path')
 const { fs } = require(`${root}lib/util/fs`)
 const settings = require(`${root}lib/util/settings`)
+const { clearCypressJsonCache } = require('../specUtils')
 
 const projectRoot = process.cwd()
-
-function clearCypressJsonCache () {
-  Object.keys(require.cache).forEach((key) => {
-    if (key.includes('cypress.json')) {
-      delete require.cache[key]
-    }
-  })
-}
 
 describe('lib/settings', () => {
   beforeEach(function () {


### PR DESCRIPTION
### User facing changelog

- You may now write your config as `cypress.js` instead of `cypress.json`. `cypress.js` must confirm to the same API, for example:

```js
module.exports = {
  video: false
}
```

### Additional details

The eventual goal is outlined [in this ticket](https://cypress-io.atlassian.net/browse/CT-305). We need to support runner specific config files; JS is more flexible than JSON for this. The first step to supporting JS as well as JSON for configuration is to load it via `require` instead of `fs.readJson`.

### How has the user experience changed?

It is still the same.

### PR Tasks

N/A
