### PR TITLE
fix: Fix "coordsHistory must be at least 2 sets of coords" error

### DIFF
--- a/packages/driver/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/click_spec.js
@@ -752,6 +752,20 @@ describe('src/cy/commands/actions/click', () => {
       })
     })
 
+    it('each click gets a full command timeout', () => {
+      cy.spy(cy, 'retry')
+
+      cy.get('#three-buttons button').click({ multiple: true }).then(() => {
+        const [firstCall, secondCall] = cy.retry.getCalls()
+        const firstCallOptions = firstCall.args[1]
+        const secondCallOptions = secondCall.args[1]
+
+        // ensure we clone the options object passed to `retry()` so that
+        // each click in `{ multiple: true }` gets its own full timeout
+        expect(firstCallOptions !== secondCallOptions, 'Expected click retry options to be different object references between clicks').to.be.true
+      })
+    })
+
     // this test needs to increase the height + width of the div
     // when we implement scrollBy the delta of the left/top
     it('can click elements which are huge and the center is naturally below the fold', () => {

--- a/packages/driver/src/cy/actionability.js
+++ b/packages/driver/src/cy/actionability.js
@@ -261,16 +261,29 @@ const getCoordinatesForEl = function (cy, $el, options) {
 }
 
 const ensureNotAnimating = function (cy, $el, coordsHistory, animationDistanceThreshold) {
-  // if we dont have at least 2 points
-  // then automatically retry
+  // if we dont have at least 2 points, we throw this error to force a
+  // retry, which will get us another point.
+  // this error is purposefully generic because if the actionability
+  //check times out, this error is the one displayed to the user and
+  // saying something like "coordsHistory must be at least 2 sets
+  // of coords" is not very useful.
+  // that would only happen if the actionability check times out, which
+  // shouldn't happen with default timeouts, but could theoretically
+  // on a very, very slow system
+  // https://github.com/cypress-io/cypress/issues/3738
   if (coordsHistory.length < 2) {
-    $errUtils.throwErrByPath('dom.animation_coords_history_invalid')
+    $errUtils.throwErrByPath('dom.actionability_failed', {
+      args: {
+        node: $dom.stringify($el),
+        cmd: cy.state('current').get('name'),
+      },
+    })
   }
 
   // verify that our element is not currently animating
   // by verifying it is still at the same coordinates within
   // 5 pixels of x/y
-  return cy.ensureElementIsNotAnimating($el, coordsHistory, animationDistanceThreshold)
+  cy.ensureElementIsNotAnimating($el, coordsHistory, animationDistanceThreshold)
 }
 
 const verify = function (cy, $el, options, callbacks) {
@@ -336,7 +349,6 @@ const verify = function (cy, $el, options, callbacks) {
   }
 
   return Promise.try(() => {
-    let retryActionability
     const coordsHistory = []
 
     const runAllChecks = function () {
@@ -426,7 +438,7 @@ const verify = function (cy, $el, options, callbacks) {
     // element passes every single check, we MUST fire the event
     // synchronously else we risk the state changing between
     // the checks and firing the event!
-    return (retryActionability = function () {
+    const retryActionability = () => {
       try {
         return runAllChecks()
       } catch (err) {
@@ -434,7 +446,9 @@ const verify = function (cy, $el, options, callbacks) {
 
         return cy.retry(retryActionability, options)
       }
-    })()
+    }
+
+    return retryActionability()
   })
 }
 

--- a/packages/driver/src/cy/commands/actions/click.js
+++ b/packages/driver/src/cy/commands/actions/click.js
@@ -172,8 +172,7 @@ module.exports = (Commands, Cypress, cy, state, config) => {
       // properties like `total` and `_retries` are mutated by
       // $actionability.verify and retrying, but each click should
       // have its own full timeout
-      // const individualOptions = options.multiple ? { ...options } : options
-      const individualOptions = options
+      const individualOptions = { ... options }
 
       // must use callbacks here instead of .then()
       // because we're issuing the clicks synchronously

--- a/packages/driver/src/cy/commands/actions/click.js
+++ b/packages/driver/src/cy/commands/actions/click.js
@@ -116,9 +116,8 @@ module.exports = (Commands, Cypress, cy, state, config) => {
         })
       }
 
-      // we want to add this delay delta to our
-      // runnables timeout so we prevent it from
-      // timing out from multiple clicks
+      // add this delay delta to the runnables timeout because we delay
+      // by it below before performing each click
       cy.timeout($actionability.delay, true, eventName)
 
       const createLog = (domEvents, fromElWindow, fromAutWindow) => {
@@ -169,11 +168,18 @@ module.exports = (Commands, Cypress, cy, state, config) => {
         .return(null)
       }
 
+      // if { multiple: true }, make a shallow copy of options, since
+      // properties like `total` and `_retries` are mutated by
+      // $actionability.verify and retrying, but each click should
+      // have its own full timeout
+      // const individualOptions = options.multiple ? { ...options } : options
+      const individualOptions = options
+
       // must use callbacks here instead of .then()
       // because we're issuing the clicks synchronously
       // once we establish the coordinates and the element
       // passes all of the internal checks
-      return $actionability.verify(cy, $el, options, {
+      return $actionability.verify(cy, $el, individualOptions, {
         onScroll ($el, type) {
           return Cypress.action('cy:scrolled', $el, type)
         },

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -293,6 +293,13 @@ module.exports = {
   },
 
   dom: {
+    actionability_failed: stripIndent`
+      ${cmd('{{cmd}}')} could not be issued because we could not determine the actionability of this element:
+
+      \`{{node}}\`
+
+      You can prevent this by passing \`{force: true}\` to disable all error checking.
+    `,
     animating: {
       message: stripIndent`\
         ${cmd('{{cmd}}')} could not be issued because this element is currently animating:
@@ -305,7 +312,6 @@ module.exports = {
           - Passing \`{animationDistanceThreshold: 20}\` which decreases the sensitivity`,
       docsUrl: 'https://on.cypress.io/element-is-animating',
     },
-    animation_coords_history_invalid: 'coordsHistory must be at least 2 sets of coords',
     animation_check_failed: 'Not enough coord points provided to calculate distance.',
     center_hidden: {
       message: stripIndent`\


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #3738

### User facing changelog

- `cy.click()` will no longer fail with "coordsHistory must be at least 2 sets of coords" when specifying `{ multiple: true }`

### Additional details

There was a bug where using `cy.click({ multiple: true })` would time out because all clicks needed to be finished in the time we normally give one click (4000ms by default). If the system was slow, the timeout was lowered, and/or there were a lot of elements to click, this became more likely.

Now, each click when using `{ multiple: true }` gets a full timeout (4000ms).

Also, the error message "coordsHistory must be at least 2 sets of coords" was confusing and not useful to users. It appeared because it happened to be the error we use to trigger an initial retry in order to test that the element is not animating between ticks. I improved the error, though with the timeout change, it's very, very unlikely now that a user will encounter it.

### How has the user experience changed?

The main experience change is that users shouldn't have to worry about click timeouts for multiple elements since each click now has more time to execute.

With the timeout change, it's much less likely users will encounter this new error message, but in case they somehow do, here's the before and after:

Before:

![Screen Shot 2021-03-23 at 10 38 11 AM](https://user-images.githubusercontent.com/1157043/112326960-6521f880-8c8b-11eb-87d0-f36259aa7501.png)

After:

![Screen Shot 2021-03-23 at 10 38 36 AM](https://user-images.githubusercontent.com/1157043/112326972-681ce900-8c8b-11eb-8e80-0901d5d3a72f.png)

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
