### PR TITLE
fix(ui): show req stub/fn when a handler is supplied

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -461,6 +461,45 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
         })
       })
 
+      it('has displayName req for spies', function () {
+        cy.intercept('/foo*').as('getFoo')
+        .then(() => {
+          $.get('/foo')
+        })
+        .wait('@getFoo')
+        .then(() => {
+          const log = _.last(cy.queue.logs()) as any
+
+          expect(log.get('displayName')).to.eq('req')
+        })
+      })
+
+      it('has displayName req stub for stubs', function () {
+        cy.intercept('/foo*', { body: 'foo' }).as('getFoo')
+        .then(() => {
+          $.get('/foo')
+        })
+        .wait('@getFoo')
+        .then(() => {
+          const log = _.last(cy.queue.logs()) as any
+
+          expect(log.get('displayName')).to.eq('req stub')
+        })
+      })
+
+      it('has displayName req fn for request handlers', function () {
+        cy.intercept('/foo*', () => {}).as('getFoo')
+        .then(() => {
+          $.get('/foo')
+        })
+        .wait('@getFoo')
+        .then(() => {
+          const log = _.last(cy.queue.logs()) as any
+
+          expect(log.get('displayName')).to.eq('req fn')
+        })
+      })
+
       // TODO: implement log niceties
       it.skip('#consoleProps', function () {
         cy.intercept('*', {

--- a/packages/runner/cypress/fixtures/errors/intercept_spec.ts
+++ b/packages/runner/cypress/fixtures/errors/intercept_spec.ts
@@ -15,7 +15,9 @@ describe('cy.intercept', () => {
           routeId: Object.keys(Cypress.state('routes'))[0],
           await: true,
         },
-        data: {},
+        data: {
+          url: '',
+        },
       })
     })
     .wait(1000) // ensure the failure happens before test ends
@@ -36,7 +38,9 @@ describe('cy.intercept', () => {
           routeId: Object.keys(Cypress.state('routes'))[0],
           await: true,
         },
-        data: {},
+        data: {
+          url: '',
+        },
       })
 
       Cypress.emit('net:event', 'before:response', {
@@ -49,7 +53,9 @@ describe('cy.intercept', () => {
           routeId: Object.keys(Cypress.state('routes'))[0],
           await: true,
         },
-        data: {},
+        data: {
+          url: '',
+        },
       })
     })
     .wait(1000) // ensure the failure happens before test ends
@@ -70,7 +76,9 @@ describe('cy.intercept', () => {
           routeId: Object.keys(Cypress.state('routes'))[0],
           await: true,
         },
-        data: {},
+        data: {
+          url: ''
+        },
       })
 
       Cypress.emit('net:event', 'network:error', {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Partially addresses #9588

### User facing changelog

- Improved the way that requests stubbed with `cy.intercept()` are displayed in the command log.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?

Previously, all `cy.intercept()` requests would be prefixed with `(req)` in the command log.

Now, there are 3 possible display names:

* `(req)`, for spies (same as before)
* `(req stub)`, for staticresponse stubs (same as cy.route's `(xhr stub)`)
* `(req fn)`, for dynamic interception (since it's not always a stub) (no parallel with cy.route)

![image](https://user-images.githubusercontent.com/1151760/117366816-d7077780-aeb0-11eb-9672-254d50bbc600.png)

Additionally, the URL display has been improved. Now, the origin (`scheme://host:port`) will not be shown if it's a request to the current origin. For comparison, `cy.route` only ever displays the path, even on a different origin, which is kinda confusing.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
