### PR TITLE
fix(ci): check for yarn before running type and build scripts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -353,11 +353,11 @@ commands:
       - run:
           name: Types check 🧩 (maybe)
           working_directory: /tmp/<<parameters.repo>>
-          command: npm run types --if-present
+          command: [[ -f yarn.lock ]] && yarn types || npm run types --if-present
       - run:
           name: Build 🏗 (maybe)
           working_directory: /tmp/<<parameters.repo>>
-          command: npm run build --if-present
+          command: [[ -f yarn.lock ]] && yarn build || npm run build --if-present
       - run:
           working_directory: /tmp/<<parameters.repo>>
           command: <<parameters.server-start-command>>

--- a/circle.yml
+++ b/circle.yml
@@ -353,11 +353,13 @@ commands:
       - run:
           name: Types check 🧩 (maybe)
           working_directory: /tmp/<<parameters.repo>>
-          command: [[ -f yarn.lock ]] && yarn types || npm run types --if-present
+          command: |
+            [[ -f yarn.lock ]] && yarn types || npm run types --if-present
       - run:
           name: Build 🏗 (maybe)
           working_directory: /tmp/<<parameters.repo>>
-          command: [[ -f yarn.lock ]] && yarn build || npm run build --if-present
+          command: |
+            [[ -f yarn.lock ]] && yarn build || npm run build --if-present
       - run:
           working_directory: /tmp/<<parameters.repo>>
           command: <<parameters.server-start-command>>


### PR DESCRIPTION
Fix for type checking against RWA: https://app.circleci.com/pipelines/github/cypress-io/cypress/17922/workflows/a7c4b548-5b3c-423e-944c-1711c970e4b8/jobs/648157/parallel-runs/0/steps/0-111