### PR TITLE
feat(types): can specify the ResponseBody type of `cy.request`

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1464,7 +1464,7 @@ declare namespace Cypress {
      * @example
      *    cy.request('http://dev.local/seed')
      */
-    request(url: string, body?: RequestBody): Chainable<Response>
+    request<T = any>(url: string, body?: RequestBody): Chainable<Response<T>>
     /**
      * Make an HTTP request with specific method.
      *
@@ -1472,7 +1472,7 @@ declare namespace Cypress {
      * @example
      *    cy.request('POST', 'http://localhost:8888/users', {name: 'Jane'})
      */
-    request(method: HttpMethod, url: string, body?: RequestBody): Chainable<Response>
+    request<T = any>(method: HttpMethod, url: string, body?: RequestBody): Chainable<Response<T>>
     /**
      * Make an HTTP request with specific behavior.
      *
@@ -1483,7 +1483,7 @@ declare namespace Cypress {
      *      followRedirect: false // turn off following redirects
      *    })
      */
-    request(options: Partial<RequestOptions>): Chainable<Response>
+    request<T = any>(options: Partial<RequestOptions>): Chainable<Response<T>>
 
     /**
      * Get the root DOM element.
@@ -5496,9 +5496,9 @@ declare namespace Cypress {
     consoleProps(): ObjectLike
   }
 
-  interface Response {
+  interface Response<T> {
     allRequestResponses: any[]
-    body: any
+    body: T
     duration: number
     headers: { [key: string]: string | string[] }
     isOkStatusCode: boolean

--- a/cli/types/tests/kitchen-sink.ts
+++ b/cli/types/tests/kitchen-sink.ts
@@ -102,26 +102,26 @@ cy.request({
 
 // Users can specify body type.
 // https://github.com/cypress-io/cypress/issues/9109
-interface ReqBody {
+interface ResBody {
   x: number
   y: string
 }
 
-cy.request<ReqBody>('http://goooooogle.com', {})
+cy.request<ResBody>('http://goooooogle.com', {})
 .then((resp) => {
-  resp // $ExpectType Response<ReqBody>
+  resp // $ExpectType Response<ResBody>
 })
 
-cy.request<ReqBody>('post', 'http://goooooogle.com', {})
+cy.request<ResBody>('post', 'http://goooooogle.com', {})
 .then((resp) => {
-  resp // $ExpectType Response<ReqBody>
+  resp // $ExpectType Response<ResBody>
 })
 
-cy.request<ReqBody>({
+cy.request<ResBody>({
   url: 'http://goooooogle.com',
   body: {}
 }).then((resp) => {
-  resp // $ExpectType Response<ReqBody>
+  resp // $ExpectType Response<ResBody>
 })
 
 // if you want a separate variable, you need specify its type

--- a/cli/types/tests/kitchen-sink.ts
+++ b/cli/types/tests/kitchen-sink.ts
@@ -85,7 +85,7 @@ cy.request({
   method: "POST",
   body: {}
 }).then((resp) => {
-  resp // $ExpectType Response
+  resp // $ExpectType Response<any>
   resp.redirectedToUrl // $ExpectType string | undefined
   resp.redirects // $ExpectType string[] | undefined
   resp.headers // $ExpectType { [key: string]: string | string[]; }
@@ -98,6 +98,30 @@ cy.request({
   qs: {
     param: 'someValue'
   }
+})
+
+// Users can specify body type.
+// https://github.com/cypress-io/cypress/issues/9109
+interface ReqBody {
+  x: number
+  y: string
+}
+
+cy.request<ReqBody>('http://goooooogle.com', {})
+.then((resp) => {
+  resp // $ExpectType Response<ReqBody>
+})
+
+cy.request<ReqBody>('post', 'http://goooooogle.com', {})
+.then((resp) => {
+  resp // $ExpectType Response<ReqBody>
+})
+
+cy.request<ReqBody>({
+  url: 'http://goooooogle.com',
+  body: {}
+}).then((resp) => {
+  resp // $ExpectType Response<ReqBody>
 })
 
 // if you want a separate variable, you need specify its type


### PR DESCRIPTION
- Closes #9109 

Thanks, @dimazuien!

### User facing changelog

- `cy.request()` now accepts a generic in TypeScript for specifying the type of the request body

### Additional details

Make the type of response body of `cy.request` generic.

- Why was this change necessary? => Generic helps users write type-safer code.
- What is affected by this change? => N/A
- Any implementation details to explain? => N/A

### How has the user experience changed?

N/A

### PR Tasks
- [x] Have tests been added/updated?
