### PR TITLE
chore: Update config with correct yml [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,42 +1,12 @@
-name: "🐛 Bug report"
-description: Report a bug found while using Cypress.
-body:
-  - type: markdown
-    attributes:
-      value: |
-        Have a question? 👉 [Start a new discussion](https://github.com/cypress-io/cypress/discussions) or [ask in chat](https://on.cypress.io/discord).
-  - type: textarea
-    id: current-behavior
-    attributes:
-      label: Current behavior
-      description: A description including screenshots, stack traces, DEBUG logs, etc. [Troubleshooting tips](https://on.cypress.io/troubleshooting).
-      placeholder: Currently...
-    validations:
-      required: true
-  - type: textarea
-    id: desired-behavior
-    attributes:
-      label: Desired behavior
-      description: Remember, we're not familiar with the app you're testing, so please provide a clear description of what should happen.
-      placeholder: In this situation, Cypress should...
-  - type: textarea
-    id: reproduction
-    attributes:
-      label: Test code to reproduce
-      description: Provide a failing test or repo we can run. You can fork [this repo](https://github.com/cypress-io/cypress-test-tiny), set up a failing test, then link to your fork.
-      placeholder: Here is my failing test code and the app code to run the tests on...
-    validations:
-      required: true
-  - type: input
-    id: version
-    attributes:
-      label: Cypress Version
-      description: Run `cypress version` to see your current version. If possible, please update Cypress to the latest version first.
-      placeholder: ex. 7.6.0
-    validations:
-      required: true
-  - type: textarea
-    id: othter
-    attributes:
-      label: Other
-      placeholder: Any other details?
+blank_issues_enabled: false
+contact_links:
+  - name: 🤔 Questions and Help
+    url: https://github.com/cypress-io/cypress/discussions
+    about: This issue tracker is not for support questions. Please refer to our Discussions.
+  - name: 💬 Chat
+    url: https://on.cypress.io/discord
+    about: Want to discuss Cypress with others? Check out our chat.
+  - name: 📃 Documentation Issue
+    url: https://github.com/cypress-io/cypress-documentation/issues/new
+    about: This issue tracker is not for documentation issues. Please open documentation issues here.
+


### PR DESCRIPTION
I had the completely wrong yml in the config.yml so the issue template chooser options not being shown properly. 