### PR TITLE
chore: fix darwin ci workflow

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -104,6 +104,9 @@ commands:
 
   build-and-persist:
     description: Save entire folder as artifact for other jobs to run without reinstalling
+    parameters:
+      executor:
+        type: executor
     steps: 
       - run:
           name: Build packages
@@ -860,7 +863,8 @@ jobs:
       - run:
           name: Top level packages
           command: yarn list --depth=0 || true
-      - build-and-persist
+      - build-and-persist:
+          executor: <<parameters.executor>>
       - store-npm-logs
 
   lint:

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ macBuildFilters: &macBuildFilters
         - develop
         - 7.0-release
         - include-electron-node-version
+        - tgriesser/chore/fix-ci-mac
 
 defaults: &defaults
   parallelism: 1
@@ -107,7 +108,11 @@ commands:
       - run:
           name: Build packages
           command: yarn build
-      - prepare-modules-cache # So we don't throw these in the workspace cache
+      - unless:
+          condition:
+            equal: [ mac, <<parameters.executor>> ]
+          steps:
+            - prepare-modules-cache # So we don't throw these in the workspace cache
       - persist_to_workspace:
           root: ~/
           paths:
@@ -467,10 +472,6 @@ commands:
         type: string
         default: "CI=true yarn start"
     steps:
-      - restore_cached_workspace
-      # make sure the binary and NPM package files are present
-      - run: ls -l
-      - run: ls -l cypress.zip cypress.tgz
       - clone-repo-and-checkout-release-branch:
           repo: <<parameters.repo>>
       - when:
@@ -601,11 +602,6 @@ commands:
         type: string
         default: "npm start --if-present"
     steps:
-      - attach_workspace:
-          at: ~/
-      # make sure the binary and NPM package files are present
-      - run: ls -l
-      - run: ls -l cypress.zip cypress.tgz
       - clone-repo-and-checkout-release-branch:
           repo: <<parameters.repo>>
       - when:
@@ -848,7 +844,19 @@ jobs:
       - checkout
       - install-required-node
       - install-build-setup
-      - unpack-dependencies
+      - unless:
+          condition:
+            equal: [ mac, <<parameters.executor>> ]
+          steps:
+            - unpack-dependencies
+      - when:
+          condition:
+            equal: [ mac, <<parameters.executor>> ]
+          steps:
+            - run:
+                name: Install node_modules
+                command: yarn --prefer-offline --frozen-lockfile
+                no_output_timeout: 20m
       - run:
           name: Top level packages
           command: yarn list --depth=0 || true
@@ -2073,16 +2081,9 @@ linux-workflow: &linux-workflow
 
 mac-workflow: &mac-workflow
   jobs:
-    - node_modules_install:
-        name: darwin-node-modules-install
-        executor: mac
-        <<: *macBuildFilters
-
     - build:
         name: darwin-build
         executor: mac
-        requires:
-          - darwin-node-modules-install        
         <<: *macBuildFilters
 
     - lint:

--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,9 @@ defaults: &defaults
     executor:
       type: executor
       default: cy-doc
+    is-mac:
+      type: boolean
+      default: false
   executor: <<parameters.executor>>
   environment:
     ## set specific timezone
@@ -840,10 +843,6 @@ jobs:
   ## restores node_modules from previous step & builds if first step skipped
   build:
     <<: *defaults
-    parameters:
-      is-mac:
-        type: boolean
-        default: false
     steps:
       - checkout
       - install-required-node

--- a/circle.yml
+++ b/circle.yml
@@ -1,16 +1,25 @@
 version: 2.1
 
+isMacParams: &isMacParams
+  is-mac:
+    type: boolean
+    default: false
+
+macDefaults: &macDefaults
+  executor: mac
+  is-mac: true
+
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
 # so just add your branch to the list here to build and test on Mac
 macBuildFilters: &macBuildFilters
+  <<: *macDefaults
   filters:
     branches:
       only:
         - develop
         - 7.0-release
         - include-electron-node-version
-        - tgriesser/chore/fix-ci-mac
 
 defaults: &defaults
   parallelism: 1
@@ -19,9 +28,7 @@ defaults: &defaults
     executor:
       type: executor
       default: cy-doc
