### PR TITLE
fix(cy.intercept): always wait for request before waiting for response

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -2899,6 +2899,18 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
       .wait('@getUsers')
     })
 
+    // @see https://github.com/cypress-io/cypress/issues/16451
+    it('yields the expected interception when two requests are raced', function () {
+      cy.intercept('/foo*', { times: 1 }, { delay: 100, body: 'bar' }).as('a')
+      cy.intercept('/foo*', { times: 1 }, 'foo').as('a')
+      cy.then(() => {
+        $.get('/foo')
+        $.get('/foo')
+      })
+      .wait('@a').its('response.body').should('eq', 'foo')
+      .wait('@a').its('response.body').should('eq', 'bar')
+    })
+
     // @see https://github.com/cypress-io/cypress/issues/9306
     context('cy.get(alias)', function () {
       it('gets the latest Interception by alias', function () {

--- a/packages/driver/src/cy/net-stubbing/wait-for-route.ts
+++ b/packages/driver/src/cy/net-stubbing/wait-for-route.ts
@@ -40,7 +40,6 @@ export function waitForRoute (alias: string, state: Cypress.State, specifier: 'r
     const request = requests[i]
 
     if (RESPONSE_WAITED_STATES.includes(request.state)) {
-      request.requestWaited = true
       request.responseWaited = true
 
       return request


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #16451

### User facing changelog

- Fixed an issue where `cy.wait()` could yield the incorrect result when used with `cy.intercept()` and several simultaneous requests.

### Additional details

- `cy.wait('@intercept')` was originally supposed to "latch" - it must wait for the request, then wait for the response. 
- it may seem unnecessary now, but the design for this emerged for the requirement for `cy.wait('@alias.request/response')`, which was scrapped
- regardless, #14885 broke the latching by allowing a request already in the `Complete` state to set requestWaited and responseWaited in one fell swoop
- this meant that in a race condition, the request yielded might not match the one which was marked as `requestWaited: true` when the request phase was waited
- reverted the `requestWaited = true` change and all tests still pass so it's good

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
