### PR TITLE
chore: exit with non-zero exit code on signal exit

### DIFF
--- a/packages/electron/lib/electron.js
+++ b/packages/electron/lib/electron.js
@@ -136,12 +136,12 @@ module.exports = {
       }
 
       return cp.spawn(execPath, argv, { stdio: 'inherit' })
-      .on('close', (code, errCode) => {
-        debug('electron closing %o', { code, errCode })
+      .on('close', (code, signal) => {
+        debug('electron closing %o', { code, signal })
 
-        if (code) {
-          debug('original command was')
-          debug(execPath, argv.join(' '))
+        if (signal) {
+          debug('electron exited with a signal, forcing code = 1 %o', { signal })
+          code = 1
         }
 
         if (cb) {

--- a/packages/server/test/e2e/7_record_spec.js
+++ b/packages/server/test/e2e/7_record_spec.js
@@ -1158,6 +1158,7 @@ describe('e2e record', () => {
           spec: '*_record.spec*',
           group: 'foo',
           ciBuildId: 1,
+          expectedExitCode: 1,
           record: true,
           snapshot: true,
         })
@@ -1181,6 +1182,7 @@ describe('e2e record', () => {
           record: true,
           group: 'foo',
           ciBuildId: 'ciBuildId123',
+          expectedExitCode: 1,
           parallel: true,
           snapshot: true,
         })


### PR DESCRIPTION
Internal-only - CLI already catches this correctly.

