### PR TITLE
build: export net-stubbing types as a declaration file

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -9,6 +9,6 @@ types/minimatch
 types/sinon
 types/sinon-chai
 # copied from net-stubbing package on build
-types/net-stubbing.ts
+types/net-stubbing.d.ts
 # ignore CLI output build folder
 build

--- a/cli/package.json
+++ b/cli/package.json
@@ -64,6 +64,7 @@
     "@babel/cli": "7.13.0",
     "@babel/preset-env": "7.13.5",
     "@cypress/sinon-chai": "2.9.1",
+    "@packages/net-stubbing": "^0.0.0-development",
     "@packages/root": "0.0.0-development",
     "@types/bluebird": "3.5.33",
     "@types/chai": "4.2.15",
@@ -100,7 +101,7 @@
     "lib",
     "index.js",
     "types/**/*.d.ts",
-    "types/net-stubbing.ts"
+    "types/net-stubbing.d.ts"
   ],
   "bin": {
     "cypress": "bin/cypress"

--- a/cli/scripts/post-install.js
+++ b/cli/scripts/post-install.js
@@ -71,4 +71,4 @@ shell.sed('-i', 'from \'sinon\';', 'from \'../sinon\';', sinonChaiFilename)
 
 // copy experimental network stubbing type definitions
 // so users can import: `import 'cypress/types/net-stubbing'`
-shell.cp(resolvePkg('@packages/net-stubbing/lib/external-types.ts'), 'types/net-stubbing.ts')
+shell.cp(resolvePkg('@packages/net-stubbing/lib/external-types.d.ts'), 'types/net-stubbing.d.ts')

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -26,7 +26,7 @@
 // hmm, how to load it better?
 /// <reference path="./cypress-npm-api.d.ts" />
 
-/// <reference path="./net-stubbing.ts" />
+/// <reference path="./net-stubbing.d.ts" />
 /// <reference path="./cypress.d.ts" />
 /// <reference path="./cypress-global-vars.d.ts" />
 /// <reference path="./cypress-type-helpers.d.ts" />

--- a/packages/net-stubbing/package.json
+++ b/packages/net-stubbing/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "main": "./lib/server",
   "scripts": {
+    "build": "tsc --declaration --emitDeclarationOnly --project .",
     "build-prod": "tsc --project .",
     "clean-deps": "rm -rf node_modules",
+    "postinstall": "yarn build",
     "test": "mocha -r @packages/ts/register --reporter mocha-multi-reporters --reporter-options configFile=../../mocha-reporter-config.json --exit test/unit/*"
   },
   "dependencies": {

--- a/packages/server-ct/index.d.ts
+++ b/packages/server-ct/index.d.ts
@@ -7,7 +7,7 @@
 
 /// <reference path="../../cli/types/cypress-npm-api.d.ts" />
 
-/// <reference path="../../cli/types/net-stubbing.ts" />
+/// <reference path="../../cli/types/net-stubbing.d.ts" />
 /// <reference path="../../cli/types/cypress.d.ts" />
 /// <reference path="../../cli/types/cypress-global-vars.d.ts" />
 /// <reference path="../../cli/types/cypress-type-helpers.d.ts" />

--- a/packages/server/index.d.ts
+++ b/packages/server/index.d.ts
@@ -7,7 +7,7 @@
 
 /// <reference path="../../cli/types/cypress-npm-api.d.ts" />
 
-/// <reference path="../../cli/types/net-stubbing.ts" />
+/// <reference path="../../cli/types/net-stubbing.d.ts" />
 /// <reference path="../../cli/types/cypress.d.ts" />
 /// <reference path="../../cli/types/cypress-global-vars.d.ts" />
 /// <reference path="../../cli/types/cypress-type-helpers.d.ts" />


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #15644

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->
Exported net-stubbing types are available as type declarations

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
This change should only effect the typings visible in the end NPM package. It was necessary for tooling which expects types to come as TS declaration files (`.d.ts`) instead of raw TS files. For example, the `bazelbuild/rules_nodejs` integration between NPM and Bazel expects this.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
None. For developers this should also be an innocuous change, assuming they are importing the types via `cypress/types/net-stubbing`. If they are somehow importing them using the `.ts` extension (via reference or other means), they'll have to change the extension only.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
   - No, this isn't really test-worthy as a filename change.
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
  - AFAICT, there is no documentation to update for this.
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
  - Unaffected
- [x] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
  - Unaffected