-    is-mac:
-      type: boolean
-      default: false
+    <<: *isMacParams
   executor: <<parameters.executor>>
   environment:
     ## set specific timezone
@@ -89,10 +96,15 @@ commands:
       - run: npm --version
 
   restore_cached_workspace:
+    parameters:
+      <<: *isMacParams
     steps:
       - attach_workspace:
           at: ~/
-      - unpack-dependencies
+      - unless:
+          condition: << parameters.is-mac >>
+          steps:
+            - unpack-dependencies
 
   prepare-modules-cache:
     steps:
@@ -108,14 +120,15 @@ commands:
   build-and-persist:
     description: Save entire folder as artifact for other jobs to run without reinstalling
     parameters:
-      is-mac:
-        type: boolean
-        default: false
+      <<: *isMacParams
     steps: 
       - run:
           name: Build packages
           command: yarn build
-      - prepare-modules-cache # So we don't throw these in the workspace cache
+      - unless:
+          condition: << parameters.is-mac >>
+          steps:
+            - prepare-modules-cache # So we don't throw these in the workspace cache
       - persist_to_workspace:
           root: ~/
           paths:
@@ -284,8 +297,10 @@ commands:
       browser:
         description: browser shortname to target
         type: string
+      <<: *isMacParams        
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           environment:
             CYPRESS_KONFIG_ENV: production
@@ -324,8 +339,10 @@ commands:
         description: enable percy
         type: boolean
         default: false
+      <<: *isMacParams        
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           command: |
             cmd=$([[ <<parameters.percy>> == 'true' ]] && echo 'yarn percy exec --') || true
@@ -350,8 +367,10 @@ commands:
         description: enable percy
         type: boolean
         default: false
+      <<: *isMacParams
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           command: |
             cmd=$([[ <<parameters.percy>> == 'true' ]] && echo 'yarn percy exec --') || true
@@ -378,8 +397,10 @@ commands:
       browser:
         description: browser shortname to target
         type: string
+      <<: *isMacParams
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           command: yarn workspace @packages/server test ./test/e2e/$(( $CIRCLE_NODE_INDEX ))_*spec* --browser <<parameters.browser>>
       - verify-mocha-results
@@ -427,8 +448,10 @@ commands:
       repo:
         description: "Name of the github repo to clone like: cypress-example-kitchensink"
         type: string
+      <<: *isMacParams        
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           name: "Cloning test project: <<parameters.repo>>"
           command: |
@@ -868,7 +891,8 @@ jobs:
   lint:
     <<: *defaults
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - install-required-node
       ## this will catch ".only"s in js/coffee as well
       - run:
@@ -890,8 +914,10 @@ jobs:
     parameters:
       required_env_var:
         type: env_var_name
+      <<: *isMacParams
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           # if this is an external pull request, the environment variables
           # are NOT set for security reasons, thus no need to poll -
@@ -918,7 +944,8 @@ jobs:
     <<: *defaults
     parallelism: 8
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run: mkdir -p cli/visual-snapshots
       - run:
           command: node cli/bin/cypress info --dev | yarn --silent term-to-html | node scripts/sanitize --type cli-info > cli/visual-snapshots/cypress-info.html
@@ -941,7 +968,8 @@ jobs:
     <<: *defaults
     parallelism: 1
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       # make sure mocha runs
       - run: yarn test-mocha
       # test binary build code
@@ -967,7 +995,8 @@ jobs:
     <<: *defaults
     parallelism: 1
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           command: ls -la types
           working_directory: cli
@@ -986,7 +1015,8 @@ jobs:
     <<: *defaults
     parallelism: 1
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run: yarn test-unit --scope @packages/server
       - verify-mocha-results:
           expectedResultCount: 1
@@ -998,7 +1028,8 @@ jobs:
     <<: *defaults
     parallelism: 1
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run: yarn test-unit --scope @packages/server-ct
       - verify-mocha-results:
           expectedResultCount: 1
@@ -1010,7 +1041,8 @@ jobs:
     <<: *defaults
     parallelism: 1
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run: yarn test-integration --scope @packages/server
       - verify-mocha-results:
           expectedResultCount: 1
