### PR TITLE
fix(circle.yml): prefer yarn over npm when yarn is available

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -346,7 +346,7 @@ commands:
           working_directory: /tmp/<<parameters.repo>>
           # force installing the freshly built binary
           command: |
-            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip npm i ~/cypress/cypress.tgz && [[ -f yarn.lock ]] && yarn
+            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip [[ -f yarn.lock ]] && yarn add ~/cypress/cypress.tgz || npm i ~/cypress/cypress.tgz
       - run:
           name: Print Cypress version
           working_directory: /tmp/<<parameters.repo>>
@@ -476,14 +476,14 @@ commands:
       - run:
           # Install with yarn if yarn.lock present
           command: |
-            [[ -f yarn.lock ]] && yarn || npm install
+            [[ -f yarn.lock ]] && yarn --frozen-lockfile || npm install
           working_directory: /tmp/<<parameters.repo>>
       - run:
           name: Install Cypress
           working_directory: /tmp/<<parameters.repo>>
           # force installing the freshly built binary
           command: |
-            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip npm i ~/cypress/cypress.tgz
+            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip [[ -f yarn.lock ]] && yarn add ~/cypress/cypress.tgz || npm i ~/cypress/cypress.tgz
       - run:
           name: Print Cypress version
           working_directory: /tmp/<<parameters.repo>>
@@ -1412,7 +1412,7 @@ jobs:
           name: Install Cypress
           working_directory: test-binary
           # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip npm i /root/cypress/cypress.tgz
+          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip [[ -f yarn.lock ]] && yarn add /root/cypress/cypress.tgz || npm i /root/cypress/cypress.tgz
       - run:
           name: Cypress version
           working_directory: test-binary
@@ -1451,7 +1451,7 @@ jobs:
       - run:
           name: Install Cypress
           working_directory: test-binary
-          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip npm install /root/cypress/cypress.tgz
+          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip [[ -f yarn.lock ]] && yarn add /root/cypress/cypress.tgz || npm i /root/cypress/cypress.tgz
       - run:
           name: Verify Cypress binary
           working_directory: test-binary
@@ -1606,7 +1606,7 @@ jobs:
           name: Install Cypress
           working_directory: /tmp/cypress-test-tiny
           # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip npm i ~/cypress/cypress.tgz
+          command: CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip [[ -f yarn.lock ]] && yarn add ~/cypress/cypress.tgz || npm i ~/cypress/cypress.tgz
       - run:
           name: Run test project
           working_directory: /tmp/cypress-test-tiny
@@ -1747,7 +1747,7 @@ jobs:
           name: Install Cypress
           working_directory: test-binary
           # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip npm i ~/cypress/cypress.tgz
+          command: CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip [[ -f yarn.lock ]] && yarn add ~/cypress/cypress.tgz || npm i ~/cypress/cypress.tgz
       - run:
           name: Cypress help
           working_directory: test-binary

--- a/circle.yml
+++ b/circle.yml
@@ -347,7 +347,7 @@ commands:
           working_directory: /tmp/<<parameters.repo>>
           # force installing the freshly built binary
           command: |
-            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]]; then yarn add ~/cypress/cypress.tgz; else npm i ~/cypress/cypress.tgz; fi
+            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]] ;then yarn add ~/cypress/cypress.tgz ;else npm i ~/cypress/cypress.tgz ;fi
       - run:
           name: Print Cypress version
           working_directory: /tmp/<<parameters.repo>>
@@ -484,7 +484,7 @@ commands:
           working_directory: /tmp/<<parameters.repo>>
           # force installing the freshly built binary
           command: |
-            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]]; then yarn add ~/cypress/cypress.tgz; else npm i ~/cypress/cypress.tgz; fi
+            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]] ;then yarn add ~/cypress/cypress.tgz ;else npm i ~/cypress/cypress.tgz ;fi
       - run:
           name: Print Cypress version
           working_directory: /tmp/<<parameters.repo>>
@@ -1413,7 +1413,7 @@ jobs:
           name: Install Cypress
           working_directory: test-binary
           # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip if [[ -f yarn.lock ]]; then yarn add /root/cypress/cypress.tgz; else npm i /root/cypress/cypress.tgz; fi
