### PR TITLE
fix: convert 0 to string in contains command

### DIFF
--- a/packages/driver/cypress/integration/commands/querying_spec.js
+++ b/packages/driver/cypress/integration/commands/querying_spec.js
@@ -2145,6 +2145,15 @@ space
         })
       })
 
+      // https://github.com/cypress-io/cypress/issues/1119
+      it('logs "0" on cy.contains(0)', function () {
+        cy.state('document').write('<span>0</span>')
+
+        cy.contains(0).then(() => {
+          expect(this.lastLog.get('message')).to.eq('0')
+        })
+      })
+
       it('#consoleProps', () => {
         const $complex = cy.$$('#complex-contains')
 

--- a/packages/driver/cypress/integration/issues/1119_spec.js
+++ b/packages/driver/cypress/integration/issues/1119_spec.js
@@ -1,0 +1,19 @@
+// https://github.com/cypress-io/cypress/issues/1119
+describe('issue 1119', () => {
+  it('logs "contains 0" on cy.contains(0)', () => {
+    cy.state('document').write('<span>0</span>')
+
+    let lastLog
+
+    cy.on('log:added', (_, log) => lastLog = log)
+
+    cy.contains(0).then(() => {
+      const lastLogText = `${lastLog.get('name')} ${lastLog.get('message')}`
+      const expectedText = 'contains 0'
+
+      expect(lastLogText).to.eq(expectedText)
+
+      cy.removeAllListeners('log:added')
+    })
+  })
+})

--- a/packages/driver/src/cy/commands/querying.js
+++ b/packages/driver/src/cy/commands/querying.js
@@ -465,6 +465,11 @@ module.exports = (Commands, Cypress, cy, state) => {
         filter = ''
       }
 
+      if (text === 0) {
+        // text can be 0 but should not be falsy
+        text = '0'
+      }
+
       if (userOptions.matchCase === true && _.isRegExp(text) && text.flags.includes('i')) {
         $errUtils.throwErrByPath('contains.regex_conflict')
       }

--- a/packages/driver/src/cy/commands/querying.js
+++ b/packages/driver/src/cy/commands/querying.js
@@ -465,6 +465,7 @@ module.exports = (Commands, Cypress, cy, state) => {
         filter = ''
       }
 
+      // https://github.com/cypress-io/cypress/issues/1119
       if (text === 0) {
         // text can be 0 but should not be falsy
         text = '0'


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/1119

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->
`cy.contains(0)` now logs correctly

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
This change fixes the issue in which 0 was not logged in the cypress console when used in the contains command

This was caused by the use of `_.compact` which removes all falsy values from the "message" array:  https://github.com/cypress-io/cypress/blob/ba8bfd27f1ac218fa3e322425039da834ba7b787/packages/driver/src/cy/commands/querying.js#L523        

My solution was to convert the falsy number `0` to t he truthy string `"0"`, another solution I considered was replacing `_.compact` with `_.without` and only filter out falsy values except from `0`, but I thought that just converting the `0` to `"0"` was a cleaner solution, but if you disagree please let me know and I can go with the `_.without` one if you prefer (or any you can suggest)

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Before the change if you queried `cy.contains(0)` all would work but you would not see `0` in the cypress console:
![Screenshot at 2021-06-17 23-06-33](https://user-images.githubusercontent.com/61631103/122478157-ccb4bf00-cfc0-11eb-9bb9-1c21583cf34a.png)
Now you will see `0`:
![Screenshot at 2021-06-17 23-01-02](https://user-images.githubusercontent.com/61631103/122478169-d1797300-cfc0-11eb-9782-e0972f313365.png)


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?


### Extra

`yarn test` passes, I hope it's enough, if it's not please let me know
![Screenshot at 2021-06-17 22-51-01](https://user-images.githubusercontent.com/61631103/122476786-a5f58900-cfbe-11eb-8885-a8e9dabc4cb9.png)
