### PR TITLE
chore: promise modernization experiment.

### DIFF
--- a/packages/driver/src/cy/commands/request.js
+++ b/packages/driver/src/cy/commands/request.js
@@ -1,10 +1,10 @@
 const _ = require('lodash')
 const whatIsCircular = require('@cypress/what-is-circular')
-const Promise = require('bluebird')
 
 const $utils = require('../../cypress/utils')
 const $errUtils = require('../../cypress/error_utils')
 const $Location = require('../../cypress/location')
+const { TimeoutError, timeout } = require('../../util/promise')
 
 const isOptional = (memo, val, key) => {
   if (_.isNull(val)) {
@@ -63,7 +63,7 @@ module.exports = (Commands, Cypress, cy, state, config) => {
     // allow our signature to be similar to cy.route
     // METHOD / URL / BODY
     // or object literal with all expanded options
-    request (...args) {
+    async request (...args) {
       const o = {}
       const userOptions = o
 
@@ -277,118 +277,123 @@ module.exports = (Commands, Cypress, cy, state, config) => {
       // because we're handling timeouts ourselves
       cy.clearTimeout('http:request')
 
-      return Promise.try(() => {
-        // https://github.com/cypress-io/cypress/issues/6178
-        // Check if body is Blob.
-        // construct.name is added because the parent of the Blob is not the same Blob
-        // if it's generated from the test spec code.
-        if (requestOpts.body instanceof Blob || requestOpts.body?.constructor.name === 'Blob') {
-          requestOpts.bodyIsBase64Encoded = true
+      try {
+        return await timeout(options.timeout, async () => {
+          // https://github.com/cypress-io/cypress/issues/6178
+          // Check if body is Blob.
+          // construct.name is added because the parent of the Blob is not the same Blob
+          // if it's generated from the test spec code.
+          if (requestOpts.body instanceof Blob || requestOpts.body?.constructor.name === 'Blob') {
+            requestOpts.bodyIsBase64Encoded = true
 
-          return Cypress.Blob.blobToBase64String(requestOpts.body).then((str) => {
-            requestOpts.body = str
-          })
-        }
-
-        // https://github.com/cypress-io/cypress/issues/1647
-        // Handle if body is FormData
-        if (requestOpts.body instanceof FormData || requestOpts.body?.constructor.name === 'FormData') {
-          const boundary = '----CypressFormDataBoundary'
-
-          // reset content-type
-          if (requestOpts.headers) {
-            delete requestOpts.headers[Object.keys(requestOpts).find((key) => key.toLowerCase() === 'content-type')]
-          } else {
-            requestOpts.headers = {}
+            await Cypress.Blob.blobToBase64String(requestOpts.body).then((str) => {
+              requestOpts.body = str
+            })
           }
 
-          // boundary is required for form data
-          // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST
-          requestOpts.headers['content-type'] = `multipart/form-data; boundary=${boundary}`
+          // https://github.com/cypress-io/cypress/issues/1647
+          // Handle if body is FormData
+          if (requestOpts.body instanceof FormData || requestOpts.body?.constructor.name === 'FormData') {
+            const boundary = '----CypressFormDataBoundary'
 
-          // socket.io ignores FormData.
-          // So, we need to encode the data into base64 string format.
-          const formBody = []
+            // reset content-type
+            if (requestOpts.headers) {
+              delete requestOpts.headers[Object.keys(requestOpts).find((key) => key.toLowerCase() === 'content-type')]
+            } else {
+              requestOpts.headers = {}
+            }
 
-          requestOpts.body.forEach((value, key) => {
+            // boundary is required for form data
+            // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST
+            requestOpts.headers['content-type'] = `multipart/form-data; boundary=${boundary}`
+
+            // socket.io ignores FormData.
+            // So, we need to encode the data into base64 string format.
+            const formBody = []
+
+            requestOpts.body.forEach((value, key) => {
             // HTTP line break style is \r\n.
             // @see https://stackoverflow.com/questions/5757290/http-header-line-break-style
-            if (value instanceof File || value?.constructor.name === 'File') {
-              formBody.push(`--${boundary}\r\n`)
-              formBody.push(`Content-Disposition: form-data; name="${key}"; filename="${value.name}"\r\n`)
-              formBody.push(`Content-Type: ${value.type || 'application/octet-stream'}\r\n`)
-              formBody.push('\r\n')
-              formBody.push(value)
-              formBody.push('\r\n')
-            } else {
-              formBody.push(`--${boundary}\r\n`)
-              formBody.push(`Content-Disposition: form-data; name="${key}"\r\n`)
-              formBody.push('\r\n')
-              formBody.push(value)
-              formBody.push('\r\n')
-            }
-          })
+              if (value instanceof File || value?.constructor.name === 'File') {
+                formBody.push(`--${boundary}\r\n`)
+                formBody.push(`Content-Disposition: form-data; name="${key}"; filename="${value.name}"\r\n`)
+                formBody.push(`Content-Type: ${value.type || 'application/octet-stream'}\r\n`)
+                formBody.push('\r\n')
+                formBody.push(value)
+                formBody.push('\r\n')
+              } else {
+                formBody.push(`--${boundary}\r\n`)
+                formBody.push(`Content-Disposition: form-data; name="${key}"\r\n`)
+                formBody.push('\r\n')
+                formBody.push(value)
+                formBody.push('\r\n')
+              }
+            })
 
-          formBody.push(`--${boundary}--\r\n`)
+            formBody.push(`--${boundary}--\r\n`)
 
-          requestOpts.bodyIsBase64Encoded = true
+            requestOpts.bodyIsBase64Encoded = true
 
-          return Cypress.Blob.blobToBase64String(new Blob(formBody)).then((str) => {
-            requestOpts.body = str
-          })
-        }
-      })
-      .then(() => {
-        return Cypress.backend('http:request', requestOpts)
-      })
-      .timeout(options.timeout)
-      .then((response) => {
-        options.response = response
+            await Cypress.Blob.blobToBase64String(new Blob(formBody)).then((str) => {
+              requestOpts.body = str
+            })
+          }
 
-        // bomb if we should fail on non okay status code
-        if (options.failOnStatusCode && (response.isOkStatusCode !== true)) {
-          $errUtils.throwErrByPath('request.status_invalid', {
+          const response = await Cypress.backend('http:request', requestOpts)
+
+          options.response = response
+
+          // bomb if we should fail on non okay status code
+          if (options.failOnStatusCode && (response.isOkStatusCode !== true)) {
+            $errUtils.throwErrByPath('request.status_invalid', {
+              onFail: options._log,
+              args: {
+                method: requestOpts.method,
+                url: requestOpts.url,
+                requestBody: response.requestBody,
+                requestHeaders: response.requestHeaders,
+                status: response.status,
+                statusText: response.statusText,
+                responseBody: response.body,
+                responseHeaders: response.headers,
+                redirects: response.redirects,
+              },
+            })
+          }
+
+          return response
+        })
+      } catch (err) {
+        if (err instanceof TimeoutError) {
+          $errUtils.throwErrByPath('request.timed_out', {
             onFail: options._log,
             args: {
-              method: requestOpts.method,
               url: requestOpts.url,
-              requestBody: response.requestBody,
-              requestHeaders: response.requestHeaders,
-              status: response.status,
-              statusText: response.statusText,
-              responseBody: response.body,
-              responseHeaders: response.headers,
-              redirects: response.redirects,
+              method: requestOpts.method,
+              timeout: options.timeout,
             },
           })
         }
 
-        return response
-      }).catch(Promise.TimeoutError, () => {
-        $errUtils.throwErrByPath('request.timed_out', {
-          onFail: options._log,
-          args: {
-            url: requestOpts.url,
-            method: requestOpts.method,
-            timeout: options.timeout,
-          },
-        })
-      }).catch({ backend: true }, (err) => {
-        $errUtils.throwErrByPath('request.loading_failed', {
-          onFail: options._log,
-          args: {
-            error: err.message,
-            method: requestOpts.method,
-            url: requestOpts.url,
-          },
-          errProps: {
-            appendToStack: {
-              title: 'From Node.js Internals',
-              content: err.stack,
+        if (err.backend === true) {
+          $errUtils.throwErrByPath('request.loading_failed', {
+            onFail: options._log,
+            args: {
+              error: err.message,
+              method: requestOpts.method,
+              url: requestOpts.url,
             },
-          },
-        })
-      })
+            errProps: {
+              appendToStack: {
+                title: 'From Node.js Internals',
+                content: err.stack,
+              },
+            },
+          })
+        }
+
+        throw err
+      }
     },
   })
 }

--- a/packages/driver/src/util/promise.js
+++ b/packages/driver/src/util/promise.js
@@ -1,0 +1,31 @@
+class TimeoutError extends Error {}
+
+const timeout = function (timeoutMillis, promise) {
+  return new Promise((resolve, reject) => {
+    let timeout = _setTimeout(() => {
+      reject(new TimeoutError)
+    }, timeoutMillis)
+
+    promise()
+    .then((val) => {
+      clearTimeout(timeout)
+
+      resolve(val)
+    })
+    .catch((err) => {
+      clearTimeout(timeout)
+
+      reject(err)
+    })
+  })
+}
+
+function _setTimeout (callback, time) {
+  return setTimeout(callback, time)
+}
+
+module.exports = {
+  _setTimeout,
+  timeout,
+  TimeoutError,
+}


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

In #15931, I discussed modernizing `Promise` usage in Cypress with @flotwig. I wrote this experiment code. Any opinion is welcome.

### Problem.

How should we test `Promise.timeout()` for timeout option?

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
