### PR TITLE
fix(desktop-gui): Align 'plugins' error message to top

### DIFF
--- a/packages/desktop-gui/src/styles/components/_alerts.scss
+++ b/packages/desktop-gui/src/styles/components/_alerts.scss
@@ -38,19 +38,12 @@
 }
 
 .full-alert-container {
-  align-items: center;
-  display: flex;
   flex-grow: 2;
-  justify-content: center;
   overflow: auto;
   padding: 30px 60px;
 }
 
 .full-alert {
-  // `margin: auto` fixes issue with flexbox vertically-centered element + oveflow
-  // https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container
-  margin: auto;
-  overflow: auto;
   padding: 20px;
   text-align: center;
 


### PR DESCRIPTION
- TR-696

### User Changelog

The plugins error message is now top-aligned.

### Additional Details

- This change was introduced in the [node-sass PR](https://github.com/cypress-io/cypress/pull/14415) in 6.3.0. 
- To restore back to the original design, the error message should be veritically centered, but I don't think this is necessary and in fact slightly counter-intuitive since when you expand the error message, the link 'moves' so that you have to move your mouse again to close the expanded error message. 
- Also, vertically centering things in CSS is 👎 

### User Experience changes

#### Cypress 6.2.0

![](http://g.recordit.co/1hSe4kXRXh.gif)

#### Before this PR

![](http://g.recordit.co/WNKLv8aPM8.gif)

#### After this PR

![](http://g.recordit.co/LXBPbjSyNO.gif)