### PR TITLE
fix: make the z-index of file opener over the reporter

### DIFF
--- a/packages/ui-components/src/file-opener/file-opener.scss
+++ b/packages/ui-components/src/file-opener/file-opener.scss
@@ -65,7 +65,7 @@ $font-sans: "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 [data-reach-dialog-overlay] {
   display: flex;
   padding: 2em 0;
-  z-index: 1;
+  z-index: 2;
 }
 
 [data-reach-dialog-content] {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->
When selecting the preferred editor for opening files in CT, we get the reporter above the dialog.

Using this PR we get the dialog over the command log panel.


- Closes CT-421

### User facing changelog
Fixed a z-index issue with "Open in IDE" modal in the Component Test Runner.

### How has the user experience changed?
![ouch](https://user-images.githubusercontent.com/5592465/113787346-772a7f00-9700-11eb-97fc-b20272b883a9.png)

