### PR TITLE
fix: vite startDevServer needs to return close()

### DIFF
--- a/npm/vite-dev-server/src/index.ts
+++ b/npm/vite-dev-server/src/index.ts
@@ -1,13 +1,14 @@
 import { debug as debugFn } from 'debug'
-import { Server } from 'http'
 import { start as createDevServer, StartDevServer } from './startServer'
 const debug = debugFn('cypress:vite-dev-server:vite')
 
 export { StartDevServer }
 
+type DoneCallback = () => unknown
+
 export interface ResolvedDevServerConfig {
   port: number
-  server: Server
+  close: (done?: DoneCallback) => void
 }
 
 export async function startDevServer (startDevServerArgs: StartDevServer): Promise<ResolvedDevServerConfig> {
@@ -18,5 +19,5 @@ export async function startDevServer (startDevServerArgs: StartDevServer): Promi
 
   debug('Component testing vite server started on port', port)
 
-  return { port, server: app.httpServer }
+  return { port, close: () => app.httpServer.close() }
 }

--- a/npm/vite-dev-server/src/index.ts
+++ b/npm/vite-dev-server/src/index.ts
@@ -19,5 +19,5 @@ export async function startDevServer (startDevServerArgs: StartDevServer): Promi
 
   debug('Component testing vite server started on port', port)
 
-  return { port, close: () => app.httpServer.close() }
+  return { port, close: app.httpServer.close }
 }


### PR DESCRIPTION
- Closes #16739

### User facing changelog
The types output by the `@cypress/vite-dev-server` need to have a `close` function to match the demanded type in the event `dev-server:start`.
