### PR TITLE
fix(component-testing): Increased timeout to allow useEffect to trigger

### DIFF
--- a/npm/react/cypress/component/advanced/timers/card-spec.js
+++ b/npm/react/cypress/component/advanced/timers/card-spec.js
@@ -8,7 +8,7 @@ it('should select null after timing out', () => {
   const onSelect = cy.stub().as('selected')
 
   mount(<Card onSelect={onSelect} />)
-  cy.get('@selected', { timeout: 5100 }).should('have.been.calledWith', null)
+  cy.get('@selected', { timeout: 5500 }).should('have.been.calledWith', null)
 })
 
 it('should accept selections', () => {


### PR DESCRIPTION
### User facing changelog
N/A

### Additional details
This will hopefully address the flake with `@cypress/react` tests on `card-spec`.