### PR TITLE
fix: properly detect `cy.intercept(url, routeMatcher, handler)` overload

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -256,6 +256,11 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
       cy.wait('@create')
     })
 
+    // @see https://github.com/cypress-io/cypress/issues/16117
+    it('can statically stub a url response with headers', () => {
+      cy.intercept('/url', { headers: { foo: 'bar' }, body: 'something' })
+    })
+
     // TODO: implement warning in cy.intercept if appropriate
     // https://github.com/cypress-io/cypress/issues/2372
     it.skip('warns if a percent-encoded URL is used', function () {

--- a/packages/driver/src/cy/net-stubbing/add-command.ts
+++ b/packages/driver/src/cy/net-stubbing/add-command.ts
@@ -19,13 +19,16 @@ import {
   validateStaticResponse,
   getBackendStaticResponse,
   hasStaticResponseKeys,
-  hasRouteMatcherKeys,
 } from './static-response-utils'
 import { registerEvents } from './events'
 import $errUtils from '../../cypress/error_utils'
 import $utils from '../../cypress/utils'
 
 const lowercaseFieldNames = (headers: { [fieldName: string]: any }) => _.mapKeys(headers, (v, k) => _.toLower(k))
+
+export function hasOnlyRouteMatcherKeys (obj: any) {
+  return !_.isEmpty(obj) && !_.isArray(obj) && _.isEmpty(_.omit(obj, _.concat(PLAIN_FIELDS, STRING_MATCHER_FIELDS, DICT_STRING_MATCHER_FIELDS)))
+}
 
 /**
  * Get all STRING_MATCHER_FIELDS paths plus any extra fields the user has added within
@@ -280,7 +283,7 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
 
   function intercept (matcher: RouteMatcher, handler?: RouteHandler | StringMatcher | RouteMatcherOptions, arg2?: RouteHandler) {
     function getMatcherOptions (): RouteMatcherOptions {
-      if (_.isString(matcher) && hasRouteMatcherKeys(handler)) {
+      if (_.isString(matcher) && hasOnlyRouteMatcherKeys(handler)) {
         // url, mergeRouteMatcher, handler
         // @ts-ignore
         if (handler.url) {

--- a/packages/driver/src/cy/net-stubbing/events/before-request.ts
+++ b/packages/driver/src/cy/net-stubbing/events/before-request.ts
@@ -94,24 +94,6 @@ export const onBeforeRequest: HandlerFn<CyHttpMessages.IncomingRequest> = (Cypre
       requestWaited: false,
       responseWaited: false,
       subscriptions: [],
-      on (eventName, handler) {
-        if (!validEvents.includes(eventName)) {
-          return $errUtils.throwErrByPath('net_stubbing.request_handling.unknown_event', {
-            args: {
-              validEvents,
-              eventName,
-            },
-          })
-        }
-
-        if (!_.isFunction(handler)) {
-          return $errUtils.throwErrByPath('net_stubbing.request_handling.event_needs_handler')
-        }
-
-        subscribe(eventName, handler)
-
-        return request
-      },
     }
   }
 
@@ -122,7 +104,24 @@ export const onBeforeRequest: HandlerFn<CyHttpMessages.IncomingRequest> = (Cypre
 
   const userReq: CyHttpMessages.IncomingHttpRequest = {
     ...req,
-    on: request.on,
+    on (eventName, handler) {
+      if (!validEvents.includes(eventName)) {
+        return $errUtils.throwErrByPath('net_stubbing.request_handling.unknown_event', {
+          args: {
+            validEvents,
+            eventName,
+          },
+        })
+      }
+
+      if (!_.isFunction(handler)) {
+        return $errUtils.throwErrByPath('net_stubbing.request_handling.event_needs_handler')
+      }
+
+      subscribe(eventName, handler)
+
+      return userReq
+    },
     continue (responseHandler?) {
       if (resolved) {
         return $errUtils.throwErrByPath('net_stubbing.request_handling.completion_called_after_resolved', { args: { cmd: 'continue' } })

--- a/packages/driver/src/cy/net-stubbing/static-response-utils.ts
+++ b/packages/driver/src/cy/net-stubbing/static-response-utils.ts
@@ -4,9 +4,6 @@ import {
   StaticResponse,
   BackendStaticResponse,
   FixtureOpts,
-  PLAIN_FIELDS,
-  STRING_MATCHER_FIELDS,
-  DICT_STRING_MATCHER_FIELDS,
 } from '@packages/net-stubbing/lib/types'
 import $errUtils from '../../cypress/error_utils'
 
@@ -124,8 +121,4 @@ export function getBackendStaticResponse (staticResponse: Readonly<StaticRespons
 
 export function hasStaticResponseKeys (obj: any) {
   return !_.isArray(obj) && (_.intersection(_.keys(obj), STATIC_RESPONSE_KEYS).length || _.isEmpty(obj))
-}
-
-export function hasRouteMatcherKeys (obj: any) {
-  return _.intersection(_.keys(obj), _.concat(PLAIN_FIELDS, STRING_MATCHER_FIELDS, DICT_STRING_MATCHER_FIELDS)).length
 }

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -92,7 +92,7 @@ export namespace CyHttpMessages {
      */
     statusMessage: string
     /**
-     * Kilobits per second to send 'body'.
+     * Kilobytes per second to send 'body'.
      */
     throttleKbps?: number
     /**
@@ -152,7 +152,7 @@ export namespace CyHttpMessages {
     alias?: string
   }
 
-  export interface IncomingHttpRequest extends IncomingRequest, InterceptionEvents {
+  export interface IncomingHttpRequest extends IncomingRequest, RequestEvents {
     /**
      * Destroy the request and respond with a network error.
      */
@@ -237,31 +237,31 @@ export interface Subscription {
   skip?: boolean
 }
 
-interface InterceptionEvents {
+interface RequestEvents {
   /**
    * Emitted before `response` and before any `req.continue` handlers.
    * Modifications to `res` will be applied to the incoming response.
    * If a promise is returned from `cb`, it will be awaited before processing other event handlers.
    */
-  on(eventName: 'before:response', cb: HttpResponseInterceptor): Interception
+  on(eventName: 'before:response', cb: HttpResponseInterceptor): this
   /**
    * Emitted after `before:response` and after any `req.continue` handlers - before the response is sent to the browser.
    * Modifications to `res` will be applied to the incoming response.
    * If a promise is returned from `cb`, it will be awaited before processing other event handlers.
    */
-  on(eventName: 'response', cb: HttpResponseInterceptor): Interception
+  on(eventName: 'response', cb: HttpResponseInterceptor): this
   /**
    * Emitted once the response to a request has finished sending to the browser.
    * Modifications to `res` have no impact.
    * If a promise is returned from `cb`, it will be awaited before processing other event handlers.
    */
-  on(eventName: 'after:response', cb: (res: CyHttpMessages.IncomingResponse) => void | Promise<void>): Interception
+  on(eventName: 'after:response', cb: (res: CyHttpMessages.IncomingResponse) => void | Promise<void>): this
 }
 
 /**
  * Request/response cycle.
  */
-export interface Interception extends InterceptionEvents {
+export interface Interception {
   id: string
   routeId: string
   /* @internal */
@@ -342,7 +342,7 @@ export interface RouteMatcherOptionsGeneric<S> {
    */
   method?: S
   /**
-   * If `true`, this will pass the request on to the next `RouteMatcher` after the request handler completes.
+   * If `true`, this handler will be called before any non-`middleware` handlers, in the order it was defined.
    * Can only be used with a dynamic request handler.
    * @default false
    */
@@ -413,7 +413,7 @@ export interface GenericStaticResponse<Fixture, Body> {
    */
   forceNetworkError?: boolean
   /**
-   * Kilobits per second to send 'body'.
+   * Kilobytes per second to send 'body'.
    */
   throttleKbps?: number
   /**


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #16117

### User facing changelog

- Fixed an issue in 7.0 where users could get a misleading "must pass a handler as the 3rd argument" error when using `cy.intercept`.
- Improved types for `cy.intercept()`.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [na] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