+          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip if [[ -f yarn.lock ]] ;then yarn add /root/cypress/cypress.tgz ;else npm i /root/cypress/cypress.tgz ;fi
       - run:
           name: Cypress version
           working_directory: test-binary
@@ -1452,7 +1452,7 @@ jobs:
       - run:
           name: Install Cypress
           working_directory: test-binary
-          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip if [[ -f yarn.lock ]]; then yarn add /root/cypress/cypress.tgz; else npm i /root/cypress/cypress.tgz; fi
+          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip if [[ -f yarn.lock ]] ;then yarn add /root/cypress/cypress.tgz ;else npm i /root/cypress/cypress.tgz ;fi
       - run:
           name: Verify Cypress binary
           working_directory: test-binary
@@ -1607,7 +1607,7 @@ jobs:
           name: Install Cypress
           working_directory: /tmp/cypress-test-tiny
           # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]]; then yarn add ~/cypress/cypress.tgz; else npm i ~/cypress/cypress.tgz; fi
+          command: CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]] ;then yarn add ~/cypress/cypress.tgz ;else npm i ~/cypress/cypress.tgz ;fi
       - run:
           name: Run test project
           working_directory: /tmp/cypress-test-tiny
@@ -1748,7 +1748,7 @@ jobs:
           name: Install Cypress
           working_directory: test-binary
           # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]]; then yarn add ~/cypress/cypress.tgz; else npm i ~/cypress/cypress.tgz; fi
+          command: CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]] ;then yarn add ~/cypress/cypress.tgz ;else npm i ~/cypress/cypress.tgz ;fi
       - run:
           name: Cypress help
           working_directory: test-binary

--- a/circle.yml
+++ b/circle.yml
@@ -347,7 +347,7 @@ commands:
           working_directory: /tmp/<<parameters.repo>>
           # force installing the freshly built binary
           command: |
-            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]] ;then yarn add ~/cypress/cypress.tgz ;else npm i ~/cypress/cypress.tgz ;fi
+            if [[ -f yarn.lock ]] ;then CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip yarn add ~/cypress/cypress.tgz ;else CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip npm i ~/cypress/cypress.tgz ;fi
       - run:
           name: Print Cypress version
           working_directory: /tmp/<<parameters.repo>>
@@ -484,7 +484,7 @@ commands:
           working_directory: /tmp/<<parameters.repo>>
           # force installing the freshly built binary
           command: |
-            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]] ;then yarn add ~/cypress/cypress.tgz ;else npm i ~/cypress/cypress.tgz ;fi
+            if [[ -f yarn.lock ]] ;then CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip yarn add ~/cypress/cypress.tgz ;else CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip npm i ~/cypress/cypress.tgz ;fi
       - run:
           name: Print Cypress version
           working_directory: /tmp/<<parameters.repo>>
@@ -1413,7 +1413,7 @@ jobs:
           name: Install Cypress
           working_directory: test-binary
           # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip if [[ -f yarn.lock ]] ;then yarn add /root/cypress/cypress.tgz ;else npm i /root/cypress/cypress.tgz ;fi
+          command:  if [[ -f yarn.lock ]] ;then CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip yarn add /root/cypress/cypress.tgz ;else CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip npm i /root/cypress/cypress.tgz ;fi
       - run:
           name: Cypress version
           working_directory: test-binary
@@ -1452,7 +1452,7 @@ jobs:
       - run:
           name: Install Cypress
           working_directory: test-binary
-          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip if [[ -f yarn.lock ]] ;then yarn add /root/cypress/cypress.tgz ;else npm i /root/cypress/cypress.tgz ;fi
+          command: if [[ -f yarn.lock ]] ;then CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip yarn add /root/cypress/cypress.tgz ;else CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip npm i /root/cypress/cypress.tgz ;fi
       - run:
           name: Verify Cypress binary
           working_directory: test-binary
@@ -1607,7 +1607,7 @@ jobs:
           name: Install Cypress
           working_directory: /tmp/cypress-test-tiny
           # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]] ;then yarn add ~/cypress/cypress.tgz ;else npm i ~/cypress/cypress.tgz ;fi
+          command: if [[ -f yarn.lock ]] ;then CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip yarn add ~/cypress/cypress.tgz ;else CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip npm i ~/cypress/cypress.tgz ;fi
       - run:
           name: Run test project
           working_directory: /tmp/cypress-test-tiny
