### PR TITLE
spike(component testing): Rough POC displaying Storybook stories within CT

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -122,13 +122,22 @@ declare namespace Cypress {
   /**
    * A Cypress spec.
    */
-  interface Spec {
+  type Spec = {
     name: string // "config_passing_spec.js"
     relative: string // "cypress/integration/config_passing_spec.js" or "__all" if clicked all specs button
     absolute: string // "/Users/janelane/app/cypress/integration/config_passing_spec.js"
     specFilter?: string // optional spec filter used by the user
     specType?: CypressSpecType
-  }
+  } & ({
+    specType: 'integration'
+  } | {
+    specType: 'component'
+    /**
+     * The source of the spec. Standard specs are marked as `cypress`,
+     * and other sources can have custom management logic
+     */
+    source: 'cypress' | 'storybook'
+  })
 
   /**
    * Window type for Application Under Test(AUT)

--- a/npm/vite-dev-server/client/initCypressTests.js
+++ b/npm/vite-dev-server/client/initCypressTests.js
@@ -3,8 +3,13 @@
 
 const supportPath = import.meta.env.__cypress_supportPath
 const originAutUrl = import.meta.env.__cypress_originAutUrl
+const originUrlPrefix = import.meta.env.__cypress_originUrlPrefix
 
-const specPath = window.location.pathname.replace(originAutUrl, '')
+let specPath = window.location.pathname.replace(originAutUrl, '')
+
+specPath = window.location.pathname.replace(originUrlPrefix, '')
+
+console.log(originAutUrl, specPath)
 
 const importsToLoad = [() => import(/* @vite-ignore */ specPath)]
 

--- a/npm/vite-dev-server/client/initCypressTests.js
+++ b/npm/vite-dev-server/client/initCypressTests.js
@@ -2,14 +2,12 @@
 // it will be used to load and kick start the selected spec
 
 const supportPath = import.meta.env.__cypress_supportPath
-const originAutUrl = import.meta.env.__cypress_originAutUrl
+const originAutUrl = import.meta.env.__cypress_originUrlRootPath
 const originUrlPrefix = import.meta.env.__cypress_originUrlPrefix
 
-let specPath = window.location.pathname.replace(originAutUrl, '')
+let specPath = window.location.pathname.replace(originAutUrl, '').replace(originUrlPrefix, '')
 
-specPath = window.location.pathname.replace(originUrlPrefix, '')
-
-console.log(originAutUrl, specPath)
+console.log(originAutUrl, originUrlPrefix, specPath)
 
 const importsToLoad = [() => import(/* @vite-ignore */ specPath)]
 

--- a/npm/vite-dev-server/client/initVirtualTest.js
+++ b/npm/vite-dev-server/client/initVirtualTest.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { mount } from '@cypress/react'
+import { composeStories } from '@storybook/testing-react'
+
+const initVirtualStorybookTest = (newStories) => {
+  describe('Generated Storybook', () => {
+    for (const [storyName, Story] of Object.entries(composeStories(newStories))) {
+      Story.displayName = storyName
+      it(storyName, () => {
+        mount(React.createElement(Story, {}, null))
+      })
+    }
+  })
+}
+
+export default initVirtualStorybookTest

