### PR TITLE
feat: rename delayMs, res.throttle, res.delay

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1230,8 +1230,8 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
     it('can delay and throttle a StaticResponse', function (done) {
       const payload = 'A'.repeat(10 * 1024)
       const throttleKbps = 10
-      const delayMs = 250
-      const expectedSeconds = payload.length / (1024 * throttleKbps) + delayMs / 1000
+      const delay = 250
+      const expectedSeconds = payload.length / (1024 * throttleKbps) + delay / 1000
 
       cy.intercept('/timeout*', (req) => {
         this.start = Date.now()
@@ -1240,7 +1240,7 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
           statusCode: 200,
           body: payload,
           throttleKbps,
-          delayMs,
+          delay,
         })
       }).then(() => {
         return $.get('/timeout').then((responseText) => {
@@ -1252,15 +1252,33 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
       })
     })
 
+    it('can delay with deprecated delayMs param', function (done) {
+      const delay = 250
+
+      cy.intercept('/timeout', (req) => {
+        this.start = Date.now()
+
+        req.reply({
+          delay,
+        })
+      }).then(() => {
+        return $.get('/timeout').then((responseText) => {
+          expect(Date.now() - this.start).to.be.closeTo(250 + 100, 100)
+
+          done()
+        })
+      })
+    })
+
     // @see https://github.com/cypress-io/cypress/issues/14446
     it('should delay the same amount on every response', () => {
-      const delayMs = 250
+      const delay = 250
 
       const testDelay = () => {
         const start = Date.now()
 
         return $.get('/timeout').then((responseText) => {
-          expect(Date.now() - start).to.be.closeTo(delayMs, 50)
+          expect(Date.now() - start).to.be.closeTo(delay, 50)
           expect(responseText).to.eq('foo')
         })
       }
@@ -1268,7 +1286,7 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
       cy.intercept('/timeout*', {
         statusCode: 200,
         body: 'foo',
-        delayMs,
+        delay,
       }).as('get')
       .then(() => testDelay()).wait('@get')
       .then(() => testDelay()).wait('@get')
@@ -1910,15 +1928,15 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
       const payload = 'A'.repeat(10 * 1024)
       const kbps = 20
       let expectedSeconds = payload.length / (1024 * kbps)
-      const delayMs = 500
+      const delay = 500
 
-      expectedSeconds += delayMs / 1000
+      expectedSeconds += delay / 1000
 
       cy.intercept('/timeout*', (req) => {
         req.reply((res) => {
           this.start = Date.now()
 
-          res.throttle(kbps).delay(delayMs).send({
+          res.throttle(kbps).delay(delay).send({
             statusCode: 200,
             body: payload,
           })
@@ -2195,8 +2213,8 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
       it('can delay and throttle', function (done) {
         const payload = 'A'.repeat(10 * 1024)
         const throttleKbps = 50
-        const delayMs = 50
-        const expectedSeconds = payload.length / (1024 * throttleKbps) + delayMs / 1000
+        const delay = 50
+        const expectedSeconds = payload.length / (1024 * throttleKbps) + delay / 1000
 
         cy.intercept('/timeout*', (req) => {
           req.reply((res) => {
@@ -2207,7 +2225,7 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
               statusCode: 200,
               body: payload,
               throttleKbps,
-              delayMs,
+              delay,
             })
           })
         }).then(() => {

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1253,13 +1253,13 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
     })
 
     it('can delay with deprecated delayMs param', function (done) {
-      const delay = 250
+      const delayMs = 250
 
-      cy.intercept('/timeout', (req) => {
+      cy.intercept('/timeout*', (req) => {
         this.start = Date.now()
 
         req.reply({
-          delay,
+          delayMs,
         })
       }).then(() => {
         return $.get('/timeout').then((responseText) => {
@@ -1844,12 +1844,12 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
       })
     })
 
-    it('can delay a proxy response using res.delay', function (done) {
+    it('can delay a proxy response using res.setDelay', function (done) {
       cy.intercept('/timeout*', (req) => {
         req.reply((res) => {
           this.start = Date.now()
 
-          res.delay(1000).send('delay worked')
+          res.setDelay(1000).send('delay worked')
         })
       }).then(() => {
         $.get('/timeout')
@@ -1882,7 +1882,7 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
       })
     })
 
-    it('can throttle a proxy response using res.throttle', function (done) {
+    it('can throttle a proxy response using res.setThrottle', function (done) {
       cy.intercept('/1mb*', (req) => {
         // don't let gzip make response smaller and throw off the timing
         delete req.headers['accept-encoding']
@@ -1890,7 +1890,7 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
         req.reply((res) => {
           this.start = Date.now()
 
-          res.throttle(1024).send()
+          res.setThrottle(1024).send()
         })
       }).then(() => {
         $.get('/1mb').done((responseText) => {
@@ -1903,7 +1903,7 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
       })
     })
 
-    it('can throttle a static response using res.throttle', function (done) {
+    it('can throttle a static response using res.setThrottle', function (done) {
       const payload = 'A'.repeat(10 * 1024)
       const kbps = 10
       const expectedSeconds = payload.length / (1024 * kbps)
@@ -1912,7 +1912,7 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
         req.reply((res) => {
           this.start = Date.now()
 
-          res.throttle(kbps).send(payload)
+          res.setThrottle(kbps).send(payload)
         })
       }).then(() => {
         $.get('/timeout').done((responseText) => {
@@ -1936,7 +1936,7 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
         req.reply((res) => {
           this.start = Date.now()
 
-          res.throttle(kbps).delay(delay).send({
+          res.setThrottle(kbps).setDelay(delay).send({
             statusCode: 200,
             body: payload,
           })
@@ -2221,7 +2221,7 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
             this.start = Date.now()
 
             // ensure .throttle and .delay are overridden
-            res.throttle(1e6).delay(1).send({
+            res.setThrottle(1e6).setDelay(1).send({
               statusCode: 200,
               body: payload,
               throttleKbps,

--- a/packages/driver/src/cy/net-stubbing/add-command.ts
+++ b/packages/driver/src/cy/net-stubbing/add-command.ts
@@ -139,6 +139,7 @@ function validateRouteMatcherOptions (routeMatcher: RouteMatcherOptions): { isVa
     }
   }
 
+  // @ts-ignore
   if (routeMatcher.matchUrlAgainstPath) {
     return err(`\`matchUrlAgainstPath\` was removed in Cypress 7.0.0 and should be removed from your tests. Your tests will run the same. For more information, visit https://on.cypress.io/migration-guide`)
   }

--- a/packages/driver/src/cy/net-stubbing/events/response.ts
+++ b/packages/driver/src/cy/net-stubbing/events/response.ts
@@ -84,8 +84,8 @@ export const onResponse: HandlerFn<CyHttpMessages.IncomingResponse> = async (Cyp
 
       return sendContinueFrame(true)
     },
-    delay (delayMs) {
-      res.delayMs = delayMs
+    delay (delay) {
+      res.delayMs = delay
 
       return this
     },

--- a/packages/driver/src/cy/net-stubbing/events/response.ts
+++ b/packages/driver/src/cy/net-stubbing/events/response.ts
@@ -84,12 +84,12 @@ export const onResponse: HandlerFn<CyHttpMessages.IncomingResponse> = async (Cyp
 
       return sendContinueFrame(true)
     },
-    delay (delay) {
-      res.delayMs = delay
+    setDelay (delay) {
+      res.delay = delay
 
       return this
     },
-    throttle (throttleKbps) {
+    setThrottle (throttleKbps) {
       res.throttleKbps = throttleKbps
 
       return this

--- a/packages/driver/src/cy/net-stubbing/static-response-utils.ts
+++ b/packages/driver/src/cy/net-stubbing/static-response-utils.ts
@@ -11,14 +11,14 @@ import {
 import $errUtils from '../../cypress/error_utils'
 
 // user-facing StaticResponse only
-export const STATIC_RESPONSE_KEYS: (keyof StaticResponse)[] = ['body', 'fixture', 'statusCode', 'headers', 'forceNetworkError', 'throttleKbps', 'delayMs']
+export const STATIC_RESPONSE_KEYS: (keyof StaticResponse)[] = ['body', 'fixture', 'statusCode', 'headers', 'forceNetworkError', 'throttleKbps', 'delay', 'delayMs']
 
 export function validateStaticResponse (cmd: string, staticResponse: StaticResponse): void {
   const err = (message) => {
     $errUtils.throwErrByPath('net_stubbing.invalid_static_response', { args: { cmd, message, staticResponse } })
   }
 
-  const { body, fixture, statusCode, headers, forceNetworkError, throttleKbps, delayMs } = staticResponse
+  const { body, fixture, statusCode, headers, forceNetworkError, throttleKbps, delay, delayMs } = staticResponse
 
   if (forceNetworkError && (body || statusCode || headers)) {
     err('`forceNetworkError`, if passed, must be the only option in the StaticResponse.')
@@ -46,8 +46,16 @@ export function validateStaticResponse (cmd: string, staticResponse: StaticRespo
     err('`throttleKbps` must be a finite, positive number.')
   }
 
+  if (delayMs && delay) {
+    err('`delayMs` and `delay` cannot both be set.')
+  }
+
   if (delayMs && (!_.isFinite(delayMs) || delayMs < 0)) {
     err('`delayMs` must be a finite, positive number.')
+  }
+
+  if (delay && (!_.isFinite(delay) || delay < 0)) {
+    err('`delay` must be a finite, positive number.')
   }
 }
 
@@ -91,7 +99,12 @@ function getFixtureOpts (fixture: string): FixtureOpts {
 }
 
 export function getBackendStaticResponse (staticResponse: Readonly<StaticResponse>): BackendStaticResponse {
-  const backendStaticResponse: BackendStaticResponse = _.omit(staticResponse, 'body', 'fixture')
+  const backendStaticResponse: BackendStaticResponse = _.omit(staticResponse, 'body', 'fixture', 'delayMs')
+
+  if (staticResponse.delayMs) {
+    // support deprecated `delayMs` usage
+    backendStaticResponse.delay = staticResponse.delayMs
+  }
 
   if (staticResponse.fixture) {
     backendStaticResponse.fixture = getFixtureOpts(staticResponse.fixture)

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -98,7 +98,7 @@ export namespace CyHttpMessages {
     /**
      * Milliseconds to delay before the response is sent.
      */
-    delayMs?: number
+    delay?: number
   }
 
   export type IncomingHttpResponse = IncomingResponse & {
@@ -115,11 +115,11 @@ export namespace CyHttpMessages {
     /**
      * Wait for `delay` milliseconds before sending the response to the client.
      */
-    delay: (delay: number) => IncomingHttpResponse
+    setDelay: (delay: number) => IncomingHttpResponse
     /**
      * Serve the response at `throttleKbps` kilobytes per second.
      */
-    throttle: (throttleKbps: number) => IncomingHttpResponse
+    setThrottle: (throttleKbps: number) => IncomingHttpResponse
   }
 
   export type IncomingRequest = BaseMessage & {

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -113,9 +113,9 @@ export namespace CyHttpMessages {
      */
     send(): void
     /**
-     * Wait for `delayMs` milliseconds before sending the response to the client.
+     * Wait for `delay` milliseconds before sending the response to the client.
      */
-    delay: (delayMs: number) => IncomingHttpResponse
+    delay: (delay: number) => IncomingHttpResponse
     /**
      * Serve the response at `throttleKbps` kilobytes per second.
      */
@@ -379,7 +379,13 @@ export type RouteHandler = string | StaticResponse | RouteHandlerController | ob
 /**
  * Describes a response that will be sent back to the browser to fulfill the request.
  */
-export type StaticResponse = GenericStaticResponse<string, string | object | boolean | null>
+export type StaticResponse = GenericStaticResponse<string, string | object | boolean | null> & {
+  /**
+   * Milliseconds to delay before the response is sent.
+   * @deprecated Use `delay` instead of `delayMs`.
+   */
+  delayMs?: number
+}
 
 export interface GenericStaticResponse<Fixture, Body> {
   /**
@@ -413,7 +419,7 @@ export interface GenericStaticResponse<Fixture, Body> {
   /**
    * Milliseconds to delay before the response is sent.
    */
-  delayMs?: number
+  delay?: number
 }
 
 /**

--- a/packages/net-stubbing/lib/internal-types.ts
+++ b/packages/net-stubbing/lib/internal-types.ts
@@ -27,7 +27,7 @@ export const SERIALIZABLE_RES_PROPS = _.concat(
   SERIALIZABLE_REQ_PROPS,
   'statusCode',
   'statusMessage',
-  'delayMs',
+  'delay',
   'throttleKbps',
 )
 

--- a/packages/net-stubbing/lib/server/middleware/response.ts
+++ b/packages/net-stubbing/lib/server/middleware/response.ts
@@ -80,7 +80,7 @@ export const InterceptResponse: ResponseMiddleware = async function () {
 
   mergeChanges(request.res as any, modifiedRes)
 
-  const bodyStream = getBodyStream(modifiedRes.body, _.pick(modifiedRes, ['throttleKbps', 'delayMs']) as any)
+  const bodyStream = getBodyStream(modifiedRes.body, _.pick(modifiedRes, ['throttleKbps', 'delay']) as any)
 
   return request.continueResponse!(bodyStream)
 }

--- a/packages/net-stubbing/lib/server/util.ts
+++ b/packages/net-stubbing/lib/server/util.ts
@@ -167,13 +167,13 @@ export function sendStaticResponse (backendRequest: Pick<InterceptedRequest, 're
     body,
   })
 
-  const bodyStream = getBodyStream(body, _.pick(staticResponse, 'throttleKbps', 'delayMs'))
+  const bodyStream = getBodyStream(body, _.pick(staticResponse, 'throttleKbps', 'delay'))
 
   onResponse!(incomingRes, bodyStream)
 }
 
-export function getBodyStream (body: Buffer | string | Readable | undefined, options: { delayMs?: number, throttleKbps?: number }): Readable {
-  const { delayMs, throttleKbps } = options
+export function getBodyStream (body: Buffer | string | Readable | undefined, options: { delay?: number, throttleKbps?: number }): Readable {
+  const { delay, throttleKbps } = options
   const pt = new PassThrough()
 
   const sendBody = () => {
@@ -197,7 +197,7 @@ export function getBodyStream (body: Buffer | string | Readable | undefined, opt
     return writable.end()
   }
 
-  delayMs ? setTimeout(sendBody, delayMs) : sendBody()
+  delay ? setTimeout(sendBody, delay) : sendBody()
 
   return pt
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- issue number here. e.g. "Closes #1234" -->

### User facing changelog

- BREAKING CHANGE: The `res.throttle` and `res.delay` functions on responses yielded to `cy.intercept()` response handlers have been renamed to `res.setThrottle` and `res.setDelay`.

### Additional details

- `delayMs` is renamed to `delay`, `delayMs` is backwards-compatible (original PR: #14822) 
    - this was reverted, but the reversion was never released, so no new changelog item

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
