### PR TITLE
feat: Support running cypress as node process (#16505)

### DIFF
--- a/cli/lib/exec/xvfb.js
+++ b/cli/lib/exec/xvfb.js
@@ -58,6 +58,12 @@ module.exports = {
   },
 
   isNeeded () {
+    if (process.env.ELECTRON_RUN_AS_NODE) {
+      debug('Environment variable ELECTRON_RUN_AS_NODE detected, xvfb is not needed')
+
+      return false // xvfb required for electron processes only.
+    }
+
     if (os.platform() !== 'linux') {
       return false
     }

--- a/packages/server/lib/ipc/ipc.js
+++ b/packages/server/lib/ipc/ipc.js
@@ -1,6 +1,6 @@
 const debug = require('debug')('cypress:server:ipc')
 
-try {
+if (require('../util/electron-app').isRunningAsElectronProcess({ debug })) {
   const {
     contextBridge,
     ipcRenderer,
@@ -10,6 +10,4 @@ try {
     on: (...args) => ipcRenderer.on(...args),
     send: (...args) => ipcRenderer.send(...args),
   })
-} catch {
-  debug('running as a node process, not an electron process')
 }

--- a/packages/server/lib/ipc/ipc.js
+++ b/packages/server/lib/ipc/ipc.js
@@ -1,9 +1,15 @@
-const {
-  contextBridge,
-  ipcRenderer,
-} = require('electron')
+const debug = require('debug')('cypress:server:ipc')
 
-contextBridge.exposeInMainWorld('ipc', {
-  on: (...args) => ipcRenderer.on(...args),
-  send: (...args) => ipcRenderer.send(...args),
-})
+try {
+  const {
+    contextBridge,
+    ipcRenderer,
+  } = require('electron')
+
+  contextBridge.exposeInMainWorld('ipc', {
+    on: (...args) => ipcRenderer.on(...args),
+    send: (...args) => ipcRenderer.send(...args),
+  })
+} catch {
+  debug('running as a node process, not an electron process')
+}

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1655,15 +1655,9 @@ module.exports = {
   },
 
   async run (options) {
-    let app = null
+    if (require('../util/electron-app').isRunningAsElectronProcess({ debug })) {
+      const app = require('electron').app
 
-    try {
-      app = require('electron').app
-    } catch {
-      debug('running as a node process, not an electron process')
-    }
-
-    if (app) {
       // electron >= 5.0.0 will exit the app if all browserwindows are closed,
       // this is obviously undesirable in run mode
       // https://github.com/cypress-io/cypress/pull/4720#issuecomment-514316695

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-console, @cypress/dev/arrow-body-multiline-braces  */
 const _ = require('lodash')
-const { app } = require('electron')
 const la = require('lazy-ass')
 const pkg = require('@packages/root')
 const path = require('path')
@@ -1506,6 +1505,10 @@ module.exports = {
   ready (options = {}) {
     debug('run mode ready with options %o', options)
 
+    if (process.env.ELECTRON_RUN_AS_NODE && !process.env.DISPLAY) {
+      debug('running electron as a node process without xvfb')
+    }
+
     _.defaults(options, {
       isTextTerminal: true,
       browser: 'electron',
@@ -1652,14 +1655,24 @@ module.exports = {
   },
 
   async run (options) {
-    // electron >= 5.0.0 will exit the app if all browserwindows are closed,
-    // this is obviously undesirable in run mode
-    // https://github.com/cypress-io/cypress/pull/4720#issuecomment-514316695
-    app.on('window-all-closed', () => {
-      debug('all BrowserWindows closed, not exiting')
-    })
+    let app = null
 
-    await app.whenReady()
+    try {
+      app = require('electron').app
+    } catch {
+      debug('running as a node process, not an electron process')
+    }
+
+    if (app) {
+      // electron >= 5.0.0 will exit the app if all browserwindows are closed,
+      // this is obviously undesirable in run mode
+      // https://github.com/cypress-io/cypress/pull/4720#issuecomment-514316695
+      app.on('window-all-closed', () => {
+        debug('all BrowserWindows closed, not exiting')
+      })
+
+      await app.whenReady()
+    }
 
     return this.ready(options)
   },

--- a/packages/server/lib/util/electron-app.js
+++ b/packages/server/lib/util/electron-app.js
@@ -13,8 +13,20 @@ const isRunning = () => {
   return Boolean(process.env.ELECTRON_RUN_AS_NODE || process.versions && process.versions.electron)
 }
 
+const isRunningAsElectronProcess = ({ debug } = {}) => {
+  const isElectronProcess = !process.env.ELECTRON_RUN_AS_NODE
+
+  if (!isElectronProcess && debug) {
+    debug('running as a node process without xvfp due to ELECTRON_RUN_AS_NODE env var')
+  }
+
+  return isElectronProcess
+}
+
 module.exports = {
   scale,
 
   isRunning,
+
+  isRunningAsElectronProcess,
 }

--- a/packages/server/lib/util/electron-app.js
+++ b/packages/server/lib/util/electron-app.js
@@ -10,7 +10,7 @@ const scale = () => {
 
 const isRunning = () => {
   // are we in the electron or the node process?
-  return Boolean(process.versions && process.versions.electron)
+  return Boolean(process.env.ELECTRON_RUN_AS_NODE || process.versions && process.versions.electron)
 }
 
 module.exports = {

--- a/packages/server/lib/util/file.js
+++ b/packages/server/lib/util/file.js
@@ -21,7 +21,9 @@ class File {
 
     this.path = options.path
 
-    this._lockFileDir = path.join(os.tmpdir(), 'cypress')
+    // If multiple user's write to a specific directory is os.tmpdir, permission errors can arrise.
+    // Instead, we make a user specific directory with os.tmpdir.
+    this._lockFileDir = path.join(os.tmpdir(), `cypress-${os.userInfo().uid}`)
     this._lockFilePath = path.join(this._lockFileDir, `${md5(this.path)}.lock`)
 
     this._queue = new pQueue({ concurrency: 1 })

--- a/packages/server/lib/util/file.js
+++ b/packages/server/lib/util/file.js
@@ -21,7 +21,7 @@ class File {
 
     this.path = options.path
 
-    // If multiple user's write to a specific directory is os.tmpdir, permission errors can arrise.
+    // If multiple users write to a specific directory is os.tmpdir, permission errors can arise.
     // Instead, we make a user specific directory with os.tmpdir.
     this._lockFileDir = path.join(os.tmpdir(), `cypress-${os.userInfo().uid}`)
     this._lockFilePath = path.join(this._lockFileDir, `${md5(this.path)}.lock`)

--- a/packages/server/test/e2e/5_headless_spec.ts
+++ b/packages/server/test/e2e/5_headless_spec.ts
@@ -4,6 +4,44 @@ import Fixtures from '../support/helpers/fixtures'
 describe('e2e headless', function () {
   e2e.setup()
 
+  describe('ELECTRON_RUN_AS_NODE', () => {
+    const baseSpec = {
+      spec: 'headless_spec.js',
+      config: {
+        env: {
+          'CI': process.env.CI,
+          'EXPECT_HEADLESS': '1',
+        },
+      },
+      headed: false,
+      processEnv: {
+        // Ensure that electron is spawned as a node process.
+        ELECTRON_RUN_AS_NODE: 1,
+        // Ensure that the current xserver is not passed to the test.
+        DISPLAY: '',
+        // Debug cypress:server:run to look for a message that electron/xvfb were not spawned.
+        DEBUG: 'cypress:server:run',
+      },
+    }
+
+    e2e.it('pass for browsers that do not need xvfb', {
+      ...baseSpec,
+      browser: ['chrome', 'chrome-beta', 'firefox'],
+      expectedExitCode: 0,
+      onRun (exec) {
+        return exec().then(({ stderr }) => {
+          expect(stderr).to.include('running electron as a node process without xvfb')
+        })
+      },
+    })
+
+    e2e.it('fails for browsers that do need xvfb', {
+      ...baseSpec,
+      expectedExitCode: 1,
+      browser: ['electron'],
+    })
+  })
+
   // cypress run --headless
   e2e.it('tests in headless mode pass', {
     spec: 'headless_spec.js',


### PR DESCRIPTION
This change checks if the environment variable
ELECTRON_RUN_AS_NODE is set. If set to true, the cypress
process is started as a normal Node.js process rather than an
electron process.

Consequently, the process does not require a display server to
run so starting a display server is skipped.

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #16505

### User facing changelog
Setting the environment variable ELECTRON_RUN_AS_NODE now causes cypress to start as a normal Node.js process rather than an electron process. Useful for environments which do not have xvfb installed, since headless browsers such as chromium can be used for testing without the system needing xvfb to be installed.

### Additional details
See https://github.com/cypress-io/cypress/issues/16505#issue-891226699

### How has the user experience changed?
Default experience has not changed. This is an opt in functionality.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
