### PR TITLE
feat(springboard): adding new user welcome modal

### DIFF
--- a/packages/springboard/cypress.json
+++ b/packages/springboard/cypress.json
@@ -19,6 +19,6 @@
   },
   "component": {
     "componentFolder": "cypress/component",
-    "testFiles": "**/*.spec.ts"
+    "testFiles": "**/*.spec.*"
   }
 }

--- a/packages/springboard/cypress/.eslintrc.json
+++ b/packages/springboard/cypress/.eslintrc.json
@@ -4,5 +4,10 @@
   ],
   "env": {
     "cypress/globals": true
+  },
+  "rules": {
+    "no-unused-vars": "off",
+    "react/react-in-jsx-scope": "off",
+    "react/jsx-no-bind": "off"
   }
 }

--- a/packages/springboard/cypress/component/BaseModal.spec.ts
+++ b/packages/springboard/cypress/component/BaseModal.spec.ts
@@ -1,0 +1,33 @@
+// @ts-nocheck
+import { h } from 'vue'
+import { mount } from '@cypress/vue'
+
+import BaseModal from '../../src/components/BaseModal.vue'
+
+describe('BaseModal', () => {
+  it('can be closed when clicking on the close button or outside of the modal', () => {
+    const closeSpy = cy.spy().as('closeSpy')
+    // TODO: Setup TSX with webpack :-(
+    const wrapper = {
+      render () {
+        return h('div',
+          [
+            h('h1', 'Body Content'),
+            h(BaseModal, {
+              onClose: closeSpy,
+            }, 'Inner Content'),
+          ])
+      },
+    }
+
+    mount(wrapper)
+    .get('[role=button]')
+    .click()
+    .get('@closeSpy')
+    .should('have.been.called')
+    .get('body')
+    .click()
+    .get('@closeSpy')
+    .should('have.been.called')
+  })
+})

--- a/packages/springboard/cypress/component/CloseButton.spec.ts
+++ b/packages/springboard/cypress/component/CloseButton.spec.ts
@@ -1,0 +1,21 @@
+// @ts-nocheck
+import { h } from 'vue'
+import { mount } from '@cypress/vue'
+
+import CloseButton from '../../src/components/CloseButton.vue'
+
+describe('CloseButton', () => {
+  it('can be rendered and emits a click event', () => {
+    const closeSpy = cy.spy().as('closeSpy')
+
+    mount({
+      render () {
+        return h(CloseButton, { onClick: closeSpy })
+      },
+    })
+    .get('[role=button]')
+    .click()
+    .get('@closeSpy')
+    .should('have.been.called')
+  })
+})

--- a/packages/springboard/cypress/component/NewUserWelcome.spec.ts
+++ b/packages/springboard/cypress/component/NewUserWelcome.spec.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+import { h } from 'vue'
+import { mount } from '@cypress/vue'
+
+import NewUserWelcome from '../../src/components/NewUserWelcome.vue'
+
+describe('NewUserWelcome', () => {
+  beforeEach(() => {
+    const closeSpy = cy.spy().as('closeSpy')
+
+    mount({
+      render () {
+        return h(NewUserWelcome, { onClose: closeSpy })
+      },
+    })
+  })
+
+  it('emits close when No Thanks text is clicked', () => {
+    cy
+    .get('[data-cy=closeWithText]')
+    .click()
+    .get('@closeSpy')
+    .should('have.been.called')
+  })
+
+  it('emits close when x button clicked', () => {
+    cy
+    .get('[data-cy=closeWithButton]')
+    .click()
+    .get('@closeSpy')
+    .should('have.been.called')
+  })
+
+  it('opens helper modal that can be closed by X button', () => {
+    cy
+    .get('[data-cy=openHelper]')
+    .click()
+    .get('[role=dialog]')
+    .should('exist')
+    .get('[role=dialog] [role=button]')
+    .click()
+    .get('[role=dialog]')
+    .should('not.exist')
+  })
+})

--- a/packages/springboard/cypress/support/index.ts
+++ b/packages/springboard/cypress/support/index.ts
@@ -1,5 +1,7 @@
 /// <reference types="cypress" />
 
