### PR TITLE
fix: add test for cy.intercept having response for multiple aliases

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -2209,6 +2209,22 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
       .wait('@image').its('response.statusCode').should('eq', 304)
     })
 
+    // https://github.com/cypress-io/cypress/issues/14522
+    it('different aliases are used for the same url', () => {
+      cy.intercept('/status-code').as('status')
+      .then(() => {
+        $.get('/status-code?code=204')
+      })
+      .wait('@status').its('response.statusCode').should('eq', 204)
+
+      cy.intercept('/status-code').as('status2')
+      .then(() => {
+        $.get('/status-code?code=301')
+      })
+      .wait('@status').its('response.statusCode').should('eq', 301)
+      .wait('@status2').its('response.statusCode').should('eq', 301)
+    })
+
     // https://github.com/cypress-io/cypress/issues/9549
     it('should handle aborted requests', () => {
       cy.intercept('https://jsonplaceholder.typicode.com/todos/1').as('xhr')


### PR DESCRIPTION
- Closes #14522 
- Closes #14205

### User facing changelog

- Fixed an issue where only the first matching alias for a route would yield a response object on `cy.wait`.

### Additional details

- this was actually fixed in #15255 - which is going into 7.x
- sainthkh opened a PR to fix this for 6.x but closed since 7.x is around the corner

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
