### PR TITLE
fix: plugin file in angular schematics

### DIFF
--- a/npm/cypress-schematic/src/schematics/ng-add/files/cypress/plugins/index.ts
+++ b/npm/cypress-schematic/src/schematics/ng-add/files/cypress/plugins/index.ts
@@ -1,2 +1,3 @@
 // Plugins enable you to tap into, modify, or extend the internal behavior of Cypress
 // For more info, visit https://on.cypress.io/plugins-api
+module.exports = (on, config) => {}


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->

### Additional details

Running `ng add @cypress/schematic --defaults --skip-confirmation` in a new Angular 12 application results in a broken setup for cypress,
as the plugin file does not have any export.

When running `ng e2e`, Cypress complains with:

```
The plugins file is missing or invalid.

Your `pluginsFile` is set to `/Users/ced-pro/Code/angular/angular-cli-diff/ponyracer/cypress/plugins/index.js`, but either the file is missing, it contains a syntax error, or threw an error when required. The `pluginsFile` must be a `.js`, `.ts`, or `.coffee` file.

Or you might have renamed the extension of your `pluginsFile`. If that's the case, restart the test runner.

Please fix this, or set `pluginsFile` to `false` if a plugins file is not necessary for your project.
```

This commit reverts the changes to the plugin file made in 96a9db4204f50a7605a5e51d51584d27aa9df164
and fixes the issue.
