### PR TITLE
chore: fix flaky e2e record passes test

### DIFF
--- a/packages/server/test/e2e/7_record_spec.js
+++ b/packages/server/test/e2e/7_record_spec.js
@@ -66,8 +66,8 @@ describe('e2e record', () => {
         `POST /runs/${runId}/instances`,
         `POST /instances/${instanceId}/tests`,
         `POST /instances/${instanceId}/results`,
-        'PUT /screenshots/1.png',
         'PUT /videos/video.mp4',
+        'PUT /screenshots/1.png',
         `PUT /instances/${instanceId}/stdout`,
 
         // spec 3
@@ -82,8 +82,8 @@ describe('e2e record', () => {
         `POST /runs/${runId}/instances`,
         `POST /instances/${instanceId}/tests`,
         `POST /instances/${instanceId}/results`,
-        'PUT /screenshots/1.png',
         'PUT /videos/video.mp4',
+        'PUT /screenshots/1.png',
         `PUT /instances/${instanceId}/stdout`,
       ])
 

--- a/packages/server/test/support/helpers/serverStub.ts
+++ b/packages/server/test/support/helpers/serverStub.ts
@@ -111,17 +111,17 @@ const routeHandlers = {
     method: 'put',
     url: '/videos/:name',
     res (req, res) {
-      return Bluebird.delay(200)
-      .then(() => {
-        return res.sendStatus(200)
-      })
+      return res.sendStatus(200)
     },
   },
   putScreenshots: {
     method: 'put',
     url: '/screenshots/:name',
     res (req, res) {
-      return res.sendStatus(200)
+      return Bluebird.delay(300)
+      .then(() => {
+        return res.sendStatus(200)
+      })
     },
   },
 


### PR DESCRIPTION
should help reduce variable failures for e2e_record_spec

for e2e record spec we assert on the order of requests to the stubbed out server. we needed a larger delay in the response handler of put/screenshots since theres a race condition in the order of put/screenshots and put/video. The video request is made first so we delay the screenshot request to make sure there's a consistent order to the requests