### PR TITLE
fix: update subject when traversing object (for `cy.invoke`)

### DIFF
--- a/packages/driver/cypress/integration/commands/connectors_spec.js
+++ b/packages/driver/cypress/integration/commands/connectors_spec.js
@@ -934,7 +934,7 @@ describe('src/cy/commands/connectors', () => {
               Command: 'invoke',
               Function: '.math.sum(1, 2, 3)',
               'With Arguments': [1, 2, 3],
-              Subject: this.obj,
+              Subject: this.obj['math'],
               Yielded: 6,
             })
           })

--- a/packages/driver/cypress/integration/issues/3871_spec.js
+++ b/packages/driver/cypress/integration/issues/3871_spec.js
@@ -1,0 +1,58 @@
+// https://github.com/cypress-io/cypress/issues/3871
+describe(`issue 3871 - Cypress invoke`, () => {
+  it(`should work on not nested properties`, () => {
+    cy.window().then((win) => {
+      win.val = 40
+      win.get = function () {
+        return this.val
+      }
+
+      cy.window().invoke(`get`).should(`eq`, 40)
+    })
+  })
+
+  it(`should work on 1 level nested properties`, () => {
+    cy.window().then((win) => {
+      win.obj = {
+        val: 41,
+        get () {
+          return this.val
+        },
+      }
+
+      cy.window().invoke(`obj.get`).should(`eq`, 41)
+    })
+  })
+
+  it(`should work on 2 level nested properties`, () => {
+    cy.window().then((win) => {
+      win.obj = {
+        innerObj: {
+          val: 42,
+          get () {
+            return this.val
+          },
+        },
+      }
+
+      cy.window().invoke(`obj.innerObj.get`).should(`eq`, 42)
+    })
+  })
+
+  it(`should work on 3 level nested properties`, () => {
+    cy.window().then((win) => {
+      win.obj = {
+        innerObj: {
+          innerInnerObj: {
+            val: 43,
+            get () {
+              return this.val
+            },
+          },
+        },
+      }
+
+      cy.window().invoke(`obj.innerObj.innerInnerObj.get`).should(`eq`, 43)
+    })
+  })
+})


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/3871

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->
`cy.invoke` improved/fixed to work on nested objects 


### How has the user experience changed?
users can now use `cy.invoke` and obtain the result they expected even when providing nested paths

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
