### PR TITLE
fix: avoid unmounting React components twice

### DIFF
--- a/npm/mount-utils/src/index.ts
+++ b/npm/mount-utils/src/index.ts
@@ -200,7 +200,7 @@ export function setupHooks (optionalCallback?: Function) {
   })
 
   // @ts-ignore
-  beforeEach(() => {
+  Cypress.on('test:before:run', () => {
     optionalCallback?.()
     cleanupStyles()
   })

--- a/npm/react/src/mount.ts
+++ b/npm/react/src/mount.ts
@@ -176,13 +176,13 @@ const _unmount = (options: { boundComponentMessage?: string, log: boolean }) => 
 // Cleanup before each run
 // NOTE: we cannot use unmount here because
 // we are not in the context of a test
-Cypress.on('test:before:run', () => {
+const preMountCleanup = () => {
   const el = document.getElementById(ROOT_ID)
 
   if (el) {
     ReactDOM.unmountComponentAtNode(el)
   }
-})
+}
 
 /**
  * Creates new instance of `mount` function with default options
@@ -317,4 +317,4 @@ export declare namespace Cypress {
 // it is required to unmount component in beforeEach hook in order to provide a clean state inside test
 // because `mount` can be called after some preparation that can side effect unmount
 // @see npm/react/cypress/component/advanced/set-timeout-example/loading-indicator-spec.js
-setupHooks(unmount)
+setupHooks(preMountCleanup)

--- a/npm/react/src/mount.ts
+++ b/npm/react/src/mount.ts
@@ -40,6 +40,8 @@ const injectStyles = (options: MountOptions) => {
  **/
 export const mount = (jsx: React.ReactNode, options: MountOptions = {}) => _mount('mount', jsx, options)
 
+let lastMountedReactDom: (typeof ReactDOM) | undefined
+
 /**
  * @see `mount`
  * @param type The type of mount executed
@@ -61,6 +63,8 @@ const _mount = (type: 'mount' | 'rerender', jsx: React.ReactNode, options: Mount
   .then(injectStyles(options))
   .then(() => {
     const reactDomToUse = options.ReactDom || ReactDOM
+
+    lastMountedReactDom = reactDomToUse
 
     const el = document.getElementById(ROOT_ID)
 
@@ -153,21 +157,23 @@ const _unmount = (options: { boundComponentMessage?: string, log: boolean }) => 
     const selector = `#${ROOT_ID}`
 
     return cy.get(selector, { log: false }).then(($el) => {
-      const wasUnmounted = ReactDOM.unmountComponentAtNode($el[0])
+      if (lastMountedReactDom) {
+        const wasUnmounted = lastMountedReactDom.unmountComponentAtNode($el[0])
 
-      if (wasUnmounted && options.log) {
-        Cypress.log({
-          name: 'unmount',
-          type: 'parent',
-          message: [options.boundComponentMessage ?? 'Unmounted component'],
-          consoleProps: () => {
-            return {
-              description: 'Unmounts React component',
-              parent: $el[0],
-              home: 'https://github.com/cypress-io/cypress',
-            }
-          },
-        })
+        if (wasUnmounted && options.log) {
+          Cypress.log({
+            name: 'unmount',
+            type: 'parent',
+            message: [options.boundComponentMessage ?? 'Unmounted component'],
+            consoleProps: () => {
+              return {
+                description: 'Unmounts React component',
+                parent: $el[0],
+                home: 'https://github.com/cypress-io/cypress',
+              }
+            },
+          })
+        }
       }
     })
   })
@@ -179,8 +185,8 @@ const _unmount = (options: { boundComponentMessage?: string, log: boolean }) => 
 const preMountCleanup = () => {
   const el = document.getElementById(ROOT_ID)
 
-  if (el) {
-    ReactDOM.unmountComponentAtNode(el)
+  if (el && lastMountedReactDom) {
+    lastMountedReactDom.unmountComponentAtNode(el)
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #16070

### User facing changelog
When clicking fast between specs we used to have a blocking error saying something about invariant,

After this PR the bug is gone.

### Additional details
Unmounting was done twice and the second time was the culprit. If the two hooks are called quickly enough, the second one will try to change the invariant of the first and trigger this issue,

NOTE: I am 99% sure this is the only problem, but, since this cleanup was necessary anyway, this PR cannot hurt. If we notice the bug in the future, we can re-open the ticket.
