### PR TITLE
feat: custom webpack config for react/plugins/babel

### DIFF
--- a/cli/schema/cypress.schema.json
+++ b/cli/schema/cypress.schema.json
@@ -278,6 +278,11 @@
           "type": "boolean",
           "default": false,
           "description": "Enables including elements within the shadow DOM when using querying commands (e.g. cy.get(), cy.find()). Can be set globally in cypress.json, per-suite or per-test in the test configuration object, or programmatically with Cypress.config()"
+        },
+        "babelLoaderOptions": {
+          "type": "object",
+          "default": null,
+          "description": "Pass options to the babel loader used by @cypress/react/plugins/babel"
         }
       }
     }

--- a/cli/schema/cypress.schema.json
+++ b/cli/schema/cypress.schema.json
@@ -278,11 +278,6 @@
           "type": "boolean",
           "default": false,
           "description": "Enables including elements within the shadow DOM when using querying commands (e.g. cy.get(), cy.find()). Can be set globally in cypress.json, per-suite or per-test in the test configuration object, or programmatically with Cypress.config()"
-        },
-        "babelLoaderOptions": {
-          "type": "object",
-          "default": null,
-          "description": "Pass options to the babel loader used by @cypress/react/plugins/babel"
         }
       }
     }

--- a/npm/react/plugins/babel/getBabelWebpackConfig.js
+++ b/npm/react/plugins/babel/getBabelWebpackConfig.js
@@ -31,16 +31,16 @@ const webpackConfigLoadsBabel = {
   * the webpack configuration
   *
   * @example
-  * module.exports = (on, config) => {   
-  *   require('@cypress/react/plugins/babel')(on, config, { 
+  * module.exports = (on, config) => {
+  *   require('@cypress/react/plugins/babel')(on, config, {
   *     setWebpackConfig: (webpackConfig) => {
   *       webpackConfig.resolve.alias = {
   *         '@my-monorepo/my-package': '../../my-package/src',
   *       }
-  *       return webpackConfig       
-  *     }     
+  *       return webpackConfig
+  *     }
   *   })
-  *   return config 
+  *   return config
   * }
   */
 module.exports = (on, config, { setWebpackConfig } = { setWebpackConfig: null }) => {

--- a/npm/react/plugins/babel/getBabelWebpackConfig.js
+++ b/npm/react/plugins/babel/getBabelWebpackConfig.js
@@ -22,6 +22,27 @@ const webpackConfigLoadsBabel = {
   },
 }
 
+/**
+  * `on` and `config` are mandatory and must be forwarded from
+  * your plugins file (`cypress/plugins/index.js` by default).
+  * the third argument is an optional object with a `setWebpackConfig`
+  * property. It's a function that will receive the webpack configuration
+  * (after babel-loader is added) that allows you to further modify
+  * the webpack configuration
+  *
+  * @example
+  * module.exports = (on, config) => {   
+  *   require('@cypress/react/plugins/babel')(on, config, { 
+  *     setWebpackConfig: (webpackConfig) => {
+  *       webpackConfig.resolve.alias = {
+  *         '@my-monorepo/my-package': '../../my-package/src',
+  *       }
+  *       return webpackConfig       
+  *     }     
+  *   })
+  *   return config 
+  * }
+  */
 module.exports = (on, config, { setWebpackConfig } = { setWebpackConfig: null }) => {
   debug('env object %o', config.env)
 

--- a/npm/react/plugins/babel/getBabelWebpackConfig.js
+++ b/npm/react/plugins/babel/getBabelWebpackConfig.js
@@ -22,7 +22,7 @@ const webpackConfigLoadsBabel = {
   },
 }
 
-module.exports = (on, config, { setWebpackConfig } = {}) => {
+module.exports = (on, config, { setWebpackConfig } = { setWebpackConfig: null }) => {
   debug('env object %o', config.env)
 
   debug('initial environments %o', {

--- a/npm/react/plugins/babel/getBabelWebpackConfig.js
+++ b/npm/react/plugins/babel/getBabelWebpackConfig.js
@@ -2,32 +2,27 @@
 // uses webpack to load your .babelrc file
 const debug = require('debug')('@cypress/react')
 
-const webpackConfigLoadsBabel = (config) => {
-  return {
-    resolve: {
-      extensions: ['.js', '.ts', '.jsx', '.tsx'],
-    },
-    mode: 'development',
-    devtool: false,
-    output: {
-      publicPath: '/',
-      chunkFilename: '[name].bundle.js',
-    },
-    module: {
-      rules: [
-        {
-          test: /\.(js|jsx|mjs|ts|tsx)$/,
-          loader: 'babel-loader',
-          ...(config.babelLoaderOptions ? {
-            options: config.babelLoaderOptions,
-          } : {}),
-        },
-      ],
-    },
-  }
+const webpackConfigLoadsBabel = {
+  resolve: {
+    extensions: ['.js', '.ts', '.jsx', '.tsx'],
+  },
+  mode: 'development',
+  devtool: false,
+  output: {
+    publicPath: '/',
+    chunkFilename: '[name].bundle.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx|mjs|ts|tsx)$/,
+        loader: 'babel-loader',
+      },
+    ],
+  },
 }
 
-module.exports = (on, config) => {
+module.exports = (on, config, { setWebpackConfig } = {}) => {
   debug('env object %o', config.env)
 
   debug('initial environments %o', {
@@ -52,5 +47,9 @@ module.exports = (on, config) => {
     NODE_ENV: process.env.NODE_ENV,
   })
 
-  return webpackConfigLoadsBabel(config)
+  if (setWebpackConfig) {
+    return setWebpackConfig(webpackConfigLoadsBabel)
+  }
+
+  return webpackConfigLoadsBabel
 }

--- a/npm/react/plugins/babel/getBabelWebpackConfig.js
+++ b/npm/react/plugins/babel/getBabelWebpackConfig.js
@@ -2,24 +2,29 @@
 // uses webpack to load your .babelrc file
 const debug = require('debug')('@cypress/react')
 
-const webpackConfigLoadsBabel = {
-  resolve: {
-    extensions: ['.js', '.ts', '.jsx', '.tsx'],
-  },
-  mode: 'development',
-  devtool: false,
-  output: {
-    publicPath: '/',
-    chunkFilename: '[name].bundle.js',
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx|mjs|ts|tsx)$/,
-        loader: 'babel-loader',
-      },
-    ],
-  },
+const webpackConfigLoadsBabel = (config) => {
+  return {
+    resolve: {
+      extensions: ['.js', '.ts', '.jsx', '.tsx'],
+    },
+    mode: 'development',
+    devtool: false,
+    output: {
+      publicPath: '/',
+      chunkFilename: '[name].bundle.js',
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx|mjs|ts|tsx)$/,
+          loader: 'babel-loader',
+          ...(config.babelLoaderOptions ? {
+            options: config.babelLoaderOptions,
+          } : {}),
+        },
+      ],
+    },
+  }
 }
 
 module.exports = (on, config) => {
@@ -47,5 +52,5 @@ module.exports = (on, config) => {
     NODE_ENV: process.env.NODE_ENV,
   })
 
-  return webpackConfigLoadsBabel
+  return webpackConfigLoadsBabel(config)
 }

--- a/npm/react/plugins/babel/index.js
+++ b/npm/react/plugins/babel/index.js
@@ -1,9 +1,9 @@
 const getBabelWebpackConfig = require('./getBabelWebpackConfig')
 const { startDevServer } = require('@cypress/webpack-dev-server')
 
-module.exports = (on, config) => {
+module.exports = (on, config, moduleOptions) => {
   on('dev-server:start', async (options) => {
-    return startDevServer({ options, webpackConfig: getBabelWebpackConfig(on, config) })
+    return startDevServer({ options, webpackConfig: getBabelWebpackConfig(on, config, moduleOptions) })
   })
 
   config.env.reactDevtools = true


### PR DESCRIPTION
- Closes #16596

### User facing changelog
Allow wepback config in @cypress/react/plugins/babel to be configurable to support running within a monorepo.

### Additional details

If running Cypress within a monorepo, babel will not search upwards beyond the working directory to find the babel config, and will fail to transpile most code including JSX.

https://babeljs.io/docs/en/config-files#monorepos

### How has the user experience changed?

Usage:


```js
// plugins/index.js
module.exports = (on, config) => {
  if (config.testingType === 'component') {
    require('@cypress/react/plugins/babel')(on, config, {
      setWebpackConfig: (webpackConfig) => {
        webpackConfig.resolve.alias = {
          '@my-monorepo/my-package': '../../my-package/src',
        }
        webpackConfig.module.rules.find(({ loader }) => loader === 'babel-loader').options = {
          rootMode: 'upward',
        }
        return webpackConfig
      },
    });
  }
  return config
};
```

### PR Tasks

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [x] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
