### PR TITLE
fix: cy.intercept delay works correctly with 204 No Content

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1682,6 +1682,30 @@ describe('network stubbing', { retries: 2 }, function () {
       .then(() => testDelay()).wait('@get')
     })
 
+    // https://github.com/cypress-io/cypress/issues/15188
+    it('delay works correctly with 204 No Content', (done) => {
+      cy.on('fail', (err) => {
+        expect(err.message).to.include('No response ever occurred')
+
+        done()
+      })
+
+      cy.intercept('POST', '/post-only', {
+        statusCode: 204, // delay is not respected
+        delay: 5000,
+      }).as('create')
+
+      cy.window().then((win) => {
+        win.eval(
+          `fetch("/post-only", {
+            method: 'POST', // *GET, POST, PUT, DELETE, etc.
+          });`,
+        )
+      })
+
+      cy.wait('@create', { timeout: 500 })
+    })
+
     // @see https://github.com/cypress-io/cypress/issues/15901
     it('can intercept utf-8 request bodies without crashing', function () {
       cy.intercept('POST', 'http://localhost:5000/api/sample')

--- a/packages/net-stubbing/lib/server/driver-events.ts
+++ b/packages/net-stubbing/lib/server/driver-events.ts
@@ -73,7 +73,7 @@ async function sendStaticResponse (state: NetStubbingState, getFixture: GetFixtu
 
   await setResponseFromFixture(getFixture, options.staticResponse)
 
-  _sendStaticResponse(request, options.staticResponse)
+  await _sendStaticResponse(request, options.staticResponse)
 }
 
 export function _restoreMatcherOptionsTypes (options: AnnotatedRouteMatcherOptions) {

--- a/packages/net-stubbing/lib/server/intercepted-request.ts
+++ b/packages/net-stubbing/lib/server/intercepted-request.ts
@@ -194,7 +194,7 @@ export class InterceptedRequest {
           }
 
           if (immediateStaticResponse) {
-            sendStaticResponse(this, immediateStaticResponse)
+            await sendStaticResponse(this, immediateStaticResponse)
 
             return data
           }

--- a/packages/net-stubbing/lib/server/middleware/response.ts
+++ b/packages/net-stubbing/lib/server/middleware/response.ts
@@ -79,7 +79,7 @@ export const InterceptResponse: ResponseMiddleware = async function () {
 
   mergeChanges(request.res as any, modifiedRes)
 
-  const bodyStream = getBodyStream(modifiedRes.body, _.pick(modifiedRes, ['throttleKbps', 'delay']) as any)
+  const bodyStream = await getBodyStream(modifiedRes.body, _.pick(modifiedRes, ['throttleKbps', 'delay']) as any)
 
   return request.continueResponse!(bodyStream)
 }


### PR DESCRIPTION
- Closes #15188

### User facing changelog

`delay` now works correctly with the `statusCode: 204`.

### Additional details
- Why was this change necessary? => `delay` didn't work correctly with `statusCode: 204`. 
- What is affected by this change? => N/A
- Any implementation details to explain? => It was happening because of `setTimeout` inside the [`getBodyStream`](https://github.com/cypress-io/cypress/blob/20de3e585fad675cb4abbd9a4764fa1c95e11a2a/packages/net-stubbing/lib/server/util.ts#L198-L226). It is called after the delay [when response is not an empty body but it isn't when it's not](https://github.com/cypress-io/cypress/blob/20de3e585fad675cb4abbd9a4764fa1c95e11a2a/packages/net-stubbing/lib/server/middleware/response.ts#L48-L54). I fixed this by changing `getBodyStream` as `async`.

### How has the user experience changed?

N/A

### PR Tasks
- [x] Have tests been added/updated?
