### PR TITLE
chore: ignore template string linting for now

### DIFF
--- a/npm/eslint-plugin-dev/lib/index.js
+++ b/npm/eslint-plugin-dev/lib/index.js
@@ -50,6 +50,8 @@ const baseRules = {
     'error',
     2,
     {
+      // TODO: fix this, we shouldn't need to ignore TemplateLiterals
+      'ignoredNodes': ['TemplateLiteral'],
       'SwitchCase': 1,
       'MemberExpression': 0,
     },
@@ -193,7 +195,8 @@ const baseRules = {
   ],
   'space-infix-ops': 'error',
   'space-unary-ops': 'error',
-  'template-curly-spacing': 'error',
+  // TODO: change this back to 'error'
+  'template-curly-spacing': 'off',
   'use-isnan': 'error',
   'valid-typeof': 'error',
 }


### PR DESCRIPTION
Merging `develop` into `7.0-release` at this commit is causing lint to crash:

https://github.com/cypress-io/cypress/pull/14690/commits/e657481ff28a45b055e4d0f0a6670564f23782ba

Lint: https://app.circleci.com/pipelines/github/cypress-io/cypress/18714/workflows/68faf81a-d57a-4944-acc8-97883dc334f8/jobs/677644

Relevant discussions:

* https://github.com/babel/babel-eslint/issues/530
* https://github.com/babel/babel-eslint/issues/799

Removing template string linting is a temporary fix, until we can devote time to migrate the deprecated `babel-eslint` to `@babel/eslint-parser` (#15745, needs work) or find another solution.