### PR TITLE
fix: Response.headers type.

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -5418,7 +5418,7 @@ declare namespace Cypress {
     allRequestResponses: any[]
     body: any
     duration: number
-    headers: { [key: string]: string }
+    headers: { [key: string]: string | string[] }
     isOkStatusCode: boolean
     redirects?: string[]
     redirectedToUrl?: string

--- a/cli/types/tests/kitchen-sink.ts
+++ b/cli/types/tests/kitchen-sink.ts
@@ -87,7 +87,8 @@ cy.request({
 }).then((resp) => {
   resp // $ExpectType Response
   resp.redirectedToUrl // $ExpectType string | undefined
-  resp.redirects // $ExpectTyep string[] | undefined
+  resp.redirects // $ExpectType string[] | undefined
+  resp.headers // $ExpectType { [key: string]: string | string[]; }
 })
 
 // specify query parameters


### PR DESCRIPTION
- Closes #14842

### User facing changelog

`set-cookie` can be `string[]`. So, the `headers` type has been changed.

### Additional details
- Why was this change necessary? => Cypress type doesn't reflect the real code.
- What is affected by this change? => N/A
- Any implementation details to explain? => N/A

### How has the user experience changed?

N/A

### PR Tasks

- [x] Have tests been added/updated?
