### PR TITLE
fix: change binary of VS Code editor found on windows to match default install

### DIFF
--- a/packages/server/lib/util/env-editors.ts
+++ b/packages/server/lib/util/env-editors.ts
@@ -129,7 +129,7 @@ const windowsEditors = [
     name: 'Brackets',
   }, {
     id: 'code',
-    binary: 'Code.exe',
+    binary: 'code',
     name: 'Visual Studio Code',
   }, {
     id: 'atom',


### PR DESCRIPTION
- Close #15080 

### User facing changelog

Cypress will now detect the default installation location of the Visual Studio Code editors on Windows machines.

### Additional details

- I just set up a Windows VM and this was where VS Code installs by default, with no `.exe` extension. 
- I manually tested that this change detects VS Code on my Windows VM now by default.

### How has user experience changed

#### Before

Didn’t detect my VS Code in Windows

<img width="392" alt="Screen Shot 2021-05-05 at 2 07 34 PM" src="https://user-images.githubusercontent.com/1271364/117198450-a808dd00-adae-11eb-9451-68efb0ff4886.png">


#### After

Now detects my VS Code in Windows

<img width="395" alt="Screen Shot 2021-05-05 at 2 29 03 PM" src="https://user-images.githubusercontent.com/1271364/117198472-af2feb00-adae-11eb-942c-cd13c5b761d7.png">


### PR Tasks

- [x] Tests? I manually tested, not sure there’s much to do beyond that
- [ ] Zenhub release tag