### PR TITLE
fix: plugin file referenced by cypress config in angular schematics

### DIFF
--- a/npm/cypress-schematic/src/schematics/ng-add/files/cypress.json
+++ b/npm/cypress-schematic/src/schematics/ng-add/files/cypress.json
@@ -3,7 +3,7 @@
   "supportFile": "<%= root%>cypress/support/index.ts",
   "videosFolder": "<%= root%>cypress/videos",
   "screenshotsFolder": "<%= root%>cypress/screenshots",
-  "pluginsFile": "<%= root%>cypress/plugins/index.js",
+  "pluginsFile": "<%= root%>cypress/plugins/index.ts",
   "fixturesFolder": "<%= root%>cypress/fixtures",
   "baseUrl": "<%= baseUrl%>"
 }


### PR DESCRIPTION
The fix in #17141 was not enough as `cypress.json` references `plugins/index.js` whereas it generates `plugins/index.ts`