### PR TITLE
fix: `res.send` of `cy.intercept` doesn't override json-related content types. 

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -2652,6 +2652,30 @@ describe('network stubbing', { retries: 2 }, function () {
       .wait('@get')
     })
 
+    // https://github.com/cypress-io/cypress/issues/17084
+    it('does not overwrite the json-related content-type header', () => {
+      cy.intercept('/json-content-type', (req) => {
+        req.on('response', (res) => {
+          res.send({
+            statusCode: 500,
+            headers: {
+              'content-type': 'application/problem+json',
+              'access-control-allow-origin': '*',
+            },
+            body: {
+              status: 500,
+              title: 'Internal Server Error',
+            },
+          })
+        })
+      })
+
+      fetch('/json-content-type')
+      .then((res) => {
+        expect(res.headers.get('content-type')).to.eq('application/problem+json')
+      })
+    })
+
     context('body parsing', function () {
       [
         'application/json',

--- a/packages/driver/src/cy/net-stubbing/events/response.ts
+++ b/packages/driver/src/cy/net-stubbing/events/response.ts
@@ -75,7 +75,14 @@ export const onResponse: HandlerFn<CyHttpMessages.IncomingResponse> = async (Cyp
         // arguments to res.send() are merged with the existing response
         const _staticResponse = _.defaults({}, staticResponse, _.pick(res, STATIC_RESPONSE_KEYS))
 
-        _.defaults(_staticResponse.headers, res.headers)
+        _staticResponse.headers = _.defaults({}, _staticResponse.headers, res.headers)
+
+        // https://github.com/cypress-io/cypress/issues/17084
+        // When a user didn't provide content-type,
+        // we remove the content-type provided by the server
+        if (!staticResponse.headers || !staticResponse.headers['content-type']) {
+          delete _staticResponse.headers['content-type']
+        }
 
         sendStaticResponse(requestId, _staticResponse)
 

--- a/packages/driver/src/cy/net-stubbing/static-response-utils.ts
+++ b/packages/driver/src/cy/net-stubbing/static-response-utils.ts
@@ -6,7 +6,6 @@ import {
   FixtureOpts,
 } from '@packages/net-stubbing/lib/types'
 import {
-  caseInsensitiveGet,
   caseInsensitiveHas,
 } from '@packages/net-stubbing/lib/util'
 import $errUtils from '../../cypress/error_utils'
@@ -120,9 +119,9 @@ export function getBackendStaticResponse (staticResponse: Readonly<StaticRespons
       // There are various json-related MIME types. We cannot simply set it as `application/json`.
       // @see https://www.iana.org/assignments/media-types/media-types.xhtml
       if (
-        !(backendStaticResponse.headers &&
-          caseInsensitiveHas(backendStaticResponse.headers, 'content-type') &&
-          caseInsensitiveGet(backendStaticResponse.headers, 'content-type').includes('json'))
+        !backendStaticResponse.headers ||
+        (backendStaticResponse.headers &&
+          !caseInsensitiveHas(backendStaticResponse.headers, 'content-type'))
       ) {
         _.set(backendStaticResponse, 'headers.content-type', 'application/json')
       }

--- a/packages/driver/src/cy/net-stubbing/static-response-utils.ts
+++ b/packages/driver/src/cy/net-stubbing/static-response-utils.ts
@@ -112,7 +112,16 @@ export function getBackendStaticResponse (staticResponse: Readonly<StaticRespons
       backendStaticResponse.body = staticResponse.body
     } else {
       backendStaticResponse.body = JSON.stringify(staticResponse.body)
-      _.set(backendStaticResponse, 'headers.content-type', 'application/json')
+
+      // There are various json-related MIME types. We cannot simply set it as `application/json`.
+      // @see https://www.iana.org/assignments/media-types/media-types.xhtml
+      if (
+        !(backendStaticResponse.headers &&
+        backendStaticResponse.headers['content-type'] &&
+        backendStaticResponse.headers['content-type'].includes('json'))
+      ) {
+        _.set(backendStaticResponse, 'headers.content-type', 'application/json')
+      }
     }
   }
 

--- a/packages/driver/src/cy/net-stubbing/static-response-utils.ts
+++ b/packages/driver/src/cy/net-stubbing/static-response-utils.ts
@@ -10,6 +10,16 @@ import $errUtils from '../../cypress/error_utils'
 // user-facing StaticResponse only
 export const STATIC_RESPONSE_KEYS: (keyof StaticResponse)[] = ['body', 'fixture', 'statusCode', 'headers', 'forceNetworkError', 'throttleKbps', 'delay', 'delayMs']
 
+function caseInsensitiveHas (obj, lowercaseProperty) {
+  for (let key of Object.keys(obj)) {
+    if (key.toLowerCase() === lowercaseProperty) {
+      return true
+    }
+  }
+
+  return false
+}
+
 export function validateStaticResponse (cmd: string, staticResponse: StaticResponse): void {
   const err = (message) => {
     $errUtils.throwErrByPath('net_stubbing.invalid_static_response', { args: { cmd, message, staticResponse } })
@@ -115,11 +125,7 @@ export function getBackendStaticResponse (staticResponse: Readonly<StaticRespons
 
       // There are various json-related MIME types. We cannot simply set it as `application/json`.
       // @see https://www.iana.org/assignments/media-types/media-types.xhtml
-      if (
-        !(backendStaticResponse.headers &&
-        backendStaticResponse.headers['content-type'] &&
-        backendStaticResponse.headers['content-type'].includes('json'))
-      ) {
+      if (backendStaticResponse.headers && !caseInsensitiveHas(backendStaticResponse.headers, 'content-type')) {
         _.set(backendStaticResponse, 'headers.content-type', 'application/json')
       }
     }

--- a/packages/driver/src/cy/net-stubbing/static-response-utils.ts
+++ b/packages/driver/src/cy/net-stubbing/static-response-utils.ts
@@ -5,20 +5,14 @@ import {
   BackendStaticResponseWithArrayBuffer,
   FixtureOpts,
 } from '@packages/net-stubbing/lib/types'
+import {
+  caseInsensitiveGet,
+  caseInsensitiveHas,
+} from '@packages/net-stubbing/lib/util'
 import $errUtils from '../../cypress/error_utils'
 
 // user-facing StaticResponse only
 export const STATIC_RESPONSE_KEYS: (keyof StaticResponse)[] = ['body', 'fixture', 'statusCode', 'headers', 'forceNetworkError', 'throttleKbps', 'delay', 'delayMs']
-
-function caseInsensitiveHas (obj, lowercaseProperty) {
-  for (let key of Object.keys(obj)) {
-    if (key.toLowerCase() === lowercaseProperty) {
-      return true
-    }
-  }
-
-  return false
-}
 
 export function validateStaticResponse (cmd: string, staticResponse: StaticResponse): void {
   const err = (message) => {
@@ -125,7 +119,11 @@ export function getBackendStaticResponse (staticResponse: Readonly<StaticRespons
 
       // There are various json-related MIME types. We cannot simply set it as `application/json`.
       // @see https://www.iana.org/assignments/media-types/media-types.xhtml
-      if (backendStaticResponse.headers && !caseInsensitiveHas(backendStaticResponse.headers, 'content-type')) {
+      if (
+        !(backendStaticResponse.headers &&
+          caseInsensitiveHas(backendStaticResponse.headers, 'content-type') &&
+          caseInsensitiveGet(backendStaticResponse.headers, 'content-type').includes('json'))
+      ) {
         _.set(backendStaticResponse, 'headers.content-type', 'application/json')
       }
     }

--- a/packages/net-stubbing/lib/server/util.ts
+++ b/packages/net-stubbing/lib/server/util.ts
@@ -16,6 +16,7 @@ import ThrottleStream from 'throttle'
 import MimeTypes from 'mime-types'
 import { CypressIncomingRequest } from '@packages/proxy'
 import { InterceptedRequest } from './intercepted-request'
+import { caseInsensitiveGet, caseInsensitiveHas } from '../util'
 
 // TODO: move this into net-stubbing once cy.route is removed
 import { parseContentType } from '@packages/server/lib/controllers/xhrs'
@@ -77,24 +78,6 @@ function _getFakeClientResponse (opts: {
   _.merge(clientResponse, opts)
 
   return clientResponse
-}
-
-const caseInsensitiveGet = function (obj, lowercaseProperty) {
-  for (let key of Object.keys(obj)) {
-    if (key.toLowerCase() === lowercaseProperty) {
-      return obj[key]
-    }
-  }
-}
-
-const caseInsensitiveHas = function (obj, lowercaseProperty) {
-  for (let key of Object.keys(obj)) {
-    if (key.toLowerCase() === lowercaseProperty) {
-      return true
-    }
-  }
-
-  return false
 }
 
 export function setDefaultHeaders (req: CypressIncomingRequest, res: IncomingMessage) {

--- a/packages/net-stubbing/lib/util.ts
+++ b/packages/net-stubbing/lib/util.ts
@@ -1,0 +1,17 @@
+export const caseInsensitiveGet = function (obj, lowercaseProperty) {
+  for (let key of Object.keys(obj)) {
+    if (key.toLowerCase() === lowercaseProperty) {
+      return obj[key]
+    }
+  }
+}
+
+export const caseInsensitiveHas = function (obj, lowercaseProperty) {
+  for (let key of Object.keys(obj)) {
+    if (key.toLowerCase() === lowercaseProperty) {
+      return true
+    }
+  }
+
+  return false
+}


### PR DESCRIPTION
- Closes #17084

### User facing changelog

`res.send` of `cy.intercept` doesn't override json-related content types. 

### Additional details
- Why was this change necessary? => There are a lot of [json-related MIME types](https://www.iana.org/assignments/media-types/media-types.xhtml). But `res.send` only allows `application/json`. 
- What is affected by this change? => N/A
- Any implementation details to explain? => I checked to set `content-type` to `application/json` only when `content-type` doesn't have the text, `json`.

### How has the user experience changed?

N/A

### PR Tasks
- [x] Have tests been added/updated?