### PR TITLE
fix: disable dev tools in run mode

### DIFF
--- a/packages/runner-ct/src/lib/state.ts
+++ b/packages/runner-ct/src/lib/state.ts
@@ -285,7 +285,7 @@ export default class State {
 
   @action
   initializePlugins = (config: Cypress.RuntimeConfigOptions, rootElement: HTMLElement) => {
-    if (config.env.reactDevtools) {
+    if (config.env.reactDevtools && !config.isTextTerminal) {
       this.loadReactDevTools(rootElement)
       .then(action(() => {
         this.readyToRunTests = true


### PR DESCRIPTION
Dev tools are not useful in run mode and they make some strange failures in CI

closes CT-326