### PR TITLE
ci: run vite tests in ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1054,6 +1054,15 @@ jobs:
       - run:
           name: Run tests
           command: yarn workspace @cypress/webpack-dev-server test
+  npm-vite-dev-server:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - check-conditional-ci
+      - run:
+          name: Run tests
+          command: yarn workspace @cypress/vite-dev-server test
 
   npm-webpack-batteries-included-preprocessor:
     <<: *defaults
@@ -1743,6 +1752,9 @@ linux-workflow: &linux-workflow
           - build
 
     - npm-webpack-dev-server:
+        requires:
+          - build
+    - npm-vite-dev-server:
         requires:
           - build
     - npm-webpack-preprocessor:


### PR DESCRIPTION
In order to deliver vite-dev-server on master we have to test it beforehand.

This adds the tests to the ci