### PR TITLE
fix: Revert cypress.json changes

### DIFF
--- a/cli/schema/cypress.schema.json
+++ b/cli/schema/cypress.schema.json
@@ -1,294 +1,281 @@
 {
   "title": "JSON schema for the https://cypress.io Test Runner's configuration file. Details at https://on.cypress.io/configuration",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "definitions": {
-    "cypressConfig": {
+  "type": "object",
+  "properties": {
+    "baseUrl": {
+      "type": "string",
+      "description": "Url used as prefix for cy.visit() or cy.request() command’s url. Example http://localhost:3030 or https://test.my-domain.com"
+    },
+    "env": {
       "type": "object",
-      "properties": {
-        "baseUrl": {
-          "type": "string",
-          "description": "Url used as prefix for cy.visit() or cy.request() command’s url. Example http://localhost:3030 or https://test.my-domain.com"
-        },
-        "env": {
-          "type": "object",
-          "description": "Any values to be set as environment variables. See https://on.cypress.io/environment-variables",
-          "body": {}
-        },
-        "ignoreTestFiles": {
-          "type": [
-            "string",
-            "array"
-          ],
-          "items": {
-            "type": "string"
-          },
-          "description": "A String or Array of glob patterns used to ignore test files that would otherwise be shown in your list of tests. Cypress uses minimatch with the options: {dot: true, matchBase: true}. We suggest using http://globtester.com to test what files would match."
-        },
-        "numTestsKeptInMemory": {
-          "type": "number",
-          "default": 50,
-          "description": "The number of tests for which snapshots and command data are kept in memory. Reduce this number if you are experiencing high memory consumption in your browser during a test run."
-        },
-        "port": {
-          "type": "number",
-          "default": null,
-          "description": "Port used to host Cypress. Normally this is a randomly generated port"
-        },
-        "reporter": {
-          "type": "string",
-          "default": "spec",
-          "description": "The reporter used when running headlessly or in CI. See https://on.cypress.io/reporters"
-        },
-        "reporterOptions": {
-          "type": "object",
-          "default": null,
-          "description": "The reporter options used. Supported options depend on the reporter. See https://on.cypress.io/reporters#Reporter-Options"
-        },
-        "testFiles": {
-          "type": [
-            "string",
-            "array"
-          ],
-          "default": "**/*.*",
-          "description": "A String or Array of string glob patterns of the test files to load. See https://on.cypress.io/configuration#Global"
-        },
-        "watchForFileChanges": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether Cypress will watch and restart tests on test file changes"
-        },
-        "defaultCommandTimeout": {
-          "type": "number",
-          "default": 4000,
-          "description": "Time, in milliseconds, to wait until most DOM based commands are considered timed out"
-        },
-        "execTimeout": {
-          "type": "number",
-          "default": 60000,
-          "description": "Time, in milliseconds, to wait for a system command to finish executing during a cy.exec() command"
-        },
-        "taskTimeout": {
-          "type": "number",
-          "default": 60000,
-          "description": "Time, in milliseconds, to wait for a task to finish executing during a cy.task() command"
-        },
-        "pageLoadTimeout": {
-          "type": "number",
-          "default": 60000,
-          "description": "Time, in milliseconds, to wait for page transition events or cy.visit(), cy.go(), cy.reload() commands to fire their page load events. Network requests are limited by the underlying operating system, and may still time out if this value is increased."
-        },
-        "requestTimeout": {
-          "type": "number",
-          "default": 5000,
-          "description": "Time, in milliseconds, to wait for an XHR request to go out in a cy.wait() command"
-        },
-        "responseTimeout": {
-          "type": "number",
-          "default": 30000,
-          "description": "Time, in milliseconds, to wait until a response in a cy.request(), cy.wait(), cy.fixture(), cy.getCookie(), cy.getCookies(), cy.setCookie(), cy.clearCookie(), cy.clearCookies(), and cy.screenshot() commands"
-        },
-        "fileServerFolder": {
-          "type": "string",
-          "default": "root project folder",
-          "description": "Path to folder where application files will attempt to be served from"
-        },
-        "fixturesFolder": {
-          "type": [
-            "string",
-            "boolean"
-          ],
-          "default": "cypress/fixtures",
-          "description": "Path to folder containing fixture files (Pass false to disable)"
-        },
-        "integrationFolder": {
-          "type": "string",
-          "default": "cypress/integration",
-          "description": "Path to folder containing integration test files"
-        },
-        "downloadsFolder": {
-          "type": "string",
-          "default": "cypress/downloads",
-          "description": "Path to folder where files downloaded during a test are saved"
-        },
-        "experimentalComponentTesting": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enabled experimental component testing, see https://github.com/cypress-io/cypress/issues/5922"
-        },
-        "componentFolder": {
-          "type": [
-            "string",
-            "boolean"
-          ],
-          "default": false,
-          "description": "Path to folder containing component test files (Pass false to disable)"
-        },
-        "pluginsFile": {
-          "type": [
-            "string",
-            "boolean"
-          ],
-          "default": "cypress/plugins/index.js",
-          "description": "Path to plugins file. (Pass false to disable)"
-        },
-        "screenshotOnRunFailure": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether Cypress will take a screenshot when a test fails during cypress run"
-        },
-        "screenshotsFolder": {
-          "type": "string",
-          "default": "cypress/screenshots",
-          "description": "Path to folder where screenshots will be saved from cy.screenshot() command or after a test fails during cypress run"
-        },
-        "supportFile": {
-          "type": [
-            "string",
-            "boolean"
-          ],
-          "default": "cypress/support/index.js",
-          "description": "Path to file to load before test files load. This file is compiled and bundled. (Pass false to disable)"
-        },
-        "videosFolder": {
-          "type": "string",
-          "default": "cypress/videos",
-          "description": "Path to folder where videos will be saved during cypress run"
-        },
-        "trashAssetsBeforeRuns": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether Cypress will trash assets within the screenshotsFolder and videosFolder before tests run with cypress run"
-        },
-        "videoCompression": {
-          "type": [
-            "number",
-            "boolean"
-          ],
-          "default": 32,
-          "description": "The quality setting for the video compression, in Constant Rate Factor (CRF). The value can be false to disable compression or a value between 0 and 51, where a lower value results in better quality (at the expense of a higher file size)."
-        },
-        "video": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether Cypress will capture a video of the tests run with cypress run"
-        },
-        "videoUploadOnPasses": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether Cypress will process, compress, and upload videos to the Dashboard even when all tests in a spec file are passing. This only applies when recording your runs to the Dashboard. Turn this off if you’d like to only upload the spec file’s video when there are failing tests."
-        },
-        "chromeWebSecurity": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether Chrome Web Security for same-origin policy and insecure mixed content is enabled. Read more about this at https://on.cypress.io/web-security"
-        },
-        "userAgent": {
-          "type": "string",
-          "default": null,
-          "description": "Enables you to override the default user agent the browser sends in all request headers. User agent values are typically used by servers to help identify the operating system, browser, and browser version. See User-Agent MDN Documentation for example user agent values here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent"
-        },
-        "blockHosts": {
-          "type": [
-            "string",
-            "array"
-          ],
-          "items": {
-            "type": "string"
-          },
-          "default": null,
-          "description": "A String or Array of hosts that you wish to block traffic for. Please read the notes for examples on using this https://on.cypress.io/configuration#blockHosts"
-        },
-        "modifyObstructiveCode": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether Cypress will search for and replace obstructive JS code found in .js or .html files that prevent Cypress from working. Please read the notes for more information on this setting. https://on.cypress.io/configuration#modifyObstructiveCode"
-        },
-        "viewportHeight": {
-          "type": "number",
-          "default": 660,
-          "description": "Default height in pixels for the application under tests’ viewport (Override with cy.viewport() command)"
-        },
-        "viewportWidth": {
-          "type": "number",
-          "default": 1000,
-          "description": "Default width in pixels for the application under tests’ viewport. (Override with cy.viewport() command)"
-        },
-        "animationDistanceThreshold": {
-          "type": "number",
-          "default": 5,
-          "description": "The distance in pixels an element must exceed over time to be considered animating"
-        },
-        "waitForAnimations": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether to wait for elements to finish animating before executing commands"
-        },
-        "scrollBehavior": {
-          "enum": [
-            false,
-            "center",
-            "top",
-            "bottom",
-            "nearest"
-          ],
-          "default": "top",
-          "description": "Viewport position to which an element should be scrolled prior to action commands. Setting `false` disables scrolling."
-        },
-        "projectId": {
-          "type": "string",
-          "default": null,
-          "description": "A 6 character string use to identify this project in the Cypress Dashboard. See https://on.cypress.io/dashboard-service#Identification"
-        },
-        "nodeVersion": {
-          "enum": [
-            "system",
-            "bundled"
-          ],
-          "default": "bundled",
-          "description": "If set to 'system', Cypress will try to find a Node.js executable on your path to use when executing your plugins. Otherwise, Cypress will use the Node version bundled with Cypress."
-        },
-        "experimentalSourceRewriting": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm."
-        },
-        "experimentalFetchPolyfill": {
-          "type": "boolean",
-          "default": false,
-          "description": "Polyfills `window.fetch` to enable Network spying and stubbing"
-        },
-        "experimentalStudio": {
-          "type": "boolean",
-          "default": false,
-          "description": "Generate and save commands directly to your test suite by interacting with your app as an end user would."
-        },
-        "retries": {
-          "type": [
-            "object",
-            "number",
-            "null"
-          ],
-          "default": {
-            "runMode": 0,
-            "openMode": 0
-          },
-          "description": "The number of times to retry a failing. Can be configured to apply only in runMode or openMode"
-        },
-        "includeShadowDom": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enables including elements within the shadow DOM when using querying commands (e.g. cy.get(), cy.find()). Can be set globally in cypress.json, per-suite or per-test in the test configuration object, or programmatically with Cypress.config()"
-        },
-        "component": {
-          "description": "Any component runner specific overrides",
-          "$ref": "#/definitions/cypressConfig"
-        },
-        "e2e": {
-          "description": "Any e2e runner specific overrides",
-          "$ref": "#/definitions/cypressConfig"
-        }
-      }
+      "description": "Any values to be set as environment variables. See https://on.cypress.io/environment-variables",
+      "body": {}
+    },
+    "ignoreTestFiles": {
+      "type": [
+        "string",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      },
+      "description": "A String or Array of glob patterns used to ignore test files that would otherwise be shown in your list of tests. Cypress uses minimatch with the options: {dot: true, matchBase: true}. We suggest using http://globtester.com to test what files would match."
+    },
+    "numTestsKeptInMemory": {
+      "type": "number",
+      "default": 50,
+      "description": "The number of tests for which snapshots and command data are kept in memory. Reduce this number if you are experiencing high memory consumption in your browser during a test run."
+    },
+    "port": {
+      "type": "number",
+      "default": null,
+      "description": "Port used to host Cypress. Normally this is a randomly generated port"
+    },
+    "reporter": {
+      "type": "string",
+      "default": "spec",
+      "description": "The reporter used when running headlessly or in CI. See https://on.cypress.io/reporters"
+    },
+    "reporterOptions": {
+      "type": "object",
+      "default": null,
+      "description": "The reporter options used. Supported options depend on the reporter. See https://on.cypress.io/reporters#Reporter-Options"
+    },
+    "testFiles": {
+      "type": [
+        "string",
+        "array"
+      ],
+      "default": "**/*.*",
+      "description": "A String or Array of string glob patterns of the test files to load. See https://on.cypress.io/configuration#Global"
+    },
+    "watchForFileChanges": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether Cypress will watch and restart tests on test file changes"
+    },
+    "defaultCommandTimeout": {
+      "type": "number",
+      "default": 4000,
+      "description": "Time, in milliseconds, to wait until most DOM based commands are considered timed out"
+    },
+    "execTimeout": {
+      "type": "number",
+      "default": 60000,
+      "description": "Time, in milliseconds, to wait for a system command to finish executing during a cy.exec() command"
+    },
+    "taskTimeout": {
+      "type": "number",
+      "default": 60000,
+      "description": "Time, in milliseconds, to wait for a task to finish executing during a cy.task() command"
+    },
+    "pageLoadTimeout": {
+      "type": "number",
+      "default": 60000,
+      "description": "Time, in milliseconds, to wait for page transition events or cy.visit(), cy.go(), cy.reload() commands to fire their page load events. Network requests are limited by the underlying operating system, and may still time out if this value is increased."
+    },
+    "requestTimeout": {
+      "type": "number",
+      "default": 5000,
+      "description": "Time, in milliseconds, to wait for an XHR request to go out in a cy.wait() command"
+    },
+    "responseTimeout": {
+      "type": "number",
+      "default": 30000,
+      "description": "Time, in milliseconds, to wait until a response in a cy.request(), cy.wait(), cy.fixture(), cy.getCookie(), cy.getCookies(), cy.setCookie(), cy.clearCookie(), cy.clearCookies(), and cy.screenshot() commands"
+    },
+    "fileServerFolder": {
+      "type": "string",
+      "default": "root project folder",
+      "description": "Path to folder where application files will attempt to be served from"
+    },
+    "fixturesFolder": {
+      "type": [
+        "string",
+        "boolean"
+      ],
+      "default": "cypress/fixtures",
+      "description": "Path to folder containing fixture files (Pass false to disable)"
+    },
+    "integrationFolder": {
+      "type": "string",
+      "default": "cypress/integration",
+      "description": "Path to folder containing integration test files"
+    },
+    "downloadsFolder": {
+      "type": "string",
+      "default": "cypress/downloads",
+      "description": "Path to folder where files downloaded during a test are saved"
+    },
+    "experimentalComponentTesting": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enabled experimental component testing, see https://github.com/cypress-io/cypress/issues/5922"
+    },
+    "componentFolder": {
+      "type": [
+        "string",
+        "boolean"
+      ],
+      "default": false,
+      "description": "Path to folder containing component test files (Pass false to disable)"
+    },
+    "pluginsFile": {
+      "type": [
+        "string",
+        "boolean"
+      ],
+      "default": "cypress/plugins/index.js",
+      "description": "Path to plugins file. (Pass false to disable)"
+    },
+    "screenshotOnRunFailure": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether Cypress will take a screenshot when a test fails during cypress run"
+    },
+    "screenshotsFolder": {
+      "type": "string",
+      "default": "cypress/screenshots",
+      "description": "Path to folder where screenshots will be saved from cy.screenshot() command or after a test fails during cypress run"
+    },
+    "supportFile": {
+      "type": [
+        "string",
+        "boolean"
+      ],
+      "default": "cypress/support/index.js",
+      "description": "Path to file to load before test files load. This file is compiled and bundled. (Pass false to disable)"
+    },
+    "videosFolder": {
+      "type": "string",
+      "default": "cypress/videos",
+      "description": "Path to folder where videos will be saved during cypress run"
+    },
+    "trashAssetsBeforeRuns": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether Cypress will trash assets within the screenshotsFolder and videosFolder before tests run with cypress run"
+    },
+    "videoCompression": {
+      "type": [
+        "number",
+        "boolean"
+      ],
+      "default": 32,
+      "description": "The quality setting for the video compression, in Constant Rate Factor (CRF). The value can be false to disable compression or a value between 0 and 51, where a lower value results in better quality (at the expense of a higher file size)."
+    },
+    "video": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether Cypress will capture a video of the tests run with cypress run"
+    },
+    "videoUploadOnPasses": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether Cypress will process, compress, and upload videos to the Dashboard even when all tests in a spec file are passing. This only applies when recording your runs to the Dashboard. Turn this off if you’d like to only upload the spec file’s video when there are failing tests."
+    },
+    "chromeWebSecurity": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether Chrome Web Security for same-origin policy and insecure mixed content is enabled. Read more about this at https://on.cypress.io/web-security"
+    },
+    "userAgent": {
+      "type": "string",
+      "default": null,
+      "description": "Enables you to override the default user agent the browser sends in all request headers. User agent values are typically used by servers to help identify the operating system, browser, and browser version. See User-Agent MDN Documentation for example user agent values here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent"
+    },
+    "blockHosts": {
+      "type": [
+        "string",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      },
+      "default": null,
+      "description": "A String or Array of hosts that you wish to block traffic for. Please read the notes for examples on using this https://on.cypress.io/configuration#blockHosts"
+    },
+    "modifyObstructiveCode": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether Cypress will search for and replace obstructive JS code found in .js or .html files that prevent Cypress from working. Please read the notes for more information on this setting. https://on.cypress.io/configuration#modifyObstructiveCode"
+    },
+    "viewportHeight": {
+      "type": "number",
+      "default": 660,
+      "description": "Default height in pixels for the application under tests’ viewport (Override with cy.viewport() command)"
+    },
+    "viewportWidth": {
+      "type": "number",
+      "default": 1000,
+      "description": "Default width in pixels for the application under tests’ viewport. (Override with cy.viewport() command)"
+    },
+    "animationDistanceThreshold": {
+      "type": "number",
+      "default": 5,
+      "description": "The distance in pixels an element must exceed over time to be considered animating"
+    },
+    "waitForAnimations": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to wait for elements to finish animating before executing commands"
+    },
+    "scrollBehavior": {
+      "enum": [
+        false,
+        "center",
+        "top",
+        "bottom",
+        "nearest"
+      ],
+      "default": "top",
+      "description": "Viewport position to which an element should be scrolled prior to action commands. Setting `false` disables scrolling."
+    },
+    "projectId": {
+      "type": "string",
+      "default": null,
+      "description": "A 6 character string use to identify this project in the Cypress Dashboard. See https://on.cypress.io/dashboard-service#Identification"
+    },
+    "nodeVersion": {
+      "enum": [
+        "system",
+        "bundled"
+      ],
+      "default": "bundled",
+      "description": "If set to 'system', Cypress will try to find a Node.js executable on your path to use when executing your plugins. Otherwise, Cypress will use the Node version bundled with Cypress."
+    },
+    "experimentalSourceRewriting": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm."
+    },
+    "experimentalFetchPolyfill": {
+      "type": "boolean",
+      "default": false,
+      "description": "Polyfills `window.fetch` to enable Network spying and stubbing"
+    },
+    "experimentalStudio": {
+      "type": "boolean",
+      "default": false,
+      "description": "Generate and save commands directly to your test suite by interacting with your app as an end user would."
+    },
+    "retries": {
+      "type": [
+        "object",
+        "number",
+        "null"
+      ],
+      "default": {
+        "runMode": 0,
+        "openMode": 0
+      },
+      "description": "The number of times to retry a failing. Can be configured to apply only in runMode or openMode"
+    },
+    "includeShadowDom": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enables including elements within the shadow DOM when using querying commands (e.g. cy.get(), cy.find()). Can be set globally in cypress.json, per-suite or per-test in the test configuration object, or programmatically with Cypress.config()"
     }
