### PR TITLE
chore: do not run Kitchensink on AppVeyor after building the binary

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -95,10 +95,5 @@ test_script:
 
   - node ./scripts/win-appveyor-build.js
 
-  - echo *** Kitchensink tests run on Chrome browser ***
-  - npm run dev -- --run-project %CD%/packages/example --browser chrome
-  - echo *** Kitchensink tests run on Edge browser ***
-  - npm run dev -- --run-project %CD%/packages/example --browser edge
-
 # Don't actually build.
 build: off


### PR DESCRIPTION
Internal: we will be running Kitchensink tests on Windows from cypress-test-example-repos like other projects https://github.com/cypress-io/cypress-test-example-repos/pull/106