### PR TITLE
feat(intercept): support regexp matcher with middleware intercepts

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -181,7 +181,7 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
         this.testRoute(options, handler, expectedEvent, expectedRoute)
       })
 
-      it('mergeRouteMatcher works when supplied', function () {
+      it('mergeRouteMatcher + string url works', function () {
         const url = '/foo*'
 
         const handler = (req) => {
@@ -209,6 +209,48 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
             url: {
               type: 'glob',
               value: url,
+            },
+            middleware: true,
+          },
+          hasInterceptor: true,
+        }
+
+        cy.intercept(url, { middleware: true }, handler).as('get')
+        .then(() => {
+          return $.get('/foo')
+        })
+        .wait('@get')
+      })
+
+      // @see https://github.com/cypress-io/cypress/pull/16390
+      it('mergeRouteMatcher + regex url works', function () {
+        const url = /^\/foo.*/
+
+        const handler = (req) => {
+          // @ts-ignore
+          const routeId = _.findKey(state('routes'), { handler })
+          const route = state('routes')[routeId!]
+
+          // @ts-ignore
+          expectedEvent.routeId = routeId
+          expect(this.emit).to.be.calledWith('backend:request', 'net', 'route:added', expectedEvent)
+
+          expect(route.handler).to.deep.eq(expectedRoute.handler)
+          expect(route.options).to.deep.eq(expectedRoute.options)
+
+          req.reply('a')
+        }
+
+        const expectedRoute = {
+          options: { url, middleware: true },
+          handler,
+        }
+
+        const expectedEvent = {
+          routeMatcher: {
+            url: {
+              type: 'regex',
+              value: String(url),
             },
             middleware: true,
           },
@@ -282,43 +324,6 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
 
         cy
         .intercept('/dump-headers*', { middleware: true }, (req) => {
-          e.push('mware req handler')
-          req.on('before:response', (res) => {
-            e.push('mware before:response')
-          })
-
-          req.on('response', (res) => {
-            e.push('mware response')
-          })
-
-          req.on('after:response', (res) => {
-            e.push('mware after:response')
-          })
-        })
-        .intercept('/dump-headers*', (req) => {
-          e.push('normal req handler')
-          req.reply(() => {
-            e.push('normal res handler')
-          })
-        })
-        .then(() => {
-          return $.get('/dump-headers')
-        })
-        .wrap(e).should('have.all.members', [
-          'mware req handler',
-          'normal req handler',
-          'mware before:response',
-          'normal res handler',
-          'mware response',
-          'mware after:response',
-        ])
-      })
-
-      it('chains middleware with regexp matcher as expected', function () {
-        const e: string[] = []
-
-        cy
-        .intercept(/dump-headers/, { middleware: true }, (req) => {
           e.push('mware req handler')
           req.on('before:response', (res) => {
             e.push('mware before:response')

--- a/packages/driver/src/cy/net-stubbing/add-command.ts
+++ b/packages/driver/src/cy/net-stubbing/add-command.ts
@@ -283,7 +283,7 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
 
   function intercept (matcher: RouteMatcher, handler?: RouteHandler | StringMatcher | RouteMatcherOptions, arg2?: RouteHandler) {
     function getMatcherOptions (): RouteMatcherOptions {
-      if (_.isString(matcher) && hasOnlyRouteMatcherKeys(handler)) {
+      if (isStringMatcher(matcher) && hasOnlyRouteMatcherKeys(handler)) {
         // url, mergeRouteMatcher, handler
         // @ts-ignore
         if (handler.url) {

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -498,7 +498,7 @@ declare global {
        *
        * @param mergeRouteMatcher Additional route matcher options to merge with `url`. Typically used for middleware.
        */
-      intercept(url: string, mergeRouteMatcher: Omit<RouteMatcherOptions, 'url'>, response: RouteHandler): Chainable<null>
+      intercept(url: StringMatcher, mergeRouteMatcher: Omit<RouteMatcherOptions, 'url'>, response: RouteHandler): Chainable<null>
       /**
        * Wait for a specific request to complete.
        *


### PR DESCRIPTION
### User facing changelog

`cy.intercept` accepts a RegExp matcher for `url` now when route matcher options are passed to it as the second argument.

### Additional details

When upgrading to Cypress 7 I had to figure out how to add a delay to one of our requests. In Cypress 6 we were just adding such intercept before other intercepts but now they are matched in the reverse order.

So we had a code like this:
```js
cy.intercept(/localization/, () => delay(500))
cy.customVisitWithSetOfCommonInterceptsInIt('')
```
but since this request was done immediately on startup of our application we couldn't just reorder those commands - because `cy.visit` only resolves after the `load` event.

So I've figured out that `{ middleware: true }` can actually save me here and to my surprise this both didn't work and didn't typecheck correctly:
```diff
-cy.intercept(/localization/, () => delay(500))
+cy.intercept(/localization/, { middleware: true }, () => delay(500))
```

The work around this is quite simple:
```diff
-cy.intercept(/localization/, { middleware: true }, () => delay(500))
+cy.intercept('**localization**', { middleware: true }, () => delay(500))
```
But I think that the DX could be improved here by just allowing a regexp matcher, unless there is a strong reason why this is not supported.

### How has the user experience changed?

It has been improved since now `cy.intercept` will accept more combination of arguments.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
