### PR TITLE
fix: remove lazy-compile-webpack-plugin, make html-webpack-plugin a dependency

### DIFF
--- a/npm/webpack-dev-server/__perf-stats/react.json
+++ b/npm/webpack-dev-server/__perf-stats/react.json
@@ -1,12882 +1,12810 @@
 {
   "misc": {
-    "compileTime": 21900
+    "compileTime": 5380
   },
   "plugins": {
-    "HtmlWebpackPlugin": 1673,
-    "CypressCTOptionsPlugin": 276
+    "HtmlWebpackPlugin": 1578,
+    "CypressCTOptionsPlugin": 173
   },
   "loaders": {
     "build": [
       {
         "averages": {
           "dataPoints": 1,
-          "median": 18,
-          "mean": 18,
+          "median": 16,
+          "mean": 16,
           "range": {
-            "start": 18,
-            "end": 18
+            "start": 16,
+            "end": 16
           }
         },
-        "activeTime": 18,
+        "activeTime": 16,
         "loaders": [
           "html-webpack-plugin"
         ],
         "subLoadersTime": {},
         "rawStartEnds": [
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/html-webpack-plugin/lib/loader.js!/Users/dmitrijkovalenko/dev/_cy/cypress/npm/webpack-dev-server/index-template.html",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-webpack-plugin/lib/loader.js!/Users/lachlan/code/work/cypress5/npm/webpack-dev-server/index-template.html",
             "fillLast": true,
             "loaders": [
               "html-webpack-plugin"
             ],
-            "start": 1612964434897,
-            "end": 1612964434915
+            "start": 1618289077027,
+            "end": 1618289077043
           }
         ]
       },
       {
         "averages": {
           "dataPoints": 3,
-          "median": 450,
-          "mean": 508,
+          "median": 70,
+          "mean": 100,
           "range": {
-            "start": 209,
-            "end": 864
+            "start": 70,
+            "end": 156
           },
-          "variance": 109751
+          "variance": 2383
         },
-        "activeTime": 1523,
+        "activeTime": 299,
         "loaders": [
           "modules with no loaders"
         ],
         "subLoadersTime": {},
         "rawStartEnds": [
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/style-loader/lib/addStyles.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-webpack-plugin/node_modules/lodash/lodash.js",
             "fillLast": true,
             "loaders": [
               "modules with no loaders"
             ],
-            "start": 1612964438666,
-            "end": 1612964439530
+            "start": 1618289077046,
+            "end": 1618289077202
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/webpack/buildin/amd-options.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/style-loader/lib/addStyles.js",
             "fillLast": true,
             "loaders": [
               "modules with no loaders"
             ],
-            "start": 1612964445500,
-            "end": 1612964445950
+            "start": 1618289078903,
+            "end": 1618289078976
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/html-webpack-plugin/node_modules/lodash/lodash.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/webpack/buildin/amd-options.js",
             "fillLast": true,
             "loaders": [
               "modules with no loaders"
             ],
-            "start": 1612964434918,
-            "end": 1612964435127
+            "start": 1618289079776,
+            "end": 1618289079846
           }
         ]
       },
       {
         "averages": {
-          "dataPoints": 1417,
-          "median": 258,
-          "mean": 477,
+          "dataPoints": 1409,
+          "median": 169,
+          "mean": 117,
           "range": {
-            "start": 3,
-            "end": 3089
+            "start": 1,
+            "end": 1319
           },
-          "variance": 316792
+          "variance": 3985
         },
-        "activeTime": 21305,
+        "activeTime": 5021,
         "loaders": [
           "babel-loader"
         ],
         "subLoadersTime": {},
         "rawStartEnds": [
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-i18next/dist/es/withTranslation.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/webpack-dev-server/dist/browser.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440655,
-            "end": 1612964443744
+            "start": 1618289077048,
+            "end": 1618289078367
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-i18next/dist/es/Translation.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/cjs/react-dom.development.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440655,
-            "end": 1612964443734
+            "start": 1618289079222,
+            "end": 1618289080123
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-i18next/dist/es/useTranslation.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/framer-motion/dist/framer-motion.es.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440654,
-            "end": 1612964443729
+            "start": 1618289079327,
+            "end": 1618289079843
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-i18next/dist/es/withSSR.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/lodash/lodash.min.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440654,
-            "end": 1612964443708
+            "start": 1618289079358,
+            "end": 1618289079741
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-i18next/dist/es/I18nextProvider.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/js-beautify/js/lib/beautify.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440654,
-            "end": 1612964443699
+            "start": 1618289079616,
+            "end": 1618289079984
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-i18next/dist/es/useSSR.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx/dist/mobx.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440654,
-            "end": 1612964443695
+            "start": 1618289079270,
+            "end": 1618289079585
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-i18next/dist/es/context.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/js-beautify/js/lib/beautify-html.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440653,
-            "end": 1612964443684
+            "start": 1618289079616,
+            "end": 1618289079928
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-i18next/dist/es/Trans.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/js-beautify/js/lib/beautify-css.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440649,
-            "end": 1612964443669
+            "start": 1618289079616,
+            "end": 1618289079865
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/i18next/dist/esm/i18next.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440649,
-            "end": 1612964443621
+            "start": 1618289079301,
+            "end": 1618289079539
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/cypress-react-selector/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/recompose/es/Recompose.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440650,
-            "end": 1612964443610
+            "start": 1618289080039,
+            "end": 1618289080264
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/utils.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/capitalize.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440649,
-            "end": 1612964443606
+            "start": 1618289079521,
+            "end": 1618289079744
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TextField/TextField.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SvgIcon/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440644,
-            "end": 1612964443582
+            "start": 1618289079906,
+            "end": 1618289080129
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Box/Box.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/utils/createSvgIcon.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440644,
-            "end": 1612964443557
+            "start": 1618289079364,
+            "end": 1618289079586
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/FormControl/FormControl.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/bind.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440644,
-            "end": 1612964443552
+            "start": 1618289079908,
+            "end": 1618289080130
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ListItem/ListItem.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/utils.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440644,
-            "end": 1612964443525
+            "start": 1618289079525,
+            "end": 1618289079746
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Button/Button.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/useAutocomplete/useAutocomplete.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440643,
-            "end": 1612964443501
+            "start": 1618289080038,
+            "end": 1618289080258
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/InputLabel/InputLabel.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/useAsObservableSource.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440644,
-            "end": 1612964443469
+            "start": 1618289079550,
+            "end": 1618289079769
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Select/Select.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/assertEnvironment.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440643,
-            "end": 1612964443451
+            "start": 1618289079555,
+            "end": 1618289079774
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/colorManipulator.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonBase/ButtonBase.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440643,
-            "end": 1612964443423
+            "start": 1618289079957,
+            "end": 1618289080172
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/FormLabel.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/popper.js/dist/esm/popper.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440634,
-            "end": 1612964443397
+            "start": 1618289080485,
+            "end": 1618289080698
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/FormGroup.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-is/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440634,
-            "end": 1612964443383
+            "start": 1618289079639,
+            "end": 1618289079851
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/FormText.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types/lib/ReactPropTypesSecret.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440634,
-            "end": 1612964443367
+            "start": 1618289079640,
+            "end": 1618289079852
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Switch.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440634,
-            "end": 1612964443361
+            "start": 1618289079544,
+            "end": 1618289079753
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/FormControl.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/getPrototypeOf.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440631,
-            "end": 1612964443355
+            "start": 1618289079931,
+            "end": 1618289080139
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/FormHelperText/FormHelperText.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/objectSpread.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440643,
-            "end": 1612964443339
+            "start": 1618289079932,
+            "end": 1618289080140
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/DropdownItem.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/stylis/dist/stylis.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440630,
-            "end": 1612964443323
+            "start": 1618289079805,
+            "end": 1618289080012
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Container.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/createClass.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440634,
-            "end": 1612964443306
+            "start": 1618289079932,
+            "end": 1618289080139
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Fade.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/classCallCheck.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440630,
-            "end": 1612964443299
+            "start": 1618289079932,
+            "end": 1618289080139
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/DropdownButton.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/styled-components/dist/styled-components.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440630,
-            "end": 1612964443287
+            "start": 1618289079278,
+            "end": 1618289079484
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/FormFile.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440633,
-            "end": 1612964443280
+            "start": 1618289079931,
+            "end": 1618289080137
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Collapse.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/possibleConstructorReturn.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440629,
-            "end": 1612964443264
+            "start": 1618289079931,
+            "end": 1618289080137
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/FormCheck.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/internal/svg-icons/createSvgIcon.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440631,
-            "end": 1612964443237
+            "start": 1618289079929,
+            "end": 1618289080134
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Form.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/objectWithoutProperties.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440630,
-            "end": 1612964443222
+            "start": 1618289079930,
+            "end": 1618289080135
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Col.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types/checkPropTypes.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440628,
-            "end": 1612964443214
+            "start": 1618289079343,
+            "end": 1618289079547
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Typography/Typography.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/possibleConstructorReturn.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440635,
-            "end": 1612964443204
+            "start": 1618289079952,
+            "end": 1618289080154
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/CloseButton.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/useLocalObservable.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440628,
-            "end": 1612964443178
+            "start": 1618289079945,
+            "end": 1618289080146
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Dropdown.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/createClass.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440630,
-            "end": 1612964443172
+            "start": 1618289079953,
+            "end": 1618289080154
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/MenuItem/MenuItem.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/useObserver.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440635,
-            "end": 1612964443154
+            "start": 1618289079957,
+            "end": 1618289080158
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Carousel.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/withTheme/withTheme.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440628,
-            "end": 1612964443135
+            "start": 1618289079959,
+            "end": 1618289080160
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/CarouselItem.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/Transition.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440629,
-            "end": 1612964443099
+            "start": 1618289080032,
+            "end": 1618289080233
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/CardColumns.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/useLocalStore.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440630,
-            "end": 1612964443097
+            "start": 1618289079944,
+            "end": 1618289080144
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/CardGroup.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/is-buffer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440629,
-            "end": 1612964443094
+            "start": 1618289079945,
+            "end": 1618289080145
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ButtonGroup.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/inherits.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440629,
-            "end": 1612964443087
+            "start": 1618289079950,
+            "end": 1618289080150
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ButtonToolbar.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/ObserverComponent.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440629,
-            "end": 1612964443080
+            "start": 1618289079952,
+            "end": 1618289080152
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Card.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/setPrototypeOf.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440629,
-            "end": 1612964443075
+            "start": 1618289079956,
+            "end": 1618289080156
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/CardImg.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/observer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440628,
-            "end": 1612964443060
+            "start": 1618289079956,
+            "end": 1618289080156
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/CardDeck.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/staticRendering.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440623,
-            "end": 1612964443053
+            "start": 1618289079957,
+            "end": 1618289080157
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/styled-components/dist/styled-components.browser.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440621,
-            "end": 1612964443049
+            "start": 1618289078785,
+            "end": 1618289078984
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Breadcrumb.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/unitless/dist/unitless.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440622,
-            "end": 1612964442883
+            "start": 1618289079804,
+            "end": 1618289080000
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/BreadcrumbItem.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/createClass.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440623,
-            "end": 1612964442872
+            "start": 1618289080039,
+            "end": 1618289080235
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Button.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/camelize.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440623,
-            "end": 1612964442863
+            "start": 1618289080040,
+            "end": 1618289080236
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Badge.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/css.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440623,
-            "end": 1612964442854
+            "start": 1618289080041,
+            "end": 1618289080237
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Alert.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/createSvgIcon.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440623,
-            "end": 1612964442842
+            "start": 1618289080043,
+            "end": 1618289080239
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/AccordionCollapse.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440623,
-            "end": 1612964442830
+            "start": 1618289079804,
+            "end": 1618289079999
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/AccordionToggle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/typeof.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440622,
-            "end": 1612964442818
+            "start": 1618289080040,
+            "end": 1618289080235
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Accordion.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/transitionEnd.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440622,
-            "end": 1612964442804
+            "start": 1618289080041,
+            "end": 1618289080236
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/mobx/dist/mobx.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/is-prop-valid/dist/is-prop-valid.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440621,
-            "end": 1612964442789
+            "start": 1618289079804,
+            "end": 1618289079998
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/radioactive-state/counter/counter-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/select-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436280,
-            "end": 1612964438072
+            "start": 1618289078483,
+            "end": 1618289078676
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/radioactive-state/counters/counters-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/invariant/browser.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436281,
-            "end": 1612964438065
+            "start": 1618289080037,
+            "end": 1618289080230
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-book-example/src/Note.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MenuItem/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436281,
-            "end": 1612964438053
+            "start": 1618289078909,
+            "end": 1618289079101
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/tutorial/tic-tac-toe-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputLabel/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436280,
-            "end": 1612964438046
+            "start": 1618289078909,
+            "end": 1618289079101
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/tutorial/shopping-list-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436279,
-            "end": 1612964438037
+            "start": 1618289078910,
+            "end": 1618289079102
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/tutorial/square-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/i18n/i18n.ts",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436280,
-            "end": 1612964438027
+            "start": 1618289078918,
+            "end": 1618289079110
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/mobx-react-lite/es/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/breakpoints.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964442302,
-            "end": 1612964444033
+            "start": 1618289080035,
+            "end": 1618289080227
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/unfetch/dist/unfetch.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/can-use-dom/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964443750,
-            "end": 1612964445481
+            "start": 1618289080036,
+            "end": 1618289080228
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/helpers/spread.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormHelperText/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964442291,
-            "end": 1612964444015
+            "start": 1618289078909,
+            "end": 1618289079100
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/i18next/dist/esm/i18next.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControl/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964442290,
-            "end": 1612964444012
+            "start": 1618289078909,
+            "end": 1618289079100
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/prop-types/factoryWithTypeCheckers.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/use-render/my-component-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964443750,
-            "end": 1612964445468
+            "start": 1618289078915,
+            "end": 1618289079106
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/framer-motion/dist/framer-motion.es.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Select/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964443670,
-            "end": 1612964445386
+            "start": 1618289078909,
+            "end": 1618289079099
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/radioactive-state/todos/todos-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/compose.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436281,
-            "end": 1612964437995
+            "start": 1618289080034,
+            "end": 1618289080224
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/object-assign/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/arrayLikeToArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964442312,
-            "end": 1612964444023
+            "start": 1618289080035,
+            "end": 1618289080225
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/icons/utils/createSvgIcon.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/reactBatchedUpdates.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964443685,
-            "end": 1612964445395
+            "start": 1618289080035,
+            "end": 1618289080225
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-book-example/src/add.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todo.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436281,
-            "end": 1612964437988
+            "start": 1618289078906,
+            "end": 1618289079095
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/enzyme/simple-context.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440621,
-            "end": 1612964442326
+            "start": 1618289078906,
+            "end": 1618289079095
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-book-example/src/Todos.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/process/browser.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436282,
-            "end": 1612964437983
+            "start": 1618289079605,
+            "end": 1618289079794
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Divider/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todos.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440620,
-            "end": 1612964442311
+            "start": 1618289078906,
+            "end": 1618289079094
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-book-example/src/components/ProductsList.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/CheckBoxOutlineBlank.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436282,
-            "end": 1612964437971
+            "start": 1618289079803,
+            "end": 1618289079990
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Checkbox/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/css.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440620,
-            "end": 1612964442309
+            "start": 1618289080033,
+            "end": 1618289080220
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ListItemText/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/styled-components/Todos.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440619,
-            "end": 1612964442307
+            "start": 1618289078905,
+            "end": 1618289079091
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ListItemIcon/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/styled-components/Todo.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440619,
-            "end": 1612964442304
+            "start": 1618289078906,
+            "end": 1618289079092
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/FormControlLabel/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/objectWithoutProperties.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440620,
-            "end": 1612964442301
+            "start": 1618289079331,
+            "end": 1618289079517
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/List/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/defineProperty.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440620,
-            "end": 1612964442298
+            "start": 1618289079332,
+            "end": 1618289079518
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/FormGroup/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/SwitchBase.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440620,
-            "end": 1612964442295
+            "start": 1618289079802,
+            "end": 1618289079988
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/lazy-loaded-suspense/Dog.tsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/IndeterminateCheckBox.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440616,
-            "end": 1612964442290
+            "start": 1618289079803,
+            "end": 1618289079989
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-dom/cjs/react-dom.development.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/CheckBox.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440610,
-            "end": 1612964442277
+            "start": 1618289079803,
+            "end": 1618289079989
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-book-example/src/add2.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/defineProperty.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436281,
-            "end": 1612964437943
+            "start": 1618289079511,
+            "end": 1618289079696
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-router-v6/in-memory-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/scriptjs/dist/script.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436277,
-            "end": 1612964437938
+            "start": 1618289080031,
+            "end": 1618289080216
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/timers/card-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/extends.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436279,
-            "end": 1612964437930
+            "start": 1618289079331,
+            "end": 1618289079515
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/renderless/mouse-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/objectWithoutProperties.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436277,
-            "end": 1612964437923
+            "start": 1618289079506,
+            "end": 1618289079690
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/use-local-storage/App.spec.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/slicedToArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436280,
-            "end": 1612964437913
+            "start": 1618289079513,
+            "end": 1618289079697
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-imports/RemotePizza.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/inheritsLoose.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436274,
-            "end": 1612964437898
+            "start": 1618289079615,
+            "end": 1618289079799
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-book-example/src/products.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/transitions/utils.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436281,
-            "end": 1612964437904
+            "start": 1618289080033,
+            "end": 1618289080217
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-axios/1-users.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/shadows.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436272,
-            "end": 1612964437863
+            "start": 1618289079328,
+            "end": 1618289079511
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/testing-lib-example/testing-lib-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/typeof.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436279,
-            "end": 1612964437870
+            "start": 1618289079615,
+            "end": 1618289079798
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-router-v6/spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/internal/svg-icons/ArrowDropDown.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436277,
-            "end": 1612964437853
+            "start": 1618289079625,
+            "end": 1618289079808
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-imports/spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/internal/svg-icons/Star.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436275,
-            "end": 1612964437847
+            "start": 1618289079626,
+            "end": 1618289079809
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/hooks/counter2-with-hooks.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/shape.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436266,
-            "end": 1612964437830
+            "start": 1618289079328,
+            "end": 1618289079510
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/framer-motion/Motion.spec.tsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/classCallCheck.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436265,
-            "end": 1612964437825
+            "start": 1618289079509,
+            "end": 1618289079691
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/set-timeout-example/app-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/internal/svg-icons/Close.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436277,
-            "end": 1612964437837
+            "start": 1618289079626,
+            "end": 1618289079808
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/test-retries/spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded/App.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436278,
-            "end": 1612964437805
+            "start": 1618289078903,
+            "end": 1618289079084
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/testing-lib-example/spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded/OtherComponent.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436278,
-            "end": 1612964437795
+            "start": 1618289078904,
+            "end": 1618289079085
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-bootstrap/modal-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/context/context.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436276,
-            "end": 1612964437789
+            "start": 1618289078905,
+            "end": 1618289079086
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/radioactive-state/utils/afterSync.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/Autocomplete/Autocomplete.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444015,
-            "end": 1612964445528
+            "start": 1618289079322,
+            "end": 1618289079503
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/common.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/js-beautify/js/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444026,
-            "end": 1612964445537
+            "start": 1618289079328,
+            "end": 1618289079509
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/interopRequireDefault.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-router/react-router.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444024,
-            "end": 1612964445532
+            "start": 1618289079420,
+            "end": 1618289079601
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/radioactive-state/utils/mutate.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/components/ProductsList.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444016,
-            "end": 1612964445523
+            "start": 1618289078489,
+            "end": 1618289078669
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/set-timeout-example/loading-indicator-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/Todos.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436278,
-            "end": 1612964437761
+            "start": 1618289078903,
+            "end": 1618289079083
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-bootstrap/dropdown-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/cssUtils.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436276,
-            "end": 1612964437744
+            "start": 1618289079326,
+            "end": 1618289079506
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/forward-ref/forward-ref.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/TemplateTag/TemplateTag.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436265,
-            "end": 1612964437707
+            "start": 1618289079695,
+            "end": 1618289079875
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/custom-command/spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Todos.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436264,
-            "end": 1612964437695
+            "start": 1618289078489,
+            "end": 1618289078668
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mock-fetch/fetch-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createSpacing.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436271,
-            "end": 1612964437701
+            "start": 1618289079326,
+            "end": 1618289079505
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/timers/card-without-effect-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/popmotion/dist/popmotion.es.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436279,
-            "end": 1612964437690
+            "start": 1618289080161,
+            "end": 1618289080340
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/hooks/counter-with-hooks.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/list-demo.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436265,
-            "end": 1612964437669
+            "start": 1618289078902,
+            "end": 1618289079080
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/portal/portal-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/Rating/Rating.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436276,
-            "end": 1612964437677
+            "start": 1618289079321,
+            "end": 1618289079499
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-imports/PizzaProps.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/zIndex.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436274,
-            "end": 1612964437660
+            "start": 1618289079326,
+            "end": 1618289079504
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/hooks/use-counter.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mobx-v6/Timer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436266,
-            "end": 1612964437621
+            "start": 1618289078901,
+            "end": 1618289079078
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/material-ui-example/select-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Note.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436270,
-            "end": 1612964437605
+            "start": 1618289078902,
+            "end": 1618289079079
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-axios/2-users-named.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/classnames/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436272,
-            "end": 1612964437521
+            "start": 1618289079985,
+            "end": 1618289080162
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/material-ui-example/simple-rating-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/add.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436271,
-            "end": 1612964437512
+            "start": 1618289078488,
+            "end": 1618289078664
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-axios/3-users-api.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/products.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436273,
-            "end": 1612964437481
+            "start": 1618289078489,
+            "end": 1618289078665
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-component/spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/history/history.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436274,
-            "end": 1612964437463
+            "start": 1618289079419,
+            "end": 1618289079595
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/counter-use-hooks/counter-hooks-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/is-buffer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436256,
-            "end": 1612964437440
+            "start": 1618289080026,
+            "end": 1618289080202
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/material-ui-example/checkbox-labels-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/grid.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436270,
-            "end": 1612964437447
+            "start": 1618289080027,
+            "end": 1618289080203
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/material-ui-example/button-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/flexbox.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436269,
-            "end": 1612964437444
+            "start": 1618289080029,
+            "end": 1618289080205
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/material-ui-example/list-item-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/todos-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436270,
-            "end": 1612964437434
+            "start": 1618289078488,
+            "end": 1618289078663
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/lab/esm/Autocomplete/Autocomplete.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/add2.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964443587,
-            "end": 1612964444750
+            "start": 1618289078489,
+            "end": 1618289078664
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/css-modules/css-modules-orange-button-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Note.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436257,
-            "end": 1612964437417
+            "start": 1618289078489,
+            "end": 1618289078664
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mobx-v6/timer-spec.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mock-fetch/user.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436271,
-            "end": 1612964437426
+            "start": 1618289078902,
+            "end": 1618289079077
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/withScriptjs.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/toConsumableArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444597,
-            "end": 1612964445748
+            "start": 1618289080003,
+            "end": 1618289080178
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/styled-components/Todos-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/palette.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436263,
-            "end": 1612964437407
+            "start": 1618289080026,
+            "end": 1618289080201
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/webpack-dev-server/dist/browser.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/object/get-prototype-of.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964434919,
-            "end": 1612964436056
+            "start": 1618289080028,
+            "end": 1618289080203
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/prop-types/lib/ReactPropTypesSecret.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/display.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444597,
-            "end": 1612964445733
+            "start": 1618289080030,
+            "end": 1618289080205
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Divider/Divider.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counters/counters-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444596,
-            "end": 1612964445726
+            "start": 1618289078488,
+            "end": 1618289078662
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/lodash/lodash.min.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/observerBatching.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964443469,
-            "end": 1612964444593
+            "start": 1618289079990,
+            "end": 1618289080164
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ListItemText/ListItemText.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/classCallCheck.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444595,
-            "end": 1612964445710
+            "start": 1618289079991,
+            "end": 1618289080165
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/lazy-loaded/other-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createBreakpoints.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436268,
-            "end": 1612964437377
+            "start": 1618289080007,
+            "end": 1618289080181
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/lazy-loaded/lazy-load-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/useForkRef.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436268,
-            "end": 1612964437372
+            "start": 1618289080025,
+            "end": 1618289080199
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/material-ui-example/autocomplete-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/positions.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436268,
-            "end": 1612964437369
+            "start": 1618289080026,
+            "end": 1618289080200
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Checkbox/Checkbox.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/tutorial/shopping-list-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444595,
-            "end": 1612964445695
+            "start": 1618289078487,
+            "end": 1618289078660
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/lab/esm/Rating/Rating.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/checkbox-labels.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964443584,
-            "end": 1612964444683
+            "start": 1618289078901,
+            "end": 1618289079074
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ThemeProvider.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/deepmerge.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444686,
-            "end": 1612964445782
+            "start": 1618289080025,
+            "end": 1618289080198
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/i18n/i18next-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counter/counter-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436266,
-            "end": 1612964437348
+            "start": 1618289078488,
+            "end": 1618289078660
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/createWithBsPrefix.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types/factoryWithTypeCheckers.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444684,
-            "end": 1612964445761
+            "start": 1618289079463,
+            "end": 1618289079635
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/FormControlLabel/FormControlLabel.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/createWithBsPrefix.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444595,
-            "end": 1612964445667
+            "start": 1618289079488,
+            "end": 1618289079660
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/lazy-loaded/app-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/elementTypeAcceptingRef.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436267,
-            "end": 1612964437325
+            "start": 1618289080022,
+            "end": 1618289080194
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/lodash/fp/_baseConvert.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/elementAcceptingRef.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964443583,
-            "end": 1612964444639
+            "start": 1618289080023,
+            "end": 1618289080195
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/lazy-loaded-suspense/lazy-loaded-suspense.spec.tsx",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/tutorial/square-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436267,
-            "end": 1612964437320
+            "start": 1618289078488,
+            "end": 1618289078659
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/condense-newlines/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/PizzaProps.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444752,
-            "end": 1612964445794
+            "start": 1618289078900,
+            "end": 1618289079071
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/styled-components/Todo-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-component/contact.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436263,
-            "end": 1612964437296
+            "start": 1618289078901,
+            "end": 1618289079072
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/List/List.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/axios-api.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444595,
-            "end": 1612964445627
+            "start": 1618289078901,
+            "end": 1618289079072
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/document/document-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Collapse.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436257,
-            "end": 1612964437285
+            "start": 1618289079488,
+            "end": 1618289079659
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/extend-shallow/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/getDisplayName.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444751,
-            "end": 1612964445767
+            "start": 1618289080021,
+            "end": 1618289080192
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ListItemIcon/ListItemIcon.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/exactProp.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444595,
-            "end": 1612964445603
+            "start": 1618289080022,
+            "end": 1618289080193
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/counter-set-state/counter-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/node_modules/scheduler/cjs/scheduler.development.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436255,
-            "end": 1612964437259
+            "start": 1618289080498,
+            "end": 1618289080669
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/css/css-orange-button-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/component.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436257,
-            "end": 1612964437252
+            "start": 1618289078900,
+            "end": 1618289079070
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/hello-world-inline-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-component/map.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436253,
-            "end": 1612964437247
+            "start": 1618289078900,
+            "end": 1618289079070
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/FormGroup/FormGroup.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/extend-shallow/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964444594,
-            "end": 1612964445579
+            "start": 1618289079323,
+            "end": 1618289079493
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/enzyme/context-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/condense-newlines/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436258,
-            "end": 1612964437238
+            "start": 1618289079324,
+            "end": 1618289079494
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/enzyme/props-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/shallowequal/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436258,
-            "end": 1612964437228
+            "start": 1618289079849,
+            "end": 1618289080019
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todos.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListSubheader/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438669,
-            "end": 1612964439631
+            "start": 1618289079853,
+            "end": 1618289080023
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/context/App-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Popper/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436264,
-            "end": 1612964437194
+            "start": 1618289079853,
+            "end": 1618289080023
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todo.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/clsx/dist/clsx.m.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438669,
-            "end": 1612964439597
+            "start": 1618289079854,
+            "end": 1618289080024
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/hello-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/formatMuiErrorMessage.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436261,
-            "end": 1612964437188
+            "start": 1618289080022,
+            "end": 1618289080192
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/context/context.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/codeBlock/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438669,
-            "end": 1612964439589
+            "start": 1618289081465,
+            "end": 1618289081635
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/context/Mock-context-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/html/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436264,
-            "end": 1612964437183
+            "start": 1618289081466,
+            "end": 1618289081636
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/enzyme/simple-context.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaListsAnd/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438668,
-            "end": 1612964439586
+            "start": 1618289081467,
+            "end": 1618289081637
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/styled-components/Todo.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaListsOr/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438668,
-            "end": 1612964439584
+            "start": 1618289081467,
+            "end": 1618289081637
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/api-test/spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaLists/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436264,
-            "end": 1612964437177
+            "start": 1618289081468,
+            "end": 1618289081638
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/lazy-loaded/App.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/timers/card-without-effect-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438668,
-            "end": 1612964439576
+            "start": 1618289078487,
+            "end": 1618289078656
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/before-hook/spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/tutorial/tic-tac-toe-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436255,
-            "end": 1612964437159
+            "start": 1618289078488,
+            "end": 1618289078657
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/styled-components/Todos.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/use-local-storage/App.spec.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438668,
-            "end": 1612964439571
+            "start": 1618289078488,
+            "end": 1618289078657
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/app-action-example/counter-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/window-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436264,
-            "end": 1612964437165
+            "start": 1618289078884,
+            "end": 1618289079053
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/emotion-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/App.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436251,
-            "end": 1612964437144
+            "start": 1618289078899,
+            "end": 1618289079068
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/stub-example/clicker-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/RemotePizza.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436263,
-            "end": 1612964437152
+            "start": 1618289078900,
+            "end": 1618289079069
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/alias/alias-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/greeting.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436254,
-            "end": 1612964437137
+            "start": 1618289078900,
+            "end": 1618289079069
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/hello-x-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/AccordionContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436253,
-            "end": 1612964437120
+            "start": 1618289079487,
+            "end": 1618289079656
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/lazy-loaded/OtherComponent.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/IconButton/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438668,
-            "end": 1612964439535
+            "start": 1618289079850,
+            "end": 1618289080019
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/shopping-list-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Chip/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436262,
-            "end": 1612964437125
+            "start": 1618289079850,
+            "end": 1618289080019
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mobx-v6/Timer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Paper/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438667,
-            "end": 1612964439527
+            "start": 1618289079850,
+            "end": 1618289080019
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-component/map.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/sizing.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438665,
-            "end": 1612964439519
+            "start": 1618289080001,
+            "end": 1618289080170
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todo-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/shadows.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436260,
-            "end": 1612964437108
+            "start": 1618289080001,
+            "end": 1618289080170
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/material-ui-example/checkbox-labels.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/chainPropTypes.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438665,
-            "end": 1612964439506
+            "start": 1618289080014,
+            "end": 1618289080183
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/square3-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/ponyfillGlobal.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436262,
-            "end": 1612964437100
+            "start": 1618289080020,
+            "end": 1618289080189
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/network/1-users-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Row.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436259,
-            "end": 1612964437094
+            "start": 1618289081448,
+            "end": 1618289081617
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/stub-example/clicker-with-delay-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/testing-lib-example/testing-lib-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436263,
-            "end": 1612964437074
+            "start": 1618289078487,
+            "end": 1618289078655
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-component/contact.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/timers/card-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438666,
-            "end": 1612964439473
+            "start": 1618289078487,
+            "end": 1618289078655
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/game-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/wrap-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436261,
-            "end": 1612964437061
+            "start": 1618289078883,
+            "end": 1618289079051
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/material-ui-example/list-demo.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/services.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438666,
-            "end": 1612964439466
+            "start": 1618289078900,
+            "end": 1618289079068
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/bind.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/Trans.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446156,
-            "end": 1612964446940
+            "start": 1618289079282,
+            "end": 1618289079450
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-book-example/src/Todos.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/context.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438666,
-            "end": 1612964439446
+            "start": 1618289079284,
+            "end": 1618289079452
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/List/ListContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/lodash/fp/_baseConvert.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446157,
-            "end": 1612964446932
+            "start": 1618289079457,
+            "end": 1618289079625
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemIcon/ListItemIcon.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446143,
-            "end": 1612964446914
+            "start": 1618289079486,
+            "end": 1618289079654
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/js-beautify/js/lib/beautify-css.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/typography.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446097,
-            "end": 1612964446859
+            "start": 1618289080000,
+            "end": 1618289080168
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@emotion/css/dist/css.browser.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/spacing.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446109,
-            "end": 1612964446869
+            "start": 1618289080001,
+            "end": 1618289080169
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-axios/axios-api.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControl/formControlState.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438665,
-            "end": 1612964439423
+            "start": 1618289080020,
+            "end": 1618289080188
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/iterableToArrayLimit.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/refType.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446108,
-            "end": 1612964446864
+            "start": 1618289080020,
+            "end": 1618289080188
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/set-timeout-example/App.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/HTMLElementType.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438664,
-            "end": 1612964439419
+            "start": 1618289080021,
+            "end": 1618289080189
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todos-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ProgressBar.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436261,
-            "end": 1612964437012
+            "start": 1618289081448,
+            "end": 1618289081616
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/setPrototypeOf.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/splitStringTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446142,
-            "end": 1612964446891
+            "start": 1618289081471,
+            "end": 1618289081639
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/TemplateTag/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/inlineArrayTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446128,
-            "end": 1612964446875
+            "start": 1618289081471,
+            "end": 1618289081639
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-router-v6/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446139,
-            "end": 1612964446885
+            "start": 1618289078486,
+            "end": 1618289078653
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/defineProperty.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/test-retries/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446142,
-            "end": 1612964446888
+            "start": 1618289078486,
+            "end": 1618289078653
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-imports/PizzaProps.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/testing-lib-example/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438665,
-            "end": 1612964439390
+            "start": 1618289078487,
+            "end": 1618289078654
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-book-by-chris-noring/components-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-world.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436260,
-            "end": 1612964436970
+            "start": 1618289078883,
+            "end": 1618289079050
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/set-timeout-example/LoadingIndicator.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemText/ListItemText.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438664,
-            "end": 1612964439374
+            "start": 1618289079486,
+            "end": 1618289079653
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-imports/greeting.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/kind-of/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438664,
-            "end": 1612964439352
+            "start": 1618289079848,
+            "end": 1618289080015
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mock-fetch/user.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Spinner.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438665,
-            "end": 1612964439349
+            "start": 1618289081447,
+            "end": 1618289081614
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Snackbar/Snackbar.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLine/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452875,
-            "end": 1612964453552
+            "start": 1618289081457,
+            "end": 1618289081624
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-book-by-chris-noring/jsx-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/PopoverTitle.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436260,
-            "end": 1612964436936
+            "start": 1618289081458,
+            "end": 1618289081625
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/full-navigation-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/removeNonPrintingValuesTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436252,
-            "end": 1612964436915
+            "start": 1618289081471,
+            "end": 1618289081638
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/testing-lib-example/fetcher.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceStringTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438664,
-            "end": 1612964439327
+            "start": 1618289081472,
+            "end": 1618289081639
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/pretty-snapshots-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceSubstitutionTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436262,
-            "end": 1612964436923
+            "start": 1618289081472,
+            "end": 1618289081639
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/listen.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Dialog/Dialog.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450604,
-            "end": 1612964451256
+            "start": 1618289081510,
+            "end": 1618289081677
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Slider/Slider.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/loading-indicator-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452874,
-            "end": 1612964453524
+            "start": 1618289078486,
+            "end": 1618289078652
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/eq.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/renderless/mouse-movement.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450588,
-            "end": 1612964451237
+            "start": 1618289078899,
+            "end": 1618289079065
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_mapToArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/borders.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450587,
-            "end": 1612964451235
+            "start": 1618289080000,
+            "end": 1618289080166
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_Uint8Array.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/style.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450588,
-            "end": 1612964451236
+            "start": 1618289080001,
+            "end": 1618289080167
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/css.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ResponsiveEmbed.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450604,
-            "end": 1612964451252
+            "start": 1618289081448,
+            "end": 1618289081614
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/network/2-users-fetch-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/useTranslation.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436259,
-            "end": 1612964436906
+            "start": 1618289079297,
+            "end": 1618289079462
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_arraySome.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormLabel/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450587,
-            "end": 1612964451232
+            "start": 1618289079472,
+            "end": 1618289079637
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_Set.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Divider/Divider.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450598,
-            "end": 1612964451241
+            "start": 1618289079486,
+            "end": 1618289079651
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-imports/RemotePizza.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438663,
-            "end": 1612964439305
+            "start": 1618289079848,
+            "end": 1618289080013
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/safeHtml/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450586,
-            "end": 1612964451228
+            "start": 1618289081463,
+            "end": 1618289081628
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/jss/dist/jss.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ClickAwayListener/ClickAwayListener.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450578,
-            "end": 1612964451218
+            "start": 1618289081464,
+            "end": 1618289081629
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/NoSsr/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/source/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450585,
-            "end": 1612964451225
+            "start": 1618289081465,
+            "end": 1618289081630
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/js-beautify/js/lib/beautify-html.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/renderless/mouse-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446097,
-            "end": 1612964446734
+            "start": 1618289078486,
+            "end": 1618289078650
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_cacheHas.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/emotion.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450585,
-            "end": 1612964451222
+            "start": 1618289078883,
+            "end": 1618289079047
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getLayoutRect.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/testing-lib-example/fetcher.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455064,
-            "end": 1612964455698
+            "start": 1618289078899,
+            "end": 1618289079063
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Slide/Slide.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/interopRequireDefault.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452953,
-            "end": 1612964453586
+            "start": 1618289079468,
+            "end": 1618289079632
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/instanceOf.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/common.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455063,
-            "end": 1612964455696
+            "start": 1618289079473,
+            "end": 1618289079637
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getComputedStyle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceResultTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455065,
-            "end": 1612964455692
+            "start": 1618289081477,
+            "end": 1618289081641
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/square4-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndentTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436263,
-            "end": 1612964436889
+            "start": 1618289081477,
+            "end": 1618289081641
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-imports/component.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-bootstrap/modal-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438664,
-            "end": 1612964439290
+            "start": 1618289078485,
+            "end": 1618289078648
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.assign.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/app-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452981,
-            "end": 1612964453607
+            "start": 1618289078486,
+            "end": 1618289078649
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/i18n/i18n.ts",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/pure-component.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439028,
-            "end": 1612964439652
+            "start": 1618289078883,
+            "end": 1618289079046
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getDocumentElement.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/LoadingIndicator.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455065,
-            "end": 1612964455689
+            "start": 1618289078899,
+            "end": 1618289079062
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-imports/services.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/withTranslation.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438663,
-            "end": 1612964439286
+            "start": 1618289079297,
+            "end": 1618289079460
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getOffsetParent.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/utils.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455064,
-            "end": 1612964455686
+            "start": 1618289079467,
+            "end": 1618289079630
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/renderless/mouse-movement.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/object-assign/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438660,
-            "end": 1612964439278
+            "start": 1618289079468,
+            "end": 1618289079631
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/css-loader/dist/runtime/api.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/List/List.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439252,
-            "end": 1612964439870
+            "start": 1618289079486,
+            "end": 1618289079649
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/fails-correctly/spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436258,
-            "end": 1612964436873
+            "start": 1618289079792,
+            "end": 1618289079955
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/createPopper.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/iterableToArrayLimit.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454953,
-            "end": 1612964455566
+            "start": 1618289079792,
+            "end": 1618289079955
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/contains.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-router-v6/in-memory-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455064,
-            "end": 1612964455677
+            "start": 1618289078486,
+            "end": 1618289078648
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/CardActionArea/CardActionArea.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/useScrollTrigger/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454910,
-            "end": 1612964455522
+            "start": 1618289079467,
+            "end": 1618289079629
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react/cjs/react.development.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/useMediaQuery/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439248,
-            "end": 1612964439859
+            "start": 1618289079467,
+            "end": 1618289079629
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getWindow.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Checkbox/Checkbox.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455063,
-            "end": 1612964455674
+            "start": 1618289079486,
+            "end": 1618289079648
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/computeAutoPlacement.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ThemeProvider.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455062,
-            "end": 1612964455670
+            "start": 1618289079784,
+            "end": 1618289079946
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/radioactive-state/todos/Todos.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/triggerBrowserReflow.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438641,
-            "end": 1612964439247
+            "start": 1618289079785,
+            "end": 1618289079947
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_Promise.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/createChainedFunction.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450656,
-            "end": 1612964451259
+            "start": 1618289079786,
+            "end": 1618289079948
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/TabContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/objectWithoutPropertiesLoose.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454910,
-            "end": 1612964455510
+            "start": 1618289079789,
+            "end": 1618289079951
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-transition-group/node_modules/dom-helpers/esm/addClass.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/arrayWithHoles.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453022,
-            "end": 1612964453621
+            "start": 1618289079791,
+            "end": 1618289079953
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/pure-component.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/nonIterableRest.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438640,
-            "end": 1612964439237
+            "start": 1618289079792,
+            "end": 1618289079954
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/RootRef/RootRef.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaListsOr/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453008,
-            "end": 1612964453605
+            "start": 1618289081445,
+            "end": 1618289081607
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-transition-group/node_modules/dom-helpers/esm/removeClass.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineTrim/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453021,
-            "end": 1612964453617
+            "start": 1618289081446,
+            "end": 1618289081608
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/getFreshSideObject.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaLists/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455066,
-            "end": 1612964455662
+            "start": 1618289081446,
+            "end": 1618289081608
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Jumbotron.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/portal/portal-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455012,
-            "end": 1612964455607
+            "start": 1618289078485,
+            "end": 1618289078646
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/detectOverflow.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-bootstrap/dropdown-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455059,
-            "end": 1612964455654
+            "start": 1618289078485,
+            "end": 1618289078646
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/CardActions/CardActions.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/counter-set-state/counter.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454911,
-            "end": 1612964455504
+            "start": 1618289078883,
+            "end": 1618289079044
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/hello-act-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Zoom/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436252,
-            "end": 1612964436843
+            "start": 1618289079466,
+            "end": 1618289079627
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/hello-world.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/withMobileDialog/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438640,
-            "end": 1612964439229
+            "start": 1618289079466,
+            "end": 1618289079627
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/RadioGroup/RadioGroup.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/withWidth/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453048,
-            "end": 1612964453637
+            "start": 1618289079467,
+            "end": 1618289079628
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ListGroupItem.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControlLabel/FormControlLabel.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454837,
-            "end": 1612964455426
+            "start": 1618289079485,
+            "end": 1618289079646
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_mapCacheHas.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/useAutocomplete/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450676,
-            "end": 1612964451261
+            "start": 1618289079797,
+            "end": 1618289079958
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ToastContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/amber.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454909,
-            "end": 1612964455492
+            "start": 1618289080455,
+            "end": 1618289080616
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/InputGroup.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/lime.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455013,
-            "end": 1612964455594
+            "start": 1618289080457,
+            "end": 1618289080618
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/getOppositeVariationPlacement.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/ownerWindow.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455062,
-            "end": 1612964455643
+            "start": 1618289080458,
+            "end": 1618289080619
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Card/Card.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_classof.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454954,
-            "end": 1612964455534
+            "start": 1618289081442,
+            "end": 1618289081603
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Media.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/counter-use-hooks/counter.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454836,
-            "end": 1612964455414
+            "start": 1618289078882,
+            "end": 1618289079042
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/expandToHashMap.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/withSSR.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455060,
-            "end": 1612964455638
+            "start": 1618289079295,
+            "end": 1618289079455
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/getVariation.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455062,
-            "end": 1612964455640
+            "start": 1618289079310,
+            "end": 1618289079470
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/CardContent/CardContent.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/defaultTheme.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454830,
-            "end": 1612964455406
+            "start": 1618289079311,
+            "end": 1618289079471
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/getBasePlacement.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/is-extendable/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455059,
-            "end": 1612964455634
+            "start": 1618289079800,
+            "end": 1618289079960
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/getMainAxisFromPlacement.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/is-whitespace/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455061,
-            "end": 1612964455636
+            "start": 1618289079801,
+            "end": 1618289079961
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/SnackbarContent/SnackbarContent.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/utils.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452868,
-            "end": 1612964453442
+            "start": 1618289079847,
+            "end": 1618289080007
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/getOppositePlacement.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/yellow.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455058,
-            "end": 1612964455632
+            "start": 1618289080456,
+            "end": 1618289080616
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Hidden/HiddenJs.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/lightGreen.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454909,
-            "end": 1612964455482
+            "start": 1618289080458,
+            "end": 1618289080618
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Figure.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useEventCallback.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455013,
-            "end": 1612964455586
+            "start": 1618289080462,
+            "end": 1618289080622
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/getAltAxis.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useTimeout.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455129,
-            "end": 1612964455702
+            "start": 1618289080463,
+            "end": 1618289080623
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/svg-icons/RadioButtonChecked.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useUpdateEffect.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454868,
-            "end": 1612964455439
+            "start": 1618289080463,
+            "end": 1618289080623
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/mount-div/spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanel/ExpansionPanel.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436258,
-            "end": 1612964436828
+            "start": 1618289081437,
+            "end": 1618289081597
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Image.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogTitle/DialogTitle.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455013,
-            "end": 1612964455582
+            "start": 1618289081438,
+            "end": 1618289081598
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/within.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/PopoverContent.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455061,
-            "end": 1612964455630
+            "start": 1618289081482,
+            "end": 1618289081642
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/wrap-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/RemotePizza.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438640,
-            "end": 1612964439208
+            "start": 1618289078485,
+            "end": 1618289078644
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/mergePaddingObject.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/useSSR.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455060,
-            "end": 1612964455627
+            "start": 1618289079295,
+            "end": 1618289079454
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/computeOffsets.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/Translation.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455058,
-            "end": 1612964455624
+            "start": 1618289079296,
+            "end": 1618289079455
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/CardHeader/CardHeader.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/teal.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454829,
-            "end": 1612964455392
+            "start": 1618289080462,
+            "end": 1618289080621
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ListGroup.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/hyphenate.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455012,
-            "end": 1612964455575
+            "start": 1618289080465,
+            "end": 1618289080624
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-book-example/src/Note.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/SplitButton.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438640,
-            "end": 1612964439202
+            "start": 1618289081436,
+            "end": 1618289081595
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Step/Step.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelSummary/ExpansionPanelSummary.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452866,
-            "end": 1612964453428
+            "start": 1618289081437,
+            "end": 1618289081596
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ButtonGroup/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Collapse/Collapse.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454215,
-            "end": 1612964454776
+            "start": 1618289081485,
+            "end": 1618289081644
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/svg-icons/RadioButtonUnchecked.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css/Button.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454906,
-            "end": 1612964455466
+            "start": 1618289078882,
+            "end": 1618289079040
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/no-visit/spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/I18nextProvider.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436259,
-            "end": 1612964436818
+            "start": 1618289079296,
+            "end": 1618289079454
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Breadcrumbs/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454219,
-            "end": 1612964454778
+            "start": 1618289079884,
+            "end": 1618289080042
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Avatar/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/addEventListener.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455057,
-            "end": 1612964455616
+            "start": 1618289080466,
+            "end": 1618289080624
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ExpansionPanelDetails/ExpansionPanelDetails.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/cancel/isCancel.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454214,
-            "end": 1612964454772
+            "start": 1618289080499,
+            "end": 1618289080657
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Backdrop/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaListsAnd/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455057,
-            "end": 1612964455613
+            "start": 1618289081436,
+            "end": 1618289081594
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/modifiers/offset.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/getScrollbarSize.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454204,
-            "end": 1612964454759
+            "start": 1618289081436,
+            "end": 1618289081594
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/AppBar/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogContentText/DialogContentText.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455056,
-            "end": 1612964455611
+            "start": 1618289081487,
+            "end": 1618289081645
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/square2-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436262,
-            "end": 1612964436815
+            "start": 1618289078485,
+            "end": 1618289078642
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/BottomNavigationAction/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/context/App.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454228,
-            "end": 1612964454781
+            "start": 1618289078878,
+            "end": 1618289079035
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ProgressBar.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/withScriptjs.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454267,
-            "end": 1612964454818
+            "start": 1618289079485,
+            "end": 1618289079642
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Hidden/HiddenCss.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/List/ListContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454907,
-            "end": 1612964455458
+            "start": 1618289079776,
+            "end": 1618289079933
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/error-boundary-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/deepOrange.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436251,
-            "end": 1612964436799
+            "start": 1618289080451,
+            "end": 1618289080608
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/square1-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/symbol-observable/es/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436262,
-            "end": 1612964436809
+            "start": 1618289080470,
+            "end": 1618289080627
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/StepButton/StepButton.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/uncontrollable/lib/esm/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452864,
-            "end": 1612964453411
+            "start": 1618289080471,
+            "end": 1618289080628
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/enums.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/spread.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454204,
-            "end": 1612964454746
+            "start": 1618289080485,
+            "end": 1618289080642
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Modal.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/cancel/CancelToken.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454828,
-            "end": 1612964455369
+            "start": 1618289080500,
+            "end": 1618289080657
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/PopoverTitle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineInlineLists/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454292,
-            "end": 1612964454827
+            "start": 1618289081431,
+            "end": 1618289081588
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/modifiers/hide.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelDetails/ExpansionPanelDetails.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454205,
-            "end": 1612964454738
+            "start": 1618289081435,
+            "end": 1618289081592
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/alert-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/inlineLists/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436250,
-            "end": 1612964436781
+            "start": 1618289081435,
+            "end": 1618289081592
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/app-action-example/counter.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelActions/ExpansionPanelActions.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438638,
-            "end": 1612964439165
+            "start": 1618289081436,
+            "end": 1618289081593
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/StepContent/StepContent.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogContent/DialogContent.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452864,
-            "end": 1612964453391
+            "start": 1618289081490,
+            "end": 1618289081647
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Radio/Radio.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/trimResultTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453132,
-            "end": 1612964453659
+            "start": 1618289081491,
+            "end": 1618289081648
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/modifiers/eventListeners.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/PizzaProps.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454206,
-            "end": 1612964454730
+            "start": 1618289078485,
+            "end": 1618289078641
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/CardActions/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css-modules/Button.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453913,
-            "end": 1612964454436
+            "start": 1618289078881,
+            "end": 1618289079037
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/popper-base.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/enzyme/simple-component.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454202,
-            "end": 1612964454725
+            "start": 1618289078882,
+            "end": 1618289079038
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ResponsiveEmbed.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/utils/getRS.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454268,
-            "end": 1612964454791
+            "start": 1618289079465,
+            "end": 1618289079621
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/CardActionArea/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormGroup/FormGroup.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453912,
-            "end": 1612964454434
+            "start": 1618289079485,
+            "end": 1618289079641
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/modifiers/arrow.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/indigo.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454203,
-            "end": 1612964454722
+            "start": 1618289079774,
+            "end": 1618289079930
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Tab.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/blueGrey.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453945,
-            "end": 1612964454458
+            "start": 1618289080448,
+            "end": 1618289080604
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Grid/Grid.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/withGoogleMap.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454034,
-            "end": 1612964454547
+            "start": 1618289080449,
+            "end": 1618289080605
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/CardMedia/CardMedia.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/removeEventListener.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454829,
-            "end": 1612964455342
+            "start": 1618289080469,
+            "end": 1618289080625
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/StepConnector/StepConnector.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/ServerStyleSheets/ServerStyleSheets.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452865,
-            "end": 1612964453376
+            "start": 1618289080508,
+            "end": 1618289080664
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/enzyme/state-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Container/Container.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436258,
-            "end": 1612964436766
+            "start": 1618289081511,
+            "end": 1618289081667
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/triggerBrowserReflow.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stackSet.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449340,
-            "end": 1612964449847
+            "start": 1618289081512,
+            "end": 1618289081668
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/replaceStringTransformer/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stackHas.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449345,
-            "end": 1612964449852
+            "start": 1618289081512,
+            "end": 1618289081668
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/TabPane.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stackGet.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453944,
-            "end": 1612964454451
+            "start": 1618289081512,
+            "end": 1618289081668
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ToggleButtonGroup.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/app-action-example/counter.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453861,
-            "end": 1612964454367
+            "start": 1618289078878,
+            "end": 1618289079033
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/SplitButton.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/runtime/api.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454056,
-            "end": 1612964454562
+            "start": 1618289078966,
+            "end": 1618289079121
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ListItemAvatar/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/utils/errors.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452774,
-            "end": 1612964453279
+            "start": 1618289079464,
+            "end": 1618289079619
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/modifiers/flip.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/utils/getOnChange.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454205,
-            "end": 1612964454710
+            "start": 1618289079465,
+            "end": 1618289079620
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/core/enhanceError.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/unsupportedProp.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452773,
-            "end": 1612964453277
+            "start": 1618289080163,
+            "end": 1618289080318
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/fn/array/from.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/requirePropFactory.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452760,
-            "end": 1612964453263
+            "start": 1618289080165,
+            "end": 1618289080320
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Spinner.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/Circle.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454070,
-            "end": 1612964454573
+            "start": 1618289080448,
+            "end": 1618289080603
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/SafeAnchor.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/brown.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449344,
-            "end": 1612964449845
+            "start": 1618289080450,
+            "end": 1618289080605
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/context/Toolbar.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/recompose/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438638,
-            "end": 1612964439138
+            "start": 1618289080483,
+            "end": 1618289080638
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Badge/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/StylesProvider/StylesProvider.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454828,
-            "end": 1612964455328
+            "start": 1618289080507,
+            "end": 1618289080662
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/CircularProgress/CircularProgress.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/styled/styled.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454818,
-            "end": 1612964455317
+            "start": 1618289080508,
+            "end": 1618289080663
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/StepLabel/StepLabel.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CssBaseline/CssBaseline.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452864,
-            "end": 1612964453362
+            "start": 1618289081510,
+            "end": 1618289081665
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Card/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RadioGroup/RadioGroupContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454054,
-            "end": 1612964454552
+            "start": 1618289081511,
+            "end": 1618289081666
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/createGenerateClassName/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stackDelete.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449345,
-            "end": 1612964449838
+            "start": 1618289081514,
+            "end": 1618289081669
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/FormFileLabel.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CircularProgress/CircularProgress.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449345,
-            "end": 1612964449835
+            "start": 1618289081516,
+            "end": 1618289081671
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ToggleButton.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Card/Card.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453861,
-            "end": 1612964454351
+            "start": 1618289081531,
+            "end": 1618289081686
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/components/GoogleMap.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonGroup/ButtonGroup.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450850,
-            "end": 1612964451339
+            "start": 1618289081533,
+            "end": 1618289081688
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-component/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449511,
-            "end": 1612964449997
+            "start": 1618289078484,
+            "end": 1618289078638
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/TabContainer.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/context/Toolbar.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453944,
-            "end": 1612964454430
+            "start": 1618289078878,
+            "end": 1618289079032
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/cypress-react-selector/src/logger.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mobx-v6/timer-view.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449480,
-            "end": 1612964449965
+            "start": 1618289078969,
+            "end": 1618289079123
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_ctx.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/setRef.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449499,
-            "end": 1612964449984
+            "start": 1618289080166,
+            "end": 1618289080320
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Pagination.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/GoogleMap.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454370,
-            "end": 1612964454855
+            "start": 1618289080448,
+            "end": 1618289080602
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-lifecycles-compat/react-lifecycles-compat.es.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/change-emitter/lib/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452759,
-            "end": 1612964453243
+            "start": 1618289080483,
+            "end": 1618289080637
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/modifiers/computeStyles.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/cancel/Cancel.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454206,
-            "end": 1612964454690
+            "start": 1618289080506,
+            "end": 1618289080660
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_coreJsData.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_ListCache.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450784,
-            "end": 1612964451267
+            "start": 1618289081509,
+            "end": 1618289081663
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_cof.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogActions/DialogActions.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450785,
-            "end": 1612964451268
+            "start": 1618289081510,
+            "end": 1618289081664
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/SelectableContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/checkbox-labels-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449340,
-            "end": 1612964449822
+            "start": 1618289078482,
+            "end": 1618289078635
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_has.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/1-users.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449486,
-            "end": 1612964449968
+            "start": 1618289078483,
+            "end": 1618289078636
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/context/App.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/2-users-named.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438638,
-            "end": 1612964439119
+            "start": 1618289078484,
+            "end": 1618289078637
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_mapCacheGet.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/3-users-api.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450784,
-            "end": 1612964451265
+            "start": 1618289078484,
+            "end": 1618289078637
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/invariant/browser.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createPalette.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446957,
-            "end": 1612964447437
+            "start": 1618289079457,
+            "end": 1618289079610
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_defined.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createMixins.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449488,
-            "end": 1612964449967
+            "start": 1618289079458,
+            "end": 1618289079611
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/createStyles/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/Polygon.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449340,
-            "end": 1612964449818
+            "start": 1618289080443,
+            "end": 1618289080596
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_isPrototype.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/Polyline.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449480,
-            "end": 1612964449958
+            "start": 1618289080445,
+            "end": 1618289080598
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ListItemSecondaryAction/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Portal/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452755,
-            "end": 1612964453233
+            "start": 1618289080446,
+            "end": 1618289080599
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseTimes.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/Marker.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449479,
-            "end": 1612964449956
+            "start": 1618289080448,
+            "end": 1618289080601
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Icon/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SwipeableDrawer/SwipeableDrawer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452863,
-            "end": 1612964453340
+            "start": 1618289081013,
+            "end": 1618289081166
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Tooltip.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Tab.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453861,
-            "end": 1612964454338
+            "start": 1618289081429,
+            "end": 1618289081582
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ModalTitle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardActionArea/CardActionArea.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454793,
-            "end": 1612964455270
+            "start": 1618289081530,
+            "end": 1618289081683
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/memoize.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/simple-rating-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449478,
-            "end": 1612964449954
+            "start": 1618289078483,
+            "end": 1618289078635
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/jss-plugin-nested/dist/jss-plugin-nested.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/forward-ref/forward-ref.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450555,
-            "end": 1612964451031
+            "start": 1618289078878,
+            "end": 1618289079030
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Modal/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/i18n/LocalizedComponent.tsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452754,
-            "end": 1612964453230
+            "start": 1618289078989,
+            "end": 1618289079141
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Popover.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/framer-motion/Motion.tsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454369,
-            "end": 1612964454845
+            "start": 1618289078990,
+            "end": 1618289079142
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_global.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/toggle-example/toggle-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449336,
-            "end": 1612964449811
+            "start": 1618289078998,
+            "end": 1618289079150
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/NavContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/TemplateTag/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449339,
-            "end": 1612964449814
+            "start": 1618289079452,
+            "end": 1618289079604
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseIsEqualDeep.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/grey.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449470,
-            "end": 1612964449945
+            "start": 1618289079891,
+            "end": 1618289080043
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_stackGet.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/cyan.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449475,
-            "end": 1612964449950
+            "start": 1618289080477,
+            "end": 1618289080629
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_DataView.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/TabContainer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450558,
-            "end": 1612964451033
+            "start": 1618289081429,
+            "end": 1618289081581
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/LinearProgress/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getTag.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452862,
-            "end": 1612964453337
+            "start": 1618289081540,
+            "end": 1618289081692
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Collapse/Collapse.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/button-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454819,
-            "end": 1612964455294
+            "start": 1618289078482,
+            "end": 1618289078633
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Chip/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/framesync/dist/framesync.es.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446957,
-            "end": 1612964447431
+            "start": 1618289080161,
+            "end": 1618289080312
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Hidden/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/ownerWindow.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453188,
-            "end": 1612964453662
+            "start": 1618289080171,
+            "end": 1618289080322
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_stackHas.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/Rectangle.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449475,
-            "end": 1612964449948
+            "start": 1618289080443,
+            "end": 1618289080594
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Hidden/Hidden.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/lightBlue.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453778,
-            "end": 1612964454251
+            "start": 1618289080480,
+            "end": 1618289080631
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/reduce.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/deepPurple.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446955,
-            "end": 1612964447427
+            "start": 1618289080480,
+            "end": 1618289080631
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_nativeKeys.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/purple.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449516,
-            "end": 1612964449988
+            "start": 1618289080481,
+            "end": 1618289080632
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/InputAdornment/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_equalObjects.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452863,
-            "end": 1612964453335
+            "start": 1618289081542,
+            "end": 1618289081693
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ExpansionPanelSummary/ExpansionPanelSummary.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/hooks/counter-with-hooks.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454187,
-            "end": 1612964454659
+            "start": 1618289078878,
+            "end": 1618289079028
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_fails.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/typescript/ts-spec.tsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449516,
-            "end": 1612964449987
+            "start": 1618289078977,
+            "end": 1618289079127
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/GridListTile/GridListTile.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/pretty/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454041,
-            "end": 1612964454512
+            "start": 1618289078994,
+            "end": 1618289079144
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/modifiers/preventOverflow.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/transpiled-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454203,
-            "end": 1612964454674
+            "start": 1618289078995,
+            "end": 1618289079145
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseRest.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Button/Button.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447213,
-            "end": 1612964447683
+            "start": 1618289079276,
+            "end": 1618289079426
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/components/Circle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450846,
-            "end": 1612964451316
+            "start": 1618289079281,
+            "end": 1618289079431
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/StepIcon/StepIcon.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createTypography.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452862,
-            "end": 1612964453332
+            "start": 1618289079457,
+            "end": 1618289079607
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ToastBody.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/style-value-types/dist/style-value-types.es.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453860,
-            "end": 1612964454330
+            "start": 1618289080158,
+            "end": 1618289080308
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/isFunction.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/hey-listen/dist/hey-listen.es.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446956,
-            "end": 1612964447425
+            "start": 1618289080159,
+            "end": 1618289080309
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/can-use-dom/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_castSlice.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446964,
-            "end": 1612964447433
+            "start": 1618289081030,
+            "end": 1618289081180
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Feedback.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/toString.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449339,
-            "end": 1612964449808
+            "start": 1618289081031,
+            "end": 1618289081181
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_stackSet.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardContent/CardContent.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449467,
-            "end": 1612964449936
+            "start": 1618289081524,
+            "end": 1618289081674
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_arrayMap.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded/lazy-load-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449470,
-            "end": 1612964449939
+            "start": 1618289078482,
+            "end": 1618289078631
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/window-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/autocomplete-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439248,
-            "end": 1612964439716
+            "start": 1618289078482,
+            "end": 1618289078631
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/MobileStepper/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mock-fetch/fetch-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452754,
-            "end": 1612964453222
+            "start": 1618289078483,
+            "end": 1618289078632
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/TabContent.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mobx-v6/timer-spec.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453945,
-            "end": 1612964454413
+            "start": 1618289078483,
+            "end": 1618289078632
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/PopoverContent.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/hooks/counter2-with-hooks.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454368,
-            "end": 1612964454836
+            "start": 1618289078877,
+            "end": 1618289079026
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Toast.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/unmount/unmount-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453860,
-            "end": 1612964454327
+            "start": 1618289078977,
+            "end": 1618289079126
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/cypress-react-selector/src/resqInjector.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/unmount/comp-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445500,
-            "end": 1612964445966
+            "start": 1618289078977,
+            "end": 1618289079126
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/forEach.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded-suspense/LazyComponent.tsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446955,
-            "end": 1612964447421
+            "start": 1618289078988,
+            "end": 1618289079137
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/spacing.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-is/cjs/react-is.development.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447189,
-            "end": 1612964447655
+            "start": 1618289079897,
+            "end": 1618289080046
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_hide.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseRest.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449336,
-            "end": 1612964449802
+            "start": 1618289080183,
+            "end": 1618289080332
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_SetCache.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardMedia/CardMedia.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450580,
-            "end": 1612964451046
+            "start": 1618289081523,
+            "end": 1618289081672
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Switch/Switch.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardHeader/CardHeader.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452746,
-            "end": 1612964453212
+            "start": 1618289081524,
+            "end": 1618289081673
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/positions.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardActions/CardActions.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447212,
-            "end": 1612964447677
+            "start": 1618289081528,
+            "end": 1618289081677
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_ListCache.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_equalArrays.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449467,
-            "end": 1612964449932
+            "start": 1618289081546,
+            "end": 1618289081695
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/querySelectorAll.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Breadcrumbs/Breadcrumbs.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452753,
-            "end": 1612964453218
+            "start": 1618289081547,
+            "end": 1618289081696
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ClickAwayListener/ClickAwayListener.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded-suspense/lazy-loaded-suspense.spec.tsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454795,
-            "end": 1612964455260
+            "start": 1618289078481,
+            "end": 1618289078629
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/recompose/es/Recompose.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded/app-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447146,
-            "end": 1612964447610
+            "start": 1618289078482,
+            "end": 1618289078630
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Table.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/list-item-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453944,
-            "end": 1612964454408
+            "start": 1618289078483,
+            "end": 1618289078631
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/emotion.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/context/forwardRef.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438638,
-            "end": 1612964439101
+            "start": 1618289080179,
+            "end": 1618289080327
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/borders.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SvgIcon/SvgIcon.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447157,
-            "end": 1612964447620
+            "start": 1618289080182,
+            "end": 1618289080330
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/typography.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_equalByTag.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447165,
-            "end": 1612964447628
+            "start": 1618289081546,
+            "end": 1618289081694
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_assocIndexOf.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/i18n/i18next-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450580,
-            "end": 1612964451043
+            "start": 1618289078481,
+            "end": 1618289078628
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-define.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded/other-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449336,
-            "end": 1612964449798
+            "start": 1618289078482,
+            "end": 1618289078629
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/NativeSelect/NativeSelectInput.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counter/Counter.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449466,
-            "end": 1612964449928
+            "start": 1618289078876,
+            "end": 1618289079023
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/withGoogleMap.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/use-lodash-fp/lodash-fp-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450895,
-            "end": 1612964451357
+            "start": 1618289078977,
+            "end": 1618289079124
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/lowerFirst.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Chip/Chip.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446955,
-            "end": 1612964447416
+            "start": 1618289080132,
+            "end": 1618289080279
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_setToArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/ownerDocument.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450579,
-            "end": 1612964451040
+            "start": 1618289080178,
+            "end": 1618289080325
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/components/Marker.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_replaceHolders.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450837,
-            "end": 1612964451298
+            "start": 1618289080194,
+            "end": 1618289080341
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Slider/ValueLabel.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createWrap.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453830,
-            "end": 1612964454291
+            "start": 1618289080196,
+            "end": 1618289080343
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/GridList/GridList.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/deprecatedPropType.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454033,
-            "end": 1612964454494
+            "start": 1618289080197,
+            "end": 1618289080344
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/popmotion/dist/popmotion.es.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-parse-stringify2/lib/stringify.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446947,
-            "end": 1612964447407
+            "start": 1618289080440,
+            "end": 1618289080587
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/shadows.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/defaults.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447208,
-            "end": 1612964447668
+            "start": 1618289080525,
+            "end": 1618289080672
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-i18next/dist/es/utils.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Modal/SimpleBackdrop.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445501,
-            "end": 1612964445960
+            "start": 1618289081600,
+            "end": 1618289081747
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/has.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/hooks/use-counter.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446954,
-            "end": 1612964447413
+            "start": 1618289078481,
+            "end": 1618289078627
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_getAllKeys.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counters/Counters.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450577,
-            "end": 1612964451036
+            "start": 1618289078876,
+            "end": 1618289079022
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/enzyme/simple-component.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getHolder.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438637,
-            "end": 1612964439095
+            "start": 1618289080195,
+            "end": 1618289080341
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/dist/mountHook.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/isMuiElement.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439238,
-            "end": 1612964439696
+            "start": 1618289080196,
+            "end": 1618289080342
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_getHolder.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/InfoWindow.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447231,
-            "end": 1612964447689
+            "start": 1618289080437,
+            "end": 1618289080583
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Grow/Grow.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-parse-stringify2/lib/parse.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453943,
-            "end": 1612964454401
+            "start": 1618289080440,
+            "end": 1618289080586
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/toggle-example/toggle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavItem.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440112,
-            "end": 1612964440569
+            "start": 1618289081602,
+            "end": 1618289081748
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/sizing.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/OverlayView.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447207,
-            "end": 1612964447664
+            "start": 1618289080436,
+            "end": 1618289080581
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_replaceHolders.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_redefine.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447230,
-            "end": 1612964447687
+            "start": 1618289081023,
+            "end": 1618289081168
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/arrayLikeToArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/TabContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446954,
-            "end": 1612964447410
+            "start": 1618289081603,
+            "end": 1618289081748
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/jss-plugin-global/dist/jss-plugin-global.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/makeStyles/makeStyles.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450556,
-            "end": 1612964451012
+            "start": 1618289080539,
+            "end": 1618289080683
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-router/react-router.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavLink.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445486,
-            "end": 1612964445940
+            "start": 1618289081605,
+            "end": 1618289081749
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Stepper/Stepper.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalFooter.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452863,
-            "end": 1612964453317
+            "start": 1618289081637,
+            "end": 1618289081781
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ToastHeader.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalDialog.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453859,
-            "end": 1612964454312
+            "start": 1618289081638,
+            "end": 1618289081782
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/style.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/3-users-api.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447189,
-            "end": 1612964447641
+            "start": 1618289078876,
+            "end": 1618289079019
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/slicedToArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Radio/RadioButtonIcon.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445496,
-            "end": 1612964445946
+            "start": 1618289081588,
+            "end": 1618289081731
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/RadioGroup/RadioGroupContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndents/stripIndents.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453777,
-            "end": 1612964454227
+            "start": 1618289081589,
+            "end": 1618289081732
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ModalBody.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndent/stripIndent.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454794,
-            "end": 1612964455244
+            "start": 1618289081590,
+            "end": 1618289081733
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/core-js/object/get-prototype-of.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineInlineLists/oneLineInlineLists.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446990,
-            "end": 1612964447439
+            "start": 1618289081641,
+            "end": 1618289081784
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_iterators.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/forward-ref/forward-ref.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449335,
-            "end": 1612964449784
+            "start": 1618289078480,
+            "end": 1618289078622
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ModalDialog.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/hooks/counter-with-hooks.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454793,
-            "end": 1612964455241
+            "start": 1618289078481,
+            "end": 1618289078623
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Grow/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/hooks/counter2-with-hooks.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453246,
-            "end": 1612964453692
+            "start": 1618289078481,
+            "end": 1618289078623
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/FormControl/formControlState.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/bind.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449337,
-            "end": 1612964449781
+            "start": 1618289079773,
+            "end": 1618289079915
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/NativeSelect/NativeSelect.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/tslib/tslib.es6.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449466,
-            "end": 1612964449910
+            "start": 1618289080145,
+            "end": 1618289080287
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Fab/Fab.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/DirectionsRenderer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454188,
-            "end": 1612964454631
+            "start": 1618289080428,
+            "end": 1618289080570
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/CardContent/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/AppBar/AppBar.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453776,
-            "end": 1612964454218
+            "start": 1618289081580,
+            "end": 1618289081722
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/DialogContent/DialogContent.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Jumbotron.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454613,
-            "end": 1612964455055
+            "start": 1618289081661,
+            "end": 1618289081803
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/jss-plugin-default-unit/dist/jss-plugin-default-unit.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Figure.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450555,
-            "end": 1612964450996
+            "start": 1618289081662,
+            "end": 1618289081804
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/SwipeableDrawer/SwipeableDrawer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Image.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452747,
-            "end": 1612964453188
+            "start": 1618289081662,
+            "end": 1618289081804
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/GridListTileBar/GridListTileBar.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Container.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454032,
-            "end": 1612964454473
+            "start": 1618289081663,
+            "end": 1618289081805
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ModalFooter.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormText.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454794,
-            "end": 1612964455235
+            "start": 1618289081663,
+            "end": 1618289081805
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Nav.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/custom-command/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454792,
-            "end": 1612964455232
+            "start": 1618289078480,
+            "end": 1618289078621
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Radio/RadioButtonIcon.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/fbjs/lib/shallowEqual.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453826,
-            "end": 1612964454265
+            "start": 1618289080430,
+            "end": 1618289080571
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/dist/mount.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/GroundOverlay.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439238,
-            "end": 1612964439676
+            "start": 1618289080432,
+            "end": 1618289080573
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-i18next/dist/es/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/ThemeProvider/ThemeProvider.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440092,
-            "end": 1612964440530
+            "start": 1618289080436,
+            "end": 1618289080577
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Link/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/mergeClasses/mergeClasses.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452859,
-            "end": 1612964453297
+            "start": 1618289080538,
+            "end": 1618289080679
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/CircularProgress/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-iobject.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453764,
-            "end": 1612964454202
+            "start": 1618289080971,
+            "end": 1618289081112
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/CardHeader/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_is-array.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453776,
-            "end": 1612964454214
+            "start": 1618289080971,
+            "end": 1618289081112
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/svg-icons/CheckCircle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_wks-define.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453839,
-            "end": 1612964454277
+            "start": 1618289080972,
+            "end": 1618289081113
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Tabs.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsNative.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453943,
-            "end": 1612964454381
+            "start": 1618289080974,
+            "end": 1618289081115
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@emotion/weak-memoize/dist/weak-memoize.browser.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stringToArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453299,
-            "end": 1612964453736
+            "start": 1618289081042,
+            "end": 1618289081183
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/CardMedia/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Symbol.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453775,
-            "end": 1612964454212
+            "start": 1618289081042,
+            "end": 1618289081183
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/FormContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavDropdown.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449338,
-            "end": 1612964449774
+            "start": 1618289081634,
+            "end": 1618289081775
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/GridListTile/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Navbar.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453274,
-            "end": 1612964453710
+            "start": 1618289081636,
+            "end": 1618289081777
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/css/Button.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ListGroup.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438637,
-            "end": 1612964439072
+            "start": 1618289081661,
+            "end": 1618289081802
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_mapCacheDelete.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/InputGroup.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450835,
-            "end": 1612964451270
+            "start": 1618289081662,
+            "end": 1618289081803
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/GridListTileBar/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/FusionTablesLayer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453263,
-            "end": 1612964453698
+            "start": 1618289080428,
+            "end": 1618289080568
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ClickAwayListener/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/useTheme/useTheme.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453764,
-            "end": 1612964454199
+            "start": 1618289080435,
+            "end": 1618289080575
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Collapse/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-keys.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453763,
-            "end": 1612964454197
+            "start": 1618289080969,
+            "end": 1618289081109
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-transition-group/node_modules/dom-helpers/esm/hasClass.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gops.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453775,
-            "end": 1612964454209
+            "start": 1618289080970,
+            "end": 1618289081110
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Row.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gopn-ext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454156,
-            "end": 1612964454590
+            "start": 1618289080970,
+            "end": 1618289081110
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/RadioGroup/useRadioGroup.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_property-desc.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453293,
-            "end": 1612964453726
+            "start": 1618289080971,
+            "end": 1618289081111
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/modifiers/popperOffsets.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_enum-keys.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454204,
-            "end": 1612964454637
+            "start": 1618289080972,
+            "end": 1618289081112
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/BottomNavigation/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-step.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454785,
-            "end": 1612964455218
+            "start": 1618289081020,
+            "end": 1618289081160
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Select/SelectInput.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepIcon/StepIcon.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449337,
-            "end": 1612964449769
+            "start": 1618289081022,
+            "end": 1618289081162
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/is-extendable/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Backdrop/Backdrop.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447012,
-            "end": 1612964447443
+            "start": 1618289081580,
+            "end": 1618289081720
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/classnames/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/OverlayTrigger.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447028,
-            "end": 1612964447459
+            "start": 1618289081634,
+            "end": 1618289081774
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/es7.symbol.observable.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavbarBrand.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449461,
-            "end": 1612964449892
+            "start": 1618289081636,
+            "end": 1618289081776
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/axios.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalTitle.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440092,
-            "end": 1612964440522
+            "start": 1618289081636,
+            "end": 1618289081776
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Navbar.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaListsAnd/oneLineCommaListsAnd.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454785,
-            "end": 1612964455215
+            "start": 1618289081649,
+            "end": 1618289081789
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Grid/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Dropdown.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453274,
-            "end": 1612964453703
+            "start": 1618289081650,
+            "end": 1618289081790
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-assign.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ListGroupItem.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453765,
-            "end": 1612964454194
+            "start": 1618289081661,
+            "end": 1618289081801
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Fade/Fade.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/framer-motion/Motion.spec.tsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454181,
-            "end": 1612964454610
+            "start": 1618289078481,
+            "end": 1618289078620
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.symbol.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/1-users.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449461,
-            "end": 1612964449889
+            "start": 1618289078876,
+            "end": 1618289079015
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/GridList/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormLabel/FormLabel.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453273,
-            "end": 1612964453701
+            "start": 1618289079770,
+            "end": 1618289079909
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/jss-plugin-camel-case/dist/jss-plugin-camel-case.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gopn.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450555,
-            "end": 1612964450980
+            "start": 1618289080969,
+            "end": 1618289081108
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Container/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getValue.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453755,
-            "end": 1612964454180
+            "start": 1618289080976,
+            "end": 1618289081115
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/kind-of/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_uid.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447028,
-            "end": 1612964447452
+            "start": 1618289080976,
+            "end": 1618289081115
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/transitions/utils.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_trimmedEndIndex.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453292,
-            "end": 1612964453716
+            "start": 1618289080978,
+            "end": 1618289081117
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/DialogTitle/DialogTitle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isObjectLike.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454612,
-            "end": 1612964455036
+            "start": 1618289080979,
+            "end": 1618289081118
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/components/BicyclingLayer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepLabel/StepLabel.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445388,
-            "end": 1612964445811
+            "start": 1618289081020,
+            "end": 1618289081159
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/is-whitespace/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/BottomNavigation/BottomNavigation.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447027,
-            "end": 1612964447446
+            "start": 1618289081579,
+            "end": 1618289081718
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/jss-plugin-vendor-prefixer/dist/jss-plugin-vendor-prefixer.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Avatar/Avatar.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450554,
-            "end": 1612964450973
+            "start": 1618289081582,
+            "end": 1618289081721
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Dialog/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/memoize.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453754,
-            "end": 1612964454171
+            "start": 1618289081587,
+            "end": 1618289081726
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/OverlayTrigger.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/inlineLists/inlineLists.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454594,
-            "end": 1612964455010
+            "start": 1618289081649,
+            "end": 1618289081788
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Box/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Modal.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440088,
-            "end": 1612964440503
+            "start": 1618289081660,
+            "end": 1618289081799
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/PageItem.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/2-users-named.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454452,
-            "end": 1612964454867
+            "start": 1618289078875,
+            "end": 1618289079013
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/CssBaseline/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react/cjs/react.development.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453755,
-            "end": 1612964454169
+            "start": 1618289079054,
+            "end": 1618289079192
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/DialogTitle/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/toggle-example/toggle.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453746,
-            "end": 1612964454159
+            "start": 1618289079181,
+            "end": 1618289079319
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/DialogActions/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/blue.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453754,
-            "end": 1612964454167
+            "start": 1618289079743,
+            "end": 1618289079881
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/counter-set-state/counter.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/unsupportedIterableToArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438637,
-            "end": 1612964439049
+            "start": 1618289080248,
+            "end": 1618289080386
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_mapCacheSet.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/printDebugValue.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450554,
-            "end": 1612964450966
+            "start": 1618289080249,
+            "end": 1618289080387
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-transition-group/esm/config.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_shared.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450951,
-            "end": 1612964451363
+            "start": 1618289080984,
+            "end": 1618289081122
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/DialogContentText/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_add-to-unscopables.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453749,
-            "end": 1612964454161
+            "start": 1618289080996,
+            "end": 1618289081134
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/DialogContent/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseLodash.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453752,
-            "end": 1612964454164
+            "start": 1618289081000,
+            "end": 1618289081138
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-transition-group/esm/TransitionGroupContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_LodashWrapper.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450950,
-            "end": 1612964451361
+            "start": 1618289081019,
+            "end": 1618289081157
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Icon/Icon.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iterators.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453745,
-            "end": 1612964454156
+            "start": 1618289081019,
+            "end": 1618289081157
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/DialogContentText/DialogContentText.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Badge/Badge.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454613,
-            "end": 1612964455024
+            "start": 1618289081579,
+            "end": 1618289081717
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_mapCacheClear.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/PageItem.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450553,
-            "end": 1612964450963
+            "start": 1618289081633,
+            "end": 1618289081771
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/NavbarBrand.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Overlay.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454785,
-            "end": 1612964455195
+            "start": 1618289081634,
+            "end": 1618289081772
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/InputLabel/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalBody.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440088,
-            "end": 1612964440497
+            "start": 1618289081660,
+            "end": 1618289081798
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TextField/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Media.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440089,
-            "end": 1612964440495
+            "start": 1618289081660,
+            "end": 1618289081798
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/NavItem.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/context/Mock-context-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454784,
-            "end": 1612964455190
+            "start": 1618289078480,
+            "end": 1618289078617
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/FormControl/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/inherits.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440088,
-            "end": 1612964440493
+            "start": 1618289079742,
+            "end": 1618289079879
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/extends.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440080,
-            "end": 1612964440483
+            "start": 1618289079743,
+            "end": 1618289079880
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ListItem/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/green.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440088,
-            "end": 1612964440491
+            "start": 1618289079743,
+            "end": 1618289079880
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ButtonGroup/ButtonGroup.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/utils/mutate.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455407,
-            "end": 1612964455810
+            "start": 1618289079751,
+            "end": 1618289079888
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Button/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440088,
-            "end": 1612964440489
+            "start": 1618289079771,
+            "end": 1618289079908
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/useTheme.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/object/define-property.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450553,
-            "end": 1612964450954
+            "start": 1618289080223,
+            "end": 1618289080360
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/NavDropdown.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/withStyles/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454784,
-            "end": 1612964455185
+            "start": 1618289080244,
+            "end": 1618289080381
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/FormHelperText/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/iterableToArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440087,
-            "end": 1612964440487
+            "start": 1618289080248,
+            "end": 1618289080385
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/jss-plugin-props-sort/dist/jss-plugin-props-sort.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/enhanceError.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450550,
-            "end": 1612964450950
+            "start": 1618289080968,
+            "end": 1618289081105
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Select/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_set-to-string-tag.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440087,
-            "end": 1612964440485
+            "start": 1618289080984,
+            "end": 1618289081121
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/js-beautify/js/lib/beautify.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/array/from.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446097,
-            "end": 1612964446495
+            "start": 1618289080984,
+            "end": 1618289081121
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/svg-icons/Warning.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_meta.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453745,
-            "end": 1612964454142
+            "start": 1618289080985,
+            "end": 1618289081122
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/re-render/spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-integer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436259,
-            "end": 1612964436654
+            "start": 1618289080995,
+            "end": 1618289081132
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/history/history.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-define.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445486,
-            "end": 1612964445879
+            "start": 1618289080998,
+            "end": 1618289081135
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/components/Polyline.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Stepper/Stepper.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450551,
-            "end": 1612964450944
+            "start": 1618289081017,
+            "end": 1618289081154
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/NavLink.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/BottomNavigationAction/BottomNavigationAction.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454783,
-            "end": 1612964455175
+            "start": 1618289081578,
+            "end": 1618289081715
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaLists/oneLineCommaLists.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440080,
-            "end": 1612964440471
+            "start": 1618289081659,
+            "end": 1618289081796
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/TemplateTag/TemplateTag.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/toArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447089,
-            "end": 1612964447479
+            "start": 1618289081660,
+            "end": 1618289081797
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/MenuItem/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/app-action-example/counter-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440087,
-            "end": 1612964440476
+            "start": 1618289078480,
+            "end": 1618289078616
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_is-array-iter.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonBase/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454592,
-            "end": 1612964454981
+            "start": 1618289079745,
+            "end": 1618289079881
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Typography/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440087,
-            "end": 1612964440474
+            "start": 1618289079751,
+            "end": 1618289079887
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/InputAdornment/InputAdornment.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/utils/afterSync.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453744,
-            "end": 1612964454131
+            "start": 1618289079751,
+            "end": 1618289079887
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_create-property.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/red.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454592,
-            "end": 1612964454979
+            "start": 1618289079751,
+            "end": 1618289079887
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Tab/Tab.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/useMediaQuery/useMediaQuery.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452746,
-            "end": 1612964453132
+            "start": 1618289079766,
+            "end": 1618289079902
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Chip/Chip.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/lodash/fp/placeholder.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447716,
-            "end": 1612964448101
+            "start": 1618289079767,
+            "end": 1618289079903
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/Overlay.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/object/set-prototype-of.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454783,
-            "end": 1612964455168
+            "start": 1618289080218,
+            "end": 1618289080354
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Modal/TrapFocus.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/typeof.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454593,
-            "end": 1612964454977
+            "start": 1618289080222,
+            "end": 1618289080358
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ExpansionPanel/ExpansionPanel.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonBase/TouchRipple.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454512,
-            "end": 1612964454894
+            "start": 1618289080242,
+            "end": 1618289080378
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/icons/CheckBox.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/arrayWithoutHoles.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440229,
-            "end": 1612964440610
+            "start": 1618289080243,
+            "end": 1618289080379
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/components/Polygon.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/node_modules/scheduler/tracing.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450551,
-            "end": 1612964450928
+            "start": 1618289080245,
+            "end": 1618289080381
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/icons/CheckBoxOutlineBlank.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/Axios.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440229,
-            "end": 1612964440605
+            "start": 1618289080550,
+            "end": 1618289080686
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-detect.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControl/FormControlContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454574,
-            "end": 1612964454949
+            "start": 1618289080551,
+            "end": 1618289080687
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/icons/Drafts.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_library.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440229,
-            "end": 1612964440602
+            "start": 1618289080959,
+            "end": 1618289081095
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Modal/SimpleBackdrop.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-pie.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454573,
-            "end": 1612964454945
+            "start": 1618289080961,
+            "end": 1618289081097
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Container/Container.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_a-function.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454773,
-            "end": 1612964455145
+            "start": 1618289080994,
+            "end": 1618289081130
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/icons/Inbox.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Nav.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440228,
-            "end": 1612964440598
+            "start": 1618289081631,
+            "end": 1618289081767
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/icons/FavoriteBorder.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Popover.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440229,
-            "end": 1612964440596
+            "start": 1618289081633,
+            "end": 1618289081769
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/popper.js/dist/esm/popper.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Pagination.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449305,
-            "end": 1612964449672
+            "start": 1618289081633,
+            "end": 1618289081769
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-call.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineTrim/oneLineTrim.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454593,
-            "end": 1612964454960
+            "start": 1618289081659,
+            "end": 1618289081795
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/LinearProgress/LinearProgress.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/styled-components/Todos-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453745,
-            "end": 1612964454111
+            "start": 1618289078479,
+            "end": 1618289078614
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/core.get-iterator-method.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/context/App-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454591,
-            "end": 1612964454957
+            "start": 1618289078480,
+            "end": 1618289078615
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TableCell/TableCell.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-router-v6/app.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452744,
-            "end": 1612964453108
+            "start": 1618289078875,
+            "end": 1618289079010
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Dialog/Dialog.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/withTheme/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454761,
-            "end": 1612964455125
+            "start": 1618289079747,
+            "end": 1618289079882
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/use-render/my-component-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/orange.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439520,
-            "end": 1612964439883
+            "start": 1618289079750,
+            "end": 1618289079885
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/icons/Favorite.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/useScrollTrigger/useScrollTrigger.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440229,
-            "end": 1612964440592
+            "start": 1618289079766,
+            "end": 1618289079901
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/components/InfoWindow.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450526,
-            "end": 1612964450889
+            "start": 1618289080218,
+            "end": 1618289080353
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_shared-key.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/nonIterableSpread.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449682,
-            "end": 1612964450044
+            "start": 1618289080247,
+            "end": 1618289080382
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/svg-icons/KeyboardArrowRight.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Switch/Switch.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454565,
-            "end": 1612964454927
+            "start": 1618289081010,
+            "end": 1618289081145
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/process/browser.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Hidden/HiddenJs.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450552,
-            "end": 1612964450913
+            "start": 1618289081622,
+            "end": 1618289081757
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mobx-v6/timer-view.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stackClear.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439519,
-            "end": 1612964439876
+            "start": 1618289081633,
+            "end": 1618289081768
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ExpansionPanelActions/ExpansionPanelActions.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanel/ExpansionPanelContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454548,
-            "end": 1612964454905
+            "start": 1618289081658,
+            "end": 1618289081793
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/BottomNavigationAction/BottomNavigationAction.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaListsOr/oneLineCommaListsOr.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455408,
-            "end": 1612964455765
+            "start": 1618289081659,
+            "end": 1618289081794
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/isArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLine/oneLine.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447748,
-            "end": 1612964448104
+            "start": 1618289081678,
+            "end": 1618289081813
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/scriptjs/dist/script.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/use-local-storage/App.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447146,
-            "end": 1612964447500
+            "start": 1618289078875,
+            "end": 1618289079009
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/svg-icons/ArrowDropDown.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/Inbox.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449338,
-            "end": 1612964449691
+            "start": 1618289079173,
+            "end": 1618289079307
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/svg-icons/KeyboardArrowLeft.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/lodash/fp/_mapping.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454566,
-            "end": 1612964454919
+            "start": 1618289079756,
+            "end": 1618289079890
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.array.iterator.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Popper/Popper.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449331,
-            "end": 1612964449682
+            "start": 1618289080137,
+            "end": 1618289080271
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ButtonBase/TouchRipple.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepContent/StepContent.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449683,
-            "end": 1612964450034
+            "start": 1618289081051,
+            "end": 1618289081185
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/lazy-loaded-suspense/LazyComponent.tsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_objectToString.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439644,
-            "end": 1612964439993
+            "start": 1618289081056,
+            "end": 1618289081190
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/isObject.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Hidden/HiddenCss.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447773,
-            "end": 1612964448122
+            "start": 1618289081621,
+            "end": 1618289081755
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@restart/hooks/esm/useForceUpdate.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Modal/TrapFocus.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452705,
-            "end": 1612964453054
+            "start": 1618289081632,
+            "end": 1618289081766
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Link/Link.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/tutorial/tic-tac-toe.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453739,
-            "end": 1612964454088
+            "start": 1618289078874,
+            "end": 1618289079007
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/radioactive-state/counter/Counter.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/CheckBox.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438105,
-            "end": 1612964438453
+            "start": 1618289079173,
+            "end": 1618289079306
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Popper/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/Favorite.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447715,
-            "end": 1612964448063
+            "start": 1618289079173,
+            "end": 1618289079306
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseReduce.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/Drafts.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447759,
-            "end": 1612964448107
+            "start": 1618289079174,
+            "end": 1618289079307
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ExpansionPanel/ExpansionPanelContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/withWidth/withWidth.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455493,
-            "end": 1612964455841
+            "start": 1618289079766,
+            "end": 1618289079899
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/css-modules/Button.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/IconButton/IconButton.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438634,
-            "end": 1612964438981
+            "start": 1618289080132,
+            "end": 1618289080265
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@restart/hooks/esm/useCallbackRef.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Paper/Paper.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452704,
-            "end": 1612964453051
+            "start": 1618289080133,
+            "end": 1618289080266
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Paper/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListSubheader/ListSubheader.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447715,
-            "end": 1612964448060
+            "start": 1618289080136,
+            "end": 1618289080269
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ListSubheader/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/object/create.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447714,
-            "end": 1612964448058
+            "start": 1618289080230,
+            "end": 1618289080363
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseEach.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/reactionCleanupTracking.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447772,
-            "end": 1612964448116
+            "start": 1618289080231,
+            "end": 1618289080364
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/framesync/dist/framesync.es.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_realNames.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446947,
-            "end": 1612964447290
+            "start": 1618289081010,
+            "end": 1618289081143
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/stubFalse.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepConnector/StepConnector.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450494,
-            "end": 1612964450837
+            "start": 1618289081056,
+            "end": 1618289081189
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/components/Rectangle.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/stub-example/clicker-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450527,
-            "end": 1612964450870
+            "start": 1618289078479,
+            "end": 1618289078611
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Table/Table.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/api-test/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452745,
-            "end": 1612964453088
+            "start": 1618289078480,
+            "end": 1618289078612
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-book-example/src/add.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/FavoriteBorder.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438104,
-            "end": 1612964438446
+            "start": 1618289079174,
+            "end": 1618289079306
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseIteratee.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/pink.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447771,
-            "end": 1612964448113
+            "start": 1618289079756,
+            "end": 1618289079888
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseUnary.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/useEventCallback.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450493,
-            "end": 1612964450835
+            "start": 1618289080143,
+            "end": 1618289080275
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TableContainer/TableContainer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/merge.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452705,
-            "end": 1612964453047
+            "start": 1618289080241,
+            "end": 1618289080373
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/js-beautify/js/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_wrapperClone.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445484,
-            "end": 1612964445825
+            "start": 1618289081006,
+            "end": 1618289081138
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/defineProperty.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/stub-example/clicker-with-delay-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445487,
-            "end": 1612964445828
+            "start": 1618289078479,
+            "end": 1618289078610
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_arrayReduce.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/CheckBoxOutlineBlank.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447714,
-            "end": 1612964448055
+            "start": 1618289079173,
+            "end": 1618289079304
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseGetTag.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TextField/TextField.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447713,
-            "end": 1612964448053
+            "start": 1618289079277,
+            "end": 1618289079408
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/components/GroundOverlay.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ToastBody.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450492,
-            "end": 1612964450832
+            "start": 1618289079279,
+            "end": 1618289079410
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/usePopperMarginModifiers.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/memoize.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451038,
-            "end": 1612964451378
+            "start": 1618289080240,
+            "end": 1618289080371
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-transition-group/esm/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/StreetViewPanorama.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451047,
-            "end": 1612964451387
+            "start": 1618289080427,
+            "end": 1618289080558
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-book-example/src/products.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormLabel.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438104,
-            "end": 1612964438443
+            "start": 1618289081681,
+            "end": 1618289081812
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/i18n/LocalizedComponent.tsx",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square2-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439643,
-            "end": 1612964439981
+            "start": 1618289078478,
+            "end": 1618289078608
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/objectWithoutProperties.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square4-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445483,
-            "end": 1612964445820
+            "start": 1618289078479,
+            "end": 1618289078609
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_castFunction.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/styled-components/Todo-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447780,
-            "end": 1612964448117
+            "start": 1618289078479,
+            "end": 1618289078609
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_createCaseFirst.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Zoom/Zoom.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447712,
-            "end": 1612964448048
+            "start": 1618289079766,
+            "end": 1618289079896
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/timers/card.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/responsivePropType.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438083,
-            "end": 1612964438416
+            "start": 1618289080240,
+            "end": 1618289080370
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-book-example/src/components/ProductsList.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputBase/utils.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438633,
-            "end": 1612964438966
+            "start": 1618289080579,
+            "end": 1618289080709
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/helpers/bind.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Slider/Slider.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445482,
-            "end": 1612964445815
+            "start": 1618289081104,
+            "end": 1618289081234
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/pretty-snapshots-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447842,
-            "end": 1612964448175
+            "start": 1618289078478,
+            "end": 1618289078607
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/useWrappedRefWithWarning.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/shopping-list-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451037,
-            "end": 1612964451370
+            "start": 1618289078478,
+            "end": 1618289078607
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Breadcrumbs/Breadcrumbs.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square1-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455408,
-            "end": 1612964455741
+            "start": 1618289078478,
+            "end": 1618289078607
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/material-ui-example/top-100-movies.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square3-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438103,
-            "end": 1612964438435
+            "start": 1618289078479,
+            "end": 1618289078608
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/classCallCheck.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/lodash/fp.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445485,
-            "end": 1612964445817
+            "start": 1618289079192,
+            "end": 1618289079321
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/FormControl/useFormControl.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/withMobileDialog/withMobileDialog.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447706,
-            "end": 1612964448038
+            "start": 1618289079765,
+            "end": 1618289079894
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_arrayEach.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/KmlLayer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447713,
-            "end": 1612964448045
+            "start": 1618289080427,
+            "end": 1618289080556
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_hasPath.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/jssPreset/jssPreset.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447795,
-            "end": 1612964448127
+            "start": 1618289080580,
+            "end": 1618289080709
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/jss-plugin-rule-value-function/dist/jss-plugin-rule-value-function.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/game-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450513,
-            "end": 1612964450845
+            "start": 1618289078477,
+            "end": 1618289078605
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TableFooter/TableFooter.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/hello-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452705,
-            "end": 1612964453037
+            "start": 1618289078478,
+            "end": 1618289078606
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/DialogActions/DialogActions.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/TrafficLayer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454760,
-            "end": 1612964455092
+            "start": 1618289080427,
+            "end": 1618289080555
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/IconButton/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/getThemeProps/getThemeProps.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447697,
-            "end": 1612964448027
+            "start": 1618289080582,
+            "end": 1618289080710
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseHas.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.get-prototype-of.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447712,
-            "end": 1612964448042
+            "start": 1618289080585,
+            "end": 1618289080712
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TableBody/TableBody.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepButton/StepButton.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452745,
-            "end": 1612964453074
+            "start": 1618289081068,
+            "end": 1618289081195
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/components/OverlayView.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseMatches.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450493,
-            "end": 1612964450820
+            "start": 1618289081073,
+            "end": 1618289081200
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/toggle-example/toggle-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todos-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439642,
-            "end": 1612964439968
+            "start": 1618289078477,
+            "end": 1618289078603
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/typeof.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/tutorial/shopping-list.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446948,
-            "end": 1612964447274
+            "start": 1618289078874,
+            "end": 1618289079000
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-keys-internal.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/BicyclingLayer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450525,
-            "end": 1612964450850
+            "start": 1618289080427,
+            "end": 1618289080553
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/style-value-types/dist/style-value-types.es.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/createStyles/createStyles.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446946,
-            "end": 1612964447270
+            "start": 1618289080585,
+            "end": 1618289080711
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/hello-x.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/createGenerateClassName/createGenerateClassName.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438082,
-            "end": 1612964438405
+            "start": 1618289080586,
+            "end": 1618289080712
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@restart/hooks/esm/usePrevious.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_shortOut.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452703,
-            "end": 1612964453025
+            "start": 1618289080587,
+            "end": 1618289080713
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ListItemAvatar/ListItemAvatar.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_composeArgs.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453732,
-            "end": 1612964454053
+            "start": 1618289080587,
+            "end": 1618289080713
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/styles/style/style-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getRawTag.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439698,
-            "end": 1612964440018
+            "start": 1618289081066,
+            "end": 1618289081192
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/CssBaseline/CssBaseline.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.to-string.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964454760,
-            "end": 1612964455080
+            "start": 1618289081071,
+            "end": 1618289081197
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/svg-icons/createSvgIcon.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Step/Step.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447695,
-            "end": 1612964448014
+            "start": 1618289081073,
+            "end": 1618289081199
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TableHead/TableHead.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types-extra/lib/isRequiredForA11y.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452703,
-            "end": 1612964453021
+            "start": 1618289081689,
+            "end": 1618289081815
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/typescript/ts-spec.tsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/webpack/buildin/global.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439641,
-            "end": 1612964439958
+            "start": 1618289078368,
+            "end": 1618289078493
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/safeHtml/safeHtml.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/webpack/buildin/module.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448402,
-            "end": 1612964448717
+            "start": 1618289078368,
+            "end": 1618289078493
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/InputBase/InputBase.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todo-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452133,
-            "end": 1612964452447
+            "start": 1618289078477,
+            "end": 1618289078602
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/unsupportedIterableToArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_apply.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448400,
-            "end": 1612964448712
+            "start": 1618289080588,
+            "end": 1618289080713
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@emotion/sheet/dist/sheet.browser.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hasUnicode.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452209,
-            "end": 1612964452519
+            "start": 1618289081067,
+            "end": 1618289081192
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.array.from.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Todos.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453731,
-            "end": 1612964454041
+            "start": 1618289078870,
+            "end": 1618289078994
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/is-in-browser/dist/module.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseSetToString.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452048,
-            "end": 1612964452357
+            "start": 1618289080574,
+            "end": 1618289080698
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/stateless-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/toFinite.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436254,
-            "end": 1612964436562
+            "start": 1618289080575,
+            "end": 1618289080699
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseIsTypedArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/jsx-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450492,
-            "end": 1612964450800
+            "start": 1618289078477,
+            "end": 1618289078600
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/framer-motion/Motion.tsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/Rating/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439641,
-            "end": 1612964439948
+            "start": 1618289079153,
+            "end": 1618289079276
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/utils/esm/deepmerge.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/Autocomplete/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447694,
-            "end": 1612964448000
+            "start": 1618289079153,
+            "end": 1618289079276
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TablePagination/TablePagination.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-parse-stringify2/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452702,
-            "end": 1612964453008
+            "start": 1618289080267,
+            "end": 1618289080390
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/oneLine/oneLine.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/withStyles/withStyles.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448401,
-            "end": 1612964448706
+            "start": 1618289080425,
+            "end": 1618289080548
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/SvgIcon/SvgIcon.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getWrapDetails.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447690,
-            "end": 1612964447994
+            "start": 1618289080576,
+            "end": 1618289080699
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/oneLineInlineLists/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/components-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447842,
-            "end": 1612964448146
+            "start": 1618289078477,
+            "end": 1618289078599
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/network/2-users-fetch.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/focusVisible.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438080,
-            "end": 1612964438383
+            "start": 1618289080131,
+            "end": 1618289080253
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Zoom/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonBase/Ripple.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452060,
-            "end": 1612964452363
+            "start": 1618289080421,
+            "end": 1618289080543
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/stripIndent/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447842,
-            "end": 1612964448143
+            "start": 1618289080422,
+            "end": 1618289080544
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/oneLineTrim/oneLineTrim.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/node_modules/react-is/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448402,
-            "end": 1612964448703
+            "start": 1618289080423,
+            "end": 1618289080545
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/animate.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/re-render/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453731,
-            "end": 1612964454032
+            "start": 1618289078477,
+            "end": 1618289078598
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Popover/Popover.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/slicedToArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452049,
-            "end": 1612964452349
+            "start": 1618289080127,
+            "end": 1618289080248
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Avatar/Avatar.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/safeHtml/safeHtml.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455865,
-            "end": 1612964456164
+            "start": 1618289081696,
+            "end": 1618289081817
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/stripIndents/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/no-visit/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447838,
-            "end": 1612964448135
+            "start": 1618289078476,
+            "end": 1618289078596
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_nodeUtil.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/transpiled.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450493,
-            "end": 1612964450790
+            "start": 1618289079164,
+            "end": 1618289079284
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_nativeCreate.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/useControlled.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452208,
-            "end": 1612964452505
+            "start": 1618289080126,
+            "end": 1618289080246
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/iterableToArrayLimit.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/NoSsr/NoSsr.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448401,
-            "end": 1612964448697
+            "start": 1618289080571,
+            "end": 1618289080691
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/scrollLeft.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Table/Tablelvl2Context.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453731,
-            "end": 1612964454026
+            "start": 1618289081140,
+            "end": 1618289081260
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/html-parse-stringify2/lib/stringify.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/TabContent.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448463,
-            "end": 1612964448757
+            "start": 1618289081425,
+            "end": 1618289081545
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/prop-types-extra/lib/utils/createChainableTypeChecker.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/fails-correctly/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450489,
-            "end": 1612964450783
+            "start": 1618289078476,
+            "end": 1618289078595
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/transpiled-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@bahmutov/cy-api/support.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439634,
-            "end": 1612964439927
+            "start": 1618289079036,
+            "end": 1618289079155
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/html-parse-stringify2/lib/parse.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/useTheme/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448462,
-            "end": 1612964448753
+            "start": 1618289080272,
+            "end": 1618289080391
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/utils/esm/elementAcceptingRef.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/ThemeProvider/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447690,
-            "end": 1612964447980
+            "start": 1618289080273,
+            "end": 1618289080392
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/oneLineCommaLists/oneLineCommaLists.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_overRest.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448401,
-            "end": 1612964448691
+            "start": 1618289080419,
+            "end": 1618289080538
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/uncontrollable/esm/utils.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_metaMap.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452207,
-            "end": 1612964452497
+            "start": 1618289080573,
+            "end": 1618289080692
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/hello-world-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.set-prototype-of.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436253,
-            "end": 1612964436542
+            "start": 1618289080599,
+            "end": 1618289080718
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/hey-listen/dist/hey-listen.es.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/OutlinedInput/OutlinedInput.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446946,
-            "end": 1612964447235
+            "start": 1618289080600,
+            "end": 1618289080719
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Tabs/TabScrollButton.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tabs/Tabs.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453730,
-            "end": 1612964454019
+            "start": 1618289080944,
+            "end": 1618289081063
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/components/TrafficLayer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tabs/TabIndicator.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450490,
-            "end": 1612964450778
+            "start": 1618289081131,
+            "end": 1618289081250
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/unmount/comp-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/animate.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439634,
-            "end": 1612964439921
+            "start": 1618289081132,
+            "end": 1618289081251
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_isIndex.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/debounce.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448349,
-            "end": 1612964448636
+            "start": 1618289081137,
+            "end": 1618289081256
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/oneLineCommaListsOr/oneLineCommaListsOr.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Table/TableContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448400,
-            "end": 1612964448687
+            "start": 1618289081140,
+            "end": 1618289081259
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/makeStyles/makeStyles.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Table.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449168,
-            "end": 1612964449455
+            "start": 1618289081425,
+            "end": 1618289081544
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/counter-use-hooks/counter.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438633,
-            "end": 1612964438919
+            "start": 1618289079102,
+            "end": 1618289079220
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/jssPreset/jssPreset.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/withStyles.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449174,
-            "end": 1612964449460
+            "start": 1618289079140,
+            "end": 1618289079258
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/utils/esm/elementTypeAcceptingRef.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/withTheme.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447684,
-            "end": 1612964447969
+            "start": 1618289079140,
+            "end": 1618289079258
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/getThemeProps/getThemeProps.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItem/ListItem.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449180,
-            "end": 1612964449465
+            "start": 1618289079277,
+            "end": 1618289079395
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/mobx-react-lite/es/utils/reactBatchedUpdates.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createBind.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446945,
-            "end": 1612964447229
+            "start": 1618289080418,
+            "end": 1618289080536
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_isIterateeCall.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/scrollLeft.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452205,
-            "end": 1612964452489
+            "start": 1618289081134,
+            "end": 1618289081252
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TablePagination/TablePaginationActions.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439632,
-            "end": 1612964439915
+            "start": 1618289081142,
+            "end": 1618289081260
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_toKey.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-keys-internal.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448348,
-            "end": 1612964448631
+            "start": 1618289081151,
+            "end": 1618289081269
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@emotion/is-prop-valid/dist/is-prop-valid.browser.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/network/2-users-fetch-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446944,
-            "end": 1612964447226
+            "start": 1618289078476,
+            "end": 1618289078593
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/nonIterableRest.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/transitions.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448400,
-            "end": 1612964448682
+            "start": 1618289079140,
+            "end": 1618289079257
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/timers/card-without-effect.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/useTheme.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438083,
-            "end": 1612964438364
+            "start": 1618289079140,
+            "end": 1618289079257
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/isLength.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/unmount/comp.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448348,
-            "end": 1612964448629
+            "start": 1618289079147,
+            "end": 1618289079264
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/isTransform.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/node_modules/scheduler/cjs/scheduler-tracing.development.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451438,
-            "end": 1612964451719
+            "start": 1618289080418,
+            "end": 1618289080535
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/pure-component.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tooltip/Tooltip.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436254,
-            "end": 1612964436534
+            "start": 1618289080943,
+            "end": 1618289081060
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/unmount/unmount-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tabs/ScrollbarSize.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439632,
-            "end": 1612964439912
+            "start": 1618289081132,
+            "end": 1618289081249
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/inlineLists/inlineLists.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/ArrowDownward.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448399,
-            "end": 1612964448679
+            "start": 1618289081146,
+            "end": 1618289081263
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@emotion/memoize/dist/memoize.browser.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_strictIndexOf.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448441,
-            "end": 1612964448721
+            "start": 1618289081151,
+            "end": 1618289081268
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseSetToString.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/makeStyles.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448461,
-            "end": 1612964448741
+            "start": 1618289079139,
+            "end": 1618289079255
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Tooltip/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/responsiveFontSizes.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452205,
-            "end": 1612964452485
+            "start": 1618289079140,
+            "end": 1618289079256
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/stripIndents/stripIndents.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/styled.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448362,
-            "end": 1612964448641
+            "start": 1618289079140,
+            "end": 1618289079256
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/hyphenateStyle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FilledInput/FilledInput.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451438,
-            "end": 1612964451717
+            "start": 1618289080606,
+            "end": 1618289080722
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TableSortLabel/TableSortLabel.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/node_modules/dom-helpers/esm/hasClass.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452701,
-            "end": 1612964452980
+            "start": 1618289080957,
+            "end": 1618289081073
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_createWrap.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tabs/TabScrollButton.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447428,
-            "end": 1612964447705
+            "start": 1618289081131,
+            "end": 1618289081247
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/utils/esm/exactProp.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Fab/Fab.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447683,
-            "end": 1612964447960
+            "start": 1618289081423,
+            "end": 1618289081539
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_castPath.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createMuiTheme.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448346,
-            "end": 1612964448623
+            "start": 1618289079139,
+            "end": 1618289079254
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_shortOut.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createStyles.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448462,
-            "end": 1612964448739
+            "start": 1618289079139,
+            "end": 1618289079254
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/core-js/object/create.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Typography/Typography.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447680,
-            "end": 1612964447956
+            "start": 1618289079275,
+            "end": 1618289079390
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/oneLineCommaListsAnd/oneLineCommaListsAnd.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.define-property.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448399,
-            "end": 1612964448675
+            "start": 1618289080606,
+            "end": 1618289080721
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/components/DirectionsRenderer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Input/Input.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450491,
-            "end": 1612964450767
+            "start": 1618289080608,
+            "end": 1618289080723
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/prop-types-extra/lib/isRequiredForA11y.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.create.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451435,
-            "end": 1612964451711
+            "start": 1618289080609,
+            "end": 1618289080724
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-transition-group/esm/ReplaceTransition.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-absolute-index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451574,
-            "end": 1612964451850
+            "start": 1618289081422,
+            "end": 1618289081537
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/withMobileDialog/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/network/1-users-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452113,
-            "end": 1612964452389
+            "start": 1618289078476,
+            "end": 1618289078590
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseAssignValue.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/colorManipulator.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452206,
-            "end": 1612964452482
+            "start": 1618289079139,
+            "end": 1618289079253
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/compose.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/ReplaceTransition.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447483,
-            "end": 1612964447758
+            "start": 1618289080416,
+            "end": 1618289080530
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/utils/esm/formatMuiErrorMessage.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-vendor/dist/css-vendor.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447680,
-            "end": 1612964447955
+            "start": 1618289081127,
+            "end": 1618289081241
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/fbjs/lib/shallowEqual.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsNaN.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448390,
-            "end": 1612964448665
+            "start": 1618289081156,
+            "end": 1618289081270
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_apply.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-dps.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448461,
-            "end": 1612964448736
+            "start": 1618289080957,
+            "end": 1618289081070
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/useMediaQuery/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iobject.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452204,
-            "end": 1612964452479
+            "start": 1618289081157,
+            "end": 1618289081270
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/helpers/typeof.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_cof.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447679,
-            "end": 1612964447953
+            "start": 1618289081158,
+            "end": 1618289081271
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/property.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Fade/Fade.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448346,
-            "end": 1612964448620
+            "start": 1618289081422,
+            "end": 1618289081535
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/arrayWithHoles.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/mount-div/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448394,
-            "end": 1612964448668
+            "start": 1618289078476,
+            "end": 1618289078588
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/is-buffer/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControl/FormControl.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448471,
-            "end": 1612964448745
+            "start": 1618289079138,
+            "end": 1618289079250
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/removeEventListener.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputLabel/InputLabel.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451434,
-            "end": 1612964451707
+            "start": 1618289079139,
+            "end": 1618289079251
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_createBaseEach.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ToastHeader.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448345,
-            "end": 1612964448617
+            "start": 1618289079275,
+            "end": 1618289079387
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/trimResultTransformer/trimResultTransformer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createCurry.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449777,
-            "end": 1612964450049
+            "start": 1618289080416,
+            "end": 1618289080528
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/react-overlays/esm/DropdownContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createRecurry.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452123,
-            "end": 1612964452395
+            "start": 1618289080619,
+            "end": 1618289080731
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/react-overlays/esm/usePopper.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.assign.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452204,
-            "end": 1612964452476
+            "start": 1618289081126,
+            "end": 1618289081238
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Backdrop/Backdrop.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/tiny-warning/dist/tiny-warning.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455865,
-            "end": 1612964456137
+            "start": 1618289081126,
+            "end": 1618289081238
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/html/html.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Grid/Grid.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448461,
-            "end": 1612964448732
+            "start": 1618289081421,
+            "end": 1618289081533
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/fn/object/set-prototype-of.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Box/Box.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448342,
-            "end": 1612964448612
+            "start": 1618289079275,
+            "end": 1618289079386
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/addEventListener.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createHybrid.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451434,
-            "end": 1612964451704
+            "start": 1618289080416,
+            "end": 1618289080527
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/useScrollTrigger/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/symbol/iterator.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452134,
-            "end": 1612964452404
+            "start": 1618289080614,
+            "end": 1618289080725
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Tabs/TabIndicator.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/utils/ChildMapping.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453730,
-            "end": 1612964454000
+            "start": 1618289080615,
+            "end": 1618289080726
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseForOwn.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/node_modules/react-is/cjs/react-is.development.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448345,
-            "end": 1612964448614
+            "start": 1618289080617,
+            "end": 1618289080728
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Popover/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createCtor.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451565,
-            "end": 1612964451834
+            "start": 1618289080620,
+            "end": 1618289080731
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/hasClass.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_toKey.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452132,
-            "end": 1612964452401
+            "start": 1618289081124,
+            "end": 1618289081235
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/fn/object/create.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseFindIndex.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448342,
-            "end": 1612964448610
+            "start": 1618289081125,
+            "end": 1618289081236
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/palette.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_toSource.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447444,
-            "end": 1612964447711
+            "start": 1618289081162,
+            "end": 1618289081273
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/core-js/object/define-property.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/enzyme/state-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447679,
-            "end": 1612964447946
+            "start": 1618289078476,
+            "end": 1618289078586
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/core-js/object/set-prototype-of.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CarouselItem.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447680,
-            "end": 1612964447947
+            "start": 1618289079274,
+            "end": 1618289079384
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/core-js/object/assign.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CloseButton.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452035,
-            "end": 1612964452302
+            "start": 1618289079275,
+            "end": 1618289079385
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/createClass.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_root.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446945,
-            "end": 1612964447211
+            "start": 1618289080617,
+            "end": 1618289080727
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/lab/esm/useAutocomplete/useAutocomplete.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputBase/InputBase.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447657,
-            "end": 1612964447923
+            "start": 1618289080939,
+            "end": 1618289081049
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/fn/object/get-prototype-of.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridList/GridList.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448342,
-            "end": 1612964448608
+            "start": 1618289081421,
+            "end": 1618289081531
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-transition-group/esm/SwitchTransition.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControl/useFormControl.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451564,
-            "end": 1612964451830
+            "start": 1618289079139,
+            "end": 1618289079248
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/display.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Carousel.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447482,
-            "end": 1612964447747
+            "start": 1618289079274,
+            "end": 1618289079383
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/utils/esm/getDisplayName.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/SwitchTransition.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447680,
-            "end": 1612964447945
+            "start": 1618289080414,
+            "end": 1618289080523
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/fn/object/define-property.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseForOwn.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448342,
-            "end": 1612964448607
+            "start": 1618289081094,
+            "end": 1618289081203
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/stripIndent/stripIndent.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MenuItem/MenuItem.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448385,
-            "end": 1612964448650
+            "start": 1618289079139,
+            "end": 1618289079247
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/core/Axios.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SnackbarContent/SnackbarContent.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451425,
-            "end": 1612964451690
+            "start": 1618289081094,
+            "end": 1618289081202
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/MenuList/MenuList.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/hyphenate-style-name/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452035,
-            "end": 1612964452300
+            "start": 1618289081120,
+            "end": 1618289081228
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-axios/3-users-api.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isMasked.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438633,
-            "end": 1612964438897
+            "start": 1618289081168,
+            "end": 1618289081276
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Paper/Paper.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css-modules/css-modules-orange-button-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448323,
-            "end": 1612964448587
+            "start": 1618289078475,
+            "end": 1618289078582
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/withWidth/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/enzyme/context-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452113,
-            "end": 1612964452377
+            "start": 1618289078475,
+            "end": 1618289078582
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TableRow/TableRow.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/style-loader/lib/urls.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452702,
-            "end": 1612964452966
+            "start": 1618289079055,
+            "end": 1618289079162
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/mobx-react-lite/es/utils/observerBatching.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormHelperText/FormHelperText.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446943,
-            "end": 1612964447206
+            "start": 1618289079138,
+            "end": 1618289079245
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseMatches.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/TransitionGroup.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448341,
-            "end": 1612964448604
+            "start": 1618289080414,
+            "end": 1618289080521
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/FormLabel/FormLabel.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/constants.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450491,
-            "end": 1612964450754
+            "start": 1618289080633,
+            "end": 1618289080740
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/inherits.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445751,
-            "end": 1612964446013
+            "start": 1618289080883,
+            "end": 1618289080990
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/classCallCheck.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Snackbar/Snackbar.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445754,
-            "end": 1612964446016
+            "start": 1618289081100,
+            "end": 1618289081207
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/clsx/dist/clsx.m.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_castPath.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447669,
-            "end": 1612964447930
+            "start": 1618289081123,
+            "end": 1618289081230
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/utils/esm/ponyfillGlobal.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.array.from.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447678,
-            "end": 1612964447939
+            "start": 1618289081174,
+            "end": 1618289081281
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/network/1-users.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MenuList/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438081,
-            "end": 1612964438341
+            "start": 1618289081174,
+            "end": 1618289081281
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/helpers/inherits.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridListTile/GridListTile.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446922,
-            "end": 1612964447182
+            "start": 1618289081420,
+            "end": 1618289081527
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/oneLineInlineLists/oneLineInlineLists.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CarouselCaption.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448386,
-            "end": 1612964448646
+            "start": 1618289080304,
+            "end": 1618289080410
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/ServerStyleSheets/ServerStyleSheets.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/symbol/iterator.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449168,
-            "end": 1612964449428
+            "start": 1618289080413,
+            "end": 1618289080519
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/flexbox.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createCaseFirst.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447482,
-            "end": 1612964447741
+            "start": 1618289080883,
+            "end": 1618289080989
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/use-lodash-fp/lodash-fp-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tab/Tab.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439632,
-            "end": 1612964439890
+            "start": 1618289080949,
+            "end": 1618289081055
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/mobx-react-lite/es/utils/utils.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isArguments.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446943,
-            "end": 1612964447201
+            "start": 1618289081116,
+            "end": 1618289081222
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/utils/esm/HTMLElementType.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridListTileBar/GridListTileBar.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447678,
-            "end": 1612964447936
+            "start": 1618289081419,
+            "end": 1618289081525
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/getComputedStyle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaLists/commaLists.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451425,
-            "end": 1612964451683
+            "start": 1618289081719,
+            "end": 1618289081825
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/react-overlays/esm/useRootClose.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/styles/style/style-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452203,
-            "end": 1612964452461
+            "start": 1618289079054,
+            "end": 1618289079159
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/svg-icons/ArrowDownward.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Select/Select.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453729,
-            "end": 1612964453987
+            "start": 1618289079138,
+            "end": 1618289079243
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/helpers/objectWithoutProperties.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/TransitionGroupContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446922,
-            "end": 1612964447178
+            "start": 1618289080312,
+            "end": 1618289080417
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/utils/esm/refType.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/symbol.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447677,
-            "end": 1612964447933
+            "start": 1618289080413,
+            "end": 1618289080518
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/createStyles.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_ie8-dom-define.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451471,
-            "end": 1612964451727
+            "start": 1618289080881,
+            "end": 1618289080986
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/AppBar/AppBar.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseHas.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455864,
-            "end": 1612964456120
+            "start": 1618289080883,
+            "end": 1618289080988
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/svg-icons/Cancel.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/property.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448341,
-            "end": 1612964448596
+            "start": 1618289081108,
+            "end": 1618289081213
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/replaceResultTransformer/replaceResultTransformer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseTimes.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449798,
-            "end": 1612964450053
+            "start": 1618289081109,
+            "end": 1618289081214
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/responsiveFontSizes.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseMatchesProperty.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451424,
-            "end": 1612964451679
+            "start": 1618289081109,
+            "end": 1618289081214
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/makeStyles.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/html/html.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451470,
-            "end": 1612964451724
+            "start": 1618289081716,
+            "end": 1618289081821
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/enzyme/props-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445753,
-            "end": 1612964446006
+            "start": 1618289078475,
+            "end": 1618289078579
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/helpers/defineProperty.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CardImg.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446922,
-            "end": 1612964447175
+            "start": 1618289079274,
+            "end": 1618289079378
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/mergeClasses/mergeClasses.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CardGroup.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449168,
-            "end": 1612964449421
+            "start": 1618289079274,
+            "end": 1618289079378
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/SvgIcon/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/SafeAnchor.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446942,
-            "end": 1612964447193
+            "start": 1618289080299,
+            "end": 1618289080403
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@emotion/serialize/dist/serialize.browser.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/config.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448060,
-            "end": 1612964448311
+            "start": 1618289080313,
+            "end": 1618289080417
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getBoundingClientRect.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Table/Table.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455842,
-            "end": 1612964456093
+            "start": 1618289080949,
+            "end": 1618289081053
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/typeof.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createBaseEach.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445753,
-            "end": 1612964446003
+            "start": 1618289081108,
+            "end": 1618289081212
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/css.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isBuffer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447483,
-            "end": 1612964447732
+            "start": 1618289081114,
+            "end": 1618289081218
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Tabs/ScrollbarSize.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Hidden/Hidden.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453730,
-            "end": 1612964453979
+            "start": 1618289081418,
+            "end": 1618289081522
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/helpers/classCallCheck.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaListsOr/commaListsOr.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446941,
-            "end": 1612964447189
+            "start": 1618289081719,
+            "end": 1618289081823
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Toolbar/Toolbar.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452700,
-            "end": 1612964452948
+            "start": 1618289079227,
+            "end": 1618289079330
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/styled/styled.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449167,
-            "end": 1612964449414
+            "start": 1618289079231,
+            "end": 1618289079334
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseIsNative.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CardDeck.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449815,
-            "end": 1612964450062
+            "start": 1618289079274,
+            "end": 1618289079377
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/uncontrollable/esm/uncontrollable.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ToastContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451762,
-            "end": 1612964452009
+            "start": 1618289080296,
+            "end": 1618289080399
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/helpers/possibleConstructorReturn.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ElementChildren.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446922,
-            "end": 1612964447168
+            "start": 1618289080303,
+            "end": 1618289080406
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/helpers/createClass.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseGetTag.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446941,
-            "end": 1612964447187
+            "start": 1618289080888,
+            "end": 1618289080991
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Popper/Popper.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gopd.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448324,
-            "end": 1612964448570
+            "start": 1618289080895,
+            "end": 1618289080998
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_an-object.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepButton/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449818,
-            "end": 1612964450064
+            "start": 1618289080896,
+            "end": 1618289080999
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@emotion/stylis/dist/stylis.browser.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableCell/TableCell.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451423,
-            "end": 1612964451669
+            "start": 1618289080948,
+            "end": 1618289081051
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/toArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableBody/TableBody.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455607,
-            "end": 1612964455853
+            "start": 1618289080949,
+            "end": 1618289081052
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getClippingRect.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_nativeKeys.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455843,
-            "end": 1612964456089
+            "start": 1618289081111,
+            "end": 1618289081214
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/objectSpread.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isTypedArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445754,
-            "end": 1612964445999
+            "start": 1618289081112,
+            "end": 1618289081215
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/mobx-react-lite/es/utils/printDebugValue.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Popover/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448030,
-            "end": 1612964448275
+            "start": 1618289081179,
+            "end": 1618289081282
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-axios/2-users-named.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaListsAnd/commaListsAnd.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438633,
-            "end": 1612964438876
+            "start": 1618289081719,
+            "end": 1618289081822
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/lab/esm/useAutocomplete/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/removeNonPrintingValuesTransformer/removeNonPrintingValuesTransformer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446920,
-            "end": 1612964447163
+            "start": 1618289081723,
+            "end": 1618289081826
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/grid.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/splitStringTransformer/splitStringTransformer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447482,
-            "end": 1612964447725
+            "start": 1618289081723,
+            "end": 1618289081826
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_isLaziable.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/inlineArrayTransformer/inlineArrayTransformer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449232,
-            "end": 1612964449475
+            "start": 1618289081724,
+            "end": 1618289081827
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/stripIndentTransformer/stripIndentTransformer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceSubstitutionTransformer/replaceSubstitutionTransformer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449815,
-            "end": 1612964450058
+            "start": 1618289081724,
+            "end": 1618289081827
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Input/Input.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceResultTransformer/replaceResultTransformer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450434,
-            "end": 1612964450676
+            "start": 1618289081729,
+            "end": 1618289081832
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/MenuList/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Card.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451565,
-            "end": 1612964451807
+            "start": 1618289079273,
+            "end": 1618289079375
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/createClass.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CardColumns.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445753,
-            "end": 1612964445994
+            "start": 1618289079274,
+            "end": 1618289079376
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_setToString.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/memoize/dist/memoize.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448030,
-            "end": 1612964448271
+            "start": 1618289080297,
+            "end": 1618289080399
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/react-overlays/esm/Dropdown.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/getComputedStyle.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451510,
-            "end": 1612964451751
+            "start": 1618289080316,
+            "end": 1618289080418
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/helpers/extends.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayReduce.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451564,
-            "end": 1612964451805
+            "start": 1618289080888,
+            "end": 1618289080990
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/FigureCaption.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseReduce.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455863,
-            "end": 1612964456104
+            "start": 1618289080894,
+            "end": 1618289080996
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/extends.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_is-object.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445750,
-            "end": 1612964445990
+            "start": 1618289080895,
+            "end": 1618289080997
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_overRest.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceStringTransformer/replaceStringTransformer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448030,
-            "end": 1612964448270
+            "start": 1618289081724,
+            "end": 1618289081826
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_copyArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormFile.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449238,
-            "end": 1612964449478
+            "start": 1618289081729,
+            "end": 1618289081831
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/components/FusionTablesLayer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndentTransformer/stripIndentTransformer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450490,
-            "end": 1612964450729
+            "start": 1618289081730,
+            "end": 1618289081832
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/FigureImage.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormControl.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455862,
-            "end": 1612964456101
+            "start": 1618289081731,
+            "end": 1618289081833
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_descriptors.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/object/set-prototype-of.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449231,
-            "end": 1612964449469
+            "start": 1618289080403,
+            "end": 1618289080504
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-transition-group/esm/TransitionGroup.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/OutlinedInput/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451563,
-            "end": 1612964451801
+            "start": 1618289080404,
+            "end": 1618289080505
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TablePagination/TablePaginationActions.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FilledInput/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453729,
-            "end": 1612964453967
+            "start": 1618289080409,
+            "end": 1618289080510
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/utils/esm/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Input/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446919,
-            "end": 1612964447156
+            "start": 1618289080409,
+            "end": 1618289080510
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Tabs/Tabs.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepContent/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452700,
-            "end": 1612964452937
+            "start": 1618289080891,
+            "end": 1618289080992
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/html/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepConnector/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448029,
-            "end": 1612964448265
+            "start": 1618289080892,
+            "end": 1618289080993
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-transition-group/esm/CSSTransition.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-lifecycles-compat/react-lifecycles-compat.es.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451550,
-            "end": 1612964451785
+            "start": 1618289080893,
+            "end": 1618289080994
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/validateModifiers.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Switch.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455822,
-            "end": 1612964456057
+            "start": 1618289081728,
+            "end": 1618289081829
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/possibleConstructorReturn.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormCheck.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445752,
-            "end": 1612964445986
+            "start": 1618289081729,
+            "end": 1618289081830
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/codeBlock/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css/css-orange-button-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448029,
-            "end": 1612964448262
+            "start": 1618289078475,
+            "end": 1618289078575
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/api-test/users.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ButtonToolbar.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438083,
-            "end": 1612964438315
+            "start": 1618289079273,
+            "end": 1618289079373
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/replaceSubstitutionTransformer/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setData.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449167,
-            "end": 1612964449399
+            "start": 1618289080396,
+            "end": 1618289080496
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-transition-group/esm/utils/ChildMapping.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createPartial.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452034,
-            "end": 1612964452266
+            "start": 1618289080397,
+            "end": 1618289080497
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/defaultTheme.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/CSSTransition.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446919,
-            "end": 1612964447150
+            "start": 1618289080403,
+            "end": 1618289080503
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_isKeyable.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/object/define-property.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451788,
-            "end": 1612964452019
+            "start": 1618289080409,
+            "end": 1618289080509
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/source/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/object/create.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448029,
-            "end": 1612964448259
+            "start": 1618289080412,
+            "end": 1618289080512
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/StylesProvider/StylesProvider.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-parse-stringify2/lib/parse-tag.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449166,
-            "end": 1612964449396
+            "start": 1618289080648,
+            "end": 1618289080748
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/tiny-warning/dist/tiny-warning.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/utils/MapChildHelper.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451900,
-            "end": 1612964452130
+            "start": 1618289080650,
+            "end": 1618289080750
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Step/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440079,
-            "end": 1612964440308
+            "start": 1618289080907,
+            "end": 1618289081007
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/getPrototypeOf.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SnackbarContent/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445753,
-            "end": 1612964445982
+            "start": 1618289080908,
+            "end": 1618289081008
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/lodash/fp/_mapping.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseEach.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445812,
-            "end": 1612964446041
+            "start": 1618289080909,
+            "end": 1618289081009
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/deprecatedPropType.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormGroup.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448024,
-            "end": 1612964448253
+            "start": 1618289081728,
+            "end": 1618289081828
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/components/KmlLayer.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/document/document-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450490,
-            "end": 1612964450719
+            "start": 1618289078475,
+            "end": 1618289078574
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/svg-icons/CheckBoxOutlineBlank.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ButtonGroup.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446917,
-            "end": 1612964447145
+            "start": 1618289079273,
+            "end": 1618289079372
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/identity.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mergeData.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448028,
-            "end": 1612964448256
+            "start": 1618289080396,
+            "end": 1618289080495
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_hashClear.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getData.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451787,
-            "end": 1612964452015
+            "start": 1618289080397,
+            "end": 1618289080496
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/hyphenate-style-name/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIteratee.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451899,
-            "end": 1612964452127
+            "start": 1618289080908,
+            "end": 1618289081007
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/objectWithoutProperties.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Button.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445752,
-            "end": 1612964445979
+            "start": 1618289079273,
+            "end": 1618289079371
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/isTableElement.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/isTransform.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455844,
-            "end": 1612964456071
+            "start": 1618289080321,
+            "end": 1618289080419
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-router-dom/react-router-dom.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/listen.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440042,
-            "end": 1612964440268
+            "start": 1618289080322,
+            "end": 1618289080420
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/safeHtml/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/hyphenateStyle.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448003,
-            "end": 1612964448229
+            "start": 1618289080322,
+            "end": 1618289080420
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/unsupportedProp.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/utils/PropTypes.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448005,
-            "end": 1612964448231
+            "start": 1618289080326,
+            "end": 1618289080424
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/core/InterceptorManager.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/arrayWithHoles.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451894,
-            "end": 1612964452118
+            "start": 1618289080328,
+            "end": 1618289080426
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/hyphenate.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/createGenerateClassName/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451898,
-            "end": 1612964452122
+            "start": 1618289080396,
+            "end": 1618289080494
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/mobx-react-lite/es/utils/assertEnvironment.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Icon/Icon.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445798,
-            "end": 1612964446021
+            "start": 1618289081417,
+            "end": 1618289081515
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/InputBase/utils.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/components/ProductsList.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449305,
-            "end": 1612964449528
+            "start": 1618289078715,
+            "end": 1618289078812
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getParentNode.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Breadcrumb.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455845,
-            "end": 1612964456068
+            "start": 1618289079272,
+            "end": 1618289079369
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/forward-ref/forward-ref.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/BreadcrumbItem.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438632,
-            "end": 1612964438854
+            "start": 1618289079273,
+            "end": 1618289079370
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/ownerWindow.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setWrapToString.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448016,
-            "end": 1612964448238
+            "start": 1618289080391,
+            "end": 1618289080488
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/OutlinedInput/OutlinedInput.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/createStyles/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450434,
-            "end": 1612964450656
+            "start": 1618289080395,
+            "end": 1618289080492
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/uniqueBy.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-create.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455824,
-            "end": 1612964456046
+            "start": 1618289081193,
+            "end": 1618289081290
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/isMuiElement.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ToggleButton.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448024,
-            "end": 1612964448245
+            "start": 1618289081395,
+            "end": 1618289081492
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_wks.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputAdornment/InputAdornment.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449304,
-            "end": 1612964449524
+            "start": 1618289081416,
+            "end": 1618289081513
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/rectToClientRect.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Alert.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455844,
-            "end": 1612964456064
+            "start": 1618289079272,
+            "end": 1618289079368
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/svg-icons/CheckBox.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/nonIterableRest.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446917,
-            "end": 1612964447136
+            "start": 1618289080332,
+            "end": 1618289080428
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/setRef.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setToString.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448015,
-            "end": 1612964448234
+            "start": 1618289080390,
+            "end": 1618289080486
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/ownerDocument.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/toInteger.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448016,
-            "end": 1612964448235
+            "start": 1618289080391,
+            "end": 1618289080487
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_string-at.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/jssPreset/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449303,
-            "end": 1612964449522
+            "start": 1618289080393,
+            "end": 1618289080489
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/react-overlays/esm/DropdownToggle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/getThemeProps/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451761,
-            "end": 1612964451980
+            "start": 1618289080394,
+            "end": 1618289080490
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/canUseDOM.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss/dist/jss.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451893,
-            "end": 1612964452112
+            "start": 1618289080811,
+            "end": 1618289080907
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-dom/node_modules/scheduler/cjs/scheduler.development.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-primitive.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452033,
-            "end": 1612964452252
+            "start": 1618289080878,
+            "end": 1618289080974
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/useEventCallback.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableFooter/TableFooter.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448004,
-            "end": 1612964448222
+            "start": 1618289080945,
+            "end": 1618289081041
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/useTheme/useTheme.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableContainer/TableContainer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449166,
-            "end": 1612964449384
+            "start": 1618289080948,
+            "end": 1618289081044
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/DropdownMenu.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemSecondaryAction/ListItemSecondaryAction.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450332,
-            "end": 1612964450550
+            "start": 1618289081395,
+            "end": 1618289081491
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getNodeName.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/counter-set-state/counter-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455844,
-            "end": 1612964456062
+            "start": 1618289078474,
+            "end": 1618289078569
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/stateless.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/counter-use-hooks/counter-hooks-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438079,
-            "end": 1612964438295
+            "start": 1618289078475,
+            "end": 1618289078570
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_LodashWrapper.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseSetData.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450368,
-            "end": 1612964450584
+            "start": 1618289080391,
+            "end": 1618289080486
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/components/StreetViewPanorama.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepLabel/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450489,
-            "end": 1612964450705
+            "start": 1618289080877,
+            "end": 1618289080972
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/core/dispatchRequest.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepIcon/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451891,
-            "end": 1612964452107
+            "start": 1618289080878,
+            "end": 1618289080973
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/inlineLists/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isLength.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447974,
-            "end": 1612964448189
+            "start": 1618289080927,
+            "end": 1618289081022
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/withStyles/withStyles.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableHead/TableHead.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449165,
-            "end": 1612964449380
+            "start": 1618289080944,
+            "end": 1618289081039
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_is-object.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/object/assign.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449853,
-            "end": 1612964450068
+            "start": 1618289080945,
+            "end": 1618289081040
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Modal/ModalManager.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ToggleButtonGroup.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453727,
-            "end": 1612964453942
+            "start": 1618289081393,
+            "end": 1618289081488
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Badge/Badge.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Tabs.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455826,
-            "end": 1612964456041
+            "start": 1618289081404,
+            "end": 1618289081499
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_getData.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/LinearProgress/LinearProgress.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448131,
-            "end": 1612964448345
+            "start": 1618289081412,
+            "end": 1618289081507
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/DropdownToggle.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/before-hook/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450320,
-            "end": 1612964450534
+            "start": 1618289078474,
+            "end": 1618289078568
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_wrapperClone.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/use-render/my-component.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450363,
-            "end": 1612964450576
+            "start": 1618289079130,
+            "end": 1618289079224
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/oneLineCommaListsAnd/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/AddTodo.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447974,
-            "end": 1612964448186
+            "start": 1618289079132,
+            "end": 1618289079226
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/oneLine/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Badge.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448003,
-            "end": 1612964448215
+            "start": 1618289079272,
+            "end": 1618289079366
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_asciiToArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/NoSsr/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449302,
-            "end": 1612964449514
+            "start": 1618289080388,
+            "end": 1618289080482
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/svg-icons/IndeterminateCheckBox.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/object/get-prototype-of.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446917,
-            "end": 1612964447128
+            "start": 1618289080389,
+            "end": 1618289080483
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/requirePropFactory.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Portal/Portal.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448015,
-            "end": 1612964448226
+            "start": 1618289080660,
+            "end": 1618289080754
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ListSubheader/ListSubheader.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Stepper/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448323,
-            "end": 1612964448534
+            "start": 1618289080875,
+            "end": 1618289080969
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/CarouselCaption.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_castFunction.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450361,
-            "end": 1612964450572
+            "start": 1618289080923,
+            "end": 1618289081017
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/slicedToArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseAssignValue.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447973,
-            "end": 1612964448183
+            "start": 1618289080924,
+            "end": 1618289081018
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseSetData.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayLikeKeys.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448104,
-            "end": 1612964448314
+            "start": 1618289080925,
+            "end": 1618289081019
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_mergeData.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseKeys.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448130,
-            "end": 1612964448340
+            "start": 1618289080925,
+            "end": 1618289081019
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/merge.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TablePagination/TablePagination.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448001,
-            "end": 1612964448210
+            "start": 1618289080944,
+            "end": 1618289081038
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/oneLineTrim/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndent/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448003,
-            "end": 1612964448212
+            "start": 1618289081392,
+            "end": 1618289081486
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_dom-create.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/TabPane.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449893,
-            "end": 1612964450102
+            "start": 1618289081407,
+            "end": 1618289081501
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_enum-bug-keys.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemAvatar/ListItemAvatar.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449894,
-            "end": 1612964450103
+            "start": 1618289081408,
+            "end": 1618289081502
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/shopping-list.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/trimResultTransformer/trimResultTransformer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438082,
-            "end": 1612964438290
+            "start": 1618289081743,
+            "end": 1618289081837
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/createMuiTheme.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_listCacheClear.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447629,
-            "end": 1612964447837
+            "start": 1618289081751,
+            "end": 1618289081845
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/html-parse-stringify2/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_listCacheDelete.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447972,
-            "end": 1612964448179
+            "start": 1618289081751,
+            "end": 1618289081845
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_unicodeToArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Map.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449303,
-            "end": 1612964449510
+            "start": 1618289081752,
+            "end": 1618289081846
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_listCacheDelete.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_MapCache.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450149,
-            "end": 1612964450355
+            "start": 1618289081752,
+            "end": 1618289081846
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_listCacheGet.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/stateless-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450150,
-            "end": 1612964450356
+            "start": 1618289078474,
+            "end": 1618289078567
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/FormFileInput.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/alias/alias-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450282,
-            "end": 1612964450488
+            "start": 1618289078474,
+            "end": 1618289078567
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/FormCheckInput.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/Todo.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450319,
-            "end": 1612964450525
+            "start": 1618289079132,
+            "end": 1618289079225
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/uncontrollable/esm/hook.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/StylesProvider/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451762,
-            "end": 1612964451968
+            "start": 1618289080356,
+            "end": 1618289080449
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Tooltip/Tooltip.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/styled/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452652,
-            "end": 1612964452858
+            "start": 1618289080357,
+            "end": 1618289080450
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/hooks/counter2-with-hooks.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/SelectableContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438632,
-            "end": 1612964438837
+            "start": 1618289080375,
+            "end": 1618289080468
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/transpiled.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Snackbar/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440023,
-            "end": 1612964440228
+            "start": 1618289080919,
+            "end": 1618289081012
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_setWrapToString.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Slider/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448129,
-            "end": 1612964448334
+            "start": 1618289080922,
+            "end": 1618289081015
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/adapters/xhr.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/hash/dist/hash.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451892,
-            "end": 1612964452096
+            "start": 1618289080923,
+            "end": 1618289081016
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/SwitchBase.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableRow/TableRow.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446917,
-            "end": 1612964447120
+            "start": 1618289080944,
+            "end": 1618289081037
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_listCacheHas.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Tooltip.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450149,
-            "end": 1612964450352
+            "start": 1618289081393,
+            "end": 1618289081486
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/divWithClassName.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Link/Link.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450393,
-            "end": 1612964450596
+            "start": 1618289081412,
+            "end": 1618289081505
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/AccordionContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-x-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450477,
-            "end": 1612964450680
+            "start": 1618289078473,
+            "end": 1618289078565
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/core-js/array/from.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/pure-component.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452368,
-            "end": 1612964452571
+            "start": 1618289078474,
+            "end": 1618289078566
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/responsivePropType.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448004,
-            "end": 1612964448206
+            "start": 1618289079129,
+            "end": 1618289079221
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/toConsumableArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/Cancel.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448129,
-            "end": 1612964448331
+            "start": 1618289080347,
+            "end": 1618289080439
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseIsArguments.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/iterableToArrayLimit.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449302,
-            "end": 1612964449504
+            "start": 1618289080355,
+            "end": 1618289080447
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ElementChildren.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/makeStyles/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450361,
-            "end": 1612964450563
+            "start": 1618289080374,
+            "end": 1618289080466
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_realNames.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/identity.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450362,
-            "end": 1612964450564
+            "start": 1618289080387,
+            "end": 1618289080479
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/FilledInput/FilledInput.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/DropdownItem.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450433,
-            "end": 1612964450635
+            "start": 1618289081750,
+            "end": 1618289081842
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/hasIn.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_DataView.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449298,
-            "end": 1612964449499
+            "start": 1618289081759,
+            "end": 1618289081851
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_listCacheSet.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/AccordionCollapse.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450149,
-            "end": 1612964450350
+            "start": 1618289079272,
+            "end": 1618289079363
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-dom/node_modules/scheduler/cjs/scheduler-tracing.development.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/createChainedFunction.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451679,
-            "end": 1612964451880
+            "start": 1618289080345,
+            "end": 1618289080436
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Tab/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/ServerStyleSheets/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452369,
-            "end": 1612964452570
+            "start": 1618289080359,
+            "end": 1618289080450
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/camelize.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/node_modules/scheduler/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447622,
-            "end": 1612964447822
+            "start": 1618289080368,
+            "end": 1618289080459
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/oneLineCommaListsOr/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Fade.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448000,
-            "end": 1612964448200
+            "start": 1618289080369,
+            "end": 1618289080460
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/oneLineCommaLists/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/symbol-observable/es/ponyfill.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448003,
-            "end": 1612964448203
+            "start": 1618289080665,
+            "end": 1618289080756
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/get.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_html.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449302,
-            "end": 1612964449502
+            "start": 1618289080872,
+            "end": 1618289080963
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/is-buffer/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SwipeableDrawer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449892,
-            "end": 1612964450092
+            "start": 1618289080873,
+            "end": 1618289080964
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/FormCheckLabel.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isIterateeCall.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450312,
-            "end": 1612964450512
+            "start": 1618289080932,
+            "end": 1618289081023
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseIndexOf.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/getStylesCreator/getStylesCreator.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449297,
-            "end": 1612964449496
+            "start": 1618289080933,
+            "end": 1618289081024
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_equalArrays.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TextareaAutosize/TextareaAutosize.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450148,
-            "end": 1612964450347
+            "start": 1618289080944,
+            "end": 1618289081035
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-keys.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/is-in-browser/dist/module.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450160,
-            "end": 1612964450359
+            "start": 1618289081210,
+            "end": 1618289081301
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/CardContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Modal/ModalManager.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450392,
-            "end": 1612964450591
+            "start": 1618289081391,
+            "end": 1618289081482
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Menu/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndents/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452672,
-            "end": 1612964452871
+            "start": 1618289081392,
+            "end": 1618289081483
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/toInteger.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Form.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448122,
-            "end": 1612964448320
+            "start": 1618289081749,
+            "end": 1618289081840
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_Symbol.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Col.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448322,
-            "end": 1612964448520
+            "start": 1618289081750,
+            "end": 1618289081841
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_a-function.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/DropdownButton.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450168,
-            "end": 1612964450366
+            "start": 1618289081750,
+            "end": 1618289081841
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ButtonBase/Ripple.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Set.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450209,
-            "end": 1612964450407
+            "start": 1618289081760,
+            "end": 1618289081851
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TableBody/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Promise.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452369,
-            "end": 1612964452567
+            "start": 1618289081760,
+            "end": 1618289081851
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TextareaAutosize/TextareaAutosize.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getAllKeys.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452699,
-            "end": 1612964452897
+            "start": 1618289081761,
+            "end": 1618289081852
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/support/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_SetCache.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436249,
-            "end": 1612964436446
+            "start": 1618289081762,
+            "end": 1618289081853
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/useForkRef.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_cacheHas.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447622,
-            "end": 1612964447819
+            "start": 1618289081764,
+            "end": 1618289081855
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/memoize.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/full-navigation-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448001,
-            "end": 1612964448198
+            "start": 1618289078473,
+            "end": 1618289078563
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_getNative.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-world-inline-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449120,
-            "end": 1612964449317
+            "start": 1618289078473,
+            "end": 1618289078563
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/withTheme/withTheme.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CardContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449166,
-            "end": 1612964449363
+            "start": 1618289080365,
+            "end": 1618289080455
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gopd.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/divWithClassName.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449893,
-            "end": 1612964450090
+            "start": 1618289080369,
+            "end": 1618289080459
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseLodash.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/mergeClasses/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450360,
-            "end": 1612964450557
+            "start": 1618289080371,
+            "end": 1618289080461
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/ownerWindow.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_string-at.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451889,
-            "end": 1612964452086
+            "start": 1618289080863,
+            "end": 1618289080953
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_setData.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_wks.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448130,
-            "end": 1612964448326
+            "start": 1618289080864,
+            "end": 1618289080954
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_objectToString.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Switch/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448322,
-            "end": 1612964448518
+            "start": 1618289080871,
+            "end": 1618289080961
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/core/transformData.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/weak-memoize/dist/weak-memoize.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452398,
-            "end": 1612964452594
+            "start": 1618289080935,
+            "end": 1618289081025
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_castSlice.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableSortLabel/TableSortLabel.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448322,
-            "end": 1612964448517
+            "start": 1618289080943,
+            "end": 1618289081033
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Portal/Portal.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MobileStepper/MobileStepper.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449890,
-            "end": 1612964450085
+            "start": 1618289081391,
+            "end": 1618289081481
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gops.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setToArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450168,
-            "end": 1612964450363
+            "start": 1618289081762,
+            "end": 1618289081852
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gopn-ext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Breadcrumbs/BreadcrumbCollapsed.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450196,
-            "end": 1612964450391
+            "start": 1618289081764,
+            "end": 1618289081854
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-transition-group/esm/Transition.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arraySome.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450281,
-            "end": 1612964450476
+            "start": 1618289081765,
+            "end": 1618289081855
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Table/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapToArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452369,
-            "end": 1612964452564
+            "start": 1618289081765,
+            "end": 1618289081855
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-create.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-world-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449132,
-            "end": 1612964449326
+            "start": 1618289078473,
+            "end": 1618289078562
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_html.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/AccordionToggle.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449893,
-            "end": 1612964450087
+            "start": 1618289079272,
+            "end": 1618289079361
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TableCell/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Menu/Menu.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452368,
-            "end": 1612964452562
+            "start": 1618289080863,
+            "end": 1618289080952
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/helpers/isAbsoluteURL.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.array.iterator.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452397,
-            "end": 1612964452591
+            "start": 1618289080865,
+            "end": 1618289080954
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_createCurry.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/wrapperLodash.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448317,
-            "end": 1612964448510
+            "start": 1618289080868,
+            "end": 1618289080957
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_createBind.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getFuncName.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448321,
-            "end": 1612964448514
+            "start": 1618289080871,
+            "end": 1618289080960
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_equalByTag.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIndexOf.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450148,
-            "end": 1612964450341
+            "start": 1618289080942,
+            "end": 1618289081031
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/warning/browser.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Toolbar/Toolbar.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451888,
-            "end": 1612964452081
+            "start": 1618289080943,
+            "end": 1618289081032
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getCompositeRect.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Popover/Popover.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455820,
-            "end": 1612964456013
+            "start": 1618289081313,
+            "end": 1618289081402
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-dom/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/webpack-dev-server/dist/aut-runner.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440042,
-            "end": 1612964440234
+            "start": 1618289078462,
+            "end": 1618289078550
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gpo.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/alert-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449109,
-            "end": 1612964449301
+            "start": 1618289078472,
+            "end": 1618289078560
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_overArg.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-act-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450173,
-            "end": 1612964450365
+            "start": 1618289078473,
+            "end": 1618289078561
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/helpers/combineURLs.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Accordion.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452397,
-            "end": 1612964452589
+            "start": 1618289079272,
+            "end": 1618289079360
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Table/TableContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/assign.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453728,
-            "end": 1612964453920
+            "start": 1618289080689,
+            "end": 1618289080777
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@bahmutov/cy-api/support.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/ThemeProvider/nested.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439885,
-            "end": 1612964440076
+            "start": 1618289080689,
+            "end": 1618289080777
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/shadows.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_ctx.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448194,
-            "end": 1612964448385
+            "start": 1618289080863,
+            "end": 1618289080951
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_getTag.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_an-object.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450128,
-            "end": 1612964450319
+            "start": 1618289080867,
+            "end": 1618289080955
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/helpers/cookies.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/void-elements/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452396,
-            "end": 1612964452587
+            "start": 1618289080868,
+            "end": 1618289080956
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_equalObjects.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_LazyWrapper.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450142,
-            "end": 1612964450332
+            "start": 1618289080868,
+            "end": 1618289080956
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseDelay.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hasPath.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451761,
-            "end": 1612964451951
+            "start": 1618289080940,
+            "end": 1618289081028
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Fade/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_enum-bug-keys.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453553,
-            "end": 1612964453743
+            "start": 1618289080942,
+            "end": 1618289081030
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ButtonBase/ButtonBase.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Modal/Modal.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449106,
-            "end": 1612964449295
+            "start": 1618289081391,
+            "end": 1618289081479
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-dp.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/utils/OverlayViewHelper.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449155,
-            "end": 1612964449344
+            "start": 1618289080689,
+            "end": 1618289080776
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/styled.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/delay.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449296,
-            "end": 1612964449485
+            "start": 1618289080689,
+            "end": 1618289080776
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/transitionEnd.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/useTheme/ThemeContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450192,
-            "end": 1612964450381
+            "start": 1618289080690,
+            "end": 1618289080777
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ListItemSecondaryAction/ListItemSecondaryAction.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_global.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453718,
-            "end": 1612964453907
+            "start": 1618289080859,
+            "end": 1618289080946
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/game.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_hide.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438081,
-            "end": 1612964438269
+            "start": 1618289080863,
+            "end": 1618289080950
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/shape.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/eq.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448189,
-            "end": 1612964448377
+            "start": 1618289080940,
+            "end": 1618289081027
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_createPartial.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_dom-create.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448317,
-            "end": 1612964448505
+            "start": 1618289080942,
+            "end": 1618289081029
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_set-proto.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/emotion-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449143,
-            "end": 1612964449331
+            "start": 1618289078472,
+            "end": 1618289078558
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/ThemeProvider/ThemeProvider.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/error-boundary-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449166,
-            "end": 1612964449354
+            "start": 1618289078473,
+            "end": 1618289078559
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_Map.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Typography/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450124,
-            "end": 1612964450312
+            "start": 1618289079116,
+            "end": 1618289079202
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_copyObject.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Button/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451761,
-            "end": 1612964451949
+            "start": 1618289079116,
+            "end": 1618289079202
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/cssUtils.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItem/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451888,
-            "end": 1612964452076
+            "start": 1618289079117,
+            "end": 1618289079203
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/trimResultTransformer/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TextField/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449121,
-            "end": 1612964449308
+            "start": 1618289079117,
+            "end": 1618289079203
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/stripIndentTransformer/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Divider/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449133,
-            "end": 1612964449320
+            "start": 1618289079271,
+            "end": 1618289079357
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_MapCache.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemText/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450123,
-            "end": 1612964450310
+            "start": 1618289079271,
+            "end": 1618289079357
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@restart/hooks/esm/useEventCallback.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/uncontrollable/lib/esm/uncontrollable.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450416,
-            "end": 1612964450603
+            "start": 1618289080686,
+            "end": 1618289080772
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@restart/hooks/esm/useMounted.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useCommittedRef.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451855,
-            "end": 1612964452042
+            "start": 1618289080688,
+            "end": 1618289080774
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TableContainer/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Uint8Array.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452367,
-            "end": 1612964452554
+            "start": 1618289081770,
+            "end": 1618289081856
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/SwipeableDrawer/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/support/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452391,
-            "end": 1612964452577
+            "start": 1618289078472,
+            "end": 1618289078557
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/webpack/buildin/global.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Box/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436244,
-            "end": 1612964436429
+            "start": 1618289079116,
+            "end": 1618289079201
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/utils/esm/chainPropTypes.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447656,
-            "end": 1612964447841
+            "start": 1618289079121,
+            "end": 1618289079206
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/createSpacing.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448189,
-            "end": 1612964448374
+            "start": 1618289079269,
+            "end": 1618289079354
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/replaceResultTransformer/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControlLabel/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449125,
-            "end": 1612964449310
+            "start": 1618289079270,
+            "end": 1618289079355
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/getStylesCreator/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Checkbox/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450422,
-            "end": 1612964450607
+            "start": 1618289079270,
+            "end": 1618289079355
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/cancel/isCancel.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemIcon/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451419,
-            "end": 1612964451604
+            "start": 1618289079271,
+            "end": 1618289079356
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-length.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/List/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451760,
-            "end": 1612964451945
+            "start": 1618289079271,
+            "end": 1618289079356
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@restart/hooks/esm/useWillUnmount.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useMounted.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451854,
-            "end": 1612964452039
+            "start": 1618289080684,
+            "end": 1618289080769
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Switch/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/uncontrollable/lib/esm/hook.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452390,
-            "end": 1612964452575
+            "start": 1618289080686,
+            "end": 1618289080771
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/ownerDocument.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SwipeableDrawer/SwipeArea.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452396,
-            "end": 1612964452581
+            "start": 1618289081221,
+            "end": 1618289081306
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/hooks/counter-with-hooks.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Toast.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438632,
-            "end": 1612964438816
+            "start": 1618289081390,
+            "end": 1618289081475
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/useControlled.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_listCacheSet.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447621,
-            "end": 1612964447805
+            "start": 1618289081771,
+            "end": 1618289081856
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Portal/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_listCacheHas.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449150,
-            "end": 1612964449334
+            "start": 1618289081771,
+            "end": 1618289081856
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/warning/warning.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450190,
-            "end": 1612964450374
+            "start": 1618289079265,
+            "end": 1618289079349
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_assignValue.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/ownerDocument.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451759,
-            "end": 1612964451943
+            "start": 1618289080678,
+            "end": 1618289080762
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TableFooter/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_shared-key.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452367,
-            "end": 1612964452551
+            "start": 1618289080856,
+            "end": 1618289080940
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@restart/hooks/esm/useSafeState.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es7.symbol.async-iterator.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453727,
-            "end": 1612964453911
+            "start": 1618289080856,
+            "end": 1618289080940
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_listCacheClear.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Container/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450123,
-            "end": 1612964450306
+            "start": 1618289081367,
+            "end": 1618289081451
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Menu/Menu.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_memoizeCapped.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450122,
-            "end": 1612964450304
+            "start": 1618289081390,
+            "end": 1618289081474
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_is-array.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormGroup/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450233,
-            "end": 1612964450415
+            "start": 1618289079270,
+            "end": 1618289079353
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/cancel/CancelToken.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useWillUnmount.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451420,
-            "end": 1612964451602
+            "start": 1618289080683,
+            "end": 1618289080766
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/css-vendor/dist/css-vendor.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/canUseDOM.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452020,
-            "end": 1612964452202
+            "start": 1618289080683,
+            "end": 1618289080766
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TableHead/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_defined.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452366,
-            "end": 1612964452548
+            "start": 1618289080855,
+            "end": 1618289080938
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/orderModifiers.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_has.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455823,
-            "end": 1612964456005
+            "start": 1618289080856,
+            "end": 1618289080939
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/capitalize.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_is-array-iter.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446916,
-            "end": 1612964447097
+            "start": 1618289081331,
+            "end": 1618289081414
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/IconButton/IconButton.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-call.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448278,
-            "end": 1612964448459
+            "start": 1618289081338,
+            "end": 1618289081421
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_createHybrid.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Stack.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448318,
-            "end": 1612964448499
+            "start": 1618289081366,
+            "end": 1618289081449
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/defaults.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RadioGroup/useRadioGroup.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451413,
-            "end": 1612964451594
+            "start": 1618289081366,
+            "end": 1618289081449
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_createAssigner.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogActions/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451760,
-            "end": 1612964451941
+            "start": 1618289081367,
+            "end": 1618289081450
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_toSource.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Dialog/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450234,
-            "end": 1612964450413
+            "start": 1618289081367,
+            "end": 1618289081450
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/stubArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CssBaseline/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451853,
-            "end": 1612964452032
+            "start": 1618289081367,
+            "end": 1618289081450
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@restart/hooks/esm/useUpdatedRef.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Radio/Radio.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452365,
-            "end": 1612964452544
+            "start": 1618289081386,
+            "end": 1618289081469
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/AbstractNav.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/AppBar/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455819,
-            "end": 1612964455998
+            "start": 1618289081387,
+            "end": 1618289081470
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@restart/context/forwardRef.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/@emotion/core/dist/core.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446915,
-            "end": 1612964447093
+            "start": 1618289079260,
+            "end": 1618289079342
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/cancel/Cancel.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/axios.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451420,
-            "end": 1612964451598
+            "start": 1618289079261,
+            "end": 1618289079343
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-absolute-index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_fails.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451759,
-            "end": 1612964451937
+            "start": 1618289080856,
+            "end": 1618289080938
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_hashGet.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/Warning.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451885,
-            "end": 1612964452063
+            "start": 1618289081229,
+            "end": 1618289081311
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_hashDelete.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Drawer/Drawer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451887,
-            "end": 1612964452065
+            "start": 1618289081230,
+            "end": 1618289081312
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TablePagination/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createBaseFor.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452364,
-            "end": 1612964452542
+            "start": 1618289081370,
+            "end": 1618289081452
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_isMasked.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CircularProgress/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450234,
-            "end": 1612964450411
+            "start": 1618289081371,
+            "end": 1618289081453
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/helpers/toConsumableArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardMedia/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451852,
-            "end": 1612964452029
+            "start": 1618289081372,
+            "end": 1618289081454
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/transitions.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardHeader/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448186,
-            "end": 1612964448362
+            "start": 1618289081372,
+            "end": 1618289081454
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/helpers/normalizeHeaderName.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardActionArea/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451883,
-            "end": 1612964452059
+            "start": 1618289081377,
+            "end": 1618289081459
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/unmount/comp.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/BottomNavigation/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440022,
-            "end": 1612964440197
+            "start": 1618289081385,
+            "end": 1618289081467
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/createBreakpoints.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Avatar/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448316,
-            "end": 1612964448491
+            "start": 1618289081386,
+            "end": 1618289081468
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_shared.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/webpack/buildin/global.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450003,
-            "end": 1612964450178
+            "start": 1618289079585,
+            "end": 1618289079666
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_iobject.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/settle.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450434,
-            "end": 1612964450609
+            "start": 1618289080851,
+            "end": 1618289080932
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-dom/node_modules/scheduler/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es7.symbol.observable.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451712,
-            "end": 1612964451887
+            "start": 1618289080852,
+            "end": 1618289080933
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@restart/hooks/esm/useMergedRefs.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseTrim.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451758,
-            "end": 1612964451933
+            "start": 1618289080852,
+            "end": 1618289080933
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TableRow/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isSymbol.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452364,
-            "end": 1612964452539
+            "start": 1618289080853,
+            "end": 1618289080934
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/tslib/tslib.es6.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/CheckCircle.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446914,
-            "end": 1612964447088
+            "start": 1618289081229,
+            "end": 1618289081310
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/focusVisible.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseToString.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447620,
-            "end": 1612964447794
+            "start": 1618289081235,
+            "end": 1618289081316
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/zIndex.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-length.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448177,
-            "end": 1612964448351
+            "start": 1618289081327,
+            "end": 1618289081408
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_metaMap.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Card/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448588,
-            "end": 1612964448762
+            "start": 1618289081378,
+            "end": 1618289081459
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-transition-group/esm/utils/PropTypes.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseHasIn.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451219,
-            "end": 1612964451393
+            "start": 1618289081381,
+            "end": 1618289081462
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_arrayFilter.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/BottomNavigationAction/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451852,
-            "end": 1612964452026
+            "start": 1618289081385,
+            "end": 1618289081466
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-integer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Badge/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450002,
-            "end": 1612964450175
+            "start": 1618289081385,
+            "end": 1618289081466
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_hashHas.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Backdrop/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451883,
-            "end": 1612964452056
+            "start": 1618289081386,
+            "end": 1618289081467
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Tabs/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452360,
-            "end": 1612964452533
+            "start": 1618289079116,
+            "end": 1618289079196
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TableSortLabel/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded-suspense/Dog.tsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452363,
-            "end": 1612964452536
+            "start": 1618289079264,
+            "end": 1618289079344
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/core/settle.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/buildURL.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452451,
-            "end": 1612964452624
+            "start": 1618289080851,
+            "end": 1618289080931
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Modal/Modal.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/core.get-iterator-method.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453717,
-            "end": 1612964453890
+            "start": 1618289081325,
+            "end": 1618289081405
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/withTheme.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RadioGroup/RadioGroup.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451413,
-            "end": 1612964451585
+            "start": 1618289081361,
+            "end": 1618289081441
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_arrayPush.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardContent/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451851,
-            "end": 1612964452023
+            "start": 1618289081375,
+            "end": 1618289081455
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/isObjectLike.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Grow/Grow.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449057,
-            "end": 1612964449228
+            "start": 1618289081376,
+            "end": 1618289081456
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-object.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardActions/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449059,
-            "end": 1612964449230
+            "start": 1618289081377,
+            "end": 1618289081457
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/NavbarContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonGroup/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451232,
-            "end": 1612964451403
+            "start": 1618289081379,
+            "end": 1618289081459
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/blueGrey.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Breadcrumbs/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451239,
-            "end": 1612964451410
+            "start": 1618289081383,
+            "end": 1618289081463
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_hashSet.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/dist/cypress-react.cjs.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451881,
-            "end": 1612964452052
+            "start": 1618289078693,
+            "end": 1618289078772
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Toolbar/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/defineProperty.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452359,
-            "end": 1612964452530
+            "start": 1618289080700,
+            "end": 1618289080779
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/radioactive-state/todos/AddTodo.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseSlice.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439870,
-            "end": 1612964440040
+            "start": 1618289081235,
+            "end": 1618289081314
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/replaceSubstitutionTransformer/replaceSubstitutionTransformer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_unicodeToArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449946,
-            "end": 1612964450116
+            "start": 1618289081239,
+            "end": 1618289081318
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/useTheme/ThemeContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Slide/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450002,
-            "end": 1612964450172
+            "start": 1618289081245,
+            "end": 1618289081324
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/mocking-axios/1-users.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RootRef/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438632,
-            "end": 1612964438801
+            "start": 1618289081245,
+            "end": 1618289081324
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/InputBase/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MenuList/MenuList.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451728,
-            "end": 1612964451897
+            "start": 1618289081310,
+            "end": 1618289081389
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/TextareaAutosize/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogTitle/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452359,
-            "end": 1612964452528
+            "start": 1618289081323,
+            "end": 1618289081402
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/mobx-react-lite/es/utils/reactionCleanupTracking.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_create-property.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447612,
-            "end": 1612964447780
+            "start": 1618289081326,
+            "end": 1618289081405
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_isStrictComparable.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ClickAwayListener/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449057,
-            "end": 1612964449225
+            "start": 1618289081347,
+            "end": 1618289081426
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseIsNaN.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RootRef/RootRef.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450001,
-            "end": 1612964450167
+            "start": 1618289081360,
+            "end": 1618289081439
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/dist/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Slide/Slide.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438465,
-            "end": 1612964438630
+            "start": 1618289081361,
+            "end": 1618289081440
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/react-overlays/esm/DropdownMenu.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsEqualDeep.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451757,
-            "end": 1612964451922
+            "start": 1618289081381,
+            "end": 1618289081460
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/helpers/parseHeaders.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseGet.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452450,
-            "end": 1612964452615
+            "start": 1618289081383,
+            "end": 1618289081462
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_export.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Select/SelectInput.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449058,
-            "end": 1612964449222
+            "start": 1618289080745,
+            "end": 1618289080823
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_strictIndexOf.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.string.iterator.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450001,
-            "end": 1612964450165
+            "start": 1618289080757,
+            "end": 1618289080835
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_stackDelete.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_wks-ext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450269,
-            "end": 1612964450433
+            "start": 1618289080758,
+            "end": 1618289080836
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Fab/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getNative.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453588,
-            "end": 1612964453752
+            "start": 1618289080850,
+            "end": 1618289080928
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/createPalette.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_asciiToArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448277,
-            "end": 1612964448440
+            "start": 1618289081239,
+            "end": 1618289081317
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/wrapperLodash.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RadioGroup/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449979,
-            "end": 1612964450142
+            "start": 1618289081246,
+            "end": 1618289081324
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/shallowequal/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-detect.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451411,
-            "end": 1612964451574
+            "start": 1618289081309,
+            "end": 1618289081387
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseHasIn.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayMap.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450000,
-            "end": 1612964450162
+            "start": 1618289081354,
+            "end": 1618289081432
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_meta.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogContentText/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450268,
-            "end": 1612964450430
+            "start": 1618289081355,
+            "end": 1618289081433
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/brown.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/OutlinedInput/NotchedOutline.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451256,
-            "end": 1612964451418
+            "start": 1618289080755,
+            "end": 1618289080832
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/helpers/buildURL.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-create.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452449,
-            "end": 1612964452611
+            "start": 1618289080761,
+            "end": 1618289080838
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_classof.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isLaziable.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455699,
-            "end": 1612964455861
+            "start": 1618289080762,
+            "end": 1618289080839
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/createMixins.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/parseHeaders.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448316,
-            "end": 1612964448477
+            "start": 1618289080849,
+            "end": 1618289080926
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/symbol-observable/es/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/array/from.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448642,
-            "end": 1612964448803
+            "start": 1618289080850,
+            "end": 1618289080927
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_wks-define.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Fade/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450118,
-            "end": 1612964450279
+            "start": 1618289081302,
+            "end": 1618289081379
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-dom/node_modules/scheduler/tracing.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_array-includes.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451262,
-            "end": 1612964451423
+            "start": 1618289081303,
+            "end": 1618289081380
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/radioactive-state/todos/Todo.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Fab/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439870,
-            "end": 1612964440030
+            "start": 1618289081303,
+            "end": 1618289081380
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/system/esm/breakpoints.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_coreJsData.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964447611,
-            "end": 1612964447771
+            "start": 1618289081305,
+            "end": 1618289081382
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/void-elements/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Collapse/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449999,
-            "end": 1612964450159
+            "start": 1618289081355,
+            "end": 1618289081432
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_getFuncName.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_listCacheGet.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449979,
-            "end": 1612964450138
+            "start": 1618289081786,
+            "end": 1618289081863
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gopn.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/top-100-movies.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450117,
-            "end": 1612964450276
+            "start": 1618289078701,
+            "end": 1618289078777
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/deepOrange.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/web.dom.iterable.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451257,
-            "end": 1612964451416
+            "start": 1618289080761,
+            "end": 1618289080837
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ExpansionPanelSummary/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_freeGlobal.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453589,
-            "end": 1612964453748
+            "start": 1618289080761,
+            "end": 1618289080837
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/style-loader/lib/urls.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseCreate.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439929,
-            "end": 1612964440087
+            "start": 1618289080763,
+            "end": 1618289080839
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseKeys.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/warning/browser.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449054,
-            "end": 1612964449212
+            "start": 1618289080769,
+            "end": 1618289080845
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseFindIndex.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/isURLSameOrigin.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449999,
-            "end": 1612964450157
+            "start": 1618289080848,
+            "end": 1618289080924
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/utils/node_modules/react-is/cjs/react-is.development.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getMatchData.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449106,
-            "end": 1612964449263
+            "start": 1618289081257,
+            "end": 1618289081333
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-pie.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridListTileBar/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450117,
-            "end": 1612964450274
+            "start": 1618289081299,
+            "end": 1618289081375
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.to-string.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridListTile/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450282,
-            "end": 1612964450439
+            "start": 1618289081300,
+            "end": 1618289081376
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/@emotion/sheet/dist/sheet.browser.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridList/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452012,
-            "end": 1612964452169
+            "start": 1618289081302,
+            "end": 1618289081378
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/react-overlays/esm/ownerDocument.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Grid/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452652,
-            "end": 1612964452809
+            "start": 1618289081302,
+            "end": 1618289081378
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/mergeByName.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelSummary/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455824,
-            "end": 1612964455981
+            "start": 1618289081323,
+            "end": 1618289081399
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseCreate.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanel/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448986,
-            "end": 1612964449142
+            "start": 1618289081323,
+            "end": 1618289081399
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/getStylesCreator/noopTheme.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogContent/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449979,
-            "end": 1612964450135
+            "start": 1618289081358,
+            "end": 1618289081434
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_stackClear.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/RadioButtonUnchecked.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450281,
-            "end": 1612964450437
+            "start": 1618289081786,
+            "end": 1618289081862
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/es7.symbol.async-iterator.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/createError.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450282,
-            "end": 1612964450438
+            "start": 1618289080848,
+            "end": 1618289080923
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/helpers/isURLSameOrigin.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsMatch.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452449,
-            "end": 1612964452605
+            "start": 1618289081257,
+            "end": 1618289081332
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/FormControl/FormControlContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_matchesStrictComparable.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448315,
-            "end": 1612964448470
+            "start": 1618289081257,
+            "end": 1618289081332
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/cypress-react-selector/src/reactHandler.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/KeyboardArrowLeft.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449054,
-            "end": 1612964449209
+            "start": 1618289081288,
+            "end": 1618289081363
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/isBuffer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemAvatar/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450112,
-            "end": 1612964450267
+            "start": 1618289081289,
+            "end": 1618289081364
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_setCacheAdd.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Link/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451412,
-            "end": 1612964451567
+            "start": 1618289081290,
+            "end": 1618289081365
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputAdornment/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438492,
-            "end": 1612964438645
+            "start": 1618289081295,
+            "end": 1618289081370
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_composeArgs.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelDetails/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448626,
-            "end": 1612964448779
+            "start": 1618289081321,
+            "end": 1618289081396
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_enum-keys.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelActions/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450267,
-            "end": 1612964450420
+            "start": 1618289081321,
+            "end": 1618289081396
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/matches.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Drawer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452599,
-            "end": 1612964452752
+            "start": 1618289081322,
+            "end": 1618289081397
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/useMediaQuery/useMediaQuery.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/Person.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452648,
-            "end": 1612964452801
+            "start": 1618289081783,
+            "end": 1618289081858
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/NativeSelect/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/RadioButtonChecked.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452651,
-            "end": 1612964452804
+            "start": 1618289081785,
+            "end": 1618289081860
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/change-emitter/lib/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/timers/card-without-effect.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448642,
-            "end": 1612964448794
+            "start": 1618289078690,
+            "end": 1618289078764
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/noop.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/add.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448665,
-            "end": 1612964448817
+            "start": 1618289078704,
+            "end": 1618289078778
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/NoSsr/NoSsr.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451410,
-            "end": 1612964451562
+            "start": 1618289079096,
+            "end": 1618289079170
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_freeGlobal.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/@emotion/utils/dist/utils.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448980,
-            "end": 1612964449131
+            "start": 1618289080718,
+            "end": 1618289080792
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/dist/getDisplayName.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_export.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440022,
-            "end": 1612964440172
+            "start": 1618289080753,
+            "end": 1618289080827
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_getWrapDetails.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isObject.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448626,
-            "end": 1612964448776
+            "start": 1618289080768,
+            "end": 1618289080842
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_LazyWrapper.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-dp.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449978,
-            "end": 1612964450128
+            "start": 1618289080775,
+            "end": 1618289080849
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_getValue.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-global/dist/jss-plugin-global.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450108,
-            "end": 1612964450258
+            "start": 1618289080844,
+            "end": 1618289080918
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/replaceStringTransformer/replaceStringTransformer.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/combineURLs.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450111,
-            "end": 1612964450261
+            "start": 1618289080846,
+            "end": 1618289080920
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/axios/lib/core/createError.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/isAbsoluteURL.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452448,
-            "end": 1612964452598
+            "start": 1618289080847,
+            "end": 1618289080921
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/makeStyles/multiKeyStore.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/transformData.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449998,
-            "end": 1612964450147
+            "start": 1618289080847,
+            "end": 1618289080921
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/withMobileDialog/withMobileDialog.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemSecondaryAction/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452595,
-            "end": 1612964452744
+            "start": 1618289081285,
+            "end": 1618289081359
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ModalContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/KeyboardArrowRight.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455828,
-            "end": 1612964455977
+            "start": 1618289081288,
+            "end": 1618289081362
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_wks-ext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/LinearProgress/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448959,
-            "end": 1612964449107
+            "start": 1618289081291,
+            "end": 1618289081365
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_uid.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Hidden/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450035,
-            "end": 1612964450183
+            "start": 1618289081297,
+            "end": 1618289081371
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/createChainedFunction.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/products.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450109,
-            "end": 1612964450257
+            "start": 1618289078705,
+            "end": 1618289078778
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/removeNonPrintingValuesTransformer/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448650,
-            "end": 1612964448797
+            "start": 1618289079097,
+            "end": 1618289079170
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_hasUnicode.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/serialize/dist/serialize.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448955,
-            "end": 1612964449102
+            "start": 1618289080717,
+            "end": 1618289080790
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.string.iterator.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/extends.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448958,
-            "end": 1612964449105
+            "start": 1618289080717,
+            "end": 1618289080790
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-router-v6/app.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_insertWrapDetails.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438631,
-            "end": 1612964438777
+            "start": 1618289080720,
+            "end": 1618289080793
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/toFinite.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/cache/dist/cache.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448620,
-            "end": 1612964448766
+            "start": 1618289080724,
+            "end": 1618289080797
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/arrayWithoutHoles.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-camel-case/dist/jss-plugin-camel-case.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448626,
-            "end": 1612964448772
+            "start": 1618289080844,
+            "end": 1618289080917
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_composeArgsRight.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_nodeUtil.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448669,
-            "end": 1612964448815
+            "start": 1618289081271,
+            "end": 1618289081344
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/makeStyles/indexCounter.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/stubFalse.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449985,
-            "end": 1612964450131
+            "start": 1618289081272,
+            "end": 1618289081345
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/ThemeProvider/nested.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Icon/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450035,
-            "end": 1612964450181
+            "start": 1618289081297,
+            "end": 1618289081370
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/ModalHeader.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/AbstractNavItem.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455827,
-            "end": 1612964455973
+            "start": 1618289081793,
+            "end": 1618289081866
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_insertWrapDetails.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/timers/card.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448680,
-            "end": 1612964448825
+            "start": 1618289078690,
+            "end": 1618289078762
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/prop-types-extra/lib/all.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/has.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450045,
-            "end": 1612964450190
+            "start": 1618289080786,
+            "end": 1618289080858
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/dist/hooks.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/lowerFirst.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440022,
-            "end": 1612964440166
+            "start": 1618289080786,
+            "end": 1618289080858
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/isTypedArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-nested/dist/jss-plugin-nested.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450109,
-            "end": 1612964450253
+            "start": 1618289080844,
+            "end": 1618289080916
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/useScrollTrigger/useScrollTrigger.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseFor.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452628,
-            "end": 1612964452772
+            "start": 1618289081262,
+            "end": 1618289081334
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/square3.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Grow/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438082,
-            "end": 1612964438225
+            "start": 1618289081265,
+            "end": 1618289081337
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/splitStringTransformer/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Menu/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448646,
-            "end": 1612964448789
+            "start": 1618289081267,
+            "end": 1618289081339
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/nonIterableSpread.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseProperty.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448680,
-            "end": 1612964448823
+            "start": 1618289081268,
+            "end": 1618289081340
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/isArguments.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsEqual.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448956,
-            "end": 1612964449099
+            "start": 1618289081269,
+            "end": 1618289081341
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_setCacheHas.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseUnary.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451406,
-            "end": 1612964451549
+            "start": 1618289081271,
+            "end": 1618289081343
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/MobileStepper/MobileStepper.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/hasIn.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453716,
-            "end": 1612964453859
+            "start": 1618289081272,
+            "end": 1618289081344
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_updateWrapDetails.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/shopping-list.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448679,
-            "end": 1612964448821
+            "start": 1618289078689,
+            "end": 1618289078760
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_stringToArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/api-test/users.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448955,
-            "end": 1612964449097
+            "start": 1618289078690,
+            "end": 1618289078761
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_getSymbols.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/@emotion/sheet/dist/sheet.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451405,
-            "end": 1612964451547
+            "start": 1618289080716,
+            "end": 1618289080787
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_getRawTag.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/normalizeHeaderName.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448954,
-            "end": 1612964449095
+            "start": 1618289080729,
+            "end": 1618289080800
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@emotion/cache/dist/cache.browser.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/forEach.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452013,
-            "end": 1612964452154
+            "start": 1618289080787,
+            "end": 1618289080858
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@emotion/hash/dist/hash.browser.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-props-sort/dist/jss-plugin-props-sort.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448979,
-            "end": 1612964449119
+            "start": 1618289080842,
+            "end": 1618289080913
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/createGenerateClassName/createGenerateClassName.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-vendor-prefixer/dist/jss-plugin-vendor-prefixer.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450110,
-            "end": 1612964450250
+            "start": 1618289080843,
+            "end": 1618289080914
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-sap.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-default-unit/dist/jss-plugin-default-unit.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449102,
-            "end": 1612964449241
+            "start": 1618289080844,
+            "end": 1618289080915
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Input/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/NativeSelect/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450070,
-            "end": 1612964450209
+            "start": 1618289081266,
+            "end": 1618289081337
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseMatchesProperty.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isKey.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448953,
-            "end": 1612964449091
+            "start": 1618289081269,
+            "end": 1618289081340
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/OutlinedInput/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_overArg.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450069,
-            "end": 1612964450207
+            "start": 1618289081270,
+            "end": 1618289081341
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseGetAllKeys.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsTypedArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451405,
-            "end": 1612964451543
+            "start": 1618289081271,
+            "end": 1618289081342
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/use-local-storage/App.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isStrictComparable.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438631,
-            "end": 1612964438767
+            "start": 1618289081272,
+            "end": 1618289081343
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/core-js/symbol/iterator.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Slider/ValueLabel.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448254,
-            "end": 1612964448390
+            "start": 1618289081283,
+            "end": 1618289081354
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/createTypography.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-assign.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448277,
-            "end": 1612964448413
+            "start": 1618289081285,
+            "end": 1618289081356
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_add-to-unscopables.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-router-dom/react-router-dom.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450068,
-            "end": 1612964450204
+            "start": 1618289079108,
+            "end": 1618289079178
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/web.dom.iterable.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/noop.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448977,
-            "end": 1612964449112
+            "start": 1618289080715,
+            "end": 1618289080785
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/inlineArrayTransformer/inlineArrayTransformer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_updateWrapDetails.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449102,
-            "end": 1612964449237
+            "start": 1618289080716,
+            "end": 1618289080786
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/FormLabel/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-rule-value-function/dist/jss-plugin-rule-value-function.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450105,
-            "end": 1612964450240
+            "start": 1618289080842,
+            "end": 1618289080912
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@restart/hooks/esm/useTimeout.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/cookies.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451405,
-            "end": 1612964451540
+            "start": 1618289080843,
+            "end": 1618289080913
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ExpansionPanelActions/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_basePropertyDeep.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453694,
-            "end": 1612964453829
+            "start": 1618289081276,
+            "end": 1618289081346
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/dist/utils.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsArguments.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440022,
-            "end": 1612964440156
+            "start": 1618289081277,
+            "end": 1618289081347
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/lab/esm/internal/svg-icons/Close.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Modal/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445973,
-            "end": 1612964446107
+            "start": 1618289081283,
+            "end": 1618289081353
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MobileStepper/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446893,
-            "end": 1612964447027
+            "start": 1618289081283,
+            "end": 1618289081353
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/core-js/symbol.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_reorder.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448254,
-            "end": 1612964448388
+            "start": 1618289080714,
+            "end": 1618289080783
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/commaListsOr/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_countHolders.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448259,
-            "end": 1612964448393
+            "start": 1618289080714,
+            "end": 1618289080783
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_redefine.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_composeArgsRight.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450107,
-            "end": 1612964450241
+            "start": 1618289080714,
+            "end": 1618289080783
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/getStylesCreator/getStylesCreator.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_core.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451300,
-            "end": 1612964451433
+            "start": 1618289080715,
+            "end": 1618289080784
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_getMapData.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/css/dist/css.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451395,
-            "end": 1612964451528
+            "start": 1618289080716,
+            "end": 1618289080785
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Snackbar/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/adapters/xhr.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452525,
-            "end": 1612964452658
+            "start": 1618289080735,
+            "end": 1618289080804
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/debounce.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_defineProperty.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452595,
-            "end": 1612964452728
+            "start": 1618289080744,
+            "end": 1618289080813
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/react-overlays/esm/popper.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/ArrowDropDown.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452647,
-            "end": 1612964452780
+            "start": 1618289080745,
+            "end": 1618289080814
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/lab/esm/Autocomplete/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useUpdatedRef.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440510,
-            "end": 1612964440642
+            "start": 1618289080802,
+            "end": 1618289080871
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/FilledInput/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.symbol.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450070,
-            "end": 1612964450202
+            "start": 1618289080842,
+            "end": 1618289080911
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Slider/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/get.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452524,
-            "end": 1612964452655
+            "start": 1618289081276,
+            "end": 1618289081345
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/lab/esm/internal/svg-icons/ArrowDropDown.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Radio/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445972,
-            "end": 1612964446102
+            "start": 1618289081280,
+            "end": 1618289081349
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseToString.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stringToPath.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449035,
-            "end": 1612964449165
+            "start": 1618289081282,
+            "end": 1618289081351
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-iobject.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/symbol/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450069,
-            "end": 1612964450199
+            "start": 1618289080735,
+            "end": 1618289080803
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-primitive.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/toConsumableArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450093,
-            "end": 1612964450223
+            "start": 1618289080737,
+            "end": 1618289080805
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_Hash.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/dispatchRequest.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451394,
-            "end": 1612964451524
+            "start": 1618289080738,
+            "end": 1618289080806
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Drawer/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/makeStyles/indexCounter.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453695,
-            "end": 1612964453825
+            "start": 1618289080739,
+            "end": 1618289080807
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/ServerStyleSheets/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/toNumber.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448898,
-            "end": 1612964449027
+            "start": 1618289080744,
+            "end": 1618289080812
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-dps.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-sap.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450108,
-            "end": 1612964450237
+            "start": 1618289080748,
+            "end": 1618289080816
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/StepLabel/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/NativeSelect/NativeSelect.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452508,
-            "end": 1612964452637
+            "start": 1618289080752,
+            "end": 1618289080820
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/withWidth/withWidth.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/reduce.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452594,
-            "end": 1612964452723
+            "start": 1618289080791,
+            "end": 1618289080859
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/mobx-react-lite/es/useObserver.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isFunction.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446893,
-            "end": 1612964447021
+            "start": 1618289080791,
+            "end": 1618289080859
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.get-prototype-of.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/sheet/dist/sheet.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448811,
-            "end": 1612964448939
+            "start": 1618289080802,
+            "end": 1618289080870
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@restart/hooks/esm/useUpdateEffect.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseDelay.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451404,
-            "end": 1612964451532
+            "start": 1618289080808,
+            "end": 1618289080876
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Stepper/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isPrototype.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452507,
-            "end": 1612964452635
+            "start": 1618289080809,
+            "end": 1618289080877
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/SnackbarContent/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isArrayLike.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452523,
-            "end": 1612964452651
+            "start": 1618289080810,
+            "end": 1618289080878
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/grey.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square3.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448950,
-            "end": 1612964449077
+            "start": 1618289078690,
+            "end": 1618289078757
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/createStyles/createStyles.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square4.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450106,
-            "end": 1612964450233
+            "start": 1618289078690,
+            "end": 1618289078757
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/deepPurple.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/InterceptorManager.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451393,
-            "end": 1612964451520
+            "start": 1618289080739,
+            "end": 1618289080806
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/@emotion/utils/dist/utils.browser.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/getStylesCreator/noopTheme.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452012,
-            "end": 1612964452139
+            "start": 1618289080739,
+            "end": 1618289080806
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Zoom/Zoom.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/makeStyles/multiKeyStore.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452572,
-            "end": 1612964452699
+            "start": 1618289080742,
+            "end": 1618289080809
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ExpansionPanel/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_WeakMap.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453695,
-            "end": 1612964453822
+            "start": 1618289080743,
+            "end": 1618289080810
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/contains.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/constant.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453711,
-            "end": 1612964453838
+            "start": 1618289080744,
+            "end": 1618289080811
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/prop-types/checkPropTypes.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-object.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440615,
-            "end": 1612964440741
+            "start": 1618289080748,
+            "end": 1618289080815
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/commaLists/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gpo.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448272,
-            "end": 1612964448398
+            "start": 1618289080749,
+            "end": 1618289080816
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.create.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/NativeSelect/NativeSelectInput.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448811,
-            "end": 1612964448937
+            "start": 1618289080752,
+            "end": 1618289080819
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/fn/symbol/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/uncontrollable/lib/esm/utils.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449019,
-            "end": 1612964449145
+            "start": 1618289080808,
+            "end": 1618289080875
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseIsEqual.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_assignValue.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449035,
-            "end": 1612964449161
+            "start": 1618289080809,
+            "end": 1618289080876
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseGet.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/keys.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449045,
-            "end": 1612964449171
+            "start": 1618289080809,
+            "end": 1618289080876
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_arrayLikeKeys.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createAssigner.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449054,
-            "end": 1612964449180
+            "start": 1618289080812,
+            "end": 1618289080879
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_set-to-string-tag.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_copyObject.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450105,
-            "end": 1612964450231
+            "start": 1618289080812,
+            "end": 1618289080879
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Drawer/Drawer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/getStylesCreator/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453694,
-            "end": 1612964453820
+            "start": 1618289080813,
+            "end": 1618289080880
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/BootstrapModalManager.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square2.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455827,
-            "end": 1612964455953
+            "start": 1618289078689,
+            "end": 1618289078755
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/inheritsLoose.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_descriptors.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445971,
-            "end": 1612964446096
+            "start": 1618289080799,
+            "end": 1618289080865
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.define-property.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_set-proto.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448809,
-            "end": 1612964448934
+            "start": 1618289080800,
+            "end": 1618289080866
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.set-prototype-of.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_copyArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448811,
-            "end": 1612964448936
+            "start": 1618289080817,
+            "end": 1618289080882
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_arrayIncludes.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isIndex.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448949,
-            "end": 1612964449074
+            "start": 1618289080817,
+            "end": 1618289080882
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-step.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayEach.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450093,
-            "end": 1612964450218
+            "start": 1618289080818,
+            "end": 1618289080883
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Step/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayIncludes.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452522,
-            "end": 1612964452647
+            "start": 1618289080819,
+            "end": 1618289080884
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Slide/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square1.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452536,
-            "end": 1612964452661
+            "start": 1618289078689,
+            "end": 1618289078753
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/commaListsAnd/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputBase/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448272,
-            "end": 1612964448396
+            "start": 1618289080817,
+            "end": 1618289080881
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_createBaseFor.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/game.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449034,
-            "end": 1612964449158
+            "start": 1618289078688,
+            "end": 1618289078751
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_memoizeCapped.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableFooter/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449050,
-            "end": 1612964449174
+            "start": 1618289080825,
+            "end": 1618289080888
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/cyan.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableRow/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451383,
-            "end": 1612964451507
+            "start": 1618289080824,
+            "end": 1618289080886
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/fn/object/assign.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/object/assign.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452539,
-            "end": 1612964452663
+            "start": 1618289080825,
+            "end": 1618289080887
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/getScrollbarSize.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/webpack/buildin/module.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452545,
-            "end": 1612964452669
+            "start": 1618289079744,
+            "end": 1618289079805
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/webpack-dev-server/dist/aut-runner.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tooltip/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436204,
-            "end": 1612964436327
+            "start": 1618289080823,
+            "end": 1618289080884
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/square4.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Toolbar/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438080,
-            "end": 1612964438203
+            "start": 1618289080824,
+            "end": 1618289080885
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-create.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TextareaAutosize/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450105,
-            "end": 1612964450228
+            "start": 1618289080824,
+            "end": 1618289080885
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/StepConnector/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tabs/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452521,
-            "end": 1612964452644
+            "start": 1618289080824,
+            "end": 1618289080885
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ExpansionPanelDetails/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableSortLabel/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453639,
-            "end": 1612964453762
+            "start": 1618289080824,
+            "end": 1618289080885
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Breadcrumbs/BreadcrumbCollapsed.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TablePagination/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456058,
-            "end": 1612964456181
+            "start": 1618289080825,
+            "end": 1618289080886
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_core.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableHead/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448810,
-            "end": 1612964448932
+            "start": 1618289080825,
+            "end": 1618289080886
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_ie8-dom-define.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableContainer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450098,
-            "end": 1612964450220
+            "start": 1618289080829,
+            "end": 1618289080890
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/tutorial/tic-tac-toe.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/hello.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438618,
-            "end": 1612964438739
+            "start": 1618289078688,
+            "end": 1618289078748
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/isSymbol.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavbarToggle.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448809,
-            "end": 1612964448930
+            "start": 1618289081820,
+            "end": 1618289081880
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/indigo.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/stateless.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448949,
-            "end": 1612964449070
+            "start": 1618289078688,
+            "end": 1618289078747
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_property-desc.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/usePopperMarginModifiers.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450104,
-            "end": 1612964450225
+            "start": 1618289081819,
+            "end": 1618289081878
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/delay.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavbarCollapse.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451371,
-            "end": 1612964451492
+            "start": 1618289081820,
+            "end": 1618289081879
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/teal.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/viewport-spec.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451383,
-            "end": 1612964451504
+            "start": 1618289078672,
+            "end": 1618289078730
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/lightBlue.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/network/2-users-fetch.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451388,
-            "end": 1612964451509
+            "start": 1618289078688,
+            "end": 1618289078746
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/RootRef/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableBody/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452545,
-            "end": 1612964452666
+            "start": 1618289080833,
+            "end": 1618289080891
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/RadioGroup/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Table/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452551,
-            "end": 1612964452672
+            "start": 1618289080833,
+            "end": 1618289080891
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/react-overlays/esm/safeFindDOMNode.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/node_modules/dom-helpers/esm/addClass.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453638,
-            "end": 1612964453759
+            "start": 1618289080840,
+            "end": 1618289080898
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/mobx-react-lite/es/observer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavbarContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446892,
-            "end": 1612964447012
+            "start": 1618289081818,
+            "end": 1618289081876
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_Stack.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/AbstractNav.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449034,
-            "end": 1612964449154
+            "start": 1618289081819,
+            "end": 1618289081877
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/StepButton/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableCell/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452522,
-            "end": 1612964452642
+            "start": 1618289080833,
+            "end": 1618289080890
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/listScrollParents.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tab/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455820,
-            "end": 1612964455940
+            "start": 1618289080834,
+            "end": 1618289080891
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/styles/withStyles.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/node_modules/dom-helpers/esm/removeClass.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446018,
-            "end": 1612964446137
+            "start": 1618289080840,
+            "end": 1618289080897
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-is/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/smoke-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446022,
-            "end": 1612964446141
+            "start": 1618289078682,
+            "end": 1618289078738
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/mergeClasses/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/network/1-users.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448898,
-            "end": 1612964449017
+            "start": 1618289078688,
+            "end": 1618289078744
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@emotion/unitless/dist/unitless.browser.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-x.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964449030,
-            "end": 1612964449149
+            "start": 1618289078687,
+            "end": 1618289078742
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/uncontrollable/esm/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/stateless-alert.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451380,
-            "end": 1612964451499
+            "start": 1618289078688,
+            "end": 1618289078743
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/lightGreen.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/error-boundary.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451383,
-            "end": 1612964451502
+            "start": 1618289078687,
+            "end": 1618289078739
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/StepContent/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/DropdownMenu.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452521,
-            "end": 1612964452640
+            "start": 1618289081837,
+            "end": 1618289081883
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/hello.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/DropdownToggle.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438081,
-            "end": 1612964438199
+            "start": 1618289081838,
+            "end": 1618289081884
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/lab/esm/Rating/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FigureCaption.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440509,
-            "end": 1612964440627
+            "start": 1618289081845,
+            "end": 1618289081891
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/BootstrapModalManager.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440615,
-            "end": 1612964440733
+            "start": 1618289081843,
+            "end": 1618289081888
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_getMatchData.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalHeader.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448808,
-            "end": 1612964448926
+            "start": 1618289081844,
+            "end": 1618289081889
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/purple.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FigureImage.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451394,
-            "end": 1612964451512
+            "start": 1618289081845,
+            "end": 1618289081890
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/pretty/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439994,
-            "end": 1612964440111
+            "start": 1618289081848,
+            "end": 1618289081893
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/inlineArrayTransformer/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448826,
-            "end": 1612964448943
+            "start": 1618289081843,
+            "end": 1618289081887
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/pink.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/warning/warning.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448949,
-            "end": 1612964449066
+            "start": 1618289081862,
+            "end": 1618289081903
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/styled/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448898,
-            "end": 1612964449014
+            "start": 1618289081865,
+            "end": 1618289081906
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/getThemeProps/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormCheckInput.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448917,
-            "end": 1612964449033
+            "start": 1618289081859,
+            "end": 1618289081898
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/red.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormFileLabel.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448948,
-            "end": 1612964449064
+            "start": 1618289081860,
+            "end": 1618289081899
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/square2.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types-extra/lib/all.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438080,
-            "end": 1612964438195
+            "start": 1618289081861,
+            "end": 1618289081900
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/use-render/my-component.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_assocIndexOf.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440019,
-            "end": 1612964440134
+            "start": 1618289081867,
+            "end": 1618289081906
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/lodash/fp.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapCacheClear.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440503,
-            "end": 1612964440618
+            "start": 1618289081868,
+            "end": 1618289081907
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/commaListsAnd/commaListsAnd.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapCacheDelete.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448741,
-            "end": 1612964448856
+            "start": 1618289081868,
+            "end": 1618289081907
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_matchesStrictComparable.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapCacheGet.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448808,
-            "end": 1612964448923
+            "start": 1618289081868,
+            "end": 1618289081907
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/recompose/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapCacheSet.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448728,
-            "end": 1612964448842
+            "start": 1618289081869,
+            "end": 1618289081908
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseSlice.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Feedback.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448768,
-            "end": 1612964448882
+            "start": 1618289081858,
+            "end": 1618289081896
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/StylesProvider/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormCheckLabel.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448897,
-            "end": 1612964449011
+            "start": 1618289081859,
+            "end": 1618289081897
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/jssPreset/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormFileInput.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448916,
-            "end": 1612964449030
+            "start": 1618289081859,
+            "end": 1618289081897
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/NavbarToggle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapCacheHas.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455817,
-            "end": 1612964455931
+            "start": 1618289081869,
+            "end": 1618289081907
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseProperty.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseGetAllKeys.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448781,
-            "end": 1612964448894
+            "start": 1618289081872,
+            "end": 1618289081909
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/toString.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getSymbols.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448782,
-            "end": 1612964448895
+            "start": 1618289081873,
+            "end": 1618289081910
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/orange.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setCacheAdd.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448948,
-            "end": 1612964449061
+            "start": 1618289081873,
+            "end": 1618289081910
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_array-includes.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setCacheHas.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451366,
-            "end": 1612964451479
+            "start": 1618289081874,
+            "end": 1618289081910
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/debounce.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/MoreHoriz.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455821,
-            "end": 1612964455934
+            "start": 1618289081875,
+            "end": 1618289081911
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/radioactive-state/utils/errors.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayFilter.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440614,
-            "end": 1612964440726
+            "start": 1618289081917,
+            "end": 1618289081949
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/mobx-react-lite/es/staticRendering.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayPush.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446892,
-            "end": 1612964447004
+            "start": 1618289081917,
+            "end": 1618289081948
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/utils/createChainedFunction.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/stubArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448809,
-            "end": 1612964448921
+            "start": 1618289081918,
+            "end": 1618289081949
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/modules/_library.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/querySelectorAll.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964450099,
-            "end": 1612964450211
+            "start": 1618289081921,
+            "end": 1618289081952
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/radioactive-state/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useForceUpdate.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964439994,
-            "end": 1612964440105
+            "start": 1618289081921,
+            "end": 1618289081952
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-is/cjs/react-is.development.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/Modal.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446878,
-            "end": 1612964446989
+            "start": 1618289081905,
+            "end": 1618289081935
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_createCtor.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Hash.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448767,
-            "end": 1612964448878
+            "start": 1618289081916,
+            "end": 1618289081946
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseFor.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getMapData.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448781,
-            "end": 1612964448892
+            "start": 1618289081916,
+            "end": 1618289081946
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/ButtonBase/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useMergedRefs.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448836,
-            "end": 1612964448947
+            "start": 1618289081922,
+            "end": 1618289081952
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/makeStyles/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/contains.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448908,
-            "end": 1612964449019
+            "start": 1618289081886,
+            "end": 1618289081915
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/amber.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/DropdownContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451379,
-            "end": 1612964451490
+            "start": 1618289081944,
+            "end": 1618289081973
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/StepIcon/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types-extra/lib/utils/createChainableTypeChecker.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452520,
-            "end": 1612964452631
+            "start": 1618289081914,
+            "end": 1618289081942
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/mobx-react-lite/es/ObserverComponent.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/hasClass.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446891,
-            "end": 1612964447001
+            "start": 1618289081925,
+            "end": 1618289081953
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_root.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/useRootClose.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448763,
-            "end": 1612964448873
+            "start": 1618289081943,
+            "end": 1618289081971
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/arrayWithHoles.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/useWaitForDOMRef.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446052,
-            "end": 1612964446161
+            "start": 1618289081944,
+            "end": 1618289081972
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/commaLists/commaLists.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/usePopper.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448742,
-            "end": 1612964448851
+            "start": 1618289081943,
+            "end": 1618289081970
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/isArrayLike.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hashClear.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448781,
-            "end": 1612964448890
+            "start": 1618289081953,
+            "end": 1618289081979
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/keys.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hashDelete.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448807,
-            "end": 1612964448916
+            "start": 1618289081954,
+            "end": 1618289081980
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_reorder.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hashHas.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448944,
-            "end": 1612964449053
+            "start": 1618289081954,
+            "end": 1618289081980
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_countHolders.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isKeyable.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448947,
-            "end": 1612964449056
+            "start": 1618289081955,
+            "end": 1618289081981
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Radio/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hashGet.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964452572,
-            "end": 1612964452681
+            "start": 1618289081954,
+            "end": 1618289081979
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/radioactive-state/utils/getRS.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hashSet.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440614,
-            "end": 1612964440722
+            "start": 1618289081955,
+            "end": 1618289081980
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/objectWithoutPropertiesLoose.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/scrollbarSize.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446046,
-            "end": 1612964446154
+            "start": 1618289081894,
+            "end": 1618289081918
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_baseIsMatch.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/popper.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448780,
-            "end": 1612964448888
+            "start": 1618289081943,
+            "end": 1618289081967
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@restart/hooks/esm/useCommittedRef.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/Dropdown.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451379,
-            "end": 1612964451487
+            "start": 1618289081905,
+            "end": 1618289081927
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/commaListsOr/commaListsOr.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/ModalManager.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448728,
-            "end": 1612964448835
+            "start": 1618289081939,
+            "end": 1618289081961
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_isKey.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/safeFindDOMNode.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448807,
-            "end": 1612964448914
+            "start": 1618289081905,
+            "end": 1618289081926
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/constants.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/DropdownToggle.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446046,
-            "end": 1612964446152
+            "start": 1618289081937,
+            "end": 1618289081957
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/blue.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/DropdownMenu.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448760,
-            "end": 1612964448866
+            "start": 1618289081938,
+            "end": 1618289081958
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/useTheme/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/ownerDocument.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448897,
-            "end": 1612964449003
+            "start": 1618289081978,
+            "end": 1618289081998
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_createRecurry.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getDocumentElement.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448944,
-            "end": 1612964449050
+            "start": 1618289082020,
+            "end": 1618289082040
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/utils/OverlayViewHelper.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/isWindow.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451365,
-            "end": 1612964451470
+            "start": 1618289082021,
+            "end": 1618289082041
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/babel-runtime/node_modules/core-js/library/fn/symbol/iterator.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/Overlay.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448727,
-            "end": 1612964448831
+            "start": 1618289081904,
+            "end": 1618289081923
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/green.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/computeAutoPlacement.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448759,
-            "end": 1612964448863
+            "start": 1618289082017,
+            "end": 1618289082036
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/constant.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/computeOffsets.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448868,
-            "end": 1612964448972
+            "start": 1618289082018,
+            "end": 1618289082037
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/assign.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getAltAxis.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451371,
-            "end": 1612964451475
+            "start": 1618289082018,
+            "end": 1618289082037
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/lime.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/contains.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451380,
-            "end": 1612964451484
+            "start": 1618289082019,
+            "end": 1618289082038
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/iterableToArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/instanceOf.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448758,
-            "end": 1612964448861
+            "start": 1618289082019,
+            "end": 1618289082038
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_defineProperty.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getWindow.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448868,
-            "end": 1612964448971
+            "start": 1618289082020,
+            "end": 1618289082039
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/ThemeProvider/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getOffsetParent.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448897,
-            "end": 1612964449000
+            "start": 1618289082020,
+            "end": 1618289082039
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/removeNonPrintingValuesTransformer/removeNonPrintingValuesTransformer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getComputedStyle.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448940,
-            "end": 1612964449043
+            "start": 1618289082021,
+            "end": 1618289082040
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/SwipeableDrawer/SwipeArea.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/within.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453693,
-            "end": 1612964453796
+            "start": 1618289082015,
+            "end": 1618289082033
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_stringToPath.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getOppositePlacement.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448806,
-            "end": 1612964448908
+            "start": 1618289082016,
+            "end": 1618289082034
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/colors/yellow.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/math.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451379,
-            "end": 1612964451481
+            "start": 1618289082016,
+            "end": 1618289082034
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/withStyles/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/detectOverflow.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448896,
-            "end": 1612964448997
+            "start": 1618289082017,
+            "end": 1618289082035
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/NavbarCollapse.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getVariation.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455816,
-            "end": 1612964455917
+            "start": 1618289082018,
+            "end": 1618289082036
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/webpack/buildin/module.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getFreshSideObject.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964436245,
-            "end": 1612964436344
+            "start": 1618289082019,
+            "end": 1618289082037
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/styles/esm/withTheme/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getLayoutRect.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448896,
-            "end": 1612964448995
+            "start": 1618289082019,
+            "end": 1618289082037
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/common-tags/es/splitStringTransformer/splitStringTransformer.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/useWrappedRefWithWarning.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448940,
-            "end": 1612964449039
+            "start": 1618289081903,
+            "end": 1618289081920
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/symbol-observable/es/ponyfill.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/createPopper.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448878,
-            "end": 1612964448976
+            "start": 1618289082013,
+            "end": 1618289082030
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_WeakMap.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getMainAxisFromPlacement.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448882,
-            "end": 1612964448979
+            "start": 1618289082015,
+            "end": 1618289082032
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/toNumber.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/mergePaddingObject.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448888,
-            "end": 1612964448985
+            "start": 1618289082016,
+            "end": 1618289082033
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/expandToHashMap.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448857,
-            "end": 1612964448953
+            "start": 1618289082016,
+            "end": 1618289082033
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/square1.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getOppositeVariationPlacement.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438080,
-            "end": 1612964438175
+            "start": 1618289082017,
+            "end": 1618289082034
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/lodash/fp/placeholder.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/offset.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446877,
-            "end": 1612964446972
+            "start": 1618289081993,
+            "end": 1618289082009
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/html-parse-stringify2/lib/parse-tag.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/preventOverflow.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448868,
-            "end": 1612964448963
+            "start": 1618289081994,
+            "end": 1618289082010
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/mobx-react-lite/es/useLocalStore.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/matches.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446877,
-            "end": 1612964446971
+            "start": 1618289081975,
+            "end": 1618289081990
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/node_modules/lodash/_basePropertyDeep.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_nativeCreate.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448806,
-            "end": 1612964448900
+            "start": 1618289081987,
+            "end": 1618289082002
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/utils/node_modules/react-is/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/flip.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964448867,
-            "end": 1612964448958
+            "start": 1618289081993,
+            "end": 1618289082008
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/OutlinedInput/NotchedOutline.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/hide.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964451364,
-            "end": 1612964451455
+            "start": 1618289081993,
+            "end": 1618289082008
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/BottomNavigation/BottomNavigation.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/popperOffsets.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455818,
-            "end": 1612964455909
+            "start": 1618289081994,
+            "end": 1618289082009
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/cypress-react-selector/src/utils.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useSafeState.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446098,
-            "end": 1612964446188
+            "start": 1618289081999,
+            "end": 1618289082014
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/mobx-react-lite/es/useLocalObservable.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/isDocument.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446878,
-            "end": 1612964446967
+            "start": 1618289082048,
+            "end": 1618289082063
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/Table/Tablelvl2Context.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useCallbackRef.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964453684,
-            "end": 1612964453773
+            "start": 1618289081975,
+            "end": 1618289081989
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/radioactive-state/utils/getOnChange.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/isOverflowing.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440614,
-            "end": 1612964440700
+            "start": 1618289081976,
+            "end": 1618289081990
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/lab/esm/internal/svg-icons/Star.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/manageAriaHidden.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445970,
-            "end": 1612964446056
+            "start": 1618289081976,
+            "end": 1618289081990
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/mobx-react-lite/es/useAsObservableSource.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/activeElement.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446878,
-            "end": 1612964446963
+            "start": 1618289081977,
+            "end": 1618289081991
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/extends.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/computeStyles.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964445967,
-            "end": 1612964446050
+            "start": 1618289081992,
+            "end": 1618289082006
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-google-maps/lib/utils/MapChildHelper.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/eventListeners.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446096,
-            "end": 1612964446179
+            "start": 1618289081993,
+            "end": 1618289082007
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getHTMLElementScroll.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/addClass.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456221,
-            "end": 1612964456304
+            "start": 1618289081997,
+            "end": 1618289082011
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/lab/esm/internal/svg-icons/createSvgIcon.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getBasePlacement.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446871,
-            "end": 1612964446953
+            "start": 1618289082015,
+            "end": 1618289082029
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getWindowScroll.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/usePrevious.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456221,
-            "end": 1612964456302
+            "start": 1618289081976,
+            "end": 1618289081989
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/node_modules/@emotion/core/dist/core.browser.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/enums.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440612,
-            "end": 1612964440692
+            "start": 1618289081991,
+            "end": 1618289082004
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/prop-types/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/arrow.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964440570,
-            "end": 1612964440648
+            "start": 1618289081992,
+            "end": 1618289082005
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/react-overlays/esm/Modal.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/popper-base.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456220,
-            "end": 1612964456297
+            "start": 1618289081992,
+            "end": 1618289082005
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/error-boundary.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/removeClass.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438079,
-            "end": 1612964438151
+            "start": 1618289081998,
+            "end": 1618289082011
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/tutorial/shopping-list.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/debounce.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438618,
-            "end": 1612964438690
+            "start": 1618289082042,
+            "end": 1618289082054
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/validateModifiers.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446097,
-            "end": 1612964446169
+            "start": 1618289082042,
+            "end": 1618289082054
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@babel/runtime/helpers/nonIterableRest.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/uniqueBy.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964446096,
-            "end": 1612964446166
+            "start": 1618289082043,
+            "end": 1618289082055
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/esm/AbstractNavItem.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/mergeByName.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964455814,
-            "end": 1612964455884
+            "start": 1618289082043,
+            "end": 1618289082055
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getDocumentRect.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getBoundingClientRect.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456169,
-            "end": 1612964456219
+            "start": 1618289082043,
+            "end": 1618289082055
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/svg-icons/MoreHoriz.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/rectToClientRect.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456220,
-            "end": 1612964456266
+            "start": 1618289082045,
+            "end": 1618289082057
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getViewportRect.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getParentNode.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456169,
-            "end": 1612964456214
+            "start": 1618289082046,
+            "end": 1618289082058
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/stateless-alert.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getCompositeRect.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438079,
-            "end": 1612964438120
+            "start": 1618289082041,
+            "end": 1618289082052
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/viewport-spec.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/listScrollParents.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438054,
-            "end": 1612964438094
+            "start": 1618289082042,
+            "end": 1618289082053
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/utils/format.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/orderModifiers.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456167,
-            "end": 1612964456207
+            "start": 1618289082042,
+            "end": 1618289082053
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/react-overlays/esm/Overlay.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getClippingRect.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456208,
-            "end": 1612964456248
+            "start": 1618289082045,
+            "end": 1618289082056
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getNodeScroll.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getNodeName.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456167,
-            "end": 1612964456204
+            "start": 1618289082046,
+            "end": 1618289082057
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/smoke-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/isTableElement.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438075,
-            "end": 1612964438110
+            "start": 1618289082046,
+            "end": 1618289082057
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/scrollbarSize.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/format.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456219,
-            "end": 1612964456253
+            "start": 1618289082061,
+            "end": 1618289082067
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/react-overlays/esm/useWaitForDOMRef.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getViewportRect.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456306,
-            "end": 1612964456337
+            "start": 1618289082062,
+            "end": 1618289082068
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/radioactive-state/counters/Counters.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getDocumentRect.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964438457,
-            "end": 1612964438486
+            "start": 1618289082062,
+            "end": 1618289082068
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getScrollParent.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getNodeScroll.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456165,
-            "end": 1612964456193
+            "start": 1618289082060,
+            "end": 1618289082065
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/isScrollParent.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getWindowScrollBarX.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456166,
-            "end": 1612964456190
+            "start": 1618289082061,
+            "end": 1618289082066
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/react-overlays/esm/ModalManager.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/isScrollParent.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456305,
-            "end": 1612964456329
+            "start": 1618289082061,
+            "end": 1618289082066
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@material-ui/core/esm/internal/svg-icons/Person.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getScrollParent.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456208,
-            "end": 1612964456229
+            "start": 1618289082062,
+            "end": 1618289082067
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/@popperjs/core/lib/dom-utils/getWindowScrollBarX.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getWindowScroll.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456167,
-            "end": 1612964456186
+            "start": 1618289082068,
+            "end": 1618289082070
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/addClass.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getHTMLElementScroll.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1612964456358,
-            "end": 1612964456372
-          },
-          {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/react-overlays/esm/isOverflowing.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1612964456339,
-            "end": 1612964456350
-          },
-          {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/webpack/buildin/global.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1612964442789,
-            "end": 1612964442795
-          },
-          {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/react-overlays/esm/manageAriaHidden.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1612964456340,
-            "end": 1612964456346
-          },
-          {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/activeElement.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1612964456351,
-            "end": 1612964456357
-          },
-          {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/removeClass.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1612964456357,
-            "end": 1612964456362
-          },
-          {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/isWindow.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1612964456373,
-            "end": 1612964456378
-          },
-          {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/webpack/buildin/module.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1612964446122,
-            "end": 1612964446125
-          },
-          {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/react-bootstrap/node_modules/dom-helpers/esm/isDocument.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1612964456379,
-            "end": 1612964456382
+            "start": 1618289082069,
+            "end": 1618289082070
           }
         ]
       },
       {
         "averages": {
           "dataPoints": 1,
-          "median": 93,
-          "mean": 93,
+          "median": 78,
+          "mean": 78,
           "range": {
-            "start": 93,
-            "end": 93
+            "start": 78,
+            "end": 78
           }
         },
-        "activeTime": 93,
+        "activeTime": 78,
         "loaders": [
-          "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/webpack-dev-server/dist/loader.js"
+          "/Users/lachlan/code/work/cypress5/npm/webpack-dev-server/dist/loader.js"
         ],
         "subLoadersTime": {},
         "rawStartEnds": [
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/webpack-dev-server/dist/loader.js!/Users/dmitrijkovalenko/dev/_cy/cypress/npm/webpack-dev-server/dist/browser.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/webpack-dev-server/dist/loader.js!/Users/lachlan/code/work/cypress5/npm/webpack-dev-server/dist/browser.js",
             "fillLast": true,
             "loaders": [
-              "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/webpack-dev-server/dist/loader.js"
+              "/Users/lachlan/code/work/cypress5/npm/webpack-dev-server/dist/loader.js"
             ],
-            "start": 1612964436058,
-            "end": 1612964436151
+            "start": 1618289078369,
+            "end": 1618289078447
           }
         ]
       },
@@ -12884,14 +12812,14 @@
         "averages": {
           "dataPoints": 9,
           "median": 1,
-          "mean": 3,
+          "mean": 2,
           "range": {
             "start": 0,
-            "end": 21
+            "end": 14
           },
-          "variance": 46
+          "variance": 20
         },
-        "activeTime": 26,
+        "activeTime": 21,
         "loaders": [
           "style-loader",
           "css-loader"
@@ -12899,208 +12827,208 @@
         "subLoadersTime": {},
         "rawStartEnds": [
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/radioactive-state/todos/todos.css",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counter/counter.css",
             "fillLast": true,
             "loaders": [
               "style-loader",
               "css-loader"
             ],
-            "start": 1612964438521,
-            "end": 1612964438542
+            "start": 1618289078813,
+            "end": 1618289078827
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/radioactive-state/counters/counters.css",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/todos.css",
             "fillLast": true,
             "loaders": [
               "style-loader",
               "css-loader"
             ],
-            "start": 1612964438542,
-            "end": 1612964438543
+            "start": 1618289078828,
+            "end": 1618289078830
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/radioactive-state/counter/counter.css",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counters/counters.css",
             "fillLast": true,
             "loaders": [
               "style-loader",
               "css-loader"
             ],
-            "start": 1612964438543,
-            "end": 1612964438544
+            "start": 1618289078827,
+            "end": 1618289078828
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/css-modules/Button.modules.css",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/tic-tac-toe.css",
             "fillLast": true,
             "loaders": [
               "style-loader",
               "css-loader"
             ],
-            "start": 1612964438635,
-            "end": 1612964438636
+            "start": 1618289078879,
+            "end": 1618289078880
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/css/Button.css",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css-modules/Button.modules.css",
             "fillLast": true,
             "loaders": [
               "style-loader",
               "css-loader"
             ],
-            "start": 1612964439639,
-            "end": 1612964439640
+            "start": 1618289078881,
+            "end": 1618289078882
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/set-timeout-example/App.css",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Todos.css",
             "fillLast": true,
             "loaders": [
               "style-loader",
               "css-loader"
             ],
-            "start": 1612964439678,
-            "end": 1612964439679
+            "start": 1618289079059,
+            "end": 1618289079060
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/tic-tac-toe.css",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css/Button.css",
             "fillLast": true,
             "loaders": [
               "style-loader",
               "css-loader"
             ],
-            "start": 1612964438639,
-            "end": 1612964438639
+            "start": 1618289079103,
+            "end": 1618289079104
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-book-example/src/Todos.css",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/App.css",
             "fillLast": true,
             "loaders": [
               "style-loader",
               "css-loader"
             ],
-            "start": 1612964439697,
-            "end": 1612964439697
+            "start": 1618289079113,
+            "end": 1618289079113
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/framer-motion/Motion.css",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/framer-motion/Motion.css",
             "fillLast": true,
             "loaders": [
               "style-loader",
               "css-loader"
             ],
-            "start": 1612964440077,
-            "end": 1612964440077
+            "start": 1618289079163,
+            "end": 1618289079163
           }
         ]
       },
       {
         "averages": {
           "dataPoints": 9,
-          "median": 317,
-          "mean": 248,
+          "median": 41,
+          "mean": 46,
           "range": {
-            "start": 49,
-            "end": 526
+            "start": 29,
+            "end": 79
           },
-          "variance": 25794
+          "variance": 306
         },
-        "activeTime": 1172,
+        "activeTime": 258,
         "loaders": [
           "css-loader"
         ],
         "subLoadersTime": {},
         "rawStartEnds": [
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/css-loader/dist/cjs.js!/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/react-tutorial/tic-tac-toe.css",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js??ref--5-1!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css-modules/Button.modules.css",
             "fillLast": true,
             "loaders": [
               "css-loader"
             ],
-            "start": 1612964438640,
-            "end": 1612964439166
+            "start": 1618289078882,
+            "end": 1618289078961
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/css-loader/dist/cjs.js??ref--5-1!/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/css-modules/Button.modules.css",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counter/counter.css",
             "fillLast": true,
             "loaders": [
               "css-loader"
             ],
-            "start": 1612964438637,
-            "end": 1612964439027
+            "start": 1618289078830,
+            "end": 1618289078895
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/css-loader/dist/cjs.js!/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/set-timeout-example/App.css",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Todos.css",
             "fillLast": true,
             "loaders": [
               "css-loader"
             ],
-            "start": 1612964439679,
-            "end": 1612964439996
+            "start": 1618289079060,
+            "end": 1618289079120
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/css-loader/dist/cjs.js!/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/react-book-example/src/Todos.css",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/tic-tac-toe.css",
             "fillLast": true,
             "loaders": [
               "css-loader"
             ],
-            "start": 1612964439697,
-            "end": 1612964439997
+            "start": 1618289078880,
+            "end": 1618289078921
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/css-loader/dist/cjs.js!/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/basic/css/Button.css",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/framer-motion/Motion.css",
             "fillLast": true,
             "loaders": [
               "css-loader"
             ],
-            "start": 1612964439640,
-            "end": 1612964439933
+            "start": 1618289079163,
+            "end": 1618289079204
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/css-loader/dist/cjs.js!/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/framer-motion/Motion.css",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/todos.css",
             "fillLast": true,
             "loaders": [
               "css-loader"
             ],
-            "start": 1612964440078,
-            "end": 1612964440272
+            "start": 1618289078863,
+            "end": 1618289078898
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/css-loader/dist/cjs.js!/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/radioactive-state/todos/todos.css",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counters/counters.css",
             "fillLast": true,
             "loaders": [
               "css-loader"
             ],
-            "start": 1612964438545,
-            "end": 1612964438660
+            "start": 1618289078863,
+            "end": 1618289078897
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/css-loader/dist/cjs.js!/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/radioactive-state/counters/counters.css",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/App.css",
             "fillLast": true,
             "loaders": [
               "css-loader"
             ],
-            "start": 1612964438613,
-            "end": 1612964438663
+            "start": 1618289079114,
+            "end": 1618289079146
           },
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/node_modules/css-loader/dist/cjs.js!/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/radioactive-state/counter/counter.css",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css/Button.css",
             "fillLast": true,
             "loaders": [
               "css-loader"
             ],
-            "start": 1612964438613,
-            "end": 1612964438662
+            "start": 1618289079105,
+            "end": 1618289079134
           }
         ]
       },
       {
         "averages": {
           "dataPoints": 1,
-          "median": 79,
-          "mean": 79,
+          "median": 62,
+          "mean": 62,
           "range": {
-            "start": 79,
-            "end": 79
+            "start": 62,
+            "end": 62
           }
         },
-        "activeTime": 79,
+        "activeTime": 62,
         "loaders": [
           "svg-url-loader",
           "svg-url-loader"
@@ -13108,41 +13036,41 @@
         "subLoadersTime": {},
         "rawStartEnds": [
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/set-timeout-example/logo.svg",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/logo.svg",
             "fillLast": true,
             "loaders": [
               "svg-url-loader",
               "svg-url-loader"
             ],
-            "start": 1612964440573,
-            "end": 1612964440652
+            "start": 1618289079232,
+            "end": 1618289079294
           }
         ]
       },
       {
         "averages": {
           "dataPoints": 1,
-          "median": 107,
-          "mean": 107,
+          "median": 114,
+          "mean": 114,
           "range": {
-            "start": 107,
-            "end": 107
+            "start": 114,
+            "end": 114
           }
         },
-        "activeTime": 107,
+        "activeTime": 114,
         "loaders": [
           "file-loader"
         ],
         "subLoadersTime": {},
         "rawStartEnds": [
           {
-            "name": "/Users/dmitrijkovalenko/dev/_cy/cypress/npm/react/cypress/component/advanced/lazy-loaded-suspense/samoyed.jpg",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded-suspense/samoyed.jpg",
             "fillLast": true,
             "loaders": [
               "file-loader"
             ],
-            "start": 1612964446057,
-            "end": 1612964446164
+            "start": 1618289079667,
+            "end": 1618289079781
           }
         ]
       }

--- a/npm/webpack-dev-server/__perf-stats/react.json
+++ b/npm/webpack-dev-server/__perf-stats/react.json
@@ -1,98 +1,52 @@
 {
   "misc": {
-    "compileTime": 5380
+    "compileTime": 4934
   },
   "plugins": {
-    "HtmlWebpackPlugin": 1578,
-    "CypressCTOptionsPlugin": 173
+    "CypressCTOptionsPlugin": 166,
+    "HtmlWebpackPlugin": 3
   },
   "loaders": {
     "build": [
       {
         "averages": {
           "dataPoints": 1,
-          "median": 16,
-          "mean": 16,
+          "median": 12,
+          "mean": 12,
           "range": {
-            "start": 16,
-            "end": 16
+            "start": 12,
+            "end": 12
           }
         },
-        "activeTime": 16,
+        "activeTime": 12,
         "loaders": [
           "html-webpack-plugin"
         ],
         "subLoadersTime": {},
         "rawStartEnds": [
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-webpack-plugin/lib/loader.js!/Users/lachlan/code/work/cypress5/npm/webpack-dev-server/index-template.html",
+            "name": "/Users/lachlan/code/work/cypress5/npm/webpack-dev-server/node_modules/html-webpack-plugin/lib/loader.js!/Users/lachlan/code/work/cypress5/npm/webpack-dev-server/index-template.html",
             "fillLast": true,
             "loaders": [
               "html-webpack-plugin"
             ],
-            "start": 1618289077027,
-            "end": 1618289077043
+            "start": 1618290215334,
+            "end": 1618290215346
           }
         ]
       },
       {
         "averages": {
-          "dataPoints": 3,
-          "median": 70,
-          "mean": 100,
+          "dataPoints": 1407,
+          "median": 193,
+          "mean": 113,
           "range": {
-            "start": 70,
-            "end": 156
+            "start": 2,
+            "end": 1196
           },
-          "variance": 2383
+          "variance": 3830
         },
-        "activeTime": 299,
-        "loaders": [
-          "modules with no loaders"
-        ],
-        "subLoadersTime": {},
-        "rawStartEnds": [
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-webpack-plugin/node_modules/lodash/lodash.js",
-            "fillLast": true,
-            "loaders": [
-              "modules with no loaders"
-            ],
-            "start": 1618289077046,
-            "end": 1618289077202
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/style-loader/lib/addStyles.js",
-            "fillLast": true,
-            "loaders": [
-              "modules with no loaders"
-            ],
-            "start": 1618289078903,
-            "end": 1618289078976
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/webpack/buildin/amd-options.js",
-            "fillLast": true,
-            "loaders": [
-              "modules with no loaders"
-            ],
-            "start": 1618289079776,
-            "end": 1618289079846
-          }
-        ]
-      },
-      {
-        "averages": {
-          "dataPoints": 1409,
-          "median": 169,
-          "mean": 117,
-          "range": {
-            "start": 1,
-            "end": 1319
-          },
-          "variance": 3985
-        },
-        "activeTime": 5021,
+        "activeTime": 4541,
         "loaders": [
           "babel-loader"
         ],
@@ -104,8 +58,8 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289077048,
-            "end": 1618289078367
+            "start": 1618290215359,
+            "end": 1618290216555
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/cjs/react-dom.development.js",
@@ -113,8 +67,8 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289079222,
-            "end": 1618289080123
+            "start": 1618290217425,
+            "end": 1618290218266
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/framer-motion/dist/framer-motion.es.js",
@@ -122,17 +76,8 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289079327,
-            "end": 1618289079843
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/lodash/lodash.min.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079358,
-            "end": 1618289079741
+            "start": 1618290217530,
+            "end": 1618290217991
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/js-beautify/js/lib/beautify.js",
@@ -140,17 +85,8 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289079616,
-            "end": 1618289079984
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx/dist/mobx.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079270,
-            "end": 1618289079585
+            "start": 1618290217660,
+            "end": 1618290218067
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/js-beautify/js/lib/beautify-html.js",
@@ -158,152 +94,26 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289079616,
-            "end": 1618289079928
+            "start": 1618290217661,
+            "end": 1618290218004
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/js-beautify/js/lib/beautify-css.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/lodash/lodash.min.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289079616,
-            "end": 1618289079865
+            "start": 1618290217561,
+            "end": 1618290217887
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/i18next/dist/esm/i18next.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx/dist/mobx.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289079301,
-            "end": 1618289079539
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/recompose/es/Recompose.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080039,
-            "end": 1618289080264
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/capitalize.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079521,
-            "end": 1618289079744
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SvgIcon/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079906,
-            "end": 1618289080129
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/utils/createSvgIcon.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079364,
-            "end": 1618289079586
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/bind.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079908,
-            "end": 1618289080130
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/utils.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079525,
-            "end": 1618289079746
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/useAutocomplete/useAutocomplete.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080038,
-            "end": 1618289080258
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/useAsObservableSource.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079550,
-            "end": 1618289079769
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/assertEnvironment.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079555,
-            "end": 1618289079774
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonBase/ButtonBase.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079957,
-            "end": 1618289080172
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/popper.js/dist/esm/popper.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080485,
-            "end": 1618289080698
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-is/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079639,
-            "end": 1618289079851
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079640,
-            "end": 1618289079852
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079544,
-            "end": 1618289079753
+            "start": 1618290217479,
+            "end": 1618290217750
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/getPrototypeOf.js",
@@ -311,4319 +121,17 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289079931,
-            "end": 1618289080139
+            "start": 1618290217793,
+            "end": 1618290218039
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/objectSpread.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types/lib/ReactPropTypesSecret.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289079932,
-            "end": 1618289080140
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/stylis/dist/stylis.browser.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079805,
-            "end": 1618289080012
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/createClass.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079932,
-            "end": 1618289080139
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/classCallCheck.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079932,
-            "end": 1618289080139
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/styled-components/dist/styled-components.browser.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079278,
-            "end": 1618289079484
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079931,
-            "end": 1618289080137
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/possibleConstructorReturn.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079931,
-            "end": 1618289080137
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/internal/svg-icons/createSvgIcon.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079929,
-            "end": 1618289080134
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/objectWithoutProperties.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079930,
-            "end": 1618289080135
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types/checkPropTypes.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079343,
-            "end": 1618289079547
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/possibleConstructorReturn.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079952,
-            "end": 1618289080154
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/useLocalObservable.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079945,
-            "end": 1618289080146
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/createClass.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079953,
-            "end": 1618289080154
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/useObserver.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079957,
-            "end": 1618289080158
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/withTheme/withTheme.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079959,
-            "end": 1618289080160
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/Transition.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080032,
-            "end": 1618289080233
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/useLocalStore.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079944,
-            "end": 1618289080144
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/is-buffer/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079945,
-            "end": 1618289080145
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/inherits.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079950,
-            "end": 1618289080150
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/ObserverComponent.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079952,
-            "end": 1618289080152
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/setPrototypeOf.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079956,
-            "end": 1618289080156
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/observer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079956,
-            "end": 1618289080156
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/staticRendering.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079957,
-            "end": 1618289080157
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078785,
-            "end": 1618289078984
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/unitless/dist/unitless.browser.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079804,
-            "end": 1618289080000
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/createClass.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080039,
-            "end": 1618289080235
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/camelize.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080040,
-            "end": 1618289080236
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/css.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080041,
-            "end": 1618289080237
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/createSvgIcon.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080043,
-            "end": 1618289080239
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079804,
-            "end": 1618289079999
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/typeof.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080040,
-            "end": 1618289080235
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/transitionEnd.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080041,
-            "end": 1618289080236
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/is-prop-valid/dist/is-prop-valid.browser.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079804,
-            "end": 1618289079998
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/select-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078483,
-            "end": 1618289078676
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/invariant/browser.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080037,
-            "end": 1618289080230
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MenuItem/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078909,
-            "end": 1618289079101
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputLabel/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078909,
-            "end": 1618289079101
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078910,
-            "end": 1618289079102
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/i18n/i18n.ts",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078918,
-            "end": 1618289079110
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/breakpoints.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080035,
-            "end": 1618289080227
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/can-use-dom/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080036,
-            "end": 1618289080228
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormHelperText/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078909,
-            "end": 1618289079100
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControl/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078909,
-            "end": 1618289079100
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/use-render/my-component-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078915,
-            "end": 1618289079106
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Select/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078909,
-            "end": 1618289079099
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/compose.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080034,
-            "end": 1618289080224
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/arrayLikeToArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080035,
-            "end": 1618289080225
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/reactBatchedUpdates.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080035,
-            "end": 1618289080225
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todo.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078906,
-            "end": 1618289079095
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/enzyme/simple-context.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078906,
-            "end": 1618289079095
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/process/browser.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079605,
-            "end": 1618289079794
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todos.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078906,
-            "end": 1618289079094
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/CheckBoxOutlineBlank.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079803,
-            "end": 1618289079990
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/css.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080033,
-            "end": 1618289080220
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/styled-components/Todos.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078905,
-            "end": 1618289079091
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/styled-components/Todo.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078906,
-            "end": 1618289079092
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/objectWithoutProperties.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079331,
-            "end": 1618289079517
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/defineProperty.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079332,
-            "end": 1618289079518
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/SwitchBase.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079802,
-            "end": 1618289079988
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/IndeterminateCheckBox.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079803,
-            "end": 1618289079989
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/CheckBox.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079803,
-            "end": 1618289079989
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/defineProperty.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079511,
-            "end": 1618289079696
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/scriptjs/dist/script.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080031,
-            "end": 1618289080216
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/extends.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079331,
-            "end": 1618289079515
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/objectWithoutProperties.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079506,
-            "end": 1618289079690
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/slicedToArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079513,
-            "end": 1618289079697
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/inheritsLoose.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079615,
-            "end": 1618289079799
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/transitions/utils.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080033,
-            "end": 1618289080217
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/shadows.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079328,
-            "end": 1618289079511
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/typeof.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079615,
-            "end": 1618289079798
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/internal/svg-icons/ArrowDropDown.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079625,
-            "end": 1618289079808
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/internal/svg-icons/Star.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079626,
-            "end": 1618289079809
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/shape.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079328,
-            "end": 1618289079510
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/classCallCheck.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079509,
-            "end": 1618289079691
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/internal/svg-icons/Close.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079626,
-            "end": 1618289079808
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded/App.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078903,
-            "end": 1618289079084
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded/OtherComponent.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078904,
-            "end": 1618289079085
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/context/context.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078905,
-            "end": 1618289079086
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/Autocomplete/Autocomplete.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079322,
-            "end": 1618289079503
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/js-beautify/js/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079328,
-            "end": 1618289079509
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-router/react-router.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079420,
-            "end": 1618289079601
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/components/ProductsList.spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078489,
-            "end": 1618289078669
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/Todos.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078903,
-            "end": 1618289079083
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/cssUtils.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079326,
-            "end": 1618289079506
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/TemplateTag/TemplateTag.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079695,
-            "end": 1618289079875
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Todos.spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078489,
-            "end": 1618289078668
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createSpacing.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079326,
-            "end": 1618289079505
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/popmotion/dist/popmotion.es.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080161,
-            "end": 1618289080340
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/list-demo.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078902,
-            "end": 1618289079080
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/Rating/Rating.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079321,
-            "end": 1618289079499
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/zIndex.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079326,
-            "end": 1618289079504
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mobx-v6/Timer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078901,
-            "end": 1618289079078
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Note.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078902,
-            "end": 1618289079079
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/classnames/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079985,
-            "end": 1618289080162
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/add.spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078488,
-            "end": 1618289078664
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/products.spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078489,
-            "end": 1618289078665
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/history/history.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079419,
-            "end": 1618289079595
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/is-buffer/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080026,
-            "end": 1618289080202
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/grid.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080027,
-            "end": 1618289080203
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/flexbox.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080029,
-            "end": 1618289080205
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/todos-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078488,
-            "end": 1618289078663
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/add2.spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078489,
-            "end": 1618289078664
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Note.spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078489,
-            "end": 1618289078664
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mock-fetch/user.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078902,
-            "end": 1618289079077
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/toConsumableArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080003,
-            "end": 1618289080178
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/palette.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080026,
-            "end": 1618289080201
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/object/get-prototype-of.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080028,
-            "end": 1618289080203
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/display.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080030,
-            "end": 1618289080205
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counters/counters-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078488,
-            "end": 1618289078662
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/observerBatching.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079990,
-            "end": 1618289080164
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/classCallCheck.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079991,
-            "end": 1618289080165
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createBreakpoints.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080007,
-            "end": 1618289080181
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/useForkRef.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080025,
-            "end": 1618289080199
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/positions.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080026,
-            "end": 1618289080200
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/tutorial/shopping-list-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078487,
-            "end": 1618289078660
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/checkbox-labels.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078901,
-            "end": 1618289079074
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/deepmerge.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080025,
-            "end": 1618289080198
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counter/counter-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078488,
-            "end": 1618289078660
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types/factoryWithTypeCheckers.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079463,
-            "end": 1618289079635
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/createWithBsPrefix.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079488,
-            "end": 1618289079660
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/elementTypeAcceptingRef.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080022,
-            "end": 1618289080194
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/elementAcceptingRef.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080023,
-            "end": 1618289080195
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/tutorial/square-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078488,
-            "end": 1618289078659
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/PizzaProps.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078900,
-            "end": 1618289079071
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-component/contact.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078901,
-            "end": 1618289079072
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/axios-api.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078901,
-            "end": 1618289079072
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Collapse.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079488,
-            "end": 1618289079659
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/getDisplayName.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080021,
-            "end": 1618289080192
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/exactProp.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080022,
-            "end": 1618289080193
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/node_modules/scheduler/cjs/scheduler.development.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080498,
-            "end": 1618289080669
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/component.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078900,
-            "end": 1618289079070
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-component/map.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078900,
-            "end": 1618289079070
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/extend-shallow/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079323,
-            "end": 1618289079493
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/condense-newlines/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079324,
-            "end": 1618289079494
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/shallowequal/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079849,
-            "end": 1618289080019
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListSubheader/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079853,
-            "end": 1618289080023
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Popper/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079853,
-            "end": 1618289080023
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/clsx/dist/clsx.m.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079854,
-            "end": 1618289080024
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/formatMuiErrorMessage.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080022,
-            "end": 1618289080192
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/codeBlock/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081465,
-            "end": 1618289081635
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/html/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081466,
-            "end": 1618289081636
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaListsAnd/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081467,
-            "end": 1618289081637
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaListsOr/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081467,
-            "end": 1618289081637
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaLists/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081468,
-            "end": 1618289081638
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/timers/card-without-effect-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078487,
-            "end": 1618289078656
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/tutorial/tic-tac-toe-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078488,
-            "end": 1618289078657
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/use-local-storage/App.spec.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078488,
-            "end": 1618289078657
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/window-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078884,
-            "end": 1618289079053
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/App.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078899,
-            "end": 1618289079068
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/RemotePizza.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078900,
-            "end": 1618289079069
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/greeting.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078900,
-            "end": 1618289079069
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/AccordionContext.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079487,
-            "end": 1618289079656
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/IconButton/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079850,
-            "end": 1618289080019
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Chip/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079850,
-            "end": 1618289080019
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Paper/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079850,
-            "end": 1618289080019
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/sizing.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080001,
-            "end": 1618289080170
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/shadows.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080001,
-            "end": 1618289080170
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/chainPropTypes.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080014,
-            "end": 1618289080183
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/ponyfillGlobal.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080020,
-            "end": 1618289080189
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Row.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081448,
-            "end": 1618289081617
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/testing-lib-example/testing-lib-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078487,
-            "end": 1618289078655
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/timers/card-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078487,
-            "end": 1618289078655
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/wrap-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078883,
-            "end": 1618289079051
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/services.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078900,
-            "end": 1618289079068
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/Trans.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079282,
-            "end": 1618289079450
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/context.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079284,
-            "end": 1618289079452
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/lodash/fp/_baseConvert.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079457,
-            "end": 1618289079625
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemIcon/ListItemIcon.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079486,
-            "end": 1618289079654
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/typography.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080000,
-            "end": 1618289080168
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/spacing.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080001,
-            "end": 1618289080169
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControl/formControlState.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080020,
-            "end": 1618289080188
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/refType.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080020,
-            "end": 1618289080188
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/HTMLElementType.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080021,
-            "end": 1618289080189
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ProgressBar.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081448,
-            "end": 1618289081616
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/splitStringTransformer/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081471,
-            "end": 1618289081639
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/inlineArrayTransformer/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081471,
-            "end": 1618289081639
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-router-v6/spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078486,
-            "end": 1618289078653
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/test-retries/spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078486,
-            "end": 1618289078653
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/testing-lib-example/spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078487,
-            "end": 1618289078654
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-world.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078883,
-            "end": 1618289079050
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemText/ListItemText.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079486,
-            "end": 1618289079653
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/kind-of/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079848,
-            "end": 1618289080015
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Spinner.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081447,
-            "end": 1618289081614
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLine/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081457,
-            "end": 1618289081624
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/PopoverTitle.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081458,
-            "end": 1618289081625
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/removeNonPrintingValuesTransformer/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081471,
-            "end": 1618289081638
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceStringTransformer/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081472,
-            "end": 1618289081639
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceSubstitutionTransformer/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081472,
-            "end": 1618289081639
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Dialog/Dialog.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081510,
-            "end": 1618289081677
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/loading-indicator-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078486,
-            "end": 1618289078652
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/renderless/mouse-movement.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078899,
-            "end": 1618289079065
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/borders.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080000,
-            "end": 1618289080166
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/style.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080001,
-            "end": 1618289080167
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ResponsiveEmbed.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081448,
-            "end": 1618289081614
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/useTranslation.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079297,
-            "end": 1618289079462
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormLabel/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079472,
-            "end": 1618289079637
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Divider/Divider.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079486,
-            "end": 1618289079651
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079848,
-            "end": 1618289080013
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/safeHtml/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081463,
-            "end": 1618289081628
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ClickAwayListener/ClickAwayListener.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081464,
-            "end": 1618289081629
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/source/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081465,
-            "end": 1618289081630
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/renderless/mouse-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078486,
-            "end": 1618289078650
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/emotion.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078883,
-            "end": 1618289079047
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/testing-lib-example/fetcher.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078899,
-            "end": 1618289079063
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/interopRequireDefault.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079468,
-            "end": 1618289079632
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/common.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079473,
-            "end": 1618289079637
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceResultTransformer/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081477,
-            "end": 1618289081641
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndentTransformer/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081477,
-            "end": 1618289081641
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-bootstrap/modal-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078485,
-            "end": 1618289078648
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/app-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078486,
-            "end": 1618289078649
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/pure-component.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078883,
-            "end": 1618289079046
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/LoadingIndicator.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078899,
-            "end": 1618289079062
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/withTranslation.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079297,
-            "end": 1618289079460
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/utils.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079467,
-            "end": 1618289079630
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/object-assign/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079468,
-            "end": 1618289079631
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/List/List.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079486,
-            "end": 1618289079649
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079792,
-            "end": 1618289079955
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/iterableToArrayLimit.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079792,
-            "end": 1618289079955
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-router-v6/in-memory-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078486,
-            "end": 1618289078648
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/useScrollTrigger/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079467,
-            "end": 1618289079629
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/useMediaQuery/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079467,
-            "end": 1618289079629
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Checkbox/Checkbox.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079486,
-            "end": 1618289079648
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ThemeProvider.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079784,
-            "end": 1618289079946
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/triggerBrowserReflow.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079785,
-            "end": 1618289079947
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/createChainedFunction.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079786,
-            "end": 1618289079948
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/objectWithoutPropertiesLoose.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079789,
-            "end": 1618289079951
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/arrayWithHoles.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079791,
-            "end": 1618289079953
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/nonIterableRest.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079792,
-            "end": 1618289079954
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaListsOr/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081445,
-            "end": 1618289081607
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineTrim/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081446,
-            "end": 1618289081608
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaLists/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081446,
-            "end": 1618289081608
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/portal/portal-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078485,
-            "end": 1618289078646
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-bootstrap/dropdown-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078485,
-            "end": 1618289078646
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/counter-set-state/counter.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078883,
-            "end": 1618289079044
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Zoom/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079466,
-            "end": 1618289079627
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/withMobileDialog/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079466,
-            "end": 1618289079627
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/withWidth/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079467,
-            "end": 1618289079628
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControlLabel/FormControlLabel.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079485,
-            "end": 1618289079646
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/useAutocomplete/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079797,
-            "end": 1618289079958
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/amber.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080455,
-            "end": 1618289080616
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/lime.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080457,
-            "end": 1618289080618
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/ownerWindow.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080458,
-            "end": 1618289080619
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_classof.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081442,
-            "end": 1618289081603
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/counter-use-hooks/counter.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078882,
-            "end": 1618289079042
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/withSSR.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079295,
-            "end": 1618289079455
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079310,
-            "end": 1618289079470
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/defaultTheme.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079311,
-            "end": 1618289079471
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/is-extendable/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079800,
-            "end": 1618289079960
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/is-whitespace/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079801,
-            "end": 1618289079961
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/utils.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079847,
-            "end": 1618289080007
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/yellow.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080456,
-            "end": 1618289080616
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/lightGreen.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080458,
-            "end": 1618289080618
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useEventCallback.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080462,
-            "end": 1618289080622
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useTimeout.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080463,
-            "end": 1618289080623
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useUpdateEffect.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080463,
-            "end": 1618289080623
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanel/ExpansionPanel.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081437,
-            "end": 1618289081597
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogTitle/DialogTitle.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081438,
-            "end": 1618289081598
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/PopoverContent.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081482,
-            "end": 1618289081642
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/RemotePizza.spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078485,
-            "end": 1618289078644
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/useSSR.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079295,
-            "end": 1618289079454
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/Translation.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079296,
-            "end": 1618289079455
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/teal.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080462,
-            "end": 1618289080621
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/hyphenate.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080465,
-            "end": 1618289080624
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/SplitButton.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081436,
-            "end": 1618289081595
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelSummary/ExpansionPanelSummary.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081437,
-            "end": 1618289081596
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Collapse/Collapse.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081485,
-            "end": 1618289081644
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css/Button.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078882,
-            "end": 1618289079040
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/I18nextProvider.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079296,
-            "end": 1618289079454
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079884,
-            "end": 1618289080042
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/addEventListener.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080466,
-            "end": 1618289080624
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/cancel/isCancel.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080499,
-            "end": 1618289080657
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaListsAnd/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081436,
-            "end": 1618289081594
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/getScrollbarSize.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081436,
-            "end": 1618289081594
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogContentText/DialogContentText.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081487,
-            "end": 1618289081645
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078485,
-            "end": 1618289078642
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/context/App.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078878,
-            "end": 1618289079035
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/withScriptjs.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079485,
-            "end": 1618289079642
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/List/ListContext.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079776,
-            "end": 1618289079933
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/deepOrange.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080451,
-            "end": 1618289080608
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/symbol-observable/es/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080470,
-            "end": 1618289080627
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/uncontrollable/lib/esm/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080471,
-            "end": 1618289080628
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/spread.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080485,
-            "end": 1618289080642
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/cancel/CancelToken.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080500,
-            "end": 1618289080657
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineInlineLists/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081431,
-            "end": 1618289081588
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelDetails/ExpansionPanelDetails.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081435,
-            "end": 1618289081592
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/inlineLists/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081435,
-            "end": 1618289081592
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelActions/ExpansionPanelActions.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081436,
-            "end": 1618289081593
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogContent/DialogContent.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081490,
-            "end": 1618289081647
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/trimResultTransformer/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081491,
-            "end": 1618289081648
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/PizzaProps.spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078485,
-            "end": 1618289078641
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css-modules/Button.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078881,
-            "end": 1618289079037
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/enzyme/simple-component.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078882,
-            "end": 1618289079038
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/utils/getRS.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079465,
-            "end": 1618289079621
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormGroup/FormGroup.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079485,
-            "end": 1618289079641
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/indigo.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079774,
-            "end": 1618289079930
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/blueGrey.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080448,
-            "end": 1618289080604
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/withGoogleMap.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080449,
-            "end": 1618289080605
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/removeEventListener.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080469,
-            "end": 1618289080625
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/ServerStyleSheets/ServerStyleSheets.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080508,
-            "end": 1618289080664
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Container/Container.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081511,
-            "end": 1618289081667
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stackSet.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081512,
-            "end": 1618289081668
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stackHas.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081512,
-            "end": 1618289081668
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stackGet.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081512,
-            "end": 1618289081668
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/app-action-example/counter.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078878,
-            "end": 1618289079033
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/runtime/api.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078966,
-            "end": 1618289079121
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/utils/errors.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079464,
-            "end": 1618289079619
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/utils/getOnChange.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079465,
-            "end": 1618289079620
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/unsupportedProp.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080163,
-            "end": 1618289080318
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/requirePropFactory.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080165,
-            "end": 1618289080320
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/Circle.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080448,
-            "end": 1618289080603
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/brown.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080450,
-            "end": 1618289080605
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/recompose/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080483,
-            "end": 1618289080638
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/StylesProvider/StylesProvider.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080507,
-            "end": 1618289080662
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/styled/styled.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080508,
-            "end": 1618289080663
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CssBaseline/CssBaseline.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081510,
-            "end": 1618289081665
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RadioGroup/RadioGroupContext.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081511,
-            "end": 1618289081666
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stackDelete.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081514,
-            "end": 1618289081669
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CircularProgress/CircularProgress.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081516,
-            "end": 1618289081671
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Card/Card.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081531,
-            "end": 1618289081686
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonGroup/ButtonGroup.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081533,
-            "end": 1618289081688
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-component/spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078484,
-            "end": 1618289078638
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/context/Toolbar.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078878,
-            "end": 1618289079032
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mobx-v6/timer-view.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078969,
-            "end": 1618289079123
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/setRef.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080166,
-            "end": 1618289080320
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/GoogleMap.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080448,
-            "end": 1618289080602
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/change-emitter/lib/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080483,
-            "end": 1618289080637
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/cancel/Cancel.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080506,
-            "end": 1618289080660
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_ListCache.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081509,
-            "end": 1618289081663
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogActions/DialogActions.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081510,
-            "end": 1618289081664
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/checkbox-labels-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078482,
-            "end": 1618289078635
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/1-users.spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078483,
-            "end": 1618289078636
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/2-users-named.spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078484,
-            "end": 1618289078637
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/3-users-api.spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078484,
-            "end": 1618289078637
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createPalette.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079457,
-            "end": 1618289079610
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createMixins.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079458,
-            "end": 1618289079611
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/Polygon.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080443,
-            "end": 1618289080596
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/Polyline.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080445,
-            "end": 1618289080598
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Portal/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080446,
-            "end": 1618289080599
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/Marker.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080448,
-            "end": 1618289080601
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SwipeableDrawer/SwipeableDrawer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081013,
-            "end": 1618289081166
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Tab.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081429,
-            "end": 1618289081582
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardActionArea/CardActionArea.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081530,
-            "end": 1618289081683
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/simple-rating-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078483,
-            "end": 1618289078635
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/forward-ref/forward-ref.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078878,
-            "end": 1618289079030
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/i18n/LocalizedComponent.tsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078989,
-            "end": 1618289079141
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/framer-motion/Motion.tsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078990,
-            "end": 1618289079142
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/toggle-example/toggle-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078998,
-            "end": 1618289079150
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/TemplateTag/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079452,
-            "end": 1618289079604
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/grey.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079891,
-            "end": 1618289080043
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/cyan.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080477,
-            "end": 1618289080629
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/TabContainer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081429,
-            "end": 1618289081581
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getTag.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081540,
-            "end": 1618289081692
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/button-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078482,
-            "end": 1618289078633
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/framesync/dist/framesync.es.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080161,
-            "end": 1618289080312
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/ownerWindow.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080171,
-            "end": 1618289080322
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/Rectangle.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080443,
-            "end": 1618289080594
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/lightBlue.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080480,
-            "end": 1618289080631
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/deepPurple.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080480,
-            "end": 1618289080631
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/purple.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080481,
-            "end": 1618289080632
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_equalObjects.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081542,
-            "end": 1618289081693
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/hooks/counter-with-hooks.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078878,
-            "end": 1618289079028
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/typescript/ts-spec.tsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078977,
-            "end": 1618289079127
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/pretty/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078994,
-            "end": 1618289079144
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/transpiled-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078995,
-            "end": 1618289079145
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Button/Button.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079276,
-            "end": 1618289079426
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079281,
-            "end": 1618289079431
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createTypography.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079457,
-            "end": 1618289079607
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/style-value-types/dist/style-value-types.es.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080158,
-            "end": 1618289080308
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/hey-listen/dist/hey-listen.es.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080159,
-            "end": 1618289080309
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_castSlice.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081030,
-            "end": 1618289081180
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/toString.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081031,
-            "end": 1618289081181
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardContent/CardContent.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081524,
-            "end": 1618289081674
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded/lazy-load-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078482,
-            "end": 1618289078631
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/autocomplete-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078482,
-            "end": 1618289078631
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mock-fetch/fetch-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078483,
-            "end": 1618289078632
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mobx-v6/timer-spec.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078483,
-            "end": 1618289078632
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/hooks/counter2-with-hooks.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078877,
-            "end": 1618289079026
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/unmount/unmount-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078977,
-            "end": 1618289079126
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/unmount/comp-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078977,
-            "end": 1618289079126
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded-suspense/LazyComponent.tsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078988,
-            "end": 1618289079137
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-is/cjs/react-is.development.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079897,
-            "end": 1618289080046
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseRest.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080183,
-            "end": 1618289080332
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardMedia/CardMedia.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081523,
-            "end": 1618289081672
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardHeader/CardHeader.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081524,
-            "end": 1618289081673
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardActions/CardActions.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081528,
-            "end": 1618289081677
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_equalArrays.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081546,
-            "end": 1618289081695
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Breadcrumbs/Breadcrumbs.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081547,
-            "end": 1618289081696
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded-suspense/lazy-loaded-suspense.spec.tsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078481,
-            "end": 1618289078629
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded/app-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078482,
-            "end": 1618289078630
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/list-item-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078483,
-            "end": 1618289078631
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/context/forwardRef.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080179,
-            "end": 1618289080327
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SvgIcon/SvgIcon.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080182,
-            "end": 1618289080330
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_equalByTag.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081546,
-            "end": 1618289081694
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/i18n/i18next-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078481,
-            "end": 1618289078628
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded/other-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078482,
-            "end": 1618289078629
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counter/Counter.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078876,
-            "end": 1618289079023
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/use-lodash-fp/lodash-fp-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078977,
-            "end": 1618289079124
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Chip/Chip.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080132,
-            "end": 1618289080279
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/ownerDocument.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080178,
-            "end": 1618289080325
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_replaceHolders.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080194,
-            "end": 1618289080341
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createWrap.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080196,
-            "end": 1618289080343
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/deprecatedPropType.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080197,
-            "end": 1618289080344
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-parse-stringify2/lib/stringify.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080440,
-            "end": 1618289080587
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/defaults.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080525,
-            "end": 1618289080672
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Modal/SimpleBackdrop.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081600,
-            "end": 1618289081747
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/hooks/use-counter.spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078481,
-            "end": 1618289078627
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counters/Counters.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078876,
-            "end": 1618289079022
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getHolder.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080195,
-            "end": 1618289080341
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/isMuiElement.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080196,
-            "end": 1618289080342
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/InfoWindow.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080437,
-            "end": 1618289080583
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-parse-stringify2/lib/parse.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080440,
-            "end": 1618289080586
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavItem.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081602,
-            "end": 1618289081748
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/OverlayView.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080436,
-            "end": 1618289080581
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_redefine.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081023,
-            "end": 1618289081168
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/TabContext.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081603,
-            "end": 1618289081748
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/makeStyles/makeStyles.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080539,
-            "end": 1618289080683
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavLink.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081605,
-            "end": 1618289081749
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalFooter.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081637,
-            "end": 1618289081781
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalDialog.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081638,
-            "end": 1618289081782
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/3-users-api.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078876,
-            "end": 1618289079019
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Radio/RadioButtonIcon.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081588,
-            "end": 1618289081731
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndents/stripIndents.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081589,
-            "end": 1618289081732
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndent/stripIndent.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081590,
-            "end": 1618289081733
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineInlineLists/oneLineInlineLists.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081641,
-            "end": 1618289081784
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/forward-ref/forward-ref.spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078480,
-            "end": 1618289078622
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/hooks/counter-with-hooks.spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078481,
-            "end": 1618289078623
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/hooks/counter2-with-hooks.spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078481,
-            "end": 1618289078623
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/bind.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079773,
-            "end": 1618289079915
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/tslib/tslib.es6.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080145,
-            "end": 1618289080287
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/DirectionsRenderer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080428,
-            "end": 1618289080570
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/AppBar/AppBar.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081580,
-            "end": 1618289081722
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Jumbotron.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081661,
-            "end": 1618289081803
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Figure.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081662,
-            "end": 1618289081804
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Image.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081662,
-            "end": 1618289081804
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Container.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081663,
-            "end": 1618289081805
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormText.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081663,
-            "end": 1618289081805
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/custom-command/spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078480,
-            "end": 1618289078621
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/fbjs/lib/shallowEqual.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080430,
-            "end": 1618289080571
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/GroundOverlay.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080432,
-            "end": 1618289080573
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/ThemeProvider/ThemeProvider.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080436,
-            "end": 1618289080577
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/mergeClasses/mergeClasses.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080538,
-            "end": 1618289080679
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-iobject.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080971,
-            "end": 1618289081112
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_is-array.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080971,
-            "end": 1618289081112
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_wks-define.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080972,
-            "end": 1618289081113
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsNative.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080974,
-            "end": 1618289081115
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stringToArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081042,
-            "end": 1618289081183
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Symbol.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081042,
-            "end": 1618289081183
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavDropdown.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081634,
-            "end": 1618289081775
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Navbar.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081636,
-            "end": 1618289081777
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ListGroup.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081661,
-            "end": 1618289081802
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/InputGroup.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081662,
-            "end": 1618289081803
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/FusionTablesLayer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080428,
-            "end": 1618289080568
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/useTheme/useTheme.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080435,
-            "end": 1618289080575
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-keys.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080969,
-            "end": 1618289081109
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gops.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080970,
-            "end": 1618289081110
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gopn-ext.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080970,
-            "end": 1618289081110
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_property-desc.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080971,
-            "end": 1618289081111
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_enum-keys.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080972,
-            "end": 1618289081112
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-step.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081020,
-            "end": 1618289081160
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepIcon/StepIcon.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081022,
-            "end": 1618289081162
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Backdrop/Backdrop.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081580,
-            "end": 1618289081720
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/OverlayTrigger.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081634,
-            "end": 1618289081774
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavbarBrand.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081636,
-            "end": 1618289081776
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalTitle.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081636,
-            "end": 1618289081776
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaListsAnd/oneLineCommaListsAnd.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081649,
-            "end": 1618289081789
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Dropdown.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081650,
-            "end": 1618289081790
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ListGroupItem.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081661,
-            "end": 1618289081801
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/framer-motion/Motion.spec.tsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078481,
-            "end": 1618289078620
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/1-users.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078876,
-            "end": 1618289079015
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormLabel/FormLabel.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079770,
-            "end": 1618289079909
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gopn.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080969,
-            "end": 1618289081108
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getValue.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080976,
-            "end": 1618289081115
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_uid.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080976,
-            "end": 1618289081115
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_trimmedEndIndex.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080978,
-            "end": 1618289081117
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isObjectLike.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080979,
-            "end": 1618289081118
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepLabel/StepLabel.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081020,
-            "end": 1618289081159
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/BottomNavigation/BottomNavigation.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081579,
-            "end": 1618289081718
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Avatar/Avatar.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081582,
-            "end": 1618289081721
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/memoize.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081587,
-            "end": 1618289081726
+            "start": 1618290217795,
+            "end": 1618290218038
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/inlineLists/inlineLists.js",
@@ -4631,629 +139,8 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081649,
-            "end": 1618289081788
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Modal.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081660,
-            "end": 1618289081799
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/2-users-named.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078875,
-            "end": 1618289079013
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react/cjs/react.development.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079054,
-            "end": 1618289079192
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/toggle-example/toggle.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079181,
-            "end": 1618289079319
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/blue.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079743,
-            "end": 1618289079881
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/unsupportedIterableToArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080248,
-            "end": 1618289080386
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/printDebugValue.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080249,
-            "end": 1618289080387
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_shared.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080984,
-            "end": 1618289081122
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_add-to-unscopables.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080996,
-            "end": 1618289081134
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseLodash.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081000,
-            "end": 1618289081138
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_LodashWrapper.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081019,
-            "end": 1618289081157
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iterators.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081019,
-            "end": 1618289081157
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Badge/Badge.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081579,
-            "end": 1618289081717
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/PageItem.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081633,
-            "end": 1618289081771
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Overlay.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081634,
-            "end": 1618289081772
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalBody.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081660,
-            "end": 1618289081798
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Media.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081660,
-            "end": 1618289081798
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/context/Mock-context-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078480,
-            "end": 1618289078617
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/inherits.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079742,
-            "end": 1618289079879
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/extends.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079743,
-            "end": 1618289079880
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/green.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079743,
-            "end": 1618289079880
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/utils/mutate.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079751,
-            "end": 1618289079888
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079771,
-            "end": 1618289079908
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/object/define-property.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080223,
-            "end": 1618289080360
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/withStyles/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080244,
-            "end": 1618289080381
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/iterableToArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080248,
-            "end": 1618289080385
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/enhanceError.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080968,
-            "end": 1618289081105
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_set-to-string-tag.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080984,
-            "end": 1618289081121
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/array/from.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080984,
-            "end": 1618289081121
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_meta.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080985,
-            "end": 1618289081122
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-integer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080995,
-            "end": 1618289081132
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-define.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080998,
-            "end": 1618289081135
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Stepper/Stepper.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081017,
-            "end": 1618289081154
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/BottomNavigationAction/BottomNavigationAction.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081578,
-            "end": 1618289081715
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaLists/oneLineCommaLists.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081659,
-            "end": 1618289081796
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/toArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081660,
-            "end": 1618289081797
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/app-action-example/counter-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078480,
-            "end": 1618289078616
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonBase/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079745,
-            "end": 1618289079881
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079751,
-            "end": 1618289079887
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/utils/afterSync.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079751,
-            "end": 1618289079887
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/red.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079751,
-            "end": 1618289079887
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/useMediaQuery/useMediaQuery.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079766,
-            "end": 1618289079902
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/lodash/fp/placeholder.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079767,
-            "end": 1618289079903
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/object/set-prototype-of.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080218,
-            "end": 1618289080354
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/typeof.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080222,
-            "end": 1618289080358
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonBase/TouchRipple.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080242,
-            "end": 1618289080378
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/arrayWithoutHoles.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080243,
-            "end": 1618289080379
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/node_modules/scheduler/tracing.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080245,
-            "end": 1618289080381
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/Axios.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080550,
-            "end": 1618289080686
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControl/FormControlContext.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080551,
-            "end": 1618289080687
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_library.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080959,
-            "end": 1618289081095
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-pie.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080961,
-            "end": 1618289081097
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_a-function.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080994,
-            "end": 1618289081130
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Nav.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081631,
-            "end": 1618289081767
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Popover.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081633,
-            "end": 1618289081769
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Pagination.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081633,
-            "end": 1618289081769
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineTrim/oneLineTrim.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081659,
-            "end": 1618289081795
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/styled-components/Todos-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078479,
-            "end": 1618289078614
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/context/App-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078480,
-            "end": 1618289078615
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-router-v6/app.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078875,
-            "end": 1618289079010
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/withTheme/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079747,
-            "end": 1618289079882
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/orange.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079750,
-            "end": 1618289079885
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/useScrollTrigger/useScrollTrigger.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079766,
-            "end": 1618289079901
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080218,
-            "end": 1618289080353
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/nonIterableSpread.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080247,
-            "end": 1618289080382
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Switch/Switch.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081010,
-            "end": 1618289081145
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Hidden/HiddenJs.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081622,
-            "end": 1618289081757
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stackClear.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081633,
-            "end": 1618289081768
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanel/ExpansionPanelContext.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081658,
-            "end": 1618289081793
+            "start": 1618290217795,
+            "end": 1618290218037
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaListsOr/oneLineCommaListsOr.js",
@@ -5261,8 +148,17 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081659,
-            "end": 1618289081794
+            "start": 1618290217794,
+            "end": 1618290218035
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaLists/oneLineCommaLists.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217794,
+            "end": 1618290218033
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLine/oneLine.js",
@@ -5270,800 +166,35 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081678,
-            "end": 1618289081813
+            "start": 1618290217794,
+            "end": 1618290218032
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/use-local-storage/App.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/select-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289078875,
-            "end": 1618289079009
+            "start": 1618290216677,
+            "end": 1618290216913
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/Inbox.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/possibleConstructorReturn.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289079173,
-            "end": 1618289079307
+            "start": 1618290217793,
+            "end": 1618290218028
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/lodash/fp/_mapping.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaListsAnd/oneLineCommaListsAnd.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289079756,
-            "end": 1618289079890
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Popper/Popper.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080137,
-            "end": 1618289080271
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepContent/StepContent.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081051,
-            "end": 1618289081185
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_objectToString.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081056,
-            "end": 1618289081190
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Hidden/HiddenCss.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081621,
-            "end": 1618289081755
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Modal/TrapFocus.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081632,
-            "end": 1618289081766
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/tutorial/tic-tac-toe.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078874,
-            "end": 1618289079007
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/CheckBox.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079173,
-            "end": 1618289079306
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/Favorite.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079173,
-            "end": 1618289079306
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/Drafts.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079174,
-            "end": 1618289079307
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/withWidth/withWidth.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079766,
-            "end": 1618289079899
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/IconButton/IconButton.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080132,
-            "end": 1618289080265
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Paper/Paper.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080133,
-            "end": 1618289080266
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListSubheader/ListSubheader.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080136,
-            "end": 1618289080269
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/object/create.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080230,
-            "end": 1618289080363
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/reactionCleanupTracking.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080231,
-            "end": 1618289080364
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_realNames.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081010,
-            "end": 1618289081143
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepConnector/StepConnector.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081056,
-            "end": 1618289081189
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/stub-example/clicker-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078479,
-            "end": 1618289078611
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/api-test/spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078480,
-            "end": 1618289078612
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/FavoriteBorder.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079174,
-            "end": 1618289079306
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/pink.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079756,
-            "end": 1618289079888
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/useEventCallback.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080143,
-            "end": 1618289080275
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/merge.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080241,
-            "end": 1618289080373
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_wrapperClone.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081006,
-            "end": 1618289081138
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/stub-example/clicker-with-delay-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078479,
-            "end": 1618289078610
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/CheckBoxOutlineBlank.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079173,
-            "end": 1618289079304
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TextField/TextField.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079277,
-            "end": 1618289079408
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ToastBody.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079279,
-            "end": 1618289079410
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/memoize.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080240,
-            "end": 1618289080371
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/StreetViewPanorama.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080427,
-            "end": 1618289080558
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormLabel.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081681,
-            "end": 1618289081812
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square2-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078478,
-            "end": 1618289078608
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square4-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078479,
-            "end": 1618289078609
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/styled-components/Todo-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078479,
-            "end": 1618289078609
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Zoom/Zoom.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079766,
-            "end": 1618289079896
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/responsivePropType.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080240,
-            "end": 1618289080370
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputBase/utils.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080579,
-            "end": 1618289080709
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Slider/Slider.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081104,
-            "end": 1618289081234
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/pretty-snapshots-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078478,
-            "end": 1618289078607
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/shopping-list-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078478,
-            "end": 1618289078607
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square1-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078478,
-            "end": 1618289078607
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square3-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078479,
-            "end": 1618289078608
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/lodash/fp.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079192,
-            "end": 1618289079321
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/withMobileDialog/withMobileDialog.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079765,
-            "end": 1618289079894
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/KmlLayer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080427,
-            "end": 1618289080556
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/jssPreset/jssPreset.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080580,
-            "end": 1618289080709
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/game-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078477,
-            "end": 1618289078605
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/hello-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078478,
-            "end": 1618289078606
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/TrafficLayer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080427,
-            "end": 1618289080555
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/getThemeProps/getThemeProps.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080582,
-            "end": 1618289080710
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.get-prototype-of.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080585,
-            "end": 1618289080712
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepButton/StepButton.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081068,
-            "end": 1618289081195
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseMatches.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081073,
-            "end": 1618289081200
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todos-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078477,
-            "end": 1618289078603
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/tutorial/shopping-list.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078874,
-            "end": 1618289079000
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/BicyclingLayer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080427,
-            "end": 1618289080553
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/createStyles/createStyles.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080585,
-            "end": 1618289080711
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/createGenerateClassName/createGenerateClassName.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080586,
-            "end": 1618289080712
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_shortOut.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080587,
-            "end": 1618289080713
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_composeArgs.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080587,
-            "end": 1618289080713
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getRawTag.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081066,
-            "end": 1618289081192
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.to-string.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081071,
-            "end": 1618289081197
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Step/Step.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081073,
-            "end": 1618289081199
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types-extra/lib/isRequiredForA11y.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081689,
-            "end": 1618289081815
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/webpack/buildin/global.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078368,
-            "end": 1618289078493
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/webpack/buildin/module.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078368,
-            "end": 1618289078493
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todo-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078477,
-            "end": 1618289078602
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_apply.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080588,
-            "end": 1618289080713
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hasUnicode.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081067,
-            "end": 1618289081192
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Todos.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078870,
-            "end": 1618289078994
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseSetToString.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080574,
-            "end": 1618289080698
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/toFinite.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080575,
-            "end": 1618289080699
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/jsx-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078477,
-            "end": 1618289078600
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/Rating/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079153,
-            "end": 1618289079276
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/Autocomplete/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079153,
-            "end": 1618289079276
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-parse-stringify2/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080267,
-            "end": 1618289080390
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/withStyles/withStyles.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080425,
-            "end": 1618289080548
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getWrapDetails.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080576,
-            "end": 1618289080699
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/components-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078477,
-            "end": 1618289078599
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/focusVisible.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080131,
-            "end": 1618289080253
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonBase/Ripple.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080421,
-            "end": 1618289080543
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080422,
-            "end": 1618289080544
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/node_modules/react-is/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080423,
-            "end": 1618289080545
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/re-render/spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078477,
-            "end": 1618289078598
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/slicedToArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080127,
-            "end": 1618289080248
+            "start": 1618290217794,
+            "end": 1618290218029
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/safeHtml/safeHtml.js",
@@ -6071,1178 +202,8 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081696,
-            "end": 1618289081817
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/no-visit/spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078476,
-            "end": 1618289078596
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/transpiled.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079164,
-            "end": 1618289079284
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/useControlled.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080126,
-            "end": 1618289080246
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/NoSsr/NoSsr.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080571,
-            "end": 1618289080691
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Table/Tablelvl2Context.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081140,
-            "end": 1618289081260
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/TabContent.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081425,
-            "end": 1618289081545
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/fails-correctly/spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078476,
-            "end": 1618289078595
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@bahmutov/cy-api/support.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079036,
-            "end": 1618289079155
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/useTheme/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080272,
-            "end": 1618289080391
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/ThemeProvider/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080273,
-            "end": 1618289080392
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_overRest.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080419,
-            "end": 1618289080538
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_metaMap.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080573,
-            "end": 1618289080692
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.set-prototype-of.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080599,
-            "end": 1618289080718
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/OutlinedInput/OutlinedInput.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080600,
-            "end": 1618289080719
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tabs/Tabs.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080944,
-            "end": 1618289081063
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tabs/TabIndicator.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081131,
-            "end": 1618289081250
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/animate.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081132,
-            "end": 1618289081251
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/debounce.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081137,
-            "end": 1618289081256
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Table/TableContext.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081140,
-            "end": 1618289081259
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Table.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081425,
-            "end": 1618289081544
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079102,
-            "end": 1618289079220
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/withStyles.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079140,
-            "end": 1618289079258
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/withTheme.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079140,
-            "end": 1618289079258
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItem/ListItem.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079277,
-            "end": 1618289079395
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createBind.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080418,
-            "end": 1618289080536
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/scrollLeft.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081134,
-            "end": 1618289081252
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TablePagination/TablePaginationActions.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081142,
-            "end": 1618289081260
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-keys-internal.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081151,
-            "end": 1618289081269
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/network/2-users-fetch-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078476,
-            "end": 1618289078593
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/transitions.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079140,
-            "end": 1618289079257
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/useTheme.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079140,
-            "end": 1618289079257
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/unmount/comp.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079147,
-            "end": 1618289079264
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/node_modules/scheduler/cjs/scheduler-tracing.development.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080418,
-            "end": 1618289080535
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tooltip/Tooltip.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080943,
-            "end": 1618289081060
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tabs/ScrollbarSize.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081132,
-            "end": 1618289081249
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/ArrowDownward.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081146,
-            "end": 1618289081263
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_strictIndexOf.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081151,
-            "end": 1618289081268
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/makeStyles.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079139,
-            "end": 1618289079255
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/responsiveFontSizes.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079140,
-            "end": 1618289079256
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/styled.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079140,
-            "end": 1618289079256
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FilledInput/FilledInput.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080606,
-            "end": 1618289080722
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/node_modules/dom-helpers/esm/hasClass.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080957,
-            "end": 1618289081073
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tabs/TabScrollButton.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081131,
-            "end": 1618289081247
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Fab/Fab.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081423,
-            "end": 1618289081539
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createMuiTheme.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079139,
-            "end": 1618289079254
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createStyles.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079139,
-            "end": 1618289079254
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Typography/Typography.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079275,
-            "end": 1618289079390
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.define-property.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080606,
-            "end": 1618289080721
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Input/Input.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080608,
-            "end": 1618289080723
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.create.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080609,
-            "end": 1618289080724
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-absolute-index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081422,
-            "end": 1618289081537
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/network/1-users-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078476,
-            "end": 1618289078590
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/colorManipulator.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079139,
-            "end": 1618289079253
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/ReplaceTransition.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080416,
-            "end": 1618289080530
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-vendor/dist/css-vendor.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081127,
-            "end": 1618289081241
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsNaN.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081156,
-            "end": 1618289081270
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-dps.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080957,
-            "end": 1618289081070
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iobject.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081157,
-            "end": 1618289081270
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_cof.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081158,
-            "end": 1618289081271
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Fade/Fade.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081422,
-            "end": 1618289081535
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/mount-div/spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078476,
-            "end": 1618289078588
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControl/FormControl.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079138,
-            "end": 1618289079250
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputLabel/InputLabel.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079139,
-            "end": 1618289079251
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ToastHeader.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079275,
-            "end": 1618289079387
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createCurry.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080416,
-            "end": 1618289080528
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createRecurry.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080619,
-            "end": 1618289080731
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.assign.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081126,
-            "end": 1618289081238
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/tiny-warning/dist/tiny-warning.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081126,
-            "end": 1618289081238
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Grid/Grid.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081421,
-            "end": 1618289081533
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Box/Box.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079275,
-            "end": 1618289079386
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createHybrid.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080416,
-            "end": 1618289080527
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/symbol/iterator.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080614,
-            "end": 1618289080725
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/utils/ChildMapping.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080615,
-            "end": 1618289080726
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/node_modules/react-is/cjs/react-is.development.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080617,
-            "end": 1618289080728
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createCtor.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080620,
-            "end": 1618289080731
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_toKey.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081124,
-            "end": 1618289081235
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseFindIndex.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081125,
-            "end": 1618289081236
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_toSource.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081162,
-            "end": 1618289081273
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/enzyme/state-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078476,
-            "end": 1618289078586
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CarouselItem.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079274,
-            "end": 1618289079384
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CloseButton.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079275,
-            "end": 1618289079385
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_root.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080617,
-            "end": 1618289080727
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputBase/InputBase.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080939,
-            "end": 1618289081049
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridList/GridList.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081421,
-            "end": 1618289081531
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControl/useFormControl.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079139,
-            "end": 1618289079248
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Carousel.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079274,
-            "end": 1618289079383
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/SwitchTransition.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080414,
-            "end": 1618289080523
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseForOwn.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081094,
-            "end": 1618289081203
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MenuItem/MenuItem.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079139,
-            "end": 1618289079247
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SnackbarContent/SnackbarContent.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081094,
-            "end": 1618289081202
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/hyphenate-style-name/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081120,
-            "end": 1618289081228
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isMasked.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081168,
-            "end": 1618289081276
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css-modules/css-modules-orange-button-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078475,
-            "end": 1618289078582
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/enzyme/context-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078475,
-            "end": 1618289078582
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/style-loader/lib/urls.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079055,
-            "end": 1618289079162
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormHelperText/FormHelperText.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079138,
-            "end": 1618289079245
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/TransitionGroup.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080414,
-            "end": 1618289080521
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/constants.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080633,
-            "end": 1618289080740
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080883,
-            "end": 1618289080990
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Snackbar/Snackbar.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081100,
-            "end": 1618289081207
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_castPath.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081123,
-            "end": 1618289081230
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.array.from.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081174,
-            "end": 1618289081281
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MenuList/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081174,
-            "end": 1618289081281
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridListTile/GridListTile.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081420,
-            "end": 1618289081527
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CarouselCaption.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080304,
-            "end": 1618289080410
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/symbol/iterator.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080413,
-            "end": 1618289080519
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createCaseFirst.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080883,
-            "end": 1618289080989
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tab/Tab.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080949,
-            "end": 1618289081055
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isArguments.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081116,
-            "end": 1618289081222
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridListTileBar/GridListTileBar.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081419,
-            "end": 1618289081525
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaLists/commaLists.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081719,
-            "end": 1618289081825
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/styles/style/style-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079054,
-            "end": 1618289079159
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Select/Select.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079138,
-            "end": 1618289079243
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/TransitionGroupContext.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080312,
-            "end": 1618289080417
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/symbol.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080413,
-            "end": 1618289080518
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_ie8-dom-define.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080881,
-            "end": 1618289080986
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseHas.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080883,
-            "end": 1618289080988
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/property.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081108,
-            "end": 1618289081213
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseTimes.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081109,
-            "end": 1618289081214
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseMatchesProperty.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081109,
-            "end": 1618289081214
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/html/html.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081716,
-            "end": 1618289081821
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/enzyme/props-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078475,
-            "end": 1618289078579
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CardImg.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079274,
-            "end": 1618289079378
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CardGroup.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079274,
-            "end": 1618289079378
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/SafeAnchor.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080299,
-            "end": 1618289080403
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/config.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080313,
-            "end": 1618289080417
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Table/Table.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080949,
-            "end": 1618289081053
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createBaseEach.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081108,
-            "end": 1618289081212
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isBuffer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081114,
-            "end": 1618289081218
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Hidden/Hidden.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081418,
-            "end": 1618289081522
+            "start": 1618290217793,
+            "end": 1618290218026
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaListsOr/commaListsOr.js",
@@ -7250,143 +211,17 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081719,
-            "end": 1618289081823
+            "start": 1618290217793,
+            "end": 1618290218024
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineTrim/oneLineTrim.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289079227,
-            "end": 1618289079330
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079231,
-            "end": 1618289079334
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CardDeck.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079274,
-            "end": 1618289079377
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ToastContext.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080296,
-            "end": 1618289080399
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ElementChildren.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080303,
-            "end": 1618289080406
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseGetTag.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080888,
-            "end": 1618289080991
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gopd.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080895,
-            "end": 1618289080998
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepButton/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080896,
-            "end": 1618289080999
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableCell/TableCell.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080948,
-            "end": 1618289081051
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableBody/TableBody.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080949,
-            "end": 1618289081052
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_nativeKeys.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081111,
-            "end": 1618289081214
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isTypedArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081112,
-            "end": 1618289081215
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Popover/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081179,
-            "end": 1618289081282
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaListsAnd/commaListsAnd.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081719,
-            "end": 1618289081822
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/removeNonPrintingValuesTransformer/removeNonPrintingValuesTransformer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081723,
-            "end": 1618289081826
+            "start": 1618290217794,
+            "end": 1618290218025
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/splitStringTransformer/splitStringTransformer.js",
@@ -7394,8 +229,35 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081723,
-            "end": 1618289081826
+            "start": 1618290217792,
+            "end": 1618290218022
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaListsAnd/commaListsAnd.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217792,
+            "end": 1618290218022
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/removeNonPrintingValuesTransformer/removeNonPrintingValuesTransformer.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217791,
+            "end": 1618290218018
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/html/html.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217792,
+            "end": 1618290218019
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/inlineArrayTransformer/inlineArrayTransformer.js",
@@ -7403,89 +265,8 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081724,
-            "end": 1618289081827
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceSubstitutionTransformer/replaceSubstitutionTransformer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081724,
-            "end": 1618289081827
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceResultTransformer/replaceResultTransformer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081729,
-            "end": 1618289081832
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Card.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079273,
-            "end": 1618289079375
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CardColumns.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079274,
-            "end": 1618289079376
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/memoize/dist/memoize.browser.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080297,
-            "end": 1618289080399
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/getComputedStyle.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080316,
-            "end": 1618289080418
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayReduce.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080888,
-            "end": 1618289080990
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseReduce.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080894,
-            "end": 1618289080996
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_is-object.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080895,
-            "end": 1618289080997
+            "start": 1618290217792,
+            "end": 1618290218018
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceStringTransformer/replaceStringTransformer.js",
@@ -7493,17 +274,8 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081724,
-            "end": 1618289081826
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormFile.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081729,
-            "end": 1618289081831
+            "start": 1618290217791,
+            "end": 1618290218016
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndentTransformer/stripIndentTransformer.js",
@@ -7511,746 +283,62 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081730,
-            "end": 1618289081832
+            "start": 1618290217790,
+            "end": 1618290218014
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormControl.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceSubstitutionTransformer/replaceSubstitutionTransformer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081731,
-            "end": 1618289081833
+            "start": 1618290217791,
+            "end": 1618290218015
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/object/set-prototype-of.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceResultTransformer/replaceResultTransformer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080403,
-            "end": 1618289080504
+            "start": 1618290217791,
+            "end": 1618290218015
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/OutlinedInput/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaLists/commaLists.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080404,
-            "end": 1618289080505
+            "start": 1618290217792,
+            "end": 1618290218016
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FilledInput/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/components/ProductsList.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080409,
-            "end": 1618289080510
+            "start": 1618290216685,
+            "end": 1618290216908
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Input/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/process/browser.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080409,
-            "end": 1618289080510
+            "start": 1618290217788,
+            "end": 1618290218011
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepContent/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/TemplateTag/TemplateTag.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080891,
-            "end": 1618289080992
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepConnector/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080892,
-            "end": 1618289080993
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-lifecycles-compat/react-lifecycles-compat.es.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080893,
-            "end": 1618289080994
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Switch.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081728,
-            "end": 1618289081829
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormCheck.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081729,
-            "end": 1618289081830
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css/css-orange-button-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078475,
-            "end": 1618289078575
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ButtonToolbar.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079273,
-            "end": 1618289079373
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setData.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080396,
-            "end": 1618289080496
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createPartial.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080397,
-            "end": 1618289080497
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/CSSTransition.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080403,
-            "end": 1618289080503
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/object/define-property.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080409,
-            "end": 1618289080509
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/object/create.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080412,
-            "end": 1618289080512
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-parse-stringify2/lib/parse-tag.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080648,
-            "end": 1618289080748
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/utils/MapChildHelper.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080650,
-            "end": 1618289080750
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Step/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080907,
-            "end": 1618289081007
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SnackbarContent/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080908,
-            "end": 1618289081008
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseEach.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080909,
-            "end": 1618289081009
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormGroup.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081728,
-            "end": 1618289081828
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/document/document-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078475,
-            "end": 1618289078574
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ButtonGroup.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079273,
-            "end": 1618289079372
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mergeData.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080396,
-            "end": 1618289080495
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getData.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080397,
-            "end": 1618289080496
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIteratee.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080908,
-            "end": 1618289081007
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Button.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079273,
-            "end": 1618289079371
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/isTransform.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080321,
-            "end": 1618289080419
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/listen.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080322,
-            "end": 1618289080420
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/hyphenateStyle.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080322,
-            "end": 1618289080420
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/utils/PropTypes.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080326,
-            "end": 1618289080424
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/arrayWithHoles.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080328,
-            "end": 1618289080426
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/createGenerateClassName/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080396,
-            "end": 1618289080494
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Icon/Icon.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081417,
-            "end": 1618289081515
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/components/ProductsList.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078715,
-            "end": 1618289078812
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Breadcrumb.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079272,
-            "end": 1618289079369
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/BreadcrumbItem.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079273,
-            "end": 1618289079370
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setWrapToString.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080391,
-            "end": 1618289080488
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/createStyles/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080395,
-            "end": 1618289080492
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-create.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081193,
-            "end": 1618289081290
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ToggleButton.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081395,
-            "end": 1618289081492
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputAdornment/InputAdornment.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081416,
-            "end": 1618289081513
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Alert.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079272,
-            "end": 1618289079368
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/nonIterableRest.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080332,
-            "end": 1618289080428
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setToString.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080390,
-            "end": 1618289080486
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/toInteger.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080391,
-            "end": 1618289080487
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/jssPreset/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080393,
-            "end": 1618289080489
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/getThemeProps/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080394,
-            "end": 1618289080490
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss/dist/jss.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080811,
-            "end": 1618289080907
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-primitive.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080878,
-            "end": 1618289080974
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableFooter/TableFooter.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080945,
-            "end": 1618289081041
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableContainer/TableContainer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080948,
-            "end": 1618289081044
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemSecondaryAction/ListItemSecondaryAction.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081395,
-            "end": 1618289081491
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/counter-set-state/counter-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078474,
-            "end": 1618289078569
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/counter-use-hooks/counter-hooks-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078475,
-            "end": 1618289078570
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseSetData.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080391,
-            "end": 1618289080486
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepLabel/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080877,
-            "end": 1618289080972
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepIcon/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080878,
-            "end": 1618289080973
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isLength.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080927,
-            "end": 1618289081022
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableHead/TableHead.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080944,
-            "end": 1618289081039
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/object/assign.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080945,
-            "end": 1618289081040
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ToggleButtonGroup.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081393,
-            "end": 1618289081488
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Tabs.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081404,
-            "end": 1618289081499
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/LinearProgress/LinearProgress.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081412,
-            "end": 1618289081507
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/before-hook/spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078474,
-            "end": 1618289078568
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/use-render/my-component.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079130,
-            "end": 1618289079224
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/AddTodo.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079132,
-            "end": 1618289079226
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Badge.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079272,
-            "end": 1618289079366
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/NoSsr/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080388,
-            "end": 1618289080482
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/object/get-prototype-of.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080389,
-            "end": 1618289080483
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Portal/Portal.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080660,
-            "end": 1618289080754
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Stepper/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080875,
-            "end": 1618289080969
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_castFunction.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080923,
-            "end": 1618289081017
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseAssignValue.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080924,
-            "end": 1618289081018
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayLikeKeys.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080925,
-            "end": 1618289081019
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseKeys.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080925,
-            "end": 1618289081019
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TablePagination/TablePagination.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080944,
-            "end": 1618289081038
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndent/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081392,
-            "end": 1618289081486
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/TabPane.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081407,
-            "end": 1618289081501
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemAvatar/ListItemAvatar.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081408,
-            "end": 1618289081502
+            "start": 1618290217790,
+            "end": 1618290218013
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/trimResultTransformer/trimResultTransformer.js",
@@ -8258,3140 +346,332 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081743,
-            "end": 1618289081837
+            "start": 1618290217791,
+            "end": 1618290218014
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_listCacheClear.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-is/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081751,
-            "end": 1618289081845
+            "start": 1618290217789,
+            "end": 1618290218011
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_listCacheDelete.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/utils.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081751,
-            "end": 1618289081845
+            "start": 1618290217670,
+            "end": 1618290217891
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Map.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/capitalize.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081752,
-            "end": 1618289081846
+            "start": 1618290217671,
+            "end": 1618290217892
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_MapCache.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Note.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081752,
-            "end": 1618289081846
+            "start": 1618290216684,
+            "end": 1618290216899
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/stateless-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/add2.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289078474,
-            "end": 1618289078567
+            "start": 1618290216684,
+            "end": 1618290216898
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/alias/alias-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Todos.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289078474,
-            "end": 1618289078567
+            "start": 1618290216685,
+            "end": 1618290216899
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/Todo.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/todos-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289079132,
-            "end": 1618289079225
+            "start": 1618290216684,
+            "end": 1618290216897
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/StylesProvider/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/add.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080356,
-            "end": 1618289080449
+            "start": 1618290216684,
+            "end": 1618290216897
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/styled/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/products.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080357,
-            "end": 1618289080450
+            "start": 1618290216685,
+            "end": 1618290216898
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/SelectableContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/use-local-storage/App.spec.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080375,
-            "end": 1618289080468
+            "start": 1618290216683,
+            "end": 1618290216895
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Snackbar/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counter/counter-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080919,
-            "end": 1618289081012
+            "start": 1618290216683,
+            "end": 1618290216895
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Slider/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counters/counters-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080922,
-            "end": 1618289081015
+            "start": 1618290216684,
+            "end": 1618290216896
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/hash/dist/hash.browser.esm.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/tutorial/tic-tac-toe-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080923,
-            "end": 1618289081016
+            "start": 1618290216683,
+            "end": 1618290216894
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableRow/TableRow.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/tutorial/square-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080944,
-            "end": 1618289081037
+            "start": 1618290216682,
+            "end": 1618290216892
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Tooltip.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/tutorial/shopping-list-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081393,
-            "end": 1618289081486
+            "start": 1618290216683,
+            "end": 1618290216893
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Link/Link.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/timers/card-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081412,
-            "end": 1618289081505
+            "start": 1618290216682,
+            "end": 1618290216891
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-x-spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/testing-lib-example/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289078473,
-            "end": 1618289078565
+            "start": 1618290216681,
+            "end": 1618290216889
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/pure-component.spec.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/testing-lib-example/testing-lib-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289078474,
-            "end": 1618289078566
+            "start": 1618290216682,
+            "end": 1618290216890
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/timers/card-without-effect-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289079129,
-            "end": 1618289079221
+            "start": 1618290216682,
+            "end": 1618290216890
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/Cancel.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/test-retries/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080347,
-            "end": 1618289080439
+            "start": 1618290216681,
+            "end": 1618290216888
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/iterableToArrayLimit.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/useAsObservableSource.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080355,
-            "end": 1618289080447
+            "start": 1618290217702,
+            "end": 1618290217909
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/makeStyles/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/useAutocomplete/useAutocomplete.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080374,
-            "end": 1618289080466
+            "start": 1618290218177,
+            "end": 1618290218384
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/identity.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/renderless/mouse-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080387,
-            "end": 1618289080479
+            "start": 1618290216680,
+            "end": 1618290216886
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/DropdownItem.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/loading-indicator-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081750,
-            "end": 1618289081842
+            "start": 1618290216681,
+            "end": 1618290216887
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_DataView.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-router-v6/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081759,
-            "end": 1618289081851
+            "start": 1618290216680,
+            "end": 1618290216885
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/AccordionCollapse.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/app-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289079272,
-            "end": 1618289079363
+            "start": 1618290216681,
+            "end": 1618290216886
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/createChainedFunction.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/is-extendable/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080345,
-            "end": 1618289080436
+            "start": 1618290217845,
+            "end": 1618290218050
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/ServerStyleSheets/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-router-v6/in-memory-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080359,
-            "end": 1618289080450
+            "start": 1618290216680,
+            "end": 1618290216884
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/node_modules/scheduler/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/is-whitespace/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080368,
-            "end": 1618289080459
+            "start": 1618290217845,
+            "end": 1618290218049
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Fade.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-bootstrap/modal-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080369,
-            "end": 1618289080460
+            "start": 1618290216680,
+            "end": 1618290216882
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/symbol-observable/es/ponyfill.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-bootstrap/dropdown-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080665,
-            "end": 1618289080756
+            "start": 1618290216680,
+            "end": 1618290216881
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_html.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/slicedToArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080872,
-            "end": 1618289080963
+            "start": 1618290217692,
+            "end": 1618290217893
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SwipeableDrawer/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/assertEnvironment.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080873,
-            "end": 1618289080964
+            "start": 1618290217713,
+            "end": 1618290217914
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isIterateeCall.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/portal/portal-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080932,
-            "end": 1618289081023
+            "start": 1618290216679,
+            "end": 1618290216879
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/getStylesCreator/getStylesCreator.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080933,
-            "end": 1618289081024
+            "start": 1618290216679,
+            "end": 1618290216878
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TextareaAutosize/TextareaAutosize.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/RemotePizza.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080944,
-            "end": 1618289081035
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/is-in-browser/dist/module.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081210,
-            "end": 1618289081301
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Modal/ModalManager.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081391,
-            "end": 1618289081482
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndents/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081392,
-            "end": 1618289081483
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Form.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081749,
-            "end": 1618289081840
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Col.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081750,
-            "end": 1618289081841
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/DropdownButton.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081750,
-            "end": 1618289081841
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Set.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081760,
-            "end": 1618289081851
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Promise.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081760,
-            "end": 1618289081851
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getAllKeys.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081761,
-            "end": 1618289081852
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_SetCache.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081762,
-            "end": 1618289081853
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_cacheHas.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081764,
-            "end": 1618289081855
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/full-navigation-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078473,
-            "end": 1618289078563
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-world-inline-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078473,
-            "end": 1618289078563
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CardContext.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080365,
-            "end": 1618289080455
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/divWithClassName.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080369,
-            "end": 1618289080459
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/mergeClasses/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080371,
-            "end": 1618289080461
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_string-at.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080863,
-            "end": 1618289080953
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_wks.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080864,
-            "end": 1618289080954
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Switch/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080871,
-            "end": 1618289080961
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/weak-memoize/dist/weak-memoize.browser.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080935,
-            "end": 1618289081025
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableSortLabel/TableSortLabel.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080943,
-            "end": 1618289081033
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MobileStepper/MobileStepper.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081391,
-            "end": 1618289081481
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setToArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081762,
-            "end": 1618289081852
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Breadcrumbs/BreadcrumbCollapsed.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081764,
-            "end": 1618289081854
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arraySome.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081765,
-            "end": 1618289081855
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapToArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081765,
-            "end": 1618289081855
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-world-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078473,
-            "end": 1618289078562
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/AccordionToggle.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079272,
-            "end": 1618289079361
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Menu/Menu.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080863,
-            "end": 1618289080952
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.array.iterator.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080865,
-            "end": 1618289080954
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/wrapperLodash.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080868,
-            "end": 1618289080957
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getFuncName.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080871,
-            "end": 1618289080960
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIndexOf.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080942,
-            "end": 1618289081031
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Toolbar/Toolbar.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080943,
-            "end": 1618289081032
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Popover/Popover.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081313,
-            "end": 1618289081402
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/webpack-dev-server/dist/aut-runner.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078462,
-            "end": 1618289078550
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/alert-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078472,
-            "end": 1618289078560
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-act-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078473,
-            "end": 1618289078561
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Accordion.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079272,
-            "end": 1618289079360
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/assign.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080689,
-            "end": 1618289080777
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/ThemeProvider/nested.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080689,
-            "end": 1618289080777
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_ctx.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080863,
-            "end": 1618289080951
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_an-object.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080867,
-            "end": 1618289080955
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/void-elements/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080868,
-            "end": 1618289080956
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_LazyWrapper.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080868,
-            "end": 1618289080956
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hasPath.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080940,
-            "end": 1618289081028
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_enum-bug-keys.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080942,
-            "end": 1618289081030
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Modal/Modal.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081391,
-            "end": 1618289081479
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/utils/OverlayViewHelper.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080689,
-            "end": 1618289080776
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/delay.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080689,
-            "end": 1618289080776
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/useTheme/ThemeContext.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080690,
-            "end": 1618289080777
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_global.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080859,
-            "end": 1618289080946
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_hide.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080863,
-            "end": 1618289080950
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/eq.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080940,
-            "end": 1618289081027
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_dom-create.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080942,
-            "end": 1618289081029
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/emotion-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078472,
-            "end": 1618289078558
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/error-boundary-spec.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078473,
-            "end": 1618289078559
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Typography/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079116,
-            "end": 1618289079202
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Button/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079116,
-            "end": 1618289079202
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItem/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079117,
-            "end": 1618289079203
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TextField/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079117,
-            "end": 1618289079203
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Divider/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079271,
-            "end": 1618289079357
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemText/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079271,
-            "end": 1618289079357
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/uncontrollable/lib/esm/uncontrollable.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080686,
-            "end": 1618289080772
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useCommittedRef.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080688,
-            "end": 1618289080774
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Uint8Array.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081770,
-            "end": 1618289081856
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/support/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078472,
-            "end": 1618289078557
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Box/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079116,
-            "end": 1618289079201
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079121,
-            "end": 1618289079206
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079269,
-            "end": 1618289079354
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControlLabel/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079270,
-            "end": 1618289079355
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Checkbox/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079270,
-            "end": 1618289079355
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemIcon/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079271,
-            "end": 1618289079356
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/List/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079271,
-            "end": 1618289079356
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useMounted.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080684,
-            "end": 1618289080769
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/uncontrollable/lib/esm/hook.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080686,
-            "end": 1618289080771
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SwipeableDrawer/SwipeArea.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081221,
-            "end": 1618289081306
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Toast.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081390,
-            "end": 1618289081475
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_listCacheSet.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081771,
-            "end": 1618289081856
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_listCacheHas.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081771,
-            "end": 1618289081856
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079265,
-            "end": 1618289079349
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/ownerDocument.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080678,
-            "end": 1618289080762
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_shared-key.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080856,
-            "end": 1618289080940
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es7.symbol.async-iterator.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080856,
-            "end": 1618289080940
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Container/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081367,
-            "end": 1618289081451
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_memoizeCapped.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081390,
-            "end": 1618289081474
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormGroup/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079270,
-            "end": 1618289079353
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useWillUnmount.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080683,
-            "end": 1618289080766
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/canUseDOM.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080683,
-            "end": 1618289080766
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_defined.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080855,
-            "end": 1618289080938
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_has.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080856,
-            "end": 1618289080939
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_is-array-iter.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081331,
-            "end": 1618289081414
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-call.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081338,
-            "end": 1618289081421
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Stack.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081366,
-            "end": 1618289081449
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RadioGroup/useRadioGroup.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081366,
-            "end": 1618289081449
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogActions/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081367,
-            "end": 1618289081450
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Dialog/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081367,
-            "end": 1618289081450
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CssBaseline/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081367,
-            "end": 1618289081450
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Radio/Radio.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081386,
-            "end": 1618289081469
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/AppBar/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081387,
-            "end": 1618289081470
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/@emotion/core/dist/core.browser.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079260,
-            "end": 1618289079342
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/axios.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079261,
-            "end": 1618289079343
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_fails.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080856,
-            "end": 1618289080938
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/Warning.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081229,
-            "end": 1618289081311
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Drawer/Drawer.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081230,
-            "end": 1618289081312
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createBaseFor.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081370,
-            "end": 1618289081452
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CircularProgress/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081371,
-            "end": 1618289081453
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardMedia/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081372,
-            "end": 1618289081454
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardHeader/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081372,
-            "end": 1618289081454
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardActionArea/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081377,
-            "end": 1618289081459
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/BottomNavigation/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081385,
-            "end": 1618289081467
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Avatar/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081386,
-            "end": 1618289081468
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/webpack/buildin/global.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079585,
-            "end": 1618289079666
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/settle.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080851,
-            "end": 1618289080932
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es7.symbol.observable.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080852,
-            "end": 1618289080933
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseTrim.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080852,
-            "end": 1618289080933
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isSymbol.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080853,
-            "end": 1618289080934
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/CheckCircle.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081229,
-            "end": 1618289081310
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseToString.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081235,
-            "end": 1618289081316
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-length.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081327,
-            "end": 1618289081408
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Card/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081378,
-            "end": 1618289081459
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseHasIn.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081381,
-            "end": 1618289081462
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/BottomNavigationAction/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081385,
-            "end": 1618289081466
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Badge/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081385,
-            "end": 1618289081466
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Backdrop/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081386,
-            "end": 1618289081467
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079116,
-            "end": 1618289079196
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded-suspense/Dog.tsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079264,
-            "end": 1618289079344
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/buildURL.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080851,
-            "end": 1618289080931
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/core.get-iterator-method.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081325,
-            "end": 1618289081405
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RadioGroup/RadioGroup.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081361,
-            "end": 1618289081441
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardContent/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081375,
-            "end": 1618289081455
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Grow/Grow.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081376,
-            "end": 1618289081456
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardActions/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081377,
-            "end": 1618289081457
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonGroup/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081379,
-            "end": 1618289081459
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Breadcrumbs/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081383,
-            "end": 1618289081463
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/dist/cypress-react.cjs.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078693,
-            "end": 1618289078772
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/defineProperty.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080700,
-            "end": 1618289080779
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseSlice.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081235,
-            "end": 1618289081314
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_unicodeToArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081239,
-            "end": 1618289081318
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Slide/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081245,
-            "end": 1618289081324
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RootRef/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081245,
-            "end": 1618289081324
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MenuList/MenuList.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081310,
-            "end": 1618289081389
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogTitle/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081323,
-            "end": 1618289081402
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_create-property.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081326,
-            "end": 1618289081405
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ClickAwayListener/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081347,
-            "end": 1618289081426
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RootRef/RootRef.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081360,
-            "end": 1618289081439
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Slide/Slide.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081361,
-            "end": 1618289081440
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsEqualDeep.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081381,
-            "end": 1618289081460
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseGet.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081383,
-            "end": 1618289081462
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Select/SelectInput.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080745,
-            "end": 1618289080823
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.string.iterator.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080757,
-            "end": 1618289080835
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_wks-ext.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080758,
-            "end": 1618289080836
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getNative.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080850,
-            "end": 1618289080928
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_asciiToArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081239,
-            "end": 1618289081317
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RadioGroup/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081246,
-            "end": 1618289081324
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-detect.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081309,
-            "end": 1618289081387
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayMap.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081354,
-            "end": 1618289081432
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogContentText/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081355,
-            "end": 1618289081433
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/OutlinedInput/NotchedOutline.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080755,
-            "end": 1618289080832
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-create.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080761,
-            "end": 1618289080838
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isLaziable.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080762,
-            "end": 1618289080839
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/parseHeaders.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080849,
-            "end": 1618289080926
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/array/from.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080850,
-            "end": 1618289080927
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Fade/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081302,
-            "end": 1618289081379
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_array-includes.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081303,
-            "end": 1618289081380
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Fab/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081303,
-            "end": 1618289081380
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_coreJsData.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081305,
-            "end": 1618289081382
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Collapse/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081355,
-            "end": 1618289081432
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_listCacheGet.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081786,
-            "end": 1618289081863
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/top-100-movies.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078701,
-            "end": 1618289078777
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/web.dom.iterable.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080761,
-            "end": 1618289080837
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_freeGlobal.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080761,
-            "end": 1618289080837
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseCreate.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080763,
-            "end": 1618289080839
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/warning/browser.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080769,
-            "end": 1618289080845
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/isURLSameOrigin.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080848,
-            "end": 1618289080924
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getMatchData.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081257,
-            "end": 1618289081333
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridListTileBar/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081299,
-            "end": 1618289081375
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridListTile/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081300,
-            "end": 1618289081376
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridList/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081302,
-            "end": 1618289081378
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Grid/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081302,
-            "end": 1618289081378
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelSummary/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081323,
-            "end": 1618289081399
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanel/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081323,
-            "end": 1618289081399
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogContent/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081358,
-            "end": 1618289081434
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/RadioButtonUnchecked.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081786,
-            "end": 1618289081862
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/createError.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080848,
-            "end": 1618289080923
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsMatch.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081257,
-            "end": 1618289081332
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_matchesStrictComparable.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081257,
-            "end": 1618289081332
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/KeyboardArrowLeft.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081288,
-            "end": 1618289081363
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemAvatar/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081289,
-            "end": 1618289081364
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Link/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081290,
-            "end": 1618289081365
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputAdornment/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081295,
-            "end": 1618289081370
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelDetails/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081321,
-            "end": 1618289081396
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelActions/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081321,
-            "end": 1618289081396
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Drawer/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081322,
-            "end": 1618289081397
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/Person.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081783,
-            "end": 1618289081858
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/RadioButtonChecked.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081785,
-            "end": 1618289081860
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/timers/card-without-effect.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078690,
-            "end": 1618289078764
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/add.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078704,
-            "end": 1618289078778
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079096,
-            "end": 1618289079170
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/@emotion/utils/dist/utils.browser.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080718,
-            "end": 1618289080792
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_export.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080753,
-            "end": 1618289080827
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isObject.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080768,
-            "end": 1618289080842
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-dp.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080775,
-            "end": 1618289080849
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-global/dist/jss-plugin-global.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080844,
-            "end": 1618289080918
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/combineURLs.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080846,
-            "end": 1618289080920
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/isAbsoluteURL.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080847,
-            "end": 1618289080921
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/transformData.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080847,
-            "end": 1618289080921
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemSecondaryAction/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081285,
-            "end": 1618289081359
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/KeyboardArrowRight.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081288,
-            "end": 1618289081362
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/LinearProgress/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081291,
-            "end": 1618289081365
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Hidden/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081297,
-            "end": 1618289081371
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/products.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078705,
-            "end": 1618289078778
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079097,
-            "end": 1618289079170
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/serialize/dist/serialize.browser.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080717,
-            "end": 1618289080790
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/extends.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080717,
-            "end": 1618289080790
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_insertWrapDetails.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080720,
-            "end": 1618289080793
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/cache/dist/cache.browser.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080724,
-            "end": 1618289080797
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-camel-case/dist/jss-plugin-camel-case.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080844,
-            "end": 1618289080917
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_nodeUtil.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081271,
-            "end": 1618289081344
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/stubFalse.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081272,
-            "end": 1618289081345
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Icon/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081297,
-            "end": 1618289081370
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/AbstractNavItem.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081793,
-            "end": 1618289081866
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/timers/card.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078690,
-            "end": 1618289078762
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/has.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080786,
-            "end": 1618289080858
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/lowerFirst.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080786,
-            "end": 1618289080858
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-nested/dist/jss-plugin-nested.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080844,
-            "end": 1618289080916
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseFor.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081262,
-            "end": 1618289081334
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Grow/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081265,
-            "end": 1618289081337
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Menu/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081267,
-            "end": 1618289081339
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseProperty.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081268,
-            "end": 1618289081340
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsEqual.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081269,
-            "end": 1618289081341
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseUnary.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081271,
-            "end": 1618289081343
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/hasIn.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081272,
-            "end": 1618289081344
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/shopping-list.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078689,
-            "end": 1618289078760
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/api-test/users.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078690,
-            "end": 1618289078761
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/@emotion/sheet/dist/sheet.browser.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080716,
-            "end": 1618289080787
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/normalizeHeaderName.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080729,
-            "end": 1618289080800
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/forEach.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080787,
-            "end": 1618289080858
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-props-sort/dist/jss-plugin-props-sort.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080842,
-            "end": 1618289080913
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-vendor-prefixer/dist/jss-plugin-vendor-prefixer.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080843,
-            "end": 1618289080914
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-default-unit/dist/jss-plugin-default-unit.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080844,
-            "end": 1618289080915
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/NativeSelect/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081266,
-            "end": 1618289081337
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isKey.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081269,
-            "end": 1618289081340
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_overArg.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081270,
-            "end": 1618289081341
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsTypedArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081271,
-            "end": 1618289081342
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isStrictComparable.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081272,
-            "end": 1618289081343
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Slider/ValueLabel.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081283,
-            "end": 1618289081354
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-assign.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081285,
-            "end": 1618289081356
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-router-dom/react-router-dom.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289079108,
-            "end": 1618289079178
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/noop.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080715,
-            "end": 1618289080785
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_updateWrapDetails.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080716,
-            "end": 1618289080786
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-rule-value-function/dist/jss-plugin-rule-value-function.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080842,
-            "end": 1618289080912
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/cookies.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080843,
-            "end": 1618289080913
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_basePropertyDeep.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081276,
-            "end": 1618289081346
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsArguments.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081277,
-            "end": 1618289081347
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Modal/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081283,
-            "end": 1618289081353
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MobileStepper/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081283,
-            "end": 1618289081353
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_reorder.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080714,
-            "end": 1618289080783
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_countHolders.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080714,
-            "end": 1618289080783
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_composeArgsRight.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080714,
-            "end": 1618289080783
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_core.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080715,
-            "end": 1618289080784
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/css/dist/css.browser.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080716,
-            "end": 1618289080785
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/adapters/xhr.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080735,
-            "end": 1618289080804
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_defineProperty.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080744,
-            "end": 1618289080813
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/ArrowDropDown.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080745,
-            "end": 1618289080814
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useUpdatedRef.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080802,
-            "end": 1618289080871
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.symbol.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080842,
-            "end": 1618289080911
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/get.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081276,
-            "end": 1618289081345
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Radio/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081280,
-            "end": 1618289081349
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stringToPath.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289081282,
-            "end": 1618289081351
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/symbol/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080735,
-            "end": 1618289080803
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/toConsumableArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080737,
-            "end": 1618289080805
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/dispatchRequest.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080738,
-            "end": 1618289080806
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/makeStyles/indexCounter.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080739,
-            "end": 1618289080807
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/toNumber.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080744,
-            "end": 1618289080812
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-sap.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080748,
-            "end": 1618289080816
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/NativeSelect/NativeSelect.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080752,
-            "end": 1618289080820
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/reduce.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080791,
-            "end": 1618289080859
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isFunction.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080791,
-            "end": 1618289080859
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/sheet/dist/sheet.browser.esm.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080802,
-            "end": 1618289080870
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseDelay.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080808,
-            "end": 1618289080876
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isPrototype.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080809,
-            "end": 1618289080877
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isArrayLike.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080810,
-            "end": 1618289080878
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square3.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078690,
-            "end": 1618289078757
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square4.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078690,
-            "end": 1618289078757
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/InterceptorManager.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080739,
-            "end": 1618289080806
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/getStylesCreator/noopTheme.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080739,
-            "end": 1618289080806
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/makeStyles/multiKeyStore.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080742,
-            "end": 1618289080809
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_WeakMap.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080743,
-            "end": 1618289080810
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/constant.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080744,
-            "end": 1618289080811
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-object.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080748,
-            "end": 1618289080815
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gpo.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080749,
-            "end": 1618289080816
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/NativeSelect/NativeSelectInput.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080752,
-            "end": 1618289080819
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/uncontrollable/lib/esm/utils.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080808,
-            "end": 1618289080875
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_assignValue.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080809,
-            "end": 1618289080876
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/keys.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080809,
-            "end": 1618289080876
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createAssigner.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080812,
-            "end": 1618289080879
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_copyObject.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080812,
-            "end": 1618289080879
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/getStylesCreator/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080813,
-            "end": 1618289080880
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square2.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078689,
-            "end": 1618289078755
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_descriptors.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080799,
-            "end": 1618289080865
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_set-proto.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080800,
-            "end": 1618289080866
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_copyArray.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080817,
-            "end": 1618289080882
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isIndex.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080817,
-            "end": 1618289080882
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayEach.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080818,
-            "end": 1618289080883
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayIncludes.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080819,
-            "end": 1618289080884
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square1.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078689,
-            "end": 1618289078753
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputBase/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080817,
-            "end": 1618289080881
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/game.jsx",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289078688,
-            "end": 1618289078751
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableFooter/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080825,
-            "end": 1618289080888
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableRow/index.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080824,
-            "end": 1618289080886
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/object/assign.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289080825,
-            "end": 1618289080887
+            "start": 1618290216679,
+            "end": 1618290216877
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/webpack/buildin/module.js",
@@ -11399,215 +679,1799 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289079744,
-            "end": 1618289079805
+            "start": 1618290217916,
+            "end": 1618290218114
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tooltip/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/js-beautify/js/lib/beautify-css.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080823,
-            "end": 1618289080884
+            "start": 1618290218095,
+            "end": 1618290218293
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Toolbar/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/PizzaProps.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080824,
-            "end": 1618289080885
+            "start": 1618290216678,
+            "end": 1618290216874
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TextareaAutosize/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Zoom/Zoom.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080824,
-            "end": 1618289080885
+            "start": 1618290217898,
+            "end": 1618290218093
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tabs/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/constants.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080824,
-            "end": 1618289080885
+            "start": 1618290217929,
+            "end": 1618290218124
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableSortLabel/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080824,
-            "end": 1618289080885
+            "start": 1618290217945,
+            "end": 1618290218140
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TablePagination/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/2-users-named.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080825,
-            "end": 1618289080886
+            "start": 1618290216678,
+            "end": 1618290216872
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableHead/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/withMobileDialog/withMobileDialog.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080825,
-            "end": 1618289080886
+            "start": 1618290217898,
+            "end": 1618290218092
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableContainer/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/objectWithoutPropertiesLoose.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080829,
-            "end": 1618289080890
+            "start": 1618290217928,
+            "end": 1618290218122
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/hello.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/useAutocomplete/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289078688,
-            "end": 1618289078748
+            "start": 1618290217934,
+            "end": 1618290218128
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavbarToggle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/arrayWithHoles.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081820,
-            "end": 1618289081880
+            "start": 1618290217936,
+            "end": 1618290218130
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/stateless.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-component/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289078688,
-            "end": 1618289078747
+            "start": 1618290216678,
+            "end": 1618290216871
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/usePopperMarginModifiers.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/withWidth/withWidth.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081819,
-            "end": 1618289081878
+            "start": 1618290217898,
+            "end": 1618290218091
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavbarCollapse.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/nonIterableRest.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081820,
-            "end": 1618289081879
+            "start": 1618290217942,
+            "end": 1618290218135
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/viewport-spec.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/3-users-api.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289078672,
-            "end": 1618289078730
+            "start": 1618290216678,
+            "end": 1618290216870
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/network/2-users-fetch.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/red.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289078688,
-            "end": 1618289078746
+            "start": 1618290217903,
+            "end": 1618290218095
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableBody/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/CheckBox.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080833,
-            "end": 1618289080891
+            "start": 1618290217941,
+            "end": 1618290218133
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Table/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/utils/MapChildHelper.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080833,
-            "end": 1618289080891
+            "start": 1618290217942,
+            "end": 1618290218134
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/node_modules/dom-helpers/esm/addClass.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/lodash/fp/_mapping.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080840,
-            "end": 1618289080898
+            "start": 1618290217896,
+            "end": 1618290218087
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavbarContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/lodash/fp/placeholder.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081818,
-            "end": 1618289081876
+            "start": 1618290217896,
+            "end": 1618290218087
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/AbstractNav.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/pink.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081819,
-            "end": 1618289081877
+            "start": 1618290217904,
+            "end": 1618290218095
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableCell/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/bind.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080833,
-            "end": 1618289080890
+            "start": 1618290217926,
+            "end": 1618290218117
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tab/index.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/1-users.spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080834,
-            "end": 1618289080891
+            "start": 1618290216678,
+            "end": 1618290216868
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/node_modules/dom-helpers/esm/removeClass.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289080840,
-            "end": 1618289080897
+            "start": 1618290217895,
+            "end": 1618290218085
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/utils/mutate.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217896,
+            "end": 1618290218086
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/indigo.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217913,
+            "end": 1618290218103
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/IndeterminateCheckBox.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217941,
+            "end": 1618290218131
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/simple-rating-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216677,
+            "end": 1618290216866
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mock-fetch/fetch-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216677,
+            "end": 1618290216866
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/utils/createSvgIcon.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217562,
+            "end": 1618290217751
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/webpack/buildin/global.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217895,
+            "end": 1618290218084
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/utils/afterSync.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217896,
+            "end": 1618290218085
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormLabel/FormLabel.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217910,
+            "end": 1618290218099
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217911,
+            "end": 1618290218100
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/i18n/i18n.ts",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217110,
+            "end": 1618290217298
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/unsupportedProp.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218188,
+            "end": 1618290218376
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/list-item-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216676,
+            "end": 1618290216863
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mobx-v6/timer-spec.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216677,
+            "end": 1618290216864
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/orange.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217888,
+            "end": 1618290218075
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/withStyles/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217890,
+            "end": 1618290218077
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControl/formControlState.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218152,
+            "end": 1618290218339
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/transitions/utils.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218152,
+            "end": 1618290218339
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/objectWithoutProperties.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217658,
+            "end": 1618290217844
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/withTheme/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217891,
+            "end": 1618290218077
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/elementAcceptingRef.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218151,
+            "end": 1618290218337
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/object/get-prototype-of.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218154,
+            "end": 1618290218340
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/button-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216676,
+            "end": 1618290216861
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/checkbox-labels-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216676,
+            "end": 1618290216861
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormHelperText/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217105,
+            "end": 1618290217290
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputLabel/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217105,
+            "end": 1618290217290
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217106,
+            "end": 1618290217291
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/classCallCheck.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217662,
+            "end": 1618290217847
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/exactProp.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218151,
+            "end": 1618290218336
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/deepmerge.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218151,
+            "end": 1618290218336
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/useEventCallback.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218187,
+            "end": 1618290218372
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded/lazy-load-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216675,
+            "end": 1618290216859
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded/other-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216675,
+            "end": 1618290216859
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/autocomplete-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216676,
+            "end": 1618290216860
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Select/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217105,
+            "end": 1618290217289
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MenuItem/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217105,
+            "end": 1618290217289
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControl/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217105,
+            "end": 1618290217289
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/i18next/dist/esm/i18next.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217507,
+            "end": 1618290217691
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/defineProperty.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217663,
+            "end": 1618290217847
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/formatMuiErrorMessage.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218151,
+            "end": 1618290218335
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/elementTypeAcceptingRef.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218151,
+            "end": 1618290218335
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded-suspense/lazy-loaded-suspense.spec.tsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216674,
+            "end": 1618290216857
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/wrap-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217104,
+            "end": 1618290217287
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/HTMLElementType.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218150,
+            "end": 1618290218333
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/useObserver.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218174,
+            "end": 1618290218357
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/observerBatching.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218175,
+            "end": 1618290218358
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/reactBatchedUpdates.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218176,
+            "end": 1618290218359
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/focusVisible.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218182,
+            "end": 1618290218365
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded/app-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216675,
+            "end": 1618290216857
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/pretty/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217103,
+            "end": 1618290217285
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/green.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217887,
+            "end": 1618290218069
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/blue.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217888,
+            "end": 1618290218070
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/chainPropTypes.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218146,
+            "end": 1618290218328
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/refType.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218148,
+            "end": 1618290218330
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/ponyfillGlobal.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218149,
+            "end": 1618290218331
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/esm/getDisplayName.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218150,
+            "end": 1618290218332
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/staticRendering.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218174,
+            "end": 1618290218356
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/createClass.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218179,
+            "end": 1618290218361
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/useControlled.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218187,
+            "end": 1618290218369
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/i18n/i18next-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216674,
+            "end": 1618290216855
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/useForkRef.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218143,
+            "end": 1618290218324
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/useLocalObservable.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218173,
+            "end": 1618290218354
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/ObserverComponent.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218174,
+            "end": 1618290218355
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/observer.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218174,
+            "end": 1618290218355
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/enzyme/simple-context.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217103,
+            "end": 1618290217283
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/useLocalStore.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218173,
+            "end": 1618290218353
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/hooks/use-counter.spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216674,
+            "end": 1618290216853
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todos.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217103,
+            "end": 1618290217282
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/compose.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218142,
+            "end": 1618290218321
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/breakpoints.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218142,
+            "end": 1618290218321
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/toConsumableArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218143,
+            "end": 1618290218322
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/grey.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218170,
+            "end": 1618290218349
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/extends.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218170,
+            "end": 1618290218349
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/classCallCheck.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218172,
+            "end": 1618290218351
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/objectSpread.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218173,
+            "end": 1618290218352
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/css.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218142,
+            "end": 1618290218320
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/createClass.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218171,
+            "end": 1618290218349
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/display.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218142,
+            "end": 1618290218319
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/hooks/counter2-with-hooks.spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216674,
+            "end": 1618290216850
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/styled-components/Todos.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217102,
+            "end": 1618290217278
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todo.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217103,
+            "end": 1618290217279
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/lodash/fp/_baseConvert.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217600,
+            "end": 1618290217776
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types/factoryWithTypeCheckers.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217609,
+            "end": 1618290217785
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/framer-motion/Motion.spec.tsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216673,
+            "end": 1618290216848
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/hooks/counter-with-hooks.spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216674,
+            "end": 1618290216849
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/TrafficLayer.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217645,
+            "end": 1618290217820
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/FusionTablesLayer.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217645,
+            "end": 1618290217820
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/spacing.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218137,
+            "end": 1618290218312
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/sizing.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218137,
+            "end": 1618290218312
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/flexbox.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218141,
+            "end": 1618290218316
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/BicyclingLayer.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217644,
+            "end": 1618290217818
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/KmlLayer.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217645,
+            "end": 1618290217819
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/withTheme/withTheme.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218128,
+            "end": 1618290218302
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/shadows.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218140,
+            "end": 1618290218314
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/palette.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218141,
+            "end": 1618290218315
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/grid.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218141,
+            "end": 1618290218315
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/context/Mock-context-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216673,
+            "end": 1618290216846
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/forward-ref/forward-ref.spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216673,
+            "end": 1618290216846
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/styled-components/Todo.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217102,
+            "end": 1618290217275
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/StreetViewPanorama.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217644,
+            "end": 1618290217817
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/withStyles/withStyles.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218128,
+            "end": 1618290218301
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/is-buffer/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218131,
+            "end": 1618290218304
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/typography.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218135,
+            "end": 1618290218308
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/style.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218136,
+            "end": 1618290218309
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/positions.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218141,
+            "end": 1618290218314
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/context/context.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217102,
+            "end": 1618290217274
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/borders.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218135,
+            "end": 1618290218307
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/custom-command/spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216673,
+            "end": 1618290216844
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/Todos.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217100,
+            "end": 1618290217271
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/top-100-movies.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217101,
+            "end": 1618290217272
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/defineProperty.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218104,
+            "end": 1618290218275
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/objectWithoutProperties.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218104,
+            "end": 1618290218275
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/context/App-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216672,
+            "end": 1618290216842
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/app-action-example/counter-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216673,
+            "end": 1618290216843
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Note.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217100,
+            "end": 1618290217270
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/internal/svg-icons/createSvgIcon.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218103,
+            "end": 1618290218273
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/inherits.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218105,
+            "end": 1618290218275
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/api-test/spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216672,
+            "end": 1618290216841
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/SwitchBase.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218126,
+            "end": 1618290218295
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/List/ListContext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218127,
+            "end": 1618290218296
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/styled-components/Todo-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216672,
+            "end": 1618290216840
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createMixins.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217601,
+            "end": 1618290217769
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/inherits.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217770,
+            "end": 1618290217938
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/classCallCheck.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218125,
+            "end": 1618290218293
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/styled-components/Todos-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216672,
+            "end": 1618290216839
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createPalette.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217600,
+            "end": 1618290217767
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createBreakpoints.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217601,
+            "end": 1618290217768
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/utils/getRS.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217610,
+            "end": 1618290217777
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/withMobileDialog/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217613,
+            "end": 1618290217780
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/utils.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217642,
+            "end": 1618290217809
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/checkbox-labels.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217100,
+            "end": 1618290217266
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/withWidth/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217613,
+            "end": 1618290217779
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Zoom/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217614,
+            "end": 1618290217780
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControlLabel/FormControlLabel.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217641,
+            "end": 1618290217807
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217770,
+            "end": 1618290217936
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/inheritsLoose.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217771,
+            "end": 1618290217937
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/internal/svg-icons/Close.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217778,
+            "end": 1618290217944
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/possibleConstructorReturn.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218119,
+            "end": 1618290218285
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/objectWithoutPropertiesLoose.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217766,
+            "end": 1618290217931
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/internal/svg-icons/Star.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217778,
+            "end": 1618290217943
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/internal/svg-icons/ArrowDropDown.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217778,
+            "end": 1618290217943
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/CheckBoxOutlineBlank.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218123,
+            "end": 1618290218288
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mobx-v6/Timer.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217100,
+            "end": 1618290217264
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/utils/errors.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217610,
+            "end": 1618290217774
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/utils/getOnChange.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217610,
+            "end": 1618290217774
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormLabel/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217624,
+            "end": 1618290217788
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/typeof.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217770,
+            "end": 1618290217934
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/createClass.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218124,
+            "end": 1618290218288
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/stub-example/clicker-with-delay-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216672,
+            "end": 1618290216835
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/common.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217624,
+            "end": 1618290217787
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Checkbox/Checkbox.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217641,
+            "end": 1618290217804
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/stub-example/clicker-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216671,
+            "end": 1618290216833
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/interopRequireDefault.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217620,
+            "end": 1618290217782
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormGroup/FormGroup.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217641,
+            "end": 1618290217803
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square4-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216671,
+            "end": 1618290216832
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mock-fetch/user.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217100,
+            "end": 1618290217261
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/material-ui-example/list-demo.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217100,
+            "end": 1618290217261
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/object-assign/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217620,
+            "end": 1618290217781
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Divider/Divider.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217641,
+            "end": 1618290217802
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square3-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216671,
+            "end": 1618290216831
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/axios-api.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217099,
+            "end": 1618290217259
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217016,
+            "end": 1618290217175
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/PizzaProps.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217099,
+            "end": 1618290217258
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-component/map.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217099,
+            "end": 1618290217258
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemText/ListItemText.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217640,
+            "end": 1618290217799
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/shopping-list-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216670,
+            "end": 1618290216828
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square1-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216671,
+            "end": 1618290216829
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square2-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216671,
+            "end": 1618290216829
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/RemotePizza.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217099,
+            "end": 1618290217257
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-component/contact.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217099,
+            "end": 1618290217257
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/toggle-example/toggle-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217187,
+            "end": 1618290217345
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/List/List.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217640,
+            "end": 1618290217798
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/pretty-snapshots-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216670,
+            "end": 1618290216827
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded/OtherComponent.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217086,
+            "end": 1618290217243
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemIcon/ListItemIcon.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217640,
+            "end": 1618290217797
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-world.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217086,
+            "end": 1618290217242
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/smoke-spec.js",
@@ -11615,467 +2479,953 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289078682,
-            "end": 1618289078738
+            "start": 1618290217086,
+            "end": 1618290217242
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/network/1-users.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/LoadingIndicator.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289078688,
-            "end": 1618289078744
+            "start": 1618290217098,
+            "end": 1618290217254
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-x.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/greeting.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289078687,
-            "end": 1618289078742
+            "start": 1618290217099,
+            "end": 1618290217255
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/stateless-alert.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/component.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289078688,
-            "end": 1618289078743
+            "start": 1618290217099,
+            "end": 1618290217255
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/error-boundary.jsx",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-imports/services.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289078687,
-            "end": 1618289078739
+            "start": 1618290217099,
+            "end": 1618290217255
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/DropdownMenu.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/inlineLists/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081837,
-            "end": 1618289081883
+            "start": 1618290217557,
+            "end": 1618290217713
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/DropdownToggle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/withScriptjs.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081838,
-            "end": 1618289081884
+            "start": 1618290217640,
+            "end": 1618290217796
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FigureCaption.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/game-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081845,
-            "end": 1618289081891
+            "start": 1618290216670,
+            "end": 1618290216825
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/BootstrapModalManager.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/App.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081843,
-            "end": 1618289081888
+            "start": 1618290217098,
+            "end": 1618290217253
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalHeader.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/i18n/LocalizedComponent.tsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081844,
-            "end": 1618289081889
+            "start": 1618290217180,
+            "end": 1618290217335
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FigureImage.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/framer-motion/Motion.tsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081845,
-            "end": 1618289081890
+            "start": 1618290217181,
+            "end": 1618290217336
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLine/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081848,
-            "end": 1618289081893
+            "start": 1618290217556,
+            "end": 1618290217711
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaLists/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081843,
-            "end": 1618289081887
+            "start": 1618290217557,
+            "end": 1618290217712
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/warning/warning.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaListsAnd/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081862,
-            "end": 1618289081903
+            "start": 1618290217557,
+            "end": 1618290217712
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineCommaListsOr/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081865,
-            "end": 1618289081906
+            "start": 1618290217557,
+            "end": 1618290217712
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormCheckInput.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded-suspense/LazyComponent.tsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081859,
-            "end": 1618289081898
+            "start": 1618290217180,
+            "end": 1618290217334
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormFileLabel.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/styled-components/dist/styled-components.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081860,
-            "end": 1618289081899
+            "start": 1618290217484,
+            "end": 1618290217638
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types-extra/lib/all.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types/checkPropTypes.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081861,
-            "end": 1618289081900
+            "start": 1618290217546,
+            "end": 1618290217700
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_assocIndexOf.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/inlineArrayTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081867,
-            "end": 1618289081906
+            "start": 1618290217554,
+            "end": 1618290217708
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapCacheClear.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaListsAnd/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081868,
-            "end": 1618289081907
+            "start": 1618290217555,
+            "end": 1618290217709
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapCacheDelete.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaListsOr/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081868,
-            "end": 1618289081907
+            "start": 1618290217556,
+            "end": 1618290217710
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapCacheGet.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/source/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081868,
-            "end": 1618289081907
+            "start": 1618290217556,
+            "end": 1618290217710
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapCacheSet.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/safeHtml/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081869,
-            "end": 1618289081908
+            "start": 1618290217556,
+            "end": 1618290217710
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Feedback.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineTrim/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081858,
-            "end": 1618289081896
+            "start": 1618290217557,
+            "end": 1618290217711
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormCheckLabel.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/counter-set-state/counter.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081859,
-            "end": 1618289081897
+            "start": 1618290217085,
+            "end": 1618290217238
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormFileInput.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/pure-component.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081859,
-            "end": 1618289081897
+            "start": 1618290217086,
+            "end": 1618290217239
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapCacheHas.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/renderless/mouse-movement.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081869,
-            "end": 1618289081907
+            "start": 1618290217098,
+            "end": 1618290217251
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseGetAllKeys.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/window-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081872,
-            "end": 1618289081909
+            "start": 1618290217152,
+            "end": 1618290217305
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getSymbols.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/transpiled-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081873,
-            "end": 1618289081910
+            "start": 1618290217185,
+            "end": 1618290217338
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setCacheAdd.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/trimResultTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081873,
-            "end": 1618289081910
+            "start": 1618290217553,
+            "end": 1618290217706
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setCacheHas.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceStringTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081874,
-            "end": 1618289081910
+            "start": 1618290217554,
+            "end": 1618290217707
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/MoreHoriz.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/removeNonPrintingValuesTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081875,
-            "end": 1618289081911
+            "start": 1618290217554,
+            "end": 1618290217707
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayFilter.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/splitStringTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081917,
-            "end": 1618289081949
+            "start": 1618290217555,
+            "end": 1618290217708
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayPush.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/html/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081917,
-            "end": 1618289081948
+            "start": 1618290217555,
+            "end": 1618290217708
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/stubArray.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/codeBlock/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081918,
-            "end": 1618289081949
+            "start": 1618290217556,
+            "end": 1618290217709
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/querySelectorAll.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/hello-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081921,
-            "end": 1618289081952
+            "start": 1618290216670,
+            "end": 1618290216822
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useForceUpdate.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/counter-use-hooks/counter.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081921,
-            "end": 1618289081952
+            "start": 1618290217085,
+            "end": 1618290217237
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/Modal.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/emotion.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081905,
-            "end": 1618289081935
+            "start": 1618290217086,
+            "end": 1618290217238
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Hash.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/unmount/unmount-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081916,
-            "end": 1618289081946
+            "start": 1618290217164,
+            "end": 1618290217316
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getMapData.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceSubstitutionTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081916,
-            "end": 1618289081946
+            "start": 1618290217554,
+            "end": 1618290217706
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useMergedRefs.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/replaceResultTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081922,
-            "end": 1618289081952
+            "start": 1618290217554,
+            "end": 1618290217706
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/contains.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/commaLists/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081886,
-            "end": 1618289081915
+            "start": 1618290217555,
+            "end": 1618290217707
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/DropdownContext.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todos-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081944,
-            "end": 1618289081973
+            "start": 1618290216669,
+            "end": 1618290216820
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types-extra/lib/utils/createChainableTypeChecker.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Todos.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081914,
-            "end": 1618289081942
+            "start": 1618290217008,
+            "end": 1618290217159
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/hasClass.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/unmount/comp-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081925,
-            "end": 1618289081953
+            "start": 1618290217165,
+            "end": 1618290217316
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/useRootClose.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/TemplateTag/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081943,
-            "end": 1618289081971
+            "start": 1618290217553,
+            "end": 1618290217704
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/useWaitForDOMRef.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndentTransformer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081944,
-            "end": 1618289081972
+            "start": 1618290217554,
+            "end": 1618290217705
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/usePopper.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css/Button.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081943,
-            "end": 1618289081970
+            "start": 1618290217085,
+            "end": 1618290217235
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hashClear.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/testing-lib-example/fetcher.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081953,
-            "end": 1618289081979
+            "start": 1618290217098,
+            "end": 1618290217248
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hashDelete.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/runtime/api.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081954,
-            "end": 1618289081980
+            "start": 1618290217160,
+            "end": 1618290217310
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hashHas.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/use-render/my-component-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081954,
-            "end": 1618289081980
+            "start": 1618290217164,
+            "end": 1618290217314
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isKeyable.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/use-lodash-fp/lodash-fp-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081955,
-            "end": 1618289081981
+            "start": 1618290217164,
+            "end": 1618290217314
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/enzyme/simple-component.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217083,
+            "end": 1618290217232
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css-modules/Button.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217084,
+            "end": 1618290217233
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mobx-v6/timer-view.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217164,
+            "end": 1618290217313
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react/cjs/react.development.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217244,
+            "end": 1618290217393
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/typescript/ts-spec.tsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217174,
+            "end": 1618290217322
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/thinking-in-components/Todo-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216669,
+            "end": 1618290216816
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/app-action-example/counter.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217081,
+            "end": 1618290217228
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/context/App.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217082,
+            "end": 1618290217229
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormGroup.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219604,
+            "end": 1618290219751
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Switch.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219604,
+            "end": 1618290219751
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/jsx-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216669,
+            "end": 1618290216815
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Breadcrumbs/Breadcrumbs.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219603,
+            "end": 1618290219749
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/AbstractNavItem.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219633,
+            "end": 1618290219779
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Carousel.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219631,
+            "end": 1618290219776
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/usePopperMarginModifiers.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219634,
+            "end": 1618290219779
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-book-by-chris-noring/components-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216669,
+            "end": 1618290216813
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/context/Toolbar.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217081,
+            "end": 1618290217225
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/popmotion/dist/popmotion.es.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218299,
+            "end": 1618290218443
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Card/Card.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219602,
+            "end": 1618290219746
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CardGroup.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219633,
+            "end": 1618290219777
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/no-visit/spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216668,
+            "end": 1618290216811
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/DropdownButton.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219631,
+            "end": 1618290219774
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Col.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219631,
+            "end": 1618290219774
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CardDeck.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219638,
+            "end": 1618290219781
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/re-render/spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216668,
+            "end": 1618290216810
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardActionArea/CardActionArea.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219603,
+            "end": 1618290219745
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormCheck.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219618,
+            "end": 1618290219760
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/BottomNavigation/BottomNavigation.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219621,
+            "end": 1618290219763
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Badge/Badge.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219624,
+            "end": 1618290219766
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Backdrop/Backdrop.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219626,
+            "end": 1618290219768
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Hidden/HiddenJs.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219630,
+            "end": 1618290219772
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CarouselItem.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219631,
+            "end": 1618290219773
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CardImg.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219638,
+            "end": 1618290219780
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/forward-ref/forward-ref.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217081,
+            "end": 1618290217222
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/utils.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218005,
+            "end": 1618290218146
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/BottomNavigationAction/BottomNavigationAction.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219620,
+            "end": 1618290219761
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/network/2-users-fetch-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216668,
+            "end": 1618290216808
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/hooks/counter-with-hooks.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217081,
+            "end": 1618290217221
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/toggle-example/toggle.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217380,
+            "end": 1618290217520
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Form.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219618,
+            "end": 1618290219758
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Hidden/HiddenCss.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219630,
+            "end": 1618290219770
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonGroup/ButtonGroup.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219603,
+            "end": 1618290219742
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/DropdownItem.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219618,
+            "end": 1618290219757
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/mount-div/spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216668,
+            "end": 1618290216806
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/hooks/counter2-with-hooks.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217081,
+            "end": 1618290217219
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Chip/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218012,
+            "end": 1618290218150
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormFile.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219617,
+            "end": 1618290219755
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormControl.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219618,
+            "end": 1618290219756
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/network/1-users-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216668,
+            "end": 1618290216805
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/CheckBoxOutlineBlank.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217374,
+            "end": 1618290217511
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/Favorite.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217375,
+            "end": 1618290217512
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218010,
+            "end": 1618290218147
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/IconButton/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218012,
+            "end": 1618290218149
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/popper.js/dist/esm/popper.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218567,
+            "end": 1618290218704
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hashGet.js",
@@ -12083,332 +3433,1925 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081954,
-            "end": 1618289081979
+            "start": 1618290219539,
+            "end": 1618290219676
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hashSet.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types-extra/lib/isRequiredForA11y.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081955,
-            "end": 1618289081980
+            "start": 1618290219647,
+            "end": 1618290219784
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/scrollbarSize.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Avatar/Avatar.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081894,
-            "end": 1618289081918
+            "start": 1618290219648,
+            "end": 1618290219785
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/popper.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/Drafts.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081943,
-            "end": 1618289081967
+            "start": 1618290217374,
+            "end": 1618290217510
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/Dropdown.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/CheckBox.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081905,
-            "end": 1618289081927
+            "start": 1618290217374,
+            "end": 1618290217510
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/ModalManager.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/FavoriteBorder.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081939,
-            "end": 1618289081961
+            "start": 1618290217375,
+            "end": 1618290217511
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/safeFindDOMNode.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Paper/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081905,
-            "end": 1618289081926
+            "start": 1618290218014,
+            "end": 1618290218150
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/DropdownToggle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Table.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081937,
-            "end": 1618289081957
+            "start": 1618290219365,
+            "end": 1618290219501
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/DropdownMenu.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ButtonGroup.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081938,
-            "end": 1618289081958
+            "start": 1618290219540,
+            "end": 1618290219676
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/ownerDocument.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Image.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081978,
-            "end": 1618289081998
+            "start": 1618290219597,
+            "end": 1618290219733
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getDocumentElement.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormText.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082020,
-            "end": 1618289082040
+            "start": 1618290219598,
+            "end": 1618290219734
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/isWindow.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormLabel.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082021,
-            "end": 1618289082041
+            "start": 1618290219598,
+            "end": 1618290219734
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/Overlay.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavbarContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081904,
-            "end": 1618289081923
+            "start": 1618290219653,
+            "end": 1618290219789
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/computeAutoPlacement.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/fails-correctly/spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082017,
-            "end": 1618289082036
+            "start": 1618290216667,
+            "end": 1618290216802
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/computeOffsets.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counter/Counter.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082018,
-            "end": 1618289082037
+            "start": 1618290217080,
+            "end": 1618290217215
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getAltAxis.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/Rating/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082018,
-            "end": 1618289082037
+            "start": 1618290217347,
+            "end": 1618290217482
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/contains.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/icons/Inbox.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082019,
-            "end": 1618289082038
+            "start": 1618290217374,
+            "end": 1618290217509
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/instanceOf.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hashHas.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082019,
-            "end": 1618289082038
+            "start": 1618290219532,
+            "end": 1618290219667
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getWindow.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Fade.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082020,
-            "end": 1618289082039
+            "start": 1618290219539,
+            "end": 1618290219674
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getOffsetParent.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ElementChildren.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082020,
-            "end": 1618289082039
+            "start": 1618290219543,
+            "end": 1618290219678
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getComputedStyle.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardActions/CardActions.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082021,
-            "end": 1618289082040
+            "start": 1618290219596,
+            "end": 1618290219731
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/within.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Container.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082015,
-            "end": 1618289082033
+            "start": 1618290219598,
+            "end": 1618290219733
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getOppositePlacement.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/withTheme.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082016,
-            "end": 1618289082034
+            "start": 1618290217333,
+            "end": 1618290217467
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/math.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/unmount/comp.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082016,
-            "end": 1618289082034
+            "start": 1618290217341,
+            "end": 1618290217475
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/detectOverflow.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/Autocomplete/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082017,
-            "end": 1618289082035
+            "start": 1618290217348,
+            "end": 1618290217482
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getVariation.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ToggleButton.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082018,
-            "end": 1618289082036
+            "start": 1618290219360,
+            "end": 1618290219494
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getFreshSideObject.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/TabPane.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082019,
-            "end": 1618289082037
+            "start": 1618290219365,
+            "end": 1618290219499
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getLayoutRect.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Drawer/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082019,
-            "end": 1618289082037
+            "start": 1618290219369,
+            "end": 1618290219503
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/useWrappedRefWithWarning.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Modal/TrapFocus.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081903,
-            "end": 1618289081920
+            "start": 1618290219532,
+            "end": 1618290219666
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/createPopper.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/createWithBsPrefix.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082013,
-            "end": 1618289082030
+            "start": 1618290219537,
+            "end": 1618290219671
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getMainAxisFromPlacement.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Dialog/Dialog.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082015,
-            "end": 1618289082032
+            "start": 1618290219571,
+            "end": 1618290219705
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/mergePaddingObject.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/1-users.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082016,
-            "end": 1618289082033
+            "start": 1618290217079,
+            "end": 1618290217212
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/expandToHashMap.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counters/Counters.jsx",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082016,
-            "end": 1618289082033
+            "start": 1618290217080,
+            "end": 1618290217213
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getOppositeVariationPlacement.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/transitions.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082017,
-            "end": 1618289082034
+            "start": 1618290217332,
+            "end": 1618290217465
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/offset.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/withStyles.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081993,
-            "end": 1618289082009
+            "start": 1618290217333,
+            "end": 1618290217466
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/preventOverflow.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/Autocomplete/Autocomplete.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081994,
-            "end": 1618289082010
+            "start": 1618290217523,
+            "end": 1618290217656
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/matches.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SwipeableDrawer/SwipeableDrawer.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081975,
-            "end": 1618289081990
+            "start": 1618290219153,
+            "end": 1618290219286
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MenuList/MenuList.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219349,
+            "end": 1618290219482
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Tooltip.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219358,
+            "end": 1618290219491
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemSecondaryAction/ListItemSecondaryAction.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219362,
+            "end": 1618290219495
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardHeader/CardHeader.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219594,
+            "end": 1618290219727
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/enzyme/state-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216667,
+            "end": 1618290216799
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217291,
+            "end": 1618290217423
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/styled.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217332,
+            "end": 1618290217464
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/useTheme.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217333,
+            "end": 1618290217465
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/use-render/my-component.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217341,
+            "end": 1618290217473
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/extends.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217533,
+            "end": 1618290217665
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/objectWithoutProperties.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217534,
+            "end": 1618290217666
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ToggleButtonGroup.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219359,
+            "end": 1618290219491
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Tabs.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219361,
+            "end": 1618290219493
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Modal/SimpleBackdrop.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219532,
+            "end": 1618290219664
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/responsiveFontSizes.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217332,
+            "end": 1618290217463
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/defineProperty.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217535,
+            "end": 1618290217666
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/forEach.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218286,
+            "end": 1618290218417
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Figure.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219594,
+            "end": 1618290219725
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardContent/CardContent.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219594,
+            "end": 1618290219725
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/divWithClassName.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219663,
+            "end": 1618290219794
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createStyles.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217332,
+            "end": 1618290217462
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/makeStyles.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217332,
+            "end": 1618290217462
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/transpiled.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217361,
+            "end": 1618290217491
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createTypography.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217532,
+            "end": 1618290217662
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_classof.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219358,
+            "end": 1618290219488
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavItem.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219457,
+            "end": 1618290219587
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardMedia/CardMedia.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219593,
+            "end": 1618290219723
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/AbstractNav.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219662,
+            "end": 1618290219792
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/enzyme/props-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216667,
+            "end": 1618290216796
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/3-users-api.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217079,
+            "end": 1618290217208
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createMuiTheme.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217332,
+            "end": 1618290217461
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/shadows.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217531,
+            "end": 1618290217660
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/recompose/es/Recompose.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218349,
+            "end": 1618290218478
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Modal/ModalManager.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219340,
+            "end": 1618290219469
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ToastBody.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219356,
+            "end": 1618290219485
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Toast.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219358,
+            "end": 1618290219487
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/TabContent.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219381,
+            "end": 1618290219510
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Tab.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219381,
+            "end": 1618290219510
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Container/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219383,
+            "end": 1618290219512
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ClickAwayListener/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219383,
+            "end": 1618290219512
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Collapse/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219384,
+            "end": 1618290219513
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CircularProgress/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219384,
+            "end": 1618290219513
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemAvatar/ListItemAvatar.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219385,
+            "end": 1618290219514
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/SplitButton.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219387,
+            "end": 1618290219516
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavDropdown.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219457,
+            "end": 1618290219586
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ListGroup.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219590,
+            "end": 1618290219719
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/InputGroup.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219592,
+            "end": 1618290219721
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/colorManipulator.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217331,
+            "end": 1618290217459
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/lodash/fp.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217394,
+            "end": 1618290217522
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/createSpacing.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217529,
+            "end": 1618290217657
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/shape.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217529,
+            "end": 1618290217657
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Chip/Chip.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218273,
+            "end": 1618290218401
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanel/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219342,
+            "end": 1618290219470
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogContentText/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219376,
+            "end": 1618290219504
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogContent/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219377,
+            "end": 1618290219505
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogActions/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219377,
+            "end": 1618290219505
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Dialog/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219377,
+            "end": 1618290219505
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CssBaseline/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219378,
+            "end": 1618290219506
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/TabContainer.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219381,
+            "end": 1618290219509
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ResponsiveEmbed.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219398,
+            "end": 1618290219526
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Hidden/Hidden.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219446,
+            "end": 1618290219574
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Backdrop/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219447,
+            "end": 1618290219575
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavLink.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219456,
+            "end": 1618290219584
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Overlay.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219457,
+            "end": 1618290219585
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavbarBrand.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219457,
+            "end": 1618290219585
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ListGroupItem.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219589,
+            "end": 1618290219717
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Jumbotron.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219592,
+            "end": 1618290219720
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/AppBar/AppBar.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219662,
+            "end": 1618290219790
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Slide/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219161,
+            "end": 1618290219288
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RadioGroup/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219162,
+            "end": 1618290219289
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Slider/Slider.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219316,
+            "end": 1618290219443
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Popover/Popover.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219328,
+            "end": 1618290219455
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogTitle/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219377,
+            "end": 1618290219504
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardMedia/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219398,
+            "end": 1618290219525
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/Warning.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219439,
+            "end": 1618290219566
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/OverlayTrigger.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219456,
+            "end": 1618290219583
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Avatar/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219465,
+            "end": 1618290219592
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanel/ExpansionPanel.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219525,
+            "end": 1618290219652
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/mocking-axios/2-users-named.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217079,
+            "end": 1618290217205
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/lab/esm/Rating/Rating.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217523,
+            "end": 1618290217649
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/invariant/browser.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218298,
+            "end": 1618290218424
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RootRef/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219162,
+            "end": 1618290219288
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Radio/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219162,
+            "end": 1618290219288
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-assign.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219172,
+            "end": 1618290219298
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapCacheSet.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219178,
+            "end": 1618290219304
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MobileStepper/MobileStepper.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219338,
+            "end": 1618290219464
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Row.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219396,
+            "end": 1618290219522
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-absolute-index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219397,
+            "end": 1618290219523
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/KeyboardArrowLeft.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219405,
+            "end": 1618290219531
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/BottomNavigation/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219445,
+            "end": 1618290219571
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Badge/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219447,
+            "end": 1618290219573
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalTitle.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219472,
+            "end": 1618290219598
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/TabContext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219556,
+            "end": 1618290219682
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/enzyme/context-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216666,
+            "end": 1618290216791
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputLabel/InputLabel.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217331,
+            "end": 1618290217456
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/style-value-types/dist/style-value-types.es.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218298,
+            "end": 1618290218423
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/hey-listen/dist/hey-listen.es.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218299,
+            "end": 1618290218424
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/reduce.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218303,
+            "end": 1618290218428
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/NativeSelect/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219173,
+            "end": 1618290219298
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isMasked.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219174,
+            "end": 1618290219299
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Popover/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219177,
+            "end": 1618290219302
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelSummary/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219335,
+            "end": 1618290219460
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Modal/Modal.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219338,
+            "end": 1618290219463
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardContent/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219401,
+            "end": 1618290219526
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardActions/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219402,
+            "end": 1618290219527
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/PopoverTitle.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219405,
+            "end": 1618290219530
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/BottomNavigationAction/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219444,
+            "end": 1618290219569
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/AppBar/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219471,
+            "end": 1618290219596
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Nav.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219472,
+            "end": 1618290219597
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelActions/ExpansionPanelActions.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219521,
+            "end": 1618290219646
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/getScrollbarSize.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219524,
+            "end": 1618290219649
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Button.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219553,
+            "end": 1618290219678
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CardContext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219670,
+            "end": 1618290219795
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/document/document-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216666,
+            "end": 1618290216790
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/tutorial/shopping-list.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217078,
+            "end": 1618290217202
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-router-v6/app.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217078,
+            "end": 1618290217202
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/framesync/dist/framesync.es.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218303,
+            "end": 1618290218427
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapCacheClear.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219175,
+            "end": 1618290219299
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelDetails/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219336,
+            "end": 1618290219460
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelActions/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219338,
+            "end": 1618290219462
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Spinner.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219395,
+            "end": 1618290219519
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardHeader/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219402,
+            "end": 1618290219526
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/KeyboardArrowRight.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219404,
+            "end": 1618290219528
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ProgressBar.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219405,
+            "end": 1618290219529
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/PopoverContent.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219405,
+            "end": 1618290219529
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Popover.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219406,
+            "end": 1618290219530
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Icon/Icon.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219438,
+            "end": 1618290219562
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Pagination.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219443,
+            "end": 1618290219567
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/PageItem.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219444,
+            "end": 1618290219568
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Navbar.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219471,
+            "end": 1618290219595
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormHelperText/FormHelperText.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217331,
+            "end": 1618290217454
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/tslib/tslib.es6.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218281,
+            "end": 1618290218404
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Slider/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219158,
+            "end": 1618290219281
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Fade/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219335,
+            "end": 1618290219458
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Fab/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219335,
+            "end": 1618290219458
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/SafeAnchor.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219396,
+            "end": 1618290219519
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputAdornment/InputAdornment.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219437,
+            "end": 1618290219560
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/CheckCircle.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219443,
+            "end": 1618290219566
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelDetails/ExpansionPanelDetails.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219517,
+            "end": 1618290219640
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Menu/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219184,
+            "end": 1618290219306
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Link/Link.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219420,
+            "end": 1618290219542
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayPush.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219436,
+            "end": 1618290219558
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/stubArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219438,
+            "end": 1618290219560
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanelSummary/ExpansionPanelSummary.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219517,
+            "end": 1618290219639
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/tutorial/tic-tac-toe.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217078,
+            "end": 1618290217199
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@bahmutov/cy-api/support.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217229,
+            "end": 1618290217350
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControl/FormControl.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217330,
+            "end": 1618290217451
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControl/useFormControl.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217331,
+            "end": 1618290217452
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/cssUtils.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217529,
+            "end": 1618290217650
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/zIndex.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217529,
+            "end": 1618290217650
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Uint8Array.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219158,
+            "end": 1618290219279
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/ownerDocument.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219188,
+            "end": 1618290219309
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/LinearProgress/LinearProgress.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219420,
+            "end": 1618290219541
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayFilter.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219437,
+            "end": 1618290219558
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/is-prop-valid/dist/is-prop-valid.browser.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218044,
+            "end": 1618290218164
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218045,
+            "end": 1618290218165
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Step/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219141,
+            "end": 1618290219261
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Card/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219418,
+            "end": 1618290219538
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Breadcrumbs/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219419,
+            "end": 1618290219539
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Fade/Fade.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219516,
+            "end": 1618290219636
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Fab/Fab.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219517,
+            "end": 1618290219637
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Dropdown.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219581,
+            "end": 1618290219701
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css-modules/css-modules-orange-button-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216666,
+            "end": 1618290216785
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css/css-orange-button-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216666,
+            "end": 1618290216785
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/lowerFirst.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218278,
+            "end": 1618290218397
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_toSource.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219134,
+            "end": 1618290219253
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/is-in-browser/dist/module.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219136,
+            "end": 1618290219255
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SnackbarContent/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219141,
+            "end": 1618290219260
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_cacheHas.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219142,
+            "end": 1618290219261
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CardActionArea/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219419,
+            "end": 1618290219538
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonGroup/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219419,
+            "end": 1618290219538
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hashDelete.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219572,
+            "end": 1618290219691
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Collapse/Collapse.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219576,
+            "end": 1618290219695
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CircularProgress/CircularProgress.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219577,
+            "end": 1618290219696
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalHeader.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219680,
+            "end": 1618290219799
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/RadioButtonUnchecked.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219681,
+            "end": 1618290219800
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalContext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219681,
+            "end": 1618290219800
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_nativeCreate.js",
@@ -12416,161 +5359,6767 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081987,
-            "end": 1618289082002
+            "start": 1618290219682,
+            "end": 1618290219801
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/flip.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/counter-set-state/counter-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081993,
-            "end": 1618289082008
+            "start": 1618290216665,
+            "end": 1618290216783
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/hide.js",
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/counter-use-hooks/counter-hooks-spec.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081993,
-            "end": 1618289082008
+            "start": 1618290216666,
+            "end": 1618290216784
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/popperOffsets.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MenuItem/MenuItem.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081994,
-            "end": 1618289082009
+            "start": 1618290217330,
+            "end": 1618290217448
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useSafeState.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/setRef.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081999,
-            "end": 1618289082014
+            "start": 1618290218277,
+            "end": 1618290218395
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/isDocument.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/ownerDocument.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082048,
-            "end": 1618289082063
+            "start": 1618290218277,
+            "end": 1618290218395
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useCallbackRef.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/deprecatedPropType.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081975,
-            "end": 1618289081989
+            "start": 1618290218278,
+            "end": 1618290218396
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/isOverflowing.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Set.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081976,
-            "end": 1618289081990
+            "start": 1618290219138,
+            "end": 1618290219256
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/manageAriaHidden.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getAllKeys.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081976,
-            "end": 1618289081990
+            "start": 1618290219139,
+            "end": 1618290219257
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/activeElement.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setToArray.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081977,
-            "end": 1618289081991
+            "start": 1618290219139,
+            "end": 1618290219257
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/computeStyles.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepButton/index.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081992,
-            "end": 1618289082006
+            "start": 1618290219140,
+            "end": 1618290219258
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/eventListeners.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/hash/dist/hash.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081993,
-            "end": 1618289082007
+            "start": 1618290219147,
+            "end": 1618290219265
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/addClass.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/weak-memoize/dist/weak-memoize.browser.esm.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081997,
-            "end": 1618289082011
+            "start": 1618290219154,
+            "end": 1618290219272
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getBasePlacement.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Stepper/Stepper.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082015,
-            "end": 1618289082029
+            "start": 1618290219155,
+            "end": 1618290219273
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/usePrevious.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RadioGroup/RadioGroupContext.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081976,
-            "end": 1618289081989
+            "start": 1618290219483,
+            "end": 1618290219601
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/enums.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogContent/DialogContent.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081991,
-            "end": 1618289082004
+            "start": 1618290219570,
+            "end": 1618290219688
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/arrow.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogActions/DialogActions.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081992,
-            "end": 1618289082005
+            "start": 1618290219571,
+            "end": 1618290219689
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/popper-base.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/CssBaseline/CssBaseline.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081992,
-            "end": 1618289082005
+            "start": 1618290219571,
+            "end": 1618290219689
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Container/Container.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219575,
+            "end": 1618290219693
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ClickAwayListener/ClickAwayListener.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219576,
+            "end": 1618290219694
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/RadioButtonChecked.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219680,
+            "end": 1618290219798
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/ownerWindow.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218277,
+            "end": 1618290218394
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/isMuiElement.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218277,
+            "end": 1618290218394
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepConnector/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219134,
+            "end": 1618290219251
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Promise.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219139,
+            "end": 1618290219256
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_SetCache.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219140,
+            "end": 1618290219257
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getMapData.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219329,
+            "end": 1618290219446
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridList/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219330,
+            "end": 1618290219447
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Grid/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219330,
+            "end": 1618290219447
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hashSet.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219515,
+            "end": 1618290219632
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/alias/alias-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216665,
+            "end": 1618290216781
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Popper/Popper.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218276,
+            "end": 1618290218392
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/requirePropFactory.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218277,
+            "end": 1618290218393
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_LodashWrapper.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219133,
+            "end": 1618290219249
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arraySome.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219150,
+            "end": 1618290219266
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_cof.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219150,
+            "end": 1618290219266
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapToArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219150,
+            "end": 1618290219266
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Switch/Switch.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219152,
+            "end": 1618290219268
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridListTileBar/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219328,
+            "end": 1618290219444
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridListTile/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219329,
+            "end": 1618290219445
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridListTile/GridListTile.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219507,
+            "end": 1618290219623
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Grid/Grid.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219511,
+            "end": 1618290219627
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Slider/ValueLabel.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219512,
+            "end": 1618290219628
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogTitle/DialogTitle.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219569,
+            "end": 1618290219685
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/DialogContentText/DialogContentText.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219570,
+            "end": 1618290219686
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/stateless-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216665,
+            "end": 1618290216780
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Select/Select.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217330,
+            "end": 1618290217445
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListSubheader/ListSubheader.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218276,
+            "end": 1618290218391
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_realNames.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219133,
+            "end": 1618290219248
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Snackbar/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219150,
+            "end": 1618290219265
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridListTileBar/GridListTileBar.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219504,
+            "end": 1618290219619
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isKeyable.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219508,
+            "end": 1618290219623
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/pure-component.spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216664,
+            "end": 1618290216778
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/before-hook/spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216665,
+            "end": 1618290216779
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Popper/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218040,
+            "end": 1618290218154
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/clsx/dist/clsx.m.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218041,
+            "end": 1618290218155
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/IconButton/IconButton.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218272,
+            "end": 1618290218386
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Paper/Paper.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218274,
+            "end": 1618290218388
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Media.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219501,
+            "end": 1618290219615
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hashClear.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219502,
+            "end": 1618290219616
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/GridList/GridList.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219511,
+            "end": 1618290219625
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-x-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216664,
+            "end": 1618290216777
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/use-local-storage/App.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217078,
+            "end": 1618290217191
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListSubheader/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218040,
+            "end": 1618290218153
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/iterableToArrayLimit.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218043,
+            "end": 1618290218156
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalBody.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219497,
+            "end": 1618290219610
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Grow/Grow.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219499,
+            "end": 1618290219612
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseLodash.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219131,
+            "end": 1618290219243
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_wrapperClone.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219133,
+            "end": 1618290219245
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalFooter.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219496,
+            "end": 1618290219608
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ModalDialog.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219496,
+            "end": 1618290219608
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Modal.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219497,
+            "end": 1618290219609
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-world-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216664,
+            "end": 1618290216775
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/useMediaQuery/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218347,
+            "end": 1618290218458
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Radio/RadioButtonIcon.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219496,
+            "end": 1618290219607
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/full-navigation-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216663,
+            "end": 1618290216773
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-world-inline-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216664,
+            "end": 1618290216774
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/style-loader/lib/urls.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217245,
+            "end": 1618290217355
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/bind.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218270,
+            "end": 1618290218380
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/arrayLikeToArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218271,
+            "end": 1618290218381
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isFunction.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218322,
+            "end": 1618290218432
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SvgIcon/SvgIcon.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218326,
+            "end": 1618290218436
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/createSvgIcon.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218351,
+            "end": 1618290218461
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/stylis/dist/stylis.browser.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218389,
+            "end": 1618290218499
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_DataView.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219130,
+            "end": 1618290219240
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/has.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218271,
+            "end": 1618290218380
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/object/define-property.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218337,
+            "end": 1618290218446
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/typeof.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218338,
+            "end": 1618290218447
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/can-use-dom/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218343,
+            "end": 1618290218452
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/scriptjs/dist/script.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218345,
+            "end": 1618290218454
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/iterableToArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218377,
+            "end": 1618290218486
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Grow/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219326,
+            "end": 1618290219435
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_coreJsData.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219327,
+            "end": 1618290219436
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Hash.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219327,
+            "end": 1618290219436
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-act-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216663,
+            "end": 1618290216771
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/styles/style/style-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217243,
+            "end": 1618290217351
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217514,
+            "end": 1618290217622
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/styles/defaultTheme.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217515,
+            "end": 1618290217623
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/object/create.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218354,
+            "end": 1618290218462
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/nonIterableSpread.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218377,
+            "end": 1618290218485
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MobileStepper/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219203,
+            "end": 1618290219311
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useTimeout.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219697,
+            "end": 1618290219805
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217318,
+            "end": 1618290217425
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Button/Button.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217483,
+            "end": 1618290217590
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/object/set-prototype-of.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218339,
+            "end": 1618290218446
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/arrayWithoutHoles.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218367,
+            "end": 1618290218474
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/unsupportedIterableToArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218377,
+            "end": 1618290218484
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/node_modules/scheduler/tracing.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218378,
+            "end": 1618290218485
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Modal/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219203,
+            "end": 1618290219310
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapCacheHas.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219204,
+            "end": 1618290219311
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/webpack-dev-server/dist/aut-runner.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216648,
+            "end": 1618290216754
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/emotion-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216662,
+            "end": 1618290216768
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218364,
+            "end": 1618290218470
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/responsivePropType.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218366,
+            "end": 1618290218472
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/typeof.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218367,
+            "end": 1618290218473
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tabs/Tabs.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219112,
+            "end": 1618290219218
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217431,
+            "end": 1618290217536
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/useTranslation.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217503,
+            "end": 1618290217608
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/slicedToArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218358,
+            "end": 1618290218463
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/memoize.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218364,
+            "end": 1618290218469
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/system/esm/merge.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218366,
+            "end": 1618290218471
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/shallowequal/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218376,
+            "end": 1618290218481
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/AddTodo.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217324,
+            "end": 1618290217428
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/radioactive-state/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217429,
+            "end": 1618290217533
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/Trans.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217490,
+            "end": 1618290217594
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/node_modules/scheduler/cjs/scheduler.development.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218582,
+            "end": 1618290218686
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tooltip/Tooltip.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219109,
+            "end": 1618290219213
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/support/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216662,
+            "end": 1618290216765
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/error-boundary-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216663,
+            "end": 1618290216766
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/Todo.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217324,
+            "end": 1618290217427
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/alert-spec.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216662,
+            "end": 1618290216764
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/setPrototypeOf.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218078,
+            "end": 1618290218180
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/Translation.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217503,
+            "end": 1618290217604
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/unitless/dist/unitless.browser.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218389,
+            "end": 1618290218490
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/withTranslation.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217503,
+            "end": 1618290217603
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/getStylesCreator/getStylesCreator.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218933,
+            "end": 1618290219033
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/getComputedStyle.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218935,
+            "end": 1618290219035
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_wks-define.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218937,
+            "end": 1618290219037
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/isTransform.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218938,
+            "end": 1618290219038
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseTrim.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218938,
+            "end": 1618290219038
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIndexOf.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218944,
+            "end": 1618290219044
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapCacheGet.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219213,
+            "end": 1618290219313
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217487,
+            "end": 1618290217586
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-dps.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218928,
+            "end": 1618290219027
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_library.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218934,
+            "end": 1618290219033
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-lifecycles-compat/react-lifecycles-compat.es.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218943,
+            "end": 1618290219042
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Drawer/Drawer.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219318,
+            "end": 1618290219417
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ExpansionPanel/ExpansionPanelContext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219708,
+            "end": 1618290219807
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/I18nextProvider.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217502,
+            "end": 1618290217600
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/Transition.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218518,
+            "end": 1618290218616
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/amber.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218547,
+            "end": 1618290218645
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Portal/Portal.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218675,
+            "end": 1618290218773
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/memoize.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218925,
+            "end": 1618290219023
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepContent/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219129,
+            "end": 1618290219227
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mapCacheDelete.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219215,
+            "end": 1618290219313
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/brown.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218547,
+            "end": 1618290218644
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/deepOrange.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218547,
+            "end": 1618290218644
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/yellow.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218548,
+            "end": 1618290218645
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_castPath.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218570,
+            "end": 1618290218667
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setWrapToString.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218587,
+            "end": 1618290218684
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setData.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218592,
+            "end": 1618290218689
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonBase/ButtonBase.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218619,
+            "end": 1618290218716
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/object/assign.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218924,
+            "end": 1618290219021
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getNative.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218925,
+            "end": 1618290219022
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tab/Tab.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219127,
+            "end": 1618290219224
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepIcon/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219129,
+            "end": 1618290219226
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SwipeableDrawer/SwipeArea.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219318,
+            "end": 1618290219415
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/context.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217501,
+            "end": 1618290217597
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/useSSR.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217501,
+            "end": 1618290217597
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-i18next/dist/es/withSSR.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217502,
+            "end": 1618290217598
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/blueGrey.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218547,
+            "end": 1618290218643
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/lime.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218552,
+            "end": 1618290218648
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/lightGreen.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218553,
+            "end": 1618290218649
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/teal.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218561,
+            "end": 1618290218657
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/cyan.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218563,
+            "end": 1618290218659
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/purple.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218569,
+            "end": 1618290218665
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/identity.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218570,
+            "end": 1618290218666
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setToString.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218570,
+            "end": 1618290218666
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_castSlice.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218576,
+            "end": 1618290218672
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_dom-create.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218923,
+            "end": 1618290219019
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_enum-bug-keys.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218925,
+            "end": 1618290219021
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RadioGroup/RadioGroup.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219317,
+            "end": 1618290219413
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RadioGroup/useRadioGroup.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219318,
+            "end": 1618290219414
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/js-beautify/js/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217486,
+            "end": 1618290217581
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseRest.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218437,
+            "end": 1618290218532
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hasPath.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218438,
+            "end": 1618290218533
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Portal/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218545,
+            "end": 1618290218640
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/lightBlue.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218565,
+            "end": 1618290218660
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Collapse.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218567,
+            "end": 1618290218662
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/deepPurple.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218569,
+            "end": 1618290218664
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_toKey.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218575,
+            "end": 1618290218670
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/toString.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218578,
+            "end": 1618290218673
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/toInteger.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218585,
+            "end": 1618290218680
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createAssigner.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218920,
+            "end": 1618290219015
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_copyObject.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218920,
+            "end": 1618290219015
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/cache/dist/cache.browser.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218923,
+            "end": 1618290219018
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepLabel/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219127,
+            "end": 1618290219222
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Radio/Radio.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219317,
+            "end": 1618290219412
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-is/cjs/react-is.development.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218090,
+            "end": 1618290218184
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseHas.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218438,
+            "end": 1618290218532
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/withGoogleMap.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218541,
+            "end": 1618290218635
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useEventCallback.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218566,
+            "end": 1618290218660
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stringToArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218580,
+            "end": 1618290218674
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_hasUnicode.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218581,
+            "end": 1618290218675
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseForOwn.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218585,
+            "end": 1618290218679
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseSetData.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218585,
+            "end": 1618290218679
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/@emotion/utils/dist/utils.browser.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218919,
+            "end": 1618290219013
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsArguments.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218921,
+            "end": 1618290219015
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/MenuList/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219221,
+            "end": 1618290219315
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/RootRef/RootRef.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219317,
+            "end": 1618290219411
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ToastHeader.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217483,
+            "end": 1618290217576
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SvgIcon/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218096,
+            "end": 1618290218189
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isLength.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218584,
+            "end": 1618290218677
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isIndex.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218584,
+            "end": 1618290218677
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/createChainedFunction.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218697,
+            "end": 1618290218790
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Slide/Slide.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219317,
+            "end": 1618290219410
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217307,
+            "end": 1618290217399
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Typography/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217307,
+            "end": 1618290217399
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TextField/TextField.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217483,
+            "end": 1618290217575
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/AccordionContext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218433,
+            "end": 1618290218525
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/AccordionCollapse.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218435,
+            "end": 1618290218527
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayReduce.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218466,
+            "end": 1618290218558
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/GoogleMap.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218541,
+            "end": 1618290218633
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/uncontrollable/lib/esm/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218613,
+            "end": 1618290218705
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Input/Input.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218668,
+            "end": 1618290218760
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/TransitionGroupContext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218669,
+            "end": 1618290218761
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/triggerBrowserReflow.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218697,
+            "end": 1618290218789
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_html.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218910,
+            "end": 1618290219002
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_assignValue.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218910,
+            "end": 1618290219002
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/serialize/dist/serialize.browser.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218918,
+            "end": 1618290219010
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/NoSsr/NoSsr.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218955,
+            "end": 1618290219047
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/hyphenateStyle.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218957,
+            "end": 1618290219049
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputBase/InputBase.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218989,
+            "end": 1618290219081
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItem/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217309,
+            "end": 1618290217400
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Button/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217309,
+            "end": 1618290217400
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TextField/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217309,
+            "end": 1618290217400
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/createChainedFunction.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218448,
+            "end": 1618290218539
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/SelectableContext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218460,
+            "end": 1618290218551
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/AccordionToggle.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218463,
+            "end": 1618290218554
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/node_modules/scheduler/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218468,
+            "end": 1618290218559
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/createGenerateClassName/createGenerateClassName.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218654,
+            "end": 1618290218745
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createCurry.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218656,
+            "end": 1618290218747
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/recompose/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218659,
+            "end": 1618290218750
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FilledInput/FilledInput.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218667,
+            "end": 1618290218758
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss/dist/jss.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218860,
+            "end": 1618290218951
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/css/dist/css.browser.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218910,
+            "end": 1618290219001
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isPrototype.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218911,
+            "end": 1618290219002
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/@emotion/sheet/dist/sheet.browser.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218912,
+            "end": 1618290219003
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/array/from.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218958,
+            "end": 1618290219049
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItem/ListItem.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217483,
+            "end": 1618290217573
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createCaseFirst.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218451,
+            "end": 1618290218541
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/Cancel.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218453,
+            "end": 1618290218543
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_castFunction.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218459,
+            "end": 1618290218549
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseEach.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218459,
+            "end": 1618290218549
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createWrap.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218460,
+            "end": 1618290218550
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseGetTag.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218473,
+            "end": 1618290218563
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/Marker.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218536,
+            "end": 1618290218626
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/Circle.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218538,
+            "end": 1618290218628
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/getThemeProps/getThemeProps.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218617,
+            "end": 1618290218707
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.create.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218646,
+            "end": 1618290218736
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/kind-of/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218655,
+            "end": 1618290218745
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/normalizeHeaderName.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218656,
+            "end": 1618290218746
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/adapters/xhr.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218662,
+            "end": 1618290218752
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/dispatchRequest.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218662,
+            "end": 1618290218752
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseDelay.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218916,
+            "end": 1618290219006
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayEach.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218458,
+            "end": 1618290218547
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218459,
+            "end": 1618290218548
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseReduce.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218471,
+            "end": 1618290218560
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/Polyline.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218535,
+            "end": 1618290218624
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/makeStyles/makeStyles.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218619,
+            "end": 1618290218708
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseMatchesProperty.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218652,
+            "end": 1618290218741
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createPartial.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218653,
+            "end": 1618290218742
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getData.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218653,
+            "end": 1618290218742
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createHybrid.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218653,
+            "end": 1618290218742
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/createStyles/createStyles.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218654,
+            "end": 1618290218743
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/InterceptorManager.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218664,
+            "end": 1618290218753
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/utils/PropTypes.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218666,
+            "end": 1618290218755
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/OutlinedInput/OutlinedInput.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218668,
+            "end": 1618290218757
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Select/SelectInput.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218896,
+            "end": 1618290218985
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/void-elements/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218961,
+            "end": 1618290219050
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Box/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217307,
+            "end": 1618290217395
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_replaceHolders.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218456,
+            "end": 1618290218544
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getHolder.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218456,
+            "end": 1618290218544
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_mergeData.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218603,
+            "end": 1618290218691
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/fbjs/lib/shallowEqual.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218606,
+            "end": 1618290218694
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/mergeClasses/mergeClasses.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218651,
+            "end": 1618290218739
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/node_modules/react-is/cjs/react-is.development.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218652,
+            "end": 1618290218740
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/property.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218652,
+            "end": 1618290218740
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/jssPreset/jssPreset.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218653,
+            "end": 1618290218741
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/utils/ChildMapping.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218667,
+            "end": 1618290218755
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/extends.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218705,
+            "end": 1618290218793
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_shortOut.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218706,
+            "end": 1618290218794
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/symbol/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218722,
+            "end": 1618290218810
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/listen.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218964,
+            "end": 1618290219052
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseTimes.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218965,
+            "end": 1618290219053
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableCell/TableCell.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219114,
+            "end": 1618290219202
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-keys-internal.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219117,
+            "end": 1618290219205
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableBody/TableBody.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219118,
+            "end": 1618290219206
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/warning/warning.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219721,
+            "end": 1618290219809
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/reactionCleanupTracking.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218420,
+            "end": 1618290218507
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/mobx-react-lite/es/utils/printDebugValue.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218421,
+            "end": 1618290218508
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/memoize/dist/memoize.browser.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218432,
+            "end": 1618290218519
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/Polygon.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218535,
+            "end": 1618290218622
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Symbol.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218606,
+            "end": 1618290218693
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseMatches.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218609,
+            "end": 1618290218696
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/ServerStyleSheets/ServerStyleSheets.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218651,
+            "end": 1618290218738
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseSetToString.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218706,
+            "end": 1618290218793
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stringToPath.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218707,
+            "end": 1618290218794
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isKey.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218709,
+            "end": 1618290218796
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-pie.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218965,
+            "end": 1618290219052
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_ListCache.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218967,
+            "end": 1618290219054
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stackSet.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218967,
+            "end": 1618290219054
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stackHas.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218969,
+            "end": 1618290219056
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stackGet.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218970,
+            "end": 1618290219057
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-vendor/dist/css-vendor.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219113,
+            "end": 1618290219200
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Snackbar/Snackbar.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219308,
+            "end": 1618290219395
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CloseButton.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218419,
+            "end": 1618290218505
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ThemeProvider.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218420,
+            "end": 1618290218506
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/CSSTransition.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218517,
+            "end": 1618290218603
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218520,
+            "end": 1618290218606
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_objectToString.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218608,
+            "end": 1618290218694
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/useTheme/useTheme.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218609,
+            "end": 1618290218695
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/context/forwardRef.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218610,
+            "end": 1618290218696
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseSlice.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218714,
+            "end": 1618290218800
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_nativeKeys.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218969,
+            "end": 1618290219055
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Table/Table.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219121,
+            "end": 1618290219207
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Typography/Typography.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217481,
+            "end": 1618290217566
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ToastContext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218419,
+            "end": 1618290218504
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isObject.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218479,
+            "end": 1618290218564
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/useTheme/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218480,
+            "end": 1618290218565
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIteratee.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218481,
+            "end": 1618290218566
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/object/get-prototype-of.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218482,
+            "end": 1618290218567
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/makeStyles/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218487,
+            "end": 1618290218572
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/config.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218518,
+            "end": 1618290218603
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/TransitionGroup.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218520,
+            "end": 1618290218605
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/InfoWindow.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218534,
+            "end": 1618290218619
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/Rectangle.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218535,
+            "end": 1618290218620
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getRawTag.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218609,
+            "end": 1618290218694
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-parse-stringify2/lib/parse.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218642,
+            "end": 1618290218727
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-parse-stringify2/lib/stringify.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218642,
+            "end": 1618290218727
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isSymbol.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218713,
+            "end": 1618290218798
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseToString.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218718,
+            "end": 1618290218803
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/helpers/toConsumableArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218726,
+            "end": 1618290218811
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_metaMap.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218728,
+            "end": 1618290218813
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stackDelete.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218973,
+            "end": 1618290219058
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_stackClear.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218975,
+            "end": 1618290219060
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isTypedArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218975,
+            "end": 1618290219060
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isBuffer.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218976,
+            "end": 1618290219061
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-integer.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218977,
+            "end": 1618290219062
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217284,
+            "end": 1618290217368
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Accordion.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217481,
+            "end": 1618290217565
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/getThemeProps/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218487,
+            "end": 1618290218571
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonBase/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218488,
+            "end": 1618290218572
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/object/define-property.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218489,
+            "end": 1618290218573
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/styled/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218496,
+            "end": 1618290218580
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/spread.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218496,
+            "end": 1618290218580
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/OverlayView.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218517,
+            "end": 1618290218601
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/change-emitter/lib/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218646,
+            "end": 1618290218730
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_asciiToArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218721,
+            "end": 1618290218805
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseFor.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218728,
+            "end": 1618290218812
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/toFinite.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218729,
+            "end": 1618290218813
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_set-to-string-tag.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218979,
+            "end": 1618290219063
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_property-desc.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218979,
+            "end": 1618290219063
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Table/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218999,
+            "end": 1618290219083
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/axios.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217481,
+            "end": 1618290217564
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/object/set-prototype-of.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218490,
+            "end": 1618290218573
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/symbol.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218491,
+            "end": 1618290218574
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/symbol/iterator.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218492,
+            "end": 1618290218575
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-parse-stringify2/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218493,
+            "end": 1618290218576
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/ThemeProvider/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218495,
+            "end": 1618290218578
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/StylesProvider/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218496,
+            "end": 1618290218579
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/GroundOverlay.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218517,
+            "end": 1618290218600
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/utils/node_modules/react-is/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218523,
+            "end": 1618290218606
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/Axios.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218527,
+            "end": 1618290218610
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/ReplaceTransition.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218534,
+            "end": 1618290218617
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/symbol-observable/es/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218646,
+            "end": 1618290218729
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_unicodeToArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218722,
+            "end": 1618290218805
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useCommittedRef.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218728,
+            "end": 1618290218811
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_a-function.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218981,
+            "end": 1618290219064
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getValue.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219059,
+            "end": 1618290219142
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableFooter/TableFooter.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219113,
+            "end": 1618290219196
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/useMediaQuery/useMediaQuery.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218501,
+            "end": 1618290218583
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/object/create.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218504,
+            "end": 1618290218586
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/esm/SwitchTransition.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218531,
+            "end": 1618290218613
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Input/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218533,
+            "end": 1618290218615
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/fn/symbol/iterator.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218631,
+            "end": 1618290218713
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseHasIn.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218900,
+            "end": 1618290218982
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseGet.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218900,
+            "end": 1618290218982
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tab/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219007,
+            "end": 1618290219089
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableContainer/TableContainer.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219113,
+            "end": 1618290219195
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/toArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219728,
+            "end": 1618290219810
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/BreadcrumbItem.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219738,
+            "end": 1618290219820
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217297,
+            "end": 1618290217378
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/List/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217478,
+            "end": 1618290217559
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Divider/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217479,
+            "end": 1618290217560
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Checkbox/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217480,
+            "end": 1618290217561
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Box/Box.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217481,
+            "end": 1618290217562
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-dom/node_modules/scheduler/cjs/scheduler-tracing.development.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218516,
+            "end": 1618290218597
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/components/DirectionsRenderer.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218517,
+            "end": 1618290218598
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/classnames/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218531,
+            "end": 1618290218612
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FilledInput/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218533,
+            "end": 1618290218614
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/OutlinedInput/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218533,
+            "end": 1618290218614
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.get-prototype-of.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218629,
+            "end": 1618290218710
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.define-property.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218630,
+            "end": 1618290218711
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/styled/styled.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218640,
+            "end": 1618290218721
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/enhanceError.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218900,
+            "end": 1618290218981
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_shared.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218985,
+            "end": 1618290219066
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gops.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219004,
+            "end": 1618290219085
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/node_modules/dom-helpers/esm/hasClass.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219016,
+            "end": 1618290219097
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isIterateeCall.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219051,
+            "end": 1618290219132
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_MapCache.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219057,
+            "end": 1618290219138
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableHead/TableHead.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219112,
+            "end": 1618290219193
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TablePagination/TablePagination.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219113,
+            "end": 1618290219194
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/BootstrapModalManager.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219729,
+            "end": 1618290219810
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/ButtonToolbar.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219738,
+            "end": 1618290219819
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Breadcrumb.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219738,
+            "end": 1618290219819
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Badge.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219739,
+            "end": 1618290219820
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-router-dom/react-router-dom.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217297,
+            "end": 1618290217377
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217478,
+            "end": 1618290217558
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemIcon/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217479,
+            "end": 1618290217559
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemText/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217479,
+            "end": 1618290217559
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControlLabel/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217480,
+            "end": 1618290217560
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormGroup/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217480,
+            "end": 1618290217560
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_core.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218630,
+            "end": 1618290218710
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.set-prototype-of.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218631,
+            "end": 1618290218711
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/StylesProvider/StylesProvider.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218639,
+            "end": 1618290218719
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/NativeSelect/NativeSelect.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218899,
+            "end": 1618290218979
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getTag.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219013,
+            "end": 1618290219093
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_LazyWrapper.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219014,
+            "end": 1618290219094
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/wrapperLodash.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219014,
+            "end": 1618290219094
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SwipeableDrawer/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219038,
+            "end": 1618290219118
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.assign.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219056,
+            "end": 1618290219136
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsNative.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219057,
+            "end": 1618290219137
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/ownerWindow.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219071,
+            "end": 1618290219151
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableRow/TableRow.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219112,
+            "end": 1618290219192
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-detect.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219239,
+            "end": 1618290219319
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/arrayWithHoles.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218508,
+            "end": 1618290218587
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/ThemeProvider/ThemeProvider.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218639,
+            "end": 1618290218718
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getWrapDetails.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218736,
+            "end": 1618290218815
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-iobject.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218990,
+            "end": 1618290219069
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/useScrollTrigger/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218990,
+            "end": 1618290219069
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tooltip/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218991,
+            "end": 1618290219070
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Toolbar/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218993,
+            "end": 1618290219072
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TextareaAutosize/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218993,
+            "end": 1618290219072
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableSortLabel/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218994,
+            "end": 1618290219073
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableRow/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218994,
+            "end": 1618290219073
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableHead/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218995,
+            "end": 1618290219074
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableFooter/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218995,
+            "end": 1618290219074
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableContainer/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218995,
+            "end": 1618290219074
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableCell/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218996,
+            "end": 1618290219075
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-step.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218996,
+            "end": 1618290219075
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-create.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218997,
+            "end": 1618290219076
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gopn.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218998,
+            "end": 1618290219077
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableBody/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218999,
+            "end": 1618290219078
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getFuncName.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219016,
+            "end": 1618290219095
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Menu/Menu.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219036,
+            "end": 1618290219115
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_meta.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219037,
+            "end": 1618290219116
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseAssignValue.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219043,
+            "end": 1618290219122
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TextareaAutosize/TextareaAutosize.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219111,
+            "end": 1618290219190
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TableSortLabel/TableSortLabel.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219112,
+            "end": 1618290219191
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217294,
+            "end": 1618290217372
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/ServerStyleSheets/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218511,
+            "end": 1618290218589
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/mergeClasses/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218511,
+            "end": 1618290218589
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/nonIterableRest.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218512,
+            "end": 1618290218590
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/iterableToArrayLimit.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218512,
+            "end": 1618290218590
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/jssPreset/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218513,
+            "end": 1618290218591
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/cancel/isCancel.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218513,
+            "end": 1618290218591
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/cancel/Cancel.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218514,
+            "end": 1618290218592
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/createStyles/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218514,
+            "end": 1618290218592
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/createGenerateClassName/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218515,
+            "end": 1618290218593
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/defaults.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218516,
+            "end": 1618290218594
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_updateWrapDetails.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218737,
+            "end": 1618290218815
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/NativeSelect/NativeSelectInput.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218899,
+            "end": 1618290218977
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_add-to-unscopables.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218988,
+            "end": 1618290219066
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tabs/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218994,
+            "end": 1618290219072
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TablePagination/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218995,
+            "end": 1618290219073
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_uid.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218997,
+            "end": 1618290219075
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_redefine.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218998,
+            "end": 1618290219076
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-keys.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218999,
+            "end": 1618290219077
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_equalByTag.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219024,
+            "end": 1618290219102
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_equalArrays.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219024,
+            "end": 1618290219102
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@emotion/sheet/dist/sheet.browser.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219026,
+            "end": 1618290219104
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Switch/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219036,
+            "end": 1618290219114
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Stepper/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219043,
+            "end": 1618290219121
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/eq.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219044,
+            "end": 1618290219122
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/useScrollTrigger/useScrollTrigger.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219109,
+            "end": 1618290219187
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Hidden/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219304,
+            "end": 1618290219382
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavbarToggle.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219735,
+            "end": 1618290219813
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CardColumns.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219737,
+            "end": 1618290219815
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Card.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219738,
+            "end": 1618290219816
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Alert.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219739,
+            "end": 1618290219817
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/dist/cypress-react.cjs.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216923,
+            "end": 1618290217000
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/@emotion/core/dist/core.browser.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217468,
+            "end": 1618290217545
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/cancel/CancelToken.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218514,
+            "end": 1618290218591
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/ArrowDropDown.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218895,
+            "end": 1618290218972
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_equalObjects.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219023,
+            "end": 1618290219100
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Toolbar/Toolbar.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219111,
+            "end": 1618290219188
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Step/Step.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219303,
+            "end": 1618290219380
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setCacheAdd.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219303,
+            "end": 1618290219380
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavbarCollapse.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219736,
+            "end": 1618290219813
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gopn-ext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219034,
+            "end": 1618290219110
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_is-array.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219034,
+            "end": 1618290219110
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_enum-keys.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219035,
+            "end": 1618290219111
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_trimmedEndIndex.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219077,
+            "end": 1618290219153
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_listCacheHas.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219099,
+            "end": 1618290219175
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_nodeUtil.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219106,
+            "end": 1618290219182
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseUnary.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219106,
+            "end": 1618290219182
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/hyphenate-style-name/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219107,
+            "end": 1618290219183
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iobject.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219109,
+            "end": 1618290219185
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-length.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219247,
+            "end": 1618290219323
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/SnackbarContent/SnackbarContent.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219303,
+            "end": 1618290219379
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/condense-newlines/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217477,
+            "end": 1618290217552
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/extend-shallow/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217478,
+            "end": 1618290217553
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isLaziable.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218889,
+            "end": 1618290218964
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/node_modules/dom-helpers/esm/removeClass.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218891,
+            "end": 1618290218966
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Map.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219098,
+            "end": 1618290219173
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_listCacheSet.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219099,
+            "end": 1618290219174
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_listCacheGet.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219101,
+            "end": 1618290219176
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_listCacheDelete.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219104,
+            "end": 1618290219179
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/stubFalse.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219105,
+            "end": 1618290219180
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/canUseDOM.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219246,
+            "end": 1618290219321
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/core.get-iterator-method.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219247,
+            "end": 1618290219322
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_create-property.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219247,
+            "end": 1618290219322
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/timers/card.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216921,
+            "end": 1618290216995
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded/App.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216933,
+            "end": 1618290217007
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/add.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216934,
+            "end": 1618290217008
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/lazy-loaded-suspense/Dog.tsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217477,
+            "end": 1618290217551
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-global/dist/jss-plugin-global.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218889,
+            "end": 1618290218963
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseCreate.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218890,
+            "end": 1618290218964
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-transition-group/node_modules/dom-helpers/esm/addClass.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218892,
+            "end": 1618290218966
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_overArg.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219098,
+            "end": 1618290219172
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsTypedArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219105,
+            "end": 1618290219179
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepButton/StepButton.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219302,
+            "end": 1618290219376
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/timers/card-without-effect.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216921,
+            "end": 1618290216994
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/colors/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290217476,
+            "end": 1618290217549
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-default-unit/dist/jss-plugin-default-unit.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218887,
+            "end": 1618290218960
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-camel-case/dist/jss-plugin-camel-case.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218888,
+            "end": 1618290218961
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-nested/dist/jss-plugin-nested.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218889,
+            "end": 1618290218962
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/api-test/users.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216920,
+            "end": 1618290216992
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/products.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216936,
+            "end": 1618290217008
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_root.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218749,
+            "end": 1618290218821
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_composeArgsRight.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218749,
+            "end": 1618290218821
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/keys.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218750,
+            "end": 1618290218822
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsMatch.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218751,
+            "end": 1618290218823
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/is-buffer/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218751,
+            "end": 1618290218823
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-props-sort/dist/jss-plugin-props-sort.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218887,
+            "end": 1618290218959
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-vendor-prefixer/dist/jss-plugin-vendor-prefixer.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218888,
+            "end": 1618290218960
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/hyphenate.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219092,
+            "end": 1618290219164
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.array.from.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219092,
+            "end": 1618290219164
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/addEventListener.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219094,
+            "end": 1618290219166
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/removeEventListener.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219095,
+            "end": 1618290219167
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/tiny-warning/dist/tiny-warning.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219095,
+            "end": 1618290219167
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_strictIndexOf.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219096,
+            "end": 1618290219168
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsNaN.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219096,
+            "end": 1618290219168
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_listCacheClear.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219097,
+            "end": 1618290219169
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-call.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219252,
+            "end": 1618290219324
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/components/ProductsList.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216940,
+            "end": 1618290217011
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_composeArgs.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218748,
+            "end": 1618290218819
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_insertWrapDetails.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218750,
+            "end": 1618290218821
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_matchesStrictComparable.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218753,
+            "end": 1618290218824
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/uncontrollable/lib/esm/hook.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218754,
+            "end": 1618290218825
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/uncontrollable/lib/esm/uncontrollable.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218756,
+            "end": 1618290218827
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isArguments.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218820,
+            "end": 1618290218891
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_ie8-dom-define.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218883,
+            "end": 1618290218954
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsEqualDeep.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218883,
+            "end": 1618290218954
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseFindIndex.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219085,
+            "end": 1618290219156
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_is-array-iter.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219252,
+            "end": 1618290219323
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemSecondaryAction/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219253,
+            "end": 1618290219324
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_assocIndexOf.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219255,
+            "end": 1618290219326
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/debounce.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219277,
+            "end": 1618290219348
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square4.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216920,
+            "end": 1618290216990
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.string.iterator.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218763,
+            "end": 1618290218833
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_basePropertyDeep.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218805,
+            "end": 1618290218875
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createBind.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218820,
+            "end": 1618290218890
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createBaseEach.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218820,
+            "end": 1618290218890
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/object/assign.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218824,
+            "end": 1618290218894
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/constant.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218824,
+            "end": 1618290218894
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gopd.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218883,
+            "end": 1618290218953
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_copyArray.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218886,
+            "end": 1618290218956
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tabs/TabIndicator.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219276,
+            "end": 1618290219346
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/animate.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219277,
+            "end": 1618290219347
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/utils/scrollLeft.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219278,
+            "end": 1618290219348
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square3.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216920,
+            "end": 1618290216989
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getMatchData.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218760,
+            "end": 1618290218829
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/symbol-observable/es/ponyfill.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218761,
+            "end": 1618290218830
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/getStylesCreator/noopTheme.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218762,
+            "end": 1618290218831
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-object.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218762,
+            "end": 1618290218831
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_export.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218763,
+            "end": 1618290218832
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/warning/browser.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218764,
+            "end": 1618290218833
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/OutlinedInput/NotchedOutline.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218799,
+            "end": 1618290218868
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/transformData.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218800,
+            "end": 1618290218869
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/createError.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218800,
+            "end": 1618290218869
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/isURLSameOrigin.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218800,
+            "end": 1618290218869
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/parseHeaders.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218801,
+            "end": 1618290218870
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/buildURL.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218801,
+            "end": 1618290218870
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/core/settle.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218801,
+            "end": 1618290218870
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_isStrictComparable.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218802,
+            "end": 1618290218871
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/hasIn.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218802,
+            "end": 1618290218871
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/get.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218802,
+            "end": 1618290218871
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_overRest.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218823,
+            "end": 1618290218892
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_defineProperty.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218826,
+            "end": 1618290218895
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_memoizeCapped.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218826,
+            "end": 1618290218895
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ListItemAvatar/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219262,
+            "end": 1618290219331
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_array-includes.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219271,
+            "end": 1618290219340
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Table/TableContext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219274,
+            "end": 1618290219343
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepLabel/StepLabel.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219281,
+            "end": 1618290219350
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square2.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216920,
+            "end": 1618290216988
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-sap.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218763,
+            "end": 1618290218831
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@babel/runtime/helpers/esm/inheritsLoose.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218765,
+            "end": 1618290218833
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/delay.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218817,
+            "end": 1618290218885
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.symbol.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218837,
+            "end": 1618290218905
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/css.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218838,
+            "end": 1618290218906
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_WeakMap.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218840,
+            "end": 1618290218908
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/toNumber.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218840,
+            "end": 1618290218908
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/NoSsr/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218849,
+            "end": 1618290218917
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputBase/utils.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218853,
+            "end": 1618290218921
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayLikeKeys.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218854,
+            "end": 1618290218922
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_Stack.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218854,
+            "end": 1618290218922
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isArrayLike.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218854,
+            "end": 1618290218922
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Table/Tablelvl2Context.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219269,
+            "end": 1618290219337
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tabs/TabScrollButton.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219276,
+            "end": 1618290219344
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Tabs/ScrollbarSize.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219277,
+            "end": 1618290219345
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_getSymbols.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219300,
+            "end": 1618290219368
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Icon/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219301,
+            "end": 1618290219369
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_set-proto.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218777,
+            "end": 1618290218844
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-gpo.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218778,
+            "end": 1618290218845
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/makeStyles/indexCounter.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218778,
+            "end": 1618290218845
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/makeStyles/multiKeyStore.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218778,
+            "end": 1618290218845
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/FormControl/FormControlContext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218836,
+            "end": 1618290218903
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/transitionEnd.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218838,
+            "end": 1618290218905
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es7.symbol.observable.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218839,
+            "end": 1618290218906
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createBaseFor.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218840,
+            "end": 1618290218907
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.object.to-string.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218851,
+            "end": 1618290218918
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_freeGlobal.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218853,
+            "end": 1618290218920
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepConnector/StepConnector.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219293,
+            "end": 1618290219360
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputAdornment/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219301,
+            "end": 1618290219368
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_setCacheHas.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219301,
+            "end": 1618290219368
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonBase/TouchRipple.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218777,
+            "end": 1618290218843
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-dp.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218778,
+            "end": 1618290218844
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_descriptors.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218778,
+            "end": 1618290218844
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseProperty.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218782,
+            "end": 1618290218848
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_apply.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218783,
+            "end": 1618290218849
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/noop.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218783,
+            "end": 1618290218849
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/combineURLs.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218790,
+            "end": 1618290218856
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/isAbsoluteURL.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218792,
+            "end": 1618290218858
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_object-create.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218814,
+            "end": 1618290218880
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/lib/utils/OverlayViewHelper.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218814,
+            "end": 1618290218880
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/assign.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218814,
+            "end": 1618290218880
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/isObjectLike.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218832,
+            "end": 1618290218898
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayMap.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218835,
+            "end": 1618290218901
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/getStylesCreator/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218836,
+            "end": 1618290218902
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/uncontrollable/lib/esm/utils.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218861,
+            "end": 1618290218927
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Link/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219293,
+            "end": 1618290219359
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseGetAllKeys.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219300,
+            "end": 1618290219366
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/square1.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216920,
+            "end": 1618290216985
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_wks-ext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218770,
+            "end": 1618290218835
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/web.dom.iterable.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218770,
+            "end": 1618290218835
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseIsEqual.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218783,
+            "end": 1618290218848
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_reorder.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218785,
+            "end": 1618290218850
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createRecurry.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218787,
+            "end": 1618290218852
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_createCtor.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218788,
+            "end": 1618290218853
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_countHolders.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218788,
+            "end": 1618290218853
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/node_modules/axios/lib/helpers/cookies.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218790,
+            "end": 1618290218855
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es7.symbol.async-iterator.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218846,
+            "end": 1618290218911
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_arrayIncludes.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218846,
+            "end": 1618290218911
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/core-js/array/from.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218847,
+            "end": 1618290218912
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-google-maps/node_modules/lodash/_baseKeys.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218858,
+            "end": 1618290218923
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_defined.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218863,
+            "end": 1618290218928
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_fails.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218863,
+            "end": 1618290218928
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/ArrowDownward.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219292,
+            "end": 1618290219357
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/LinearProgress/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219293,
+            "end": 1618290219358
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/shopping-list.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216920,
+            "end": 1618290216984
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/html-parse-stringify2/lib/parse-tag.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218775,
+            "end": 1618290218839
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/useTheme/ThemeContext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218777,
+            "end": 1618290218841
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_global.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218864,
+            "end": 1618290218928
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_string-at.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218865,
+            "end": 1618290218929
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iter-define.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218865,
+            "end": 1618290218929
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_has.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218866,
+            "end": 1618290218930
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_hide.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218866,
+            "end": 1618290218930
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/game.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216919,
+            "end": 1618290216982
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/styles/esm/ThemeProvider/nested.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218776,
+            "end": 1618290218839
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_ctx.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218867,
+            "end": 1618290218930
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/TablePagination/TablePaginationActions.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219291,
+            "end": 1618290219354
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_is-object.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218878,
+            "end": 1618290218940
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_an-object.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218878,
+            "end": 1618290218940
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_to-primitive.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218879,
+            "end": 1618290218941
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepContent/StepContent.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219291,
+            "end": 1618290219353
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/ButtonBase/Ripple.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218878,
+            "end": 1618290218939
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_shared-key.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218879,
+            "end": 1618290218940
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/StepIcon/StepIcon.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219291,
+            "end": 1618290219352
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/network/2-users-fetch.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216918,
+            "end": 1618290216978
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_iterators.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218877,
+            "end": 1618290218937
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/hello.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216918,
+            "end": 1618290216976
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/_wks.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218873,
+            "end": 1618290218931
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.array.iterator.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218873,
+            "end": 1618290218931
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/jss-plugin-rule-value-function/dist/jss-plugin-rule-value-function.esm.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218874,
+            "end": 1618290218932
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/InputBase/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290218875,
+            "end": 1618290218933
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/viewport-spec.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216901,
+            "end": 1618290216958
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/network/1-users.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216918,
+            "end": 1618290216975
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/hello-x.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216918,
+            "end": 1618290216973
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/error-boundary.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216915,
+            "end": 1618290216969
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/stateless-alert.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216914,
+            "end": 1618290216967
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/stateless.jsx",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290216918,
+            "end": 1618290216970
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/DropdownMenu.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219777,
+            "end": 1618290219828
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/DropdownToggle.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219778,
+            "end": 1618290219829
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FigureCaption.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219788,
+            "end": 1618290219832
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FigureImage.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219789,
+            "end": 1618290219832
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/Modal.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219822,
+            "end": 1618290219863
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/history/history.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219826,
+            "end": 1618290219867
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useWillUnmount.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219827,
+            "end": 1618290219868
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/Dropdown.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219834,
+            "end": 1618290219875
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormCheckInput.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219802,
+            "end": 1618290219842
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormCheckLabel.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219803,
+            "end": 1618290219843
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/CarouselCaption.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219804,
+            "end": 1618290219844
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormContext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219794,
+            "end": 1618290219833
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/Breadcrumbs/BreadcrumbCollapsed.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219797,
+            "end": 1618290219836
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormFileInput.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219802,
+            "end": 1618290219841
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/NavContext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219802,
+            "end": 1618290219841
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/camelize.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219826,
+            "end": 1618290219865
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/contains.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219796,
+            "end": 1618290219834
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types-extra/lib/all.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219797,
+            "end": 1618290219835
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/Feedback.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219801,
+            "end": 1618290219839
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/FormFileLabel.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219802,
+            "end": 1618290219840
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/Person.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219809,
+            "end": 1618290219847
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useMounted.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219827,
+            "end": 1618290219865
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/esm/useWrappedRefWithWarning.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219844,
+            "end": 1618290219881
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/Overlay.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219815,
+            "end": 1618290219851
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-router/react-router.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219825,
+            "end": 1618290219861
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/hasClass.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219849,
+            "end": 1618290219885
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/safeFindDOMNode.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219815,
+            "end": 1618290219850
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useUpdateEffect.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219849,
+            "end": 1618290219884
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndent/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219824,
+            "end": 1618290219858
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndents/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219824,
+            "end": 1618290219857
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineInlineLists/index.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219825,
+            "end": 1618290219858
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/querySelectorAll.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219855,
+            "end": 1618290219888
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useMergedRefs.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219856,
+            "end": 1618290219889
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/scrollbarSize.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219823,
+            "end": 1618290219855
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@material-ui/core/esm/internal/svg-icons/MoreHoriz.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219854,
+            "end": 1618290219886
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useForceUpdate.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219856,
+            "end": 1618290219888
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/prop-types-extra/lib/utils/createChainableTypeChecker.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219857,
+            "end": 1618290219889
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/DropdownMenu.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219884,
+            "end": 1618290219909
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/DropdownToggle.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219885,
+            "end": 1618290219910
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/DropdownContext.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219885,
+            "end": 1618290219910
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useUpdatedRef.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219881,
+            "end": 1618290219905
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/useWaitForDOMRef.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219873,
+            "end": 1618290219896
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndent/stripIndent.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219879,
+            "end": 1618290219902
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/oneLineInlineLists/oneLineInlineLists.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219880,
+            "end": 1618290219903
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/useRootClose.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219873,
+            "end": 1618290219895
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/common-tags/es/stripIndents/stripIndents.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219879,
+            "end": 1618290219901
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/usePopper.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219873,
+            "end": 1618290219894
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/popper.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219872,
+            "end": 1618290219892
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/ModalManager.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219878,
+            "end": 1618290219898
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/removeClass.js",
@@ -12578,44 +12127,332 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289081998,
-            "end": 1618289082011
+            "start": 1618290219928,
+            "end": 1618290219948
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/debounce.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/addClass.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082042,
-            "end": 1618289082054
+            "start": 1618290219928,
+            "end": 1618290219948
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/validateModifiers.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getOffsetParent.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082042,
-            "end": 1618289082054
+            "start": 1618290219946,
+            "end": 1618290219966
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/uniqueBy.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/isWindow.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082043,
-            "end": 1618289082055
+            "start": 1618290219953,
+            "end": 1618290219973
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/mergeByName.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/instanceOf.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082043,
-            "end": 1618289082055
+            "start": 1618290219946,
+            "end": 1618290219965
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getDocumentElement.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219947,
+            "end": 1618290219966
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getComputedStyle.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219947,
+            "end": 1618290219966
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getVariation.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219944,
+            "end": 1618290219962
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getFreshSideObject.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219945,
+            "end": 1618290219963
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/contains.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219946,
+            "end": 1618290219964
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getWindow.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219947,
+            "end": 1618290219965
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/preventOverflow.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219921,
+            "end": 1618290219938
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/computeAutoPlacement.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219944,
+            "end": 1618290219961
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/computeOffsets.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219945,
+            "end": 1618290219962
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getAltAxis.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219945,
+            "end": 1618290219962
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getLayoutRect.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219946,
+            "end": 1618290219963
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/hide.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219920,
+            "end": 1618290219936
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/offset.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219921,
+            "end": 1618290219937
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useSafeState.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219925,
+            "end": 1618290219941
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/createPopper.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219940,
+            "end": 1618290219956
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getMainAxisFromPlacement.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219942,
+            "end": 1618290219958
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/within.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219942,
+            "end": 1618290219958
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/mergePaddingObject.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219942,
+            "end": 1618290219958
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/expandToHashMap.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219943,
+            "end": 1618290219959
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/math.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219943,
+            "end": 1618290219959
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getOppositePlacement.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219943,
+            "end": 1618290219959
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getOppositeVariationPlacement.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219944,
+            "end": 1618290219960
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/detectOverflow.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219944,
+            "end": 1618290219960
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/activeElement.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219907,
+            "end": 1618290219922
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/flip.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219920,
+            "end": 1618290219935
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/popperOffsets.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219921,
+            "end": 1618290219936
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/getBasePlacement.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219942,
+            "end": 1618290219957
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/useCallbackRef.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219904,
+            "end": 1618290219918
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@restart/hooks/esm/usePrevious.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219908,
+            "end": 1618290219922
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/ownerDocument.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219910,
+            "end": 1618290219923
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/computeStyles.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219919,
+            "end": 1618290219932
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/eventListeners.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219920,
+            "end": 1618290219933
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getBoundingClientRect.js",
@@ -12623,53 +12460,53 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082043,
-            "end": 1618289082055
+            "start": 1618290219969,
+            "end": 1618290219982
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/rectToClientRect.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/isOverflowing.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082045,
-            "end": 1618289082057
+            "start": 1618290219912,
+            "end": 1618290219924
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getParentNode.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/react-overlays/esm/manageAriaHidden.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082046,
-            "end": 1618289082058
+            "start": 1618290219912,
+            "end": 1618290219924
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getCompositeRect.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/matches.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082041,
-            "end": 1618289082052
+            "start": 1618290219913,
+            "end": 1618290219925
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/listScrollParents.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/modifiers/arrow.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082042,
-            "end": 1618289082053
+            "start": 1618290219919,
+            "end": 1618290219931
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/orderModifiers.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/validateModifiers.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082042,
-            "end": 1618289082053
+            "start": 1618290219968,
+            "end": 1618290219980
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getClippingRect.js",
@@ -12677,8 +12514,8 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082045,
-            "end": 1618289082056
+            "start": 1618290219969,
+            "end": 1618290219981
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getNodeName.js",
@@ -12686,8 +12523,89 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082046,
-            "end": 1618289082057
+            "start": 1618290219970,
+            "end": 1618290219982
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getParentNode.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219971,
+            "end": 1618290219983
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/enums.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219919,
+            "end": 1618290219930
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/popper-base.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219920,
+            "end": 1618290219931
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getCompositeRect.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219967,
+            "end": 1618290219978
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/listScrollParents.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219968,
+            "end": 1618290219979
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/debounce.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219968,
+            "end": 1618290219979
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/uniqueBy.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219969,
+            "end": 1618290219980
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/mergeByName.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219969,
+            "end": 1618290219980
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/rectToClientRect.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219970,
+            "end": 1618290219981
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/isTableElement.js",
@@ -12695,35 +12613,26 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082046,
-            "end": 1618289082057
+            "start": 1618290219972,
+            "end": 1618290219983
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/format.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/orderModifiers.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082061,
-            "end": 1618289082067
+            "start": 1618290219968,
+            "end": 1618290219978
           },
           {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getViewportRect.js",
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/react-bootstrap/node_modules/dom-helpers/esm/isDocument.js",
             "fillLast": true,
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082062,
-            "end": 1618289082068
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getDocumentRect.js",
-            "fillLast": true,
-            "loaders": [
-              "babel-loader"
-            ],
-            "start": 1618289082062,
-            "end": 1618289082068
+            "start": 1618290219977,
+            "end": 1618290219987
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getNodeScroll.js",
@@ -12731,8 +12640,8 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082060,
-            "end": 1618289082065
+            "start": 1618290219983,
+            "end": 1618290219988
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getWindowScrollBarX.js",
@@ -12740,8 +12649,8 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082061,
-            "end": 1618289082066
+            "start": 1618290219984,
+            "end": 1618290219989
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/isScrollParent.js",
@@ -12749,8 +12658,35 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082061,
-            "end": 1618289082066
+            "start": 1618290219984,
+            "end": 1618290219989
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getViewportRect.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219985,
+            "end": 1618290219990
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getDocumentRect.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219985,
+            "end": 1618290219990
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/utils/format.js",
+            "fillLast": true,
+            "loaders": [
+              "babel-loader"
+            ],
+            "start": 1618290219986,
+            "end": 1618290219991
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getScrollParent.js",
@@ -12758,8 +12694,8 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082062,
-            "end": 1618289082067
+            "start": 1618290219985,
+            "end": 1618290219989
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getWindowScroll.js",
@@ -12767,8 +12703,8 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082068,
-            "end": 1618289082070
+            "start": 1618290219991,
+            "end": 1618290219993
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/@popperjs/core/lib/dom-utils/getHTMLElementScroll.js",
@@ -12776,22 +12712,22 @@
             "loaders": [
               "babel-loader"
             ],
-            "start": 1618289082069,
-            "end": 1618289082070
+            "start": 1618290219991,
+            "end": 1618290219993
           }
         ]
       },
       {
         "averages": {
           "dataPoints": 1,
-          "median": 78,
-          "mean": 78,
+          "median": 71,
+          "mean": 71,
           "range": {
-            "start": 78,
-            "end": 78
+            "start": 71,
+            "end": 71
           }
         },
-        "activeTime": 78,
+        "activeTime": 71,
         "loaders": [
           "/Users/lachlan/code/work/cypress5/npm/webpack-dev-server/dist/loader.js"
         ],
@@ -12803,8 +12739,8 @@
             "loaders": [
               "/Users/lachlan/code/work/cypress5/npm/webpack-dev-server/dist/loader.js"
             ],
-            "start": 1618289078369,
-            "end": 1618289078447
+            "start": 1618290216556,
+            "end": 1618290216627
           }
         ]
       },
@@ -12812,14 +12748,14 @@
         "averages": {
           "dataPoints": 9,
           "median": 1,
-          "mean": 2,
+          "mean": 1,
           "range": {
             "start": 0,
-            "end": 14
+            "end": 3
           },
-          "variance": 20
+          "variance": 1
         },
-        "activeTime": 21,
+        "activeTime": 11,
         "loaders": [
           "style-loader",
           "css-loader"
@@ -12833,78 +12769,8 @@
               "style-loader",
               "css-loader"
             ],
-            "start": 1618289078813,
-            "end": 1618289078827
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/todos.css",
-            "fillLast": true,
-            "loaders": [
-              "style-loader",
-              "css-loader"
-            ],
-            "start": 1618289078828,
-            "end": 1618289078830
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counters/counters.css",
-            "fillLast": true,
-            "loaders": [
-              "style-loader",
-              "css-loader"
-            ],
-            "start": 1618289078827,
-            "end": 1618289078828
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/tic-tac-toe.css",
-            "fillLast": true,
-            "loaders": [
-              "style-loader",
-              "css-loader"
-            ],
-            "start": 1618289078879,
-            "end": 1618289078880
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css-modules/Button.modules.css",
-            "fillLast": true,
-            "loaders": [
-              "style-loader",
-              "css-loader"
-            ],
-            "start": 1618289078881,
-            "end": 1618289078882
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Todos.css",
-            "fillLast": true,
-            "loaders": [
-              "style-loader",
-              "css-loader"
-            ],
-            "start": 1618289079059,
-            "end": 1618289079060
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css/Button.css",
-            "fillLast": true,
-            "loaders": [
-              "style-loader",
-              "css-loader"
-            ],
-            "start": 1618289079103,
-            "end": 1618289079104
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/App.css",
-            "fillLast": true,
-            "loaders": [
-              "style-loader",
-              "css-loader"
-            ],
-            "start": 1618289079113,
-            "end": 1618289079113
+            "start": 1618290217036,
+            "end": 1618290217039
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/framer-motion/Motion.css",
@@ -12913,36 +12779,115 @@
               "style-loader",
               "css-loader"
             ],
-            "start": 1618289079163,
-            "end": 1618289079163
+            "start": 1618290217356,
+            "end": 1618290217358
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counters/counters.css",
+            "fillLast": true,
+            "loaders": [
+              "style-loader",
+              "css-loader"
+            ],
+            "start": 1618290217039,
+            "end": 1618290217040
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/todos.css",
+            "fillLast": true,
+            "loaders": [
+              "style-loader",
+              "css-loader"
+            ],
+            "start": 1618290217040,
+            "end": 1618290217041
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/tic-tac-toe.css",
+            "fillLast": true,
+            "loaders": [
+              "style-loader",
+              "css-loader"
+            ],
+            "start": 1618290217082,
+            "end": 1618290217083
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css-modules/Button.modules.css",
+            "fillLast": true,
+            "loaders": [
+              "style-loader",
+              "css-loader"
+            ],
+            "start": 1618290217084,
+            "end": 1618290217085
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Todos.css",
+            "fillLast": true,
+            "loaders": [
+              "style-loader",
+              "css-loader"
+            ],
+            "start": 1618290217183,
+            "end": 1618290217184
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css/Button.css",
+            "fillLast": true,
+            "loaders": [
+              "style-loader",
+              "css-loader"
+            ],
+            "start": 1618290217292,
+            "end": 1618290217293
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/App.css",
+            "fillLast": true,
+            "loaders": [
+              "style-loader",
+              "css-loader"
+            ],
+            "start": 1618290217303,
+            "end": 1618290217303
           }
         ]
       },
       {
         "averages": {
           "dataPoints": 9,
-          "median": 41,
+          "median": 34,
           "mean": 46,
           "range": {
-            "start": 29,
-            "end": 79
+            "start": 27,
+            "end": 100
           },
-          "variance": 306
+          "variance": 574
         },
-        "activeTime": 258,
+        "activeTime": 298,
         "loaders": [
           "css-loader"
         ],
         "subLoadersTime": {},
         "rawStartEnds": [
           {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Todos.css",
+            "fillLast": true,
+            "loaders": [
+              "css-loader"
+            ],
+            "start": 1618290217184,
+            "end": 1618290217284
+          },
+          {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js??ref--5-1!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css-modules/Button.modules.css",
             "fillLast": true,
             "loaders": [
               "css-loader"
             ],
-            "start": 1618289078882,
-            "end": 1618289078961
+            "start": 1618290217085,
+            "end": 1618290217150
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counter/counter.css",
@@ -12950,26 +12895,8 @@
             "loaders": [
               "css-loader"
             ],
-            "start": 1618289078830,
-            "end": 1618289078895
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/react-book-example/src/Todos.css",
-            "fillLast": true,
-            "loaders": [
-              "css-loader"
-            ],
-            "start": 1618289079060,
-            "end": 1618289079120
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/tic-tac-toe.css",
-            "fillLast": true,
-            "loaders": [
-              "css-loader"
-            ],
-            "start": 1618289078880,
-            "end": 1618289078921
+            "start": 1618290217041,
+            "end": 1618290217095
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/framer-motion/Motion.css",
@@ -12977,26 +12904,8 @@
             "loaders": [
               "css-loader"
             ],
-            "start": 1618289079163,
-            "end": 1618289079204
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/todos.css",
-            "fillLast": true,
-            "loaders": [
-              "css-loader"
-            ],
-            "start": 1618289078863,
-            "end": 1618289078898
-          },
-          {
-            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counters/counters.css",
-            "fillLast": true,
-            "loaders": [
-              "css-loader"
-            ],
-            "start": 1618289078863,
-            "end": 1618289078897
+            "start": 1618290217358,
+            "end": 1618290217401
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/set-timeout-example/App.css",
@@ -13004,8 +12913,8 @@
             "loaders": [
               "css-loader"
             ],
-            "start": 1618289079114,
-            "end": 1618289079146
+            "start": 1618290217304,
+            "end": 1618290217339
           },
           {
             "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/css/Button.css",
@@ -13013,22 +12922,86 @@
             "loaders": [
               "css-loader"
             ],
-            "start": 1618289079105,
-            "end": 1618289079134
+            "start": 1618290217293,
+            "end": 1618290217327
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/basic/react-tutorial/tic-tac-toe.css",
+            "fillLast": true,
+            "loaders": [
+              "css-loader"
+            ],
+            "start": 1618290217083,
+            "end": 1618290217112
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/counters/counters.css",
+            "fillLast": true,
+            "loaders": [
+              "css-loader"
+            ],
+            "start": 1618290217069,
+            "end": 1618290217097
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/css-loader/dist/cjs.js!/Users/lachlan/code/work/cypress5/npm/react/cypress/component/advanced/radioactive-state/todos/todos.css",
+            "fillLast": true,
+            "loaders": [
+              "css-loader"
+            ],
+            "start": 1618290217069,
+            "end": 1618290217096
+          }
+        ]
+      },
+      {
+        "averages": {
+          "dataPoints": 2,
+          "median": 91,
+          "mean": 81,
+          "range": {
+            "start": 70,
+            "end": 91
+          },
+          "variance": 221
+        },
+        "activeTime": 161,
+        "loaders": [
+          "modules with no loaders"
+        ],
+        "subLoadersTime": {},
+        "rawStartEnds": [
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/webpack/buildin/amd-options.js",
+            "fillLast": true,
+            "loaders": [
+              "modules with no loaders"
+            ],
+            "start": 1618290217915,
+            "end": 1618290218006
+          },
+          {
+            "name": "/Users/lachlan/code/work/cypress5/node_modules/style-loader/lib/addStyles.js",
+            "fillLast": true,
+            "loaders": [
+              "modules with no loaders"
+            ],
+            "start": 1618290217101,
+            "end": 1618290217171
           }
         ]
       },
       {
         "averages": {
           "dataPoints": 1,
-          "median": 62,
-          "mean": 62,
+          "median": 68,
+          "mean": 68,
           "range": {
-            "start": 62,
-            "end": 62
+            "start": 68,
+            "end": 68
           }
         },
-        "activeTime": 62,
+        "activeTime": 68,
         "loaders": [
           "svg-url-loader",
           "svg-url-loader"
@@ -13042,22 +13015,22 @@
               "svg-url-loader",
               "svg-url-loader"
             ],
-            "start": 1618289079232,
-            "end": 1618289079294
+            "start": 1618290217432,
+            "end": 1618290217500
           }
         ]
       },
       {
         "averages": {
           "dataPoints": 1,
-          "median": 114,
-          "mean": 114,
+          "median": 99,
+          "mean": 99,
           "range": {
-            "start": 114,
-            "end": 114
+            "start": 99,
+            "end": 99
           }
         },
-        "activeTime": 114,
+        "activeTime": 99,
         "loaders": [
           "file-loader"
         ],
@@ -13069,8 +13042,8 @@
             "loaders": [
               "file-loader"
             ],
-            "start": 1618289079667,
-            "end": 1618289079781
+            "start": 1618290217822,
+            "end": 1618290217921
           }
         ]
       }

--- a/npm/webpack-dev-server/__snapshots__/makeWebpackConfig.spec.ts.js
+++ b/npm/webpack-dev-server/__snapshots__/makeWebpackConfig.spec.ts.js
@@ -11,7 +11,6 @@ exports['makeWebpackConfig ignores userland webpack `output.publicPath` 1'] = {
   },
   "plugins": [
     "HtmlWebpackPlugin",
-    "CypressCTOptionsPlugin",
-    "LazyCompilePlugin"
+    "CypressCTOptionsPlugin"
   ]
 }

--- a/npm/webpack-dev-server/package.json
+++ b/npm/webpack-dev-server/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@cypress/lazy-compile-webpack-plugin": "0.0.0-development",
     "debug": "4.3.2",
+    "html-webpack-plugin": "^4.0.0",
     "semver": "^7.3.4",
     "webpack-merge": "^5.4.0"
   },
@@ -26,7 +27,6 @@
     "webpack-dev-server": "^3.11.0"
   },
   "peerDependencies": {
-    "html-webpack-plugin": "^4.0.0",
     "webpack": ">=4",
     "webpack-dev-server": "^3.0.0"
   },

--- a/npm/webpack-dev-server/package.json
+++ b/npm/webpack-dev-server/package.json
@@ -10,7 +10,6 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@cypress/lazy-compile-webpack-plugin": "0.0.0-development",
     "debug": "4.3.2",
     "html-webpack-plugin": "^4.0.0",
     "semver": "^7.3.4",

--- a/npm/webpack-dev-server/src/makeWebpackConfig.ts
+++ b/npm/webpack-dev-server/src/makeWebpackConfig.ts
@@ -3,11 +3,9 @@ import * as path from 'path'
 import * as webpack from 'webpack'
 import { merge } from 'webpack-merge'
 import defaultWebpackConfig from './webpack.config'
-import LazyCompilePlugin from '@cypress/lazy-compile-webpack-plugin'
 import CypressCTOptionsPlugin, { CypressCTOptionsPluginOptions } from './plugin'
 
 const debug = debugFn('cypress:webpack-dev-server:makeWebpackConfig')
-const WEBPACK_MAJOR_VERSION = Number(webpack.version.split('.')[0])
 
 const removeList = ['HtmlWebpackPlugin', 'PreloadPlugin']
 
@@ -22,30 +20,6 @@ export interface UserWebpackDevServerOptions {
 interface MakeWebpackConfigOptions extends CypressCTOptionsPluginOptions, UserWebpackDevServerOptions {
   devServerPublicPathRoute: string
   isOpenMode: boolean
-}
-
-// TODO: Validate if this actually improvement performance.
-// Usage:
-// const mergedConfig = merge<webpack.Configuration>(
-//   userWebpackConfig,
-//   defaultWebpackConfig,
-//   dynamicWebpackConfig,
-//   getLazyCompilationWebpackConfig(options) <= here, at the end of the chain
-// )
-/* eslint-disable @typescript-eslint/no-unused-vars */
-function getLazyCompilationWebpackConfig (options: MakeWebpackConfigOptions): webpack.Configuration {
-  if (options.disableLazyCompilation || !options.isOpenMode) {
-    return {}
-  }
-
-  switch (WEBPACK_MAJOR_VERSION) {
-    case 4:
-      return { plugins: [new LazyCompilePlugin()] }
-    case 5:
-      return { experiments: { lazyCompilation: true } } as webpack.Configuration
-    default:
-      return { }
-  }
 }
 
 export async function makeWebpackConfig (userWebpackConfig: webpack.Configuration, options: MakeWebpackConfigOptions): Promise<webpack.Configuration> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19133,7 +19133,7 @@ html-webpack-plugin@4.0.0-beta.5:
     tapable "^1.1.0"
     util.promisify "1.0.0"
 
-html-webpack-plugin@^4.5.0:
+html-webpack-plugin@^4.0.0, html-webpack-plugin@^4.5.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz#76fc83fa1a0f12dd5f7da0404a54e2699666bc12"
   integrity sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes no specific issue, but lots of problems regarding webpack and dependencies people reported on Discord.

### User facing changelog

- Remove the usage of `webpack-lazy-compile-plugin` from `@cypress/webpack-dev-server`. It's causing problems.
- Default to use `webpack-html-plugin@4` (which is now a dependency). 
- Confirm we support `webpack-html-plugin@5` if the user has that installed, which assumes `webpack@5` is also installed (those two are designed to work together. `html-webpack-plugin@5` does [not support `webpack@4` and below](https://github.com/jantimon/html-webpack-plugin/blob/main/package.json#L59).

### Additional details

The `npm/react` has some weird incompatibility with when combined with `html-webpack-plugin` and `webpack-lazy-compile-plugin`. I just removed `webpack-lazy-compile-plugin` and it worked fine. Now it works with `html-webpack-plugin` 3.x and 4.x.

I am not entirely clear on what or how `webpack-lazy-compile-plugin` makes things faster. The [readme](https://github.com/cypress-io/cypress/tree/develop/npm/lazy-compile-webpack-plugin#ignores) specifically notes that "lazy compiler always ignores requests from html-webpack-plugin", interestingly enough, which I am fairly sure is not the behavior we want.

Either way it seems like this plugin is not doing anything useful. I'm not sure how we even came to the conclusion it was making things faster in the first place, because I could not see change in perf with/without it.

Here's how I benchmarked it (using the infrastructure Dmitriy added a few months ago).

1. Get current develop
2. Build everything (`yarn`)
3. `cd npm/react`
4. `WEBPACK_PERF_MEASURE=1 WEBPACK_PERF_MEASURE_UPDATE=1  WEBPACK_PERF_MEASURE_COMPARE=react yarn cy:run`
5. This creates a new file with the latest benchmarks. You can see with `git diff`. I committed it.

Now we have some up-to-date benchmarks (they had not been updated in months). We should probably be running and checking this on CI every build, to see if we have any speed regressions. Anyway, onwards:

 
- went to `makeWebpackConfig.ts` and removed the `getLazyCompilationWebpackConfig`  call.
- did ` yarn build` in `npm/webpack-dev-server`. Builds a version not using `lazy-compile-plugin`.
- ran `WEBPACK_PERF_MEASURE=1 WEBPACK_PERF_MEASURE_COMPARE=react yarn cy:run`

Right above the webpack output it logs the timing:

```
═════════════════════════════════════════
WEBPACK_PERF_MEASURE
Before: 5.38s
After: 5.363s
No sufficient build time difference
═════════════════════════════════════════
```

Seems this plugin is not actually having the performance improvement we might have expected.
 
With this knowledge, I made the changes in this PR. Those are: 

- adding`html-webpack-plugin@^4` as a dependency to `@cypress/webpack-dev-server`. No longer a peer dep. No more confusing installation. 
- removing the `getLazyCompilationWebpackConfig`. (I left the code there, just in case it turns out I missed something and we do need it). 
- ran `yarn install` to install `html-webpack-plugin@4` as a dep in `@cypress/webpack-dev-server/node_modules`, instead of using the one in the root `node_modules` (which is 3.x).
- ran the benchmark script again: `WEBPACK_PERF_MEASURE=1 WEBPACK_PERF_MEASURE_COMPARE=react yarn cy:run`.

```
═════════════════════════════════════════
WEBPACK_PERF_MEASURE
Before: 5.38s
After: 5.084s
New build is faster: +6%
═════════════════════════════════════════
```

Faster! I guess `html-webpack-plugin@4` has some optimizations than 3.x did not have. With this knowledge I re-ran the command to save the benchmarks and committed everything. Lastly, I ran `yarn cy:open` to make sure it still works okay, it does.

It should be noted this was all tested with `webpack@4`. We need some projects set up to use `webpack@5` (and `html-webpack-plugin@5` - [they dropped support for webpack 4](https://github.com/jantimon/html-webpack-plugin/blob/main/package.json#L59)). For now, I cloned [this project I made with webpack 5](https://github.com/lmiller1990/cypress-react-webpack-5-example). I just copy-pasted the build files from `@cypress/webpack-dev-server` into `node_modules` and tested. It worked. I was using `webpack@5` and `html-webpack-plugin@5.3`.

Conclusion:

- removed `lazy-compile-html-webpack`, which means we may not even need the fork + windows fix anymore.
- added `html-webpack-plugin@4` as a dependency. No need to mess around with peer dependencies anymore.
- general speed increase for anyone using `webpack-html-plugin@3`.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

No longer depends on the user's webpack-html-plugin version. Less peer dependencies to mess around with. Also removed buggy, not useful `lazy-compile-plugin`.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
