### PR TITLE
chore(deps): downgrade electron to v12.0.0-beta.14

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -24,7 +24,7 @@
     "minimist": "1.2.5"
   },
   "devDependencies": {
-    "electron": "12.0.2",
+    "electron": "12.0.0-beta.14",
     "execa": "4.1.0",
     "mocha": "3.5.3"
   },


### PR DESCRIPTION
Fixes #15853 

### User facing changelog

- Fixed an issue causing tests to run slowly after upgrading to 7.0.0, especially when run with constrained CPU resources.
- Downgradeded bundled Chrome version to 87.

### Additional details

Electron v12.0.0-beta.16 and above contain an unknown bug causing a major slowdown when video recording is enabled. For now maybe we can downgrade Electron to this last known good version, v12.0.0-beta.14

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
