### PR TITLE
fix: add the type definition for cy.writeFile with 4 arguments.

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2147,7 +2147,6 @@ declare namespace Cypress {
     ```
     cy.writeFile('path/to/ascii.txt', 'Hello World', 'utf8', {
       flag: 'a+',
-      encoding: 'ascii'
     }).then((text) => {
       expect(text).to.equal('Hello World') // true
     })

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2141,7 +2141,7 @@ declare namespace Cypress {
     /**
      * Write to a file with the specified encoding and contents.
      *
-     * The `encoding` option in `options` precedes the `encoding` argument.
+     * An `encoding` option in `options` will override the `encoding` argument.
      *
      * @see https://on.cypress.io/writefile
     ```

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2138,6 +2138,22 @@ declare namespace Cypress {
     ```
      */
     writeFile<C extends FileContents>(filePath: string, contents: C, options?: Partial<WriteFileOptions>): Chainable<C>
+    /**
+     * Write to a file with the specified encoding and contents.
+     *
+     * The `encoding` option in `options` precedes the `encoding` argument.
+     *
+     * @see https://on.cypress.io/writefile
+    ```
+    cy.writeFile('path/to/ascii.txt', 'Hello World', 'utf8', {
+      flag: 'a+',
+      encoding: 'ascii'
+    }).then((text) => {
+      expect(text).to.equal('Hello World') // true
+    })
+    ```
+     */
+    writeFile<C extends FileContents>(filePath: string, contents: C, encoding: Encodings, options?: Partial<WriteFileOptions>): Chainable<C>
 
     /**
      * jQuery library bound to the AUT

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -465,6 +465,10 @@ cy.writeFile('../file.path', '', {
   flag: 'a+',
   encoding: 'utf-8'
 })
+cy.writeFile('../file.path', '', 'ascii', {
+  flag: 'a+',
+  encoding: 'utf-8'
+})
 
 cy.get('foo').click()
 cy.get('foo').click({


### PR DESCRIPTION
- Closes #15353

### User facing changelog

Add the type definition for `cy.writeFile` with 4 arguments. 

### Additional details
- Why was this change necessary? => 4 argument definition is valid, but it doesn't exist. 
- What is affected by this change? => N/A
- Any implementation details to explain? => N/A

### How has the user experience changed?

N/A

### PR Tasks
- [x] Have tests been added/updated?
