### PR TITLE
chore: remove invalid nohoist

### DIFF
--- a/npm/react/package.json
+++ b/npm/react/package.json
@@ -130,11 +130,6 @@
   ],
   "unpkg": "dist/cypress-react.browser.js",
   "module": "dist/cypress-react.esm-bundler.js",
-  "workspaces": {
-    "nohoist": [
-      "cypress-circleci-reporter"
-    ]
-  },
   "peerDependenciesMeta": {
     "@babel/core": {
       "optional": true


### PR DESCRIPTION
This is causing this warning on `yarn install`: 

```
warning nohoist config is ignored in "@cypress/react" because it is not a private package. If you think nohoist should be allowed in public packages, please submit an issue for your use case.
```

I'm assuming this is a mistake then?