@@ -1021,7 +1053,8 @@ jobs:
   server-performance-tests:
     <<: *defaults
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           command: yarn workspace @packages/server test-performance
       - verify-mocha-results:
@@ -1037,6 +1070,7 @@ jobs:
     parallelism: 8
     steps:
       - run-e2e-tests:
+          is-mac: << parameters.is-mac >>
           browser: chrome
 
   server-e2e-tests-electron:
@@ -1044,6 +1078,7 @@ jobs:
     parallelism: 8
     steps:
       - run-e2e-tests:
+          is-mac: << parameters.is-mac >>
           browser: electron
 
   server-e2e-tests-firefox:
@@ -1051,12 +1086,14 @@ jobs:
     parallelism: 8
     steps:
       - run-e2e-tests:
+          is-mac: << parameters.is-mac >>
           browser: firefox
 
   server-e2e-tests-non-root:
     <<: *defaults
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           command: yarn workspace @packages/server test ./test/e2e/non_root*spec* --browser electron
       - verify-mocha-results
@@ -1107,7 +1144,8 @@ jobs:
     <<: *defaults
     parallelism: 2
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           command: yarn build-prod
           working_directory: packages/desktop-gui
@@ -1132,7 +1170,8 @@ jobs:
     <<: *defaults
     parallelism: 1
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           # will use PERCY_TOKEN environment variable if available
           command: |
@@ -1149,7 +1188,8 @@ jobs:
   reporter-integration-tests:
     <<: *defaults
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           command: yarn build-for-tests
           working_directory: packages/reporter
@@ -1172,7 +1212,8 @@ jobs:
   ui-components-integration-tests:
     <<: *defaults
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           command: yarn build-for-tests
           working_directory: packages/ui-components
@@ -1192,7 +1233,8 @@ jobs:
   npm-webpack-preprocessor:
     <<: *defaults
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           name: Build
           command: yarn workspace @cypress/webpack-preprocessor build
@@ -1229,14 +1271,16 @@ jobs:
   npm-webpack-dev-server:
     <<: *defaults
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           name: Run tests
           command: yarn workspace @cypress/webpack-dev-server test
   npm-vite-dev-server:
     <<: *defaults
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           name: Run tests
           command: yarn test --reporter cypress-circleci-reporter --reporter-options resultsDir=./test_results
@@ -1250,7 +1294,8 @@ jobs:
   npm-rollup-dev-server:
     <<: *defaults
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           name: Run tests
           command: yarn workspace @cypress/rollup-dev-server test
@@ -1258,7 +1303,8 @@ jobs:
   npm-webpack-batteries-included-preprocessor:
     <<: *defaults
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           name: Run tests
           command: yarn workspace @cypress/webpack-batteries-included-preprocessor test
@@ -1267,7 +1313,8 @@ jobs:
     <<: *defaults
     parallelism: 3
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           name: Build
           command: yarn workspace @cypress/vue build
@@ -1284,7 +1331,8 @@ jobs:
   npm-design-system:
     <<: *defaults
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           name: Build
           command: yarn workspace @cypress/design-system build
@@ -1299,7 +1347,8 @@ jobs:
     <<: *defaults
     parallelism: 8
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - restore_cache:
           name: Restore yarn cache
           key: v{{ .Environment.CACHE_VERSION }}-{{ arch }}-npm-react-babel-cache
@@ -1320,7 +1369,8 @@ jobs:
   npm-create-cypress-tests:
     <<: *defaults
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run: yarn workspace create-cypress-tests build
       - run:
           name: Run unit test
@@ -1329,7 +1379,8 @@ jobs:
   npm-eslint-plugin-dev:
     <<: *defaults
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           name: Run tests
           command: yarn workspace @cypress/eslint-plugin-dev test
@@ -1337,7 +1388,8 @@ jobs:
   npm-release:
     <<: *defaults
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run:
           name: Release packages after all jobs pass
           command: yarn npm-release
@@ -1346,7 +1398,8 @@ jobs:
     <<: *defaults
     shell: /bin/bash --login
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - build-binary
       - build-npm-package
       - run:
@@ -1428,7 +1481,8 @@ jobs:
     <<: *defaults
     steps:
       # needs uploaded NPM and test binary
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       - run: ls -la
       # make sure JSON files with uploaded urls are present
       - run: ls -la binary-url.json npm-package-url.json
