### PR TITLE
fix: enable contextIsolation by default in Electron

### DIFF
--- a/packages/server/lib/gui/windows.ts
+++ b/packages/server/lib/gui/windows.ts
@@ -135,8 +135,6 @@ export function defaults (options = {}) {
       partition: null,
       webSecurity: true,
       nodeIntegration: false,
-      // TODO: enable contextIsolation for Cypress browser (default in Electron 12)
-      contextIsolation: false,
       backgroundThrottling: false,
     },
   })

--- a/packages/server/lib/ipc/ipc.js
+++ b/packages/server/lib/ipc/ipc.js
@@ -1,5 +1,9 @@
-let ipc = require('electron').ipcRenderer
+const {
+  contextBridge,
+  ipcRenderer,
+} = require('electron')
 
-process.once('loaded', function () {
-  global.ipc = ipc
+contextBridge.exposeInMainWorld('ipc', {
+  on: (...args) => ipcRenderer.on(...args),
+  send: (...args) => ipcRenderer.send(...args),
 })


### PR DESCRIPTION
- Closes <!-- issue number here. e.g. "Closes #1234" -->

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

### Additional details

- This became the default with Electron 12, we should follow the defaults as closely as possible.
- Users can override using `before:browser:launch` API
- internal change: contextBridge.exposeInMainWorld must now be used to expose preload APIs, but this only affects the `ipc` object used by `desktop-gui`, so it should not affect users: https://www.electronjs.org/docs/tutorial/context-isolation

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [na] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
