### PR TITLE
fix: Nextjs Component Testing Example

### DIFF
--- a/npm/react/examples/nextjs/package.json
+++ b/npm/react/examples/nextjs/package.json
@@ -14,15 +14,15 @@
   },
   "devDependencies": {
     "@cypress/react": "file:../../dist",
+    "@cypress/webpack-dev-server": "^1.1.3",
     "@mdx-js/loader": "^1.6.16",
     "@next/mdx": "10.1.2",
     "@zeit/next-sass": "^1.0.1",
     "check-code-coverage": "1.9.2",
     "cypress-circleci-reporter": "0.2.0",
     "next": "10.1.2",
-    "@cypress/webpack-dev-server": "^1.1.3",
     "webpack": "4.x",
-    "webpack-dev-server": "^3.11.2
+    "webpack-dev-server": "^3.11.2"
   },
   "license": "MIT"
 }

--- a/npm/react/examples/nextjs/package.json
+++ b/npm/react/examples/nextjs/package.json
@@ -20,7 +20,7 @@
     "check-code-coverage": "1.9.2",
     "cypress-circleci-reporter": "0.2.0",
     "next": "10.1.2",
-    "@cypress/webpack-dev-server": "^1.1.3"
+    "@cypress/webpack-dev-server": "^1.1.3",
     "webpack": "4.x",
     "webpack-dev-server": "^3.11.2
   },

--- a/npm/react/examples/nextjs/package.json
+++ b/npm/react/examples/nextjs/package.json
@@ -14,15 +14,14 @@
   },
   "devDependencies": {
     "@cypress/react": "file:../../dist",
-    "@cypress/webpack-dev-server": "^1.1.3",
+    "@cypress/webpack-dev-server": "0.0.0-development",
     "@mdx-js/loader": "^1.6.16",
     "@next/mdx": "10.1.2",
     "@zeit/next-sass": "^1.0.1",
     "check-code-coverage": "1.9.2",
     "cypress-circleci-reporter": "0.2.0",
     "next": "10.1.2",
-    "webpack": "4.x",
-    "webpack-dev-server": "^3.11.2"
+    "webpack": "^4.44.1"
   },
   "license": "MIT"
 }

--- a/npm/react/examples/nextjs/package.json
+++ b/npm/react/examples/nextjs/package.json
@@ -19,7 +19,10 @@
     "@zeit/next-sass": "^1.0.1",
     "check-code-coverage": "1.9.2",
     "cypress-circleci-reporter": "0.2.0",
-    "next": "10.1.2"
+    "next": "10.1.2",
+    "@cypress/webpack-dev-server": "^1.1.3"
+    "webpack": "4.x",
+    "webpack-dev-server": "^3.11.2
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Added missing dependencies for users to be able to look at the dependencies and run the tests on their machines.

This code shouldn't affect anything code related on `cypress` package, is more for documentation's sake



Closes #16054