-  },
-  "$ref": "#/definitions/cypressConfig"
+  }
 }

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -8,7 +8,7 @@ declare namespace Cypress {
   type RequestBody = string | object
   type ViewportOrientation = 'portrait' | 'landscape'
   type PrevSubject = 'optional' | 'element' | 'document' | 'window'
-  type PluginConfig = (on: PluginEvents, config: PluginConfigOptions, mode: 'e2e' | 'component') => void | ConfigOptions | Promise<ConfigOptions>
+  type PluginConfig = (on: PluginEvents, config: PluginConfigOptions) => void | ConfigOptions | Promise<ConfigOptions>
 
   interface CommandOptions {
     prevSubject: boolean | PrevSubject | PrevSubject[]

--- a/npm/react/cypress/plugins/index.js
+++ b/npm/react/cypress/plugins/index.js
@@ -60,11 +60,7 @@ const webpackConfig = {
 /**
  * @type Cypress.PluginConfig
  */
-module.exports = (on, config, mode) => {
-  if (mode !== 'component') {
-    throw Error('This is an component project. mode should be `component`.')
-  }
-
+module.exports = (on, config) => {
   on('dev-server:start', (options) => {
     return startDevServer({ options, webpackConfig, disableLazyCompilation: false })
   })

--- a/npm/vue/cypress/plugins/index.js
+++ b/npm/vue/cypress/plugins/index.js
@@ -5,11 +5,7 @@ const webpackConfig = require('../../webpack.config')
 /**
  * @type Cypress.PluginConfig
  */
-module.exports = (on, config, mode) => {
-  if (mode !== 'component') {
-    throw Error('This is a component testing project. mode should be `component`.')
-  }
-
+module.exports = (on, config) => {
   require('@cypress/code-coverage/task')(on, config)
   on('dev-server:start', (options) => startDevServer({ options, webpackConfig }))
 

--- a/packages/server-ct/src/project-ct.ts
+++ b/packages/server-ct/src/project-ct.ts
@@ -47,7 +47,7 @@ export class ProjectCt extends ProjectBase<ServerCt> {
     this.server.socket.changeToUrl(targetUrl)
   }
 
-  open (options: Record<string, unknown>) {
+  open (options) {
     this._server = new ServerCt()
 
     return super.open(options, {
@@ -85,7 +85,6 @@ export class ProjectCt extends ProjectBase<ServerCt> {
     return plugins.init(allowedCfg, {
       projectRoot: this.projectRoot,
       configFile: settings.pathToConfigFile(this.projectRoot, options),
-      mode: options.mode,
     })
     .then((modifiedCfg) => {
       debug('plugin config yielded: %o', modifiedCfg)

--- a/packages/server/lib/config.js
+++ b/packages/server/lib/config.js
@@ -209,8 +209,8 @@ module.exports = {
       return this.set({
         projectName: this.getNameFromRoot(projectRoot),
         projectRoot,
-        config: settings,
-        envFile,
+        config: _.cloneDeep(settings),
+        envFile: _.cloneDeep(envFile),
         options,
       })
     })

--- a/packages/server/lib/open_project.js
+++ b/packages/server/lib/open_project.js
@@ -328,7 +328,7 @@ const moduleFactory = () => {
       debug('opening project %s', path)
       debug('and options %o', options)
 
-      return openProject.open({ ...options, mode: args.testingType })
+      return openProject.open(options)
       .return(this)
     },
   }

--- a/packages/server/lib/plugins/child/run_plugins.js
+++ b/packages/server/lib/plugins/child/run_plugins.js
@@ -37,13 +37,7 @@ const getDefaultPreprocessor = function (config) {
 
 let plugins
 
-/**
- * @param {EventEmitter} ipc
- * @param {object} config
- * @param {string} pluginsFile
- * @param {'component' | 'e2e'} string
- */
-const load = (ipc, config, pluginsFile, mode) => {
+const load = (ipc, config, pluginsFile) => {
   debug('run plugins function')
 
   let eventIdCount = 0
@@ -93,7 +87,7 @@ const load = (ipc, config, pluginsFile, mode) => {
   .try(() => {
     debug('run plugins function')
 
-    return plugins(register, config, mode)
+    return plugins(register, config)
   })
   .tap(() => {
     if (!registeredEventsByName['file:preprocessor']) {
@@ -198,10 +192,10 @@ const runPlugins = (ipc, pluginsFile, projectRoot) => {
     return
   }
 
-  ipc.on('load', (config, mode) => {
+  ipc.on('load', (config) => {
     debug('plugins load file "%s"', pluginsFile)
     debug('passing config %o', config)
-    load(ipc, config, pluginsFile, mode)
+    load(ipc, config, pluginsFile)
   })
 
   ipc.on('execute', (event, ids, args) => {

--- a/packages/server/lib/plugins/index.js
+++ b/packages/server/lib/plugins/index.js
@@ -113,7 +113,7 @@ const init = (config, options) => {
       version: pkg.version,
     })
 
-    ipc.send('load', config, options.mode)
+    ipc.send('load', config)
 
     ipc.on('loaded', (newCfg, registrations) => {
       _.omit(config, 'projectRoot', 'configFile')

--- a/packages/server/lib/project-e2e.ts
+++ b/packages/server/lib/project-e2e.ts
@@ -14,7 +14,7 @@ export class ProjectE2E extends ProjectBase<ServerE2E> {
     return 'e2e'
   }
 
-  open (options: Record<string, unknown>) {
+  open (options) {
     this._server = new ServerE2E()
 
     return super.open(options, {
@@ -59,7 +59,6 @@ export class ProjectE2E extends ProjectBase<ServerE2E> {
     return plugins.init(cfg, {
       projectRoot: this.projectRoot,
       configFile: settings.pathToConfigFile(this.projectRoot, options),
-      mode: options.mode,
       onError (err) {
         debug('got plugins error', err.stack)
 

--- a/packages/server/lib/util/settings.js
+++ b/packages/server/lib/util/settings.js
@@ -93,10 +93,6 @@ module.exports = {
     }, _.cloneDeep(obj))
   },
 
-  isComponentTesting (options = {}) {
-    return options.experimentalComponentTesting || options.componentTesting || options.testingType === 'component'
-  },
-
   configFile (options = {}) {
     return options.configFile === false ? false : (options.configFile || 'cypress.json')
   },
@@ -155,16 +151,6 @@ module.exports = {
     .catch({ code: 'ENOENT' }, () => {
       return this._write(file, {})
     }).then((json = {}) => {
-      if (this.isComponentTesting(options) && 'component' in json) {
-        json = { ...json, ...json.component }
-        delete json.component
-      }
-
-      if (!this.isComponentTesting(options) && 'e2e' in json) {
-        json = { ...json, ...json.e2e }
-        delete json.e2e
-      }
-
       const changed = this._applyRewriteRules(json)
 
       // if our object is unchanged

--- a/packages/server/lib/util/settings.js
+++ b/packages/server/lib/util/settings.js
@@ -140,14 +140,7 @@ module.exports = {
 
     const file = this.pathToConfigFile(projectRoot, options)
 
-    const requireAsync = (file) => {
-      return Promise.try(() => require(file))
-    }
-
-    return requireAsync(file)
-    .catch({ code: 'MODULE_NOT_FOUND' }, () => {
-      return this._write(file, {})
-    })
+    return fs.readJsonAsync(file)
     .catch({ code: 'ENOENT' }, () => {
       return this._write(file, {})
     }).then((json = {}) => {

--- a/packages/server/test/e2e/6_visit_spec.js
+++ b/packages/server/test/e2e/6_visit_spec.js
@@ -5,7 +5,6 @@ const https = require('https')
 const useragent = require('express-useragent')
 const { allowDestroy } = require('@packages/network')
 const e2e = require('../support/helpers/e2e').default
-const { clearCypressJsonCache } = require('../specUtils')
 
 // create an HTTPS server that forces TLSv1
 const startTlsV1Server = (port) => {
@@ -117,10 +116,6 @@ foo\
 }
 
 describe('e2e visit', () => {
-  beforeEach(() => {
-    clearCypressJsonCache()
-  })
-
   context('low response timeout', () => {
     e2e.setup({
       settings: {

--- a/packages/server/test/e2e/6_web_security_spec.js
+++ b/packages/server/test/e2e/6_web_security_spec.js
@@ -1,5 +1,4 @@
 const e2e = require('../support/helpers/e2e').default
-const { clearCypressJsonCache } = require('../specUtils')
 
 const onServer = function (app) {
   app.get('/link', (req, res) => {
@@ -52,10 +51,6 @@ const onServer = function (app) {
 }
 
 describe('e2e web security', () => {
-  beforeEach(() => {
-    clearCypressJsonCache()
-  })
-
   e2e.setup({
     servers: [{
       port: 4466,

--- a/packages/server/test/e2e/7_record_spec.js
+++ b/packages/server/test/e2e/7_record_spec.js
@@ -16,9 +16,6 @@ const {
   postInstanceTestsResponse,
 } = require('../support/helpers/serverStub')
 const { expectRunsToHaveCorrectTimings } = require('../support/helpers/resultsUtils')
-const postRunResponseWithWarnings = jsonSchemas.getExample('postRunResponse')('2.2.0')
-const postRunResponse = _.assign({}, postRunResponseWithWarnings, { warnings: [] })
-const postRunInstanceResponse = jsonSchemas.getExample('postRunInstanceResponse')('2.1.0')
 
 const e2ePath = Fixtures.projectPath('e2e')
 const outputPath = path.join(e2ePath, 'output.json')
@@ -691,14 +688,13 @@ describe('e2e record', () => {
     })
 
     describe('create run 500', () => {
-      const routes = [{
-        method: 'post',
-        url: '/runs',
-        req: 'postRunRequest@2.2.0',
-        res (req, res) {
-          return res.sendStatus(500)
+      const routes = createRoutes({
+        postRun: {
+          res (req, res) {
+            return res.sendStatus(500)
+          },
         },
-      }]
+      })
 
       setupStubbedServer(routes)
 

--- a/packages/server/test/e2e/7_record_spec.js
+++ b/packages/server/test/e2e/7_record_spec.js
@@ -16,7 +16,9 @@ const {
   postInstanceTestsResponse,
 } = require('../support/helpers/serverStub')
 const { expectRunsToHaveCorrectTimings } = require('../support/helpers/resultsUtils')
-const { clearCypressJsonCache } = require('../specUtils')
+const postRunResponseWithWarnings = jsonSchemas.getExample('postRunResponse')('2.2.0')
+const postRunResponse = _.assign({}, postRunResponseWithWarnings, { warnings: [] })
+const postRunInstanceResponse = jsonSchemas.getExample('postRunInstanceResponse')('2.1.0')
 
 const e2ePath = Fixtures.projectPath('e2e')
 const outputPath = path.join(e2ePath, 'output.json')
@@ -689,17 +691,14 @@ describe('e2e record', () => {
     })
 
     describe('create run 500', () => {
-      beforeEach(() => {
-        clearCypressJsonCache()
-      })
-
-      const routes = createRoutes({
-        postRun: {
-          res (req, res) {
-            return res.sendStatus(500)
-          },
+      const routes = [{
+        method: 'post',
+        url: '/runs',
+        req: 'postRunRequest@2.2.0',
+        res (req, res) {
+          return res.sendStatus(500)
         },
-      })
+      }]
 
       setupStubbedServer(routes)
 

--- a/packages/server/test/integration/plugins_spec.js
+++ b/packages/server/test/integration/plugins_spec.js
@@ -26,7 +26,6 @@ describe('lib/plugins', () => {
 
     const options = {
       onWarning,
-      mode: 'e2e',
     }
 
     return plugins.init(projectConfig, options)

--- a/packages/server/test/specUtils.ts
+++ b/packages/server/test/specUtils.ts
@@ -46,11 +46,3 @@ export const getFs = () => {
 
   return recurse({ root: mockfs.getMockRoot() }, -1).root
 }
-
-export const clearCypressJsonCache = () => {
-  Object.keys(require.cache).forEach((key) => {
-    if (key.includes('cypress.json')) {
-      delete require.cache[key]
-    }
-  })
-}

--- a/packages/server/test/support/fixtures/projects/chrome-browser-preferences/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/chrome-browser-preferences/cypress/plugins/index.js
@@ -3,11 +3,7 @@ const { expect } = require('chai')
 const fse = require('fs-extra')
 const path = require('path')
 
-module.exports = (on, config, mode) => {
-  if (mode !== 'e2e') {
-    throw Error('This is an e2e project. mode should be `e2e`.')
-  }
-
+module.exports = (on, config) => {
   const parentPid = process.ppid
   let { PATH_TO_CHROME_PROFILE } = config.env
 

--- a/packages/server/test/support/fixtures/projects/component-tests/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/component-tests/cypress/plugins/index.js
@@ -13,11 +13,7 @@ const webpackConfig = {
 /**
  * @type Cypress.PluginConfig
  */
-module.exports = (on, config, mode) => {
-  if (mode !== 'e2e') {
-    throw Error('This is an e2e project. mode should be `e2e`.')
-  }
-
+module.exports = (on, config) => {
   require('@cypress/code-coverage/task')(on, config)
   on('dev-server:start', (options) => startDevServer({ options, webpackConfig }))
 

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/plugins/index.js
@@ -11,11 +11,7 @@ const { useFixedFirefoxResolution } = require('../../../utils')
 /**
  * @type {Cypress.PluginConfig}
  */
-module.exports = (on, config, mode) => {
-  if (mode !== 'e2e') {
-    throw Error('This is an e2e project. mode should be `e2e`.')
-  }
-
+module.exports = (on, config) => {
   let performance = {
     track: () => Promise.resolve(),
   }

--- a/packages/server/test/support/fixtures/projects/firefox-memory/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/firefox-memory/cypress/plugins/index.js
@@ -20,11 +20,7 @@ let timings = []
 let rss = []
 let intervalId
 
-module.exports = (on, config, mode) => {
-  if (mode !== 'e2e') {
-    throw Error('This is an e2e project. mode should be `e2e`.')
-  }
-
+module.exports = (on, config) => {
   on('task', {
     'console' (...args) {
       console.log(...args)

--- a/packages/server/test/support/fixtures/projects/plugin-before-browser-launch-deprecation/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/plugin-before-browser-launch-deprecation/cypress/plugins/index.js
@@ -109,11 +109,7 @@ const getHandlersByType = (type) => {
   }
 }
 
-module.exports = (on, config, mode) => {
-  if (mode !== 'e2e') {
-    throw Error('This is an e2e project. mode should be `e2e`.')
-  }
-
+module.exports = (on, config) => {
   const beforeBrowserLaunchHandler = config.env.BEFORE_BROWSER_LAUNCH_HANDLER
 
   if (!beforeBrowserLaunchHandler) {

--- a/packages/server/test/support/fixtures/projects/plugin-config-version/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/plugin-config-version/cypress/plugins/index.js
@@ -1,10 +1,6 @@
 const semver = require('semver')
 
-module.exports = (on, config, mode) => {
-  if (mode !== 'e2e') {
-    throw Error('This is an e2e project. mode should be `e2e`.')
-  }
-
+module.exports = (on, config) => {
   if (!semver.valid(config.version)) {
     throw new Error('config.version is invalid')
   }

--- a/packages/server/test/support/fixtures/projects/plugin-config/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/plugin-config/cypress/plugins/index.js
@@ -1,8 +1,4 @@
-module.exports = (on, config, mode) => {
-  if (mode !== 'e2e') {
-    throw Error('This is an e2e project. mode should be `e2e`.')
-  }
-
+module.exports = (on, config) => {
   return new Promise((resolve) => {
     setTimeout(resolve, 100)
   })

--- a/packages/server/test/support/fixtures/projects/plugin-event-deprecated/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/plugin-event-deprecated/cypress/plugins/index.js
@@ -1,8 +1,4 @@
-module.exports = (on, config, mode) => {
-  if (mode !== 'e2e') {
-    throw Error('This is an e2e project. mode should be `e2e`.')
-  }
-
+module.exports = (on, config) => {
   if (config.env.NO_MUTATE_RETURN) {
     on('before:browser:launch', (browser, options) => {
       // this will emit a warning

--- a/packages/server/test/support/fixtures/projects/read-only-project-root/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/read-only-project-root/cypress/plugins/index.js
@@ -1,11 +1,7 @@
 const fs = require('fs')
 const { expect } = require('chai')
 
-module.exports = (on, config, mode) => {
-  if (mode !== 'e2e') {
-    throw Error('This is an e2e project. mode should be `e2e`.')
-  }
-
+module.exports = (on, config) => {
   expect(process.geteuid()).to.not.eq(0)
   console.log('✅ not running as root')
 

--- a/packages/server/test/support/fixtures/projects/retries-2/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/retries-2/cypress/plugins/index.js
@@ -5,11 +5,7 @@ const { useFixedFirefoxResolution } = require('../../../utils')
 /**
  * @type {Cypress.PluginConfig}
  */
-module.exports = (on, config, mode) => {
-  if (mode !== 'e2e') {
-    throw Error('This is an e2e project. mode should be `e2e`.')
-  }
-
+module.exports = (on, config) => {
   on('before:browser:launch', (browser, options) => {
     useFixedFirefoxResolution(browser, options, config)
 

--- a/packages/server/test/unit/config_spec.js
+++ b/packages/server/test/unit/config_spec.js
@@ -56,8 +56,7 @@ describe('lib/config', () => {
 
       this.setup = (cypressJson = {}, cypressEnvJson = {}) => {
         sinon.stub(settings, 'read').withArgs(this.projectRoot).resolves(cypressJson)
-
-        return sinon.stub(settings, 'readEnv').withArgs(this.projectRoot).resolves(cypressEnvJson)
+        sinon.stub(settings, 'readEnv').withArgs(this.projectRoot).resolves(cypressEnvJson)
       }
     })
 
@@ -78,6 +77,19 @@ describe('lib/config', () => {
       return config.get(this.projectRoot)
       .then((obj) => {
         expect(obj.projectName).to.eq('project')
+      })
+    })
+
+    it('clones settings and env settings, so they are not mutated', function () {
+      const settings = { foo: 'bar' }
+      const envSettings = { baz: 'qux' }
+
+      this.setup(settings, envSettings)
+
+      return config.get(this.projectRoot)
+      .then(() => {
+        expect(settings).to.deep.equal({ foo: 'bar' })
+        expect(envSettings).to.deep.equal({ baz: 'qux' })
       })
     })
 

--- a/packages/server/test/unit/settings_spec.js
+++ b/packages/server/test/unit/settings_spec.js
@@ -3,15 +3,10 @@ require('../spec_helper')
 const path = require('path')
 const { fs } = require(`${root}lib/util/fs`)
 const settings = require(`${root}lib/util/settings`)
-const { clearCypressJsonCache } = require('../specUtils')
 
 const projectRoot = process.cwd()
 
 describe('lib/settings', () => {
-  beforeEach(function () {
-    clearCypressJsonCache()
-  })
-
   context('with no configFile option', () => {
     beforeEach(function () {
       this.setup = (obj = {}) => {

--- a/packages/server/test/unit/settings_spec.js
+++ b/packages/server/test/unit/settings_spec.js
@@ -111,42 +111,6 @@ describe('lib/settings', () => {
         })
       })
 
-      it('promises cypress.json and merges CT specific properties for via testingType: component', function () {
-        return this.setup({ a: 'b', component: { a: 'c' } })
-        .then(() => {
-          return settings.read(projectRoot, { testingType: 'component' })
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ a: 'c' })
-        })
-      })
-
-      it('promises cypress.json and merges CT specific properties for via componentTesting: true', function () {
-        return this.setup({ a: 'b', component: { a: 'c' } })
-        .then(() => {
-          return settings.read(projectRoot, { componentTesting: true })
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ a: 'c' })
-        })
-      })
-
-      it('promises cypress.json and merges CT specific properties for via experimentalComponentTesting: true', function () {
-        return this.setup({ a: 'b', component: { a: 'c' } })
-        .then(() => {
-          return settings.read(projectRoot, { experimentalComponentTesting: true })
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ a: 'c' })
-        })
-      })
-
-      it('promises cypress.json and merges e2e specific properties', function () {
-        return this.setup({ a: 'b', e2e: { a: 'c' } })
-        .then(() => {
-          return settings.read(projectRoot)
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ a: 'c' })
-        })
-      })
-
       it('renames commandTimeout -> defaultCommandTimeout', function () {
         return this.setup({ commandTimeout: 30000, foo: 'bar' })
         .then(() => {


### PR DESCRIPTION
- Closes #15497

### User facing changelog

- Cypress no longer write extra config values to `cypress.json` when adding the project ID

### Additional details

This was caused by a combination of using `require` to obtain the contents of `cypress.json` and mutating the config object itself. Since node caches required modules, it mutated the in-memory cache of the `cypress.json`, so subsequent 'reads' had the mutated content with extra values, which then got written back to the file when writing the project ID.

This reverts PRs #15444 and #15263.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
