### PR TITLE
chore: update extract-zip to 2.0.1

### DIFF
--- a/cli/lib/tasks/unzip.js
+++ b/cli/lib/tasks/unzip.js
@@ -70,18 +70,6 @@ const unzip = ({ zipFilePath, installDir, progress }) => {
         const unzipWithNode = () => {
           debug('unzipping with node.js (slow)')
 
-          const endFn = (err) => {
-            if (err) {
-              debug('error %s', err.message)
-
-              return reject(err)
-            }
-
-            debug('node unzip finished')
-
-            return resolve()
-          }
-
           const opts = {
             dir: installDir,
             onEntry: tick,
@@ -89,7 +77,19 @@ const unzip = ({ zipFilePath, installDir, progress }) => {
 
           debug('calling Node extract tool %s %o', zipFilePath, opts)
 
-          return unzipTools.extract(zipFilePath, opts, endFn)
+          return unzipTools.extract(zipFilePath, opts)
+          .then(() => {
+            debug('node unzip finished')
+
+            return resolve()
+          })
+          .catch((err) => {
+            if (err) {
+              debug('error %s', err.message)
+
+              return reject(err)
+            }
+          })
         }
 
         const unzipFallback = _.once(unzipWithNode)

--- a/cli/package.json
+++ b/cli/package.json
@@ -40,7 +40,7 @@
     "eventemitter2": "^6.4.3",
     "execa": "4.1.0",
     "executable": "^4.1.1",
-    "extract-zip": "^1.7.0",
+    "extract-zip": "2.0.1",
     "fs-extra": "^9.1.0",
     "getos": "^3.2.1",
     "is-ci": "^3.0.0",

--- a/cli/test/lib/tasks/unzip_spec.js
+++ b/cli/test/lib/tasks/unzip_spec.js
@@ -76,11 +76,11 @@ describe('lib/tasks/unzip', function () {
     it('can try unzip first then fall back to node unzip', function (done) {
       const zipFilePath = path.join('test', 'fixture', 'example.zip')
 
-      sinon.stub(unzip.utils.unzipTools, 'extract').callsFake((filePath, opts, cb) => {
+      sinon.stub(unzip.utils.unzipTools, 'extract').callsFake((filePath, opts) => {
         debug('unzip extract called with %s', filePath)
         expect(filePath, 'zipfile is the same').to.equal(zipFilePath)
-        expect(cb, 'has callback').to.be.a('function')
-        setTimeout(cb, 10)
+
+        return new Promise((resolve) => resolve())
       })
 
       const unzipChildProcess = new events.EventEmitter()
@@ -117,11 +117,11 @@ describe('lib/tasks/unzip', function () {
     it('calls node unzip just once', function (done) {
       const zipFilePath = path.join('test', 'fixture', 'example.zip')
 
-      sinon.stub(unzip.utils.unzipTools, 'extract').callsFake((filePath, opts, cb) => {
+      sinon.stub(unzip.utils.unzipTools, 'extract').callsFake((filePath, opts) => {
         debug('unzip extract called with %s', filePath)
         expect(filePath, 'zipfile is the same').to.equal(zipFilePath)
-        expect(cb, 'has callback').to.be.a('function')
-        setTimeout(cb, 10)
+
+        return new Promise((resolve) => resolve())
       })
 
       const unzipChildProcess = new events.EventEmitter()
@@ -169,11 +169,11 @@ describe('lib/tasks/unzip', function () {
     it('calls node unzip just once', function (done) {
       const zipFilePath = path.join('test', 'fixture', 'example.zip')
 
-      sinon.stub(unzip.utils.unzipTools, 'extract').callsFake((filePath, opts, cb) => {
+      sinon.stub(unzip.utils.unzipTools, 'extract').callsFake((filePath, opts) => {
         debug('unzip extract called with %s', filePath)
         expect(filePath, 'zipfile is the same').to.equal(zipFilePath)
-        expect(cb, 'has callback').to.be.a('function')
-        setTimeout(cb, 10)
+
+        return new Promise((resolve) => resolve())
       })
 
       const unzipChildProcess = new events.EventEmitter()

--- a/yarn.lock
+++ b/yarn.lock
@@ -17581,17 +17581,7 @@ extract-text-webpack-plugin@4.0.0-beta.0:
     schema-utils "^0.4.5"
     webpack-sources "^1.1.0"
 
-extract-zip@^1.0.3, extract-zip@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.7.0.tgz#556cc3ae9df7f452c493a0cfb51cc30277940927"
-  integrity sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==
-  dependencies:
-    concat-stream "^1.6.2"
-    debug "^2.6.9"
-    mkdirp "^0.5.4"
-    yauzl "^2.10.0"
-
-extract-zip@^2.0.1:
+extract-zip@2.0.1, extract-zip@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
   integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
@@ -17601,6 +17591,16 @@ extract-zip@^2.0.1:
     yauzl "^2.10.0"
   optionalDependencies:
     "@types/yauzl" "^2.9.1"
+
+extract-zip@^1.0.3:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.7.0.tgz#556cc3ae9df7f452c493a0cfb51cc30277940927"
+  integrity sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==
+  dependencies:
+    concat-stream "^1.6.2"
+    debug "^2.6.9"
+    mkdirp "^0.5.4"
+    yauzl "^2.10.0"
 
 extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"


### PR DESCRIPTION
- Closes #6896

### User facing changelog

Update extract-zip to 2.0.1 to fix dependency warning.

### Additional details
- Why was this change necessary? => Remove dependency warning.
- What is affected by this change? => N/A
- Any implementation details to explain? => Callback API is removed from [2.0.0](https://github.com/maxogden/extract-zip/releases/tag/v2.0.0). 

### How has the user experience changed?

N/A

### PR Tasks

N/A