### PR TITLE
chore: Update package.json/readmes for npm packages to better find changelog

### DIFF
--- a/cli/__snapshots__/build_spec.js
+++ b/cli/__snapshots__/build_spec.js
@@ -3,7 +3,6 @@ exports['package.json build outputs expected properties 1'] = {
   "engines": "test engines",
   "version": "x.y.z",
   "description": "Cypress.io end to end testing tool",
-  "author": "Brian Mann",
   "homepage": "https://github.com/cypress-io/cypress",
   "license": "MIT",
   "bugs": {

--- a/cli/scripts/build.js
+++ b/cli/scripts/build.js
@@ -8,7 +8,6 @@ const fs = require('../lib/fs')
 const {
   version,
   description,
-  author,
   homepage,
   license,
   bugs,
@@ -31,7 +30,6 @@ function preparePackageForNpmRelease (json) {
   _.extend(json, {
     version,
     description,
-    author,
     homepage,
     license,
     bugs,

--- a/cli/test/lib/build_spec.js
+++ b/cli/test/lib/build_spec.js
@@ -11,10 +11,6 @@ const hasVersion = (json) => {
   return la(is.semver(json.version), 'cannot find version', json)
 }
 
-const hasAuthor = (json) => {
-  return la(json.author === 'Brian Mann', 'wrong author name', json)
-}
-
 const changeVersion = R.assoc('version', 'x.y.z')
 
 describe('package.json build', () => {
@@ -30,9 +26,8 @@ describe('package.json build', () => {
     sinon.stub(fs, 'outputJsonAsync').resolves()
   })
 
-  it('author name and version', () => {
+  it('version', () => {
     return makeUserPackageFile()
-    .tap(hasAuthor)
     .tap(hasVersion)
   })
 

--- a/npm/create-cypress-tests/README.md
+++ b/npm/create-cypress-tests/README.md
@@ -50,3 +50,7 @@ Here is a list of available configuration options:
 ## License
 
 The project is licensed under the terms of [MIT license](../../LICENSE)
+
+## Changelog
+
+[Changelog](./CHANGELOG.md)

--- a/npm/create-cypress-tests/package.json
+++ b/npm/create-cypress-tests/package.json
@@ -44,5 +44,5 @@
   },
   "license": "MIT",
   "repository": "https://github.com/cypress-io/cypress.git",
-  "author": "Cypress.io team"
+  "homepage": "https://github.com/cypress-io/cypress/blob/master/npm/create-cypress-tests/#readme"
 }

--- a/npm/design-system/README.md
+++ b/npm/design-system/README.md
@@ -75,3 +75,7 @@ TODO: Add netlify site support and static app wrapper
 2. Import the first component inside of RunnerCT
 3. Hook up tests to circle
 4. Publish the package on npm (switch `package.json`'s `publishConfig` to 'public' instead of 'restricted' and then merge into master)
+
+## Changelog
+
+[Changelog](./CHANGELOG.md)

--- a/npm/design-system/package.json
+++ b/npm/design-system/package.json
@@ -98,7 +98,7 @@
     "type": "git",
     "url": "https://github.com/cypress-io/cypress.git"
   },
-  "author": "Cypress.io",
+  "homepage": "https://github.com/cypress-io/cypress/blob/master/npm/design-system/#readme",
   "keywords": [
     "design-system",
     "cypress",

--- a/npm/eslint-plugin-dev/README.md
+++ b/npm/eslint-plugin-dev/README.md
@@ -206,3 +206,7 @@ then set the following settings:
 ## License
 
 This project is licensed under the terms of the [MIT license](/LICENSE.md).
+
+## Changelog
+
+[Changelog](./CHANGELOG.md)

--- a/npm/eslint-plugin-dev/package.json
+++ b/npm/eslint-plugin-dev/package.json
@@ -45,7 +45,6 @@
     "url": "https://github.com/cypress-io/cypress.git"
   },
   "homepage": "https://github.com/cypress-io/cypress/tree/master/npm/eslint-plugin-dev#readme",
-  "author": "Chris Breiding (chris@cypress.io)",
   "bugs": {
     "url": "https://github.com/cypress-io/cypress/issues/new?assignees=&labels=npm%3A%20%40cypress%2Feslint-plugin-dev&template=bug-report.md"
   },

--- a/npm/mount-utils/README.md
+++ b/npm/mount-utils/README.md
@@ -8,3 +8,7 @@ It is used in:
 
 - [`@cypress/react`](https://github.com/cypress-io/cypress/tree/develop/npm/react)
 - [`@cypress/vue`](https://github.com/cypress-io/cypress/tree/develop/npm/vue)
+
+## Changelog
+
+[Changelog](./CHANGELOG.md)

--- a/npm/react/README.md
+++ b/npm/react/README.md
@@ -397,6 +397,10 @@ Because finding and modifying Webpack settings while running this plugin is done
 DEBUG=@cypress/react,find-webpack
 ```
 
+## Changelog
+
+[Changelog](./CHANGELOG.md)
+
 ## Related tools
 
 Same feature for unit testing components from other frameworks using Cypress

--- a/npm/react/examples/visual-sudoku/package.json
+++ b/npm/react/examples/visual-sudoku/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "homepage": "https://raravi.github.io/sudoku",
   "license": "MIT",
-  "author": "Amith Raravi <amith.raravi@gmail.com>",
   "scripts": {
     "build": "react-scripts build",
     "cy:open": "node ../../../../scripts/cypress open-ct",

--- a/npm/react/package.json
+++ b/npm/react/package.json
@@ -43,7 +43,6 @@
     "@material-ui/pickers": "3.2.10",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.1.1",
-    "@testing-library/cypress": "7.0.1",
     "@types/chalk": "2.2.0",
     "@types/semver": "7.3.4",
     "arg": "4.1.3",
@@ -117,8 +116,7 @@
     "type": "git",
     "url": "https://github.com/cypress-io/cypress.git"
   },
-  "homepage": "https://on.cypress.io/component-testing",
-  "author": "Gleb Bahmutov <gleb.bahmutov@gmail.com>",
+  "homepage": "https://github.com/cypress-io/cypress/blob/master/npm/react/#readme",
   "bugs": "https://github.com/cypress-io/cypress/issues/new?assignees=&labels=npm%3A%20%40cypress%2Freact&template=1-bug-report.md&title=",
   "keywords": [
     "react",

--- a/npm/vite-dev-server/README.md
+++ b/npm/vite-dev-server/README.md
@@ -58,3 +58,7 @@ Install `@cypress/vue` or `@cypress/react` to get this package working properly
 
 Vite is reponsible for compiling and bundling all the files. We use its error overlay to display any transpiling error.
 Omly runtime errors have to be handled through cypress
+
+## Changelog
+
+[Changelog](./CHANGELOG.md)

--- a/npm/vue/README.md
+++ b/npm/vue/README.md
@@ -669,6 +669,10 @@ Support: if you find any problems with this module, [tweet](https://twitter.com/
 
 This project is licensed under the terms of the [MIT license](/LICENSE).
 
+## Changelog
+
+[Changelog](./CHANGELOG.md)
+
 ## Badges
 
 Let the world know your project is using Cypress.io to test with this cool badge

--- a/npm/vue/package.json
+++ b/npm/vue/package.json
@@ -71,8 +71,7 @@
     "type": "git",
     "url": "https://github.com/cypress-io/cypress.git"
   },
-  "homepage": "https://on.cypress.io/component-testing",
-  "author": "Gleb Bahmutov <gleb.bahmutov@gmail.com>",
+  "homepage": "https://github.com/cypress-io/cypress/blob/master/npm/vue/#readme",
   "bugs": "https://github.com/cypress-io/cypress/issues/new?assignees=&labels=npm%3A%20%40cypress%2Fvue&template=1-bug-report.md&title=",
   "keywords": [
     "cypress",

--- a/npm/webpack-batteries-included-preprocessor/README.md
+++ b/npm/webpack-batteries-included-preprocessor/README.md
@@ -60,3 +60,7 @@ This project is licensed under the terms of the [MIT license](/LICENSE.md).
 
 [semantic-image]: https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg
 [semantic-url]: https://github.com/semantic-release/semantic-release
+
+## Changelog
+
+[Changelog](./CHANGELOG.md)

--- a/npm/webpack-batteries-included-preprocessor/package.json
+++ b/npm/webpack-batteries-included-preprocessor/package.json
@@ -55,7 +55,6 @@
     "url": "https://github.com/cypress-io/cypress.git"
   },
   "homepage": "https://github.com/cypress-io/cypress/tree/master/npm/webpack-batteries-included-preprocessor#readme",
-  "author": "Chris Breiding <chris@cypress.io>",
   "bugs": "https://github.com/cypress-io/cypress/issues/new?assignees=&labels=npm%3A%20webpack-batteries-included-preprocessor&template=1-bug-report.md&title=",
   "keywords": [
     "cypress",

--- a/npm/webpack-dev-server/README.md
+++ b/npm/webpack-dev-server/README.md
@@ -93,3 +93,7 @@ In order to update the `{name-of-project}.json` file and use new stats as a base
 ```sh
 WEBPACK_PERF_MEASURE=true WEBPACK_PERF_MEASURE_UPDATE=true WEBPACK_PERF_MEASURE_COMPARE={name-of-project} yarn cypress run-ct
 ```
+
+## Changelog
+
+[Changelog](./CHANGELOG.md)

--- a/npm/webpack-preprocessor/README.md
+++ b/npm/webpack-preprocessor/README.md
@@ -205,3 +205,7 @@ This project is licensed under the terms of the [MIT license](/LICENSE.md).
 
 [semantic-image]: https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg
 [semantic-url]: https://github.com/semantic-release/semantic-release
+
+## Changelog
+
+[Changelog](./CHANGELOG.md)

--- a/npm/webpack-preprocessor/examples/react-app/package.json
+++ b/npm/webpack-preprocessor/examples/react-app/package.json
@@ -11,7 +11,6 @@
     "test": "../../node_modules/.bin/cypress run --dev"
   },
   "license": "ISC",
-  "author": "",
   "keywords": [],
   "browserslist": {
     "production": [

--- a/npm/webpack-preprocessor/examples/use-babelrc/package.json
+++ b/npm/webpack-preprocessor/examples/use-babelrc/package.json
@@ -8,6 +8,5 @@
     "test": "../../node_modules/.bin/cypress run --dev"
   },
   "license": "ISC",
-  "author": "",
   "keywords": []
 }

--- a/npm/webpack-preprocessor/examples/use-ts-loader/package.json
+++ b/npm/webpack-preprocessor/examples/use-ts-loader/package.json
@@ -13,6 +13,5 @@
     "typescript": "^4.2.3"
   },
   "license": "ISC",
-  "author": "",
   "keywords": []
 }

--- a/npm/webpack-preprocessor/package.json
+++ b/npm/webpack-preprocessor/package.json
@@ -76,7 +76,6 @@
     "url": "https://github.com/cypress-io/cypress.git"
   },
   "homepage": "https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor#readme",
-  "author": "Chris Breiding <chris@cypress.io>",
   "bugs": "https://github.com/cypress-io/cypress/issues/new?assignees=&labels=npm%3A%20%40cypress%2Fwebpack-preprocessor&template=1-bug-report.md&title=",
   "keywords": [
     "cypress",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,6 @@
     "url": "https://github.com/cypress-io/cypress.git"
   },
   "homepage": "https://github.com/cypress-io/cypress",
-  "author": "Brian Mann",
   "bugs": {
     "url": "https://github.com/cypress-io/cypress/issues"
   },


### PR DESCRIPTION
Inspired by this issue: https://github.com/cypress-io/cypress/issues/16471

They said they use `yarn upgrade-interactive` to update. This seems to link to the `homepage` field from the package.json


<img width="884" alt="Screen Shot 2021-05-12 at 11 44 38 AM" src="https://user-images.githubusercontent.com/1271364/118021182-92e8fc80-b320-11eb-8910-f6bbc1ef6bbe.png">

- Update package.json `homepage` field to link to each packages readme
- Add a "Changelog" link to each npm packages readme
- Remove the `author` field from all package.json files. There is no single author of Cypress or its packages. 
- Removed `author` from published npm package. Verified that this is not required to publish a package to npm.