### PR TITLE
fix(runner-ct): correctly scale runner-ct when spec list is hidden

### DIFF
--- a/packages/runner-ct/src/app/RunnerCt.tsx
+++ b/packages/runner-ct/src/app/RunnerCt.tsx
@@ -61,8 +61,6 @@ const App: React.FC<AppProps> = observer(
 
     const [isResizing, setIsResizing] = React.useState(false)
 
-    const [isSpecsListOpen, setIsSpecsListOpen] = React.useState(isOpenMode)
-
     // const windowSize = useWindowSize()
     const [activeIndex, setActiveIndex] = React.useState<number>(0)
     const headerRef = React.useRef(null)
@@ -122,7 +120,7 @@ const App: React.FC<AppProps> = observer(
           type: 'js',
           onClick: () => {
             onNavItemClick(0)
-            setIsSpecsListOpen(!isSpecsListOpen)
+            props.state.setIsSpecsListOpen(!props.state.isSpecsListOpen)
           },
         },
       },
@@ -140,12 +138,12 @@ const App: React.FC<AppProps> = observer(
 
     function toggleSpecsList () {
       setActiveIndex((val) => val === 0 ? undefined : 0)
-      setIsSpecsListOpen((val) => !val)
+      props.state.setIsSpecsListOpen(!props.state.isSpecsListOpen)
     }
 
     function focusSpecsList () {
       setActiveIndex(0)
-      setIsSpecsListOpen(true)
+      props.state.setIsSpecsListOpen(true)
 
       // a little trick to focus field on the next tick of event loop
       // to prevent the handled keydown/keyup event to fill input with "/"
@@ -204,9 +202,9 @@ const App: React.FC<AppProps> = observer(
         <SplitPane
           split="vertical"
           // do not allow resizing of this for now, simplifes calculation for scale of AUT.
-          minSize={hideIfScreenshotting(() => isSpecsListOpen ? 30 : 0)}
-          maxSize={hideIfScreenshotting(() => isSpecsListOpen ? 600 : 0)}
-          defaultSize={hideIfScreenshotting(() => isSpecsListOpen ? DEFAULT_LIST_WIDTH : 0)}
+          minSize={hideIfScreenshotting(() => props.state.isSpecsListOpen ? 30 : 0)}
+          maxSize={hideIfScreenshotting(() => state.isSpecsListOpen ? 600 : 0)}
+          defaultSize={hideIfScreenshotting(() => state.isSpecsListOpen ? DEFAULT_LIST_WIDTH : 0)}
           className="primary"
           // @ts-expect-error split-pane ref types are weak so we are using our custom type for ref
           ref={splitPaneRef}

--- a/packages/runner-ct/src/app/RunnerCt.tsx
+++ b/packages/runner-ct/src/app/RunnerCt.tsx
@@ -187,7 +187,7 @@ const App: React.FC<AppProps> = observer(
     }
 
     function hideSpecsListIfNecessary () {
-      if (state.screenshotting || !isSpecsListOpen) {
+      if (state.screenshotting || !props.state.isSpecsListOpen) {
         return true
       }
 

--- a/packages/runner-ct/src/app/RunnerCt.tsx
+++ b/packages/runner-ct/src/app/RunnerCt.tsx
@@ -17,6 +17,7 @@ import Message from '../message/message'
 import EventManager from '../lib/event-manager'
 import { SpecList } from '../SpecList'
 import { useGlobalHotKey } from '../lib/useHotKey'
+import { debounce } from '../lib/debounce'
 import { LeftNavMenu } from './LeftNavMenu'
 import styles from './RunnerCt.module.scss'
 import { Plugins } from './Plugins'
@@ -58,7 +59,6 @@ const App: React.FC<AppProps> = observer(
 
     const { state, eventManager, config } = props
 
-    // const windowSize = useWindowSize()
     const [activeIndex, setActiveIndex] = React.useState<number>(0)
     const headerRef = React.useRef(null)
 
@@ -80,7 +80,7 @@ const App: React.FC<AppProps> = observer(
         })
       }
 
-      window.addEventListener('resize', onWindowResize)
+      window.addEventListener('resize', debounce(onWindowResize))
       window.dispatchEvent(new Event('resize'))
     }
 
@@ -211,7 +211,7 @@ const App: React.FC<AppProps> = observer(
           className="primary"
           // @ts-expect-error split-pane ref types are weak so we are using our custom type for ref
           ref={splitPaneRef}
-          onChange={onSpecListPaneChange}
+          onChange={debounce(onSpecListPaneChange)}
 
         >
           <SpecList
@@ -232,7 +232,7 @@ const App: React.FC<AppProps> = observer(
             maxSize={hideIfScreenshotting(() => 600)}
             defaultSize={hideIfScreenshotting(() => DEFAULT_REPORTER_WIDTH)}
             className="primary"
-            onChange={onReporterSplitPaneChange}
+            onChange={debounce(onReporterSplitPaneChange)}
           >
             <ReporterContainer
               state={props.state}
@@ -249,7 +249,7 @@ const App: React.FC<AppProps> = observer(
                   ? DEFAULT_PLUGINS_HEIGHT
                   // show the small not resize-able panel with buttons or nothing
                   : state.isAnyPluginToShow ? PLUGIN_BAR_HEIGHT : 0)}
-              onChange={onPluginsSplitPaneChange}
+              onChange={debounce(onPluginsSplitPaneChange)}
             >
               <div className={cs(
                 'runner',

--- a/packages/runner-ct/src/app/RunnerCt.tsx
+++ b/packages/runner-ct/src/app/RunnerCt.tsx
@@ -219,7 +219,7 @@ const App: React.FC<AppProps> = observer(
             selectedSpecs={state.spec ? [state.spec.absolute] : []}
             className={
               cs(styles.specsList, {
-                'display-none': state.screenshotting || !isOpenMode,
+                'display-none': state.screenshotting,
               })
             }
             onSelectSpec={runSpec}

--- a/packages/runner-ct/src/lib/debounce.ts
+++ b/packages/runner-ct/src/lib/debounce.ts
@@ -1,0 +1,16 @@
+export const debounce = (callback) => {
+  let timeout
+
+  // Return a function to run debounced
+  return function (...args: any[]) {
+    // If there's a timer, cancel it
+    if (timeout) {
+      window.cancelAnimationFrame(timeout)
+    }
+
+    // Setup the new requestAnimationFrame()
+    timeout = window.requestAnimationFrame(() => {
+      callback.apply({}, args)
+    })
+  }
+}

--- a/packages/runner-ct/src/lib/state.ts
+++ b/packages/runner-ct/src/lib/state.ts
@@ -27,6 +27,7 @@ interface Defaults {
   reporterWidth: number | null
   pluginsHeight: number | null
   specListWidth: number | null
+  isSpecsListOpen: boolean
 
   viewportHeight: number
   viewportWidth: number
@@ -57,6 +58,7 @@ const _defaults: Defaults = {
 
   reporterWidth: null,
   specListWidth: DEFAULT_LIST_WIDTH,
+  isSpecsListOpen: true,
 
   url: '',
   highlightUrl: false,
@@ -100,6 +102,7 @@ export default class State {
   @observable reporterWidth = _defaults.reporterWidth
   @observable pluginsHeight = _defaults.pluginsHeight
   @observable specListWidth = _defaults.specListWidth
+  @observable isSpecsListOpen = _defaults.isSpecsListOpen
 
   // what the dom reports, always in pixels
   @observable absoluteReporterWidth = 0
@@ -150,7 +153,11 @@ export default class State {
     // width of the other parts of the UI from the window.innerWidth
     // we also need to consider the margin around the aut iframe
     // window.innerWidth - leftNav - specList - reporter - aut-iframe-margin
-    const autAreaWidth = this.windowWidth - LEFT_NAV_WIDTH - this.specListWidth - this.reporterWidth - (AUT_IFRAME_MARGIN.X * 2)
+    const autAreaWidth = this.windowWidth
+      - LEFT_NAV_WIDTH
+      - (this.isSpecsListOpen ? this.specListWidth : 0) // if spec list is closed, don't need to consider it.
+      - this.reporterWidth
+      - (AUT_IFRAME_MARGIN.X * 2)
 
     // same for the height.
     // height - pluginsHeight (0 if no plugins are open) - plugin-bar-height - header-height - margin
@@ -206,6 +213,10 @@ export default class State {
   @action updateAutViewportDimensions (dimensions: { viewportWidth: number, viewportHeight: number }) {
     this.viewportHeight = dimensions.viewportHeight
     this.viewportWidth = dimensions.viewportWidth
+  }
+
+  @action setIsSpecsListOpen (open: boolean) {
+    this.isSpecsListOpen = open
   }
 
   @action setIsLoading (isLoading) {


### PR DESCRIPTION
When calculating the scale for the AUT `<iframe>`, we should not subtract the width of the spec list if the spec list is closed.

## Before:

![image](https://user-images.githubusercontent.com/19196536/110594041-0a3acc80-81c8-11eb-815d-ead69223eb16.png)

## After:

![image](https://user-images.githubusercontent.com/19196536/110594065-10c94400-81c8-11eb-8ac5-9e04610bfee6.png)
