### PR TITLE
feat: Support Bearer token injection alongside Basic Auth

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -17,8 +17,9 @@ declare namespace Cypress {
     [key: string]: any
   }
   interface Auth {
-    username: string
-    password: string
+    username?: string
+    password?: string
+    bearer?: string
   }
 
   interface Backend {
@@ -2995,13 +2996,14 @@ declare namespace Cypress {
     /**
      * Cypress will automatically apply the right authorization headers
      * if you’re attempting to visit an application that requires
-     * Basic Authentication.
+     * Basic Authentication or a Bearer Token.
      *
      * @example
      *    cy.visit('https://www.acme.com/', {
      *      auth: {
      *        username: 'wile',
-     *        password: 'coyote'
+     *        password: 'coyote',
+     *        bearer: "abc123"
      *      }
      *    })
      */

--- a/cli/types/tests/kitchen-sink.ts
+++ b/cli/types/tests/kitchen-sink.ts
@@ -33,6 +33,12 @@ cy.visit('https://www.acme.com/', {
   }
 })
 
+cy.visit('https://www.acme.com/', {
+  auth: {
+    bearer: "abc123"
+  }
+})
+
 const serverOptions: Partial<Cypress.ServerOptions> = {
   delay: 100,
   ignore: () => true

--- a/packages/proxy/lib/http/request-middleware.ts
+++ b/packages/proxy/lib/http/request-middleware.ts
@@ -81,7 +81,7 @@ const StripUnsupportedAcceptEncoding: RequestMiddleware = function () {
   this.next()
 }
 
-function reqNeedsBasicAuthHeaders (req, { auth, origin }: CyServer.RemoteState) {
+function reqNeedsAuthHeaders (req, { auth, origin }: CyServer.RemoteState) {
   //if we have auth headers, this request matches our origin, protection space, and the user has not supplied auth headers
   return auth && !req.headers['authorization'] && cors.urlMatchesOriginProtectionSpace(req.proxiedUrl, origin)
 }
@@ -89,11 +89,16 @@ function reqNeedsBasicAuthHeaders (req, { auth, origin }: CyServer.RemoteState) 
 const MaybeSetBasicAuthHeaders: RequestMiddleware = function () {
   const remoteState = this.getRemoteState()
 
-  if (remoteState.auth && reqNeedsBasicAuthHeaders(this.req, remoteState)) {
+  if (remoteState.auth && reqNeedsAuthHeaders(this.req, remoteState)) {
     const { auth } = remoteState
-    const base64 = Buffer.from(`${auth.username}:${auth.password}`).toString('base64')
 
-    this.req.headers['authorization'] = `Basic ${base64}`
+    if (auth.username && auth.password) {
+      const base64 = Buffer.from(`${auth.username}:${auth.password}`).toString('base64')
+
+      this.req.headers['authorization'] = `Basic ${base64}`
+    } else if (auth.bearer) {
+      this.req.headers['authorization'] = `Bearer ${auth.bearer}`
+    }
   }
 
   this.next()

--- a/packages/proxy/lib/http/request-middleware.ts
+++ b/packages/proxy/lib/http/request-middleware.ts
@@ -86,7 +86,7 @@ function reqNeedsAuthHeaders (req, { auth, origin }: CyServer.RemoteState) {
   return auth && !req.headers['authorization'] && cors.urlMatchesOriginProtectionSpace(req.proxiedUrl, origin)
 }
 
-const MaybeSetBasicAuthHeaders: RequestMiddleware = function () {
+const MaybeSetAuthHeaders: RequestMiddleware = function () {
   const remoteState = this.getRemoteState()
 
   if (remoteState.auth && reqNeedsAuthHeaders(this.req, remoteState)) {
@@ -151,6 +151,6 @@ export default {
   RedirectToClientRouteIfUnloaded,
   EndRequestsToBlockedHosts,
   StripUnsupportedAcceptEncoding,
-  MaybeSetBasicAuthHeaders,
+  MaybeSetAuthHeaders,
   SendRequestOutgoing,
 }

--- a/packages/proxy/test/unit/http/request-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/request-middleware.spec.ts
@@ -11,7 +11,7 @@ describe('http/request-middleware', function () {
       'RedirectToClientRouteIfUnloaded',
       'EndRequestsToBlockedHosts',
       'StripUnsupportedAcceptEncoding',
-      'MaybeSetBasicAuthHeaders',
+      'MaybeSetAuthHeaders',
       'SendRequestOutgoing',
     ])
   })

--- a/packages/server/index.d.ts
+++ b/packages/server/index.d.ts
@@ -33,6 +33,7 @@ export namespace CyServer {
     auth?: {
       username: string
       password: string
+      bearer: string
     }
     domainName: string
     strategy: 'file' | 'http'


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #4837

### User facing changelog
- Support `Bearer` tokens inside `auth` option blocks. 

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Allows a user to use the Cypress proxy middleware to inject `Bearer` tokens via the `Authorization` header. Currently on basic auth is supported.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
