### PR TITLE
chore: retry failed driver tests and let the dashboard calculate flake

### DIFF
--- a/packages/driver/cypress.json
+++ b/packages/driver/cypress.json
@@ -7,5 +7,9 @@
   "reporter": "cypress-multi-reporters",
   "reporterOptions": {
     "configFile": "../../mocha-reporter-config.json"
+  },
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
   }
 }


### PR DESCRIPTION
### Additional details
- Retrying failed driver tests lets the dashboard automatically calculate flake
- TODO: update the Dashboard PR status checks and add flaky test (but do not require)