+import 'windi.css'
+
 Cypress.Commands.add('visitIndex', (options?: Partial<Cypress.VisitOptions>) => {
   // disable livereload within the Cypress-loaded desktop GUI. it doesn't fully
   // reload the app because the stubbed out ipc calls don't work after the first

--- a/packages/springboard/src/components/BaseModal.vue
+++ b/packages/springboard/src/components/BaseModal.vue
@@ -1,10 +1,5 @@
 <template>
-  <div
-    class="overlay"
-    ref="overlay"
-    @click.self="$emit('close')"
-    @keypress.esc="$emit('close')"
-  >
+  <div class="overlay" ref="overlay" @click.self="$emit('close')" role="dialog">
     <div class="wrapper">
       <CloseButton @click="$emit('close')"></CloseButton>
       <div class="content">
@@ -15,25 +10,16 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref } from "vue";
+import { defineComponent } from "vue";
 import CloseButton from "./CloseButton.vue";
 
 export default defineComponent({
-  setup() {
-    const overlay = ref<HTMLElement | null>(null);
-    onMounted(() => {
-      if (overlay && overlay.value) {
-        overlay.value.focus();
-      }
-    });
-    return {
-      overlay,
-    };
-  },
   components: {
     CloseButton,
   },
-  emits: ["close"],
+  emits: {
+    close: null,
+  },
 });
 </script>
 

--- a/packages/springboard/src/components/BaseModal.vue
+++ b/packages/springboard/src/components/BaseModal.vue
@@ -1,0 +1,49 @@
+<template>
+  <div
+    class="overlay"
+    ref="overlay"
+    @click.self="$emit('close')"
+    @keypress.esc="$emit('close')"
+  >
+    <div class="wrapper">
+      <CloseButton @click="$emit('close')"></CloseButton>
+      <div class="content">
+        <slot></slot>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, onMounted, ref } from "vue";
+import CloseButton from "./CloseButton.vue";
+
+export default defineComponent({
+  setup() {
+    const overlay = ref<HTMLElement | null>(null);
+    onMounted(() => {
+      if (overlay && overlay.value) {
+        overlay.value.focus();
+      }
+    });
+    return {
+      overlay,
+    };
+  },
+  components: {
+    CloseButton,
+  },
+  emits: ["close"],
+});
+</script>
+
+
+<style lang="scss" scoped>
+.overlay {
+  @apply bg-gray-900 bg-opacity-40 absolute block top-0 left-0 w-[calc(100%)] h-[calc(100%)];
+}
+
+.wrapper {
+  @apply w-128 bg-white min-h-64 p-8 h-auto my-[calc(10%)] mx-auto relative;
+}
+</style>

--- a/packages/springboard/src/components/CloseButton.vue
+++ b/packages/springboard/src/components/CloseButton.vue
@@ -1,0 +1,9 @@
+<template>
+  <span class="closeButton">❌</span>
+</template>
+
+<style lang="scss" scoped>
+.closeButton {
+  @apply cursor-pointer absolute top-4 right-4 hover:opacity-50;
+}
+</style>

--- a/packages/springboard/src/components/CloseButton.vue
+++ b/packages/springboard/src/components/CloseButton.vue
@@ -1,6 +1,15 @@
 <template>
-  <span class="closeButton">❌</span>
+  <span class="closeButton" role="button">❌</span>
 </template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  setup() {},
