### PR TITLE
chore(component-testing): improve UX around devtools

### DIFF
--- a/packages/runner-ct/src/plugins/ReactDevtools.tsx
+++ b/packages/runner-ct/src/plugins/ReactDevtools.tsx
@@ -4,6 +4,7 @@ import {
   activate as activateBackend,
   initialize as initializeBackend,
 } from 'react-devtools-inline/backend'
+import { ReactDevtoolsFallback } from './ReactDevtoolsFallback'
 import { initialize as initializeFrontend } from 'react-devtools-inline/frontend'
 import { UIPlugin } from './UIPlugin'
 
@@ -17,6 +18,12 @@ export function create (root: HTMLElement): UIPlugin {
   const devtoolsRoot = ReactDomExperimental.unstable_createRoot(root)
 
   function mount () {
+    if (!document.querySelector('.aut-iframe')) {
+      devtoolsRoot.render(<ReactDevtoolsFallback />)
+
+      return
+    }
+
     if (!isFirstMount) {
       // if devtools were unmounted it is closing the bridge, so we need to reinitialize the bridge on our side
       DevTools = initializeFrontend(_contentWindow)

--- a/packages/runner-ct/src/plugins/ReactDevtoolsFallback.tsx
+++ b/packages/runner-ct/src/plugins/ReactDevtoolsFallback.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import './devtools-fallback.scss'
+
+export const ReactDevtoolsFallback: React.FC = () => {
+  return (
+    <p className='react-devtools-fallback'>Select a spec or re-run the current spec to activate devtools.</p>
+  )
+}

--- a/packages/runner-ct/src/plugins/devtools-fallback.scss
+++ b/packages/runner-ct/src/plugins/devtools-fallback.scss
@@ -1,0 +1,8 @@
+.react-devtools-fallback {
+  width: 100%;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 70%;
+}


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://cypress-io.atlassian.net/browse/CT-315

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

Improve UI and UX around devtools in CT runner by:

- preventing crash when launching devtools without a spec selected
- add a useful message explaining why devtools may not be showing up

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

N/A

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

I added a fallback message if devtools cannot be displayed and some useful instructions on how to get them to show:

![image](https://user-images.githubusercontent.com/19196536/109752892-f5d95b80-7c2c-11eb-8291-0ab02de1c330.png)


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

N/A