### PR TITLE
fix: set the value of testingType in project-ct

### DIFF
--- a/packages/server-ct/src/project-ct.ts
+++ b/packages/server-ct/src/project-ct.ts
@@ -88,6 +88,12 @@ export class ProjectCt extends ProjectBase<ServerCt> {
       const updatedConfig = config.updateWithPluginValues(cfg, modifiedCfg)
 
       updatedConfig.componentTesting = true
+
+      // This value is normally set up in the `packages/server/lib/plugins/index.js#110`
+      // But if we don't return it in the plugins function, it never gets set
+      // Since there is no chance that it will have any other value here, we set it to "component"
+      // This allows users to not return config in the `cypress/plugins/index.js` file
+      // https://github.com/cypress-io/cypress/issues/16860
       updatedConfig.resolved.testingType = { value: 'component' }
 
       debug('updated config: %o', updatedConfig)

--- a/packages/server-ct/src/project-ct.ts
+++ b/packages/server-ct/src/project-ct.ts
@@ -88,6 +88,7 @@ export class ProjectCt extends ProjectBase<ServerCt> {
       const updatedConfig = config.updateWithPluginValues(cfg, modifiedCfg)
 
       updatedConfig.componentTesting = true
+      updatedConfig.resolved.testingType = { value: 'component' }
 
       debug('updated config: %o', updatedConfig)
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #16860

### User facing changelog
Before this PR launching cypress open-ct (Component Testing) with the function exported by `cypress/plugins/index.js` returning nothing would yield a "No test found" error.
Now we can omit this `return config` if it is not changed in the function.

### Additional details

```js
const path = require('path')
const { startDevServer } = require('../dist')

module.exports = (on, config) => {
  on('dev-server:start', async (options) => {
    return startDevServer({
      options,
      viteConfig: {
        configFile: path.resolve(__dirname, '..', 'vite.config.ts'),
      },
    })
  })

  return config; // << this statement is not necessary anymore
}
```

The main file to review is the last one: [project-ct.ts](https://github.com/cypress-io/cypress/pull/16885/files#diff-1973eee6e4c774537a1f964ab8d6bb83b8f9d81be34ddcb2fe484439050d90cb)
The rest are examples updates and changes to scaffolding with `create cypress-tests` to reflect the simplified setup.

### How has the user experience changed?
**Before**: with no return config every spec file would yield the error below
<img width="1200" alt="Screen Shot 2021-06-09 at 5 02 24 PM" src="https://user-images.githubusercontent.com/5592465/121435431-7bfbf100-c944-11eb-80de-2dd559806dd9.png">

**After**: tests are running with or without the `return config`

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->

