### PR TITLE
fix(webpack-dev-server): remove need for webpack html plugin

### DIFF
--- a/npm/webpack-dev-server/index-template.html
+++ b/npm/webpack-dev-server/index-template.html
@@ -8,5 +8,6 @@
   </head>
   <body>
     <div id="__cy_root"></div>
+    <script type="text/javascript" src="/__cypress/src/main.js"></script>
   </body>
 </html>

--- a/npm/webpack-dev-server/package.json
+++ b/npm/webpack-dev-server/package.json
@@ -25,7 +25,6 @@
     "webpack-dev-server": "^3.11.0"
   },
   "peerDependencies": {
-    "html-webpack-plugin": "^4.0.0",
     "webpack": ">=4",
     "webpack-dev-server": "^3.0.0"
   },

--- a/npm/webpack-dev-server/src/makeWebpackConfig.ts
+++ b/npm/webpack-dev-server/src/makeWebpackConfig.ts
@@ -1,10 +1,12 @@
 import { debug as debugFn } from 'debug'
 import * as path from 'path'
 import * as webpack from 'webpack'
+import * as fs from 'fs'
 import { merge } from 'webpack-merge'
 import defaultWebpackConfig from './webpack.config'
 import LazyCompilePlugin from 'lazy-compile-webpack-plugin'
 import CypressCTOptionsPlugin, { CypressCTOptionsPluginOptions } from './plugin'
+import { MiniHtmlWebpackPlugin } from './miniWebpackHtmlPlugin'
 
 const debug = debugFn('cypress:webpack-dev-server:makeWebpackConfig')
 const WEBPACK_MAJOR_VERSION = Number(webpack.version.split('.')[0])
@@ -59,6 +61,9 @@ export async function makeWebpackConfig (userWebpackConfig: webpack.Configuratio
       publicPath,
     },
     plugins: [
+      new MiniHtmlWebpackPlugin({
+        template: fs.readFileSync(path.resolve(__dirname, '..', 'index-template.html'), 'utf8'),
+      }),
       new CypressCTOptionsPlugin({
         files,
         projectRoot,
@@ -74,6 +79,9 @@ export async function makeWebpackConfig (userWebpackConfig: webpack.Configuratio
     dynamicWebpackConfig,
     getLazyCompilationWebpackConfig(options),
   )
+
+  // ignore the user's HtmlWebpackPlugin - we will it for them via `MiniHtmlWebpackPlugin`
+  mergedConfig.plugins = mergedConfig.plugins.filter((x) => x.constructor.name !== 'HtmlWebpackPlugin')
 
   mergedConfig.entry = entry
 

--- a/npm/webpack-dev-server/src/miniWebpackHtmlPlugin.ts
+++ b/npm/webpack-dev-server/src/miniWebpackHtmlPlugin.ts
@@ -1,0 +1,22 @@
+import { RawSource } from 'webpack-sources'
+import webpack from 'webpack'
+
+const pluginName = 'MiniHtmlWebpackPlugin'
+
+export class MiniHtmlWebpackPlugin {
+  #template: string
+
+  constructor (options: { template: string }) {
+    this.#template = options.template
+  }
+
+  apply (compiler: webpack.Compiler) {
+    compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
+      compilation.hooks.additionalAssets.tap({ name: pluginName },
+        (assets) => {
+          // @ts-ignore this does exist, the types are just wrong.
+          compilation.emitAsset('index.html', new RawSource(this.#template))
+        })
+    })
+  }
+}

--- a/npm/webpack-dev-server/src/miniWebpackHtmlPlugin.ts
+++ b/npm/webpack-dev-server/src/miniWebpackHtmlPlugin.ts
@@ -1,21 +1,21 @@
 import { RawSource } from 'webpack-sources'
-import webpack from 'webpack'
+import type { Compiler } from 'webpack'
 
 const pluginName = 'MiniHtmlWebpackPlugin'
 
 export class MiniHtmlWebpackPlugin {
-  #template: string
+  template: string
 
   constructor (options: { template: string }) {
-    this.#template = options.template
+    this.template = options.template
   }
 
-  apply (compiler: webpack.Compiler) {
+  apply (compiler: Compiler) {
     compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
       compilation.hooks.additionalAssets.tap({ name: pluginName },
         (assets) => {
           // @ts-ignore this does exist, the types are just wrong.
-          compilation.emitAsset('index.html', new RawSource(this.#template))
+          compilation.emitAsset('index.html', new RawSource(this.template))
         })
     })
   }

--- a/npm/webpack-dev-server/src/webpack.config.js
+++ b/npm/webpack-dev-server/src/webpack.config.js
@@ -1,7 +1,4 @@
-// @ts-check
 const path = require('path')
-const fs = require('fs')
-const { MiniHtmlWebpackPlugin } = require('./miniWebpackHtmlPlugin')
 
 /** @type {import('webpack').Configuration} */
 module.exports = {
@@ -15,9 +12,4 @@ module.exports = {
     filename: '[name].js',
     path: path.resolve(__dirname, 'dist'),
   },
-  plugins: [
-    new MiniHtmlWebpackPlugin({
-      template: fs.readFileSync(path.resolve(__dirname, '..', 'index-template.html'), 'utf8'),
-    }),
-  ],
 }

--- a/npm/webpack-dev-server/src/webpack.config.js
+++ b/npm/webpack-dev-server/src/webpack.config.js
@@ -1,5 +1,7 @@
+// @ts-check
 const path = require('path')
-const HtmlWebpackPlugin = require('html-webpack-plugin')
+const fs = require('fs')
+const { MiniHtmlWebpackPlugin } = require('./miniWebpackHtmlPlugin')
 
 /** @type {import('webpack').Configuration} */
 module.exports = {
@@ -13,7 +15,9 @@ module.exports = {
     filename: '[name].js',
     path: path.resolve(__dirname, 'dist'),
   },
-  plugins: [new HtmlWebpackPlugin({
-    template: path.resolve(__dirname, '..', 'index-template.html'),
-  })],
+  plugins: [
+    new MiniHtmlWebpackPlugin({
+      template: fs.readFileSync(path.resolve(__dirname, '..', 'index-template.html'), 'utf8'),
+    }),
+  ],
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #15865

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

Remove the `HtmlWebpackPlugin` dependency from `@cypress/webpack-dev-server`.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Supporting two versions of webpack is complex, supporting all the relevant versions of the plugins is even moreso. Instead of using the the complex `HtmlWebpackPlugin` for a fraction of it's features, I'm implemented a much more simple version that does the same thing we need it to do.

We also filter the user's webpack plugins and remove and `HtmlWebpackPlugin` that they supply, since we do not need it anymore. Now users will not need to worry about dependency issues relating the the plugin.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
