### PR TITLE
fix: remove failing imports

### DIFF
--- a/npm/design-system/src/index.scss
+++ b/npm/design-system/src/index.scss
@@ -1,7 +1,4 @@
 // Color map
-@import '~@fortawesome/fontawesome-free/css/all.min.css';
-@import '~normalize.css';
-
 $colors: (
   black: rgba(0, 0, 0, 1),
   metal-90: rgba(33, 36, 38, 1),


### PR DESCRIPTION
The normalize and fontawesome css files were never succesfully imported.
Nobody complained, and the errors in the command prompts are triggering. 
If we want to load normalize in the future, I suggest to do it in a separate PR.

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes CT-381

### User facing changelog

Errors `Refused to apply style` are gone from the console in open-ct

### Additional details
The two file had `@import` statements that were left as is during compilation. At runtime, the server tried to reach those files but given the context could not find it.
If these files need to be in the stack it would be nice to inline them.
For now, there is no regression and the error is gone.

