### PR TITLE
chore: should hide reporter when theres no spec selected

### DIFF
--- a/packages/runner-ct/cypress/component/RunnerCt.spec.tsx
+++ b/packages/runner-ct/cypress/component/RunnerCt.spec.tsx
@@ -5,6 +5,12 @@ import RunnerCt from '../../src/app/RunnerCt'
 import State from '../../src/lib/state'
 import '@packages/runner/src/main.scss'
 
+const selectors = {
+  reporter: '[data-cy=reporter]',
+  specsList: '[data-cy=specs-list]',
+  searchInput: 'input[placeholder="Find spec..."]',
+}
+
 class FakeEventManager {
   start = () => { }
   on = () => { }
@@ -13,32 +19,22 @@ class FakeEventManager {
 }
 
 const fakeConfig = { projectName: 'Project', env: {}, isTextTerminal: false } as any as Cypress.RuntimeConfigOptions
+const makeState = (options = {}) => (new State({
+  reporterWidth: 500,
+  spec: null,
+  specs: [{ relative: '/test.js', absolute: 'root/test.js', name: 'test.js' }],
+  ...options,
+}))
 
 describe('RunnerCt', () => {
   beforeEach(() => {
     cy.viewport(1000, 500)
   })
 
-  function assertSpecsListIs (state: 'closed' | 'open') {
-    // for some reason should("not.be.visible") doesn't work here so ensure that specs list was outside of screen
-    cy.get('[data-cy=specs-list]').then(($el) => {
-      const { width } = $el[0].getBoundingClientRect()
-
-      // SplitPane adds a 1px margin on the edge. No big deal. That's why the assertions are 1 and 301 instead of 1 and 300.
-      state === 'closed' ? expect(width).to.eq(1) : expect(width).to.eq(301)
-    })
-  }
-
   it('renders RunnerCt', () => {
-    const state = new State({
-      reporterWidth: 500,
-      spec: null,
-      specs: [{ relative: '/test.js', absolute: 'root/test.js', name: 'test.js' }],
-    })
-
     mount(
       <RunnerCt
-        state={state}
+        state={makeState()}
         // @ts-ignore - this is difficult to stub. Real one breaks things.
         eventManager={new FakeEventManager()}
         config={fakeConfig}
@@ -49,15 +45,9 @@ describe('RunnerCt', () => {
   })
 
   it('renders RunnerCt for video recording', () => {
-    const state = new State({
-      reporterWidth: 500,
-      spec: null,
-      specs: [{ relative: '/test.js', absolute: 'root/test.js', name: 'test.js' }],
-    })
-
     mount(
       <RunnerCt
-        state={state}
+        state={makeState()}
         // @ts-ignore - this is difficult to stub. Real one breaks things.
         eventManager={new FakeEventManager()}
         config={{ ...fakeConfig, isTextTerminal: true }}
@@ -69,15 +59,9 @@ describe('RunnerCt', () => {
 
   context('keyboard shortcuts', () => {
     beforeEach(() => {
-      const state = new State({
-        reporterWidth: 500,
-        spec: null,
-        specs: [{ relative: '/test.js', absolute: 'root/test.js', name: 'test.js' }],
-      })
-
       mount(
         <RunnerCt
-          state={state}
+          state={makeState()}
           // @ts-ignore - this is difficult to stub. Real one breaks things.
           eventManager={new FakeEventManager()}
           config={fakeConfig}
@@ -88,17 +72,31 @@ describe('RunnerCt', () => {
     })
 
     it('toggles specs list drawer using shortcut', () => {
-      cy.realPress(['Meta', 'B'])
-      cy.wait(400) // can not wait for this animation automatically :(
-      assertSpecsListIs('closed')
+      cy.get(selectors.specsList).should('be.visible')
 
       cy.realPress(['Meta', 'B'])
-      assertSpecsListIs('open')
+      cy.get(selectors.specsList).should('not.be.visible')
+
+      cy.realPress(['Meta', 'B'])
+      cy.get(selectors.specsList).should('be.visible')
     })
 
     it('focuses the search field on "/"', () => {
       cy.realPress('/')
-      cy.get('input[placeholder="Find spec..."]').should('be.focused')
+      cy.get(selectors.searchInput).should('be.focused')
+    })
+  })
+
+  context('no spec selected', () => {
+    it('hides reporter', () => {
+      mount(<RunnerCt
+        state={makeState({ spec: null })}
+        // @ts-ignore - this is difficult to stub. Real one breaks things.
+        eventManager={new FakeEventManager()}
+        config={fakeConfig} />)
+
+      cy.get(selectors.reporter).should('not.be.visible')
+      cy.percySnapshot()
     })
   })
 })

--- a/packages/runner-ct/src/app/ReporterContainer.tsx
+++ b/packages/runner-ct/src/app/ReporterContainer.tsx
@@ -20,7 +20,7 @@ export const ReporterContainer = observer(
   function ReporterContainer (props: ReporterContainerProps) {
     if (!props.state.spec) {
       return (
-        <div className='no-spec'>
+        <div className='no-spec' data-cy="reporter">
           <NoSpecSelected />
         </div>
       )
@@ -28,6 +28,7 @@ export const ReporterContainer = observer(
 
     return (
       <Reporter
+        data-cy="reporter"
         runMode={props.state.runMode}
         runner={props.eventManager.reporterBus}
         className={cs({ 'display-none': props.state.screenshotting }, styles.reporter)}

--- a/packages/runner-ct/src/app/RunnerCt.module.scss
+++ b/packages/runner-ct/src/app/RunnerCt.module.scss
@@ -56,6 +56,7 @@ $box-shadow-closest: 0px 0px 5px rgba(0, 0, 0, 0.4);
 
 .runner {
   box-shadow: unset;
+  left: 0 !important;
 }
 
 .reporter {

--- a/packages/runner-ct/src/app/RunnerCt.tsx
+++ b/packages/runner-ct/src/app/RunnerCt.tsx
@@ -175,6 +175,14 @@ const App: React.FC<AppProps> = observer(
       return callback()
     }
 
+    function hideReporterIfNecessary (callback: () => number) {
+      if (state.screenshotting || !state.spec) {
+        return 0
+      }
+
+      return callback()
+    }
+
     const leftNav = state.screenshotting
       ? <span />
       : (
@@ -225,9 +233,9 @@ const App: React.FC<AppProps> = observer(
 
           <SplitPane
             split="vertical"
-            minSize={hideIfScreenshotting(() => 100)}
-            maxSize={hideIfScreenshotting(() => 600)}
-            defaultSize={hideIfScreenshotting(() => DEFAULT_REPORTER_WIDTH)}
+            minSize={hideReporterIfNecessary(() => 100)}
+            maxSize={hideReporterIfNecessary(() => 600)}
+            defaultSize={hideReporterIfNecessary(() => DEFAULT_REPORTER_WIDTH)}
             className="primary"
             onChange={onReporterSplitPaneChange}
           >

--- a/packages/runner-ct/src/app/RunnerCt.tsx
+++ b/packages/runner-ct/src/app/RunnerCt.tsx
@@ -183,6 +183,14 @@ const App: React.FC<AppProps> = observer(
       return callback()
     }
 
+    function hideSpecsListIfNecessary () {
+      if (state.screenshotting || !isSpecsListOpen) {
+        return true
+      }
+
+      return false
+    }
+
     const leftNav = state.screenshotting
       ? <span />
       : (
@@ -225,7 +233,7 @@ const App: React.FC<AppProps> = observer(
             selectedSpecs={state.spec ? [state.spec.absolute] : []}
             className={
               cs(styles.specsList, {
-                'display-none': state.screenshotting,
+                'display-none': hideSpecsListIfNecessary(),
               })
             }
             onSelectSpec={runSpec}


### PR DESCRIPTION
Fixes [CT-342](https://cypress-io.atlassian.net/browse/CT-342).

There was a regression which caused the spec list placeholder to be shown when no spec was selected. This PR fixes that.

Before:
![Screen Shot 2021-03-10 at 2 16 56 PM](https://user-images.githubusercontent.com/2801156/110684548-46136900-81ab-11eb-844f-24eebc95b680.png)

After: 
![Screen Shot 2021-03-10 at 2 21 31 PM](https://user-images.githubusercontent.com/2801156/110685097-eb2e4180-81ab-11eb-88ba-7ba89e438e6a.png)


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
