### PR TITLE
fix: `cy.type()` should not change the value attr of button-like inputs.

### DIFF
--- a/packages/driver/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_spec.js
@@ -495,25 +495,6 @@ describe('src/cy/commands/actions/type - #type', () => {
       'image',
       'reset',
       'submit',
-    ], (type) => {
-      describe(`[type=${type}]`, () => {
-        let input
-
-        beforeEach(() => {
-          input = cy.$$(`<input type='${type}' id='button-like-input-type-${type}' value="foo" />`)
-          cy.$$('body').append(input)
-        })
-
-        it(`value does not change when typing on `, () => {
-          cy
-          .get(`#button-like-input-type-${type}`)
-          .type('bar')
-          .should('have.value', 'foo')
-        })
-      })
-    })
-
-    _.each([
       'checkbox',
       'radio',
     ], (type) => {
@@ -530,20 +511,6 @@ describe('src/cy/commands/actions/type - #type', () => {
           .get(`#button-like-input-type-${type}`)
           .type('bar')
           .should('have.value', 'foo')
-        })
-
-        it('is not checked when the typed chars do not contain space', () => {
-          cy
-          .get(`#button-like-input-type-${type}`)
-          .type('bar')
-          .should('not.be.checked')
-        })
-
-        it('is checked when the typed chars contain space', () => {
-          cy
-          .get(`#button-like-input-type-${type}`)
-          .type('bar ')
-          .should('be.checked')
         })
       })
     })

--- a/packages/driver/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_spec.js
@@ -489,6 +489,66 @@ describe('src/cy/commands/actions/type - #type', () => {
     })
   })
 
+  describe('button-like input types', () => {
+    _.each([
+      'button',
+      'image',
+      'reset',
+      'submit',
+    ], (type) => {
+      describe(`[type=${type}]`, () => {
+        let input
+
+        beforeEach(() => {
+          input = cy.$$(`<input type='${type}' id='button-like-input-type-${type}' value="foo" />`)
+          cy.$$('body').append(input)
+        })
+
+        it(`value does not change when typing on `, () => {
+          cy
+          .get(`#button-like-input-type-${type}`)
+          .type('bar')
+          .should('have.value', 'foo')
+        })
+      })
+    })
+
+    _.each([
+      'checkbox',
+      'radio',
+    ], (type) => {
+      describe(`[type=${type}]`, () => {
+        let input
+
+        beforeEach(() => {
+          input = cy.$$(`<input type='${type}' id='button-like-input-type-${type}' value="foo" />`)
+          cy.$$('body').append(input)
+        })
+
+        it(`value does not change when typing on `, () => {
+          cy
+          .get(`#button-like-input-type-${type}`)
+          .type('bar')
+          .should('have.value', 'foo')
+        })
+
+        it('is not checked when the typed chars do not contain space', () => {
+          cy
+          .get(`#button-like-input-type-${type}`)
+          .type('bar')
+          .should('not.be.checked')
+        })
+
+        it('is checked when the typed chars contain space', () => {
+          cy
+          .get(`#button-like-input-type-${type}`)
+          .type('bar ')
+          .should('be.checked')
+        })
+      })
+    })
+  })
+
   describe('tabindex', () => {
     beforeEach(function () {
       this.$div = cy.$$('#tabindex')

--- a/packages/driver/src/cy/commands/actions/type.js
+++ b/packages/driver/src/cy/commands/actions/type.js
@@ -400,12 +400,21 @@ module.exports = function (Commands, Cypress, cy, state, config) {
             return type()
           }
 
+          let command = 'click'
+
+          // When $elToClick is button-like and the typed chars don't include space
+          // we should not click the element.
+          // So, we need to focus rather than click.
+          if ($elements.isButtonLike($elToClick) && !chars.includes(' ')) {
+            command = 'focus'
+          }
+
           // click the element first to simulate focus
           // and typical user behavior in case the window
           // is out of focus
           // cannot just call .focus, since children of contenteditable will not receive cursor
           // with .focus()
-          return cy.now('click', $elToClick, {
+          return cy.now(command, $elToClick, {
             $el: $elToClick,
             log: false,
             verify: false,

--- a/packages/driver/src/cy/commands/actions/type.js
+++ b/packages/driver/src/cy/commands/actions/type.js
@@ -400,21 +400,12 @@ module.exports = function (Commands, Cypress, cy, state, config) {
             return type()
           }
 
-          let command = 'click'
-
-          // When $elToClick is button-like and the typed chars don't include space
-          // we should not click the element.
-          // So, we need to focus rather than click.
-          if ($elements.isButtonLike($elToClick) && !chars.includes(' ')) {
-            command = 'focus'
-          }
-
           // click the element first to simulate focus
           // and typical user behavior in case the window
           // is out of focus
           // cannot just call .focus, since children of contenteditable will not receive cursor
           // with .focus()
-          return cy.now(command, $elToClick, {
+          return cy.now('click', $elToClick, {
             $el: $elToClick,
             log: false,
             verify: false,

--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -321,6 +321,10 @@ const shouldUpdateValue = (el: HTMLElement, key: KeyDetails, options: typeOption
       return false
     }
 
+    if ($elements.isButtonLike(el) && !options.force) {
+      return false
+    }
+
     const isNumberInputType = $elements.isInput(el) && $elements.isInputType(el, 'number')
 
     if (isNumberInputType) {

--- a/packages/driver/src/dom/elements.ts
+++ b/packages/driver/src/dom/elements.ts
@@ -800,6 +800,21 @@ const isTextLike = function (el: HTMLElement): el is HTMLTextLikeElement {
   ])
 }
 
+const isButtonLike = (el: HTMLElement) => {
+  const type = (type) => {
+    return isInputType(el, type)
+  }
+
+  return _.some([
+    type('button'),
+    type('image'),
+    type('reset'),
+    type('submit'),
+    type('checkbox'),
+    type('radio'),
+  ])
+}
+
 const isInputAllowingImplicitFormSubmission = function ($el) {
   const type = (type) => {
     return isInputType($el, type)
@@ -1340,6 +1355,7 @@ export {
   isChild,
   isScrollable,
   isTextLike,
+  isButtonLike,
   isDescendent,
   isContentEditable,
   isSame,


### PR DESCRIPTION
- Closes #15913

### User facing changelog

* `cy.type()` will not change the `value` attribute of button-like inputs(`button`, `submit`, `reset`, `image`, `radio`, `checkbox`).

### Additional details
- Why was this change necessary? => For those elements, `cy.type()` didn't reflect the browser behavior.
- What is affected by this change? => N/A
- Any implementation details to explain? => It does not update the input when it is button-like.

### How has the user experience changed?

N/A

### Note

I tried to implement 'check on pressing space', but failed because simply changing cypress command doesn't work on Firefox. 

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?