### PR TITLE
feat: add separate cypress:server:info log source

### DIFF
--- a/packages/server/lib/modes/record.js
+++ b/packages/server/lib/modes/record.js
@@ -3,6 +3,7 @@ const la = require('lazy-ass')
 const chalk = require('chalk')
 const check = require('check-more-types')
 const debug = require('debug')('cypress:server:record')
+const logCommitInfo = require('debug')('cypress:server:info')
 const Promise = require('bluebird')
 const isForkPr = require('is-fork-pr')
 const commitInfo = require('@cypress/commit-info')
@@ -309,6 +310,16 @@ const createRun = Promise.method((options = {}) => {
   debug('commit information from Git or from environment variables')
   debug(commit)
 
+  const ci = {
+    params: ciProvider.ciParams(),
+    provider: ciProvider.provider(),
+  }
+
+  // write git commit and CI provider information
+  // in its own log source to expose separately
+  logCommitInfo('commit information %o', commit)
+  logCommitInfo('CI provider information %o', ci)
+
   return api.createRun({
     specs,
     group,
@@ -320,10 +331,7 @@ const createRun = Promise.method((options = {}) => {
     recordKey,
     specPattern,
     testingType,
-    ci: {
-      params: ciProvider.ciParams(),
-      provider: ciProvider.provider(),
-    },
+    ci,
     commit,
   })
   .tap((response) => {
@@ -587,6 +595,9 @@ const createRunAndRecordSpecs = (options = {}) => {
   .then((git) => {
     debug('found the following git information')
     debug(git)
+    // also log the git info under its own log source
+    // to potentially expose less sensitive information
+    logCommitInfo(git)
 
     const platform = {
       osCpus: sys.osCpus,

--- a/packages/server/lib/modes/record.js
+++ b/packages/server/lib/modes/record.js
@@ -3,7 +3,7 @@ const la = require('lazy-ass')
 const chalk = require('chalk')
 const check = require('check-more-types')
 const debug = require('debug')('cypress:server:record')
-const logCommitInfo = require('debug')('cypress:server:info')
+const debugCiInfo = require('debug')('cypress:server:record:ci-info')
 const Promise = require('bluebird')
 const isForkPr = require('is-fork-pr')
 const commitInfo = require('@cypress/commit-info')
@@ -306,10 +306,6 @@ const createRun = Promise.method((options = {}) => {
   specs = _.map(specs, getSpecRelativePath)
 
   const commit = getCommitFromGitOrCi(git)
-
-  debug('commit information from Git or from environment variables')
-  debug(commit)
-
   const ci = {
     params: ciProvider.ciParams(),
     provider: ciProvider.provider(),
@@ -317,8 +313,8 @@ const createRun = Promise.method((options = {}) => {
 
   // write git commit and CI provider information
   // in its own log source to expose separately
-  logCommitInfo('commit information %o', commit)
-  logCommitInfo('CI provider information %o', ci)
+  debugCiInfo('commit information %o', commit)
+  debugCiInfo('CI provider information %o', ci)
 
   return api.createRun({
     specs,
@@ -593,11 +589,8 @@ const createRunAndRecordSpecs = (options = {}) => {
 
   return commitInfo.commitInfo(projectRoot)
   .then((git) => {
-    debug('found the following git information')
-    debug(git)
-    // also log the git info under its own log source
-    // to potentially expose less sensitive information
-    logCommitInfo(git)
+    debugCiInfo('found the following git information')
+    debugCiInfo(git)
 
     const platform = {
       osCpus: sys.osCpus,


### PR DESCRIPTION
- Closes #16236

### User facing changelog

You can use the following DEBUG log source to only see the commit information and CI provider information collected and sent to the Dashboard

```
DEBUG=cypress:server:record:ci-info
```

### Additional details

Before if you wanted to see why part of the Git or CI provider info was missing from the Cypress Dashboard you had to expose the entire API log source. Now they are separate so you can safely debug the commit info without dumping everything

### PR Tasks

- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/3892
