### PR TITLE
fix: cy.contains does not return <body> when the finding text is in <script> or <style>

### DIFF
--- a/packages/driver/cypress/integration/commands/querying_spec.js
+++ b/packages/driver/cypress/integration/commands/querying_spec.js
@@ -1573,13 +1573,15 @@ describe('src/cy/commands/querying', () => {
     it('will not find script elements', () => {
       cy.$$('<script>// some-script-content </script>').appendTo(cy.$$('body'))
 
-      cy.contains('some-script-content').should('not.match', 'script')
+      // "will not find" means "it does not exist"
+      cy.contains('some-script-content').should('not.exist')
     })
 
     it('will not find style elements', () => {
       cy.$$('<style> some-style-content {} </style>').appendTo(cy.$$('body'))
 
-      cy.contains('some-style-content').should('not.match', 'style')
+      // "will not find" means "it does not exist"
+      cy.contains('some-style-content').should('not.exist')
     })
 
     it('finds the nearest element by :contains selector', () => {
@@ -1892,7 +1894,7 @@ space
 </pre>\
 `).appendTo(cy.$$('body'))
 
-        cy.contains('White space').should('not.match', 'pre')
+        cy.contains('White space').should('not.exist')
         cy.get('#whitespace5').contains('White\nspace')
       })
 

--- a/packages/driver/src/dom/elements.ts
+++ b/packages/driver/src/dom/elements.ts
@@ -1121,8 +1121,12 @@ const getContainsSelector = (text, filter = '', options: {
     // We need to use other type of quote characters.
     const textToFind = escapedText.includes(`\'`) ? `"${escapedText}"` : `'${escapedText}'`
 
+    // https://github.com/cypress-io/cypress/issues/14861
+    // body is added to ":not" list
+    // because Sizzle returns <body> when the content of <script> or <style> contains the text
+
     // use custom cy-contains selector that is registered above
-    return `${filter}:not(script,style):cy-contains(${textToFind}), ${filter}[type='submit'][value~=${textToFind}]`
+    return `${filter}:not(script,style,body):cy-contains(${textToFind}), ${filter}[type='submit'][value~=${textToFind}]`
   })
 
   return selectors.join()


### PR DESCRIPTION
- Closes #14861

### User facing changelog

`cy.contains` does not return `<body>` when the finding text is in `<script>` or `<style>`.

### Additional details
- Why was this change necessary? => `cy.contains` should return "element not found" even if the finding text is in <script> or <style> tags.
- What is affected by this change? => Please check the note "Is this a breaking change?" below.
- Any implementation details to explain? => Added "body" to the ":not" list. 

### Is this a breaking change?

In some tests like below,

https://github.com/cypress-io/cypress/blob/8286fcd0b9b9950f7dd08d8ca73f80d9cdf845e3/packages/driver/cypress/integration/commands/querying_spec.js#L1573-L1577

the test fails after this change, because `cy.contains()` does not return any element. 

Should we call this behavior a bug or a breaking change?

### How has the user experience changed?

N/A

### PR Tasks

- [x] Have tests been added/updated?
