### PR TITLE
feat(webpack-dev-server): support custom index-template for webpack dev server

### DIFF
--- a/npm/react/examples/nextjs/next.config.js
+++ b/npm/react/examples/nextjs/next.config.js
@@ -1,4 +1,3 @@
 const withMDX = require('@next/mdx')()
-const withSass = require('@zeit/next-sass')
 
-module.exports = withSass(withMDX())
+module.exports = withMDX()

--- a/npm/react/examples/nextjs/pages/index.js
+++ b/npm/react/examples/nextjs/pages/index.js
@@ -1,11 +1,12 @@
 import * as React from 'react'
 import { Search } from '../components/Search'
 import HelloWorld from '../components/HelloWorld.mdx'
+import styles from '../styles/Home.module.css'
 
 function IndexPage ({ asyncProp }) {
   return (
     <main>
-      <h1>Welcome to Next.js</h1>
+      <h1 className={styles.welcome}>Welcome to Next.js</h1>
 
       {asyncProp && (
         <p data-testid="server-result">

--- a/npm/react/examples/nextjs/styles/Home.module.css
+++ b/npm/react/examples/nextjs/styles/Home.module.css
@@ -1,0 +1,3 @@
+.welcome {
+  color: blue;
+}

--- a/npm/react/plugins/next/index-template.html
+++ b/npm/react/plugins/next/index-template.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>Components App</title>
+    <div id="__next_css__DO_NOT_USE__"></div>
+  </head>
+  <body>
+    <div id="__cy_root"></div>
+  </body>
+</html>

--- a/npm/react/plugins/next/index.js
+++ b/npm/react/plugins/next/index.js
@@ -1,4 +1,5 @@
 const findNextWebpackConfig = require('./findNextWebpackConfig')
+const path = require('path')
 
 module.exports = (on, config) => {
   on('dev-server:start', async (options) => {
@@ -7,7 +8,11 @@ module.exports = (on, config) => {
     // require('webpack') now points to nextjs bundled version
     const { startDevServer } = require('@cypress/webpack-dev-server')
 
-    return startDevServer({ options, webpackConfig })
+    return startDevServer({
+      options,
+      webpackConfig,
+      template: path.resolve(__dirname, 'index-template.html'),
+    })
   })
 
   config.env.reactDevtools = true

--- a/npm/webpack-dev-server/README.md
+++ b/npm/webpack-dev-server/README.md
@@ -58,6 +58,16 @@ Webpack-dev-server fulfills his reponsibilities by
     - picks the spec that should be run
     - runs the `AUT-Runner.ts` to load and launch the support file and the current spec
 
+## API
+
+`startDevServer` takes an object of options.
+
+- `options` (required): this contains various internal configuration. It's provided as the first argument to the `dev-server:start` event. Just make sure you pass it.
+- `webpackConfig` (optional): the webpack config used by your application. We provide some [presets](https://github.com/cypress-io/cypress/tree/develop/npm/react/plugins), but you can pass the `webpackConfig` manually, too.
+- `template` (optional): by default [this index.html](https://github.com/cypress-io/cypress/blob/develop/npm/webpack-dev-server/index-template.html) is used. You can provide your own using this option. This is useful if you'd like to include some CDN links, or in some way customize the default html. If you are passing this option, ensure your `index.html` contains the same content as [the default template](https://github.com/cypress-io/cypress/blob/develop/npm/webpack-dev-server/index-template.html). Some of our presets include a custom `index.html`, such as [Next](https://github.com/cypress-io/cypress/tree/develop/npm/react/plugins/next). 
+
+See [npm/react/plugins/next](https://github.com/cypress-io/cypress/blob/develop/npm/react/plugins/next/index.js) for a full example using all the options.
+
 ## Performance tests 
 
 In order to get webpack performance statistics run `yarn cypress open-ct` or `yarn cypress run-ct` with `WEBPACK_PERF_MEASURE` env variable:

--- a/npm/webpack-dev-server/src/makeWebpackConfig.ts
+++ b/npm/webpack-dev-server/src/makeWebpackConfig.ts
@@ -2,7 +2,7 @@ import { debug as debugFn } from 'debug'
 import * as path from 'path'
 import * as webpack from 'webpack'
 import { merge } from 'webpack-merge'
-import defaultWebpackConfig from './webpack.config'
+import makeDefaultWebpackConfig from './webpack.config'
 import CypressCTOptionsPlugin, { CypressCTOptionsPluginOptions } from './plugin'
 
 const debug = debugFn('cypress:webpack-dev-server:makeWebpackConfig')
@@ -20,13 +20,14 @@ export interface UserWebpackDevServerOptions {
 interface MakeWebpackConfigOptions extends CypressCTOptionsPluginOptions, UserWebpackDevServerOptions {
   devServerPublicPathRoute: string
   isOpenMode: boolean
+  template?: string
 }
 
 const OsSeparatorRE = RegExp(`\\${path.sep}`, 'g')
 const posixSeparator = '/'
 
 export async function makeWebpackConfig (userWebpackConfig: webpack.Configuration, options: MakeWebpackConfigOptions): Promise<webpack.Configuration> {
-  const { projectRoot, devServerPublicPathRoute, files, supportFile, devServerEvents } = options
+  const { projectRoot, devServerPublicPathRoute, files, supportFile, devServerEvents, template } = options
 
   debug(`User passed in webpack config with values %o`, userWebpackConfig)
 
@@ -79,7 +80,7 @@ export async function makeWebpackConfig (userWebpackConfig: webpack.Configuratio
 
   const mergedConfig = merge<webpack.Configuration>(
     userWebpackConfig,
-    defaultWebpackConfig,
+    makeDefaultWebpackConfig(template),
     dynamicWebpackConfig,
   )
 

--- a/npm/webpack-dev-server/src/startServer.ts
+++ b/npm/webpack-dev-server/src/startServer.ts
@@ -8,11 +8,13 @@ export interface StartDevServer extends UserWebpackDevServerOptions {
   options: Cypress.DevServerOptions
   /* support passing a path to the user's webpack config */
   webpackConfig?: Record<string, any>
+  /* base html template to render in AUT */
+  template?: string
 }
 
 const debug = Debug('cypress:webpack-dev-server:start')
 
-export async function start ({ webpackConfig: userWebpackConfig, options, ...userOptions }: StartDevServer, exitProcess = process.exit): Promise<WebpackDevServer> {
+export async function start ({ webpackConfig: userWebpackConfig, template, options, ...userOptions }: StartDevServer, exitProcess = process.exit): Promise<WebpackDevServer> {
   if (!userWebpackConfig) {
     debug('User did not pass in any webpack configuration')
   }
@@ -22,6 +24,7 @@ export async function start ({ webpackConfig: userWebpackConfig, options, ...use
 
   const webpackConfig = await makeWebpackConfig(userWebpackConfig || {}, {
     files: options.specs,
+    template,
     projectRoot,
     devServerPublicPathRoute,
     devServerEvents: options.devServerEvents,

--- a/npm/webpack-dev-server/src/webpack.config.js
+++ b/npm/webpack-dev-server/src/webpack.config.js
@@ -1,19 +1,24 @@
 const path = require('path')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 
-/** @type {import('webpack').Configuration} */
-module.exports = {
-  mode: 'development',
-  optimization: {
-    splitChunks: {
-      chunks: 'all',
+/**
+ * @param {string} [template] - base template to use
+ * @returns {import('webpack').Configuration}
+ */
+module.exports = function makeDefaultConfig (template) {
+  return {
+    mode: 'development',
+    optimization: {
+      splitChunks: {
+        chunks: 'all',
+      },
     },
-  },
-  output: {
-    filename: '[name].js',
-    path: path.resolve(__dirname, 'dist'),
-  },
-  plugins: [new HtmlWebpackPlugin({
-    template: path.resolve(__dirname, '..', 'index-template.html'),
-  })],
+    output: {
+      filename: '[name].js',
+      path: path.resolve(__dirname, 'dist'),
+    },
+    plugins: [new HtmlWebpackPlugin({
+      template: template || path.resolve(__dirname, '..', 'index-template.html'),
+    })],
+  }
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #16243

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

Support passing a custom `index-template.html` to the Webpack Dev Server `startDevServer` function.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Some frameworks like Next.js expect certain HTML tags to exist in the document, [as explained here](https://github.com/cypress-io/cypress/issues/16243#issuecomment-828121505). Specifically an element with the id `__next_css__DO_NOT_USE__` should exist when the component is imported. This PR also updates the Next.js plugin to provide a modified `index.html` with the required tag.

This has a secondary use of letting users include things like CDN links in their default template, like Storybook's `preview-head.html`. They'll also need to include `<div id="__cy_root">`, and asking them to do so is not really ideal, so I'm not really advertising this feature at the moment, other than a small note in the Webpack Dev Server README. Long term, I think we should take a custom `index.html` and inject `__cy_root` programatically, so the user does not need to think about this sort of thing when providing a custom template.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

CSS modules (default for Next.js) works out of the box.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
