### PR TITLE
fix: Prevent null snapshots from being stored and causing errors

### DIFF
--- a/packages/driver/cypress/integration/cypress/log_spec.js
+++ b/packages/driver/cypress/integration/cypress/log_spec.js
@@ -24,6 +24,16 @@ describe('src/cypress/log', function () {
       expect(result).to.equal(log)
     })
 
+    // https://github.com/cypress-io/cypress/issues/15816
+    it('does not add snapshot if createSnapshot returns null', function () {
+      this.cy.createSnapshot.returns(null)
+
+      const log = this.log()
+      const result = log.snapshot()
+
+      expect(result.get('snapshots')).to.have.length(0)
+    })
+
     it('is no-op if not interactive', function () {
       this.config.withArgs('isInteractive').returns(false)
 

--- a/packages/driver/src/cy/snapshots.js
+++ b/packages/driver/src/cy/snapshots.js
@@ -158,6 +158,9 @@ const create = ($$, state) => {
       // are no side effects from cloning it. see below for how we re-attach
       // it to the AUT document
       // https://github.com/cypress-io/cypress/issues/8679
+      // this can fail if snapshotting before the page has fully loaded,
+      // so we catch this below and return null for the snapshot
+      // https://github.com/cypress-io/cypress/issues/15816
       const $body = $$(snapshotDocument.importNode($$('body')[0], true))
 
       // for the head and body, get an array of all CSS,

--- a/packages/driver/src/cypress/log.js
+++ b/packages/driver/src/cypress/log.js
@@ -329,8 +329,13 @@ const Log = function (cy, state, config, obj) {
 
       const snapshots = this.get('snapshots') || []
 
-      // insert at index 'at' or whatever is the next position
-      snapshots[options.at || snapshots.length] = snapshot
+      // don't add snapshot if we couldn't create one, which can happen
+      // if the snapshotting process errors
+      // https://github.com/cypress-io/cypress/issues/15816
+      if (snapshot) {
+        // insert at index 'at' or whatever is the next position
+        snapshots[options.at || snapshots.length] = snapshot
+      }
 
       this.set('snapshots', snapshots)
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #15816

### User facing changelog

- Fixed an issue where hovering over a command log without a snapshot would cause the error `Cannot read property 'name' of null`

### Additional details

Snapshotting can fail for various reasons. In the issue this closes, it was because the snapshot happens before the page fully loads, but it can also fail if the page is cross-origin. We [catch such failures when creating the snapshot and return `null`](https://github.com/cypress-io/cypress/blob/e9457e2d09546cb6a5e78413367fcb32a5f056b3/packages/driver/src/cy/snapshots.js#L219-L221), but the log [adds that `null` value to the list of snapshots](https://github.com/cypress-io/cypress/blob/e9457e2d09546cb6a5e78413367fcb32a5f056b3/packages/driver/src/cypress/log.js#L331-L334). When the user hovers over the command and we try to display the snapshot, it's expected to be a proper snapshot object and throws when we try to access properties on it. The solution is simply to not add `null` snapshots to the list of the log's snapshots. Then it's properly recognized as "missing" (which is correct, since we can't get a snapshot of it) and we display that to the user without erroring.

### How has the user experience changed?

Hovering over commands with a missing snapshot no longer errors.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
