### PR TITLE
feat(npm/webpack-preprocessor): release npm/webpack-preprocessor 4.8.0

### DIFF
--- a/npm/webpack-preprocessor/index.ts
+++ b/npm/webpack-preprocessor/index.ts
@@ -330,8 +330,6 @@ const preprocessor: WebpackPreprocessor = (options: PreprocessorOptions = {}): F
     // when we should watch, we hook into the 'compile' hook so we know when
     // to rerun the tests
     if (file.shouldWatch) {
-      debug('watching')
-
       if (compiler.hooks) {
         // TODO compile.tap takes "string | Tap"
         // so seems we just need to pass plugin.name
@@ -352,7 +350,9 @@ const preprocessor: WebpackPreprocessor = (options: PreprocessorOptions = {}): F
 
       if (file.shouldWatch) {
         // in this case the bundler is webpack.Compiler.Watching
-        (bundler as webpack.Compiler.Watching).close(cb)
+        if (bundler && 'close' in bundler) {
+          bundler.close(cb)
+        }
       }
     })
 
@@ -380,8 +380,10 @@ preprocessor.__reset = () => {
   bundles = {}
 }
 
-function cleanseError (err: string) {
-  return err.replace(/\n\s*at.*/g, '').replace(/From previous event:\n?/g, '')
+function cleanseError (err: string | Error) {
+  let msg = typeof err === 'string' ? err : err.message
+
+  return msg.replace(/\n\s*at.*/g, '').replace(/From previous event:\n?/g, '')
 }
 
 export = preprocessor


### PR DESCRIPTION
New minor version release.Eexperimental-ish Webpack 5 support (well, not experimental. It works, but users need to polyfill node APIs).

I cherry-picked the commit from the branch that was merged into develop.