### PR TITLE
fix: cy command call inside should() doesn't create an infinite loop

### DIFF
--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -234,6 +234,14 @@ describe('src/cy/commands/assertions', () => {
         })
       })
 
+      // https://github.com/cypress-io/cypress/issues/14656
+      it('does not get into an infinite loop', () => {
+        cy.wrap('bar')
+        .should(() => {
+          cy.wrap('foo')
+        })
+      })
+
       context('remote jQuery instances', () => {
         beforeEach(function () {
           this.remoteWindow = cy.state('window')

--- a/packages/driver/src/cy/commands/navigation.js
+++ b/packages/driver/src/cy/commands/navigation.js
@@ -351,6 +351,10 @@ module.exports = (Commands, Cypress, cy, state, config) => {
   reset()
 
   Cypress.on('test:before:run:async', () => {
+    // Initialize a lock record object for cy.should command.
+    // Check the detail in the comment in cy/commands/asserting.js.
+    state('shouldLock', {})
+
     // reset any state on the backend
     // TODO: this is a bug in e2e it needs to be returned
     return Cypress.backend('reset:server:state')


### PR DESCRIPTION
- Closes #14656

Coming soon...

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
