### PR TITLE
fix: Restore previous electron window size in interactive mode

### DIFF
--- a/packages/server/lib/browsers/electron.js
+++ b/packages/server/lib/browsers/electron.js
@@ -164,22 +164,23 @@ module.exports = {
 
   _getAutomation,
 
-  _render (url, projectRoot, automation, options = {}) {
-    const win = Windows.create(projectRoot, options)
+  _render (url, automation, preferences = {}, options = {}) {
+    const win = Windows.create(options.projectRoot, preferences)
 
-    if (options.browser.isHeadless) {
+    if (preferences.browser.isHeadless) {
       // seemingly the only way to force headless to a certain screen size
-      // electron BrowserWindow constructor is not respecting width/height options
-      win.setSize(options.width, options.height)
-    } else {
-      // we maximize in headed mode, this is consistent with chrome+firefox headed
+      // electron BrowserWindow constructor is not respecting width/height preferences
+      win.setSize(preferences.width, preferences.height)
+    } else if (options.isTextTerminal) {
+      // we maximize in headed mode as long as it's run mode
+      // this is consistent with chrome+firefox headed
       win.maximize()
     }
 
-    automation.use(_getAutomation(win, options))
+    automation.use(_getAutomation(win, preferences))
 
-    return this._launch(win, url, automation, options)
-    .tap(_maybeRecordVideo(win.webContents, options))
+    return this._launch(win, url, automation, preferences)
+    .tap(_maybeRecordVideo(win.webContents, preferences))
   },
 
   _launchChild (e, url, parent, projectRoot, state, options, automation) {
@@ -403,7 +404,10 @@ module.exports = {
 
       debug('launching browser window to url: %s', url)
 
-      return this._render(url, projectRoot, automation, preferences)
+      return this._render(url, automation, preferences, {
+        projectRoot: options.projectRoot,
+        isTextTerminal: options.isTextTerminal,
+      })
       .then(async (win) => {
         await _installExtensions(win, launchOptions.extensions, options)
 

--- a/packages/server/test/unit/browsers/electron_spec.js
+++ b/packages/server/test/unit/browsers/electron_spec.js
@@ -82,13 +82,18 @@ describe('lib/browsers/electron', () => {
 
         options = Windows.defaults(options)
 
-        const keys = _.keys(electron._render.firstCall.args[3])
+        const preferencesKeys = _.keys(electron._render.firstCall.args[2])
 
-        expect(_.keys(options)).to.deep.eq(keys)
+        expect(_.keys(options)).to.deep.eq(preferencesKeys)
+
+        expect(electron._render.firstCall.args[3]).to.deep.eql({
+          projectRoot: this.options.projectRoot,
+          isTextTerminal: this.options.isTextTerminal,
+        })
 
         expect(electron._render).to.be.calledWith(
           this.url,
-          this.options.projectRoot,
+          this.automation,
         )
       })
     })
@@ -112,7 +117,7 @@ describe('lib/browsers/electron', () => {
 
       return electron.open('electron', this.url, this.options, this.automation)
       .then(() => {
-        const options = electron._render.firstCall.args[3]
+        const options = electron._render.firstCall.args[2]
 
         expect(options).to.include.keys('onFocus', 'onNewWindow', 'onCrashed')
       })
@@ -129,7 +134,7 @@ describe('lib/browsers/electron', () => {
 
       return electron.open('electron', this.url, this.options, this.automation)
       .then(() => {
-        const options = electron._render.firstCall.args[3]
+        const options = electron._render.firstCall.args[2]
 
         expect(options).to.include.keys('foo', 'onFocus', 'onNewWindow', 'onCrashed')
       })
@@ -286,6 +291,8 @@ describe('lib/browsers/electron', () => {
         setSize: sinon.stub(),
       }
 
+      this.preferences = { ...this.options }
+
       sinon.stub(menu, 'set')
       sinon.stub(electron, '_setProxy').resolves()
       sinon.stub(electron, '_launch').resolves()
@@ -295,29 +302,46 @@ describe('lib/browsers/electron', () => {
     })
 
     it('creates window instance and calls launch with window', function () {
-      return electron._render(this.url, this.options.projectRoot, this.automation, this.options)
+      return electron._render(this.url, this.automation, this.preferences, this.options)
       .then(() => {
         expect(Windows.create).to.be.calledWith(this.options.projectRoot, this.options)
-        expect(this.newWin.maximize).called
         expect(this.newWin.setSize).not.called
-        expect(electron._launch).to.be.calledWith(this.newWin, this.url, this.automation, this.options)
+        expect(electron._launch).to.be.calledWith(this.newWin, this.url, this.automation, this.preferences)
       })
     })
 
     it('calls setSize on electron window if headless', function () {
-      const options = { ...this.options, browser: { isHeadless: true }, width: 100, height: 200 }
+      const preferences = { ...this.preferences, browser: { isHeadless: true }, width: 100, height: 200 }
 
-      return electron._render(this.url, this.options.projectRoot, this.automation, options)
+      return electron._render(this.url, this.automation, preferences, this.options)
       .then(() => {
         expect(this.newWin.maximize).not.called
         expect(this.newWin.setSize).calledWith(100, 200)
       })
     })
 
+    it('maximizes electron window if headed and not interactive', function () {
+      this.options.isTextTerminal = true
+
+      return electron._render(this.url, this.automation, this.preferences, this.options)
+      .then(() => {
+        expect(this.newWin.maximize).to.be.called
+      })
+    })
+
+    it('does not maximize electron window if interactive', function () {
+      this.options.isTextTerminal = false
+
+      return electron._render(this.url, this.automation, this.preferences, this.options)
+      .then(() => {
+        expect(this.newWin.maximize).not.to.be.called
+      })
+    })
+
     it('registers onRequest automation middleware', function () {
       sinon.spy(this.automation, 'use')
 
-      return electron._render(this.url, this.options.projectRoot, this.automation, this.options)
+      return electron._render(this.url, this.automation, this.preferences, this.options)
       .then(() => {
         expect(Windows.create).to.be.calledWith(this.options.projectRoot, this.options)
         expect(this.automation.use).to.be.called


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog

N/A - Not yet released

### Additional details

https://github.com/cypress-io/cypress/pull/15686 causes the Electron browser window to always maximize on launch when headed. This is for the sake of video recording, but we don't want this behavior in interactive mode.

### How has the user experience changed?

**Before**

![electron-maximize-before](https://user-images.githubusercontent.com/1157043/113594695-07d06480-9606-11eb-9db3-b6a72609cdfd.gif)


**After**

![electron-maximize-after](https://user-images.githubusercontent.com/1157043/113594703-0b63eb80-9606-11eb-9c9e-4986ee1c1217.gif)


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- N/A Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
