### PR TITLE
fix: Cypress.cookies.debug() regression

### DIFF
--- a/packages/extension/gulpfile.ts
+++ b/packages/extension/gulpfile.ts
@@ -16,7 +16,15 @@ const manifest = (done) => {
   .pipe(gulp.dest('dist'))
   .on('end', () => {
     return fs.readJson('dist/manifest.json', function (err, json) {
-      json.version = pkg.version
+      let version: string = pkg.version
+
+      // https://github.com/cypress-io/cypress/issues/15032
+      // '-development' inside version string makes Chrome fail to load the extension
+      if (version.endsWith('-development')) {
+        version = version.split('-')[0]
+      }
+
+      json.version = version
 
       return fs.writeJson('dist/manifest.json', json, { spaces: 2 }, done)
     })

--- a/packages/extension/gulpfile.ts
+++ b/packages/extension/gulpfile.ts
@@ -8,11 +8,9 @@ const clean = (done) => {
   rimraf('dist', done)
 }
 
-const manifest = (done) => {
-  gulp.src('app/manifest.json')
+const manifest = () => {
+  return gulp.src('app/manifest.json')
   .pipe(gulp.dest('dist'))
-
-  return null
 }
 
 const background = (cb) => {

--- a/packages/extension/gulpfile.ts
+++ b/packages/extension/gulpfile.ts
@@ -1,11 +1,8 @@
-import fs from 'fs-extra'
 import gulp from 'gulp'
 import rimraf from 'rimraf'
 import webpack from 'webpack'
 import cypressIcons from '@cypress/icons'
 import webpackConfig from './webpack.config.js'
-
-const pkg = require('./package.json')
 
 const clean = (done) => {
   rimraf('dist', done)
@@ -14,21 +11,6 @@ const clean = (done) => {
 const manifest = (done) => {
   gulp.src('app/manifest.json')
   .pipe(gulp.dest('dist'))
-  .on('end', () => {
-    return fs.readJson('dist/manifest.json', function (err, json) {
-      let version: string = pkg.version
-
-      // https://github.com/cypress-io/cypress/issues/15032
-      // '-development' inside version string makes Chrome fail to load the extension
-      if (version.endsWith('-development')) {
-        version = version.split('-')[0]
-      }
-
-      json.version = version
-
-      return fs.writeJson('dist/manifest.json', json, { spaces: 2 }, done)
-    })
-  })
 
   return null
 }

--- a/packages/extension/webpack.config.js
+++ b/packages/extension/webpack.config.js
@@ -3,6 +3,10 @@ const path = require('path')
 module.exports = {
   mode: process.env.NODE_ENV || 'development',
   entry: './app/init.js',
+  // https://github.com/cypress-io/cypress/issues/15032
+  // Default webpack output setting is "eval".
+  // Chrome doesn't allow "eval" inside extensions.
+  devtool: 'inline-cheap-source-map',
   module: {
     rules: [
       {


### PR DESCRIPTION
- Closes #15032

### User facing changelog

`Cypress.cookies.debug(true)` doesn't show cookie-related messages on the console window. 

### Additional details
- Why was this change necessary? => Fix regression.
- What is affected by this change? => N/A

### Any implementation details to explain?

* This happened because Chrome extensions cannot parse version name like "0.0.0-development". Cypress extension wasn't loaded and the `automation:push:request` message wasn't sent. 
* Chrome extensions doesn't allow "eval". I had to change the bundling policy of the webpack. 

### How has the user experience changed?

N/A

### Problem: How should I test this?

As far as I know, there is no way to test correct message is shown on the console window. In the current project setup, we're testing the mocks. We suppose that the extension is loaded successfully. But this bug happened because the loading failed. 

### PR Tasks
- [ ] Have tests been added/updated? => Is this possible?
