### PR TITLE
chore: Add test-runner team as code owners of packages/cli

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Each line is a file pattern followed by one or more owners.
+
+# Test Runner team are owners of code within root packages and cli
+/packages/  @cypress-io/test-runner
+/cli/  @cypress-io/test-runner

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,26 @@
 # Each line is a file pattern followed by one or more owners.
 
 # Test Runner team are owners of code within root packages and cli
-/packages/  @cypress-io/test-runner
 /cli/  @cypress-io/test-runner
+/packages/coffee/  @cypress-io/test-runner
+/packages/datetime-utils/  @cypress-io/test-runner
+/packages/desktop-gui/  @cypress-io/test-runner
+/packages/driver/  @cypress-io/test-runner
+/packages/electron/  @cypress-io/test-runner
+/packages/example/  @cypress-io/test-runner
+/packages/extension/  @cypress-io/test-runner
+/packages/https-proxy/  @cypress-io/test-runner
+/packages/launcher/  @cypress-io/test-runner
+/packages/net-stubbing/  @cypress-io/test-runner
+/packages/network/  @cypress-io/test-runner
+/packages/proxy/  @cypress-io/test-runner
+/packages/reporter/  @cypress-io/test-runner
+/packages/rewriter/  @cypress-io/test-runner
+/packages/root/  @cypress-io/test-runner
+/packages/runner/  @cypress-io/test-runner
+/packages/server/  @cypress-io/test-runner
+/packages/socket/  @cypress-io/test-runner
+/packages/static/  @cypress-io/test-runner
+/packages/ts/  @cypress-io/test-runner
+/packages/ui-components/  @cypress-io/test-runner
+/packages/web-config/  @cypress-io/test-runner


### PR DESCRIPTION
### Summary

This should request review from the Test Runner team for any PRs that are opened that touch the code within the root `packages` (except for `runner-ct` and `server-ct`) or `cli` directories.

This should then follow the rules of our PR assignment (selecting 2 TR team members to review based on our PR review criteria) *Note: we may want to revisit this logic since we don’t use it anymore*

**We are not required to review the code before it can be merged in.**

This should hopefully serve as a notification to our team of PRs requiring us to look at it.

### Additional Details

Code owners file does not allow `!` negate syntax lol.

---

>Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. 
>
>Code owners are not automatically requested to review draft pull requests.
>
>https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

