### PR TITLE
fix: Remove the dot from the extension in create file dialog

### DIFF
--- a/packages/server/lib/gui/dialog.ts
+++ b/packages/server/lib/gui/dialog.ts
@@ -35,10 +35,10 @@ export const showSaveDialog = (integrationFolder: string) => {
     showsTagField: false,
     filters: [{
       name: 'JavaScript',
-      extensions: ['.js'],
+      extensions: ['js'],
     }, {
       name: 'TypeScript',
-      extensions: ['.ts'],
+      extensions: ['ts'],
     }, {
       name: 'Other',
       extensions: ['*'],


### PR DESCRIPTION
- close #16131

### User facing changelog

Changing files extensions when creating a new test file should no longer add extra dots to the filename. 

### Additional Details

- The Electron API doesn’t show the dots in the extension: https://www.electronjs.org/docs/api/dialog#dialogshowopendialogsyncbrowserwindow-options
- I don’t know if this fixes the issue, as it looked like this may only occur in Windows
- Is there a way to test this? 