### PR TITLE
fix: Add flag to delay update in chrome

### DIFF
--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -92,6 +92,9 @@ const DEFAULT_ARGS = [
   '--safebrowsing-disable-download-protection',
   '--disable-client-side-phishing-detection',
   '--disable-component-update',
+  // Simulate when chrome needs an update.
+  // This prevents an 'update' from displaying til the given date
+  `--simulate-outdated-no-au='Tue, 31 Dec 2099 23:59:59 GMT'`,
   '--disable-default-apps',
 
   // These flags are for webcam/WebRTC testing


### PR DESCRIPTION
- close #16693 

### User Facing Changelog

Cypress now passes a flag to Chrome to prevent update notifications in some cases.

### Additional Details

- There's [some discussion](https://stackoverflow.com/questions/58993181/disable-chromium-can-not-update-chromium-window-notification) on the web that in certain cases the `--disable-component-update` doesn't disable updating.
- I actually had a hard time testing this flag because you'd have to simulate Chrome needing an update, auto-updating, and also failing the update for some reason. The user confirmed it fixed their issue: https://github.com/cypress-io/cypress/issues/16693#issuecomment-848944961
- Chrome notes on this flag: https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/upgrade_detector/upgrade_detector_impl.cc;l=420;drc=9fcc9d7b2915b6192ee6810eec54c50deb6313c6
	>// The outdated simulation can work without a value, which means outdated
    >// now, or with a value that must be a well formed date/time string that
    >// overrides the build date.

