### PR TITLE
fix(webpack): allow load custom asset on windows

### DIFF
--- a/npm/webpack-dev-server/src/makeWebpackConfig.ts
+++ b/npm/webpack-dev-server/src/makeWebpackConfig.ts
@@ -23,6 +23,7 @@ interface MakeWebpackConfigOptions extends CypressCTOptionsPluginOptions, UserWe
 }
 
 const OsSeparatorRE = RegExp(`\\${path.sep}`, 'g')
+const posixSeparator = '/'
 
 export async function makeWebpackConfig (userWebpackConfig: webpack.Configuration, options: MakeWebpackConfigOptions): Promise<webpack.Configuration> {
   const { projectRoot, devServerPublicPathRoute, files, supportFile, devServerEvents } = options
@@ -34,11 +35,12 @@ export async function makeWebpackConfig (userWebpackConfig: webpack.Configuratio
   debug(`Support file`, supportFile)
 
   const entry = path.resolve(__dirname, './browser.js')
-
-  // The second line here replaces backslashes on windows with posix compatible slash
-  // See https://github.com/cypress-io/cypress/issues/16097
-  const publicPath = path.join(devServerPublicPathRoute, '/')
-  .replace(OsSeparatorRE, '/')
+  const publicPath = (path.sep === posixSeparator)
+    ? path.join(devServerPublicPathRoute, posixSeparator)
+    // The second line here replaces backslashes on windows with posix compatible slash
+    // See https://github.com/cypress-io/cypress/issues/16097
+    : path.join(devServerPublicPathRoute, posixSeparator)
+    .replace(OsSeparatorRE, posixSeparator)
 
   const dynamicWebpackConfig = {
     output: {

--- a/npm/webpack-dev-server/src/makeWebpackConfig.ts
+++ b/npm/webpack-dev-server/src/makeWebpackConfig.ts
@@ -33,7 +33,10 @@ export async function makeWebpackConfig (userWebpackConfig: webpack.Configuratio
 
   const entry = path.resolve(__dirname, './browser.js')
 
+  // The second line here replaces backslashes on windows with posix compatible slash
+  // See https://github.com/cypress-io/cypress/issues/16097
   const publicPath = path.join(devServerPublicPathRoute, '/')
+  .replace(/\\/g, '/')
 
   const dynamicWebpackConfig = {
     output: {

--- a/npm/webpack-dev-server/src/makeWebpackConfig.ts
+++ b/npm/webpack-dev-server/src/makeWebpackConfig.ts
@@ -22,6 +22,8 @@ interface MakeWebpackConfigOptions extends CypressCTOptionsPluginOptions, UserWe
   isOpenMode: boolean
 }
 
+const OsSeparatorRE = RegExp(`\\${path.sep}`, 'g')
+
 export async function makeWebpackConfig (userWebpackConfig: webpack.Configuration, options: MakeWebpackConfigOptions): Promise<webpack.Configuration> {
   const { projectRoot, devServerPublicPathRoute, files, supportFile, devServerEvents } = options
 
@@ -36,7 +38,7 @@ export async function makeWebpackConfig (userWebpackConfig: webpack.Configuratio
   // The second line here replaces backslashes on windows with posix compatible slash
   // See https://github.com/cypress-io/cypress/issues/16097
   const publicPath = path.join(devServerPublicPathRoute, '/')
-  .replace(/\\/g, '/')
+  .replace(OsSeparatorRE, '/')
 
   const dynamicWebpackConfig = {
     output: {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- closes #16097

### User facing changelog
On windows, before this fix, fonts and other assets (images) could not be used since their path was not hitting the `__cypress/src/` root

### Additional details
Was discovered with Jason Fairchild on Discord

### How has the user experience changed?
Before the fix
![bug](https://user-images.githubusercontent.com/5592465/115436376-89142380-a1d0-11eb-89f6-99d6572b7949.png)




