### PR TITLE
chore: remove deprecated renovate config, lets see what the message looks like without this. [skip ci]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,8 +15,7 @@
     "type: dependencies",
     "renovate"
   ],
-  "commitMessage": "{{semanticPrefix}}Update {{depName}} to {{newVersion}} 🌟",
-  "prTitle": "{{semanticPrefix}}{{#if isPin}}Pin{{else}}Update{{/if}} dependency {{depName}} to version {{#if isRange}}{{newVersion}}{{else}}{{#if isMajor}}{{newVersionMajor}}.x{{else}}{{newVersion}}{{/if}}{{/if}} 🌟",
+  "commitMessageSuffix": "🌟",
   "prHourlyLimit": 1,
   "prConcurrentLimit": 1,
   "updateNotScheduled": false,


### PR DESCRIPTION
They deprecated commitMessage and prTitle. It’s supposed to prefix with semantic commit automatically, so let’s just see what their autogenerated title looks like.