### PR TITLE
fix: default aut scale to 1

### DIFF
--- a/packages/runner-ct/src/lib/state.ts
+++ b/packages/runner-ct/src/lib/state.ts
@@ -175,6 +175,8 @@ export default class State {
         autAreaHeight / this.viewportHeight,
       )
     }
+
+    return 1
   }
 
   @computed get _containerWidth () {


### PR DESCRIPTION
Fix scaling.

## Before

Notice the AUT does not rescale when hiding the spec list.

https://user-images.githubusercontent.com/19196536/110751677-eba00880-828f-11eb-97c1-6385a25f426b.mov

## After

https://user-images.githubusercontent.com/19196536/110751738-ff4b6f00-828f-11eb-9b26-e585d0ece10b.mov

