### PR TITLE
chore: don't restore node_modules for binary tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -89,6 +89,11 @@ commands:
           at: ~/
       - unpack-dependencies
 
+  restore_cached_binary:
+    steps:
+      - attach_workspace:
+          at: ~/
+
   prepare-modules-cache:
     parameters:
       dont-move:
@@ -462,7 +467,7 @@ commands:
         description: "Name of the github repo to clone like: cypress-example-kitchensink"
         type: string
     steps:
-      - restore_cached_workspace
+      - restore_cached_binary
       - run:
           name: "Cloning test project: <<parameters.repo>>"
           command: |


### PR DESCRIPTION
### Additional details

Skips restoring the `node_modules` when restoring the binary for binary tests. This both improves CI time and helps avoid issues where the node resolution would incorrectly resolve a module from a parent `node_modules`.