### PR TITLE
chore: Turn on test retries in run mode for other packages

### DIFF
--- a/packages/reporter/cypress.json
+++ b/packages/reporter/cypress.json
@@ -6,5 +6,9 @@
   "reporter": "../../node_modules/cypress-multi-reporters/index.js",
   "reporterOptions": {
     "configFile": "../../mocha-reporter-config.json"
+  },
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
   }
 }

--- a/packages/runner/cypress.json
+++ b/packages/runner/cypress.json
@@ -1,4 +1,8 @@
 {
   "projectId": "ypt4pf",
-  "baseUrl": "http://localhost:3500"
+  "baseUrl": "http://localhost:3500",
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
+  }
 }

--- a/packages/runner/cypress/integration/retries.mochaEvents.spec.js
+++ b/packages/runner/cypress/integration/retries.mochaEvents.spec.js
@@ -18,7 +18,7 @@ const threeTestsWithRetry = {
   },
 }
 
-describe('src/cypress/runner retries mochaEvents', () => {
+describe('src/cypress/runner retries mochaEvents', { retries: 0 }, () => {
   // NOTE: for test-retries
   it('can set retry config', () => {
     runIsolatedCypress({}, { config: { retries: 1 } })

--- a/packages/runner/cypress/integration/runner.mochaEvents.spec.js
+++ b/packages/runner/cypress/integration/runner.mochaEvents.spec.js
@@ -13,7 +13,7 @@ const threeTestsWithHooks = {
   suites: { 'suite 1': { hooks: ['before', 'beforeEach', 'afterEach', 'after'], tests: ['test 1', 'test 2', 'test 3'] } },
 }
 
-describe('src/cypress/runner', () => {
+describe('src/cypress/runner', { retries: 0 }, () => {
   describe('tests finish with correct state', () => {
     describe('hook failures', () => {
       it('fail in [before]', () => {

--- a/packages/runner/cypress/integration/studio.mochaEvents.spec.js
+++ b/packages/runner/cypress/integration/studio.mochaEvents.spec.js
@@ -1,7 +1,7 @@
 const helpers = require('../support/helpers')
 
 const { createCypress } = helpers
-const { runIsolatedCypress, snapshotMochaEvents } = createCypress({ config: { experimentalStudio: true, isTextTerminal: true } })
+const { runIsolatedCypress, snapshotMochaEvents } = createCypress({ config: { experimentalStudio: true, isTextTerminal: true, retries: 0 } })
 
 describe('studio mocha events', () => {
   it('only runs a single test by id', () => {

--- a/packages/runner/cypress/integration/studio.mochaEvents.spec.js
+++ b/packages/runner/cypress/integration/studio.mochaEvents.spec.js
@@ -3,7 +3,7 @@ const helpers = require('../support/helpers')
 const { createCypress } = helpers
 const { runIsolatedCypress, snapshotMochaEvents } = createCypress({ config: { experimentalStudio: true, isTextTerminal: true, retries: 0 } })
 
-describe('studio mocha events', () => {
+describe('studio mocha events', { retries: 0 }, () => {
   it('only runs a single test by id', () => {
     runIsolatedCypress('cypress/fixtures/studio/basic_spec.js', {
       state: {

--- a/packages/ui-components/cypress.json
+++ b/packages/ui-components/cypress.json
@@ -4,5 +4,9 @@
   "reporter": "../../node_modules/cypress-multi-reporters/index.js",
   "reporterOptions": {
     "configFile": "../../mocha-reporter-config.json"
+  },
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
   }
 }


### PR DESCRIPTION
We’d like to use test retries for the UIs tested in Cypress (outside of the driver)