### PR TITLE
fix: false negatives on multibyte utf8 characters.

### DIFF
--- a/patches/istextorbinary+5.12.0.patch
+++ b/patches/istextorbinary+5.12.0.patch
@@ -1,0 +1,145 @@
+diff --git a/node_modules/istextorbinary/edition-esnext/index.js b/node_modules/istextorbinary/edition-esnext/index.js
+index 2781914..504ade7 100644
+--- a/node_modules/istextorbinary/edition-esnext/index.js
++++ b/node_modules/istextorbinary/edition-esnext/index.js
+@@ -132,7 +132,20 @@ function getEncoding(buffer, opts) {
+ 		return encoding
+ 	} else {
+ 		// Extract
+-		const chunkEnd = Math.min(buffer.length, chunkBegin + chunkLength)
++		chunkBegin = getChunkBegin(buffer, chunkBegin)
++		if (chunkBegin === -1) {
++			return binaryEncoding
++		}
++
++		const chunkEnd = getChunkEnd(
++			buffer,
++			Math.min(buffer.length, chunkBegin + chunkLength)
++		)
++
++		if (chunkEnd > buffer.length) {
++			return binaryEncoding
++		}
++
+ 		const contentChunkUTF8 = buffer.toString(textEncoding, chunkBegin, chunkEnd)
+ 		// Detect encoding
+ 		for (let i = 0; i < contentChunkUTF8.length; ++i) {
+@@ -149,3 +162,117 @@ function getEncoding(buffer, opts) {
+ 	}
+ }
+ exports.getEncoding = getEncoding
++
++// The functions below are created to handle multibyte utf8 characters.
++// To understand how the encoding works,
++// check this article: https://en.wikipedia.org/wiki/UTF-8#Encoding
++
++function getChunkBegin(buf, chunkBegin) {
++	// If it's the beginning, just return.
++	if (chunkBegin === 0) {
++		return 0
++	}
++
++	if (!isLaterByteOfUtf8(buf[chunkBegin])) {
++		return chunkBegin
++	}
++
++	let begin = chunkBegin - 3
++
++	if (begin >= 0) {
++		if (isFirstByteOf4ByteChar(buf[begin])) {
++			return begin
++		}
++	}
++
++	begin = chunkBegin - 2
++
++	if (begin >= 0) {
++		if (
++			isFirstByteOf4ByteChar(buf[begin]) ||
++			isFirstByteOf3ByteChar(buf[begin])
++		) {
++			return begin
++		}
++	}
++
++	begin = chunkBegin - 1
++
++	if (begin >= 0) {
++		// Is it a 4-byte, 3-byte utf8 character?
++		if (
++			isFirstByteOf4ByteChar(buf[begin]) ||
++			isFirstByteOf3ByteChar(buf[begin]) ||
++			isFirstByteOf2ByteChar(buf[begin])
++		) {
++			return begin
++		}
++	}
++
++	return -1
++}
++
++function getChunkEnd(buf, chunkEnd) {
++	// If it's the end, just return.
++	if (chunkEnd === buf.length) {
++		return chunkEnd
++	}
++
++	let index = chunkEnd - 3
++
++	if (index >= 0) {
++		if (isFirstByteOf4ByteChar(buf[index])) {
++			return chunkEnd + 1
++		}
++	}
++
++	index = chunkEnd - 2
++
++	if (index >= 0) {
++		if (isFirstByteOf4ByteChar(buf[index])) {
++			return chunkEnd + 2
++		}
++
++		if (isFirstByteOf3ByteChar(buf[index])) {
++			return chunkEnd + 1
++		}
++	}
++
++	index = chunkEnd - 1
++
++	if (index >= 0) {
++		if (isFirstByteOf4ByteChar(buf[index])) {
++			return chunkEnd + 3
++		}
++
++		if (isFirstByteOf3ByteChar(buf[index])) {
++			return chunkEnd + 2
++		}
++
++		if (isFirstByteOf2ByteChar(buf[index])) {
++			return chunkEnd + 1
++		}
++	}
++
++	return chunkEnd
++}
++
++function isFirstByteOf4ByteChar(byte) {
++	// eslint-disable-next-line no-bitwise
++	return byte >> 3 === 30 // 11110xxx?
++}
++
++function isFirstByteOf3ByteChar(byte) {
++	// eslint-disable-next-line no-bitwise
++	return byte >> 4 === 14 // 1110xxxx?
++}
++
++function isFirstByteOf2ByteChar(byte) {
++	// eslint-disable-next-line no-bitwise
++	return byte >> 5 === 6 // 110xxxxx?
++}
++
++function isLaterByteOfUtf8(byte) {
++	// eslint-disable-next-line no-bitwise
++	return byte >> 6 === 2 // 10xxxxxx?
++}
+\ No newline at end of file


### PR DESCRIPTION
- Closes #16292

### User facing changelog

The algorithm that `istextorbinary` uses doesn't care about the multibyte utf8 characters. This PR fixes this problem. 

### Additional details
- Why was this change necessary? => `istextorbinary` often fails to detect strings when there are multibyte utf8 characters like Cyrillic, CJK, emoji, etc.
- What is affected by this change? => N/A
- Any implementation details to explain? => I created a patch for the changes I made at https://github.com/bevry/istextorbinary/pull/214

### How has the user experience changed?

**Before:** Returns `ArrayBuffer`.
**After:** Returns `string`.

### PR Tasks
- [x] Have tests been added/updated?