### PR TITLE
test: add test for async errors being caught by AUT error handlers

### DIFF
--- a/packages/driver/cypress/fixtures/errors.html
+++ b/packages/driver/cypress/fixtures/errors.html
@@ -54,7 +54,7 @@
     document.querySelector(".trigger-async-error").addEventListener('click', function () {
       setTimeout(function () {
         one('async error')
-      }, 500)
+      }, 0)
     })
 
     document.querySelector(".trigger-unhandled-rejection").addEventListener('click', function () {

--- a/packages/driver/cypress/integration/e2e/uncaught_errors_spec.js
+++ b/packages/driver/cypress/integration/e2e/uncaught_errors_spec.js
@@ -83,6 +83,20 @@ describe('uncaught errors', () => {
     cy.get('.trigger-async-error').click()
   })
 
+  // we used to wrap timers with "proxy" tracking functions
+  // this has been called from the top frame
+  // and thus its error handler has been catching the error and not the one in AUT
+  it('async error triggers the app-under-test error handler', () => {
+    // mute auto-failing this test
+    cy.once('uncaught:exception', () => false)
+
+    cy.visit('/fixtures/errors.html')
+    cy.get('.trigger-async-error').click()
+
+    cy.get('.error-one').invoke('text').should('equal', 'async error')
+    cy.get('.error-two').invoke('text').should('equal', 'async error')
+  })
+
   it('unhandled rejection triggers uncaught:exception and has promise as third argument', (done) => {
     cy.once('uncaught:exception', (err, runnable, promise) => {
       expect(err.stack).to.include('promise rejection')


### PR DESCRIPTION
### User facing changelog

None - or maybe just too detailed for it to be worthwhile documenting. Unless you think otherwise.

### Additional details

This test would not pass before https://github.com/cypress-io/cypress/pull/14826 and from the user's perspective this is the expected behavior so I think it's worth having a test for it if the issue got fixed.

### How has the user experience changed?

It didn't

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
