### PR TITLE
feat: cy.intercept provides req.query.

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1681,19 +1681,15 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
 
     // https://github.com/cypress-io/cypress/issues/16327
     context('request url querystring', () => {
-      // cy.window() is used instead of $.get in the tests below.
-      // because $.get() appends query like _=12345 next to our query.
       it('parse query correctly', () => {
         cy.intercept({ url: '/users*' }, (req) => {
           expect(req.query.someKey).to.deep.equal('someValue')
           expect(req.query).to.deep.equal({ someKey: 'someValue' })
         }).as('getUrl')
 
-        cy.window().then((win) => {
-          const xhr = new win.XMLHttpRequest()
-
-          xhr.open('GET', '/users?someKey=someValue')
-          xhr.send()
+        $.get({
+          url: '/users?someKey=someValue',
+          cache: true,
         })
 
         cy.wait('@getUrl')
@@ -1709,11 +1705,9 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
             expect(req.url).to.eq('http://localhost:3500/users?a=b')
           }).as('getUrl')
 
-          cy.window().then((win) => {
-            const xhr = new win.XMLHttpRequest()
-
-            xhr.open('GET', '/users?someKey=someValue')
-            xhr.send()
+          $.get({
+            url: '/users?someKey=someValue',
+            cache: true,
           })
 
           cy.wait('@getUrl')
@@ -1727,11 +1721,9 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
             expect(req.url).to.eq('http://localhost:3500/users?a=b&c=d')
           }).as('getUrl')
 
-          cy.window().then((win) => {
-            const xhr = new win.XMLHttpRequest()
-
-            xhr.open('GET', '/users?a=b')
-            xhr.send()
+          $.get({
+            url: '/users?a=b',
+            cache: true,
           })
 
           cy.wait('@getUrl')
@@ -1749,11 +1741,9 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
             expect(req.url).to.eq('http://localhost:3500/users?a=b&c=d')
           }).as('getUrl')
 
-          cy.window().then((win) => {
-            const xhr = new win.XMLHttpRequest()
-
-            xhr.open('GET', '/users?someKey=someValue')
-            xhr.send()
+          $.get({
+            url: '/users?someKey=someValue',
+            cache: true,
           })
 
           cy.wait('@getUrl')
@@ -1771,31 +1761,60 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
             expect(req.url).to.eq('http://localhost:3500/users?a=b')
           }).as('getUrl')
 
-          cy.window().then((win) => {
-            const xhr = new win.XMLHttpRequest()
-
-            xhr.open('GET', '/users?someKey=someValue')
-            xhr.send()
+          $.get({
+            url: '/users?someKey=someValue',
+            cache: true,
           })
 
           cy.wait('@getUrl')
         })
 
-        it('by setting new url', () => {
-          cy.intercept({ url: '/users*' }, (req) => {
-            req.url = 'http://localhost:3500/users?a=b'
+        context('by setting new url', () => {
+          it('absolute path', () => {
+            cy.intercept({ url: '/users*' }, (req) => {
+              req.url = 'http://localhost:3500/users?a=b'
 
-            expect(req.query).to.deep.eq({ a: 'b' })
-          }).as('getUrl')
+              expect(req.query).to.deep.eq({ a: 'b' })
+            }).as('getUrl')
 
-          cy.window().then((win) => {
-            const xhr = new win.XMLHttpRequest()
+            $.get({
+              url: '/users?someKey=someValue',
+              cache: true,
+            })
 
-            xhr.open('GET', '/users?someKey=someValue')
-            xhr.send()
+            cy.wait('@getUrl')
           })
 
-          cy.wait('@getUrl')
+          it('relative path', () => {
+            cy.intercept({ url: '/users*' }, (req) => {
+              req.url = '/users?a=b'
+
+              expect(req.query).to.deep.eq({ a: 'b' })
+              expect(req.url).to.eq('http://localhost:3500/users?a=b')
+            }).as('getUrl')
+
+            $.get({
+              url: '/users?someKey=someValue',
+              cache: true,
+            })
+
+            cy.wait('@getUrl')
+          })
+
+          it('empty string', () => {
+            cy.intercept({ url: '/users*' }, (req) => {
+              req.url = ''
+
+              expect(req.query).to.deep.eq({})
+            }).as('getUrl')
+
+            $.get({
+              url: '/users?someKey=someValue',
+              cache: true,
+            })
+
+            cy.wait('@getUrl')
+          })
         })
       })
     })

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1816,6 +1816,55 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
             cy.wait('@getUrl')
           })
         })
