### PR TITLE
chore: Remove jobs that are no longer necessary to run in Circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1516,7 +1516,7 @@ jobs:
   # Use:
   #   specify pull request number
   #   and the recipe folder
-
+  
   # test-binary-against-recipe-pull-request:
   #   <<: *defaults
   #   steps:
@@ -1818,15 +1818,14 @@ linux-workflow: &linux-workflow
     # on "develop" this branch will be ignored anyway
     # and someone else might use this job definition for another
     # feature branch and would just update the branch filter
-    
     # - test-binary-against-recipe-pull-request:
     #     name: Test cypress run parsing
     #     filters:
     #       branches:
     #         only:
     #           - cli-to-module-api-7760
-        requires:
-          - create-build-artifacts
+        # requires:
+        #   - create-build-artifacts
     - test-binary-against-awesome-typescript-loader:
         requires:
           - create-build-artifacts

--- a/circle.yml
+++ b/circle.yml
@@ -1506,6 +1506,27 @@ jobs:
           repo: cypress-example-recipes
           command: npm run test:ci:firefox
 
+  # This is a special job. It allows you to test the current
+  # built test runner against a pull request in the repo
+  # cypress-example-recipes.
+  # Imagine you are working on a feature and want to show / test a recipe
+  # You would need to run the built test runner before release
+  # against a PR that cannot be merged until the new version
+  # of the test runner is released.
+  # Use:
+  #   specify pull request number
+  #   and the recipe folder
+
+  # test-binary-against-recipe-pull-request:
+  #   <<: *defaults
+  #   steps:
+  #     # test a specific pull request by number from cypress-example-recipes
+  #     - test-binary-against-repo:
+  #         repo: cypress-example-recipes
+  #         command: npm run test:ci
+  #         pull_request_id: 515
+  #         folder: examples/fundamentals__typescript
+
   "test-binary-against-kitchensink":
     <<: *defaults
     steps:
@@ -1797,12 +1818,13 @@ linux-workflow: &linux-workflow
     # on "develop" this branch will be ignored anyway
     # and someone else might use this job definition for another
     # feature branch and would just update the branch filter
-    - test-binary-against-recipe-pull-request:
-        name: Test cypress run parsing
-        filters:
-          branches:
-            only:
-              - cli-to-module-api-7760
+    
+    # - test-binary-against-recipe-pull-request:
+    #     name: Test cypress run parsing
+    #     filters:
+    #       branches:
+    #         only:
+    #           - cli-to-module-api-7760
         requires:
           - create-build-artifacts
     - test-binary-against-awesome-typescript-loader:

--- a/circle.yml
+++ b/circle.yml
@@ -1506,31 +1506,6 @@ jobs:
           repo: cypress-example-recipes
           command: npm run test:ci:firefox
 
-  # This is a special job. It allows you to test the current
-  # built test runner against a pull request in the repo
-  # cypress-example-recipes.
-  # Imagine you are working on a feature and want to show / test a recipe
-  # You would need to run the built test runner before release
-  # against a PR that cannot be merged until the new version
-  # of the test runner is released.
-  # Use:
-  #   specify pull request number
-  #   and the recipe folder
-  test-binary-against-recipe-pull-request:
-    <<: *defaults
-    steps:
-      # test a specific pull request by number from cypress-example-recipes
-      - test-binary-against-repo:
-          repo: cypress-example-recipes
-          command: npm run test:ci
-          pull_request_id: 515
-          folder: examples/fundamentals__typescript
-      - test-binary-against-repo:
-          repo: cypress-example-recipes
-          command: npm test
-          pull_request_id: 513
-          folder: examples/fundamentals__module-api-wrap
-
   "test-binary-against-kitchensink":
     <<: *defaults
     steps:
@@ -1783,12 +1758,6 @@ linux-workflow: &linux-workflow
     - test-kitchensink:
         requires:
           - build
-        filters:
-          branches:
-            ignore:
-              ## TODO: remove this upon merging the PR
-              - rename-blacklisthosts
-              - pull/7622
     - test-kitchensink-against-staging:
         context: test-runner:record-tests
         filters:
@@ -1819,12 +1788,6 @@ linux-workflow: &linux-workflow
     - test-binary-against-kitchensink:
         requires:
           - create-build-artifacts
-        filters:
-          branches:
-            ignore:
-              ## TODO: remove this upon merging the PR
-              - rename-blacklisthosts
-              - pull/7622
     # when working on a feature or a fix,
     # you are probably working in a branch
     # and you want to run a specific PR in the cypress-example-recipes


### PR DESCRIPTION
These jobs are testing against very old PRs/branches in our example repos that are no longer necessary.

I would personally just delete the job, but the comments seem pretty yelly about not deleting them, so I just commented them out. Open to a second opinion.