### PR TITLE
chore: run driver, runner tests in electron

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1101,6 +1101,13 @@ jobs:
       - run-runner-integration-tests:
           browser: firefox
 
+  runner-integration-tests-electron:
+    <<: *defaults
+    parallelism: 2
+    steps:
+      - run-runner-integration-tests:
+          browser: electron
+
   runner-ct-integration-tests-chrome:
     <<: *defaults
     parallelism: 1
@@ -1122,6 +1129,13 @@ jobs:
     steps:
       - run-driver-integration-tests:
           browser: firefox
+
+  driver-integration-tests-electron:
+    <<: *defaults
+    parallelism: 5
+    steps:
+      - run-driver-integration-tests:
+          browser: electron
 
   desktop-gui-integration-tests-2x:
     <<: *defaults
@@ -1881,20 +1895,22 @@ linux-workflow: &linux-workflow
     - driver-integration-tests-firefox:
         requires:
           - build
+    - driver-integration-tests-electron:
+        requires:
+          - build
     - runner-integration-tests-chrome:
         requires:
           - build
     - runner-integration-tests-firefox:
         requires:
           - build
+    - runner-integration-tests-electron:
+        requires:
+          - build
     - runner-ct-integration-tests-chrome:
         requires:
           - build
 
-    ## TODO: add these back in when flaky tests are fixed
-    # - driver-integration-tests-electron:
-    #     requires:
-    #       - build
     - desktop-gui-integration-tests-2x:
         requires:
           - build
@@ -1907,7 +1923,6 @@ linux-workflow: &linux-workflow
     - ui-components-integration-tests:
         requires:
           - build
-
     - npm-webpack-dev-server:
         requires:
           - build
@@ -1962,8 +1977,10 @@ linux-workflow: &linux-workflow
           - runner-ct-integration-tests-chrome
           - runner-integration-tests-firefox
           - runner-integration-tests-chrome
+          - runner-integration-tests-electron
           - driver-integration-tests-firefox
           - driver-integration-tests-chrome
+          - driver-integration-tests-electron
           - server-e2e-tests-non-root
           - server-e2e-tests-firefox
           - server-e2e-tests-electron

--- a/packages/driver/cypress/integration/e2e/testConfigOverrides.spec.js
+++ b/packages/driver/cypress/integration/e2e/testConfigOverrides.spec.js
@@ -5,6 +5,7 @@ describe('per-test config', () => {
     ranFirefox: false,
     ranChrome: false,
     ranChromium: false,
+    ranElectron: false,
   }
 
   after(function () {
@@ -15,6 +16,7 @@ describe('per-test config', () => {
         ranChrome: false,
         ranChromium: false,
         ranFirefox: true,
+        ranElectron: false,
       })
     }
 
@@ -23,6 +25,7 @@ describe('per-test config', () => {
         ranChrome: true,
         ranChromium: false,
         ranFirefox: false,
+        ranElectron: false,
       })
     }
 
@@ -31,6 +34,16 @@ describe('per-test config', () => {
         ranChrome: false,
         ranChromium: true,
         ranFirefox: false,
+        ranElectron: false,
+      })
+    }
+
+    if (Cypress.browser.name === 'electron') {
+      return expect(testState).deep.eq({
+        ranChrome: false,
+        ranChromium: false,
+        ranFirefox: false,
+        ranElectron: true,
       })
     }
 
@@ -83,6 +96,13 @@ describe('per-test config', () => {
   }, () => {
     testState.ranFirefox = true
     expect(Cypress.browser.name).eq('firefox')
+  })
+
+  it('can specify only run in electron', {
+    browser: 'electron',
+  }, () => {
+    testState.ranElectron = true
+    expect(Cypress.browser.name).eq('electron')
   })
 
   describe('mutating global config via Cypress.config and Cypress.env', () => {


### PR DESCRIPTION
Per the team's discussion in retrospective, it's possible that the flake has been addressed since 2 years ago and these tests can be reenabled.

PR that originally disabled tests: https://github.com/cypress-io/cypress/pull/5326