### PR TITLE
fix: verify relative path for no specs message

### DIFF
--- a/packages/reporter/cypress/integration/spec_title_spec.ts
+++ b/packages/reporter/cypress/integration/spec_title_spec.ts
@@ -24,7 +24,7 @@ describe('spec title', () => {
     start({
       relative: '__all',
       name: '',
-      absolute: '',
+      absolute: '__all',
     })
 
     cy.get('.runnable-header').should('have.text', 'All Specs')
@@ -38,7 +38,7 @@ describe('spec title', () => {
     start({
       relative: '__all',
       name: '',
-      absolute: '',
+      absolute: '__all',
       specFilter: 'cof',
     })
 

--- a/packages/reporter/src/runnables/runnables.tsx
+++ b/packages/reporter/src/runnables/runnables.tsx
@@ -34,13 +34,15 @@ const RunnablesEmptyState = ({ spec, eventManager = events }: RunnablesEmptyStat
     eventManager.emit('studio:init:suite', 'r1')
   }
 
+  const isAllSpecs = spec.absolute === '__all' || spec.relative === '__all'
+
   return (
     <div className='no-tests'>
       <h2>
         <i className='fas fa-exclamation-triangle' /> No tests found.
       </h2>
       <p>Cypress could not detect tests in this file.</p>
-      { spec.absolute !== '__all' && (
+      { !isAllSpecs && (
         <>
           <FileOpener fileDetails={{
             column: 0,


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes GROW-189

Not sure if this would have made any difference in production, but checking the `relative` url in addition to the `absolute` path fixes the way that the zero state displays for some tests. I've also modified those tests here to more reflect what the actual situation would be like. These changes should also fix some [Percy snapshots](https://percy.io/cypress-io/cypress/builds/9260916/changed/524233424) that worked fine but didn't show the ui that we really wanted.
