### PR TITLE
fix: Fix actionability when element has scroll-behavior: smooth

### DIFF
--- a/packages/driver/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/click_spec.js
@@ -1607,6 +1607,24 @@ describe('src/cy/commands/actions/click', () => {
           expect(args[2]).to.eq(animationDistanceThreshold)
         })
       })
+
+      describe('scroll-behavior', () => {
+        afterEach(() => {
+          cy.get('html').invoke('css', 'scrollBehavior', 'inherit')
+        })
+
+        // https://github.com/cypress-io/cypress/issues/3200
+        it('can scroll to and click elements in html with scroll-behavior: smooth', () => {
+          cy.get('html').invoke('css', 'scrollBehavior', 'smooth')
+          cy.get('#table tr:first').click()
+        })
+
+        // https://github.com/cypress-io/cypress/issues/3200
+        it('can scroll to and click elements in ancestor element with scroll-behavior: smooth', () => {
+          cy.get('#dom').invoke('css', 'scrollBehavior', 'smooth')
+          cy.get('#table tr:first').click()
+        })
+      })
     })
 
     describe('assertion verification', () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #3200

### User facing changelog

- Interacting with an element that requires scrolling within an element with `scroll-behavior: smooth` no longer fails Cypress's actionability check

### Additional details

The solution involves setting all `scroll-behavior` to `inherit` before scrolling and then resetting it after scrolling by injecting a style tag and then removing it.

### How has the user experience changed?

Commands that require actionability (e.g. click) no longer fail to find the element when it's within another element with `scroll-behavior: smooth`.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
