### PR TITLE
fix: position: sticky visibility.

### DIFF
--- a/packages/driver/cypress/fixtures/sticky.html
+++ b/packages/driver/cypress/fixtures/sticky.html
@@ -1,0 +1,29 @@
+<html>
+<body>
+  <div id="parent" style="display:flex; height: 90vh;">
+    <div id="Preselect" style="flex:1; background-color:aquamarine; height: 100%;">
+      Preselect
+    </div>
+    <div id="Details" style="flex:1; background-color:blue; height: 100%; overflow:scroll;">
+      Details
+      <div id="modal" style="background-color: chartreuse; height: 80vh; width: 90%; position: fixed; display: block; left:5%; top:5%;">
+        <div id="sticky" style="background-color: darkgray; position:sticky; bottom: 10%; width:9%; height:10%;">
+          <button id="button" style="background-color: darkred; color:white;">
+            click me
+          </button>
+          <div id="message"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+<script>
+  const btn = document.getElementById('button')
+  const msg = document.getElementById('message')
+
+  btn.onclick = (e) => {
+    msg.innerHTML = 'Success!'
+  }
+</script>
+
+</html>

--- a/packages/driver/cypress/integration/dom/visibility_spec.ts
+++ b/packages/driver/cypress/integration/dom/visibility_spec.ts
@@ -780,6 +780,11 @@ describe('src/cypress/dom/visibility', () => {
         expect(this.$childPointerEventsNone.find('span')).to.be.visible
         expect(this.$childPointerEventsNone.find('span')).to.not.be.hidden
       })
+
+      it('is visible when position: sticky', () => {
+        cy.visit('fixtures/sticky.html')
+        cy.get('#button').should('be.visible')
+      })
     })
 
     describe('css display', function () {

--- a/packages/driver/src/dom/visibility.js
+++ b/packages/driver/src/dom/visibility.js
@@ -87,7 +87,7 @@ const isHidden = (el, methodName = 'isHidden()', options = { checkOpacity: true 
     return true // is hidden
   }
 
-  if (elOrAncestorIsFixed($el)) {
+  if (elOrAncestorIsFixedOrSticky($el)) {
     return elIsNotElementFromPoint($el)
   }
 
@@ -218,12 +218,8 @@ const canClipContent = function ($el, $ancestor) {
   return true
 }
 
-const elOrAncestorIsFixed = function ($el) {
-  const $stickyOrFixedEl = $elements.getFirstFixedOrStickyPositionParent($el)
-
-  if ($stickyOrFixedEl) {
-    return $stickyOrFixedEl.css('position') === 'fixed'
-  }
+const elOrAncestorIsFixedOrSticky = function ($el) {
+  return !!$elements.getFirstFixedOrStickyPositionParent($el)
 }
 
 const elAtCenterPoint = function ($el) {
@@ -509,7 +505,7 @@ const getReasonIsHidden = function ($el, options = { checkOpacity: true }) {
   }
 
   // nested else --___________--
-  if (elOrAncestorIsFixed($el)) {
+  if (elOrAncestorIsFixedOrSticky($el)) {
     if (elIsNotElementFromPoint($el)) {
       // show the long element here
       const covered = $elements.stringify(elAtCenterPoint($el))


### PR DESCRIPTION
- Closes #14938

### User facing changelog

It checks the visibility correctly when an element has "position: sticky".

### Additional details
- Why was this change necessary? => visibility function doesn't handle "position: sticky" properly.
- What is affected by this change? => N/A
- Any implementation details to explain? => N/A

### How has the user experience changed?

N/A

### PR Tasks
- [x] Have tests been added/updated?
