### PR TITLE
fix: better handle unconventional browser version

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -60,7 +60,7 @@ declare namespace Cypress {
      */
     displayName: string
     version: string
-    majorVersion: number
+    majorVersion: number | string
     path: string
     isHeaded: boolean
     isHeadless: boolean

--- a/packages/launcher/lib/detect.ts
+++ b/packages/launcher/lib/detect.ts
@@ -26,17 +26,13 @@ export const setMajorVersion = <T extends HasVersion>(browser: T): T => {
   let majorVersion = browser.majorVersion
 
   if (browser.version) {
-    majorVersion = browser.version.split('.')[0]
+    majorVersion = parseInt(browser.version.split('.')[0]) || browser.version
     log(
       'browser %s version %s major version %s',
       browser.name,
       browser.version,
       majorVersion,
     )
-
-    if (majorVersion) {
-      majorVersion = parseInt(majorVersion)
-    }
   }
 
   return extend({}, browser, { majorVersion })

--- a/packages/launcher/test/unit/detect_spec.ts
+++ b/packages/launcher/test/unit/detect_spec.ts
@@ -39,15 +39,29 @@ describe('browser detection', () => {
   })
 
   context('#setMajorVersion', () => {
-    const foundBrowser = {
-      name: 'test browser',
-      version: '11.22.33',
-    }
+    it('major version is converted to number when string of numbers', () => {
+      const foundBrowser = {
+        name: 'test browser',
+        version: '11.22.33',
+      }
 
-    const res = setMajorVersion(foundBrowser)
+      const res = setMajorVersion(foundBrowser)
 
-    // @ts-ignore
-    expect(res.majorVersion, 'major version was converted to number').to.equal(11)
+      // @ts-ignore
+      expect(res.majorVersion).to.equal(11)
+    })
+
+    it('falls back to version when unconventional browser version', () => {
+      const foundBrowser = {
+        name: 'test browser',
+        version: 'VMware Fusion 12.1.0',
+      }
+
+      const res = setMajorVersion(foundBrowser)
+
+      // @ts-ignore
+      expect(res.majorVersion).to.equal(foundBrowser.version)
+    })
   })
 
   context('#detectByPath', () => {

--- a/packages/server/lib/browsers/utils.ts
+++ b/packages/server/lib/browsers/utils.ts
@@ -244,7 +244,7 @@ export = {
       const version = process.versions.chrome || ''
 
       if (version) {
-        majorVersion = parseFloat(version.split('.')[0])
+        majorVersion = parseFloat(version.split('.')[0]) || version
       }
 
       const electronBrowser: FoundBrowser = {

--- a/packages/server/lib/browsers/utils.ts
+++ b/packages/server/lib/browsers/utils.ts
@@ -38,6 +38,10 @@ const getBrowserPath = (browser) => {
   )
 }
 
+const getMajorVersion = (version) => {
+  return parseFloat(version.split('.')[0]) || version
+}
+
 const defaultLaunchOptions: {
   preferences: {[key: string]: any}
   extensions: string[]
@@ -193,6 +197,8 @@ export = {
 
   getBrowserPath,
 
+  getMajorVersion,
+
   getProfileDir,
 
   getExtensionDir,
@@ -244,7 +250,7 @@ export = {
       const version = process.versions.chrome || ''
 
       if (version) {
-        majorVersion = parseFloat(version.split('.')[0]) || version
+        majorVersion = getMajorVersion(version)
       }
 
       const electronBrowser: FoundBrowser = {

--- a/packages/server/test/unit/browsers/browsers_spec.js
+++ b/packages/server/test/unit/browsers/browsers_spec.js
@@ -128,6 +128,24 @@ describe('lib/browsers/index', () => {
       expect(onWarning).to.be.calledWithMatch({ type: 'DEPRECATED_BEFORE_BROWSER_LAUNCH_ARGS' })
     })
   })
+
+  context('.getMajorVersion', () => {
+    it('returns first number when string of numbers', () => {
+      expect(utils.getMajorVersion('91.0.4472.106')).to.eq(91) // Chromium format
+      expect(utils.getMajorVersion('91.0a1')).to.eq(91) // Firefox format
+    })
+
+    it('is empty string when empty string', () => {
+      expect(utils.getMajorVersion('')).to.eq('') // fallback if no version
+    })
+
+    // https://github.com/cypress-io/cypress/issues/15485
+    it('returns version when unconventional version format', () => {
+      const vers = 'VMware Fusion 12.1.0'
+
+      expect(utils.getMajorVersion(vers)).to.eq(vers)
+    })
+  })
 })
 
 // Ooo, browser clean up tests are disabled?!!


### PR DESCRIPTION
- close #15485 

### User facing changelog

- Cypress now better handles running when browsers with unconventional versions are present on the machine.

### Additional Details

- The Edge browser in VMWare has a weird version so the majorVersion ends up being `null`. We completely error when running `cypress run` in a situation where the `majorVersion` is null, even if they're NOT RUNNING that browser. This seems like not great behavior in itself, but I didn't address this. 
	```
	Found an error while validating the `browsers` list. Expected `majorVersion` to be a string or a positive number.
	```
- Decided to just fallback to 'version' if the 'majorVersion' ends up being invalid. The majorVersion is just for UI purposes really anyway and a string is acceptable.
- I feel like there could be a better test for this? Not sure how to test this locally.

```
  - Name: edge
  - Channel: stable
  - Version: VMware Fusion 12.1.0
  - Executable: /Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge
 ```

### User experience changes

#### Before

```
Found an error while validating the `browsers` list. Expected `majorVersion` to be a string or a positive number.
```

#### After

Shouldn't show this error since `majorVersion` will match version

### PR Checks

- [x] Updated tests
- [ ] Zenhub release