### PR TITLE
test: add a failing test for not failing tests after last command com…

### DIFF
--- a/packages/driver/cypress/fixtures/errors.html
+++ b/packages/driver/cypress/fixtures/errors.html
@@ -54,7 +54,7 @@
     document.querySelector(".trigger-async-error").addEventListener('click', function () {
       setTimeout(function () {
         one('async error')
-      }, 0)
+      }, 100)
     })
 
     document.querySelector(".trigger-unhandled-rejection").addEventListener('click', function () {

--- a/packages/driver/cypress/integration/e2e/uncaught_errors_spec.js
+++ b/packages/driver/cypress/integration/e2e/uncaught_errors_spec.js
@@ -172,4 +172,13 @@ describe('uncaught errors', () => {
       })
     }).get('button:first').click()
   })
+
+  it('fails test based on an uncaught error after last command and before completing', (done) => {
+    cy.on('fail', () => {
+      done()
+    })
+
+    cy.visit('/fixtures/errors.html')
+    cy.get('.trigger-async-error').click()
+  })
 })


### PR DESCRIPTION
### User facing changelog

None yet as this is just a failing test for now

### Additional details

This is just a failing test that depicts the problem which I have described in more detail [here](https://github.com/cypress-io/cypress/pull/9077#issuecomment-722278467). I've recognized why this happens in your code but fixing it is beyond me for the moment - somebody with more expertise about the codebase should take care of that, cc @chrisbreiding

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
