### PR TITLE
fix: cy.log only shows the first 2 args.

### DIFF
--- a/packages/driver/cypress/integration/commands/misc_spec.js
+++ b/packages/driver/cypress/integration/commands/misc_spec.js
@@ -67,7 +67,7 @@ describe('src/cy/commands/misc', () => {
         return cy.log('foobarbaz', [{}]).then(function () {
           expect(this.lastLog.invoke('consoleProps')).to.deep.eq({
             Command: 'log',
-            args: [{}],
+            args: [[{}]],
             message: 'foobarbaz',
           })
         })
@@ -82,6 +82,16 @@ describe('src/cy/commands/misc', () => {
           return await Object.keys(data).length
         }).then((test) => {
           expect(test).to.eq(1)
+        })
+      })
+
+      // https://github.com/cypress-io/cypress/issues/16068
+      it('log does not have limit to the number of arguments', function () {
+        cy.log('msg', 1, 2, 3, 4)
+        .then(() => {
+          const { lastLog } = this
+
+          expect(lastLog.get('message')).to.eq('msg, 1, 2, 3, 4')
         })
       })
     })

--- a/packages/driver/src/cy/commands/misc.js
+++ b/packages/driver/src/cy/commands/misc.js
@@ -16,7 +16,7 @@ module.exports = (Commands, Cypress, cy, state) => {
       return arg
     },
 
-    log (msg, args) {
+    log (msg, ...args) {
       // https://github.com/cypress-io/cypress/issues/8084
       // The return value of cy.log() corrupts the command stack, so cy.then() returned the wrong value
       // when cy.log() is used inside it.
@@ -36,7 +36,7 @@ module.exports = (Commands, Cypress, cy, state) => {
       Cypress.log({
         end: true,
         snapshot: true,
-        message: [msg, args],
+        message: [msg, ...args],
         consoleProps () {
           return {
             message: msg,


### PR DESCRIPTION
- Closes #16068

### User facing changelog

`cy.log()` will show all the arguments, not the first 2.

### Additional details
- Why was this change necessary? => `cy.log` didn't behave as the document. 
- What is affected by this change? => N/A
- Any implementation details to explain? => Use `...` operator for the args.

### How has the user experience changed?

**before:**

![image](https://user-images.githubusercontent.com/8130013/116336732-07497900-a814-11eb-9d91-70e51250db86.png)

**after:**

![Screenshot from 2021-04-28 11-23-28](https://user-images.githubusercontent.com/8130013/116336842-33fd9080-a814-11eb-8c1b-ac2a09c206eb.png)



### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
