### PR TITLE
chore: add showedOnBoardingModal back to allowed state keys

### DIFF
--- a/packages/server/lib/saved_state.js
+++ b/packages/server/lib/saved_state.js
@@ -9,6 +9,8 @@ const { fs } = require('./util/fs')
 
 const stateFiles = {}
 
+// TODO: remove `showedOnBoardingModal` from this list - it is only included so that misleading `allowed` are not thrown
+// now that it has been removed from use
 const allowed = `
 appWidth
 appHeight
@@ -22,6 +24,7 @@ browserY
 isAppDevToolsOpen
 isBrowserDevToolsOpen
 reporterWidth
+showedOnBoardingModal
 showedNewProjectBanner
 firstOpenedCypress
 showedStudioModal


### PR DESCRIPTION
### User facing changelog

n/a 

### Additional details

- unreleased bug uncovered in https://github.com/cypress-io/cypress/pull/15826
- apparently, removing a saved state key that still exists for users will cause cypress to run it through normalizeAndAllowSet again, causing the warning: 
![image](https://user-images.githubusercontent.com/1151760/123162006-9f07c400-d45f-11eb-84d2-de6edfc90df7.png)
- followup for proper fix: https://github.com/cypress-io/cypress/issues/17087


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
