### PR TITLE
docs: Add README for some newly added packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Each line is a file pattern followed by one or more owners.
 
-# Test Runner team are owners of code within root packages and cli
+# Test Runner team are owners of code within root packages concerning e2e, cli, and other utils
+/.github/  @cypress-io/test-runner
 /browser-versions.json  @cypress-io/test-runner
 /cli/  @cypress-io/test-runner
 /packages/coffee/  @cypress-io/test-runner
@@ -19,9 +20,11 @@
 /packages/rewriter/  @cypress-io/test-runner
 /packages/root/  @cypress-io/test-runner
 /packages/runner/  @cypress-io/test-runner
+/packages/runner-shared/  @cypress-io/test-runner
 /packages/server/  @cypress-io/test-runner
 /packages/socket/  @cypress-io/test-runner
 /packages/static/  @cypress-io/test-runner
 /packages/ts/  @cypress-io/test-runner
 /packages/ui-components/  @cypress-io/test-runner
 /packages/web-config/  @cypress-io/test-runner
+/scripts/  @cypress-io/test-runner

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,11 +282,13 @@ Here is a list of the core packages in this repository with a short description,
  | [reporter](./packages/reporter)       | `@packages/reporter`    | The reporter shows the running results of the tests (The Command Log UI).    |
  | [root](./packages/root)               | `@packages/root`        | Dummy package pointing at the root of the repository.                        |
  | [runner](./packages/runner)           | `@packages/runner`      | The runner is the minimal "chrome" around the user's application under test. |
+ | [runner-ct](./packages/runner-ct)           | `@packages/runner-ct`      | The runner for component testing |
+ | [runner-shared](./packages/runner-shared)           | `@packages/runner-shared`      | The shared components between the `runner` and the `runner-ct` packages |
  | [server](./packages/server)           | `@packages/server`      | The <3 of Cypress. This orchestrates everything. The backend node process.   |
  | [socket](./packages/socket)           | `@packages/socket`      | A wrapper around socket.io to provide common libraries.                      |
  | [static](./packages/static)           | `@packages/static`      | Serves static assets used in the Cypress GUI.                                |
  | [ts](./packages/ts)                   | `@packages/ts`          | A centralized version of typescript.                                         |
- 
+
 Public packages live within the [`npm`](./npm) folder and are standalone modules that get independently published to npm under the `@cypress/` namespace. These packages generally contain extensions, plugins, or other packages that are complementary to, yet independent of, the main Cypress app.
 
 Here is a list of the npm packages in this repository:

--- a/packages/runner-ct/README.md
+++ b/packages/runner-ct/README.md
@@ -1,0 +1,45 @@
+# Runner CT
+
+The runner-ct is where the code for the component testing's runner lives and has the following responsibilities:
+
+- Displaying the component specs list and all states around that in the runner
+
+## Developing
+
+### Watching
+
+This watches and compiles all changes as you make them.
+
+```bash
+yarn workspace @packages/runner-ct watch
+```
+
+## Building
+
+### For development
+
+```bash
+yarn workspace @packages/runner-ct build
+```
+
+### For production
+
+```bash
+yarn workspace @packages/runner-ct build-prod
+```
+
+## Testing
+
+### Cypress Tests
+
+You can run Cypress tests found in [`cypress/component`](./cypress/component):
+
+```bash
+yarn workspace @packages/runner-ct cypress:open
+```
+
+To watch and reload changes to the runner while testing you'll want to run:
+
+```bash
+yarn workspace @packages/runner-ct watch
+```

--- a/packages/runner-shared/README.md
+++ b/packages/runner-shared/README.md
@@ -1,0 +1,20 @@
+# Runner Shared
+
+The runner-shared contains the shared components between the `runner` (use for  end-to-end testing) and the `runner-ct` (used for component testing) including:
+
+- Shared empty states
+- Shared error states
+- Containers, headers and iframe components
+- Selector playground and Cypress Studio
+
+## Developing
+
+The components are imported to the [`runner`](../runner/README.md#Developing)  and `runner-ct` packages respectively. Please see their instructions for develoment.
+
+## Testing
+
+### Unit Tests
+
+```bash
+yarn workspace @packages/runner-shared test
+```

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -2,7 +2,7 @@
 
 ![Runner](https://cloud.githubusercontent.com/assets/1157043/17947042/e9352ae2-6a18-11e6-85af-3670c7cfba03.png)
 
-The runner is the minimal "chrome" around the user's app and has the following responsibilities:
+The runner is the minimal "chrome" around the user's app for end-to-end testing and has the following responsibilities:
 
 - Managing communication between the driver, the reporter, the extension, and the server
 - Managing the viewport size and scale


### PR DESCRIPTION
- Add README for runner-shared and runner-ct packages
- Update codeowners so e2e team is reequested for review on changes to runner-shared, .github, and scripts

### Additional Details

We want to ensure all newly added packages are properly documented for open source contributors and our own team by adding a README that describes:

- What the package does.
- How to work within the package to watch files and run tests.
- Any other necessary info. 

For a good example, see the [reporter/README.md](https://github.com/cypress-io/cypress/tree/develop/packages/reporter).
