### PR TITLE
fix: bumps deps for npm/vue

### DIFF
--- a/npm/vue/package.json
+++ b/npm/vue/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@cypress/mount-utils": "0.0.0-development",
-    "@vue/test-utils": "^2.0.0-rc.4"
+    "@vue/test-utils": "^2.0.0-rc.9"
   },
   "devDependencies": {
     "@babel/core": "7.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9011,10 +9011,10 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.9.tgz#09882d745ded52b07e4481d036659d733edd2a9a"
   integrity sha512-lv20q1O5dybwro+V+vnxHCmSIxi9mvTORSgAbGrANGYK8zF4K1S9TOankIvdkcvfZ88IR95O2pTI2Pb3c3BaNg==
 
-"@vue/test-utils@^2.0.0-rc.4":
-  version "2.0.0-rc.6"
-  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.0.0-rc.6.tgz#d0aac24d20450d379e183f70542c0822670b8783"
-  integrity sha512-0cnQBVH589PwgqWpyv1fgCAz+9Ram/MsvN3ZEAEVXi1aPuhUa22EudGc0WezQ9PKwR+L40NrBmt3JBXE2tSRRQ==
+"@vue/test-utils@^2.0.0-rc.9":
+  version "2.0.0-rc.9"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.0.0-rc.9.tgz#b3f817d710a1d0ae2084143520c9d8d3c552bfa6"
+  integrity sha512-iJNAAfXTTSd2/5vUZpFbUwUwC8w3hbFu8s9ptKkZGsiw6pO6mFsaLs2rzI3Ea/8hwqcF3K7Wp2diKOdzqmb6qg==
 
 "@vue/web-component-wrapper@^1.2.0":
   version "1.3.0"


### PR DESCRIPTION
Update to the latest version of `@vue/test-utils`, which has a [bug fix relating to the module extension](https://github.com/vuejs/vue-test-utils-next/releases/tag/v2.0.0-rc.9).