### PR TITLE
fix: Use next devserver instead of cypress webpack devserver

### DIFF
--- a/npm/react/plugins/next/index.js
+++ b/npm/react/plugins/next/index.js
@@ -1,16 +1,129 @@
-const findNextWebpackConfig = require('./findNextWebpackConfig')
+const next = require("next");
+const { createServer } = require("http");
+const path = require("path");
+const fs = require("fs");
 
-module.exports = (on, config) => {
-  on('dev-server:start', async (options) => {
-    const webpackConfig = await findNextWebpackConfig(config)
+const makeReloader = (testDir, supportFile, specFile) => {
+  const supportFileImport = supportFile
+    ? `()=>import(${JSON.stringify(
+        path.join("..", "projectRoot", supportFile)
+      )})`
+    : `()=>Promise.resolve()`;
+  const specFileImport = specFile
+    ? `()=>import(${JSON.stringify(path.join("..", "projectRoot", specFile))})`
+    : `()=>Promise.resolve()`;
+  const fileContent = `
+        import React from 'react'
+        export default function ReLoader(){
+        React.useEffect(()=>{
+            const Cypress = window.Cypress = (window.opener || window.parent).Cypress
+            if (!Cypress) {
+            throw new Error('Tests cannot run without a reference to Cypress!')
+            }
+            Cypress.onSpecWindow(window,[
+                ${supportFileImport},
+                ${specFileImport}
+                ] )
+            Cypress.action('app:window:before:load', window)
+        },[])
+        return null
+        }`;
+  fs.writeFileSync(
+    path.join(testDir, "components", "testloader.js"),
+    fileContent
+  );
+};
+module.exports = function (on, config) {
+  on("dev-server:start", async (options) => {
+    const testDir = path.join(options.config.projectRoot, ".next", ".cypress");
+    await fs.promises.rmdir(testDir, { recursive: true });
+    await fs.promises.mkdir(path.join(testDir, "pages"), { recursive: true });
+    await fs.promises.mkdir(path.join(testDir, "components"));
+    await fs.promises.symlink(
+      options.config.projectRoot,
+      path.join(testDir, "projectRoot"),
+      "junction"
+    );
+    const supportFile = path.relative(
+      options.config.projectRoot,
+      options.config.supportFile
+    );
+    const nextConfig = {
+      webpack(config) {
+        return config;
+      },
+    };
+    try {
+      Object.assign(
+        nextConfig,
+        require(path.join(config.projectRoot, "next.config.js"))
+      );
+    } catch {
+      console.log("no next.config.js found,using default");
+    }
+    const originalConfigFn = nextConfig.webpack;
+    nextConfig.webpack = (config, options) => {
+      const newConfig = originalConfigFn(config, options);
+      newConfig.resolve.symlinks = false; //otherwise spec files are not transpiled as symlink resolves outside projectRoot
+      return newConfig;
+    };
+    makeReloader(testDir, supportFile);
+    await fs.promises.writeFile(
+      path.join(testDir, "pages", "[[...catchall]].js"),
+      `
+        import React from 'react'
+            import TestLoader from '../components/testloader'
+            export default function App(){
+                return <>
+                    <div id="__cy_root"></div>
+                    <TestLoader/>
+                </>
+                }`
+    );
+    const app = next({
+      dev: true,
+      dir: testDir,
+      conf: nextConfig,
+    });
+    await app.prepare();
+    const handler = app.getRequestHandler();
+    let specPath = null;
+    // ideally would ouput a file similar to https://github.com/cypress-io/cypress/blob/develop/npm/webpack-dev-server/src/loader.ts
+    // but for some reason options.specs always seems to be an empty array so use this hack instead
 
-    // require('webpack') now points to nextjs bundled version
-    const { startDevServer } = require('@cypress/webpack-dev-server')
+    const server = createServer((req, res) => {
+      if (
+        req.headers.__cypress_spec_path &&
+        specPath != req.headers.__cypress_spec_path
+      ) {
+        specPath = req.headers.__cypress_spec_path;
+        makeReloader(testDir, supportFile, specPath);
+      }
 
-    return startDevServer({ options, webpackConfig })
-  })
+      handler(req, res);
+    });
+    options.devServerEvents.on("dev-server:specs:changed", (specs) => {
+      //regenerate specs file if can get to work as planned (see comment above)
+      console.log(specs);
+    });
+    return new Promise((res, rej) => {
+      server.listen(0, "127.0.0.1", (err) => {
+        if (err) rej();
+        console.log(`listening on ${server.address().port}`);
+        res({
+          port: server.address().port,
+          close: (done) => {
+            console.log("shutting down next app");
+            app.close().then(() => {
+              console.log("shutting down devserver");
+              server.close(() => {
+                done && done();
+              });
+            });
+          },
+        });
+      });
+    });
+  });
+};
 
-  config.env.reactDevtools = true
-
-  return config
-}


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #15864<!-- issue number here. e.g. "Closes #1234" -->

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->
Uses next server to host component testing in next apps
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Fixes problems caused by multiple versions of webpack being in use simultaneously

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Should not affect user experience

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->
