### PR TITLE
fix(angular): set rxjs versions > 6.6.0 as dependency

### DIFF
--- a/npm/angular/package.json
+++ b/npm/angular/package.json
@@ -54,7 +54,7 @@
     "primeng": "11.3.2",
     "raw-loader": "1.0.0",
     "renderkid": "2.0.5",
-    "rxjs": "6.6.7",
+    "rxjs": "~6.6.0",
     "semantic-release": "17.4.2",
     "to-string-loader": "1.1.6",
     "ts-loader": "8.1.0",

--- a/npm/cypress-schematic/package.json
+++ b/npm/cypress-schematic/package.json
@@ -25,7 +25,7 @@
     "@angular-devkit/schematics": "^12.0.0",
     "@schematics/angular": "^12.0.0",
     "jsonc-parser": "^3.0.0",
-    "rxjs": "6.6.2"
+    "rxjs": "~6.6.0"
   },
   "devDependencies": {
     "@angular-devkit/schematics-cli": "^12.0.0",


### PR DESCRIPTION
### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->

Set Angular schemantics rxjs version as approximately equivalent to version 6.6

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Currently version 6.6.2 would be installed but angular projects relate to the latest rxjs 6.x release

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

The latest rxjs version will be installed
