### PR TITLE
fix: `times` of `cy.intercept` doesn't work correctly with `req.continue`

### DIFF
--- a/packages/driver/cypress/fixtures/request.html
+++ b/packages/driver/cypress/fixtures/request.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="text/javascript" src="/node_modules/jquery/dist/jquery.js"></script>
+  </head>
+  <body>
+    <button id="request">request</button>
+    <div id="result"></div>
+    <script type="text/javascript">
+      $(function(){
+        $("button#request").click(function(){
+          $.ajax({
+            method: "POST",
+            url: "/post-only",
+            data: JSON.stringify({client: 'data'})
+          })
+          .then((data) => {
+            $('#result').text(data)
+          })
+        })
+      })
+    </script>
+  </body>
+</html>

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -2129,6 +2129,29 @@ describe('network stubbing', { retries: 2 }, function () {
           .get('@3.all').should('have.length', 2)
           .get('@4.all').should('have.length', 3)
         })
+
+        context('stopPropagation: true', () => {
+          it('works with continue', () => {
+            cy.intercept({
+              method: 'POST',
+              times: 1,
+              url: '/post-only',
+            },
+            (req) => {
+              req.continue((res) => {
+                res.body = 'stubbed data'
+              })
+            }).as('interceptor')
+
+            cy.visit('fixtures/request.html')
+
+            cy.get('#request').click()
+            cy.get('#result').should('contain', 'stubbed data')
+
+            cy.get('#request').click()
+            cy.get('#result').should('contain', 'client')
+          })
+        })
       })
     })
 

--- a/packages/net-stubbing/lib/server/intercepted-request.ts
+++ b/packages/net-stubbing/lib/server/intercepted-request.ts
@@ -180,7 +180,7 @@ export class InterceptedRequest {
           await handleSubscription(subscription)
 
           if (stopPropagationNow) {
-            break outerLoop
+            break
           }
         }
 
@@ -198,6 +198,10 @@ export class InterceptedRequest {
 
             return data
           }
+        }
+
+        if (stopPropagationNow) {
+          break outerLoop
         }
       }
     }


### PR DESCRIPTION
- Closes #16821

### User facing changelog

The `times` option of the `cy.intercept`  works correctly with `req.continue`.

### Additional details
- Why was this change necessary? => `times` option should work correctly with `req.continue()`
- What is affected by this change? => N/A
- Any implementation details to explain? => Because of [`break outerLoop` here](https://github.com/cypress-io/cypress/blob/85a4cf69919707e936bee9a9aee22a53627d38bf/packages/net-stubbing/lib/server/intercepted-request.ts#L183), the `times` check code below wasn't executed. 

### How has the user experience changed?

N/A

### Note

`times` also doesn't work with `req.reply`. I tried to fix it but it breaks the current tests and it would enlarge this PR. So, I decided to open [an issue about it](https://github.com/cypress-io/cypress/issues/17139) and tackle it later. 

### PR Tasks
- [x] Have tests been added/updated?