### PR TITLE
fix: cy.intercept adds access-control-expose-headers for cors requests

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -919,6 +919,101 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
         })
       })
     })
+
+    // https://github.com/cypress-io/cypress/issues/15050
+    describe('cors expose header', () => {
+      // a different domain from the page own domain
+      const corsUrl = 'http://diff.foobar.com:3501/cors'
+
+      before(() => {
+        cy.visit('http://127.0.0.1:3500/fixtures/dom.html')
+      })
+
+      it('headers option is not set => no expose-header', () => {
+        cy
+        .intercept('/cors*', {})
+        .as('corsRequest')
+        .then(() => {
+          return $.get(corsUrl)
+        })
+
+        cy.wait('@corsRequest').then((res) => {
+          let headers = res.response?.headers
+
+          expect(headers).to.not.have.property('access-control-expose-headers')
+        })
+      })
+
+      it('headers option only has the accessible headers from the cors request => no expose-header', () => {
+        cy
+        .intercept('/cors*', {
+          body: { success: true },
+          headers: {
+            'cache-control': 'no-cache',
+            'content-language': 'en-US',
+            'content-type': 'text/html',
+            'Expires': 'Wed, 21 Oct 2015 07:28:00 GMT',
+            'Last-Modified': 'Wed, 21 Oct 2015 07:28:00 GMT',
+            'Pragma': 'no-cache',
+          },
+        })
+        .as('corsRequest')
+        .then(() => {
+          return $.get(corsUrl)
+        })
+
+        cy.wait('@corsRequest').then((res) => {
+          let headers = res.response?.headers
+
+          expect(headers).to.not.have.property('access-control-expose-headers')
+        })
+      })
+
+      it('headers option does not have the accessible header => include expose-header', () => {
+        cy
+        .intercept('/cors*', {
+          body: { success: true },
+          headers: {
+            'cache-control': 'no-cache',
+            'content-language': 'en-US',
+            'x-token': 'token',
+          },
+        })
+        .as('corsRequest')
+        .then(() => {
+          return $.get(corsUrl)
+        })
+
+        cy.wait('@corsRequest').then((res) => {
+          let headers = res.response?.headers
+
+          expect(headers!['access-control-expose-headers']).to.eq('*')
+          expect(headers!['x-token']).to.eq('token')
+        })
+      })
+
+      it('headers option has access-control-expose-headers => does not override', () => {
+        cy
+        .intercept('/cors*', {
+          body: { success: true },
+          headers: {
+            'access-control-expose-headers': 'x-token',
+            'x-token': 'token',
+          },
+        })
+        .as('corsRequest')
+        .then(() => {
+          return $.get(corsUrl)
+        })
+
+        cy.wait('@corsRequest').then((res) => {
+          let headers = res.response?.headers
+
+          expect(headers!['access-control-expose-headers']).to.eq('x-token')
+          expect(headers!['x-token']).to.eq('token')
+        })
+      })
+    })
   })
 
   context('stubbing with static responses', function () {

--- a/packages/net-stubbing/lib/server/util.ts
+++ b/packages/net-stubbing/lib/server/util.ts
@@ -104,6 +104,28 @@ export function setDefaultHeaders (req: CypressIncomingRequest, res: IncomingMes
     }
   }
 
+  // https://github.com/cypress-io/cypress/issues/15050
+  // Check if res.headers has a custom header.
+  // If so, set access-control-expose-headers to '*'.
+  const hasCustomHeader = Object.keys(res.headers).some((header) => {
+    // The list of header items that can be accessed from cors request
+    // without access-control-expose-headers
+    // @see https://stackoverflow.com/a/37931084/1038927
+    return ![
+      'cache-control',
+      'content-language',
+      'content-type',
+      'expires',
+      'last-modified',
+      'pragma',
+    ].includes(header.toLowerCase())
+  })
+
+  // We should not override the user's access-control-expose-headers setting.
+  if (hasCustomHeader && !res.headers['access-control-expose-headers']) {
+    setDefaultHeader('access-control-expose-headers', _.constant('*'))
+  }
+
   setDefaultHeader('access-control-allow-origin', () => caseInsensitiveGet(req.headers, 'origin') || '*')
   setDefaultHeader('access-control-allow-credentials', _.constant('true'))
 }


### PR DESCRIPTION
- Closes #15050

### User facing changelog

`cy.intercept()` adds `access-control-expose-headers` header for CORS requests. 

### Additional details
- Why was this change necessary? => This causes some unnecessary confusion for some use cases. 
- What is affected by this change? => N/A
- Any implementation details to explain? => When there is a custom header, we add `access-control-expose-headers` automatically to avoid confusion.

### How has the user experience changed?

**Before:** If it's a CORS request, you need to remember to add `access-control-expose-headers` to get header information from `cy.intercept()`.

```js
cy
.intercept('/cors*', {
  body: { success: true },
  headers: {
    'access-control-expose-headers': 'x-token', // This line is required
    'x-token': 'token',
  },
})
```

**After:** Cypress automatically handles it.

```js
cy
.intercept('/cors*', {
  body: { success: true },
  headers: {
    // It isn't necessary.
    'x-token': 'token',
  },
})
```

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?