### PR TITLE
feat: Support application/xhtml content type of cy.visit()

### DIFF
--- a/packages/server/lib/server-e2e.ts
+++ b/packages/server/lib/server-e2e.ts
@@ -23,7 +23,7 @@ import statusCode from './util/status_code'
 type WarningErr = Record<string, any>
 
 const fullyQualifiedRe = /^https?:\/\//
-const textHtmlContentTypeRe = /^text\/html/i
+const htmlContentTypesRe = /^(text\/html|application\/xhtml)/i
 
 const debug = Debug('cypress:server:server-e2e')
 
@@ -32,7 +32,7 @@ const isResponseHtml = function (contentType, responseBuffer) {
     // want to match anything starting with 'text/html'
     // including 'text/html;charset=utf-8' and 'Text/HTML'
     // https://github.com/cypress-io/cypress/issues/8506
-    return textHtmlContentTypeRe.test(contentType)
+    return htmlContentTypesRe.test(contentType)
   }
 
   const body = _.invoke(responseBuffer, 'toString')

--- a/packages/server/test/integration/server_spec.js
+++ b/packages/server/test/integration/server_spec.js
@@ -474,12 +474,13 @@ describe('Server', () => {
         .get('/c').reply(200, 'notHtml', { 'content-type': 'text/html;charset=utf-8' })
         // invalid, but let's be tolerant
         .get('/d').reply(200, 'notHtml', { 'content-type': 'text/html;' })
+        .get('/e').reply(200, 'notHtml', { 'content-type': 'application/xhtml+xml' })
 
         const bad = await this.server._onResolveUrl('http://example.com/a', {}, this.automationRequest)
 
         expect(bad.isHtml).to.be.false
 
-        for (const path of ['/b', '/c', '/d']) {
+        for (const path of ['/b', '/c', '/d', '/e']) {
           const details = await this.server._onResolveUrl(`http://example.com${path}`, {}, this.automationRequest)
 
           expect(details.isHtml).to.be.true


### PR DESCRIPTION
- Closes #15738

### User facing changelog
Allow cy.visit() to work with pages that return application/xhtml* content-type

### Additional details
See the description on the ticket

Before:
![image](https://user-images.githubusercontent.com/13640334/113293009-245e5b00-92ed-11eb-85ce-6b297ffe9407.png)

After:
![image](https://user-images.githubusercontent.com/13640334/113294470-efeb9e80-92ee-11eb-9877-01f2445056b2.png)

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
