### PR TITLE
fix: initialise nextjs webpack before importing devserver

### DIFF
--- a/npm/react/plugins/next/index.js
+++ b/npm/react/plugins/next/index.js
@@ -1,10 +1,12 @@
-const { startDevServer } = require('@cypress/webpack-dev-server')
 const findNextWebpackConfig = require('./findNextWebpackConfig')
 
 module.exports = (on, config) => {
   on('dev-server:start', async (options) => {
-    return startDevServer({ options, webpackConfig: await findNextWebpackConfig(config) })
+    const webpackConfig=await findNextWebpackConfig(config)
+    const { startDevServer } = require('@cypress/webpack-dev-server')
+    return startDevServer({ options, webpackConfig})
   })
+
 
   config.env.reactDevtools = true
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #15864<!-- issue number here. e.g. "Closes #1234" -->

### User facing changelog
Fixed integration with nextjs for component test runner
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

### Additional details

NextJs provides its own webpack bundle, rather than listing it as a [peer] dependency. This leads to two separate instances, and potentially two separate versions, of webpack being in use simultaneously.
The NextJs config adds a require hook such that `require('webpack')` returns the bundled NextJs version appropriate to the `{future:webpack5}` setting in `config.next.js` - but as the `@cypress/webpack-devserver` package requires webpack, this only works if that package is `require`d __after__ the next config file has run

<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
`cypress open-ct` now progresses to show test runner when next config is used as per the example in the repository
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

