### PR TITLE
fix: specs overflow horizontally and z-index issues

### DIFF
--- a/npm/design-system/src/components/SpecList/SpecList.module.scss
+++ b/npm/design-system/src/components/SpecList/SpecList.module.scss
@@ -41,7 +41,7 @@
   position: relative;
   color: unset;
   text-decoration: none;
-  display: inline-block;
+  display: block;
   width: 100%;
   &:hover {
     background: opacify($color: $metal-05, $amount: 0.2);

--- a/packages/runner-ct/src/SpecList/components/SearchSpec.scss
+++ b/packages/runner-ct/src/SpecList/components/SearchSpec.scss
@@ -1,3 +1,5 @@
+@use '../../variables.scss' as *;
+
 .specs-list-search-input-container {
   display: flex;
   justify-content: flex-start;
@@ -8,7 +10,8 @@
   padding: 8px;
   box-sizing: border-box;
   background-color: white;
-  z-index: 10;
+  box-shadow: $shadow-xs;
+  z-index: 1;
   
   input { 
     width: 100%;

--- a/packages/runner-ct/src/app/RunnerCt.module.scss
+++ b/packages/runner-ct/src/app/RunnerCt.module.scss
@@ -55,6 +55,7 @@ $box-shadow-closest: 0px 0px 5px rgba(0, 0, 0, 0.4);
   height: 100%;
   display: flex;
   flex-direction: column;
+  z-index: 0;
 }
 
 .runner {


### PR DESCRIPTION
This is a followup fix for the stylesheets that are preventing larger app's test suites from rendering at all (contd. #15542)