### PR TITLE
fix(vite): autorefresh new spec files

### DIFF
--- a/npm/vite-dev-server/src/makeCypressPlugin.ts
+++ b/npm/vite-dev-server/src/makeCypressPlugin.ts
@@ -21,15 +21,28 @@ const INIT_FILEPATH = resolve(__dirname, '../client/initCypressTests.js')
 
 const HMR_DEPENDENCY_LOOKUP_MAX_ITERATION = 50
 
+function getSpecsSet (specs: Spec[]) {
+  return new Set<string>(specs.map((spec) => spec.absolute))
+}
+
+interface Spec{
+  absolute: string
+  relative: string
+}
+
 export const makeCypressPlugin = (
   projectRoot: string,
   supportFilePath: string,
   devServerEvents: EventEmitter,
-  specs: {absolute: string, relative: string}[],
+  specs: Spec[],
 ): Plugin => {
   let base = '/'
 
-  const specsPathsSet = new Set<string>(specs.map((spec) => spec.absolute))
+  let specsPathsSet = getSpecsSet(specs)
+
+  devServerEvents.on('dev-server:specs:changed', (specs: Spec[]) => {
+    specsPathsSet = getSpecsSet(specs)
+  })
 
   const posixSupportFilePath = supportFilePath ? convertPathToPosix(resolve(projectRoot, supportFilePath)) : undefined
 


### PR DESCRIPTION
### User facing changelog

When adding a new spec file in vite-dev-server to run, the server is suppose to re-run the tests when making a change to it. 
Previously, it was only done with files existing at startup. Now, the list of files updates.

### Reproduction

- open cypress open ct in vitejs. In this repo, the simplest is to do the following.

```node
cd npm/vite-dev-server
yarn cy:open
```

- Open one of the spec files in Cypress, open the same file in vscode
- Change the file in vscode
- It will re-run the current spec (expected)

- Now add a new spec file (a file named `npm/vite-dev-server/cypress/components/test.spec.js`)
- The file appears in Cypress
- Click on it to open it
- Now add a test in this new file and save
- BUG: The file should be re-run and is simply left alone
- FIXED: The file now re-runs