+});
+</script>
+
 
 <style lang="scss" scoped>
 .closeButton {

--- a/packages/springboard/src/components/NewUserWelcome.vue
+++ b/packages/springboard/src/components/NewUserWelcome.vue
@@ -1,13 +1,19 @@
 <template>
   <div class="welcomeWrapper">
-    <CloseButton @click="close" />
+    <CloseButton data-cy="closeWithButton" @click="close" />
     <h3 class="title">Welcome to Cypress!</h3>
     <p class="subtitle">
       Cypress allows you to write both e2e (end-to-end) and component tests.
     </p>
     <p class="buttonWrapper">
-      <button class="underline" @click="close">No thanks</button>
-      <button class="outlineButton" @click="showHelper = true">
+      <button class="underline" data-cy="closeWithText" @click="close">
+        No thanks
+      </button>
+      <button
+        class="outlineButton"
+        data-cy="openHelper"
+        @click="showHelper = true"
+      >
         Help me choose >
       </button>
     </p>

--- a/packages/springboard/src/components/NewUserWelcome.vue
+++ b/packages/springboard/src/components/NewUserWelcome.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="welcomeWrapper">
+    <CloseButton @click="close" />
+    <h3 class="title">Welcome to Cypress!</h3>
+    <p class="subtitle">
+      Cypress allows you to write both e2e (end-to-end) and component tests.
+    </p>
+    <p class="buttonWrapper">
+      <button class="underline" @click="close">No thanks</button>
+      <button class="outlineButton" @click="showHelper = true">
+        Help me choose >
+      </button>
+    </p>
+  </div>
+  <BaseModal v-if="showHelper" @close="showHelper = false">
+    <p>Some content here</p>
+  </BaseModal>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from "vue";
+import BaseModal from "./BaseModal.vue";
+import CloseButton from "./CloseButton.vue";
+
+export default defineComponent({
+  emits: ["close"],
+  components: {
+    BaseModal,
+    CloseButton,
+  },
+  setup(_, { emit }) {
+    return {
+      showHelper: ref(false),
+      close: () => emit("close"),
+    };
+  },
+});
+</script>
+
+<style scoped lang="scss">
+  .welcomeWrapper {
+    @apply p-8 m-4 pb-10 bg-blue-200 rounded-xl max-w-128 relative grid gap-4;
+  }
+
+  .buttonWrapper {
+    @apply text-right
+        grid grid-flow-col
+        justify-end
+        absolute
+        bottom-4
+        right-4;
+  }
+
+  .title {
+    @apply text-size-1.5rem;
+  }
+
+  .subtitle {
+    @apply text-gray-600;
+  }
+
+  button {
+    @apply px-2 py-0.5 text-blue-900 text-size-0.8rem;
+    @apply hover:opacity-70;
+  }
+
+  .outlineButton {
+    @apply border-blue-900 border-width-1px border-solid rounded-xl;
+  }
+</style>

--- a/packages/springboard/src/components/SelectWizard.vue
+++ b/packages/springboard/src/components/SelectWizard.vue
@@ -3,8 +3,12 @@
     Welcome! What kind of tests would you like to run?
   </h2>
 
+  <div class="max-w-128 mx-auto my-0">
+    <NewUserWelcome v-if="showNewUserFlow" @close="dismissNewUserWelcome" />
+  </div>
+
   <div class="text-center">
-    <RunnerButton 
+    <RunnerButton
       v-for="testingType of testingTypes"
       :key="testingType"
       :testingType="testingType"
@@ -15,28 +19,38 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, markRaw, computed } from 'vue'
-import { useStore } from '../store'
-import { TestingType, testingTypes } from '../types/shared'
-import RunnerButton from './RunnerButton.vue'
+import { defineComponent, markRaw, computed } from "vue";
+import { useStore } from "../store";
+import { TestingType, testingTypes } from "../types/shared";
+import RunnerButton from "./RunnerButton.vue";
+import NewUserWelcome from "./NewUserWelcome.vue";
 
 export default defineComponent({
   components: {
-    RunnerButton
+    RunnerButton,
+    NewUserWelcome,
   },
 
   setup() {
-    const store = useStore()
+    const store = useStore();
 
     const selectTestingType = (testingType: TestingType) => {
-      store.setTestingType(testingType)
-    }
+      store.setTestingType(testingType);
+    };
+
+    const dismissNewUserWelcome = () => {
+      store.setDismissedHelper(true);
+    };
 
     return {
       testingTypes: markRaw(testingTypes),
       selectTestingType,
-      selectedTestingType: computed(() => store.getState().testingType)
-    }
-  }
-})
+      showNewUserFlow: computed(
+        () => store.getState().firstOpen && !store.getState().hasDismissedHelper
+      ),
+      selectedTestingType: computed(() => store.getState().testingType),
+      dismissNewUserWelcome,
+    };
+  },
+});
 </script>

--- a/packages/springboard/src/store/index.ts
+++ b/packages/springboard/src/store/index.ts
@@ -4,6 +4,8 @@ import { TestingType } from '../types/shared'
 
 interface State {
   testingType: TestingType | undefined
+  firstOpen: boolean
+  hasDismissedHelper: boolean
   component: {
     framework: SupportedFramework | undefined
   }
@@ -11,6 +13,8 @@ interface State {
 
 function createInitialState (): State {
   return {
+    firstOpen: true,
+    hasDismissedHelper: false,
     testingType: undefined,
     component: {
       framework: undefined,
@@ -39,14 +43,21 @@ class Store {
     this.state.testingType = testingType
   }
 
+  setDismissedHelper (hasDismissed) {
+    this.state.hasDismissedHelper = hasDismissed
+  }
+
   setComponentFramework (framework: SupportedFramework) {
     this.state.component.framework = framework
   }
 }
 
 // useful for testing
-export function createStore (initialState: State = createInitialState()) {
-  return new Store(initialState)
+export function createStore (stateOverrides = {}) {
+  return new Store({
+    ...createInitialState(),
+    ...stateOverrides,
+  })
 }
 
 export const store = new Store(createInitialState())

--- a/packages/springboard/vue-shims.d.ts
+++ b/packages/springboard/vue-shims.d.ts
@@ -3,4 +3,9 @@ import { DefineComponent } from 'vue'
 declare module '*.vue' {
   const component: DefineComponent
   export default component
+}
+
+declare module '*.vue.ts' {
+  const component: DefineComponent
+  export default component
 } 


### PR DESCRIPTION
### Adding a new user welcome modal as a placeholder for new content

https://user-images.githubusercontent.com/2801156/121584896-f9386c00-c9ff-11eb-9ab4-d94378c9ef3b.mov

<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