@@ -1748,7 +1748,7 @@ jobs:
           name: Install Cypress
           working_directory: test-binary
           # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]] ;then yarn add ~/cypress/cypress.tgz ;else npm i ~/cypress/cypress.tgz ;fi
+          command: if [[ -f yarn.lock ]] ;then CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip yarn add ~/cypress/cypress.tgz ;else CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip npm i ~/cypress/cypress.tgz ;fi
       - run:
           name: Cypress help
           working_directory: test-binary

--- a/circle.yml
+++ b/circle.yml
@@ -346,7 +346,7 @@ commands:
           working_directory: /tmp/<<parameters.repo>>
           # force installing the freshly built binary
           command: |
-            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip [[ -f yarn.lock ]] && yarn add ~/cypress/cypress.tgz || npm i ~/cypress/cypress.tgz
+            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]]; then yarn add ~/cypress/cypress.tgz; else npm i ~/cypress/cypress.tgz; fi
       - run:
           name: Print Cypress version
           working_directory: /tmp/<<parameters.repo>>
@@ -483,7 +483,7 @@ commands:
           working_directory: /tmp/<<parameters.repo>>
           # force installing the freshly built binary
           command: |
-            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip [[ -f yarn.lock ]] && yarn add ~/cypress/cypress.tgz || npm i ~/cypress/cypress.tgz
+            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]]; then yarn add ~/cypress/cypress.tgz; else npm i ~/cypress/cypress.tgz; fi
       - run:
           name: Print Cypress version
           working_directory: /tmp/<<parameters.repo>>
@@ -1412,7 +1412,7 @@ jobs:
           name: Install Cypress
           working_directory: test-binary
           # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip [[ -f yarn.lock ]] && yarn add /root/cypress/cypress.tgz || npm i /root/cypress/cypress.tgz
+          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip if [[ -f yarn.lock ]]; then yarn add /root/cypress/cypress.tgz; else npm i /root/cypress/cypress.tgz; fi
       - run:
           name: Cypress version
           working_directory: test-binary
@@ -1451,7 +1451,7 @@ jobs:
       - run:
           name: Install Cypress
           working_directory: test-binary
-          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip [[ -f yarn.lock ]] && yarn add /root/cypress/cypress.tgz || npm i /root/cypress/cypress.tgz
+          command: CYPRESS_INSTALL_BINARY=/root/cypress/cypress.zip if [[ -f yarn.lock ]]; then yarn add /root/cypress/cypress.tgz; else npm i /root/cypress/cypress.tgz; fi
       - run:
           name: Verify Cypress binary
           working_directory: test-binary
@@ -1606,7 +1606,7 @@ jobs:
           name: Install Cypress
           working_directory: /tmp/cypress-test-tiny
           # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip [[ -f yarn.lock ]] && yarn add ~/cypress/cypress.tgz || npm i ~/cypress/cypress.tgz
+          command: CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]]; then yarn add ~/cypress/cypress.tgz; else npm i ~/cypress/cypress.tgz; fi
       - run:
           name: Run test project
           working_directory: /tmp/cypress-test-tiny
@@ -1747,7 +1747,7 @@ jobs:
           name: Install Cypress
           working_directory: test-binary
           # force installing the freshly built binary
-          command: CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip [[ -f yarn.lock ]] && yarn add ~/cypress/cypress.tgz || npm i ~/cypress/cypress.tgz
+          command: CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip if [[ -f yarn.lock ]]; then yarn add ~/cypress/cypress.tgz; else npm i ~/cypress/cypress.tgz; fi
       - run:
           name: Cypress help
           working_directory: test-binary

--- a/circle.yml
+++ b/circle.yml
@@ -37,6 +37,7 @@ testBinaryFirefox: &testBinaryFirefox
       only:
         - develop
         - 7.0-release
+        - fix/use-yarn-over-npm-circle
   requires:
     - create-build-artifacts
 


### PR DESCRIPTION
Attempting a fix for the build issue seen here: 

https://app.circleci.com/pipelines/github/cypress-io/cypress/18828/workflows/04ec99a3-9bf2-42fa-8097-8d155713a5e9/jobs/682005

## Description

I'm replacing instances of `npm i` with `yarn` when `yarn` is available **and** ensuring that the `--frozen-lockfile` flag is being passed so that the dependencies do not update (if an update is available).