### PR TITLE
chore: Remove percy-finalize from required jobs for npm-release

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1908,7 +1908,6 @@ linux-workflow: &linux-workflow
           - ui-components-integration-tests
           - reporter-integration-tests
           - Linux lint
-          - percy-finalize
           - desktop-gui-component-tests
           - desktop-gui-integration-tests-2x
           - runner-ct-integration-tests-chrome


### PR DESCRIPTION
The `percy-finalize` job cannot be required for `npm-release` job because this job cannot be run by outside contributors (they do not have authorization to percy token) - so the jobs never complete for outside contributors. 

See example: https://app.circleci.com/pipelines/github/cypress-io/cypress/18279/workflows/6e02eaff-954b-4a53-ba78-bf53e9c04c07