### PR TITLE
fix: cy.wait can handle multiple intercepts to a single url

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -2225,6 +2225,21 @@ describe('network stubbing', { retries: 2 }, function () {
       .wait('@image').its('response.statusCode').should('eq', 304)
     })
 
+    // https://github.com/cypress-io/cypress/issues/14522
+    it('different aliases are used for the same url', () => {
+      cy.intercept('/status-code').as('status')
+      .then(() => {
+        $.get('/status-code?code=204')
+      })
+      .wait('@status').its('response.statusCode').should('eq', 204)
+
+      cy.intercept('/status-code').as('status2')
+      .then(() => {
+        $.get('/status-code?code=301')
+      })
+      .wait('@status2').its('response.statusCode').should('eq', 301)
+    })
+
     // https://github.com/cypress-io/cypress/issues/9549
     it('should handle aborted requests', () => {
       cy.intercept('https://jsonplaceholder.typicode.com/todos/1').as('xhr')

--- a/packages/net-stubbing/lib/server/route-matching.ts
+++ b/packages/net-stubbing/lib/server/route-matching.ts
@@ -132,6 +132,14 @@ export function getRouteForRequest (routes: BackendRoute[], req: CypressIncoming
   })
 }
 
+export function getAllRoutesForRequest (routes: BackendRoute[], req: CypressIncomingRequest, prevRoute?: BackendRoute) {
+  const possibleRoutes = prevRoute ? routes.slice(_.findIndex(routes, prevRoute) + 1) : routes
+
+  return _.filter(possibleRoutes, (route) => {
+    return _doesRouteMatch(route.routeMatcher, req)
+  })
+}
+
 function isPreflightRequest (req: CypressIncomingRequest) {
   return req.method === 'OPTIONS' && req.headers['access-control-request-method']
 }


### PR DESCRIPTION
- Closes #14522
- Closes #14205

### User facing changelog

When a user set up multiple intercepts to a single url, `cy.wait` couldn't wait for the second and later responses.

### Additional details
- Why was this change necessary? => fix `cy.intercept`, `cy.wait` bugs.
- What is affected by this change? => N/A
- Any implementation details to explain? => Even if requests are sent multiple times for a single url, the response is sent only once. Because of that, we have to send response multiple times on `InterceptResponse`. 

### How has the user experience changed?

N/A

### PR Tasks

- [x] Have tests been added/updated?