### PR TITLE
fix: Correct attempt numbers during retries

### DIFF
--- a/packages/server/__snapshots__/3_retries_spec.ts.js
+++ b/packages/server/__snapshots__/3_retries_spec.ts.js
@@ -17,8 +17,8 @@ exports['retries / supports retries'] = `
   Running:  fail-twice.js                                                                   (1 of 1)
 
 
-  (Attempt 1 of 3) fail twice
   (Attempt 2 of 3) fail twice
+  (Attempt 3 of 3) fail twice
   ✓ fail twice
 
   1 passing

--- a/packages/server/__snapshots__/5_screenshots_spec.js
+++ b/packages/server/__snapshots__/5_screenshots_spec.js
@@ -29,8 +29,8 @@ exports['e2e screenshots / passes'] = `
     ✓ accepts screenshot after multiple tries if somehow app has pixels that match helper pixels
     ✓ can capture element screenshots
     ✓ retries each screenshot for up to  XX:XX
-    (Attempt 1 of 3) screenshots in a retried test
     (Attempt 2 of 3) screenshots in a retried test
+    (Attempt 3 of 3) screenshots in a retried test
     2) screenshots in a retried test
     ✓ ensures unique paths for non-named screenshots
     3) ensures unique paths when there's a non-named screenshot and a failure

--- a/packages/server/__snapshots__/5_spec_isolation_spec.js
+++ b/packages/server/__snapshots__/5_spec_isolation_spec.js
@@ -20,12 +20,12 @@ exports['e2e spec_isolation / failing with retries enabled'] = `
 
   simple failing hook spec
     beforeEach hooks
-      (Attempt 1 of 2) never gets here
+      (Attempt 2 of 2) never gets here
       1) "before each" hook for "never gets here"
     pending
       - is pending
     afterEach hooks
-      (Attempt 1 of 2) runs this
+      (Attempt 2 of 2) runs this
       2) "after each" hook for "runs this"
     after hooks
       ✓ runs this
@@ -102,7 +102,7 @@ Although you have test retries enabled, we do not retry tests when \`before all\
 
 
   simple retrying spec
-    (Attempt 1 of 2) t1
+    (Attempt 2 of 2) t1
     1) t1
     ✓ t2
 

--- a/packages/server/lib/reporter.js
+++ b/packages/server/lib/reporter.js
@@ -281,7 +281,7 @@ class Reporter {
       this.runner.on('retry', (test) => {
         const runnable = this.runnables[test.id]
         const padding = '  '.repeat(runnable.titlePath().length)
-        const retryMessage = mochaColor('medium', `(Attempt ${test.currentRetry + 1} of ${test.retries + 1})`)
+        const retryMessage = mochaColor('medium', `(Attempt ${test.currentRetry + 2} of ${test.retries + 1})`)
 
         // Log: `(Attempt 1 of 2) test title` when a test retries
         // eslint-disable-next-line no-console


### PR DESCRIPTION


### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->
Retry attempt numbers in the run log now include the first attempt. So last attempt is no longer `2 of 3` but correctly `3 of 3`

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
This just annoyed me in the logs. The retry attempts have the total number including the first attempt, but only counts by the number of retries, so the log is always things like:
Attempt 1 of 3
Attempt 2 of 3

and then finishes with a fail. I thought it was small enough to not create an issue for and just fix

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

See snapshot test diffs

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
