### PR TITLE
fix: Don't send mouse events to non-Node parent nodes

### DIFF
--- a/packages/driver/src/cy/mouse.js
+++ b/packages/driver/src/cy/mouse.js
@@ -286,7 +286,7 @@ const create = (state, keyboard, focused, Cypress) => {
 
         const elsToSendMouseleave = []
 
-        while (curParent && curParent.ownerDocument && curParent !== commonAncestor) {
+        while (curParent && curParent instanceof Node && curParent.ownerDocument && curParent !== commonAncestor) {
           elsToSendMouseleave.push(curParent)
           curParent = curParent.parentNode
         }
@@ -317,7 +317,7 @@ const create = (state, keyboard, focused, Cypress) => {
           let curParent = el
           const elsToSendMouseenter = []
 
-          while (curParent && curParent.ownerDocument && curParent !== commonAncestor) {
+          while (curParent && curParent instanceof Node && curParent.ownerDocument && curParent !== commonAncestor) {
             elsToSendMouseenter.push(curParent)
             curParent = curParent.parentNode
           }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
None

### Additional details
Some webcomponent elements have a `parentNode` that is not an instance of `Node`. These should not be sent mouse events as they will fail. This might have to do with using ShadyDOM. I don't have time at the moment to research it further. However, even without it causing an issue, it's reasonable to check that you're sending these events to an actual `Node`.

<img width="519" alt="Screen Shot 2021-04-11 at 10 49 19 AM" src="https://user-images.githubusercontent.com/1289042/114314227-dbb25900-9ac7-11eb-9d65-05e1171233fa.png">
<img width="675" alt="Screen Shot 2021-04-11 at 11 10 14 AM" src="https://user-images.githubusercontent.com/1289042/114314233-dead4980-9ac7-11eb-8f82-ba18f9b2912e.png">



### How has the user experience changed?
None

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
