### PR TITLE
fix(desktop-gui): correctly display component and e2e config values

### DIFF
--- a/packages/desktop-gui/src/settings/configuration.jsx
+++ b/packages/desktop-gui/src/settings/configuration.jsx
@@ -21,6 +21,10 @@ const formatValue = (value) => {
     return _.map(value, valueToString).join(', ')
   }
 
+  if (_.isObject(value) && _.keys(value).length === 0) {
+    return '{}'
+  }
+
   if (_.isObject(value)) {
     return valueToString(value)
   }

--- a/packages/desktop-gui/src/settings/configuration_spec.jsx
+++ b/packages/desktop-gui/src/settings/configuration_spec.jsx
@@ -3,6 +3,16 @@ import React from 'react'
 import { mount } from '@cypress/react'
 import '../main.scss'
 
+const TestConfiguration = (props) => (
+  <div className="settings">
+    <div className="settings-wrapper">
+      <div className="settings-config">
+        <Configuration project={props.project} />
+      </div>
+    </div>
+  </div>
+)
+
 /* global cy */
 describe('Configuration', () => {
   it('loads and shows resolved value from cli', () => {
@@ -17,19 +27,24 @@ describe('Configuration', () => {
     }
 
     // apply additional markup for CSS styles to work
-    const TestConfiguration = () => (
-      <div className="settings">
-        <div className="settings-wrapper">
-          <div className="settings-config">
-            <Configuration project={project} />
-          </div>
-        </div>
-      </div>
-    )
 
-    mount(<TestConfiguration />)
+    mount(<TestConfiguration project={project} />)
 
     cy.contains('.key-value-pair-value', 'http://localhost:1234')
     .should('have.class', 'cli')
+  })
+
+  it('shows an {} for an empty object', () => {
+    const project = {
+      resolvedConfig: {
+        e2e: {
+          value: {},
+        },
+      },
+    }
+
+    mount(<TestConfiguration project={project} />)
+    cy.get('[role=treeitem]').contains('e2e:')
+    cy.get('[role=treeitem]').contains('{}')
   })
 })

--- a/packages/server/lib/util/settings.js
+++ b/packages/server/lib/util/settings.js
@@ -150,12 +150,10 @@ module.exports = {
     }).then((json = {}) => {
       if (this.isComponentTesting(options) && 'component' in json) {
         json = { ...json, ...json.component }
-        delete json.component
       }
 
       if (!this.isComponentTesting(options) && 'e2e' in json) {
         json = { ...json, ...json.e2e }
-        delete json.e2e
       }
 
       const changed = this._applyRewriteRules(json)

--- a/packages/server/test/unit/settings_spec.js
+++ b/packages/server/test/unit/settings_spec.js
@@ -111,7 +111,7 @@ describe('lib/settings', () => {
         .then(() => {
           return settings.read(projectRoot, { testingType: 'component' })
         }).then((obj) => {
-          expect(obj).to.deep.eq({ a: 'c' })
+          expect(obj).to.deep.eq({ a: 'c', component: { a: 'c' } })
         })
       })
 
@@ -120,7 +120,7 @@ describe('lib/settings', () => {
         .then(() => {
           return settings.read(projectRoot)
         }).then((obj) => {
-          expect(obj).to.deep.eq({ a: 'c' })
+          expect(obj).to.deep.eq({ a: 'c', e2e: { a: 'c' } })
         })
       })
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #16269

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

Fix a bug where `e2e` and `component` configuration values were not correctly showing in the Cypress launcher.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

It looks like in the original PR that implemented this feature, we intentionally removed the `component` and `e2e` values when merging the config. This makes the actual `cypress.json` config and what's shown in the Desktop GUI different, which could be lead to confusion. This PR changes the behavior and leaves the overridden values in the `config` object, even after merging them based on `testingType`.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

- show `{}` for empty object
- correctly show `e2e` overrides:

![image](https://user-images.githubusercontent.com/19196536/116643438-6940e480-a9b4-11eb-9889-f4cbc6c5c841.png)

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
