### PR TITLE
feat(npm/webpack-preprocessor): WIP support webpack 5 alongside webpack 4

### DIFF
--- a/npm/webpack-preprocessor/index.ts
+++ b/npm/webpack-preprocessor/index.ts
@@ -330,8 +330,14 @@ const preprocessor: WebpackPreprocessor = (options: PreprocessorOptions = {}): F
     // when we should watch, we hook into the 'compile' hook so we know when
     // to rerun the tests
     if (file.shouldWatch) {
-      debug('watching')
-      compiler.hooks.compile.tap(plugin, onCompile)
+      if (compiler.hooks) {
+        // TODO compile.tap takes "string | Tap"
+        // so seems we just need to pass plugin.name
+        // @ts-ignore
+        compiler.hooks.compile.tap(plugin, onCompile)
+      } else {
+        compiler.plugin('compile', onCompile)
+      }
     }
 
     const bundler = file.shouldWatch ? compiler.watch(watchOptions, handle) : compiler.run(handle)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/8900

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog-->

Experimental support for webpack v5 alongside webpack v4 in `@cypress/webpack-preprocessor`.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Initially, I tried to make a `next` version of `@cypress/webpack-preprocessor` that would support Webpack 5. I then updated all the dependencies in the monorepo to webpack 5, and tried to get everything to pass.

I got everything to compile. I got *most* of the tests to pass, but not all. A lot of our dependencies (or their dependencies, etc) are coupled to webpack 4.

The main problem is that webpack 5 deprecated auto polyfills of node modules. I tried a few things, like using a polyfill, providing custom implementations. It got pretty close to passing (around 95% of specs passing in `packages`).

There are some hard blockers:

- some examples in `npm/react/examples` and `npm/webpack-preprocessor/examples` can never pass. Specifically, ones using tools like CRA, which have not yet upgraded to Webpack 5.
- ideally, we should upgrade Cypress to use Webpack 5, too.

For now, I think we should try and support webpack 4 an 5 alongside each other, like I've done here. The next version of `@cypress/webpack-preprocessor`, which will be v6, will drop support for Webpack 4. At this point we should transition Cypress to use webpack 5 internally, too. It's a big change, so it might take some time. This is another compelling reason to do this incremental update.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

- can use with webpack v5
- users will need to deal with webpack 5 breaking changes, mainly the deprecation of auto polyfilled core node modules. They could use [this polyfill](https://github.com/cypress-io/cypress/issues/8900#issuecomment-815032431) for general use cases.
 
### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
