### PR TITLE
chore: fix failing "should handle aborted requests" test

### DIFF
--- a/packages/driver/cypress/fixtures/xhr-abort.html
+++ b/packages/driver/cypress/fixtures/xhr-abort.html
@@ -5,13 +5,13 @@
     <script>
       function abortAndRequestAgain() {
         let xhr = new XMLHttpRequest();
-        xhr.open("GET", "https://jsonplaceholder.typicode.com/todos/1");
+        xhr.open("GET", "https://jsonplaceholder.cypress.io/todos/1");
         xhr.responseType = "json";
         xhr.send();
         xhr.abort();
 
         xhr = new XMLHttpRequest();
-        xhr.open("GET", "https://jsonplaceholder.typicode.com/todos/1");
+        xhr.open("GET", "https://jsonplaceholder.cypress.io/todos/1");
         xhr.responseType = "json";
         xhr.send();
         xhr.onload = () => {

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -2620,7 +2620,7 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
 
     // https://github.com/cypress-io/cypress/issues/9549
     it('should handle aborted requests', () => {
-      cy.intercept('https://jsonplaceholder.typicode.com/todos/1').as('xhr')
+      cy.intercept('https://jsonplaceholder.cypress.io/todos/1').as('xhr')
       cy.visit('fixtures/xhr-abort.html')
       cy.get('#btn').click()
       cy.get('pre').contains('delectus') // response body renders to page


### PR DESCRIPTION
Looks like typicode's jsonplaceholder went down and broke this test. Luckily we host our own.