### PR TITLE
fix: don't destroy browserwindow on process.exit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ branches:
   only:
     - master
     - develop
-    - sem-next-ver
+    - 7.0-release
     - /win*/
     - feature/cross-platform-wizard
 

--- a/packages/server/lib/browsers/electron.js
+++ b/packages/server/lib/browsers/electron.js
@@ -405,7 +405,12 @@ module.exports = {
             return win.webContents.getOSProcessId()
           })],
           browserWindow: win,
-          kill () {
+          kill: (isProcessExit) => {
+            if (isProcessExit) {
+              // if the process is exiting, all BrowserWindows will be destroyed anyways
+              return
+            }
+
             return tryToCall(win, 'destroy')
           },
           removeAllListeners () {

--- a/packages/server/lib/browsers/index.js
+++ b/packages/server/lib/browsers/index.js
@@ -11,34 +11,33 @@ const isBrowserFamily = check.oneOf(['chromium', 'firefox'])
 
 let instance = null
 
-const kill = function (unbind) {
-  // cleanup our running browser
-  // instance
+const kill = function (unbind, isProcessExit) {
+  // Clean up the instance when the browser is closed
   if (!instance) {
+    debug('browsers.kill called with no active instance')
+
     return Promise.resolve()
   }
 
-  return new Promise((resolve) => {
-    if (unbind) {
-      instance.removeAllListeners()
-    }
+  const _instance = instance
 
-    instance.once('exit', (...args) => {
+  instance = null
+
+  if (unbind) {
+    _instance.removeAllListeners()
+  }
+
+  return new Promise((resolve) => {
+    _instance.once('exit', () => {
       debug('browser process killed')
 
-      return resolve.apply(null, args)
+      resolve()
     })
 
     debug('killing browser process')
 
-    instance.kill()
-
-    return cleanup()
+    _instance.kill(isProcessExit)
   })
-}
-
-const cleanup = () => {
-  return instance = null
 }
 
 const getBrowserLauncher = function (browser) {
@@ -141,7 +140,7 @@ const throwBrowserNotFound = function (browserName, browsers = []) {
   return errors.throw('BROWSER_NOT_FOUND_BY_NAME', browserName, names)
 }
 
-process.once('exit', kill)
+process.once('exit', () => kill(true, true))
 
 module.exports = {
   ensureAndGetByNameOrPath,
@@ -211,8 +210,7 @@ module.exports = {
         // enable the browser to configure the interface
         instance.once('exit', () => {
           options.onBrowserClose()
-
-          return cleanup()
+          instance = null
         })
 
         // TODO: instead of waiting an arbitrary

--- a/scripts/win-appveyor-build.js
+++ b/scripts/win-appveyor-build.js
@@ -25,7 +25,7 @@ const isRightBranch = () => {
     process.env.APPVEYOR_REPO_COMMIT_MESSAGE || ''
   ).includes('[build binary]')
 
-  const branchesToBuildBinary = ['develop', 'sem-next-ver']
+  const branchesToBuildBinary = ['develop', '7.0-release']
 
   return branchesToBuildBinary.includes(branch) || shouldForceBinaryBuild
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #9164

### User facing changelog

- Fixed a segfault that occurred when exiting Cypress with Electron tests still running.

### Additional details

- destroying the BrowserWindows during process.exit seems to sporadically cause segfaults

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
