### PR TITLE
fix: cy command call inside should() doesn't create an infinite loop

### DIFF
--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -234,6 +234,14 @@ describe('src/cy/commands/assertions', () => {
         })
       })
 
+      // https://github.com/cypress-io/cypress/issues/14656
+      it('does not get into an infinite loop', () => {
+        cy.wrap('bar')
+        .should(() => {
+          cy.wrap('foo')
+        })
+      })
+
       context('remote jQuery instances', () => {
         beforeEach(function () {
           this.remoteWindow = cy.state('window')


### PR DESCRIPTION
- Closes #14656

### User facing changelog

cy command call inside `cy.should()` caused an infinite loop. This PR fixes this issue.

### Additional details
- Why was this change necessary? => It's not unnatural to call cy commands like `cy.wrap()` inside `cy.should()`. But it can cause infinite loop.
- What is affected by this change? => N/A
- Any implementation details to explain? => Check below.

### Why it happened

```js
// example code
it('gets into a loop', () => {
  cy.wrap('bar')
    .should(() => {
      cy.wrap('foo')
    })
})
```

When we run the example code above, Cypress initially creates a command stack like below:

```
wrap('bar')
should <-
```

Then, it runs the callback function of the `should()`. It adds Cypress commands into the stack. 

```
wrap('bar')
wrap('foo') <-
should 
```

As you can see, `should` is still at the end of the stack. But the problem happens here. After finishing `wrap('foo')`, Cypress tries to run `should`. And `should` adds another `wrap('foo')` to the stack, which looks like below:

```
wrap('bar')
wrap('foo')
wrap('foo') <-
should 
```

This goes on and on. That's why an infinite loop has been created. 

As it's the problem of handling stacks inside `should` callback, almost any cy command can cause similar problems.

For example, the code below can cause the same problem.

```js
// another loop code
it('gets into a loop', () => {
  cy.wrap('bar')
    .should(() => {
      cy.get('p')
    })
})
```

### How this PR solves the problem. 

This PR solves the problem by adding dummy commands. (It's just like I did in #8699.) 

When running `should` callback, one dummy command(** below) that skips next `should` callback call like below:

```
wrap('bar')
wrap('foo') <-
skip-should-fn-call **
should 
```

`skip-should-fn-call` dummy command sets state variable and skips the next should function call. 

But this change makes `should` not to try again when something failed. 

Because of that, when an error is thrown inside the callback function, it skips the `skip-should-fn-call`. 

### How has the user experience changed?

N/A

### PR Tasks
- [x] Have tests been added/updated?
