### PR TITLE
fix: only log process.emitWarning outside of production

### DIFF
--- a/packages/server/test/e2e/0_max_listeners_spec.ts
+++ b/packages/server/test/e2e/0_max_listeners_spec.ts
@@ -15,6 +15,9 @@ describe('max listeners warning spec', () => {
     browser: 'electron',
     project: projectPath,
     spec: '*',
+    processEnv: {
+      CYPRESS_INTERNAL_ENV: 'production',
+    },
     onRun: async (exec) => {
       const integrationPath = path.join(projectPath, 'cypress/integration')
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- issue number here. e.g. "Closes #1234" -->

### User facing changelog

- Fixed an issue introduced in 7.0.0 where certain Node.js warnings were incorrectly printed to `stderr` in production builds of Cypress.

### Additional details

fix for typo in #15723 

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