+
+        context('throwing errors correctly', () => {
+          it('defineproperty', (done) => {
+            cy.on('fail', (err) => {
+              expect(err.message).to.eq('`defineProperty()` is not allowed.')
+
+              done()
+            })
+
+            cy.intercept({ url: '/users*' }, (req) => {
+              Object.defineProperty(req.query, 'key', {
+                enumerable: false,
+                configurable: false,
+                writable: false,
+                value: 'static',
+              })
+
+              expect(req.query).to.deep.eq({})
+            }).as('getUrl')
+
+            $.get({
+              url: '/users?someKey=someValue',
+              cache: true,
+            })
+
+            cy.wait('@getUrl')
+          })
+
+          it('setPrototypeOf', (done) => {
+            cy.on('fail', (err) => {
+              expect(err.message).to.eq('`setPrototypeOf()` is not allowed.')
+
+              done()
+            })
+
+            cy.intercept({ url: '/users*' }, (req) => {
+              Object.setPrototypeOf(req.query, null)
+
+              expect(req.query).to.deep.eq({})
+            }).as('getUrl')
+
+            $.get({
+              url: '/users?someKey=someValue',
+              cache: true,
+            })
+
+            cy.wait('@getUrl')
+          })
+        })
       })
     })
 

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1681,15 +1681,19 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
 
     // https://github.com/cypress-io/cypress/issues/16327
     context('request url querystring', () => {
+      // In the code below, cy.window() is used instead of $.get.
+      // It's because XHR is not sent on Firefox and it's flaky on Chrome.
       it('parse query correctly', () => {
         cy.intercept({ url: '/users*' }, (req) => {
           expect(req.query.someKey).to.deep.equal('someValue')
           expect(req.query).to.deep.equal({ someKey: 'someValue' })
         }).as('getUrl')
 
-        $.get({
-          url: '/users?someKey=someValue',
-          cache: true,
+        cy.window().then((win) => {
+          const xhr = new win.XMLHttpRequest()
+
+          xhr.open('GET', '/users?someKey=someValue')
+          xhr.send()
         })
 
         cy.wait('@getUrl')
@@ -1705,9 +1709,11 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
             expect(req.url).to.eq('http://localhost:3500/users?a=b')
           }).as('getUrl')
 
-          $.get({
-            url: '/users?someKey=someValue',
-            cache: true,
+          cy.window().then((win) => {
+            const xhr = new win.XMLHttpRequest()
+
+            xhr.open('GET', '/users?someKey=someValue')
+            xhr.send()
           })
 
           cy.wait('@getUrl')
@@ -1721,9 +1727,11 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
             expect(req.url).to.eq('http://localhost:3500/users?a=b&c=d')
           }).as('getUrl')
 
-          $.get({
-            url: '/users?a=b',
-            cache: true,
+          cy.window().then((win) => {
+            const xhr = new win.XMLHttpRequest()
+
+            xhr.open('GET', '/users?a=b')
+            xhr.send()
           })
 
           cy.wait('@getUrl')
@@ -1741,9 +1749,11 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
             expect(req.url).to.eq('http://localhost:3500/users?a=b&c=d')
           }).as('getUrl')
 
-          $.get({
-            url: '/users?someKey=someValue',
-            cache: true,
+          cy.window().then((win) => {
+            const xhr = new win.XMLHttpRequest()
+
+            xhr.open('GET', '/users?someKey=someValue')
+            xhr.send()
           })
 
           cy.wait('@getUrl')
@@ -1761,9 +1771,11 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
             expect(req.url).to.eq('http://localhost:3500/users?a=b')
           }).as('getUrl')
 
-          $.get({
-            url: '/users?someKey=someValue',
-            cache: true,
+          cy.window().then((win) => {
+            const xhr = new win.XMLHttpRequest()
+
+            xhr.open('GET', '/users?someKey=someValue')
+            xhr.send()
           })
 
           cy.wait('@getUrl')
@@ -1777,9 +1789,11 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
               expect(req.query).to.deep.eq({ a: 'b' })
             }).as('getUrl')
 
-            $.get({
-              url: '/users?someKey=someValue',
-              cache: true,
+            cy.window().then((win) => {
+              const xhr = new win.XMLHttpRequest()
+
+              xhr.open('GET', '/users?someKey=someValue')
+              xhr.send()
             })
 
             cy.wait('@getUrl')
@@ -1793,9 +1807,11 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
               expect(req.url).to.eq('http://localhost:3500/users?a=b')
             }).as('getUrl')
 
-            $.get({
-              url: '/users?someKey=someValue',
-              cache: true,
+            cy.window().then((win) => {
+              const xhr = new win.XMLHttpRequest()
+
+              xhr.open('GET', '/users?someKey=someValue')
+              xhr.send()
             })
 
             cy.wait('@getUrl')
@@ -1808,9 +1824,11 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
               expect(req.query).to.deep.eq({})
             }).as('getUrl')
 
-            $.get({
-              url: '/users?someKey=someValue',
-              cache: true,
+            cy.window().then((win) => {
+              const xhr = new win.XMLHttpRequest()
+
+              xhr.open('GET', '/users?someKey=someValue')
+              xhr.send()
             })
 
             cy.wait('@getUrl')
@@ -1836,9 +1854,11 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
               expect(req.query).to.deep.eq({})
             }).as('getUrl')
 
-            $.get({
-              url: '/users?someKey=someValue',
-              cache: true,
+            cy.window().then((win) => {
+              const xhr = new win.XMLHttpRequest()
+
+              xhr.open('GET', '/users?someKey=someValue')
+              xhr.send()
             })
 
             cy.wait('@getUrl')
@@ -1857,9 +1877,11 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
               expect(req.query).to.deep.eq({})
             }).as('getUrl')
 
-            $.get({
-              url: '/users?someKey=someValue',
-              cache: true,
+            cy.window().then((win) => {
+              const xhr = new win.XMLHttpRequest()
+
+              xhr.open('GET', '/users?someKey=someValue')
+              xhr.send()
             })
 
             cy.wait('@getUrl')

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1758,6 +1758,45 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
 
           cy.wait('@getUrl')
         })
+
+        it('by deleting query member', () => {
+          cy.intercept({ url: '/users*' }, (req) => {
+            req.query = {
+              a: 'b',
+              c: 'd',
+            }
+
+            delete req.query.c
+
+            expect(req.url).to.eq('http://localhost:3500/users?a=b')
+          }).as('getUrl')
+
+          cy.window().then((win) => {
+            const xhr = new win.XMLHttpRequest()
+
+            xhr.open('GET', '/users?someKey=someValue')
+            xhr.send()
+          })
+
+          cy.wait('@getUrl')
+        })
+
+        it('by setting new url', () => {
+          cy.intercept({ url: '/users*' }, (req) => {
+            req.url = 'http://localhost:3500/users?a=b'
+
+            expect(req.query).to.deep.eq({ a: 'b' })
+          }).as('getUrl')
+
+          cy.window().then((win) => {
+            const xhr = new win.XMLHttpRequest()
+
+            xhr.open('GET', '/users?someKey=someValue')
+            xhr.send()
+          })
+
+          cy.wait('@getUrl')
+        })
       })
     })
 

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1714,6 +1714,24 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
 
         cy.wait('@getUrl')
       })
