### PR TITLE
feat: Remove experimentalRunEvents flag

### DIFF
--- a/cli/schema/cypress.schema.json
+++ b/cli/schema/cypress.schema.json
@@ -245,11 +245,6 @@
       "default": "bundled",
       "description": "If set to 'system', Cypress will try to find a Node.js executable on your path to use when executing your plugins. Otherwise, Cypress will use the Node version bundled with Cypress."
     },
-    "experimentalRunEvents": {
-      "type": "boolean",
-      "default": false,
-      "description": "Allows listening to the `before:run`, `after:run`, `before:spec`, and `after:spec` events in the plugins file."
-    },
     "experimentalSourceRewriting": {
       "type": "boolean",
       "default": false,

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2583,11 +2583,6 @@ declare namespace Cypress {
      */
     firefoxGcInterval: Nullable<number | { runMode: Nullable<number>, openMode: Nullable<number> }>
     /**
-     * Allows listening to the `before:run`, `after:run`, `before:spec`, and `after:spec` events in the plugins file.
-     * @default false
-     */
-    experimentalRunEvents: boolean
-    /**
      * Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement
      * algorithm.
      * @default false

--- a/packages/server/__snapshots__/3_plugins_spec.js
+++ b/packages/server/__snapshots__/3_plugins_spec.js
@@ -431,9 +431,13 @@ The following validation error was thrown by your plugins file (\`/foo/bar/.proj
 You passed: \`invalid:event\`
 
 The following are valid events:
-- dev-server:start
+- after:run
 - after:screenshot
+- after:spec
 - before:browser:launch
+- before:run
+- before:spec
+- dev-server:start
 - file:preprocessor
 - task
 

--- a/packages/server/__snapshots__/4_plugin_run_events_spec.ts.js
+++ b/packages/server/__snapshots__/4_plugin_run_events_spec.ts.js
@@ -5,11 +5,10 @@ exports['e2e plugin run events / sends events'] = `
   (Run Starting)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Cypress:      1.2.3                                                                            │
-  │ Browser:      FooBrowser 88                                                                    │
-  │ Specs:        2 found (run_events_spec_1.js, run_events_spec_2.js)                             │
-  │ Searched:     cypress/integration/*                                                            │
-  │ Experiments:  experimentalRunEvents=true                                                       │
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      2 found (run_events_spec_1.js, run_events_spec_2.js)                               │
+  │ Searched:   cypress/integration/*                                                              │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
 
 before:run: cypress/integration/run_events_spec_1.js electron
@@ -98,11 +97,10 @@ exports['e2e plugin run events / handles video being deleted in after:spec'] = `
   (Run Starting)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Cypress:      1.2.3                                                                            │
-  │ Browser:      FooBrowser 88                                                                    │
-  │ Specs:        1 found (after_spec_deletes_video.js)                                            │
-  │ Searched:     cypress/integration/*                                                            │
-  │ Experiments:  experimentalRunEvents=true                                                       │
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      1 found (after_spec_deletes_video.js)                                              │
+  │ Searched:   cypress/integration/*                                                              │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
 
 
@@ -150,15 +148,6 @@ This error will not alter the exit code.
 
 `
 
-exports['e2e plugin run events / fails if experimentalRunEvents is not enabled'] = `
-The following validation error was thrown by your plugins file (\`/foo/bar/.projects/plugin-run-events/cypress/plugins/index.js\`).
-
- Error: The \`before:run\` event requires the experimentalRunEvents flag to be enabled.
-
-To enable it, set \`"experimentalRunEvents": true\` in your cypress.json
-      [stack trace lines]
-`
-
 exports['e2e plugin run events / fails run if event handler throws'] = `
 
 ====================================================================================================
@@ -166,11 +155,10 @@ exports['e2e plugin run events / fails run if event handler throws'] = `
   (Run Starting)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Cypress:      1.2.3                                                                            │
-  │ Browser:      FooBrowser 88                                                                    │
-  │ Specs:        1 found (run_event_throws_spec.js)                                               │
-  │ Searched:     cypress/integration/*                                                            │
-  │ Experiments:  experimentalRunEvents=true                                                       │
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      1 found (run_event_throws_spec.js)                                                 │
+  │ Searched:   cypress/integration/*                                                              │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
 
 

--- a/packages/server/lib/config_options.ts
+++ b/packages/server/lib/config_options.ts
@@ -75,11 +75,6 @@ export const options = [
     validation: v.isBoolean,
     isExperimental: true,
   }, {
-    name: 'experimentalRunEvents',
-    defaultValue: false,
-    validation: v.isBoolean,
-    isExperimental: true,
-  }, {
     name: 'experimentalSourceRewriting',
     defaultValue: false,
     validation: v.isBoolean,

--- a/packages/server/lib/config_options.ts
+++ b/packages/server/lib/config_options.ts
@@ -299,12 +299,16 @@ export const breakingOptions = [
     errorKey: 'EXPERIMENTAL_SAMESITE_REMOVED',
     isWarning: true,
   }, {
-    name: 'experimentalShadowDomSupport',
-    errorKey: 'EXPERIMENTAL_SHADOW_DOM_REMOVED',
-    isWarning: true,
-  }, {
     name: 'experimentalNetworkStubbing',
     errorKey: 'EXPERIMENTAL_NETWORK_STUBBING_REMOVED',
+    isWarning: true,
+  }, {
+    name: 'experimentalRunEvents',
+    errorKey: 'EXPERIMENTAL_RUN_EVENTS_REMOVED',
+    isWarning: true,
+  }, {
+    name: 'experimentalShadowDomSupport',
+    errorKey: 'EXPERIMENTAL_SHADOW_DOM_REMOVED',
     isWarning: true,
   },
 ]

--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -919,6 +919,11 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
         It is no longer necessary for using \`cy.intercept()\` (formerly \`cy.route2()\`).
 
         You can safely remove this option from your config.`
+    case 'EXPERIMENTAL_RUN_EVENTS_REMOVED':
+      return stripIndent`\
+        The \`experimentalRunEvents\` configuration option was removed in Cypress version \`6.7.0\`. It is no longer necessary when listening to run events in the plugins file.
+
+        You can safely remove this option from your config.`
     case 'INCOMPATIBLE_PLUGIN_RETRIES':
       return stripIndent`\
       We've detected that the incompatible plugin \`cypress-plugin-retries\` is installed at \`${arg1}\`.

--- a/packages/server/lib/experiments.ts
+++ b/packages/server/lib/experiments.ts
@@ -53,7 +53,6 @@ interface StringValues {
 const _summaries: StringValues = {
   experimentalComponentTesting: 'Framework-specific component testing, uses `componentFolder` to load component specs.',
   experimentalFetchPolyfill: 'Polyfills `window.fetch` to enable Network spying and stubbing.',
-  experimentalRunEvents: 'Allows listening to the `before:run`, `after:run`, `before:spec`, and `after:spec` events in the plugins file.',
   experimentalSourceRewriting: 'Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm.',
   experimentalStudio: 'Generate and save commands directly to your test suite by interacting with your app as an end user would.',
 }
@@ -71,7 +70,6 @@ const _summaries: StringValues = {
 const _names: StringValues = {
   experimentalComponentTesting: 'Component Testing',
   experimentalFetchPolyfill: 'Fetch polyfill',
-  experimentalRunEvents: 'Run Events',
   experimentalSourceRewriting: 'Improved source rewriting',
   experimentalStudio: 'Studio',
 }

--- a/packages/server/lib/plugins/child/validate_event.js
+++ b/packages/server/lib/plugins/child/validate_event.js
@@ -11,42 +11,25 @@ const isFunction = (event, handler) => {
   return validate(_.isFunction, handler, `The handler for the event \`${event}\` must be a function`)
 }
 
-const isValidRunEvent = (event, handler, config) => {
-  if (!config.experimentalRunEvents) {
-    return createErrorResult(`The \`${event}\` event requires the experimentalRunEvents flag to be enabled.
-
-To enable it, set \`"experimentalRunEvents": true\` in your cypress.json`)
-  }
-
-  return isFunction(event, handler)
-}
-
 const isObject = (event, handler) => {
   return validate(_.isPlainObject, handler, `The handler for the event \`${event}\` must be an object`)
 }
 
 const eventValidators = {
-  'dev-server:start': isFunction,
+  '_get:task:body': isFunction,
+  '_get:task:keys': isFunction,
+  'after:run': isFunction,
   'after:screenshot': isFunction,
+  'after:spec': isFunction,
   'before:browser:launch': isFunction,
+  'before:run': isFunction,
+  'before:spec': isFunction,
+  'dev-server:start': isFunction,
   'file:preprocessor': isFunction,
   'task': isObject,
-  '_get:task:keys': isFunction,
-  '_get:task:body': isFunction,
-}
-
-const runEvents = {
-  'after:run': true,
-  'after:spec': true,
-  'before:run': true,
-  'before:spec': true,
 }
 
 const validateEvent = (event, handler, config) => {
-  if (runEvents[event]) {
-    return isValidRunEvent(event, handler, config)
-  }
-
   const validator = eventValidators[event]
 
   if (!validator) {

--- a/packages/server/lib/plugins/run_events.js
+++ b/packages/server/lib/plugins/run_events.js
@@ -5,8 +5,6 @@ const plugins = require('../plugins')
 
 module.exports = {
   execute: Promise.method((eventName, config = {}, ...args) => {
-    if (!config.experimentalRunEvents) return
-
     if (!plugins.has(eventName)) return
 
     return plugins.execute(eventName, ...args)

--- a/packages/server/test/e2e/4_plugin_run_events_spec.ts
+++ b/packages/server/test/e2e/4_plugin_run_events_spec.ts
@@ -21,18 +21,6 @@ describe('e2e plugin run events', () => {
     snapshot: true,
   })
 
-  e2e.it('fails if experimentalRunEvents is not enabled', {
-    browser: 'electron',
-    project: Fixtures.projectPath('plugin-run-events'),
-    spec: '*',
-    snapshot: true,
-    expectedExitCode: 1,
-    config: {
-      experimentalRunEvents: false,
-      video: false,
-    },
-  })
-
   e2e.it('fails run if event handler throws', {
     browser: 'electron',
     project: Fixtures.projectPath('plugin-run-event-throws'),

--- a/packages/server/test/support/fixtures/projects/plugin-after-spec-deletes-video/cypress.json
+++ b/packages/server/test/support/fixtures/projects/plugin-after-spec-deletes-video/cypress.json
@@ -1,5 +1,4 @@
 {
-  "experimentalRunEvents": true,
   "fixturesFolder": false,
   "supportFile": false
 }

--- a/packages/server/test/support/fixtures/projects/plugin-run-event-throws/cypress.json
+++ b/packages/server/test/support/fixtures/projects/plugin-run-event-throws/cypress.json
@@ -1,5 +1,4 @@
 {
-  "experimentalRunEvents": true,
   "fixturesFolder": false,
   "supportFile": false
 }

--- a/packages/server/test/support/fixtures/projects/plugin-run-events/cypress.json
+++ b/packages/server/test/support/fixtures/projects/plugin-run-events/cypress.json
@@ -1,5 +1,4 @@
 {
-  "experimentalRunEvents": true,
   "fixturesFolder": false,
   "supportFile": false
 }

--- a/packages/server/test/unit/config_spec.js
+++ b/packages/server/test/unit/config_spec.js
@@ -1247,7 +1247,6 @@ describe('lib/config', () => {
             execTimeout: { value: 60000, from: 'default' },
             experimentalComponentTesting: { value: false, from: 'default' },
             experimentalFetchPolyfill: { value: false, from: 'default' },
-            experimentalRunEvents: { value: false, from: 'default' },
             experimentalSourceRewriting: { value: false, from: 'default' },
             experimentalStudio: { value: false, from: 'default' },
             fileServerFolder: { value: '', from: 'default' },
@@ -1328,7 +1327,6 @@ describe('lib/config', () => {
             execTimeout: { value: 60000, from: 'default' },
             experimentalComponentTesting: { value: false, from: 'default' },
             experimentalFetchPolyfill: { value: false, from: 'default' },
-            experimentalRunEvents: { value: false, from: 'default' },
             experimentalSourceRewriting: { value: false, from: 'default' },
             experimentalStudio: { value: false, from: 'default' },
             env: {

--- a/packages/server/test/unit/config_spec.js
+++ b/packages/server/test/unit/config_spec.js
@@ -1210,6 +1210,16 @@ describe('lib/config', () => {
       expect(warning).to.be.calledWith('EXPERIMENTAL_SHADOW_DOM_REMOVED')
     })
 
+    it('warns if experimentalRunEvents is passed', async function () {
+      const warning = sinon.spy(errors, 'warning')
+
+      await this.defaults('experimentalRunEvents', true, {
+        experimentalRunEvents: true,
+      })
+
+      expect(warning).to.be.calledWith('EXPERIMENTAL_RUN_EVENTS_REMOVED')
+    })
+
     // @see https://github.com/cypress-io/cypress/pull/9185
     it('warns if experimentalNetworkStubbing is passed', async function () {
       const warning = sinon.spy(errors, 'warning')

--- a/packages/server/test/unit/plugins/child/validate_event_spec.js
+++ b/packages/server/test/unit/plugins/child/validate_event_spec.js
@@ -4,10 +4,14 @@ const _ = require('lodash')
 const validateEvent = require('../../../../lib/plugins/child/validate_event')
 
 const events = [
+  ['after:run', 'a function', () => {}],
+  ['after:screenshot', 'a function', () => {}],
+  ['after:spec', 'a function', () => {}],
+  ['before:browser:launch', 'a function', () => {}],
+  ['before:run', 'a function', () => {}],
+  ['before:spec', 'a function', () => {}],
   ['dev-server:start', 'a function', () => {}],
   ['file:preprocessor', 'a function', () => {}],
-  ['before:browser:launch', 'a function', () => {}],
-  ['after:screenshot', 'a function', () => {}],
   ['task', 'an object', {}],
 ]
 
@@ -21,9 +25,13 @@ describe('lib/plugins/child/validate_event', () => {
 You passed: \`undefined\`
 
 The following are valid events:
-- dev-server:start
+- after:run
 - after:screenshot
+- after:spec
 - before:browser:launch
+- before:run
+- before:spec
+- dev-server:start
 - file:preprocessor
 - task
 `)
@@ -45,9 +53,13 @@ The following are valid events:
 You passed: \`invalid:event:name\`
 
 The following are valid events:
-- dev-server:start
+- after:run
 - after:screenshot
+- after:spec
 - before:browser:launch
+- before:run
+- before:spec
+- dev-server:start
 - file:preprocessor
 - task
 `)
@@ -67,39 +79,6 @@ The following are valid events:
       const { isValid } = validateEvent(event, validValue)
 
       expect(isValid).to.be.true
-    })
-  })
-
-  describe('run events', () => {
-    const runEvents = [
-      'after:run',
-      'before:run',
-      'before:spec',
-      'after:spec',
-    ]
-
-    _.each(runEvents, (event) => {
-      it(`returns error when ${event} event is registed without experimentalRunEvents flag enabled`, () => {
-        const { isValid, error } = validateEvent(event, {}, { experimentalRunEvents: false })
-
-        expect(isValid).to.be.false
-        expect(error.message).to.equal(`The \`${event}\` event requires the experimentalRunEvents flag to be enabled.
-
-To enable it, set \`"experimentalRunEvents": true\` in your cypress.json`)
-      })
-
-      it(`returns error when event handler of ${event} is not a function`, () => {
-        const { isValid, error } = validateEvent(event, 'invalid type', { experimentalRunEvents: true })
-
-        expect(isValid).to.be.false
-        expect(error.message).to.equal(`The handler for the event \`${event}\` must be a function`)
-      })
-
-      it(`returns success when event handler of ${event} is a function`, () => {
-        const { isValid } = validateEvent(event, () => {}, { experimentalRunEvents: true })
-
-        expect(isValid).to.be.true
-      })
     })
   })
 })

--- a/packages/server/test/unit/plugins/run_events_spec.js
+++ b/packages/server/test/unit/plugins/run_events_spec.js
@@ -13,7 +13,7 @@ describe('lib/plugins/run_events', () => {
     })
 
     it('returns a promise noop if event is not registered', () => {
-      return runEvents.execute('before:spec', enabled)
+      return runEvents.execute('before:spec', {})
       .then(() => {
         expect(plugins.execute).not.to.be.called
       })
@@ -23,7 +23,7 @@ describe('lib/plugins/run_events', () => {
       plugins.has.returns(true)
       plugins.execute.resolves('the result')
 
-      return runEvents.execute('before:spec', enabled, 'arg1', 'arg2')
+      return runEvents.execute('before:spec', {}, 'arg1', 'arg2')
       .then(() => {
         expect(plugins.execute).to.be.calledWith('before:spec', 'arg1', 'arg2')
       })
@@ -33,7 +33,7 @@ describe('lib/plugins/run_events', () => {
       plugins.has.returns(true)
       plugins.execute.resolves('the result')
 
-      return runEvents.execute('before:spec', enabled, 'arg1', 'arg2')
+      return runEvents.execute('before:spec', {}, 'arg1', 'arg2')
       .then((result) => {
         expect(result).to.equal('the result')
       })
@@ -43,7 +43,7 @@ describe('lib/plugins/run_events', () => {
       plugins.has.returns(true)
       plugins.execute.rejects({ stack: 'The event threw an error' })
 
-      return runEvents.execute('before:spec', enabled, 'arg1', 'arg2')
+      return runEvents.execute('before:spec', {}, 'arg1', 'arg2')
       .then(() => {
         expect(errors.throw).to.be.calledWith('PLUGINS_RUN_EVENT_ERROR', 'before:spec', 'The event threw an error')
       })

--- a/packages/server/test/unit/plugins/run_events_spec.js
+++ b/packages/server/test/unit/plugins/run_events_spec.js
@@ -5,20 +5,11 @@ const plugins = require(`${root}../lib/plugins`)
 const runEvents = require(`${root}../lib/plugins/run_events`)
 
 describe('lib/plugins/run_events', () => {
-  const enabled = { experimentalRunEvents: true }
-
   context('#execute', () => {
     beforeEach(() => {
       sinon.stub(plugins, 'execute')
       sinon.stub(plugins, 'has').returns(false)
       sinon.stub(errors, 'throw')
-    })
-
-    it('returns a promise noop if experimentalRunEvents is false', () => {
-      return runEvents.execute('before:spec', { experimentalRunEvents: false })
-      .then(() => {
-        expect(plugins.execute).not.to.be.called
-      })
     })
 
     it('returns a promise noop if event is not registered', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -34704,6 +34704,11 @@ vue@2.6.11:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
   integrity sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==
 
+vue@2.6.12:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
+  integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
+
 vuex@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.1.1.tgz#0c264bfe30cdbccf96ab9db3177d211828a5910e"


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Addresses [TR-671](https://cypress-io.atlassian.net/browse/TR-671)

### User facing changelog

- The `experimentalRunEvents` configuration flag has been removed. It is no longer necessary to enable listening to run events in the plugins file.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/3621
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [x] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
