### PR TITLE
fix: properly generate source map path to files outside project root

### DIFF
--- a/packages/driver/src/cypress/source_map_utils.js
+++ b/packages/driver/src/cypress/source_map_utils.js
@@ -54,12 +54,17 @@ const getSourceContents = (filePath, sourceFile) => {
 }
 
 const getSourcePosition = (filePath, position) => {
-  if (!sourceMapConsumers[filePath]) return null
+  const sourceMapConsumer = sourceMapConsumers[filePath]
 
-  const sourcePosition = sourceMapConsumers[filePath].originalPositionFor(position)
-  const { source: file, line, column } = sourcePosition
+  if (!sourceMapConsumer) return null
 
-  if (!file || line == null || column == null) return
+  const sourcePosition = sourceMapConsumer.originalPositionFor(position)
+  const { source, line, column } = sourcePosition
+
+  if (!source || line == null || column == null) return
+
+  const sourceIndex = sourceMapConsumer._absoluteSources.indexOf(source)
+  const file = sourceMapConsumer._sources.at(sourceIndex)
 
   return {
     file,

--- a/packages/driver/src/cypress/source_map_utils.js
+++ b/packages/driver/src/cypress/source_map_utils.js
@@ -63,6 +63,9 @@ const getSourcePosition = (filePath, position) => {
 
   if (!source || line == null || column == null) return
 
+  // if the file is outside of the projectRoot
+  // originalPositionFor will not provide the correct relative path
+  // https://github.com/cypress-io/cypress/issues/16255
   const sourceIndex = sourceMapConsumer._absoluteSources.indexOf(source)
   const file = sourceMapConsumer._sources.at(sourceIndex)
 

--- a/packages/driver/src/cypress/stack_utils.js
+++ b/packages/driver/src/cypress/stack_utils.js
@@ -251,7 +251,11 @@ const getSourceDetailsForLine = (projectRoot, line) => {
 
   const originalFile = sourceDetails.file
 
-  const relativeFile = path.normalize(stripCustomProtocol(originalFile))
+  let relativeFile = stripCustomProtocol(originalFile)
+
+  if (relativeFile) {
+    relativeFile = path.normalize(relativeFile)
+  }
 
   return {
     function: sourceDetails.function,

--- a/packages/driver/src/cypress/stack_utils.js
+++ b/packages/driver/src/cypress/stack_utils.js
@@ -251,7 +251,7 @@ const getSourceDetailsForLine = (projectRoot, line) => {
 
   const originalFile = sourceDetails.file
 
-  const relativeFile = stripCustomProtocol(originalFile)
+  const relativeFile = path.normalize(stripCustomProtocol(originalFile))
 
   return {
     function: sourceDetails.function,

--- a/packages/server/test/e2e/0_error_ui_spec.ts
+++ b/packages/server/test/e2e/0_error_ui_spec.ts
@@ -1,5 +1,6 @@
 import e2e, { expect } from '../support/helpers/e2e'
 import Fixtures from '../support/helpers/fixtures'
+import path from 'path'
 
 const verifyPassedAndFailedAreSame = (expectedFailures) => {
   return ({ stdout }) => {
@@ -27,5 +28,15 @@ describe('e2e error ui', function () {
         return exec().then(verifyPassedAndFailedAreSame(1))
       },
     })
+  })
+
+  // https://github.com/cypress-io/cypress/issues/16255
+  e2e.it('handles errors when integration folder is outside of project root', {
+    project: path.join(Fixtures.projectPath('integration-outside-project-root'), 'project-root'),
+    spec: '../../../integration/failing_spec.js',
+    expectedExitCode: 1,
+    onRun (exec) {
+      return exec().then(verifyPassedAndFailedAreSame(1))
+    },
   })
 })

--- a/packages/server/test/support/fixtures/projects/integration-outside-project-root/integration/failing_spec.js
+++ b/packages/server/test/support/fixtures/projects/integration-outside-project-root/integration/failing_spec.js
@@ -1,0 +1,24 @@
+/**
+ * This tests the error UI for a certain webpack preprocessor setup.
+ * It does this by having a test fail and then a subsequent test run that
+ * verifies the appearance of the command log.
+ */
+
+import { fail, verify } from '../../e2e/cypress/support/util'
+
+context('validation errors', function () {
+  beforeEach(() => {
+    Cypress.config('isInteractive', true)
+  })
+
+  fail(this, () => {
+    cy.viewport()
+  })
+
+  verify(this, {
+    line: 15,
+    column: 8,
+    message: 'can only accept a string preset or',
+    stack: ['throwErrBadArgs', 'From Your Spec Code:'],
+  })
+})

--- a/packages/server/test/support/fixtures/projects/integration-outside-project-root/project-root/cypress.json
+++ b/packages/server/test/support/fixtures/projects/integration-outside-project-root/project-root/cypress.json
@@ -1,0 +1,3 @@
+{
+  "integrationFolder": "../integration"
+}


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #16255

### User facing changelog
Fixes an issue where tests located outside of the `projectRoot` would not open in IDE and generated studio commands would not save

### Additional details
Our source map consumer would not return the correct path for files that exist outside the project root. For example, `webpack:///../integration/test.spec.js` would be returned as `webpack:///integration/test.spec.js`. These changes return the correct path.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
