### PR TITLE
feat: adding electron support for cypress component testing

### DIFF
--- a/cli/lib/exec/open.js
+++ b/cli/lib/exec/open.js
@@ -36,7 +36,7 @@ module.exports = {
     }
 
     if (isComponentTesting) {
-      args.push('--componentTesting')
+      args.push('--testing-type', 'component')
     }
 
     debug('opening from options %j', options)

--- a/cli/lib/exec/run.js
+++ b/cli/lib/exec/run.js
@@ -184,7 +184,7 @@ module.exports = {
       }
 
       if (isComponentTesting) {
-        args.push('--componentTesting')
+        args.push('--testing-type', 'component')
       }
 
       debug('run to spawn.start args %j', args)

--- a/cli/test/lib/cli_spec.js
+++ b/cli/test/lib/cli_spec.js
@@ -630,12 +630,14 @@ describe('cli', () => {
 
     it('spawns server with correct args for component-testing', () => {
       this.exec('open-ct --dev')
-      expect(spawn.start.firstCall.args[0]).to.include('--componentTesting')
+      expect(spawn.start.firstCall.args[0]).to.include('--testing-type')
+      expect(spawn.start.firstCall.args[0]).to.include('component')
     })
 
     it('runs server with correct args for component-testing', () => {
       this.exec('run-ct --dev')
-      expect(spawn.start.firstCall.args[0]).to.include('--componentTesting')
+      expect(spawn.start.firstCall.args[0]).to.include('--testing-type')
+      expect(spawn.start.firstCall.args[0]).to.include('component')
     })
 
     it('does display open-ct command in the help', () => {

--- a/npm/eslint-plugin-dev/lib/index.js
+++ b/npm/eslint-plugin-dev/lib/index.js
@@ -50,6 +50,8 @@ const baseRules = {
     'error',
     2,
     {
+      // TODO: fix this, we shouldn't need to ignore TemplateLiterals
+      'ignoredNodes': ['TemplateLiteral'],
       'SwitchCase': 1,
       'MemberExpression': 0,
     },
@@ -193,7 +195,8 @@ const baseRules = {
   ],
   'space-infix-ops': 'error',
   'space-unary-ops': 'error',
-  'template-curly-spacing': 'error',
+  // TODO: change this back to 'error'
+  'template-curly-spacing': 'off',
   'use-isnan': 'error',
   'valid-typeof': 'error',
 }

--- a/packages/server/lib/browsers/electron.js
+++ b/packages/server/lib/browsers/electron.js
@@ -23,15 +23,10 @@ let instance = null
 
 const tryToCall = function (win, method) {
   try {
-    debug('win is destroyed', win.isDestroyed())
     if (!win.isDestroyed()) {
       if (_.isString(method)) {
-        debug('calling win at method as string', method, win[method])
-
         return win[method]()
       }
-
-      debug('invoking method directly', method)
 
       return method()
     }

--- a/packages/server/lib/browsers/electron.js
+++ b/packages/server/lib/browsers/electron.js
@@ -23,10 +23,15 @@ let instance = null
 
 const tryToCall = function (win, method) {
   try {
+    debug('win is destroyed', win.isDestroyed())
     if (!win.isDestroyed()) {
       if (_.isString(method)) {
+        debug('calling win at method as string', method, win[method])
+
         return win[method]()
       }
+
+      debug('invoking method directly', method)
 
       return method()
     }

--- a/packages/server/lib/browsers/index.js
+++ b/packages/server/lib/browsers/index.js
@@ -10,20 +10,18 @@ const check = require('check-more-types')
 const isBrowserFamily = check.oneOf(['chromium', 'firefox'])
 
 let instance = null
-let instanceIsBeingDestroyed = false
 
 const kill = function (unbind) {
-  // When closing our running browser instance we must take care
-  // to avoid calling methods twice on it
-  if (!instance || instanceIsBeingDestroyed) {
+  // Clean up the instance when the browser is closed
+  if (!instance) {
     return Promise.resolve()
   }
-
-  instanceIsBeingDestroyed = true
 
   return new Promise((resolve) => {
     if (unbind) {
       instance.removeAllListeners()
+
+      return resolve.apply(null, [unbind])
     }
 
     instance.once('exit', (...args) => {
@@ -41,8 +39,6 @@ const kill = function (unbind) {
 }
 
 const cleanup = () => {
-  instanceIsBeingDestroyed = false
-
   return instance = null
 }
 

--- a/packages/server/lib/browsers/index.js
+++ b/packages/server/lib/browsers/index.js
@@ -12,19 +12,21 @@ const isBrowserFamily = check.oneOf(['chromium', 'firefox'])
 let instance = null
 
 const kill = function (unbind) {
+  let _instance = instance
+
   // Clean up the instance when the browser is closed
   if (!instance) {
     return Promise.resolve()
   }
 
+  cleanup()
+
   return new Promise((resolve) => {
     if (unbind) {
-      instance.removeAllListeners()
-
-      return resolve.apply(null, [unbind])
+      _instance.removeAllListeners()
     }
 
-    instance.once('exit', (...args) => {
+    _instance.once('exit', (...args) => {
       debug('browser process killed')
 
       return resolve.apply(null, args)
@@ -32,7 +34,7 @@ const kill = function (unbind) {
 
     debug('killing browser process')
 
-    instance.kill()
+    _instance.kill()
 
     return cleanup()
   })

--- a/packages/server/lib/browsers/index.js
+++ b/packages/server/lib/browsers/index.js
@@ -10,13 +10,16 @@ const check = require('check-more-types')
 const isBrowserFamily = check.oneOf(['chromium', 'firefox'])
 
 let instance = null
+let instanceIsBeingDestroyed = false
 
 const kill = function (unbind) {
-  // cleanup our running browser
-  // instance
-  if (!instance) {
+  // When closing our running browser instance we must take care
+  // to avoid calling methods twice on it
+  if (!instance || instanceIsBeingDestroyed) {
     return Promise.resolve()
   }
+
+  instanceIsBeingDestroyed = true
 
   return new Promise((resolve) => {
     if (unbind) {
@@ -38,6 +41,8 @@ const kill = function (unbind) {
 }
 
 const cleanup = () => {
+  instanceIsBeingDestroyed = false
+
   return instance = null
 }
 

--- a/packages/server/lib/cypress.js
+++ b/packages/server/lib/cypress.js
@@ -60,10 +60,6 @@ const exitErr = (err) => {
   })
 }
 
-const isComponentTesting = (options) => {
-  return options.testingType === 'component'
-}
-
 module.exports = {
   isCurrentlyRunningElectron () {
     return require('./util/electron-app').isRunning()
@@ -78,20 +74,14 @@ module.exports = {
       // that means we're already running in electron
       // like in production and we shouldn't spawn a new
       // process
-      if (isComponentTesting(options) || this.isCurrentlyRunningElectron()) {
+      if (this.isCurrentlyRunningElectron()) {
         // if we weren't invoked from the CLI
         // then display a warning to the user
         if (!options.invokedFromCli) {
           warning('INVOKED_BINARY_OUTSIDE_NPM_MODULE')
         }
 
-        // just run the gui code directly here
-        // and pass our options directly to main
-        if (isComponentTesting(options)) {
-          debug(`skipping running Electron when in ${mode} mode`)
-        } else {
-          debug('running Electron currently')
-        }
+        debug('running Electron currently')
 
         return require('./modes')(mode, options)
       }

--- a/packages/server/lib/modes/interactive-ct.js
+++ b/packages/server/lib/modes/interactive-ct.js
@@ -3,7 +3,7 @@ const serverCt = require('@packages/server-ct')
 const run = (options) => {
   const { projectRoot } = options
 
-  options.browser = options.browser || 'chrome'
+  options.browser = options.browser || 'electron'
 
   return serverCt.start(projectRoot, options)
 }

--- a/packages/server/lib/modes/record.js
+++ b/packages/server/lib/modes/record.js
@@ -273,7 +273,7 @@ const createRun = Promise.method((options = {}) => {
     ciBuildId: null,
   })
 
-  let { projectId, recordKey, platform, git, specPattern, specs, parallel, ciBuildId, group, tags, testingType } = options
+  let { projectId, recordKey, platform, git, specPattern, specs, parallel, ciBuildId, group, tags } = options
 
   if (recordKey == null) {
     recordKey = env.get('CYPRESS_RECORD_KEY')
@@ -319,7 +319,6 @@ const createRun = Promise.method((options = {}) => {
     projectId,
     recordKey,
     specPattern,
-    testingType,
     ci: {
       params: ciProvider.ciParams(),
       provider: ciProvider.provider(),
@@ -563,7 +562,21 @@ const _postInstanceTests = ({
 }
 
 const createRunAndRecordSpecs = (options = {}) => {
-  const { specPattern, specs, sys, browser, projectId, config, projectRoot, runAllSpecs, parallel, ciBuildId, group, project, onError, testingType } = options
+  const { specPattern,
+    specs,
+    sys,
+    browser,
+    projectId,
+    config,
+    projectRoot,
+    runAllSpecs,
+    parallel,
+    ciBuildId,
+    group,
+    project,
+    onError,
+    testingType,
+  } = options
   const recordKey = options.key
 
   // we want to normalize this to an array to send to API

--- a/packages/server/lib/modes/record.js
+++ b/packages/server/lib/modes/record.js
@@ -273,7 +273,7 @@ const createRun = Promise.method((options = {}) => {
     ciBuildId: null,
   })
 
-  let { projectId, recordKey, platform, git, specPattern, specs, parallel, ciBuildId, group, tags } = options
+  let { projectId, recordKey, platform, git, specPattern, specs, parallel, ciBuildId, group, tags, testingType } = options
 
   if (recordKey == null) {
     recordKey = env.get('CYPRESS_RECORD_KEY')
@@ -319,6 +319,7 @@ const createRun = Promise.method((options = {}) => {
     projectId,
     recordKey,
     specPattern,
+    testingType,
     ci: {
       params: ciProvider.ciParams(),
       provider: ciProvider.provider(),
@@ -562,7 +563,7 @@ const _postInstanceTests = ({
 }
 
 const createRunAndRecordSpecs = (options = {}) => {
-  const { specPattern, specs, sys, browser, projectId, config, projectRoot, runAllSpecs, parallel, ciBuildId, group, project, onError } = options
+  const { specPattern, specs, sys, browser, projectId, config, projectRoot, runAllSpecs, parallel, ciBuildId, group, project, onError, testingType } = options
   const recordKey = options.key
 
   // we want to normalize this to an array to send to API
@@ -593,6 +594,7 @@ const createRunAndRecordSpecs = (options = {}) => {
       ciBuildId,
       projectId,
       specPattern,
+      testingType,
     })
     .then((resp) => {
       if (!resp) {

--- a/packages/server/lib/modes/run-ct.js
+++ b/packages/server/lib/modes/run-ct.js
@@ -1,6 +1,6 @@
 const run = (options) => {
   // TODO: make sure if we need to run this in electron by default to match e2e behavior?
-  options.browser = options.browser || 'chrome'
+  options.browser = options.browser || 'electron'
   options.runAllSpecsInSameBrowserSession = true
 
   require('../plugins/dev-server').emitter.on('dev-server:compile:error', (error) => {

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1407,7 +1407,7 @@ module.exports = {
       })
 
       return Promise.try(() => {
-        return options.testingType === 'component' &&
+        return config.testingType === 'component' &&
               openProject.closeBrowser()
       })
       .then(() => {

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1407,7 +1407,9 @@ module.exports = {
       })
 
       return Promise.try(() => {
-        return config.testingType === 'component' && openProject.closeBrowser()
+        return browser.name !== 'electron' &&
+              config.testingType === 'component' &&
+              openProject.closeBrowser()
       })
       .then(() => {
         return runEvents.execute('after:run', config, moduleAPIResults)

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1153,7 +1153,7 @@ module.exports = {
   },
 
   waitForTestsToFinishRunning (options = {}) {
-    const { project, screenshots, startedVideoCapture, endVideoCapture, videoName, compressedVideoName, videoCompression, videoUploadOnPasses, exit, spec, estimated, quiet, config } = options
+    const { project, screenshots, startedVideoCapture, endVideoCapture, videoName, compressedVideoName, videoCompression, videoUploadOnPasses, exit, spec, estimated, quiet, config, testingType } = options
 
     // https://github.com/cypress-io/cypress/issues/2370
     // delay 1 second if we're recording a video to give
@@ -1229,7 +1229,7 @@ module.exports = {
         }
       }
 
-      if (options.testingType === 'e2e') {
+      if (testingType === 'e2e') {
         // always close the browser now as opposed to letting
         // it exit naturally with the parent process due to
         // electron bug in windows
@@ -1274,7 +1274,7 @@ module.exports = {
       headed: options.browser.name !== 'electron',
     })
 
-    const { config, browser, sys, headed, outputPath, specs, specPattern, beforeSpecRun, afterSpecRun, runUrl, parallel, group, tag } = options
+    const { config, browser, sys, headed, outputPath, specs, specPattern, beforeSpecRun, afterSpecRun, runUrl, parallel, group, tag, testingType } = options
 
     const isHeadless = !headed
 
@@ -1407,7 +1407,7 @@ module.exports = {
       })
 
       return Promise.try(() => {
-        return config.testingType === 'component' &&
+        return testingType === 'component' &&
               openProject.closeBrowser()
       })
       .then(() => {
@@ -1513,8 +1513,7 @@ module.exports = {
     })
 
     const socketId = random.id()
-
-    const { projectRoot, record, key, ciBuildId, parallel, group, browser: browserName, tag } = options
+    const { projectRoot, record, key, ciBuildId, parallel, group, browser: browserName, tag, testingType } = options
 
     // this needs to be a closure over `this.exitEarly` and not a reference
     // because `this.exitEarly` gets overwritten in `this.listenForProjectEnd`
@@ -1609,6 +1608,7 @@ module.exports = {
               headed: options.headed,
               quiet: options.quiet,
               outputPath: options.outputPath,
+              testingType: options.testingType,
             })
             .tap((runSpecs) => {
               if (!options.quiet) {
@@ -1630,6 +1630,7 @@ module.exports = {
               browser,
               parallel,
               ciBuildId,
+              testingType,
               project,
               projectId,
               projectRoot,

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1229,7 +1229,7 @@ module.exports = {
         }
       }
 
-      if (config.testingType === 'e2e') {
+      if (options.testingType === 'e2e') {
         // always close the browser now as opposed to letting
         // it exit naturally with the parent process due to
         // electron bug in windows
@@ -1407,8 +1407,7 @@ module.exports = {
       })
 
       return Promise.try(() => {
-        return browser.name !== 'electron' &&
-              config.testingType === 'component' &&
+        return options.testingType === 'component' &&
               openProject.closeBrowser()
       })
       .then(() => {
@@ -1469,7 +1468,7 @@ module.exports = {
           videoCompression: options.videoCompression,
           videoUploadOnPasses: options.videoUploadOnPasses,
           quiet: options.quiet,
-          runAllSpecsInSameBrowserSession: options.runAllSpecsInSameBrowserSession,
+          testingType: options.testingType,
         }),
 
         connection: this.waitForBrowserToConnect({
@@ -1482,7 +1481,7 @@ module.exports = {
           socketId: options.socketId,
           webSecurity: options.webSecurity,
           projectRoot: options.projectRoot,
-        }, config.testingType === 'e2e' || firstSpec),
+        }, options.testingType === 'e2e' || firstSpec),
       })
     })
   },

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1153,7 +1153,7 @@ module.exports = {
   },
 
   waitForTestsToFinishRunning (options = {}) {
-    const { project, screenshots, startedVideoCapture, endVideoCapture, videoName, compressedVideoName, videoCompression, videoUploadOnPasses, exit, spec, estimated, quiet, config, runAllSpecsInSameBrowserSession } = options
+    const { project, screenshots, startedVideoCapture, endVideoCapture, videoName, compressedVideoName, videoCompression, videoUploadOnPasses, exit, spec, estimated, quiet, config } = options
 
     // https://github.com/cypress-io/cypress/issues/2370
     // delay 1 second if we're recording a video to give
@@ -1161,7 +1161,7 @@ module.exports = {
     // to avoid chopping off the end of the video
     const delay = this.getVideoRecordingDelay(startedVideoCapture)
 
-    return this.listenForProjectEnd(project, exit, runAllSpecsInSameBrowserSession)
+    return this.listenForProjectEnd(project, exit)
     .delay(delay)
     .then(async (results) => {
       _.defaults(results, {
@@ -1229,7 +1229,7 @@ module.exports = {
         }
       }
 
-      if (!runAllSpecsInSameBrowserSession) {
+      if (config.testingType === 'e2e') {
         // always close the browser now as opposed to letting
         // it exit naturally with the parent process due to
         // electron bug in windows
@@ -1274,7 +1274,7 @@ module.exports = {
       headed: options.browser.name !== 'electron',
     })
 
-    const { config, browser, sys, headed, outputPath, specs, specPattern, beforeSpecRun, afterSpecRun, runUrl, parallel, group, tag, runAllSpecsInSameBrowserSession } = options
+    const { config, browser, sys, headed, outputPath, specs, specPattern, beforeSpecRun, afterSpecRun, runUrl, parallel, group, tag } = options
 
     const isHeadless = !headed
 
@@ -1407,7 +1407,7 @@ module.exports = {
       })
 
       return Promise.try(() => {
-        return runAllSpecsInSameBrowserSession && openProject.closeBrowser()
+        return config.testingType === 'component' && openProject.closeBrowser()
       })
       .then(() => {
         return runEvents.execute('after:run', config, moduleAPIResults)
@@ -1480,7 +1480,7 @@ module.exports = {
           socketId: options.socketId,
           webSecurity: options.webSecurity,
           projectRoot: options.projectRoot,
-        }, !options.runAllSpecsInSameBrowserSession || firstSpec),
+        }, config.testingType === 'e2e' || firstSpec),
       })
     })
   },
@@ -1577,7 +1577,7 @@ module.exports = {
             chromePolicyCheck.run(onWarning)
           }
 
-          if (options.componentTesting) {
+          if (options.testingType === 'component') {
             specs = specs.filter((spec) => {
               return spec.specType === 'component'
             })
@@ -1608,7 +1608,6 @@ module.exports = {
               headed: options.headed,
               quiet: options.quiet,
               outputPath: options.outputPath,
-              runAllSpecsInSameBrowserSession: options.runAllSpecsInSameBrowserSession,
             })
             .tap((runSpecs) => {
               if (!options.quiet) {

--- a/packages/server/lib/open_project.js
+++ b/packages/server/lib/open_project.js
@@ -311,7 +311,7 @@ const moduleFactory = () => {
       debug('and options %o', options)
 
       // store the currently open project
-      openProject = args.componentTesting ? new ProjectCt(path) : new ProjectE2E(path)
+      openProject = args.testingType === 'component' ? new ProjectCt(path) : new ProjectE2E(path)
 
       _.defaults(options, {
         onReloadBrowser: () => {

--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -186,7 +186,7 @@ module.exports = {
       'run-mode': 'isTextTerminal',
       'run-project': 'runProject',
       'smoke-test': 'smokeTest',
-      'component-testing': 'componentTesting',
+      'testing-type': 'testingType',
     }
 
     // takes an array of args and converts
@@ -213,11 +213,14 @@ module.exports = {
       // set in case we
       // bypassed the cli
       cwd: process.cwd(),
+      testingType: 'e2e',
     })
     .mapValues(coerceUtil)
     .value()
 
     debug('argv parsed: %o', options)
+
+    // throw new Error()
 
     // if we are updating we may have to pluck out the
     // appPath + execPath from the options._ because
@@ -329,8 +332,6 @@ module.exports = {
     if (options.smokeTest) {
       options.pong = options.ping
     }
-
-    options.testingType = options.componentTesting ? 'component' : 'e2e'
 
     debug('argv options: %o', options)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1965,7 +1965,7 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.10.4", "@babel/types@^7.12.13", "@babel/types@^7.12.7", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.13":
+"@babel/types@^7.10.4", "@babel/types@^7.12.10", "@babel/types@^7.12.13", "@babel/types@^7.12.7", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.13":
   version "7.13.14"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.14.tgz#c35a4abb15c7cd45a2746d78ab328e362cbace0d"
   integrity sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -229,7 +229,7 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/generator@^7.13.0", "@babel/generator@^7.4.0", "@babel/generator@^7.4.4", "@babel/generator@^7.6.0", "@babel/generator@^7.7.7", "@babel/generator@^7.9.0":
+"@babel/generator@^7.11.5", "@babel/generator@^7.12.5", "@babel/generator@^7.13.0", "@babel/generator@^7.13.9", "@babel/generator@^7.4.0", "@babel/generator@^7.4.4", "@babel/generator@^7.6.0", "@babel/generator@^7.7.7", "@babel/generator@^7.9.0":
   version "7.13.9"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.13.9.tgz#3a7aa96f9efb8e2be42d38d80e2ceb4c64d8de39"
   integrity sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==
@@ -238,7 +238,14 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/helper-annotate-as-pure@^7.0.0", "@babel/helper-annotate-as-pure@^7.10.4", "@babel/helper-annotate-as-pure@^7.12.13":
+"@babel/helper-annotate-as-pure@^7.0.0", "@babel/helper-annotate-as-pure@^7.10.4":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz#54ab9b000e60a93644ce17b3f37d313aaf1d115d"
+  integrity sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==
+  dependencies:
+    "@babel/types" "^7.12.10"
+
+"@babel/helper-annotate-as-pure@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.13.tgz#0f58e86dfc4bb3b1fcd7db806570e177d439b6ab"
   integrity sha512-7YXfX5wQ5aYM/BOlbSccHDbuXXFPxeoUmfWtz8le2yTkTZc+BxsiEnENFoi2SlmA8ewDkG2LgIMIVzzn2h8kfw==
@@ -314,7 +321,7 @@
   dependencies:
     "@babel/types" "^7.13.0"
 
-"@babel/helper-function-name@^7.12.13":
+"@babel/helper-function-name@^7.10.4", "@babel/helper-function-name@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz#93ad656db3c3c2232559fd7b2c3dbdcbe0eb377a"
   integrity sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==
@@ -345,12 +352,26 @@
   dependencies:
     "@babel/types" "^7.13.0"
 
+"@babel/helper-member-expression-to-functions@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz#dfe368f26d426a07299d8d6513821768216e6d72"
+  integrity sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==
+  dependencies:
+    "@babel/types" "^7.13.12"
+
 "@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.8.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz#ec67e4404f41750463e455cc3203f6a32e93fcb0"
   integrity sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==
   dependencies:
     "@babel/types" "^7.12.13"
+
+"@babel/helper-module-imports@^7.12.1":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz#c6a369a6f3621cb25da014078684da9196b61977"
+  integrity sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
+  dependencies:
+    "@babel/types" "^7.13.12"
 
 "@babel/helper-module-transforms@^7.10.4", "@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.9.0":
   version "7.12.1"
@@ -394,7 +415,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz#806526ce125aed03373bc416a828321e3a6a33af"
   integrity sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
 
-"@babel/helper-remap-async-to-generator@^7.13.0":
+"@babel/helper-remap-async-to-generator@^7.12.1", "@babel/helper-remap-async-to-generator@^7.13.0":
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.13.0.tgz#376a760d9f7b4b2077a9dd05aa9c3927cadb2209"
   integrity sha512-pUQpFBE9JvC9lrQbpX0TmeNIy5s7GnZjna2lhhcHC7DzgBs6fWn722Y5cfwgrtrqc7NAJwMvOa0mKhq6XaE4jg==
@@ -402,6 +423,16 @@
     "@babel/helper-annotate-as-pure" "^7.12.13"
     "@babel/helper-wrap-function" "^7.13.0"
     "@babel/types" "^7.13.0"
+
+"@babel/helper-replace-supers@^7.12.1":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz#6442f4c1ad912502481a564a7386de0c77ff3804"
+  integrity sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.13.12"
+    "@babel/helper-optimise-call-expression" "^7.12.13"
+    "@babel/traverse" "^7.13.0"
+    "@babel/types" "^7.13.12"
 
 "@babel/helper-replace-supers@^7.12.13", "@babel/helper-replace-supers@^7.13.0":
   version "7.13.0"
@@ -434,7 +465,7 @@
   dependencies:
     "@babel/types" "^7.12.1"
 
-"@babel/helper-split-export-declaration@^7.12.13":
+"@babel/helper-split-export-declaration@^7.11.0", "@babel/helper-split-export-declaration@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz#e9430be00baf3e88b0e13e6f9d4eaf2136372b05"
   integrity sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==
@@ -470,10 +501,19 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
-"@babel/highlight@^7.0.0", "@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13", "@babel/highlight@^7.8.3":
+"@babel/highlight@^7.0.0", "@babel/highlight@^7.10.4", "@babel/highlight@^7.8.3":
   version "7.13.8"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.8.tgz#10b2dac78526424dfc1f47650d0e415dfd9dc481"
   integrity sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.12.13":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.10.tgz#a8b2a66148f5b27d666b15d81774347a731d52d1"
+  integrity sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     chalk "^2.0.0"
@@ -484,20 +524,20 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.0.tgz#49b9b6ee213e5634fa80361dae139effef893f78"
   integrity sha512-w80kxEMFhE3wjMOQkfdTvv0CSdRSJZptIlLhU4eU/coNJeWjduspUFz+IRnBbAq6m5XYBFMoT1TNkk9K9yf10g==
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.12.13", "@babel/parser@^7.13.0", "@babel/parser@^7.13.4", "@babel/parser@^7.4.3", "@babel/parser@^7.4.5", "@babel/parser@^7.6.0", "@babel/parser@^7.7.0", "@babel/parser@^7.9.0":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.12.13", "@babel/parser@^7.13.4", "@babel/parser@^7.4.3", "@babel/parser@^7.4.5", "@babel/parser@^7.6.0", "@babel/parser@^7.7.0", "@babel/parser@^7.9.0":
   version "7.13.9"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.9.tgz#ca34cb95e1c2dd126863a84465ae8ef66114be99"
   integrity sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw==
+
+"@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.12.7", "@babel/parser@^7.13.13", "@babel/parser@^7.13.9":
+  version "7.13.13"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.13.tgz#42f03862f4aed50461e543270916b47dd501f0df"
+  integrity sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==
 
 "@babel/parser@^7.12.0":
   version "7.13.11"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.11.tgz#f93ebfc99d21c1772afbbaa153f47e7ce2f50b88"
   integrity sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q==
-
-"@babel/parser@^7.13.9":
-  version "7.13.13"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.13.tgz#42f03862f4aed50461e543270916b47dd501f0df"
-  integrity sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==
 
 "@babel/parser@^7.7.7":
   version "7.12.11"
@@ -1836,7 +1876,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.0.0", "@babel/template@^7.12.13", "@babel/template@^7.4.0", "@babel/template@^7.4.4", "@babel/template@^7.5.4", "@babel/template@^7.6.0", "@babel/template@^7.7.4", "@babel/template@^7.8.6":
+"@babel/template@^7.0.0", "@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.4.0", "@babel/template@^7.4.4", "@babel/template@^7.6.0", "@babel/template@^7.7.4", "@babel/template@^7.8.6":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
   integrity sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==
@@ -1845,17 +1885,55 @@
     "@babel/parser" "^7.12.13"
     "@babel/types" "^7.12.13"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.5", "@babel/traverse@^7.6.0", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.4", "@babel/traverse@^7.9.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.13.0.tgz#6d95752475f86ee7ded06536de309a65fc8966cc"
-  integrity sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==
+"@babel/template@^7.5.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
+  integrity sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/parser" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.5", "@babel/traverse@^7.6.0", "@babel/traverse@^7.7.0", "@babel/traverse@^7.9.0":
+  version "7.11.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.11.5.tgz#be777b93b518eb6d76ee2e1ea1d143daa11e61c3"
+  integrity sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.11.5"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/parser" "^7.11.5"
+    "@babel/types" "^7.11.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
+"@babel/traverse@^7.12.1", "@babel/traverse@^7.13.0":
+  version "7.13.13"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.13.13.tgz#39aa9c21aab69f74d948a486dd28a2dbdbf5114d"
+  integrity sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==
   dependencies:
     "@babel/code-frame" "^7.12.13"
-    "@babel/generator" "^7.13.0"
+    "@babel/generator" "^7.13.9"
     "@babel/helper-function-name" "^7.12.13"
     "@babel/helper-split-export-declaration" "^7.12.13"
-    "@babel/parser" "^7.13.0"
-    "@babel/types" "^7.13.0"
+    "@babel/parser" "^7.13.13"
+    "@babel/types" "^7.13.13"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.7.4":
+  version "7.12.8"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.8.tgz#c1c2983bf9ba0f4f0eaa11dff7e77fa63307b2a4"
+  integrity sha512-EIRQXPTwFEGRZyu6gXbjfpNORN1oZvwuzJbxcXjAgWV0iqXYDszN1Hx3FVm6YgZfu1ZQbCVAk3l+nIw95Xll9Q==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.5"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/parser" "^7.12.7"
+    "@babel/types" "^7.12.7"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.19"
@@ -1878,7 +1956,7 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.11.5", "@babel/types@^7.12.0", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.12.17", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.6.0", "@babel/types@^7.7.0", "@babel/types@^7.7.4", "@babel/types@^7.9.0", "@babel/types@^7.9.5":
+"@babel/types@^7.0.0", "@babel/types@^7.11.5", "@babel/types@^7.12.0", "@babel/types@^7.12.1", "@babel/types@^7.12.17", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.6.0", "@babel/types@^7.7.0", "@babel/types@^7.7.4", "@babel/types@^7.9.0", "@babel/types@^7.9.5":
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.0.tgz#74424d2816f0171b4100f0ab34e9a374efdf7f80"
   integrity sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==
@@ -1887,7 +1965,7 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.12.10", "@babel/types@^7.13.0":
+"@babel/types@^7.10.4", "@babel/types@^7.12.13", "@babel/types@^7.12.7", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.13":
   version "7.13.14"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.14.tgz#c35a4abb15c7cd45a2746d78ab328e362cbace0d"
   integrity sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Related to #15704
- Closes https://cypress-io.atlassian.net/browse/CT-403

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

By default the Component Test Runner will launch in Electron to improve UX and maintain consistency with the E2E Runner.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We did not support Electron in the Component Test Runner. This means that users would have needed to install Chrome on their CI machines, which isn't acceptable. Now, we support Electron, Chrome, and Firefox.

Additionally, we use Electron by default. This is a UX improvement so that there is only on system tray application.

Adding Electron support for Cypress CT revealed an issue with our logic when we destroy Electron BrowserWindows. We attempt to do so safely, but our safety checks don't prevent certain race conditions. I tried to refactor server/lib/browsers.js to make sure the instance wasn't cached so we couldn't destroy it twice, but this led to other test failures.

Rather than risk deeper breaking changes, we limited the fix so that we only tear down the browser when we're not in Electron. This behaves as expected.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

![image](https://user-images.githubusercontent.com/19196536/112923304-62bf1300-9151-11eb-8e9a-0f0c70015da3.png)

- Launch Electron by default in open-ct
- Run mode is headless by default in run-ct

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