--- a/npm/vite-dev-server/src/makeCypressPlugin.ts
+++ b/npm/vite-dev-server/src/makeCypressPlugin.ts
@@ -43,7 +43,7 @@ export const makeCypressPlugin = (
         return {
           define: {
             'import.meta.env.__cypress_supportPath': JSON.stringify(normalizedSupportFilePath),
-            'import.meta.env.__cypress_originAutUrl': JSON.stringify(`__cypress/iframes/${convertPathToPosix(projectRoot)}/`),
+            'import.meta.env.__cypress_originUrlRootPath': JSON.stringify(`${convertPathToPosix(projectRoot)}/`),
             'import.meta.env.__cypress_originUrlPrefix': JSON.stringify(`__cypress/iframes/`),
           },
         }

--- a/npm/vite-dev-server/src/makeCypressPlugin.ts
+++ b/npm/vite-dev-server/src/makeCypressPlugin.ts
@@ -44,6 +44,7 @@ export const makeCypressPlugin = (
           define: {
             'import.meta.env.__cypress_supportPath': JSON.stringify(normalizedSupportFilePath),
             'import.meta.env.__cypress_originAutUrl': JSON.stringify(`__cypress/iframes/${convertPathToPosix(projectRoot)}/`),
+            'import.meta.env.__cypress_originUrlPrefix': JSON.stringify(`__cypress/iframes/`),
           },
         }
       }

