### PR TITLE
chore: fix retry flaky tests in net_stubbing_spec

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -11,7 +11,8 @@ const testFail = (cb, expectedDocsUrl = 'https://on.cypress.io/intercept') => {
   })
 }
 
-describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function () {
+// TODO: Network retries leak between tests, causing flake.
+describe('network stubbing', { retries: 2 }, function () {
   const { $, _, sinon, state, Promise } = Cypress
 
   beforeEach(function () {
@@ -1258,8 +1259,7 @@ describe('network stubbing', { retries: { runMode: 2, openMode: 0 } }, function 
       })
     })
 
-    // TODO: flaky - unable to reproduce outside of CI
-    it('still works after a cy.visit', { retries: 2 }, function () {
+    it('still works after a cy.visit', function () {
       cy.intercept(/foo/, {
         body: JSON.stringify({ foo: 'bar' }),
         headers: {

--- a/packages/driver/cypress/integration/commands/traversals_spec.js
+++ b/packages/driver/cypress/integration/commands/traversals_spec.js
@@ -41,10 +41,6 @@ describe('src/cy/commands/traversals', () => {
 
       describe('errors', {
         defaultCommandTimeout: 100,
-        retries: {
-          openMode: 0,
-          runMode: 2,
-        },
       }, () => {
         it('throws when options.length isnt a number', (done) => {
           cy.on('fail', (err) => {


### PR DESCRIPTION
### Additional details

We tell Cypress we're in "open" mode for runner tests, so the retries config was incorrect. Fixes tests causing increased flake in CI lately.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
