### PR TITLE
fix(types): add testingType definition

### DIFF
--- a/cli/types/cypress-npm-api.d.ts
+++ b/cli/types/cypress-npm-api.d.ts
@@ -160,7 +160,7 @@ declare namespace CypressCommandLine {
      * Specify the type of tests to execute.
      * @default "e2e"
      */
-    testingType: 'e2e' | 'component'
+    testingType: Cypress.TestingType
   }
 
   // small utility types to better express meaning of other types

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -8,6 +8,7 @@ declare namespace Cypress {
   type RequestBody = string | object
   type ViewportOrientation = 'portrait' | 'landscape'
   type PrevSubject = 'optional' | 'element' | 'document' | 'window'
+  type TestingType = 'e2e' | 'component'
   type PluginConfig = (on: PluginEvents, config: PluginConfigOptions) => void | ConfigOptions | Promise<ConfigOptions>
 
   interface CommandOptions {
@@ -250,6 +251,11 @@ declare namespace Cypress {
      * Internal class for LocalStorage management.
      */
     LocalStorage: LocalStorage
+
+    /**
+     * Current testing type, determined by the Test Runner chosen to run.
+     */
+    testingType: TestingType
 
     /**
      * Fire automation:request event for internal use.
@@ -2799,7 +2805,7 @@ declare namespace Cypress {
     /**
      * Type of test and associated runner that was launched.
      */
-    testingType: 'e2e' | 'component'
+    testingType: TestingType
     /**
      * Cypress version.
      */

--- a/cli/types/tests/plugins-config.ts
+++ b/cli/types/tests/plugins-config.ts
@@ -14,6 +14,7 @@ const pluginConfig2: Cypress.PluginConfig = (on, config) => {
   config.videoCompression // $ExpectType: number | false
   config.projectRoot // $ExpectType: string
   config.version // $ExpectType: string
+  config.testingType // $ExpectType: TestingType
 
   on('before:browser:launch', (browser, options) => {
     browser.displayName // $ExpectType string


### PR DESCRIPTION
- Closes #16725

### User facing changelog

[`testingType` definition](https://docs.cypress.io/api/cypress-api/testing-type#Syntax) doesn't exist in `Cypress` interface.

### Additional details
- Why was this change necessary? => The definition doesn't exist. 
- What is affected by this change? => N/A
- Any implementation details to explain? => N/A

### How has the user experience changed?

N/A

### PR Tasks
- [x] Have tests been added/updated?
