### PR TITLE
fix: Better handle `preventScroll` options when passed to  `element.focus()`

### DIFF
--- a/packages/driver/cypress/integration/commands/actions/focus_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/focus_spec.js
@@ -45,6 +45,19 @@ describe('src/cy/commands/actions/focus', () => {
       })
     })
 
+    it('bubbles focus event options', () => {
+      // The browser will try to read the preventScroll option if present
+      const optionGetter = cy.stub()
+      const fakeOptions = Object.defineProperty({}, 'preventScroll', {
+        get: optionGetter,
+      })
+
+      cy.get('#focus input').then(($input) => {
+        $input[0].focus(fakeOptions)
+        expect(optionGetter).to.be.calledOnce
+      })
+    })
+
     it('manually blurs focused subject as a fallback', () => {
       let blurred = false
 

--- a/packages/driver/cypress/integration/commands/actions/focus_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/focus_spec.js
@@ -45,7 +45,8 @@ describe('src/cy/commands/actions/focus', () => {
       })
     })
 
-    it('bubbles focus event options', () => {
+    // https://github.com/cypress-io/cypress/issues/15294
+    it('proxies focus event options', () => {
       // The browser will try to read the preventScroll option if present
       const optionGetter = cy.stub()
       const fakeOptions = Object.defineProperty({}, 'preventScroll', {

--- a/packages/driver/src/cy/focused.js
+++ b/packages/driver/src/cy/focused.js
@@ -157,7 +157,7 @@ const create = (state) => {
     return el.dispatchEvent(focusinEvt)
   }
 
-  const interceptFocus = (el) => {
+  const interceptFocus = (el, win, opts) => {
     // normally programmatic focus calls cause "primed" focus/blur
     // events if the window is not in focus
     // so we fire fake events to act as if the window
@@ -165,12 +165,12 @@ const create = (state) => {
     const $focused = getFocused()
 
     if ((!$focused || $focused[0] !== el) && $elements.isW3CFocusable(el)) {
-      fireFocus(el)
+      fireFocus(el, opts)
 
       return
     }
 
-    $elements.callNativeMethod(el, 'focus')
+    $elements.callNativeMethod(el, 'focus', opts)
   }
 
   const interceptBlur = (el) => {


### PR DESCRIPTION
Closes https://github.com/cypress-io/cypress/issues/15294

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->
Calls to `.focus()` with options are now passing the options down the line instead of dropping them.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
As can be seen in the implementation of the focus interceptors: https://github.com/cypress-io/cypress/blob/b222dc08a415ff2a9d05345915b75fec71072512/packages/driver/src/cypress/cy.js#L307-L309

`FocusOptions` as defined in the [`HTMLElement.focus()` specs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/focus) are supported. Unfortunately, they are dropped right after in the `interceptFocus` method, preventing them to actually reach any native code.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Cypress was not correctly handling call to focus with options like `{ preventScroll: true }`

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
