### PR TITLE
fix: --config-file can now handle absolute paths.

### DIFF
--- a/packages/server/lib/util/settings.js
+++ b/packages/server/lib/util/settings.js
@@ -58,7 +58,7 @@ const renameSupportFolder = (obj) => {
 
 module.exports = {
   _pathToFile (projectRoot, file) {
-    return path.join(projectRoot, file)
+    return path.isAbsolute(file) ? file : path.join(projectRoot, file)
   },
 
   _err (type, file, err) {

--- a/packages/server/test/unit/util/settings_spec.js
+++ b/packages/server/test/unit/util/settings_spec.js
@@ -1,0 +1,22 @@
+require('../../spec_helper')
+const setting = require(`../../../lib/util/settings`)
+
+describe('lib/util/settings', () => {
+  describe('pathToConfigFile', () => {
+    it('supports relative path', () => {
+      const path = setting.pathToConfigFile('/users/tony/cypress', {
+        configFile: 'e2e/config.json',
+      })
+
+      expect(path).to.equal('/users/tony/cypress/e2e/config.json')
+    })
+
+    it('supports absolute path', () => {
+      const path = setting.pathToConfigFile('/users/tony/cypress', {
+        configFile: '/users/pepper/cypress/e2e/cypress.config.json',
+      })
+
+      expect(path).to.equal('/users/pepper/cypress/e2e/cypress.config.json')
+    })
+  })
+})


### PR DESCRIPTION
Co-authored-by: Guillaume Viguier <guillaume.viguier-just@propulse-lab.com>

- Closes #6136

Thanks, @guillaumevp!

### User facing changelog

`--config-file` option can handle absolute paths.

### Additional details
- Why was this change necessary? => `--config-file` options couldn't handle absolute paths. 
- What is affected by this change? =>  N/A
- Any implementation details to explain? => N/A

### How has the user experience changed?

N/A

### PR Tasks
- [x] Have tests been added/updated?
