### PR TITLE
fix: Do not print 'uploading' stdout when --quiet mode is passed

### DIFF
--- a/packages/server/__snapshots__/7_record_spec.js
+++ b/packages/server/__snapshots__/7_record_spec.js
@@ -2646,3 +2646,17 @@ Available browsers found on your system are:
 - browser2
 - browser3
 `
+
+exports['e2e record quiet mode respects quiet mode 1'] = `
+
+
+  record pass
+    ✓ passes
+    - is pending
+
+
+  1 passing
+  1 pending
+
+
+`

--- a/packages/server/lib/modes/record.js
+++ b/packages/server/lib/modes/record.js
@@ -112,7 +112,7 @@ const getSpecRelativePath = (spec) => {
 }
 
 const uploadArtifacts = (options = {}) => {
-  const { video, screenshots, videoUploadUrl, shouldUploadVideo, screenshotUploadUrls } = options
+  const { video, screenshots, videoUploadUrl, shouldUploadVideo, screenshotUploadUrls, quiet } = options
 
   const uploads = []
   let count = 0
@@ -125,8 +125,10 @@ const uploadArtifacts = (options = {}) => {
 
   const send = (pathToFile, url) => {
     const success = () => {
-      // eslint-disable-next-line no-console
-      return console.log(`  - Done Uploading ${nums()}`, chalk.blue(pathToFile))
+      if (!quiet) {
+        // eslint-disable-next-line no-console
+        return console.log(`  - Done Uploading ${nums()}`, chalk.blue(pathToFile))
+      }
     }
 
     const fail = (err) => {
@@ -135,8 +137,10 @@ const uploadArtifacts = (options = {}) => {
         stack: err.stack,
       })
 
-      // eslint-disable-next-line no-console
-      return console.log(`  - Failed Uploading ${nums()}`, chalk.red(pathToFile))
+      if (!quiet) {
+        // eslint-disable-next-line no-console
+        return console.log(`  - Failed Uploading ${nums()}`, chalk.red(pathToFile))
+      }
     }
 
     return uploads.push(
@@ -158,7 +162,7 @@ const uploadArtifacts = (options = {}) => {
     })
   }
 
-  if (!uploads.length) {
+  if (!uploads.length && !quiet) {
     // eslint-disable-next-line no-console
     console.log('  - Nothing to Upload')
   }
@@ -581,6 +585,7 @@ const createRunAndRecordSpecs = (options = {}) => {
     project,
     onError,
     testingType,
+    quiet,
   } = options
   const recordKey = options.key
 
@@ -667,15 +672,17 @@ const createRunAndRecordSpecs = (options = {}) => {
 
         debug('after spec run %o', { spec })
 
-        // eslint-disable-next-line no-console
-        console.log('')
+        if (!quiet) {
+          // eslint-disable-next-line no-console
+          console.log('')
 
-        terminal.header('Uploading Results', {
-          color: ['blue'],
-        })
+          terminal.header('Uploading Results', {
+            color: ['blue'],
+          })
 
-        // eslint-disable-next-line no-console
-        console.log('')
+          // eslint-disable-next-line no-console
+          console.log('')
+        }
 
         return postInstanceResults({
           group,
@@ -699,6 +706,7 @@ const createRunAndRecordSpecs = (options = {}) => {
             videoUploadUrl,
             shouldUploadVideo,
             screenshotUploadUrls,
+            quiet,
           })
           .finally(() => {
             // always attempt to upload stdout

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1638,6 +1638,7 @@ module.exports = {
               specPattern,
               runAllSpecs,
               onError,
+              quiet: options.quiet,
             })
           }
 

--- a/packages/server/test/e2e/7_record_spec.js
+++ b/packages/server/test/e2e/7_record_spec.js
@@ -451,6 +451,21 @@ describe('e2e record', () => {
     })
   })
 
+  context('quiet mode', () => {
+    setupStubbedServer(createRoutes())
+
+    it('respects quiet mode', function () {
+      return e2e.exec(this, {
+        key: 'f858a2bc-b469-4e48-be67-0876339ee7e1',
+        spec: 'record_pass*',
+        record: true,
+        snapshot: true,
+        expectedExitCode: 0,
+        quiet: true,
+      })
+    })
+  })
+
   context('recordKey', () => {
     setupStubbedServer(createRoutes())
 


### PR DESCRIPTION
- Close #16268 

### User facing changelog

When passing the `—quiet` flag, Cypress will no longer print uploading output to stdout.

### Additional Details

- The issue also mentions that Cypress warnings are displayed (specifically the one about being over their recording limit). 
- We don’t want to quiet warnings, as many of them are beneficial to understanding why the run is not running/recording. Although I can see the argument to silence this specific warning. 
- I decided not to silence any warnings in this PR and focus on the stdout that should not be logged.

### How has the user experience changed?

#### Before

When passing `--quiet` flag during recording

<img width="860" alt="Screen Shot 2021-04-29 at 9 09 29 AM" src="https://user-images.githubusercontent.com/1271364/116575201-0c6dfd00-a8d4-11eb-8eae-165e62cba716.png">

#### After

When passing `--quiet` flag during recording

<img width="219" alt="Screen Shot 2021-04-29 at 10 17 11 AM" src="https://user-images.githubusercontent.com/1271364/116575260-17c12880-a8d4-11eb-8fc5-a470553368c4.png">


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->


