### PR TITLE
fix: Correctly specify @cypress/webpack-dev-server peerDependencies

### DIFF
--- a/npm/webpack-dev-server/package.json
+++ b/npm/webpack-dev-server/package.json
@@ -25,9 +25,9 @@
     "webpack-dev-server": "^3.11.0"
   },
   "peerDependencies": {
-    "html-webpack-plugin": ">=4",
+    "html-webpack-plugin": "^4.0.0",
     "webpack": ">=4",
-    "webpack-dev-server": ">=4"
+    "webpack-dev-server": "^3.0.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
- Closes #15805 and and #15813

### User facing changelog
Fixes incorrectly versioned `peerDependencies` for the `@cypress/webpack-dev-server` package. The package now requires `webpack-dev-server@^3.0.0` rather than `>= 4`