@@ -1463,7 +1517,8 @@ jobs:
   "test-npm-module-and-verify-binary":
     <<: *defaults
     steps:
-      - restore_cached_workspace
+      - restore_cached_workspace:
+          is-mac: <<parameters.is-mac>>
       # make sure we have cypress.zip received
       - run: ls -l
       - run: ls -l cypress.zip cypress.tgz
@@ -2086,13 +2141,10 @@ mac-workflow: &mac-workflow
   jobs:
     - build:
         name: darwin-build
-        executor: mac
-        is-mac: true
         <<: *macBuildFilters
 
     - lint:
         name: darwin-lint
-        executor: mac
         <<: *macBuildFilters
         requires:
           - darwin-build
@@ -2105,29 +2157,26 @@ mac-workflow: &mac-workflow
           - test-runner:sign-mac-binary
           - test-runner:upload
           - test-runner:commit-status-checks
-        executor: mac
         <<: *macBuildFilters
         requires:
           - darwin-build
 
     - test-kitchensink:
         name: darwin-test-kitchensink
-        executor: mac
         <<: *macBuildFilters
         requires:
           - darwin-build
 
     - test-binary-against-kitchensink:
         name: darwin-test-binary-against-kitchensink
-        executor: mac
         <<: *macBuildFilters
         requires:
           - darwin-create-build-artifacts
 
     - test-binary-against-staging:
+        <<: *macDefaults
         context: test-runner:record-tests
         name: darwin-test-binary-against-staging
-        executor: mac
         filters:
           branches:
             only:
@@ -2137,9 +2186,9 @@ mac-workflow: &mac-workflow
           - darwin-create-build-artifacts
 
     - test-binary-and-npm-against-other-projects:
+        <<: *macDefaults
         context: test-runner:trigger-test-jobs
         name: darwin-test-binary-and-npm-against-other-projects
-        executor: mac
         filters:
           branches:
             only:

--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,7 @@ macBuildFilters: &macBuildFilters
         - develop
         - 7.0-release
         - include-electron-node-version
+        - tgriesser/chore/fix-ci-mac
 
 defaults: &defaults
   parallelism: 1

--- a/circle.yml
+++ b/circle.yml
@@ -105,17 +105,14 @@ commands:
   build-and-persist:
     description: Save entire folder as artifact for other jobs to run without reinstalling
     parameters:
-      executor:
-        type: executor
+      is-mac:
+        type: boolean
+        default: false
     steps: 
       - run:
           name: Build packages
           command: yarn build
-      - unless:
-          condition:
-            equal: [ mac, <<parameters.executor>> ]
-          steps:
-            - prepare-modules-cache # So we don't throw these in the workspace cache
+      - prepare-modules-cache # So we don't throw these in the workspace cache
       - persist_to_workspace:
           root: ~/
           paths:
@@ -843,18 +840,20 @@ jobs:
   ## restores node_modules from previous step & builds if first step skipped
   build:
     <<: *defaults
+    parameters:
+      is-mac:
+        type: boolean
+        default: false
     steps:
       - checkout
       - install-required-node
       - install-build-setup
       - unless:
-          condition:
-            equal: [ mac, <<parameters.executor>> ]
+          condition: << parameters.is-mac >>
           steps:
             - unpack-dependencies
       - when:
-          condition:
-            equal: [ mac, <<parameters.executor>> ]
+          condition: << parameters.is-mac >>
           steps:
             - run:
                 name: Install node_modules
@@ -864,7 +863,7 @@ jobs:
           name: Top level packages
           command: yarn list --depth=0 || true
       - build-and-persist:
-          executor: <<parameters.executor>>
+          is-mac: << parameters.is-mac >>
       - store-npm-logs
 
   lint:
@@ -2089,6 +2088,7 @@ mac-workflow: &mac-workflow
     - build:
         name: darwin-build
         executor: mac
+        is-mac: true
         <<: *macBuildFilters
 
     - lint:


### PR DESCRIPTION
Follow up to #16115

The caching approach is broken in the `mac` workflow, so we'll just keep to the previous behavior until we find a workaround 