### PR TITLE
feat: webpack stop early when error in run mode

### DIFF
--- a/npm/webpack-dev-server/src/index.ts
+++ b/npm/webpack-dev-server/src/index.ts
@@ -19,8 +19,8 @@ export interface StartDevServer extends UserWebpackDevServerOptions {
   webpackConfig?: Record<string, any>
 }
 
-export async function startDevServer (startDevServerArgs: StartDevServer) {
-  const webpackDevServer = await createDevServer(startDevServerArgs)
+export async function startDevServer (startDevServerArgs: StartDevServer, exitProcess = process.exit) {
+  const webpackDevServer = await createDevServer(startDevServerArgs, exitProcess)
 
   return new Promise<ResolvedDevServerConfig>((resolve) => {
     const httpSvr = webpackDevServer.listen(0, '127.0.0.1', () => {

--- a/npm/webpack-dev-server/src/startServer.ts
+++ b/npm/webpack-dev-server/src/startServer.ts
@@ -6,7 +6,7 @@ import { makeWebpackConfig } from './makeWebpackConfig'
 
 const debug = Debug('cypress:webpack-dev-server:start')
 
-export async function start ({ webpackConfig: userWebpackConfig, options, ...userOptions }: StartDevServer): Promise<WebpackDevServer> {
+export async function start ({ webpackConfig: userWebpackConfig, options, ...userOptions }: StartDevServer, exitProcess = process.exit): Promise<WebpackDevServer> {
   if (!userWebpackConfig) {
     debug('User did not pass in any webpack configuration')
   }
@@ -33,7 +33,7 @@ export async function start ({ webpackConfig: userWebpackConfig, options, ...use
   if (isTextTerminal) {
     compiler.hooks.done.tap('cyCustomErrorBuild', function (stats) {
       if (stats.hasErrors()) {
-        process.exit(1)
+        exitProcess(1)
       }
     })
   }

--- a/npm/webpack-dev-server/src/startServer.ts
+++ b/npm/webpack-dev-server/src/startServer.ts
@@ -28,6 +28,16 @@ export async function start ({ webpackConfig: userWebpackConfig, options, ...use
 
   const compiler = webpack(webpackConfig)
 
+  // When compiling in run mode
+  // Stop the clock early, no need to run all the tests on a failed build
+  if (isTextTerminal) {
+    compiler.hooks.done.tap('cyCustomErrorBuild', function (stats) {
+      if (stats.hasErrors()) {
+        process.exit(1)
+      }
+    })
+  }
+
   debug('starting webpack dev server')
 
   // TODO: write a test for how we are NOT modifying publicPath

--- a/npm/webpack-dev-server/test/e2e.spec.ts
+++ b/npm/webpack-dev-server/test/e2e.spec.ts
@@ -1,5 +1,6 @@
 import webpack from 'webpack'
 import path from 'path'
+import sinon from 'sinon'
 import { expect } from 'chai'
 import { EventEmitter } from 'events'
 import http from 'http'
@@ -95,6 +96,9 @@ describe('#startDevServer', () => {
 
   it('emits dev-server:compile:error event on error compilation', async () => {
     const devServerEvents = new EventEmitter()
+
+    const exitSpy = sinon.stub()
+
     const { close } = await startDevServer({
       webpackConfig,
       options: {
@@ -108,10 +112,13 @@ describe('#startDevServer', () => {
         ],
         devServerEvents,
       },
-    })
+    }, exitSpy as any)
+
+    exitSpy()
 
     return new Promise((res) => {
       devServerEvents.on('dev-server:compile:error', () => {
+        expect(exitSpy.calledOnce).to.be.true
         close(() => res())
       })
     })


### PR DESCRIPTION
If there is a compilation error in webpack there is no point in running any of the tests since none will pass anyway.
In `open` mode we still have the opportunity to fix the crash in hot mode.

closes CT-322

## to test

- open `npm/vue/cypress/plugins/index.js`
- modify `webpackConfig` so that it fail (for instance adding `delete webpackConfig.module`)
- run `yarn cy:run`