### PR TITLE
fix: checked-for-updates event properly sends, and update banner is displayed

### DIFF
--- a/packages/server/lib/updater.js
+++ b/packages/server/lib/updater.js
@@ -6,6 +6,7 @@ const pkg = require('@packages/root')
 const { agent } = require('@packages/network')
 const konfig = require('./konfig')
 const { machineId } = require('./util/machine_id')
+
 const _getManifest = ({ id, initialLaunch, testingType }) => {
   const url = konfig('desktop_manifest_url')
 
@@ -14,8 +15,9 @@ const _getManifest = ({ id, initialLaunch, testingType }) => {
     headers: {
       'x-cypress-version': pkg.version,
       'x-os-name': os.platform(),
+      'x-arch': os.arch(),
       'x-machine-id': id,
-      'x-initial-launch:': String(initialLaunch),
+      'x-initial-launch': String(initialLaunch),
       'x-testing-type': testingType,
     },
     agent,

--- a/packages/server/test/unit/updater_spec.js
+++ b/packages/server/test/unit/updater_spec.js
@@ -1,30 +1,46 @@
 require('../spec_helper')
 
-const machineId = require(`${root}lib/util/machine_id`)
+const os = require('os')
 const rp = require('@cypress/request-promise')
-const Updater = require(`${root}lib/updater`)
 const pkg = require('@packages/root')
+const machineId = require(`${root}lib/util/machine_id`)
+const Updater = require(`${root}lib/updater`)
 
 describe('lib/updater', () => {
-  context('_getManifest', () => {
+  context('._getManifest', () => {
+    const BASE_URL = 'https://download.cypress.io'
+
+    beforeEach(function () {
+      nock.cleanAll()
+
+      nock.enableNetConnect()
+    })
+
     it('sends the right headers', () => {
-      sinon.stub(rp, 'get').resolves({})
+      sinon.stub(os, 'platform').returns('win32')
+      sinon.stub(os, 'arch').returns('x32')
 
-      Updater._getManifest({ testingType: 'type', initialLaunch: true, id: 'machine-id' })
+      nock(BASE_URL)
+      .matchHeader('x-cypress-version', pkg.version)
+      .matchHeader('x-os-name', 'win32')
+      .matchHeader('x-arch', 'x32')
+      .matchHeader('x-machine-id', 'machine-id')
+      .matchHeader('x-initial-launch', 'true')
+      .matchHeader('x-testing-type', 'type')
+      .get('/desktop.json')
+      .reply(200, {
+        version: '1000.0.0',
+      })
 
-      expect(rp.get).to.be.calledWithMatch({
-        headers: {
-          'x-cypress-version': pkg.version,
-          'x-os-name': 'linux',
-          'x-machine-id': 'machine-id',
-          'x-initial-launch:': 'true',
-          'x-testing-type': 'type',
-        },
+      return Updater
+      ._getManifest({ testingType: 'type', initialLaunch: true, id: 'machine-id' })
+      .then((resp) => {
+        expect(resp.version).to.eq('1000.0.0')
       })
     })
   })
 
-  context('check', () => {
+  context('.check', () => {
     const version = pkg.version
 
     beforeEach(() => {


### PR DESCRIPTION
- Closes #15829 

### User facing changelog
The update banner will now display again when there are updated versions of cypress

### PR Tasks
- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
