### PR TITLE
fix: add missing script for building wizard

### DIFF
--- a/npm/create-cypress-tests/package.json
+++ b/npm/create-cypress-tests/package.json
@@ -5,7 +5,7 @@
   "private": false,
   "main": "index.js",
   "scripts": {
-    "build": "yarn prepare-example && tsc -p ./tsconfig.json && chmod +x dist/src/index.js && node scripts/example copy-to ./dist/initial-template && copy src/**/*.template.js dist/src",
+    "build": "yarn prepare-example && tsc -p ./tsconfig.json && node scripts/example copy-to ./dist/initial-template && yarn copy \"./src/**/*.template.js\" \"./dist/src\"",
     "build-prod": "yarn build",
     "prepare-example": "node scripts/example copy-to ./initial-template",
     "test": "cross-env TS_NODE_PROJECT=./tsconfig.test.json mocha --config .mocharc.json './src/**/*.test.ts'",

--- a/npm/create-cypress-tests/package.json
+++ b/npm/create-cypress-tests/package.json
@@ -6,6 +6,7 @@
   "main": "index.js",
   "scripts": {
     "build": "yarn prepare-example && tsc -p ./tsconfig.json && chmod +x dist/src/index.js && node scripts/example copy-to ./dist/initial-template && copy src/**/*.template.js dist/src",
+    "build-prod": "yarn build",
     "prepare-example": "node scripts/example copy-to ./initial-template",
     "test": "cross-env TS_NODE_PROJECT=./tsconfig.test.json mocha --config .mocharc.json './src/**/*.test.ts'",
     "test:watch": "yarn test -w"

--- a/npm/react/README.md
+++ b/npm/react/README.md
@@ -74,7 +74,7 @@ npx create-cypress-tests --component-testing
 
 Or continue with manual installation in the plugin file
 
-Tell Cypress how your React application is transpiled or bundled (using Webpack), so Cypress can load your components. For example, if you use `react-scripts` (even after ejecting) do:
+1. Tell Cypress how your React application is transpiled or bundled (using Webpack), so Cypress can load your components. For example, if you use `react-scripts` (even after ejecting) do:
 
 ```js
 // cypress/plugins/index.js
@@ -88,6 +88,13 @@ module.exports = (on, config) => {
 
 See [Recipes](./docs/recipes.md) for more examples.
 
+2. You can specify where component spec files are located. For example, to have them located in `src` folder use:
+
+```json
+{
+  "componentFolder": "src"
+}
+```
 
 ## API
 

--- a/npm/react/README.md
+++ b/npm/react/README.md
@@ -69,18 +69,12 @@ npm install --save-dev cypress @cypress/react
 You can use our command line wizard to give you instructions on configuring this plugin. It will try to determine which framework or bundling tool you are using and give you instructions on right configuration.
 
 ```sh
-@cypress/react init
+npx create-cypress-tests --component-testing
 ```
 
-Or continue with manual installation:
+Or continue with manual installation in the plugin file
 
-1. Include this plugin from your project's `cypress/support/index.js`
-
-```js
-require('@cypress/react/support')
-```
-
-2. Tell Cypress how your React application is transpiled or bundled (using Webpack), so Cypress can load your components. For example, if you use `react-scripts` (even after ejecting) do:
+Tell Cypress how your React application is transpiled or bundled (using Webpack), so Cypress can load your components. For example, if you use `react-scripts` (even after ejecting) do:
 
 ```js
 // cypress/plugins/index.js
@@ -94,14 +88,6 @@ module.exports = (on, config) => {
 
 See [Recipes](./docs/recipes.md) for more examples.
 
-3. ⚠️ Turn the experimental component support on in your `cypress.json`. You can also specify where component spec files are located. For example, to have them located in `src` folder use:
-
-```json
-{
-  "experimentalComponentTesting": true,
-  "componentFolder": "src"
-}
-```
 
 ## API
 


### PR DESCRIPTION

As mentioned in #15450 we need to deliver the wizard again and probably update the Readme.md for `@cypress/react`.