### PR TITLE
fix: chrome should be the default for CT

### DIFF
--- a/packages/server/lib/modes/interactive-ct.js
+++ b/packages/server/lib/modes/interactive-ct.js
@@ -3,7 +3,7 @@ const serverCt = require('@packages/server-ct')
 const run = (options) => {
   const { projectRoot } = options
 
-  options.browser = options.browser || 'electron'
+  options.browser = options.browser || 'chrome'
 
   return serverCt.start(projectRoot, options)
 }


### PR DESCRIPTION
When swapping electron to be the default browser for `open` mode, I discovered an issue where Electron's Devtools stop showing children in the element tree on subsequent page reloads.

**Before test re-run**
<img width="863" alt="il7E1" src="https://user-images.githubusercontent.com/2801156/113456322-e93a5580-93da-11eb-9cf7-e4606754a1a8.png">

**After test re-run**
<img width="768" alt="CvgLP" src="https://user-images.githubusercontent.com/2801156/113456325-ed667300-93da-11eb-8057-6a6d304494da.png">


### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

### Additional details
An issue like this makes Electron unusable for CT's open mode. We need to use Chrome.


### How has the user experience changed?
We use Chrome for Open Mode in CT.

<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

