### PR TITLE
chore: Disable all formatting on save in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,8 @@
     "typescriptreact",
     "json"
   ],
+  // And avoid any other formatters such as the built in VSCode one
+  "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },


### PR DESCRIPTION
Just a simple developer change, though I'm not sure if it's inline with the goals of the project or not.

I found vscode still formatting the code with the native formatter as I have that in my global user settings, so I put this in here temporarily while working contributing my issue, but thought it may be worth it for everyone to have? Also this is the only place to overwrite global settings as far as I know, I don't think I can overwrite the local settings checked in in a separate file that I can gitignore locally