### PR TITLE
refactor: simplify vue mount

### DIFF
--- a/npm/webpack-dev-server/src/aut-runner.ts
+++ b/npm/webpack-dev-server/src/aut-runner.ts
@@ -33,7 +33,8 @@ export function init (importPromises, parent = (window.opener || window.parent))
   // Cleaning up platform between tests is the responsibility of the specific adapter
   // because unmounting react/vue component should be done using specific framework API
   // (for devtools and to get rid of global event listeners from previous tests.)
-  Cypress.on('test:before:run', () => {
+  // Cypress.on('test:before:run', () => {
+  before(() => {
     document.body.innerHTML = ''
     document.head.innerHTML = headInnerHTML
     appendTargetIfNotExists('__cy_root')


### PR DESCRIPTION
Something about changing `before` to `Cypress.on('test:before:run')` breaks one specific test, this one: https://app.circleci.com/pipelines/github/cypress-io/cypress/18194/workflows/92cfba01-a7cb-400e-9eca-f0b1afc0e113/jobs/657723/tests#failed-test-0