### PR TITLE
fix(video): crop all odd resolutions to be even

### DIFF
--- a/packages/server/lib/video_capture.js
+++ b/packages/server/lib/video_capture.js
@@ -216,6 +216,10 @@ module.exports = {
           return ended.resolve()
         })
 
+        // this is to prevent the error "invalid data input" error
+        // when input frames have an odd resolution
+        .videoFilters(`crop='floor(in_w/2)*2:floor(in_h/2)*2'`)
+
         if (options.webmInput) {
           cmd
           .inputFormat('webm')
@@ -227,13 +231,6 @@ module.exports = {
           // 'vsync vfr' (variable framerate) works perfectly but fails on top page navigation
           // since video timestamp resets to 0, timestamps already written will be dropped
           // .outputOption('-vsync vfr')
-
-          // this is to prevent the error "invalid data input" error
-          // when input frames have an odd resolution
-          .videoFilters(`crop='floor(in_w/2)*2:floor(in_h/2)*2'`)
-
-          // same as above but scales instead of crops
-          // .videoFilters("scale=trunc(iw/2)*2:trunc(ih/2)*2")
         } else {
           cmd
           .inputFormat('image2pipe')


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #3491

### User facing changelog

- Fixed an issue that could cause an `ffmpeg` error ("width not divisible by 2") during video recording in Chromium-family browsers, including Chrome, Electron, and Edge.

### Additional details

- apparently the h264 codec requires an even resolution: https://stackoverflow.com/a/20848224/3474615
- odd resolutions will error
- this fixes the issue by cropping the video by 1 pixel on the right or bottom, as needed, to reach an even resolution
- we already do this for Firefox

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [na] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