--- a/npm/vite-dev-server/src/startServer.ts
+++ b/npm/vite-dev-server/src/startServer.ts
@@ -37,11 +37,12 @@ const virtualStoriesPlugin = (registeredStories: Set<string>): Plugin => {
   return {
     name: '@cypress/vite-dev-server/storybook',
     load: (fileId) => {
+      debug(`Loading ${fileId}`)
       if (registeredStories.has(fileId)) {
         // Virtual story spec
         debug('Loading virtual')
 
-        return `import * as stories from '${fileId.replace('/@virtual:', '')}';
+        return `import * as stories from '/${fileId.replace('/@virtual:', '')}';
         import virtualTest from '${INIT_VIRTUAL_TEST_PATH}';
         virtualTest(stories);`
       }
@@ -64,7 +65,7 @@ const resolveServerConfig = async ({ viteConfig, options }: StartDevServer): Pro
 
   const storybookStorySpecs = options.specs.filter((s) => {
     return s.specType === 'component' && s.source === 'storybook'
-  }).map((s) => `/${s.absolute}`)
+  }).map((s) => `/${s.relative}`)
 
   finalConfig.plugins = [...(viteConfig.plugins || []), virtualStoriesPlugin(new Set(storybookStorySpecs)), makeCypressPlugin(projectRoot, supportFile, options.devServerEvents, options.specs)]
 

--- a/packages/runner-ct/src/app/RunnerCt.tsx
+++ b/packages/runner-ct/src/app/RunnerCt.tsx
@@ -21,7 +21,7 @@ import { LeftNavMenu } from './LeftNavMenu'
 import { SpecContent } from './SpecContent'
 import { hideIfScreenshotting, hideSpecsListIfNecessary } from '../lib/hideGuard'
 import { namedObserver } from '../lib/mobx'
-import { SpecList } from './SpecList/SpecList'
+import { File, SpecList } from './SpecList/SpecList'
 import { NoSpec } from './NoSpec'
 
 import styles from './RunnerCt.module.scss'
@@ -81,8 +81,6 @@ const buildNavItems = (eventManager: typeof EventManager, toggleIsSetListOpen: (
   },
 ]
 
-const removeRelativeRegexp = /\.\.\//gi
-
 const RunnerCt = namedObserver('RunnerCt',
   (props: RunnerCtProps) => {
     const searchRef = React.useRef<HTMLInputElement>(null)
@@ -93,15 +91,13 @@ const RunnerCt = namedObserver('RunnerCt',
     const [activeIndex, setActiveIndex] = React.useState<number>(0)
 
     // TODO: Fix ids
-    const runSpec = React.useCallback((path: string) => {
+    const runSpec = React.useCallback((file: File) => {
       setActiveIndex(0)
       // We request an absolute path from the dev server but the spec list displays relative paths
-      // For this reason to match the spec we remove leading relative paths. Eg ../../foo.js -> foo.js.
-      const filePath = path.replace(removeRelativeRegexp, '')
-      const selectedSpec = props.state.specs.find((spec) => spec.absolute.includes(filePath))
+      const selectedSpec = props.state.specs.find((spec) => spec.absolute === file.absolute)
 
       if (!selectedSpec) {
-        throw Error(`Could not find spec matching ${path}.`)
+        throw Error(`Could not find spec matching ${file.absolute}.`)
       }
 
       state.setSingleSpec(selectedSpec)

--- a/packages/runner-ct/src/app/SpecList/SpecList.tsx
+++ b/packages/runner-ct/src/app/SpecList/SpecList.tsx
@@ -15,7 +15,7 @@ export interface SpecListProps {
   specs: Cypress.Cypress['spec'][]
   selectedFile?: string
   searchRef: React.MutableRefObject<HTMLInputElement>
-  onFileClick: (path: string) => void
+  onFileClick: (file: File) => void
 }
 
 const fuzzyTransform = <T, >(node: T, indexes: number[]) => ({
@@ -23,10 +23,14 @@ const fuzzyTransform = <T, >(node: T, indexes: number[]) => ({
   indexes,
 })
 
+export interface File extends FileBase {
+  absolute: string
+}
+
 export const SpecList: React.FC<SpecListProps> = ({ searchRef, className, specs, selectedFile, onFileClick }) => {
   const fileTreeRef = useRef<VirtualizedTreeRef>()
 
-  const files = useMemo(() => specs.map((spec) => ({ path: spec.relative })), [specs])
+  const files = useMemo(() => specs.map(({ relative, absolute }) => ({ path: relative, absolute })), [specs])
 
   const { setSearch, matches } = useFuzzySort({
     search: '',
@@ -38,8 +42,8 @@ export const SpecList: React.FC<SpecListProps> = ({ searchRef, className, specs,
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const onInput = useMemo(() => throttle(setSearch, 100), [])
 
-  const onFilePress = useCallback((file: SpecificTreeNode<TreeFile<FileBase>>) => onFileClick(file.node.id), [onFileClick])
-  const onFolderKeyDown = useCallback((folder: SpecificTreeNode<TreeFolder<FileBase>>, event: React.KeyboardEvent<HTMLDivElement>) => {
+  const onFilePress = useCallback((file: SpecificTreeNode<TreeFile<File>>) => onFileClick(file.node.file), [onFileClick])
+  const onFolderKeyDown = useCallback((folder: SpecificTreeNode<TreeFolder<File>>, event: React.KeyboardEvent<HTMLDivElement>) => {
     if (folder.isFirst && event.key === 'ArrowUp') {
       event.preventDefault()
 

--- a/packages/server-ct/src/project-ct.ts
+++ b/packages/server-ct/src/project-ct.ts
@@ -39,6 +39,8 @@ export class ProjectCt extends ProjectBase<ServerCt> {
   open (options: Record<string, unknown>) {
     this._server = new ServerCt()
 
+    debug('open')
+
     return super.open(options, {
       onOpen: (cfg) => {
         const cfgForComponentTesting = this.addComponentTestingUniqueDefaults(cfg)
@@ -98,7 +100,15 @@ export class ProjectCt extends ProjectBase<ServerCt> {
       // the plugin event for 'dev-server:start' and get back
       // @ts-ignore - let's not attempt to TS all the things in packages/server
 
-      return specsUtil.find(modifiedConfig)
+      return specsUtil.find(modifiedConfig).then((specs) => {
+        return [...specs, {
+          name: 'core/input/Input.stories.tsx',
+          relative: '@virtual:src/core/input/Input.stories.tsx',
+          absolute: '@virtual:/Users/adam/code/cypress/npm/design-system/src/core/input/Input.stories.tsx',
+          specType: 'component',
+          source: 'storybook',
+        }]
+      })
       .filter((spec: Cypress.Cypress['spec']) => {
         return spec.specType === 'component'
       })

--- a/packages/server-ct/src/project-ct.ts
+++ b/packages/server-ct/src/project-ct.ts
@@ -39,8 +39,6 @@ export class ProjectCt extends ProjectBase<ServerCt> {
   open (options: Record<string, unknown>) {
     this._server = new ServerCt()
 
-    debug('open')
-
     return super.open(options, {
       onOpen: (cfg) => {
         const cfgForComponentTesting = this.addComponentTestingUniqueDefaults(cfg)

--- a/packages/server-ct/src/specs-store.ts
+++ b/packages/server-ct/src/specs-store.ts
@@ -39,11 +39,8 @@ export class SpecsStore {
     }
   }
 
-  storeSpecFiles (): Bluebird<void> {
-    return this.getSpecFiles()
-    .then((specFiles) => {
-      this.specFiles = specFiles
-    })
+  setSpecFiles (specFiles: SpecFiles) {
+    this.specFiles = specFiles
   }
 
   getSpecFiles (): Bluebird<SpecFiles> {
@@ -52,15 +49,7 @@ export class SpecsStore {
     searchOptions.searchFolder = this.specDirectory
     searchOptions.testFiles = this.testFiles
 
-    return findSpecsOfType(searchOptions).then((r) => {
-      return ([...r, {
-        name: 'core/input/Input.stories.tsx',
-        relative: '@virtual:src/core/input/Input.stories.tsx',
-        absolute: '@virtual:/Users/adam/code/cypress/npm/design-system/src/core/input/Input.stories.tsx',
-        specType: 'component',
-        source: 'storybook',
-      }])
-    })
+    return findSpecsOfType(searchOptions)
   }
 
   watch (options?: SpecsWatcherOptions) {

--- a/packages/server-ct/src/specs-store.ts
+++ b/packages/server-ct/src/specs-store.ts
@@ -52,7 +52,15 @@ export class SpecsStore {
     searchOptions.searchFolder = this.specDirectory
     searchOptions.testFiles = this.testFiles
 
-    return findSpecsOfType(searchOptions)
+    return findSpecsOfType(searchOptions).then((r) => {
+      return ([...r, {
+        name: 'core/input/Input.stories.tsx',
+        relative: '@virtual:src/core/input/Input.stories.tsx',
+        absolute: '@virtual:/Users/adam/code/cypress/npm/design-system/src/core/input/Input.stories.tsx',
+        specType: 'component',
+        source: 'storybook',
+      }])
+    })
   }
 
   watch (options?: SpecsWatcherOptions) {

--- a/packages/server/lib/util/specs.js
+++ b/packages/server/lib/util/specs.js
@@ -220,8 +220,30 @@ const find = (config, specPattern) => {
 
     searchOptions.searchFolder = config.componentFolder
 
-    return findSpecsOfType(searchOptions, specPattern)
-    .then(setTestType(SPEC_TYPES.COMPONENT))
+    const componentTests = findSpecsOfType(searchOptions, specPattern).then((specs) => {
+      return specs.map((spec) => {
+        return {
+          ...spec,
+          specType: SPEC_TYPES.COMPONENT,
+          source: 'cypress',
+        }
+      })
+    })
+
+    const storybookTests = findSpecsOfType({
+      ...searchOptions,
+      testFiles: ['**/*.stories.{js,jsx,ts,tsx}'],
+    }, specPattern).then((specs) => {
+      return specs.map((spec) => {
+        return {
+          ...spec,
+          specType: SPEC_TYPES.COMPONENT,
+          source: 'storybook',
+        }
+      })
+    })
+
+    return Promise.all([componentTests, storybookTests]).then(([components, storybooks]) => [...components, ...storybooks])
   }
 
   const printFoundSpecs = (foundSpecs) => {


### PR DESCRIPTION
Very rough demonstration of taking raw Storybook stories and converting them into psuedo-tests that can be used to display the story. The idea is that the user would be able to "preview" and play with these stories, then upon pressing a button create a real test on filesystem.

The only real change so far is the `virtualStoriesPlugin` which allows loading a "virtual" (non-disk) file that contains the setup code to generate tests from a given story file.