### PR TITLE
chore: Fix some percy snapshot flakiness

### DIFF
--- a/packages/desktop-gui/cypress/integration/settings_spec.js
+++ b/packages/desktop-gui/cypress/integration/settings_spec.js
@@ -482,6 +482,11 @@ describe('Settings', () => {
         })
 
         it('shows message that user must be logged in to view record keys', () => {
+          // turn off animation to ensure panel is fully expanded in time for percy snapshot
+          cy.get('body').then(($body) => {
+            $body.append('<style>.rc-collapse-anim-active { transition: none !important; }<style>')
+          })
+
           cy.get('.empty-well').should('contain', 'must be logged in')
           cy.percySnapshot()
         })
@@ -496,6 +501,11 @@ describe('Settings', () => {
 
           this.ipc.getRecordKeys.onCall(1).resolves(this.keys)
 
+          // turn off animation to ensure panel is fully expanded in time for percy snapshot
+          cy.get('body').then(($body) => {
+            $body.append('<style>.rc-collapse-anim-active { transition: none !important; }<style>')
+          })
+
           cy.get('.empty-well button').click()
           cy.contains('Log In to Dashboard').click().should(() => {
             expect(this.ipc.getRecordKeys).to.be.calledTwice
@@ -503,6 +513,9 @@ describe('Settings', () => {
 
           cy.get('.settings-record-key')
           .contains(`cypress run --record --key ${this.keys[0].id}`)
+
+          // extra insurance that panel in background is fully expanded
+          cy.contains('You can change this key')
 
           cy.percySnapshot()
         })

--- a/packages/reporter/cypress/integration/header_spec.ts
+++ b/packages/reporter/cypress/integration/header_spec.ts
@@ -45,12 +45,12 @@ describe('header', () => {
       cy.wrap(runner.emit).should('be.calledWith', 'focus:tests')
     })
 
-    it('shows \'Tests\' when >= 400px wide', () => {
+    it('shows \'Tests\' when >= 398px wide', () => {
       cy.get('.focus-tests span').should('be.visible')
     })
 
-    it('hides \'Tests\' < 400px wide', () => {
-      cy.viewport(399, 450)
+    it('hides \'Tests\' < 398px wide', () => {
+      cy.viewport(397, 450)
       cy.get('.focus-tests span').should('not.be.visible')
     })
   })

--- a/packages/reporter/src/header/header.scss
+++ b/packages/reporter/src/header/header.scss
@@ -164,7 +164,7 @@
 
   // utilizing element size queries: https://github.com/marcj/css-element-queries
   // styles take effect when width is greater than or equal to the specified amount
-  &[min-width~="400px"] {
+  &[min-width~="398px"] {
     header button {
       width: 50px;
     }


### PR DESCRIPTION
### User facing changelog

N/A - internal only

### Additional details

Fixes a few flaky percy snapshots I've noticed. The commits/comments have more details for each.

Here's an example of the flake in the desktop-gui ones: https://percy.io/cypress-io/cypress/builds/9022886/changed/511561142?browser=chrome&browser_ids=16&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=800&widths=400%2C800
