### PR TITLE
chore(test): fix setting packages/driver tests retries

### DIFF
--- a/packages/driver/cypress.json
+++ b/packages/driver/cypress.json
@@ -7,9 +7,5 @@
   "reporter": "cypress-multi-reporters",
   "reporterOptions": {
     "configFile": "../../mocha-reporter-config.json"
-  },
-  "retries": {
-    "runMode": 2,
-    "openMode": 0
   }
 }

--- a/packages/driver/cypress/support/defaults.js
+++ b/packages/driver/cypress/support/defaults.js
@@ -14,6 +14,11 @@ beforeEach(() => {
     // necessary or else snapshots will not be taken
     // and we can't test them
     Cypress.config('numTestsKeptInMemory', 1)
+
+    // we want to only enable retries in runMode
+    // and because we set `isInteractive` above
+    // we have to set retries here
+    Cypress.config('retries', 2)
   }
 
   // remove all event listeners


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- setting `retries` in cypress.json for our driver/integration tests doesn't work since we mutate `isInteractive` to trick runMode into running as openMode. So now we set retries in a similarly hacky way
- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
