### PR TITLE
fix(runner-ct): scale AUT correctly

### DIFF
--- a/packages/runner-ct/cypress/component/ResizeReporter.spec.tsx
+++ b/packages/runner-ct/cypress/component/ResizeReporter.spec.tsx
@@ -7,6 +7,13 @@ import eventManager from '../../src/lib/event-manager'
 import { testSpecFile } from '../fixtures/testSpecFile'
 import { makeState, fakeConfig, getPort } from './utils'
 
+/**
+ * Specs using a real `eventManager` need to be
+ * one-per-file or strange things happen.
+ * TODO: Figure out why this is the case and remove this
+ * limitation
+ */
+
 describe('RunnerCt', () => {
   beforeEach(() => {
     cy.viewport(1000, 500)

--- a/packages/runner-ct/cypress/component/ResizeReporter.spec.tsx
+++ b/packages/runner-ct/cypress/component/ResizeReporter.spec.tsx
@@ -5,6 +5,7 @@ import RunnerCt from '../../src/app/RunnerCt'
 import State from '../../src/lib/state'
 import '@packages/runner/src/main.scss'
 import eventManager from '../../src/lib/event-manager'
+import { testSpecFile } from '../fixtures/testSpecFile'
 
 const fakeConfig = { projectName: 'Project', env: {}, isTextTerminal: false } as any as Cypress.RuntimeConfigOptions
 const makeState = (options = {}) => (new State({
@@ -13,22 +14,6 @@ const makeState = (options = {}) => (new State({
   specs: [{ relative: '/test.js', absolute: 'root/test.js', name: 'test.js' }],
   ...options,
 }, fakeConfig))
-
-const testSpecFile = `
-  <html>
-    <head>
-      <meta charset="utf-8">
-      <meta http-equiv="X-UA-Compatible" content="IE=edge">
-      <meta name="viewport" content="width=device-width,initial-scale=1.0">
-      <title>Components App</title>
-    </head>
-    <body>
-      <div id="__cy_root"></div>
-    <script type="text/javascript">
-      // NO-OP is fine for now
-    </script></body>
-  </html>
-`
 
 describe('RunnerCt', () => {
   beforeEach(() => {

--- a/packages/runner-ct/cypress/component/ResizeReporter.spec.tsx
+++ b/packages/runner-ct/cypress/component/ResizeReporter.spec.tsx
@@ -14,7 +14,6 @@ const makeState = (options = {}) => (new State({
   ...options,
 }, fakeConfig))
 
-
 const testSpecFile = `
   <html>
     <head>
@@ -39,7 +38,7 @@ describe('RunnerCt', () => {
   it('resizes reporter', () => {
     cy.intercept('GET', 'http://localhost:60728/undefined/iframes//test.js', {
       statusCode: 200,
-      body: testSpecFile
+      body: testSpecFile,
     })
 
     mount(
@@ -61,15 +60,15 @@ describe('RunnerCt', () => {
 
       // resize reporter
       cy.get('.Resizer.vertical').eq(2)
-        .trigger('mousedown', { eventConstructor: 'MouseEvent' })
-        .trigger('mousemove', -200, -200, { eventConstructor: 'MouseEvent', force: true })
-        .trigger('mouseup')
-
+      .trigger('mousedown', { eventConstructor: 'MouseEvent' })
+      .trigger('mousemove', -200, -200, { eventConstructor: 'MouseEvent', force: true })
+      .trigger('mouseup')
 
       // AUT scale should be different.
       cy.get('.size-container').then(($el) => {
         const newStyle = $el.attr('style')
         const [, newScale] = newStyle.match(/transform.\s(.+);/)
+
         expect(newScale).not.to.eq(initialScale)
       })
     })

--- a/packages/runner-ct/cypress/component/ResizeReporter.spec.tsx
+++ b/packages/runner-ct/cypress/component/ResizeReporter.spec.tsx
@@ -2,18 +2,10 @@
 import React from 'react'
 import { mount } from '@cypress/react'
 import RunnerCt from '../../src/app/RunnerCt'
-import State from '../../src/lib/state'
 import '@packages/runner/src/main.scss'
 import eventManager from '../../src/lib/event-manager'
 import { testSpecFile } from '../fixtures/testSpecFile'
-
-const fakeConfig = { projectName: 'Project', env: {}, isTextTerminal: false } as any as Cypress.RuntimeConfigOptions
-const makeState = (options = {}) => (new State({
-  reporterWidth: 500,
-  spec: null,
-  specs: [{ relative: '/test.js', absolute: 'root/test.js', name: 'test.js' }],
-  ...options,
-}, fakeConfig))
+import { makeState, fakeConfig } from './utils'
 
 describe('RunnerCt', () => {
   beforeEach(() => {
@@ -30,7 +22,6 @@ describe('RunnerCt', () => {
       <RunnerCt
         state={makeState()}
         eventManager={eventManager}
-        // @ts-ignore - TODO: define a good test config.
         config={fakeConfig}
       />,
     )

--- a/packages/runner-ct/cypress/component/ResizeReporter.spec.tsx
+++ b/packages/runner-ct/cypress/component/ResizeReporter.spec.tsx
@@ -5,7 +5,7 @@ import RunnerCt from '../../src/app/RunnerCt'
 import '@packages/runner/src/main.scss'
 import eventManager from '../../src/lib/event-manager'
 import { testSpecFile } from '../fixtures/testSpecFile'
-import { makeState, fakeConfig } from './utils'
+import { makeState, fakeConfig, getPort } from './utils'
 
 describe('RunnerCt', () => {
   beforeEach(() => {
@@ -13,7 +13,9 @@ describe('RunnerCt', () => {
   })
 
   it('resizes reporter', () => {
-    cy.intercept('GET', 'http://localhost:60728/undefined/iframes//test.js', {
+    const port = getPort(location.href)
+
+    cy.intercept('GET', `http://localhost:${port}/undefined/iframes//test.js`, {
       statusCode: 200,
       body: testSpecFile,
     })

--- a/packages/runner-ct/cypress/component/ResizeReporter.spec.tsx
+++ b/packages/runner-ct/cypress/component/ResizeReporter.spec.tsx
@@ -1,0 +1,79 @@
+/// <reference types="@percy/cypress" />
+import React from 'react'
+import { mount } from '@cypress/react'
+import RunnerCt from '../../src/app/RunnerCt'
+import State from '../../src/lib/state'
+import '@packages/runner/src/main.scss'
+import eventManager from '../../src/lib/event-manager'
+
+const fakeConfig = { projectName: 'Project', env: {}, isTextTerminal: false } as any as Cypress.RuntimeConfigOptions
+const makeState = (options = {}) => (new State({
+  reporterWidth: 500,
+  spec: null,
+  specs: [{ relative: '/test.js', absolute: 'root/test.js', name: 'test.js' }],
+  ...options,
+}, fakeConfig))
+
+
+const testSpecFile = `
+  <html>
+    <head>
+      <meta charset="utf-8">
+      <meta http-equiv="X-UA-Compatible" content="IE=edge">
+      <meta name="viewport" content="width=device-width,initial-scale=1.0">
+      <title>Components App</title>
+    </head>
+    <body>
+      <div id="__cy_root"></div>
+    <script type="text/javascript">
+      // NO-OP is fine for now
+    </script></body>
+  </html>
+`
+
+describe('RunnerCt', () => {
+  beforeEach(() => {
+    cy.viewport(1000, 500)
+  })
+
+  it('resizes reporter', () => {
+    cy.intercept('GET', 'http://localhost:60728/undefined/iframes//test.js', {
+      statusCode: 200,
+      body: testSpecFile
+    })
+
+    mount(
+      <RunnerCt
+        state={makeState()}
+        eventManager={eventManager}
+        // @ts-ignore - TODO: define a good test config.
+        config={fakeConfig}
+      />,
+    )
+
+    // select spec.
+    cy.get('[data-item="/test.js"').click()
+
+    cy.get('.size-container').then(($el) => {
+      const style = $el.attr('style')
+      // extract inline transform value.
+      const [, initialScale] = style.match(/transform.\s(.+);/)
+
+      // resize reporter
+      cy.get('.Resizer.vertical').eq(2)
+        .trigger('mousedown', { eventConstructor: 'MouseEvent' })
+        .trigger('mousemove', -200, -200, { eventConstructor: 'MouseEvent', force: true })
+        .trigger('mouseup')
+
+
+      // AUT scale should be different.
+      cy.get('.size-container').then(($el) => {
+        const newStyle = $el.attr('style')
+        const [, newScale] = newStyle.match(/transform.\s(.+);/)
+        expect(newScale).not.to.eq(initialScale)
+      })
+    })
+
+    cy.percySnapshot()
+  })
+})

--- a/packages/runner-ct/cypress/component/ResizeSpecList.spec.tsx
+++ b/packages/runner-ct/cypress/component/ResizeSpecList.spec.tsx
@@ -5,7 +5,7 @@ import RunnerCt from '../../src/app/RunnerCt'
 import '@packages/runner/src/main.scss'
 import eventManager from '../../src/lib/event-manager'
 import { testSpecFile } from '../fixtures/testSpecFile'
-import { makeState, fakeConfig } from './utils'
+import { makeState, fakeConfig, getPort } from './utils'
 
 describe('RunnerCt', () => {
   beforeEach(() => {
@@ -13,7 +13,9 @@ describe('RunnerCt', () => {
   })
 
   it('resizes spec list', () => {
-    cy.intercept('GET', 'http://localhost:60728/undefined/iframes//test.js', {
+    const port = getPort(location.href)
+
+    cy.intercept('GET', `http://localhost:${port}/undefined/iframes//test.js`, {
       statusCode: 200,
       body: testSpecFile,
     })

--- a/packages/runner-ct/cypress/component/ResizeSpecList.spec.tsx
+++ b/packages/runner-ct/cypress/component/ResizeSpecList.spec.tsx
@@ -1,0 +1,80 @@
+
+/// <reference types="@percy/cypress" />
+import React from 'react'
+import { mount } from '@cypress/react'
+import RunnerCt from '../../src/app/RunnerCt'
+import State from '../../src/lib/state'
+import '@packages/runner/src/main.scss'
+import eventManager from '../../src/lib/event-manager'
+
+const fakeConfig = { projectName: 'Project', env: {}, isTextTerminal: false } as any as Cypress.RuntimeConfigOptions
+const makeState = (options = {}) => (new State({
+  reporterWidth: 500,
+  spec: null,
+  specs: [{ relative: '/test.js', absolute: 'root/test.js', name: 'test.js' }],
+  ...options,
+}, fakeConfig))
+
+
+const testSpecFile = `
+  <html>
+    <head>
+      <meta charset="utf-8">
+      <meta http-equiv="X-UA-Compatible" content="IE=edge">
+      <meta name="viewport" content="width=device-width,initial-scale=1.0">
+      <title>Components App</title>
+    </head>
+    <body>
+      <div id="__cy_root"></div>
+    <script type="text/javascript">
+      // NO-OP is fine for now
+    </script></body>
+  </html>
+`
+
+describe('RunnerCt', () => {
+  beforeEach(() => {
+    cy.viewport(1000, 500)
+  })
+
+  it('resizes spec list', () => {
+    cy.intercept('GET', 'http://localhost:60728/undefined/iframes//test.js', {
+      statusCode: 200,
+      body: testSpecFile
+    })
+
+    mount(
+      <RunnerCt
+        state={makeState()}
+        eventManager={eventManager}
+        // @ts-ignore - TODO: define a good test config.
+        config={fakeConfig}
+      />,
+    )
+
+    // select spec.
+    cy.get('[data-item="/test.js"').click()
+
+    cy.get('.size-container').then(($el) => {
+      const style = $el.attr('style')
+      // extract inline transform value.
+      const [, initialScale] = style.match(/transform.\s(.+);/)
+
+      // resize reporter
+      cy.get('.Resizer.vertical').eq(1)
+        .trigger('mousedown', { eventConstructor: 'MouseEvent' })
+        .trigger('mousemove', -200, -200, { eventConstructor: 'MouseEvent', force: true })
+        .trigger('mouseup')
+
+
+      // AUT scale should be different.
+      cy.get('.size-container').then(($el) => {
+        const newStyle = $el.attr('style')
+        const [, newScale] = newStyle.match(/transform.\s(.+);/)
+        expect(newScale).not.to.eq(initialScale)
+      })
+    })
+
+    cy.percySnapshot()
+  })
+})

--- a/packages/runner-ct/cypress/component/ResizeSpecList.spec.tsx
+++ b/packages/runner-ct/cypress/component/ResizeSpecList.spec.tsx
@@ -7,6 +7,13 @@ import eventManager from '../../src/lib/event-manager'
 import { testSpecFile } from '../fixtures/testSpecFile'
 import { makeState, fakeConfig, getPort } from './utils'
 
+/**
+ * Specs using a real `eventManager` need to be
+ * one-per-file or strange things happen.
+ * TODO: Figure out why this is the case and remove this
+ * limitation
+ */
+
 describe('RunnerCt', () => {
   beforeEach(() => {
     cy.viewport(1000, 500)

--- a/packages/runner-ct/cypress/component/ResizeSpecList.spec.tsx
+++ b/packages/runner-ct/cypress/component/ResizeSpecList.spec.tsx
@@ -1,4 +1,3 @@
-
 /// <reference types="@percy/cypress" />
 import React from 'react'
 import { mount } from '@cypress/react'
@@ -14,7 +13,6 @@ const makeState = (options = {}) => (new State({
   specs: [{ relative: '/test.js', absolute: 'root/test.js', name: 'test.js' }],
   ...options,
 }, fakeConfig))
-
 
 const testSpecFile = `
   <html>
@@ -40,7 +38,7 @@ describe('RunnerCt', () => {
   it('resizes spec list', () => {
     cy.intercept('GET', 'http://localhost:60728/undefined/iframes//test.js', {
       statusCode: 200,
-      body: testSpecFile
+      body: testSpecFile,
     })
 
     mount(
@@ -62,15 +60,15 @@ describe('RunnerCt', () => {
 
       // resize reporter
       cy.get('.Resizer.vertical').eq(1)
-        .trigger('mousedown', { eventConstructor: 'MouseEvent' })
-        .trigger('mousemove', -200, -200, { eventConstructor: 'MouseEvent', force: true })
-        .trigger('mouseup')
-
+      .trigger('mousedown', { eventConstructor: 'MouseEvent' })
+      .trigger('mousemove', -200, -200, { eventConstructor: 'MouseEvent', force: true })
+      .trigger('mouseup')
 
       // AUT scale should be different.
       cy.get('.size-container').then(($el) => {
         const newStyle = $el.attr('style')
         const [, newScale] = newStyle.match(/transform.\s(.+);/)
+
         expect(newScale).not.to.eq(initialScale)
       })
     })

--- a/packages/runner-ct/cypress/component/ResizeSpecList.spec.tsx
+++ b/packages/runner-ct/cypress/component/ResizeSpecList.spec.tsx
@@ -5,6 +5,7 @@ import RunnerCt from '../../src/app/RunnerCt'
 import State from '../../src/lib/state'
 import '@packages/runner/src/main.scss'
 import eventManager from '../../src/lib/event-manager'
+import { testSpecFile } from '../fixtures/testSpecFile'
 
 const fakeConfig = { projectName: 'Project', env: {}, isTextTerminal: false } as any as Cypress.RuntimeConfigOptions
 const makeState = (options = {}) => (new State({
@@ -13,22 +14,6 @@ const makeState = (options = {}) => (new State({
   specs: [{ relative: '/test.js', absolute: 'root/test.js', name: 'test.js' }],
   ...options,
 }, fakeConfig))
-
-const testSpecFile = `
-  <html>
-    <head>
-      <meta charset="utf-8">
-      <meta http-equiv="X-UA-Compatible" content="IE=edge">
-      <meta name="viewport" content="width=device-width,initial-scale=1.0">
-      <title>Components App</title>
-    </head>
-    <body>
-      <div id="__cy_root"></div>
-    <script type="text/javascript">
-      // NO-OP is fine for now
-    </script></body>
-  </html>
-`
 
 describe('RunnerCt', () => {
   beforeEach(() => {

--- a/packages/runner-ct/cypress/component/ResizeSpecList.spec.tsx
+++ b/packages/runner-ct/cypress/component/ResizeSpecList.spec.tsx
@@ -2,18 +2,10 @@
 import React from 'react'
 import { mount } from '@cypress/react'
 import RunnerCt from '../../src/app/RunnerCt'
-import State from '../../src/lib/state'
 import '@packages/runner/src/main.scss'
 import eventManager from '../../src/lib/event-manager'
 import { testSpecFile } from '../fixtures/testSpecFile'
-
-const fakeConfig = { projectName: 'Project', env: {}, isTextTerminal: false } as any as Cypress.RuntimeConfigOptions
-const makeState = (options = {}) => (new State({
-  reporterWidth: 500,
-  spec: null,
-  specs: [{ relative: '/test.js', absolute: 'root/test.js', name: 'test.js' }],
-  ...options,
-}, fakeConfig))
+import { makeState, fakeConfig } from './utils'
 
 describe('RunnerCt', () => {
   beforeEach(() => {
@@ -30,7 +22,6 @@ describe('RunnerCt', () => {
       <RunnerCt
         state={makeState()}
         eventManager={eventManager}
-        // @ts-ignore - TODO: define a good test config.
         config={fakeConfig}
       />,
     )

--- a/packages/runner-ct/cypress/component/RunnerCt.spec.tsx
+++ b/packages/runner-ct/cypress/component/RunnerCt.spec.tsx
@@ -2,8 +2,8 @@
 import React from 'react'
 import { mount } from '@cypress/react'
 import RunnerCt from '../../src/app/RunnerCt'
-import State from '../../src/lib/state'
 import '@packages/runner/src/main.scss'
+import { makeState, fakeConfig } from './utils'
 
 const selectors = {
   reporter: '[data-cy=reporter]',
@@ -30,14 +30,6 @@ class FakeEventManager {
   notifyRunningSpec = noop
   saveState: Function = () => { }
 }
-
-const fakeConfig = { projectName: 'Project', env: {}, isTextTerminal: false } as any as Cypress.RuntimeConfigOptions
-const makeState = (options = {}) => (new State({
-  reporterWidth: 500,
-  spec: null,
-  specs: [{ relative: '/test.js', absolute: 'root/test.js', name: 'test.js' }],
-  ...options,
-}, fakeConfig))
 
 describe('RunnerCt', () => {
   beforeEach(() => {

--- a/packages/runner-ct/cypress/component/RunnerCt.spec.tsx
+++ b/packages/runner-ct/cypress/component/RunnerCt.spec.tsx
@@ -4,7 +4,6 @@ import { mount } from '@cypress/react'
 import RunnerCt from '../../src/app/RunnerCt'
 import State from '../../src/lib/state'
 import '@packages/runner/src/main.scss'
-import eventManager from '../../src/lib/event-manager'
 
 const selectors = {
   reporter: '[data-cy=reporter]',
@@ -40,25 +39,22 @@ const makeState = (options = {}) => (new State({
   ...options,
 }, fakeConfig))
 
-const testSpecFile = `
-  <html>
-    <head>
-      <meta charset="utf-8">
-      <meta http-equiv="X-UA-Compatible" content="IE=edge">
-      <meta name="viewport" content="width=device-width,initial-scale=1.0">
-      <title>Components App</title>
-    </head>
-    <body>
-      <div id="__cy_root"></div>
-    <script type="text/javascript">
-      // NO-OP is fine for now
-    </script></body>
-  </html>
-`
-
 describe('RunnerCt', () => {
   beforeEach(() => {
     cy.viewport(1000, 500)
+  })
+
+  it('renders RunnerCt', () => {
+    mount(
+      <RunnerCt
+        state={makeState()}
+        // @ts-ignore - this is difficult to stub. Real one breaks things.
+        eventManager={new FakeEventManager()}
+        config={fakeConfig}
+      />,
+    )
+
+    cy.percySnapshot()
   })
 
   it('renders RunnerCt for video recording', () => {

--- a/packages/runner-ct/cypress/component/RunnerCt.spec.tsx
+++ b/packages/runner-ct/cypress/component/RunnerCt.spec.tsx
@@ -4,6 +4,7 @@ import { mount } from '@cypress/react'
 import RunnerCt from '../../src/app/RunnerCt'
 import State from '../../src/lib/state'
 import '@packages/runner/src/main.scss'
+import eventManager from '../../src/lib/event-manager'
 
 const selectors = {
   reporter: '[data-cy=reporter]',
@@ -39,23 +40,27 @@ const makeState = (options = {}) => (new State({
   ...options,
 }, fakeConfig))
 
+const testSpecFile = `
+  <html>
+    <head>
+      <meta charset="utf-8">
+      <meta http-equiv="X-UA-Compatible" content="IE=edge">
+      <meta name="viewport" content="width=device-width,initial-scale=1.0">
+      <title>Components App</title>
+    </head>
+    <body>
+      <div id="__cy_root"></div>
+    <script type="text/javascript">
+      // NO-OP is fine for now
+    </script></body>
+  </html>
+`
+
 describe('RunnerCt', () => {
   beforeEach(() => {
     cy.viewport(1000, 500)
   })
 
-  it('renders RunnerCt', () => {
-    mount(
-      <RunnerCt
-        state={makeState()}
-        // @ts-ignore - this is difficult to stub. Real one breaks things.
-        eventManager={new FakeEventManager()}
-        config={fakeConfig}
-      />,
-    )
-
-    cy.percySnapshot()
-  })
 
   it('renders RunnerCt for video recording', () => {
     mount(

--- a/packages/runner-ct/cypress/component/RunnerCt.spec.tsx
+++ b/packages/runner-ct/cypress/component/RunnerCt.spec.tsx
@@ -61,7 +61,6 @@ describe('RunnerCt', () => {
     cy.viewport(1000, 500)
   })
 
-
   it('renders RunnerCt for video recording', () => {
     mount(
       <RunnerCt

--- a/packages/runner-ct/cypress/component/utils.ts
+++ b/packages/runner-ct/cypress/component/utils.ts
@@ -1,6 +1,6 @@
 import State from '../../src/lib/state'
 
-export const fakeConfig = { projectName: 'Project', env: {}, isTextTerminal: false } as any as Cypress.RuntimeConfigOptions
+export const fakeConfig = { projectName: 'Project', env: {}, isTextTerminal: false } as Partial<Cypress.RuntimeConfigOptions>
 
 export const makeState = (options = {}) => {
   return (new State({

--- a/packages/runner-ct/cypress/component/utils.ts
+++ b/packages/runner-ct/cypress/component/utils.ts
@@ -10,3 +10,9 @@ export const makeState = (options = {}) => {
     ...options,
   }, fakeConfig))
 }
+
+export const getPort = (href: string) => {
+  const [, port] = href.match(/localhost:(.+?)\//)
+
+  return port
+}

--- a/packages/runner-ct/cypress/component/utils.ts
+++ b/packages/runner-ct/cypress/component/utils.ts
@@ -1,0 +1,12 @@
+import State from '../../src/lib/state'
+
+export const fakeConfig = { projectName: 'Project', env: {}, isTextTerminal: false } as any as Cypress.RuntimeConfigOptions
+
+export const makeState = (options = {}) => {
+  return (new State({
+    reporterWidth: 500,
+    spec: null,
+    specs: [{ relative: '/test.js', absolute: 'root/test.js', name: 'test.js' }],
+    ...options,
+  }, fakeConfig))
+}

--- a/packages/runner-ct/cypress/fixtures/testSpecFile.ts
+++ b/packages/runner-ct/cypress/fixtures/testSpecFile.ts
@@ -1,0 +1,15 @@
+export const testSpecFile = `
+  <html>
+    <head>
+      <meta charset="utf-8">
+      <meta http-equiv="X-UA-Compatible" content="IE=edge">
+      <meta name="viewport" content="width=device-width,initial-scale=1.0">
+      <title>Components App</title>
+    </head>
+    <body>
+      <div id="__cy_root"></div>
+    <script type="text/javascript">
+      // NO-OP is fine for now
+    </script></body>
+  </html>
+`

--- a/packages/runner-ct/src/app/RunnerCt.tsx
+++ b/packages/runner-ct/src/app/RunnerCt.tsx
@@ -166,7 +166,7 @@ const RunnerCt = namedObserver('RunnerCt',
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
-    function updateSpecListWidth(width: number) {
+    function updateSpecListWidth (width: number) {
       state.updateSpecListWidth(width)
     }
 

--- a/packages/runner-ct/src/app/RunnerCt.tsx
+++ b/packages/runner-ct/src/app/RunnerCt.tsx
@@ -166,7 +166,7 @@ const RunnerCt = namedObserver('RunnerCt',
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
-    function updateSpecListWidth (width: number) {
+    const updateSpecListWidth = (width: number) => {
       state.updateSpecListWidth(width)
     }
 

--- a/packages/runner-ct/src/app/RunnerCt.tsx
+++ b/packages/runner-ct/src/app/RunnerCt.tsx
@@ -166,6 +166,10 @@ const RunnerCt = namedObserver('RunnerCt',
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
+    function updateSpecListWidth(width: number) {
+      state.updateSpecListWidth(width)
+    }
+
     return (
       <SplitPane
         split="vertical"
@@ -193,7 +197,7 @@ const RunnerCt = namedObserver('RunnerCt',
             borderLeft: '1px solid rgba(230, 232, 234, 1)' /* $metal-20 */,
           }}
           onDragFinished={persistWidth('ctSpecListWidth')}
-          onChange={debounce(state.updateSpecListWidth)}
+          onChange={debounce(updateSpecListWidth)}
         >
           <SpecList
             specs={props.state.specs}

--- a/packages/runner-ct/src/app/SpecContent.tsx
+++ b/packages/runner-ct/src/app/SpecContent.tsx
@@ -83,7 +83,7 @@ export const SpecContent = namedObserver('SpecContent', (props: SpecContentProps
 })
 
 const SpecContentWrapper = namedObserver('SpecContentWrapper', (props: React.PropsWithChildren<SpecContentWrapperProps>) => {
-  function updateReporterWidth(width: number) {
+  function updateReporterWidth (width: number) {
     props.state.updateReporterWidth(width)
   }
 

--- a/packages/runner-ct/src/app/SpecContent.tsx
+++ b/packages/runner-ct/src/app/SpecContent.tsx
@@ -83,7 +83,7 @@ export const SpecContent = namedObserver('SpecContent', (props: SpecContentProps
 })
 
 const SpecContentWrapper = namedObserver('SpecContentWrapper', (props: React.PropsWithChildren<SpecContentWrapperProps>) => {
-  function updateReporterWidth (width: number) {
+  const updateReporterWidth = (width: number) => {
     props.state.updateReporterWidth(width)
   }
 

--- a/packages/runner-ct/src/app/SpecContent.tsx
+++ b/packages/runner-ct/src/app/SpecContent.tsx
@@ -30,6 +30,10 @@ interface SpecContentWrapperProps {
 }
 
 export const SpecContent = namedObserver('SpecContent', (props: SpecContentProps) => {
+  function updatePluginsHeight (height: number) {
+    props.state.updatePluginsHeight(height)
+  }
+
   return (
     <SpecContentWrapper state={props.state} onSplitPaneChange={props.state.updateReporterWidth}>
       <ReporterContainer
@@ -46,7 +50,7 @@ export const SpecContent = namedObserver('SpecContent', (props: SpecContentProps
             ? props.state.pluginsHeight
           // show the small not resize-able panel with buttons or nothing
             : props.state.isAnyPluginToShow ? PLUGIN_BAR_HEIGHT : 0)}
-        onChange={debounce(props.state.updatePluginsHeight)}
+        onChange={debounce(updatePluginsHeight)}
       >
         <div className={cs(
           'runner',
@@ -78,19 +82,29 @@ export const SpecContent = namedObserver('SpecContent', (props: SpecContentProps
   )
 })
 
-const SpecContentWrapper = namedObserver('SpecContentWrapper', (props: React.PropsWithChildren<SpecContentWrapperProps>) => props.state.spec ? (
-  <SplitPane
-    split='vertical'
-    minSize={hideReporterIfNecessary(props.state, () => 100)}
-    maxSize={hideReporterIfNecessary(props.state, () => 600)}
-    defaultSize={hideReporterIfNecessary(props.state, () => props.state.reporterWidth)}
-    className='primary'
-    onChange={debounce(props.onSplitPaneChange)}
-  >
-    {props.children}
-  </SplitPane>
-) : (
-  <div>
-    {props.children}
-  </div>
-))
+const SpecContentWrapper = namedObserver('SpecContentWrapper', (props: React.PropsWithChildren<SpecContentWrapperProps>) => {
+  function updateReporterWidth(width: number) {
+    props.state.updateReporterWidth(width)
+  }
+
+  if (props.state.spec) {
+    return (
+      <SplitPane
+        split='vertical'
+        minSize={hideReporterIfNecessary(props.state, () => 100)}
+        maxSize={hideReporterIfNecessary(props.state, () => 600)}
+        defaultSize={hideReporterIfNecessary(props.state, () => props.state.reporterWidth)}
+        className='primary'
+        onChange={debounce(updateReporterWidth)}
+      >
+        {props.children}
+      </SplitPane>
+    )
+  }
+
+  return (
+    <div>
+      {props.children}
+    </div>
+  )
+})

--- a/packages/runner-ct/src/iframe/iframes.scss
+++ b/packages/runner-ct/src/iframe/iframes.scss
@@ -6,8 +6,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  // 40px is hard-coded in RunnerCt. Height of plugins bar.
-  height: calc(100% - 40px);
 }
 
 .iframes-ct-container-screenshotting {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://cypress-io.atlassian.net/browse/CT-390

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

N/A - this product is not user facing yet.


### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

In [this refactor](https://github.com/cypress-io/cypress/pull/15617) the AUT scaling was broken. I am not 100% clear on exactly why but [this does not work](https://github.com/cypress-io/cypress/pull/15617/files#diff-8503e32c6d767fd2ddb45768cb4514dad1a1c40940db86dfbf9fe5a71ea2d4f9R50) as you'd expect. When doing

```tsx
<SplitPane
  onChange={debounce(props.state.updatePluginsHeight)}
/>
```

The `props.state.updatePluginsHeight` function will always receive the same width. I guess it is capturing the initial argument in the closure?

I fixed it by doing this:

```tsx

function onChange (width: number) {
  props.state.updatePluginsHeight(width)
}

<SplitPane
  onChange={debounce(onChange)}
/>
```

The RunnerCt test infra is not perfect, but I managed to add some tests. Oddly enough, tests using a real `eventManager` must be *one per file* or bizarre things happen and `window.Cypress` is undefined. I tried debugging this but I couldn't see the problem. For now, this is a good work around to prevent this regression for what feels like the 10th time.


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Now the AUT correctly scales when you resize the panes.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)--> 
