### PR TITLE
fix(vite-dev-server): fix url to the client on win

### DIFF
--- a/npm/vite-dev-server/src/makeCypressPlugin.ts
+++ b/npm/vite-dev-server/src/makeCypressPlugin.ts
@@ -14,7 +14,7 @@ function convertPathToPosix (path: string): string {
     : path.replace(OSSepRE, '/')
 }
 
-const INIT_FILEPATH = posix.resolve(__dirname, '../client/initCypressTests.js')
+const INIT_FILEPATH = resolve(__dirname, '../client/initCypressTests.js')
 
 export const makeCypressPlugin = (
   projectRoot: string,


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #16219

### User facing changelog
Fix url to the vite `initCypressTest.js` client on windows.

### Additional details

- When opening a spec on windows in vite we had a bad blocking error preventing the spec form from even being loaded.
- the problem is that `posix.resolve()` will not behave fine if its arguments are non-posix. And `__dirname` on windows is backslash based.
