### PR TITLE
demo: Showing the last snapshot for a test on hover

### DIFF
--- a/packages/driver/src/cypress/runner.js
+++ b/packages/driver/src/cypress/runner.js
@@ -1719,6 +1719,9 @@ const create = (specWindow, mocha, Cypress, cy, state) => {
 
       test = getTestById(testId)
 
+      // Store attrs as last log under test
+      _logsById[testId] = attrs
+
       if (test) {
         // pluralize the instrument
         // as a property on the runnable

--- a/packages/reporter/src/test/test.tsx
+++ b/packages/reporter/src/test/test.tsx
@@ -118,7 +118,9 @@ class Test extends Component<TestProps> {
   _header () {
     const { model } = this.props
 
-    return (<>
+    return (<div onMouseEnter={() => {
+      this.props.events.emit('show:snapshot', model.id)
+    }}>
       <i aria-hidden='true' className='runnable-state fas' />
       <span className='runnable-title'>
         <span>{model.title}</span>
@@ -134,7 +136,7 @@ class Test extends Component<TestProps> {
           </a>
         </Tooltip>
       </span>
-    </>)
+    </div>)
   }
 
   _contents () {


### PR DESCRIPTION
Demonstrates storing and loading the _last_ snapshot for a given test in pursuit of solving #16595. Hovering over a test title in the reporter will switch to that snapshot.