### PR TITLE
fix: only dedupe video recording frames for webminput (firefox)

### DIFF
--- a/packages/server/lib/video_capture.js
+++ b/packages/server/lib/video_capture.js
@@ -155,18 +155,21 @@ module.exports = {
         return
       }
 
-      if (lengths[data.length]) {
+      if (options.webmInput) {
+        if (lengths[data.length]) {
         // this prevents multiple chunks of webm metadata from being written to the stream
         // which would crash ffmpeg
-        debugFrames('duplicate length frame received:', data.length)
+          debugFrames('duplicate length frame received:', data.length)
 
-        return
+          return
+        }
+
+        lengths[data.length] = true
       }
 
       writtenChunksCount++
 
       debugFrames('writing video frame')
-      lengths[data.length] = true
 
       if (wantsWrite) {
         if (!(wantsWrite = pt.write(data))) {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #16648

### User facing changelog

* Fixed an issue where video recordings in Chrome, Chromium, and Electron browsers would drop frames, with the frequency increasing along with the length of the video.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
