### PR TITLE
fix: make "New Spec File" a button link style

### DIFF
--- a/packages/desktop-gui/src/specs/specs-list.jsx
+++ b/packages/desktop-gui/src/specs/specs-list.jsx
@@ -151,7 +151,7 @@ class SpecsList extends Component {
             </Tooltip>
           </div>
           <div className='new-file-button'>
-            <button className='btn btn-primary' onClick={this._createNewFile.bind(this)}>New Spec File</button>
+            <button className='btn btn-link' onClick={this._createNewFile}><i className="fa fa-plus"></i> New Spec File</button>
           </div>
         </header>
         {this._specsList()}
@@ -289,7 +289,7 @@ class SpecsList extends Component {
     specsStore.toggleExpandSpecFolder(specFolderPath)
   }
 
-  _createNewFile (e) {
+  _createNewFile = (e) => {
     e.preventDefault()
     e.stopPropagation()
 
@@ -405,7 +405,7 @@ class SpecsList extends Component {
         <div className='empty-well'>
           <h5>
             No files found in
-            <code onClick={this._openIntegrationFolder.bind(this)}>
+            <code onClick={this._openIntegrationFolder}>
               {this.props.project.integrationFolder}
             </code>
           </h5>
@@ -425,7 +425,7 @@ class SpecsList extends Component {
       <div className="first-test-banner alert alert-info alert-dismissible">
         <p>We've created some sample tests around key Cypress concepts. Run the first one or create your own test file.</p>
         <p><a onClick={this._openHelp}>How to write tests</a></p>
-        <button className="close" onClick={this._removeFirstTestBanner.bind(this)}><span>&times;</span></button>
+        <button className="close" onClick={this._removeFirstTestBanner}><span>&times;</span></button>
       </div>
     )
   }
@@ -440,7 +440,7 @@ class SpecsList extends Component {
     )
   }
 
-  _openIntegrationFolder () {
+  _openIntegrationFolder = () => {
     ipc.openFinder(this.props.project.integrationFolder)
   }
 
@@ -449,7 +449,7 @@ class SpecsList extends Component {
     ipc.externalOpen('https://on.cypress.io/writing-first-test')
   }
 
-  _removeFirstTestBanner () {
+  _removeFirstTestBanner = () => {
     this.setState({ firstTestBannerDismissed: true })
   }
 }


### PR DESCRIPTION
### User facing changelog
- Changed style of "New Spec File" to be a link style instead of a primary button

### How has the user experience changed?

The previous style was way too aggressive to be a primary button, and distracted from the already existing primary button (which was the browser dropdown).

![image](https://user-images.githubusercontent.com/1268976/113791681-30de1b80-9712-11eb-9d9a-b154fd5ce2fd.png)

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
