### PR TITLE
fix: use close event when asking the browser for its version

### DIFF
--- a/packages/launcher/lib/utils.ts
+++ b/packages/launcher/lib/utils.ts
@@ -22,7 +22,11 @@ export const utils = {
         resolve({ stderr, stdout })
       }
 
-      proc.on('exit', finish)
+      // the "exit" event might happen before
+      // the child streams are finished, thus we use
+      // the "close" event
+      // https://github.com/cypress-io/cypress/issues/8611
+      proc.on('close', finish)
 
       proc.stdout.on('data', (chunk) => {
         stdout += chunk


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Maybe addresses https://github.com/cypress-io/cypress/issues/8611

### User facing changelog

- When verifying Cypress, we now listen for the 'close' event instead of the 'exit' event in an effort to fix some situations where the browser cannot be found even though it is on the system.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
