### PR TITLE
fix: ensure @cypress/schematic is installed as devDependency

### DIFF
--- a/npm/cypress-schematic/package.json
+++ b/npm/cypress-schematic/package.json
@@ -56,5 +56,8 @@
     "registry": "http://registry.npmjs.org/"
   },
   "builders": "./src/builders/builders.json",
+  "ng-add": {
+    "save": "devDependencies"
+  },
   "schematics": "./src/schematics/collection.json"
 }


### PR DESCRIPTION
- close issue #16954 
- closing PR #16956 in favor of this one.

### User Facing Changelog

- Update package.json to ensure schematic is installed as devDependency

### Additional Details

>Use the `save` option of `ng-add` to configure if the library should be added to the `dependencies`, the `devDepedencies`, or not saved at all in the project's `package.json` configuration file. https://angular.io/guide/schematics-for-libraries#define-dependency-type
- Not sure if there’s a way y’all have set up already to test this.