+
+      it('reconcile changes on query to url', () => {
+        cy.intercept({ url: '/users*' }, (req) => {
+          expect(req.query.a).to.eq('b')
+          req.query.c = 'd'
+
+          expect(req.url).to.eq('http://localhost:3500/users?a=b&c=d')
+        }).as('getUrl')
+
+        cy.window().then((win) => {
+          const xhr = new win.XMLHttpRequest()
+
+          xhr.open('GET', '/users?a=b')
+          xhr.send()
+        })
+
+        cy.wait('@getUrl')
+      })
     })
 
     context('request events', function () {

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1681,6 +1681,8 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
 
     // https://github.com/cypress-io/cypress/issues/16327
     context('request url querystring', () => {
+      // cy.window() is used instead of $.get in the tests below.
+      // because $.get() appends query like _=12345 next to our query.
       it('parse query correctly', () => {
         cy.intercept({ url: '/users*' }, (req) => {
           expect(req.query.someKey).to.deep.equal('someValue')

--- a/packages/driver/src/cy/net-stubbing/events/before-request.ts
+++ b/packages/driver/src/cy/net-stubbing/events/before-request.ts
@@ -121,6 +121,12 @@ export const onBeforeRequest: HandlerFn<CyHttpMessages.IncomingRequest> = (Cypre
 
   const createQueryObject = () => {
     try {
+      if (/^(?:[a-z]+:)?\/\//i.test(req.url) === false) {
+        const { protocol, hostname, port } = window.location
+
+        req.url = `${protocol}//${hostname}${port ? `:${port}` : ''}${req.url}`
+      }
+
       const url = new URL(req.url)
       const urlSearchParams = new URLSearchParams(url.search)
       const result = {}

--- a/packages/driver/src/cy/net-stubbing/events/before-request.ts
+++ b/packages/driver/src/cy/net-stubbing/events/before-request.ts
@@ -130,7 +130,7 @@ export const onBeforeRequest: HandlerFn<CyHttpMessages.IncomingRequest> = (Cypre
       }
 
       return result
-    } catch { // invalid url
+    } catch { // avoid when url is "".
       return {}
     }
   }

--- a/packages/driver/src/cy/net-stubbing/events/before-request.ts
+++ b/packages/driver/src/cy/net-stubbing/events/before-request.ts
@@ -121,6 +121,33 @@ export const onBeforeRequest: HandlerFn<CyHttpMessages.IncomingRequest> = (Cypre
 
   const userReq: CyHttpMessages.IncomingHttpRequest = {
     ...req,
+    get query () {
+      const url = new URL(req.url)
+      const urlSearchParams = new URLSearchParams(url.search)
+      const result = {}
+
+      for (let pair of urlSearchParams.entries()) {
+        result[pair[0]] = pair[1]
+      }
+
+      return result
+    },
+
+    set query (userQuery) {
+      const url = new URL(req.url)
+      const urlSearchParams = new URLSearchParams(userQuery)
+
+      url.search = urlSearchParams.toString()
+      req.url = url.toString()
+    },
+
+    get url () {
+      return req.url
+    },
+
+    set url (userUrl) {
+      req.url = userUrl
+    },
     on (eventName, handler) {
       if (!validEvents.includes(eventName)) {
         return $errUtils.throwErrByPath('net_stubbing.request_handling.unknown_event', {

--- a/packages/driver/src/cy/net-stubbing/events/before-request.ts
+++ b/packages/driver/src/cy/net-stubbing/events/before-request.ts
@@ -166,6 +166,18 @@ export const onBeforeRequest: HandlerFn<CyHttpMessages.IncomingRequest> = (Cypre
 
         return true
       },
+
+      defineProperty () {
+        $errUtils.throwErrByPath('net_stubbing.request_handling.defineproperty_is_not_allowed')
+
+        return false
+      },
+
+      setPrototypeOf () {
+        $errUtils.throwErrByPath('net_stubbing.request_handling.setprototypeof_is_not_allowed')
+
+        return false
+      },
     })
   }
 

--- a/packages/driver/src/cy/net-stubbing/events/before-request.ts
+++ b/packages/driver/src/cy/net-stubbing/events/before-request.ts
@@ -152,6 +152,14 @@ export const onBeforeRequest: HandlerFn<CyHttpMessages.IncomingRequest> = (Cypre
 
         return true
       },
+
+      deleteProperty (target, key) {
+        delete target[key]
+
+        updateUrlParams(target)
+
+        return true
+      },
     })
   }
 
@@ -172,6 +180,10 @@ export const onBeforeRequest: HandlerFn<CyHttpMessages.IncomingRequest> = (Cypre
     },
     set url (userUrl) {
       req.url = userUrl
+
+      // reset query variables
+      queryObj = createQueryObject()
+      queryProxy = createQueryProxy(queryObj)
     },
     on (eventName, handler) {
       if (!validEvents.includes(eventName)) {

--- a/packages/driver/src/cy/net-stubbing/events/before-request.ts
+++ b/packages/driver/src/cy/net-stubbing/events/before-request.ts
@@ -119,6 +119,22 @@ export const onBeforeRequest: HandlerFn<CyHttpMessages.IncomingRequest> = (Cypre
   let resolved = false
   let handlerCompleted = false
 
+  const createQueryObject = () => {
+    try {
+      const url = new URL(req.url)
+      const urlSearchParams = new URLSearchParams(url.search)
+      const result = {}
+
+      for (let pair of urlSearchParams.entries()) {
+        result[pair[0]] = pair[1]
+      }
+
+      return result
+    } catch { // invalid url
+      return {}
+    }
+  }
+
   const updateUrlParams = (paramsObj) => {
     const url = new URL(req.url)
     const urlSearchParams = new URLSearchParams(paramsObj)
@@ -139,13 +155,7 @@ export const onBeforeRequest: HandlerFn<CyHttpMessages.IncomingRequest> = (Cypre
     })
   }
 
-  let queryObj = {}
-  const url = new URL(req.url)
-  const urlSearchParams = new URLSearchParams(url.search)
-
-  for (let pair of urlSearchParams.entries()) {
-    queryObj[pair[0]] = pair[1]
-  }
+  let queryObj = createQueryObject()
   let queryProxy = createQueryProxy(queryObj)
 
   const userReq: CyHttpMessages.IncomingHttpRequest = {

--- a/packages/driver/src/cypress/error_messages.js
+++ b/packages/driver/src/cypress/error_messages.js
@@ -1001,6 +1001,8 @@ module.exports = {
           You passed: ${format(eventName)}`, 10)
       },
       event_needs_handler: `\`req.on()\` requires the second parameter to be a function.`,
+      defineproperty_is_not_allowed: `\`defineProperty()\` is not allowed.`,
+      setprototypeof_is_not_allowed: `\`setPrototypeOf()\` is not allowed.`,
     },
     request_error: {
       network_error: ({ innerErr, req, route }) => {

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -132,6 +132,10 @@ export namespace CyHttpMessages {
      */
     url: string
     /**
+     * URL query string as object.
+     */
+    query: Record<string, string|number>
+    /**
      * The HTTP version used in the request. Read only.
      */
     httpVersion: string


### PR DESCRIPTION
- Closes #16327

### User facing changelog

`cy.intercept` provides req.query.


### Additional details
- Why was this change necessary? => When there's query on url, it's convenient to have parsed query string. 
- What is affected by this change? => N/A
- Any implementation details to explain? => I added `query`, `url` getter and setter to `req` object.

### How has the user experience changed?

**Before:** `req.query` => `undefined`.
**After:** `req.query` => `{ a: 'b' }`

### PR Tasks
- [x] Have tests been added/updated?
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? => https://github.com/cypress-io/cypress-documentation/pull/3986
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?