### PR TITLE
fix: does not show more than one .should('contain') assertion when chained after .should('be.visible')

### DIFF
--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -127,6 +127,17 @@ describe('src/cy/commands/assertions', () => {
       }).should('deep.eq', { foo: 'baz' })
     })
 
+    // https://github.com/cypress-io/cypress/issues/16006
+    it(`does not show more than one .should('contain') assertion when chained after .should('be.visible')`, function () {
+      cy.get('#data-number')
+      .should('be.visible')
+      .should('contain', 'span')
+      .should('contain', 'with')
+      .then(function () {
+        expect(this.logs[2].get('message')).to.contain('**span**')
+      })
+    })
+
     describe('function argument', () => {
       it('waits until function is true', () => {
         const button = cy.$$('button:first')
@@ -2492,7 +2503,7 @@ describe('src/cy/commands/assertions', () => {
 
         cy.get('button:first').should('have.focus')
         .then(() => {
-          expect(stub).to.be.calledThrice
+          expect(stub).to.be.calledTwice
         })
       })
     })

--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -128,13 +128,14 @@ describe('src/cy/commands/assertions', () => {
     })
 
     // https://github.com/cypress-io/cypress/issues/16006
-    it(`does not show more than one .should('contain') assertion when chained after .should('be.visible')`, function () {
+    it(`shows all .should('contain') assertions when chained after .should('be.visible')`, function () {
       cy.get('#data-number')
       .should('be.visible')
       .should('contain', 'span')
       .should('contain', 'with')
       .then(function () {
         expect(this.logs[2].get('message')).to.contain('**span**')
+        expect(this.logs[3].get('message')).to.contain('**with**')
       })
     })
 

--- a/packages/driver/src/cy/commands/asserting.js
+++ b/packages/driver/src/cy/commands/asserting.js
@@ -59,9 +59,14 @@ module.exports = function (Commands, Cypress, cy, state) {
 
     const applyChainer = function (memo, value) {
       if (value === lastChainer && !isCheckingExistence) {
-        if (_.isFunction(memo[value])) {
+        // https://github.com/cypress-io/cypress/issues/16006
+        // Referring some commands like 'visible'  triggers assert function in chai_jquery.js
+        // It creates duplicated messages and confuses users.
+        const cmd = memo[value]
+
+        if (_.isFunction(cmd)) {
           try {
-            return memo[value].apply(memo, args)
+            return cmd.apply(memo, args)
           } catch (err) {
             // if we made it all the way to the actual
             // assertion but its set to retry false then
@@ -74,7 +79,7 @@ module.exports = function (Commands, Cypress, cy, state) {
             throw err
           }
         } else {
-          return memo[value]
+          return cmd
         }
       } else {
         return memo[value]


### PR DESCRIPTION
- Closes #16006

### User facing changelog

Cypress now correctly shows all `.should('contain')` assertions when chained after `.should('be.visible')`.

### Additional details
- Why was this change necessary? => Cypress showed some messages like `should('contain')` twice and hid other assertions.
- What is affected by this change? => N/A
- Any implementation details to explain? => When `applyChainer` in `asserting.js` triggered `assert` in `chai_jquery.js` every time `memo[value]` is called. I limited it to be called once. 

### How has the user experience changed?

```js
cy.get('#x')
  .should('be.visible')
  .should('contain', 'Something')
  .should('contain', '+123')
```

#### Before

<img width="706" alt="Screen Shot 2021-04-28 at 12 04 35 PM" src="https://user-images.githubusercontent.com/1271364/116444035-ef74f380-a819-11eb-87d1-da5c98bcbe0f.png">


#### After

<img width="589" alt="Screen Shot 2021-04-28 at 12 03 34 PM" src="https://user-images.githubusercontent.com/1271364/116443894-d0766180-a819-11eb-9a28-d1f19d8b13ee.png">


### PR Tasks

- [x] Have tests been added/updated?