### PR TITLE
feat: schematic adds ng e2e to scripts

### DIFF
--- a/npm/cypress-schematic/src/schematics/cypress/index.ts
+++ b/npm/cypress-schematic/src/schematics/cypress/index.ts
@@ -92,6 +92,7 @@ function updateDependencies (options: any): Rule {
 function addCypressTestScriptsToPackageJson (): Rule {
   return (tree: Tree) => {
     addPropertyToPackageJson(tree, ['scripts'], {
+      'e2e': 'ng e2e',
       'cy:open': 'cypress open',
       'cy:run': 'cypress run',
     })


### PR DESCRIPTION
Refs #16514

### User facing changelog

- Angular schematic now adds `ng e2e` to scripts

### Additional details

New projects generated with Angular v12 do not have the `e2e` script.
This PR adds such a script (in addition to the existing `cy:run` and `cy:open`)

### How has the user experience changed?

It is now possible to run `yarn e2e` out of the box.

### PR Tasks

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
