### PR TITLE
chore: fix mac build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ macBuildFilters: &macBuildFilters
     branches:
       only:
         - develop
+        - tgriesser/fix/mac-build
 
 defaults: &defaults
   parallelism: 1

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -11,6 +11,8 @@
     "entitlementsInherit": "./scripts/entitlements.mac.inherit.plist",
     "type": "distribution",
     "binaries": [
+      "./build/mac/Cypress.app/Contents/Resources/app/packages/server/node_modules/babel-plugin-add-module-exports/node_modules/fsevents/build/Release/.node",
+      "./build/mac/Cypress.app/Contents/Resources/app/packages/server/node_modules/babel-plugin-add-module-exports/node_modules/fsevents/build/Release/fse.node",
       "./build/mac/Cypress.app/Contents/Resources/app/packages/server/node_modules/@ffmpeg-installer/darwin-x64/ffmpeg",
       "./build/mac/Cypress.app/Contents/Resources/app/packages/server/node_modules/watchpack-chokidar2/node_modules/fsevents/build/Release/.node",
       "./build/mac/Cypress.app/Contents/Resources/app/packages/server/node_modules/watchpack-chokidar2/node_modules/fsevents/build/Release/fse.node",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -205,6 +205,7 @@
     ]
   },
   "optionalDependencies": {
+    "fsevents": "^2",
     "registry-js": "1.15.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19652,7 +19652,7 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
-fsevents@^2.1.2, fsevents@~2.3.1:
+fsevents@^2, fsevents@^2.1.2, fsevents@~2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==


### PR DESCRIPTION
### Additional details

- Adds missing fsevents binaries
- Adds `fsevents` to optionalDependencies to ensure hoisting within package
