### PR TITLE
chore: remove git add from precommit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,14 +238,8 @@
     ]
   },
   "lint-staged": {
-    "*.coffee": [
-      "yarn stop-only --folder",
-      "git add"
-    ],
-    "*.{js,jsx,ts,tsx,json,eslintrc}": [
-      "eslint --fix",
-      "git add"
-    ]
+    "*.coffee": "yarn stop-only --folder",
+    "*.{js,jsx,ts,tsx,json,eslintrc}": "eslint --fix"
   },
   "resolutions": {
     "**/@types/cheerio": "0.22.21",


### PR DESCRIPTION
There was never a need to have `git add` in the husky hooks but recently I've been getting a warning message that looks like the following so I figured it's time to make the change now

> ⚠ Some of your tasks use `git add` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.