### PR TITLE
fix(ui): display duplicate aliases in command log

### DIFF
--- a/packages/reporter/cypress/fixtures/runnables_commands.json
+++ b/packages/reporter/cypress/fixtures/runnables_commands.json
@@ -113,7 +113,8 @@
           "event": true,
           "testId": "r3",
           "timeout": 4000,
-          "type": "parent"
+          "type": "parent",
+          "alias": "dup0"
         },
         {
           "hookId": "r3",
@@ -126,7 +127,8 @@
           "event": true,
           "testId": "r3",
           "timeout": 4000,
-          "type": "parent"
+          "type": "parent",
+          "alias": "dup1"
         },
         {
           "hookId": "r3",

--- a/packages/reporter/cypress/integration/commands_spec.ts
+++ b/packages/reporter/cypress/integration/commands_spec.ts
@@ -228,12 +228,26 @@ describe('commands', () => {
       .should('have.text', '4')
     })
 
+    it('displays names of duplicates', () => {
+      cy.contains('GET --- /dup').closest('.command').find('.command-alias')
+      .should('have.text', 'dup0, dup1')
+    })
+
     it('expands all events after clicking arrow', () => {
       cy.contains('GET --- /dup').closest('.command').find('.command-expander').click()
       cy.get('.command-name-xhr').should('have.length', 6)
       cy.contains('GET --- /dup').closest('.command').find('.duplicates')
       .should('be.visible')
       .find('.command').should('have.length', 3)
+    })
+
+    it('splits up duplicate names when expanded', () => {
+      cy.contains('GET --- /dup').closest('.command').as('cmd')
+
+      cy.get('@cmd').find('.command-expander').click()
+      cy.get('@cmd').find('.command-alias').as('alias')
+      cy.get('@alias').its(0).should('have.text', 'dup0')
+      cy.get('@alias').its(1).should('have.text', 'dup1')
     })
   })
 

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -78,22 +78,31 @@ const AliasesReferences = observer(({ model, aliasesWithDuplicates }: AliasesRef
 ))
 
 interface AliasesProps {
+  isOpen: boolean
   model: CommandModel
   aliasesWithDuplicates: Array<Alias> | null
 }
 
-const Aliases = observer(({ model, aliasesWithDuplicates }: AliasesProps) => {
+const Aliases = observer(({ model, aliasesWithDuplicates, isOpen }: AliasesProps) => {
   if (!model.alias) return null
 
   return (
     <span>
-      {_.map(([] as Array<Alias>).concat(model.alias), (alias) => (
-        <Tooltip key={alias} placement='top' title={`${model.displayMessage} aliased as: '${alias}'`} className='cy-tooltip'>
-          <span className={cs('command-alias', `${model.aliasType}`, { 'show-count': shouldShowCount(aliasesWithDuplicates, alias, model) })}>
-            {alias}
-          </span>
-        </Tooltip>
-      ))}
+      {_.map(([] as Array<Alias>).concat(model.alias), (alias) => {
+        const aliases = [alias]
+
+        if (!isOpen && model.hasDuplicates) {
+          aliases.push(..._.compact(model.duplicates.map((dupe) => dupe.alias)))
+        }
+
+        return (
+          <Tooltip key={alias} placement='top' title={`${model.displayMessage} aliased as: ${aliases.map((alias) => `'${alias}'`).join(', ')}`} className='cy-tooltip'>
+            <span className={cs('command-alias', `${model.aliasType}`, { 'show-count': shouldShowCount(aliasesWithDuplicates, alias, model) })}>
+              {aliases.join(', ')}
+            </span>
+          </Tooltip>
+        )
+      })}
     </span>
   )
 })
@@ -213,7 +222,7 @@ class Command extends Component<Props> {
                   <span className='num-elements'>{model.numElements}</span>
                 </Tooltip>
                 <span className='alias-container'>
-                  <Aliases model={model} aliasesWithDuplicates={aliasesWithDuplicates} />
+                  <Aliases model={model} aliasesWithDuplicates={aliasesWithDuplicates} isOpen={this.isOpen} />
                   <Tooltip placement='top' title={`This event occurred ${model.numDuplicates} times`} className='cy-tooltip'>
                     <span className={cs('num-duplicates', { 'has-alias': model.alias })}>{model.numDuplicates}</span>
                   </Tooltip>

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -224,7 +224,7 @@ class Command extends Component<Props> {
                 <span className='alias-container'>
                   <Aliases model={model} aliasesWithDuplicates={aliasesWithDuplicates} isOpen={this.isOpen} />
                   <Tooltip placement='top' title={`This event occurred ${model.numDuplicates} times`} className='cy-tooltip'>
-                    <span className={cs('num-duplicates', { 'has-alias': model.alias })}>{model.numDuplicates}</span>
+                    <span className={cs('num-duplicates', { 'has-alias': model.alias, 'has-duplicates': model.numDuplicates > 1 })}>{model.numDuplicates}</span>
                   </Tooltip>
                 </span>
               </span>

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -104,10 +104,6 @@
         padding: 0 5px;
         display: inline-block;
 
-        &.show-count {
-          padding-right: 2px;
-        }
-
         &.route {
           background-color: $yellow-medium;
         }
@@ -122,7 +118,13 @@
         }
 
         &.show-count {
+          padding-right: 2px;
           border-radius: 10px 0 0 10px;
+          max-width: 200px;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          vertical-align: top;
         }
       }
 
@@ -148,8 +150,13 @@
 
       .num-duplicates.has-alias {
         border-radius: 10px;
-        line-height: 2;
+        line-height: 1;
         padding: 3px 5px 3px 5px;
+      }
+
+      .num-duplicates.has-alias.has-duplicates {
+        border-radius: 0 10px 10px 0;
+        padding: 4px 5px 2px 3px;
       }
 
       .command-alias-count {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Partially addresses #9588

### User facing changelog

- Improved the way that `cy.intercept()` and `cy.route()` requests with multiple aliases are displayed in the command log.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

The aliases are now displayed in one line (ignore the lack of badge background, this is just a test):

![image](https://user-images.githubusercontent.com/1151760/117363298-efc15e80-aeab-11eb-908a-78379a05b906.png)

But the list can still be expanded, in which case it's unjoined:

![image](https://user-images.githubusercontent.com/1151760/117363386-0bc50000-aeac-11eb-8eee-83949c74dcfc.png)


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
