### PR TITLE
ci: release vue3 on master

### DIFF
--- a/npm/vue/.releaserc.js
+++ b/npm/vue/.releaserc.js
@@ -1,7 +1,12 @@
 module.exports = {
   ...require('../../.releaserc.base'),
   branches: [
-    'npm/vue/v2',
+    // we need to keep this branch in here even if no used because semantic-release demands
+    // that we have at least one branch that has no config
+    'next/npm/vue',
+    // this line forces releasing 2.X releases on the latest channel
+    { name: 'npm/vue/v2', range: '2.X.X' },
+    // this one releases v3 on master as beta on the next channel
     { name: 'master', channel: 'next', prerelease: 'beta' },
   ],
 }

--- a/npm/vue/.releaserc.js
+++ b/npm/vue/.releaserc.js
@@ -1,7 +1,7 @@
 module.exports = {
   ...require('../../.releaserc.base'),
   branches: [
-    { name: 'npm/vue/v2', channel: 'latest', range: '2.x' },
+    'npm/vue/v2',
     { name: 'master', channel: 'next', prerelease: 'beta' },
   ],
 }


### PR DESCRIPTION
Semantic-release **demands** we have a branch with no configuration.

This change on the master branch does not change much. But the same change has been done on branch `npm/vue/v2` and delivers what it is supposed to deliver (vue 2 code on latest)
