### PR TITLE
feat: allow to import/require files in CRA plugin out of src

### DIFF
--- a/npm/react/plugins/utils/get-transpile-folders.js
+++ b/npm/react/plugins/utils/get-transpile-folders.js
@@ -1,6 +1,9 @@
 // @ts-check
+const path = require('path')
+
 function getTranspileFolders (config) {
-  const folders = []
+  const rawFolders = config.addTranspiledFolders ?? []
+  const folders = rawFolders.map((folder) => path.resolve(config.projectRoot, folder))
 
   // user can disable folders, so check first
   if (config.componentFolder) {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #16379

### User facing changelog

Add an option to the `@cypress/react/plugins/react-scripts` to allow additional folders to be transpiled and imported in the project 

### Additional details

When trying to mount storybook stories, we have to import `.storybook/preview.js` to get global imports and global decorators. These are outside of `cypress` and `src` and would fail with cra webpack-config.

### How has the user experience changed?

We added an option to the plugin, the API has not changed. 
