### PR TITLE
fix: improve React `mountHook` type

### DIFF
--- a/npm/react/src/mountHook.ts
+++ b/npm/react/src/mountHook.ts
@@ -1,9 +1,22 @@
 import * as React from 'react'
+
 import { mount } from './mount'
+
+type MountHookResult<T> = {
+  readonly current: T | null | undefined
+  readonly error: Error | null
+}
+
+type ResultContainer<T> = {
+  result: MountHookResult<T>
+  addResolver: (resolver: () => void) => void
+  setValue: (val: T) => void
+  setError: (err: Error) => void
+}
 
 // mounting hooks inside a test component mostly copied from
 // https://github.com/testing-library/react-hooks-testing-library/blob/master/src/pure.js
-function resultContainer<T> () {
+function resultContainer<T> (): ResultContainer<T> {
   let value: T | undefined | null = null
   let error: Error | null = null
   const resolvers: any[] = []
@@ -29,7 +42,7 @@ function resultContainer<T> () {
 
   return {
     result,
-    addResolver: (resolver: any) => {
+    addResolver: (resolver: (() => void)) => {
       resolvers.push(resolver)
     },
     setValue: (val: T) => updateResult(val),
@@ -54,28 +67,25 @@ function TestHook ({ callback, onError, children }: TestHookProps) {
     }
   }
 
-  // TODO decide what the test hook component should show
-  // maybe nothing, or maybe useful information about the hook?
-  // maybe its current properties?
-  // return <div>TestHook</div>
   return null
 }
 
 /**
  * Mounts a React hook function in a test component for testing.
  *
- * @see https://github.com/bahmutov/@cypress/react#advanced-examples
  */
-export const mountHook = (hookFn: (...args: any[]) => any) => {
-  const { result, setValue, setError } = resultContainer()
+export const mountHook = <T>(hookFn: (...args: any[]) => T) => {
+  const { result, setValue, setError } = resultContainer<T>()
 
-  return mount(
-    React.createElement(TestHook, {
-      callback: hookFn,
-      onError: setError,
-      children: setValue,
-    }),
-  ).then(() => {
+  const componentTest: React.ReactElement = React.createElement(TestHook, {
+    callback: hookFn,
+    onError: setError,
+    children: setValue,
+  })
+
+  return mount(componentTest).then(() => {
     cy.wrap(result)
+
+    return result
   })
 }

--- a/npm/react/src/mountHook.ts
+++ b/npm/react/src/mountHook.ts
@@ -59,8 +59,8 @@ type TestHookProps = {
 function TestHook ({ callback, onError, children }: TestHookProps) {
   try {
     children(callback())
-  } catch (err) {
-    if (err.then) {
+  } catch (err: any) {
+    if ('then' in err) {
       throw err
     } else {
       onError(err)
@@ -83,9 +83,5 @@ export const mountHook = <T>(hookFn: (...args: any[]) => T) => {
     children: setValue,
   })
 
-  return mount(componentTest).then(() => {
-    cy.wrap(result)
-
-    return result
-  })
+  return mount(componentTest).then(() => result)
 }


### PR DESCRIPTION
- Closes #17236

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->
Cypress React mount hook have correct types . Fixes #17236.

### How has the user experience changed?
Improved types (example on `use-counter.spec.js`
**Before**
![image](https://user-images.githubusercontent.com/2922851/124838289-cf368300-df86-11eb-9366-19eb2df59e47.png)

**After**
![image](https://user-images.githubusercontent.com/2922851/124838334-e5dcda00-df86-11eb-8824-3ad65e73db9e.png)


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated? _Should I add tests ?_
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? _None for the moment, but as I see, there is not documentation about the `mountHook` function_