### PR TITLE
chore: Remove @cypress/listr-verbose-renderer

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -20,7 +20,6 @@
     "unit": "cross-env BLUEBIRD_DEBUG=1 NODE_ENV=test mocha --reporter mocha-multi-reporters --reporter-options configFile=../mocha-reporter-config.json"
   },
   "dependencies": {
-    "@cypress/listr-verbose-renderer": "^0.4.1",
     "@cypress/request": "^2.88.5",
     "@cypress/xvfb": "^1.2.4",
     "@types/node": "^14.14.31",


### PR DESCRIPTION
### User facing changelog

Remove @cypress/listr-verbose-renderer which was previously vendored in #16855

### Additional details

The dep was vendored in #16855

### How has the user experience changed?
No user facing changes