### PR TITLE
fix(types): when user returns `any` type, `then` doesn't wrap it with `JQuery`.

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1825,6 +1825,12 @@ declare namespace Cypress {
      *
      * @see https://on.cypress.io/then
      */
+    then<S extends string | number | boolean>(fn: (this: ObjectLike, currentSubject: Subject) => S): Chainable<S>
+    /**
+     * Enables you to work with the subject yielded from the previous command / promise.
+     *
+     * @see https://on.cypress.io/then
+     */
     then<S extends HTMLElement>(fn: (this: ObjectLike, currentSubject: Subject) => S): Chainable<JQuery<S>>
     /**
      * Enables you to work with the subject yielded from the previous command / promise.
@@ -1837,7 +1843,7 @@ declare namespace Cypress {
      *
      * @see https://on.cypress.io/then
      */
-    then<S extends object | any[] | string | number | boolean>(fn: (this: ObjectLike, currentSubject: Subject) => S): Chainable<S>
+    then<S extends any[] | object>(fn: (this: ObjectLike, currentSubject: Subject) => S): Chainable<S>
     /**
      * Enables you to work with the subject yielded from the previous command / promise.
      *

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -257,6 +257,15 @@ describe('then', () => {
       $p // $ExpectType JQuery<HTMLParagraphElement>
     })
   })
+
+  // https://github.com/cypress-io/cypress/issues/16669
+  it('any as default', () => {
+    cy.get('body')
+    .then(() => ({} as any))
+    .then(v => {
+      v // $ExpectType any
+    })
+  })
 })
 
 cy.wait(['@foo', '@bar'])


### PR DESCRIPTION
- Closes #16669
 
### User facing changelog

When `any` type value is returned from the last function, then argument was wrapped with `JQuery`. It is a bad default. This PR fixes this issue.

### Additional details
- Why was this change necessary? => `then` wraps `any` with `JQuery` by default and it's a bad default. 
- What is affected by this change? => N/A
- Any implementation details to explain? => `any` matches any types. So, I broke the catch-all definition with premitives and object types. 

### How has the user experience changed?

N/A

### PR Tasks
- [x] Have tests been added/updated?
