### PR TITLE
fix: cy.then shows wrong type when collection of HTMLElement's is provided

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1823,6 +1823,12 @@ declare namespace Cypress {
      *
      * @see https://on.cypress.io/then
      */
+    then<S extends ArrayLike<HTMLElement>>(fn: (this: ObjectLike, currentSubject: Subject) => S): Chainable<JQuery<S extends ArrayLike<infer T> ? T : never>>
+    /**
+     * Enables you to work with the subject yielded from the previous command / promise.
+     *
+     * @see https://on.cypress.io/then
+     */
     then<S extends object | any[] | string | number | boolean>(fn: (this: ObjectLike, currentSubject: Subject) => S): Chainable<S>
     /**
      * Enables you to work with the subject yielded from the previous command / promise.
@@ -1836,6 +1842,12 @@ declare namespace Cypress {
      * @see https://on.cypress.io/then
      */
      then<S extends HTMLElement>(options: Partial<Timeoutable>, fn: (this: ObjectLike, currentSubject: Subject) => S): Chainable<JQuery<S>>
+     /**
+      * Enables you to work with the subject yielded from the previous command / promise.
+      *
+      * @see https://on.cypress.io/then
+      */
+      then<S extends ArrayLike<HTMLElement>>(options: Partial<Timeoutable>, fn: (this: ObjectLike, currentSubject: Subject) => S): Chainable<JQuery<S extends ArrayLike<infer T> ? T : never>>
     /**
      * Enables you to work with the subject yielded from the previous command / promise.
      *

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -239,6 +239,15 @@ describe('then', () => {
       $div // $ExpectType JQuery<HTMLDivElement>
     })
 
+    cy.get('div')
+    .then(($div) => {
+      $div // $ExpectType JQuery<HTMLDivElement>
+      return [$div[0]]
+    })
+    .then(($div) => {
+      $div // $ExpectType JQuery<HTMLDivElement>
+    })
+
     cy.get('p')
     .then(($p) => {
       $p // $ExpectType JQuery<HTMLParagraphElement>


### PR DESCRIPTION
### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

`cy.then` will show correct type when collection of HTMLElement's is provided.

### Additional details

- Why was this change necessary? => When a collection of HTMLElement's is return from the previous cy.then, it is automatically wrapped with JQuery, but this behavior was not reflected in the function type.
- What is affected by this change? => N/A
- Any implementation details to explain? => Added new definition for the function.

Related issues / PRs:

https://github.com/cypress-io/cypress/issues/8440
https://github.com/cypress-io/cypress/issues/14875
https://github.com/cypress-io/cypress/pull/15624

### How has the user experience changed?

N/A

### PR Tasks

<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
