### PR TITLE
build: release react on next/npm/react with next

### DIFF
--- a/npm/react/releaserc.js
+++ b/npm/react/releaserc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  ...require('./.releaserc.base'),
+  branches: [
+    'master',
+    { name: 'next/npm/react', channel: 'next', prerelease: 'alpha' },
+  ],
+}


### PR DESCRIPTION
Add a release file to specify that we can release @cypress/react on the next channel on the next/npm/react branch