### PR TITLE
fix: nextUntil failure caused by PR 14965

### DIFF
--- a/packages/driver/cypress/fixtures/dom.html
+++ b/packages/driver/cypress/fixtures/dom.html
@@ -654,27 +654,27 @@
         Cross domain iframe:<br>
         <iframe id="iframe-cross-domain" src="http://localhost:3501/fixtures/generic.html"></iframe>
       </div>
-    </div>
 
-    <form id="form-validation" action="/action_page.php">
-      <div>
-        <label for="item">Item:</label>
-        <input id="item" type="text" name="item" required />
-      </div>
-    
-      <div>
-        <label for="quantity">Quantity (between 1 and 5):</label>
-        <input
-          type="number"
-          id="quantity"
-          name="quantity"
-          min="1"
-          max="5"
-          required
-        />
-      </div>
-    
-      <input type="submit" />
-    </form>
+      <form id="form-validation" action="/action_page.php">
+        <div>
+          <label for="item">Item:</label>
+          <input id="item" type="text" name="item" required />
+        </div>
+      
+        <div>
+          <label for="quantity">Quantity (between 1 and 5):</label>
+          <input
+            type="number"
+            id="quantity"
+            name="quantity"
+            min="1"
+            max="5"
+            required
+          />
+        </div>
+      
+        <input type="submit" />
+      </form>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
- Closes None
- Related to #14965

### User facing changelog

Fix the test failure caused by #14965.

### Additional details
- Why was this change necessary? N/A
- What is affected by this change? N/A
- Any implementation details to explain? => It was happening because I placed the form outside the root `div` element.

### How has the user experience changed?

N/A

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

test is not added because the goal of this PR is fixing the failing test.