### PR TITLE
chore: allow nextVersion to be overridden by NEXT_VERSION

### DIFF
--- a/scripts/get-next-version.js
+++ b/scripts/get-next-version.js
@@ -8,7 +8,8 @@ const currentVersion = require('../package.json').version
 const bump = Bluebird.promisify(bumpCb)
 const paths = ['packages', 'cli']
 
-let nextVersion
+// allow the semantic next version to be overridden by environment
+let nextVersion = process.env.NEXT_VERSION
 
 const getNextVersionForPath = async (path) => {
   const { releaseType } = await bump({ preset: 'angular', path })


### PR DESCRIPTION
By popular demand!

If defined, `NEXT_VERSION` acts the same as the old `NEXT_DEV_VERSION` environment variable. Otherwise, semantic commits are used.

Generally, if you want to build a higher version number, you can just add a commit with the correct semantic commit message. But there's no way to build a lower version number without using `NEXT_VERSION`.