### PR TITLE
fix: don't pass invalid signal to subprocess.exit on crash

### DIFF
--- a/packages/server/lib/browsers/electron.js
+++ b/packages/server/lib/browsers/electron.js
@@ -431,8 +431,8 @@ module.exports = {
             return win.webContents.getOSProcessId()
           })],
           browserWindow: win,
-          kill: (isProcessExit) => {
-            if (isProcessExit) {
+          kill () {
+            if (this.isProcessExit) {
               // if the process is exiting, all BrowserWindows will be destroyed anyways
               return
             }

--- a/packages/server/lib/browsers/index.js
+++ b/packages/server/lib/browsers/index.js
@@ -36,7 +36,9 @@ const kill = function (unbind, isProcessExit) {
 
     debug('killing browser process')
 
-    _instance.kill(isProcessExit)
+    _instance.isProcessExit = isProcessExit
+
+    _instance.kill()
   })
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #15943

### User facing changelog

Fixed an issue where crashes in Cypress would cause a misleading "Unknown signal: true" error after the actual crash message.

### Additional details

- no users reported, but i have seen it a few times with random crashes

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
