### PR TITLE
chore: missing human-interval is breaking binary

### DIFF
--- a/packages/server-ct/package.json
+++ b/packages/server-ct/package.json
@@ -18,6 +18,7 @@
     "debug": "4.3.2",
     "express": "4.17.1",
     "http-proxy": "1.18.1",
+    "human-interval": "1.0.0",
     "lodash": "4.17.20",
     "send": "0.17.1"
   },


### PR DESCRIPTION
By chance I found a crasher introduced by #15699 when testingType was added to the dashboard requests yesterday morning. It was only visible when the binary was built and prevented CT from launching at all. It was a simple missed dep.