### PR TITLE
fix: starting cdp screencast when video:false

### DIFF
--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1049,9 +1049,7 @@ module.exports = {
    * in the same browser
    */
   writeVideoFrameCallback () {
-    if (this.currentWriteVideoFrameCallback) {
-      return this.currentWriteVideoFrameCallback(...arguments)
-    }
+    return this.currentWriteVideoFrameCallback(...arguments)
   },
 
   waitForBrowserToConnect (options = {}, shouldLaunchBrowser = true) {
@@ -1061,8 +1059,10 @@ module.exports = {
 
     // short circuit current browser callback so that we
     // can rewire it without relaunching the browser
-    this.currentWriteVideoFrameCallback = writeVideoFrame
-    options.writeVideoFrame = this.writeVideoFrameCallback.bind(this)
+    if (writeVideoFrame) {
+      this.currentWriteVideoFrameCallback = writeVideoFrame
+      options.writeVideoFrame = this.writeVideoFrameCallback.bind(this)
+    }
 
     // without this the run mode is only setting new spec
     // path for next spec in launch browser.

--- a/packages/server/test/unit/modes/run_spec.js
+++ b/packages/server/test/unit/modes/run_spec.js
@@ -276,6 +276,7 @@ describe('lib/modes/run', () => {
       .then(() => {
         expect(openProject.closeBrowser).to.be.calledThrice
         expect(runMode.launchBrowser).to.be.calledThrice
+        expect(runMode.launchBrowser.firstCall.args[0]).not.property('writeVideoFrame')
         expect(errors.warning).to.be.calledWith('TESTS_DID_NOT_START_RETRYING', 'Retrying...')
         expect(errors.warning).to.be.calledWith('TESTS_DID_NOT_START_RETRYING', 'Retrying again...')
         expect(errors.get).to.be.calledWith('TESTS_DID_NOT_START_FAILED')


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->
This regression was introduced due to requirement for component testing to switch `writeVideoFrame` callbacks when the specs switch without closing the browser.
- Closes #16030


 other questions about CT video recording
- for CT, is a new video saved for each spec? Does the video compression happen between each spec while the browser is open? 
- when is the video uploaded when recording to the dashboard, after each spec?




### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->
Bug fix: fixed issue causing decreased performance in chromium browsers due to requesting screencast frames when video is disabled
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
