### PR TITLE
fix(ui): improve "Routes" display for cy.intercept

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1,4 +1,4 @@
-import { _getDisplayUrlMatcher } from '@packages/driver/src/cy/net-stubbing/route-matcher-log'
+import { getDisplayUrlMatcher } from '@packages/driver/src/cy/net-stubbing/route-matcher-log'
 import { RouteMatcherOptions } from '@packages/net-stubbing/lib/external-types'
 
 const testFail = (cb, expectedDocsUrl = 'https://on.cypress.io/intercept') => {
@@ -507,7 +507,7 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
       })
 
       // @see https://github.com/cypress-io/cypress/issues/9403
-      // see _getDisplayUrlMatcher unit tests for more test cases
+      // see getDisplayUrlMatcher unit tests for more test cases
       it('stringifies complex matchers', function () {
         cy.intercept({ hostname: 'foo.net', port: 1234 }).then(function () {
           expect(this.lastLog.get('url')).to.eq('{hostname: foo.net, port: 1234}')
@@ -3242,10 +3242,10 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
   })
 
   context('unit tests', function () {
-    context('#_getDisplayUrlMatcher', function () {
+    context('#getDisplayUrlMatcher', function () {
       function testDisplayUrl (title: string, expectedDisplayUrl: string, matcher: Partial<RouteMatcherOptions>) {
         return it(title, function () {
-          expect(_getDisplayUrlMatcher(matcher)).to.eq(expectedDisplayUrl)
+          expect(getDisplayUrlMatcher(matcher)).to.eq(expectedDisplayUrl)
         })
       }
 

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1,3 +1,6 @@
+import { _getDisplayUrlMatcher } from '@packages/driver/src/cy/net-stubbing/route-matcher-log'
+import { RouteMatcherOptions } from '@packages/net-stubbing/lib/external-types'
+
 const testFail = (cb, expectedDocsUrl = 'https://on.cypress.io/intercept') => {
   cy.on('fail', (err) => {
     // @ts-ignore
@@ -500,6 +503,15 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
       it('uses the wildcard URL', function () {
         cy.intercept('*', {}).then(function () {
           expect(this.lastLog.get('url')).to.eq('*')
+        })
+      })
+
+      // @see https://github.com/cypress-io/cypress/issues/9403
+      // see _getDisplayUrlMatcher unit tests for more test cases
+      it('stringifies complex matchers', function () {
+        cy.intercept({ hostname: 'foo.net', port: 1234 }).then(function () {
+          expect(this.lastLog.get('url')).to.eq('{hostname: foo.net, port: 1234}')
+          expect(this.lastLog.get('method')).to.eq('*')
         })
       })
 
@@ -3226,6 +3238,24 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
 
         cy.wait('@get.url')
       })
+    })
+  })
+
+  context('unit tests', function () {
+    context('#_getDisplayUrlMatcher', function () {
+      function testDisplayUrl (title: string, expectedDisplayUrl: string, matcher: Partial<RouteMatcherOptions>) {
+        return it(title, function () {
+          expect(_getDisplayUrlMatcher(matcher)).to.eq(expectedDisplayUrl)
+        })
+      }
+
+      testDisplayUrl('with only url', 'http://google.net', { url: 'http://google.net' })
+      testDisplayUrl('with url + method', 'http://google.net', { method: 'GET', url: 'http://google.net' })
+      testDisplayUrl('with regex url', '/foo/', { url: /foo/ })
+      testDisplayUrl('with only path', '/foo', { path: '/foo' })
+      testDisplayUrl('with only pathname', '/foo', { pathname: '/foo' })
+      testDisplayUrl('with host + port', '{hostname: foo.net, port: 1234}', { hostname: 'foo.net', port: 1234 })
+      testDisplayUrl('with url and query', '{url: http://something, query: {a: b}}', { url: 'http://something', query: { a: 'b' } })
     })
   })
 })

--- a/packages/driver/src/cy/net-stubbing/add-command.ts
+++ b/packages/driver/src/cy/net-stubbing/add-command.ts
@@ -20,6 +20,9 @@ import {
   getBackendStaticResponse,
   hasStaticResponseKeys,
 } from './static-response-utils'
+import {
+  getRouteMatcherLogConfig,
+} from './route-matcher-log'
 import { registerEvents } from './events'
 import $errUtils from '../../cypress/error_utils'
 import $utils from '../../cypress/utils'
@@ -163,61 +166,6 @@ function validateRouteMatcherOptions (routeMatcher: RouteMatcherOptions): { isVa
 export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, state: Cypress.State) {
   const { emitNetEvent } = registerEvents(Cypress, cy)
 
-  function getNewRouteLog (matcher: RouteMatcherOptions, isStubbed: boolean, alias: string | void, staticResponse?: StaticResponse) {
-    let obj: Partial<Cypress.LogConfig> = {
-      name: 'route',
-      instrument: 'route',
-      isStubbed,
-      numResponses: 0,
-      consoleProps: () => {
-        return {
-          Method: obj.method,
-          URL: obj.url,
-          Status: obj.status,
-          'Route Matcher': matcher,
-          'Static Response': staticResponse,
-          Alias: alias,
-        }
-      },
-    }
-
-    ;['method', 'url'].forEach((k) => {
-      if (matcher[k]) {
-        obj[k] = String(matcher[k]) // stringify RegExp
-      } else {
-        obj[k] = '*'
-      }
-    })
-
-    if (staticResponse) {
-      if (staticResponse.statusCode) {
-        obj.status = staticResponse.statusCode
-      } else {
-        obj.status = 200
-      }
-
-      if (staticResponse.body) {
-        obj.response = String(staticResponse.body)
-      } else {
-        obj.response = '< empty body >'
-      }
-    }
-
-    if (!obj.response) {
-      if (isStubbed) {
-        obj.response = '< callback function >'
-      } else {
-        obj.response = '< passthrough >'
-      }
-    }
-
-    if (alias) {
-      obj.alias = alias
-    }
-
-    return Cypress.log(obj)
-  }
-
   function addRoute (matcher: RouteMatcherOptions, handler?: RouteHandler) {
     const routeId = getUniqueId()
 
@@ -270,7 +218,7 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
     }
 
     state('routes')[routeId] = {
-      log: getNewRouteLog(matcher, !!handler, alias, staticResponse),
+      log: Cypress.log(getRouteMatcherLogConfig(matcher, !!handler, alias, staticResponse)),
       options: matcher,
       handler,
       hitCount: 0,

--- a/packages/driver/src/cy/net-stubbing/route-matcher-log.ts
+++ b/packages/driver/src/cy/net-stubbing/route-matcher-log.ts
@@ -9,7 +9,7 @@ import $utils from '../../cypress/utils'
 // properties that, if they are the only ones set, make sense to display as the display url
 const standaloneDisplayUrlProps: Array<keyof RouteMatcherOptions> = ['url', 'path', 'pathname']
 
-export function _getDisplayUrlMatcher (matcher: RouteMatcherOptions): string {
+export function getDisplayUrlMatcher (matcher: RouteMatcherOptions): string {
   const displayMatcher = _.omit(matcher, 'method')
   const displayMatcherKeys = _.keys(displayMatcher)
 
@@ -26,7 +26,7 @@ export function getRouteMatcherLogConfig (matcher: RouteMatcherOptions, isStubbe
   const obj: Partial<Cypress.LogConfig> = {
     name: 'route',
     method: String(matcher.method || '*'),
-    url: _getDisplayUrlMatcher(matcher),
+    url: getDisplayUrlMatcher(matcher),
     instrument: 'route',
     isStubbed,
     numResponses: 0,

--- a/packages/driver/src/cy/net-stubbing/route-matcher-log.ts
+++ b/packages/driver/src/cy/net-stubbing/route-matcher-log.ts
@@ -1,0 +1,72 @@
+import _ from 'lodash'
+
+import {
+  RouteMatcherOptions,
+  StaticResponse,
+} from '@packages/net-stubbing/lib/types'
+import $utils from '../../cypress/utils'
+
+// properties that, if they are the only ones set, make sense to display as the display url
+const standaloneDisplayUrlProps: Array<keyof RouteMatcherOptions> = ['url', 'path', 'pathname']
+
+export function _getDisplayUrlMatcher (matcher: RouteMatcherOptions): string {
+  const displayMatcher = _.omit(matcher, 'method')
+  const displayMatcherKeys = _.keys(displayMatcher)
+
+  for (const prop of standaloneDisplayUrlProps) {
+    if (_.has(matcher, prop) && displayMatcherKeys.length === 1) {
+      return String(matcher[prop])
+    }
+  }
+
+  return $utils.stringify(displayMatcher)
+}
+
+export function getRouteMatcherLogConfig (matcher: RouteMatcherOptions, isStubbed: boolean, alias: string | void, staticResponse?: StaticResponse): Partial<Cypress.LogConfig> {
+  const obj: Partial<Cypress.LogConfig> = {
+    name: 'route',
+    method: String(matcher.method || '*'),
+    url: _getDisplayUrlMatcher(matcher),
+    instrument: 'route',
+    isStubbed,
+    numResponses: 0,
+    consoleProps: () => {
+      return {
+        Method: obj.method,
+        URL: obj.url,
+        Status: obj.status,
+        'Route Matcher': matcher,
+        'Static Response': staticResponse,
+        Alias: alias,
+      }
+    },
+  }
+
+  if (staticResponse) {
+    if (staticResponse.statusCode) {
+      obj.status = staticResponse.statusCode
+    } else {
+      obj.status = 200
+    }
+
+    if (staticResponse.body) {
+      obj.response = String(staticResponse.body)
+    } else {
+      obj.response = '< empty body >'
+    }
+  }
+
+  if (!obj.response) {
+    if (isStubbed) {
+      obj.response = '< callback function >'
+    } else {
+      obj.response = '< passthrough >'
+    }
+  }
+
+  if (alias) {
+    obj.alias = alias
+  }
+
+  return obj
+}

--- a/packages/reporter/src/routes/routes.tsx
+++ b/packages/reporter/src/routes/routes.tsx
@@ -62,7 +62,7 @@ const Routes = observer(({ model }: RoutesProps) => (
               <thead>
                 <tr>
                   <th>Method</th>
-                  <th>Url</th>
+                  <th>Route Matcher</th>
                   <th>Stubbed</th>
                   <th>Alias</th>
                   <th>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #9403

### User facing changelog

- Improved the way that `cy.intercept` matchers are displayed in the command log when using RouteMatcher properties besides `url` and `method`.

### Additional details

- [x] should we rename the column from 'Url' to something else? `Matcher`? `RouteMatcher/URL`? `Matcher (RouteMatcher, url, etc...)`?

### How has the user experience changed?

Compared to #9403, now routes that use non-url properties are displayed in a better way

![image](https://user-images.githubusercontent.com/1151760/117858500-78117c00-b27d-11eb-91e1-7b9eff3486a5.png)


See unit tests for more examples of stringification:

https://github.com/cypress-io/cypress/blob/d85db41b8526ae2947c661a7edb07af43ec59582/packages/driver/cypress/integration/commands/net_stubbing_spec.ts#L3244-L3258

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
