### PR TITLE
fix: prevent stubbed cy.intercepts from reaching server

### DIFF
--- a/packages/driver/cypress/plugins/server.js
+++ b/packages/driver/cypress/plugins/server.js
@@ -151,6 +151,17 @@ const createApp = (port) => {
     .send('<html><body>server error</body></html>')
   })
 
+  let _var = ''
+
+  app.get('/set-var', (req, res) => {
+    _var = req.query.v
+    res.sendStatus(200)
+  })
+
+  app.get('/get-var', (req, res) => {
+    res.send(_var)
+  })
+
   app.use(express.static(path.join(__dirname, '..')))
 
   app.use(require('errorhandler')())

--- a/packages/net-stubbing/lib/server/middleware/request.ts
+++ b/packages/net-stubbing/lib/server/middleware/request.ts
@@ -148,5 +148,11 @@ export const InterceptRequest: RequestMiddleware = async function () {
   // @ts-ignore
   mergeChanges(request.req, req)
 
+  if (request.responseSent) {
+    // request has been fulfilled with a response already, do not send the request outgoing
+    // @see https://github.com/cypress-io/cypress/issues/15841
+    return this.end()
+  }
+
   return request.continueRequest()
 }

--- a/packages/net-stubbing/lib/server/middleware/response.ts
+++ b/packages/net-stubbing/lib/server/middleware/response.ts
@@ -28,8 +28,6 @@ export const InterceptResponse: ResponseMiddleware = async function () {
     return this.next()
   }
 
-  request.incomingRes = this.incomingRes
-
   request.onResponse = (incomingRes, resStream) => {
     this.incomingRes = incomingRes
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #15841

### User facing changelog

Fixed an issue introduced in 7.0.0 where requests with responses stubbed via `cy.intercept(routeMatcher, staticResponse)` would still be sent to the destination server.

### Additional details

Introduced in #15255 

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
