### PR TITLE
fix: case issue create cypress tests with `react/plugins/load-webpack`

### DIFF
--- a/npm/create-cypress-tests/__snapshots__/reactWebpackFile.test.ts.js
+++ b/npm/create-cypress-tests/__snapshots__/reactWebpackFile.test.ts.js
@@ -7,7 +7,7 @@ module.exports = (on, config) => {
   if (config.testingType === "component") {
     injectDevServer(on, config, {
       // TODO replace with valid webpack config path
-      webpackFileName: './webpack.config.js'
+      webpackFilename: './webpack.config.js'
     });
   }
 
@@ -23,7 +23,7 @@ const something = require("something");
 module.exports = (on, config) => {
   if (config.testingType === "component") {
     injectDevServer(on, config, {
-      webpackFileName: 'config/webpack.config.js'
+      webpackFilename: 'config/webpack.config.js'
     });
   }
 

--- a/npm/create-cypress-tests/src/component-testing/templates/react/reactWebpackFile.ts
+++ b/npm/create-cypress-tests/src/component-testing/templates/react/reactWebpackFile.ts
@@ -25,7 +25,7 @@ export const WebpackTemplate: Template<{ webpackConfigPath: string }> = {
         includeWarnComment
           ? '  // TODO replace with valid webpack config path'
           : '',
-        `  webpackFileName: '${webpackConfigPath}'`,
+        `  webpackFilename: '${webpackConfigPath}'`,
         '})',
       ].join('\n'), { preserveComments: true }),
     }


### PR DESCRIPTION
closes #16960

Output code before that was be failing to render component testing.

```js
// cypress/plugins/index.js
const injectDevServer = require("@cypress/react/plugins/load-webpack");
module.exports = (on, config) => {
  if (config.testingType === "component") {
    injectDevServer(on, config, {
      webpackFileName: 'config/webpack.config.js'
    });
  }

  return config; // IMPORTANT to return a config
};
```

Output code after my change (change in the case)

```js
      webpackFilename: 'config/webpack.config.js'
```