### PR TITLE
fix: can send binary data with cy.request.

### DIFF
--- a/packages/driver/cypress/integration/commands/request_spec.js
+++ b/packages/driver/cypress/integration/commands/request_spec.js
@@ -473,6 +473,27 @@ describe('src/cy/commands/request', () => {
       })
     })
 
+    describe('binary data', () => {
+      it('can send binary data', () => {
+        const body = new Blob([[1, 2, 3, 4]], { type: 'application/octet-stream' })
+
+        cy.request(
+          {
+            body,
+            method: 'POST',
+            url: 'http://localhost:3500/dump-octet-body',
+            headers: {
+              'Content-Type': 'application/octet-stream',
+            },
+          },
+        )
+        .then((response) => {
+          expect(response.status).to.equal(200)
+          expect(response.body).to.contain('1,2,3,4')
+        })
+      })
+    })
+
     describe('subjects', () => {
       it('resolves with response obj', () => {
         const resp = {

--- a/packages/driver/cypress/integration/commands/request_spec.js
+++ b/packages/driver/cypress/integration/commands/request_spec.js
@@ -474,7 +474,8 @@ describe('src/cy/commands/request', () => {
     })
 
     describe('binary data', () => {
-      it('can send binary data', () => {
+      // https://github.com/cypress-io/cypress/issues/6178
+      it('can send Blob', () => {
         const body = new Blob([[1, 2, 3, 4]], { type: 'application/octet-stream' })
 
         cy.request(

--- a/packages/driver/cypress/integration/commands/request_spec.js
+++ b/packages/driver/cypress/integration/commands/request_spec.js
@@ -490,7 +490,13 @@ describe('src/cy/commands/request', () => {
         )
         .then((response) => {
           expect(response.status).to.equal(200)
-          expect(response.body).to.contain('1,2,3,4')
+
+          // When user-passed body to the Nodejs server is a Buffer,
+          // Nodejs doesn't provide any decoder in the response.
+          // So, we need to decode it ourselves.
+          const dec = new TextDecoder()
+
+          expect(dec.decode(response.body)).to.contain('1,2,3,4')
         })
       })
     })

--- a/packages/driver/cypress/plugins/server.js
+++ b/packages/driver/cypress/plugins/server.js
@@ -141,9 +141,7 @@ const createApp = (port) => {
   })
 
   app.all('/dump-octet-body', (req, res) => {
-    const body = Buffer.from(JSON.parse(req.body.toString()).data)
-
-    return res.send(`<html><body>it worked!<br>request body:<br>${body.toString()}</body></html>`)
+    return res.send(`<html><body>it worked!<br>request body:<br>${req.body.toString()}</body></html>`)
   })
 
   app.get('/status-404', (req, res) => {

--- a/packages/driver/cypress/plugins/server.js
+++ b/packages/driver/cypress/plugins/server.js
@@ -26,6 +26,7 @@ const createApp = (port) => {
   app.use(require('compression')())
   app.use(bodyParser.urlencoded({ extended: false }))
   app.use(bodyParser.json())
+  app.use(bodyParser.raw())
   app.use(require('method-override')())
 
   app.head('/', (req, res) => {
@@ -137,6 +138,12 @@ const createApp = (port) => {
 
   app.get('/dump-headers', (req, res) => {
     return res.send(`<html><body>request headers:<br>${JSON.stringify(req.headers)}</body></html>`)
+  })
+
+  app.all('/dump-octet-body', (req, res) => {
+    const body = Buffer.from(JSON.parse(req.body.toString()).data)
+
+    return res.send(`<html><body>it worked!<br>request body:<br>${body.toString()}</body></html>`)
   })
 
   app.get('/status-404', (req, res) => {

--- a/packages/driver/src/cy/commands/request.js
+++ b/packages/driver/src/cy/commands/request.js
@@ -283,11 +283,10 @@ module.exports = (Commands, Cypress, cy, state, config) => {
         // construct.name is added because the parent of the Blob is not the same Blob
         // if it's generated from the test spec code.
         if (requestOpts.body instanceof Blob || requestOpts?.body?.constructor.name === 'Blob') {
+          requestOpts.bodyIsBase64Encoded = true
+
           return Cypress.Blob.blobToBase64String(requestOpts.body).then((str) => {
-            requestOpts.body = {
-              isBinary: true,
-              base64: str,
-            }
+            requestOpts.body = str
           })
         }
       })

--- a/packages/driver/src/cy/commands/request.js
+++ b/packages/driver/src/cy/commands/request.js
@@ -285,7 +285,7 @@ module.exports = (Commands, Cypress, cy, state, config) => {
         if (requestOpts.body instanceof Blob || requestOpts?.body?.constructor.name === 'Blob') {
           return Cypress.Blob.blobToBase64String(requestOpts.body).then((str) => {
             requestOpts.body = {
-              contentType: requestOpts.body.type,
+              isBinary: true,
               base64: str,
             }
           })

--- a/packages/server/lib/request.js
+++ b/packages/server/lib/request.js
@@ -504,14 +504,6 @@ module.exports = function (options = {}) {
         response.body = this.parseJsonBody(response.body)
       }
 
-      // https://github.com/cypress-io/cypress/pull/6178
-      // When user-passed body to the Nodejs server is Buffer,
-      // Nodejs doesn't provide the decoder in the response.
-      // So, we need to decode it ourselves.
-      if (Buffer.isBuffer(response.body) && typeis(response, ['text/*'])) {
-        response.body = response.body.toString()
-      }
-
       return response
     },
 

--- a/packages/server/lib/request.js
+++ b/packages/server/lib/request.js
@@ -705,6 +705,12 @@ module.exports = function (options = {}) {
         delete options.body
       }
 
+      // https://github.com/cypress-io/cypress/issues/6178
+      // if body is a Blob
+      if (options?.body?.base64 && options?.body?.contentType) {
+        options.body = Buffer.from(options?.body.base64, 'base64')
+      }
+
       const self = this
 
       const send = () => {

--- a/packages/server/lib/request.js
+++ b/packages/server/lib/request.js
@@ -706,9 +706,15 @@ module.exports = function (options = {}) {
       }
 
       // https://github.com/cypress-io/cypress/issues/6178
-      // if body is a Blob
-      if (options?.body?.base64 && options?.body?.isBinary) {
-        options.body = Buffer.from(options?.body.base64, 'base64')
+      if (options.bodyIsBase64Encoded) {
+        try {
+          debug('body is base64 format: %s', options.body)
+          options.body = Buffer.from(options.body, 'base64')
+        } catch (e) {
+          debug('failed to parse base64 body.')
+
+          throw e
+        }
 
         // These options should be set to send raw Buffer.
         options.encoding = null

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -115,6 +115,7 @@
     "trash": "5.2.0",
     "tree-kill": "1.2.2",
     "ts-node": "8.5.4",
+    "type-is": "1.6.18",
     "underscore.string": "3.3.5",
     "url-parse": "1.5.1",
     "uuid": "8.3.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -115,7 +115,6 @@
     "trash": "5.2.0",
     "tree-kill": "1.2.2",
     "ts-node": "8.5.4",
-    "type-is": "1.6.18",
     "underscore.string": "3.3.5",
     "url-parse": "1.5.1",
     "uuid": "8.3.2",


### PR DESCRIPTION
- Closes #6178

### User facing changelog

`cy.request` can now send blob data.

### Additional details
- Why was this change necessary? => Blob data was ignored because it cannot be serialized with `JSON.stringify`. 
- What is affected by this change? => N/A
- Any implementation details to explain? => Blob is encoded into base64 in the client and decoded and encoded to Buffer in the server and send it.

### How has the user experience changed?

N/A

### Possible Problem

`@cypress/request-promise` encodes `Buffer` into an object. Maybe this format might not be what users want. 

### PR Tasks

- [x] Have tests been added/updated?
