### PR TITLE
fix(component-testing): Proper focus ring on SpecList

### DIFF
--- a/npm/design-system/src/core/input/IconInput.tsx
+++ b/npm/design-system/src/core/input/IconInput.tsx
@@ -32,9 +32,9 @@ export type IconInputProps = InputProps<{
 } & Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>>
 & RefAttributes<HTMLInputElement>
 
-export const IconInput: React.FC<IconInputProps> = (props) => <InputBase {...props} inputRenderer={IconInputComponent} />
+export const IconInput: React.FC<IconInputProps> = (props) => <InputBase {...props} InputRenderer={IconInputComponent} />
 
-const IconInputComponent: InputRenderer<IconInputProps> = ({ size = 'm', prefixIcon, suffixIcon, className, ...props }, inputProps, inputRef) => {
+const IconInputComponent: InputRenderer<IconInputProps> = ({ componentProps: { size = 'm', prefixIcon, suffixIcon, className, ...props }, inputProps, inputRef }) => {
   const iconSize = modifySize(size, 2)
   const { isFocused, focusProps } = useFocusRing({ isTextInput: true })
 

--- a/npm/design-system/src/core/input/Input.stories.tsx
+++ b/npm/design-system/src/core/input/Input.stories.tsx
@@ -30,6 +30,9 @@ export const Icon = createStory(() => (
       <input />
     </div>
     <div>
+      <InputComponent label={{ type: 'aria', contents: 'foo' }} />
+    </div>
+    <div>
       <IconInputComponent
         label={{ type: 'aria', contents: 'full width input' }}
         prefixIcon={{

--- a/npm/design-system/src/core/input/Input.tsx
+++ b/npm/design-system/src/core/input/Input.tsx
@@ -1,4 +1,30 @@
-import * as React from 'react'
-import { basicInputRenderer, InputBase, InputProps } from './InputBase'
+import React, { InputHTMLAttributes } from 'react'
+import { useFocusRing } from 'react-aria'
+import cs from 'classnames'
 
-export const Input: React.FC<InputProps<{}>> = (props) => <InputBase {...props} inputRenderer={basicInputRenderer} />
+import { focusClass } from 'css/derived/util'
+import { BasicInput, BasicInputProps, InputBase, InputProps, InputRenderer } from './InputBase'
+
+import styles from './InputBase.module.scss'
+
+export const Input: React.FC<InputProps<{}>> = (props) => (
+  <InputBase
+    {...props}
+    InputRenderer={BasicInputRenderer}
+  />
+)
+
+// TODO: The types here are not as elegant as I would like
+const BasicInputRenderer: InputRenderer<Omit<BasicInputProps, 'inputRef'>> = ({ componentProps, inputProps, inputRef }) => {
+  const { isFocused, focusProps } = useFocusRing({ isTextInput: true })
+
+  return (
+    <span
+      className={cs(styles.wrapper, {
+        [focusClass]: isFocused,
+      }, componentProps.className)}
+    >
+      <BasicInput {...inputProps as Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>} {...focusProps} {...componentProps} inputRef={inputRef} className={inputProps.className} />
+    </span>
+  )
+}

--- a/npm/design-system/src/core/input/InputBase.module.scss
+++ b/npm/design-system/src/core/input/InputBase.module.scss
@@ -7,3 +7,11 @@ input.input {
   border: 1px solid $control-border-color;
   border-radius: $button-radius;
 }
+
+/**
+ * Wrapper for standalone inputs to allow for a proper focus ring
+ */
+.wrapper {
+  display: inline-block;
+  position: relative;
+}

--- a/npm/design-system/src/core/input/InputBase.tsx
+++ b/npm/design-system/src/core/input/InputBase.tsx
@@ -36,13 +36,19 @@ export type InputProps<T> = SharedInputBaseProps & {
   style?: CSSProperties
 } & T
 
-export type InputRenderer<T> = (componentProps: Omit<InputProps<T>, 'label'>, inputProps: InputHTMLAttributes<HTMLInputElement>, inputRef: RefObject<HTMLTextAreaElement | HTMLInputElement>) => ReactNode
+export interface InputRendererProps<T> {
+  componentProps: Omit<InputProps<T>, 'label'>
+  inputProps: InputHTMLAttributes<HTMLInputElement>
+  inputRef: RefObject<HTMLTextAreaElement | HTMLInputElement>
+}
+
+export type InputRenderer<T> = React.FC<InputRendererProps<T>>
 
 export type InputBaseProps<T> = SharedInputBaseProps & {
-  inputRenderer: InputRenderer<T>
+  InputRenderer: InputRenderer<T>
 } & T
 
-export const InputBase = <T, >({ inputRenderer, label, textArea, inputRef: externalInputRef = null, ...props }: InputBaseProps<T>) => {
+export const InputBase = <T, >({ InputRenderer, label, textArea, inputRef: externalInputRef = null, ...props }: InputBaseProps<T>) => {
   const inputRef = useRef<HTMLTextAreaElement | HTMLInputElement>(null)
 
   useCombinedRefs(inputRef, externalInputRef)
@@ -72,7 +78,7 @@ export const InputBase = <T, >({ inputRenderer, label, textArea, inputRef: exter
         </label>
       )}
       {/* TODO: This cast is incorrect. It can be textarea */}
-      {inputRenderer(props as Omit<InputProps<T>, 'label'>, inputProps as InputHTMLAttributes<HTMLInputElement>, inputRef)}
+      <InputRenderer componentProps={props as Omit<InputProps<T>, 'label'>} inputProps={inputProps as InputHTMLAttributes<HTMLInputElement>} inputRef={inputRef} />
     </>
   )
 }
@@ -96,7 +102,3 @@ export const BasicInput: React.FC<BasicInputProps> = ({ inputRef, className, siz
     ? <textarea {...props as TextareaHTMLAttributes<HTMLTextAreaElement>} ref={inputRef as RefObject<HTMLTextAreaElement>} className={cs(textClass, styles.input, className)} />
     : <input {...props as InputHTMLAttributes<HTMLInputElement>} ref={inputRef as RefObject<HTMLInputElement>} className={cs(textClass, styles.input, className)} />
 }
-
-// TODO: The types here are not as elegant as I would like
-export const basicInputRenderer: InputRenderer<Omit<BasicInputProps, 'inputRef'>> = (props, inputProps, inputRef) =>
-  <BasicInput {...inputProps as Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>} {...props} inputRef={inputRef} className={cs(inputProps.className, props.className)} />

--- a/npm/design-system/src/css/derived/export.scss
+++ b/npm/design-system/src/css/derived/export.scss
@@ -21,25 +21,27 @@
 }
 
 // Spacing
-  @each $name, $text-def in $spacing {
-    $suffix: str-replace('' + $name, 'space-', '');
+@each $name, $text-def in $spacing {
+  $suffix: str-replace('' + $name, 'space-', '');
 
-    .#{'padding-' + $suffix} {
-      @include padding($suffix)
-    }
+  .#{'padding-' + $suffix} {
+    @include padding($suffix)
   }
+}
 
 // Surfaces
-  @each $name, $def in $shadow {
-    $suffix: str-replace('' + $name, 'shadow-', '');
+@each $name, $def in $shadow {
+  $suffix: str-replace('' + $name, 'shadow-', '');
 
-    .#{'depth-' + $suffix} {
-      @include depth($suffix)
-    }
+  .#{'depth-' + $suffix} {
+    @include depth($suffix)
   }
+}
 
-.focused {
-  @include focused;
+body {
+  .focused {
+    @include focused;
+  } 
 }
 
 // Typography
@@ -49,30 +51,28 @@
   --font-stack-mono: #{$internal-font-stack-mono};
 }
 
-// :root {
-  @each $name, $text-def in $text {
-    .#{$name} {
-      @include text(str-replace($name, 'text-', ''))
-    }
+@each $name, $text-def in $text {
+  .#{$name} {
+    @include text(str-replace($name, 'text-', ''))
   }
+}
 
-  .text-mono-m {
-    @include text-mono-m;
-  }
+.text-mono-m {
+  @include text-mono-m;
+}
 
-  .text-mono-s {
-    @include text-mono-s;
-  }
+.text-mono-s {
+  @include text-mono-s;
+}
 
-  .line-height-normal {
-    @include line-height-normal;
-  }
+.line-height-normal {
+  @include line-height-normal;
+}
 
-  .line-height-condensed {
-    @include line-height-condensed;
-  }
+.line-height-condensed {
+  @include line-height-condensed;
+}
 
-  .line-height-tight {
-    @include line-height-tight;
-  }
-// }
+.line-height-tight {
+  @include line-height-tight;
+}

--- a/npm/design-system/src/css/surfaces.scss
+++ b/npm/design-system/src/css/surfaces.scss
@@ -46,4 +46,8 @@ $button-radius: 0.5rem; // 8px
   &:focus {
     outline: none;
   }
+
+  input:focus {
+    outline: none;
+  }
 }


### PR DESCRIPTION
### Additional details
The focus ring on `design-system` inputs were not properly being displayed, making it unclear when the inputs were focused.

### How has the user experience changed?
<img width="403" alt="Screen Shot 2021-04-27 at 12 18 42 PM" src="https://user-images.githubusercontent.com/238679/116299569-b6258080-a752-11eb-87ce-303b61731cc7.png">