### PR TITLE
fix: Ensure binary request body is not mutated by cy.intercept

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1089,6 +1089,25 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
         .reload()
         .contains('div', 'it loaded')
       })
+
+      // @see https://github.com/cypress-io/cypress/issues/15898
+      // @see https://github.com/cypress-io/cypress/issues/16223
+      it('works when uploading a binary file', function () {
+        cy.fixture('media/cypress.png').as('image')
+        cy.intercept('POST', '/upload').as('upload')
+
+        cy.window().then((win) => {
+          const blob = Cypress.Blob.base64StringToBlob(this.image, 'image/png')
+          const xhr = new win.XMLHttpRequest()
+          const formData = new win.FormData()
+
+          formData.append('file', blob)
+          xhr.open('POST', '/upload', true)
+          xhr.send(formData)
+        })
+
+        cy.wait('@upload')
+      })
     })
   })
 

--- a/packages/driver/cypress/plugins/server.js
+++ b/packages/driver/cypress/plugins/server.js
@@ -162,6 +162,10 @@ const createApp = (port) => {
     res.send(_var)
   })
 
+  app.post('/upload', (req, res) => {
+    res.sendStatus(200)
+  })
+
   app.use(express.static(path.join(__dirname, '..')))
 
   app.use(require('errorhandler')())

--- a/packages/net-stubbing/lib/server/middleware/request.ts
+++ b/packages/net-stubbing/lib/server/middleware/request.ts
@@ -145,7 +145,7 @@ export const InterceptRequest: RequestMiddleware = async function () {
     // if the body is binary, don't recursively merge it or it will get
     // incorrectly converted from a Buffer into an array
     // @see https://github.com/cypress-io/cypress/issues/15898
-    const serializableProps = _.reject(SERIALIZABLE_REQ_PROPS, (key) => key === 'body')
+    const serializableProps = _.without(SERIALIZABLE_REQ_PROPS, 'body')
 
     _.merge(before, _.pick(after, serializableProps))
 

--- a/packages/net-stubbing/lib/server/middleware/request.ts
+++ b/packages/net-stubbing/lib/server/middleware/request.ts
@@ -118,15 +118,16 @@ export const InterceptRequest: RequestMiddleware = async function () {
     throw new Error('req.body must be a string or a Buffer')
   }
 
-  const encoding = getBodyEncoding(req)
+  const bodyEncoding = getBodyEncoding(req)
+  const bodyIsBinary = bodyEncoding === 'binary'
 
-  if (encoding === 'binary') {
+  if (bodyIsBinary) {
     debug('req.body contained non-utf8 characters, treating as binary content %o', { requestId: request.id, req: _.pick(this.req, 'url') })
   }
 
   // leave the requests that send a binary buffer unchanged
   // but we can work with the "normal" string requests
-  if (encoding !== 'binary') {
+  if (!bodyIsBinary) {
     req.body = req.body.toString('utf8')
   }
 
@@ -141,7 +142,18 @@ export const InterceptRequest: RequestMiddleware = async function () {
     // resolve and propagate any changes to the URL
     request.req.proxiedUrl = after.url = url.resolve(request.req.proxiedUrl, after.url)
 
-    _.merge(before, _.pick(after, SERIALIZABLE_REQ_PROPS))
+    // if the body is binary, don't recursively merge it or it will get
+    // incorrectly converted from a Buffer into an array
+    // @see https://github.com/cypress-io/cypress/issues/15898
+    const serializableProps = _.reject(SERIALIZABLE_REQ_PROPS, (key) => key === 'body')
+
+    _.merge(before, _.pick(after, serializableProps))
+
+    if (bodyIsBinary) {
+      before.body = after.body
+    } else {
+      _.merge(before, { body: after.body })
+    }
 
     mergeDeletedHeaders(before, after)
   }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #15898
- Closes #16223

### User facing changelog

- Cypress no longer crashes with an error when testing a binary file upload

### Additional details

We recursively merge request properties after running the request through middleware, but in the case of a binary request body, which is a buffer, lodash identifies it as an array and the merging turns it into an array of numbers. That causes the error when it hits `request`, because it loops through the array and tries to write numbers into the request, which are invalid. It needs to remain a buffer for `request` to properly write it.

This fixes it by not trying to recursively merge binary buffers but overwriting them entirely after middleware runs.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
