### PR TITLE
chore(tests): update e2e tests to not visit live sites

### DIFF
--- a/packages/server/test/e2e/5_stdout_spec.js
+++ b/packages/server/test/e2e/5_stdout_spec.js
@@ -1,7 +1,24 @@
 const e2e = require('../support/helpers/e2e').default
 
 describe('e2e stdout', () => {
-  e2e.setup()
+  e2e.setup({
+    servers: [{
+      port: 1777,
+      https: true,
+      onServer: (app) => {
+        app.get('/', (req, res) => {
+          res.set('content-type', 'text/html').end('it worked')
+        })
+      },
+    }],
+    settings: {
+      hosts: {
+        'www.google.com': '127.0.0.1',
+        'www.apple.com': '127.0.0.1',
+        '*.cypress.io': '127.0.0.1',
+      },
+    },
+  })
 
   it('displays errors from failures', function () {
     return e2e.exec(this, {

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/stdout_passing_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/stdout_passing_spec.js
@@ -26,6 +26,12 @@ describe('stdout_passing_spec', () => {
     it('cypress1', () => {})
 
     it('visits cypress', () => {
+      cy.on('uncaught:exception', () => {
+        // cypress.io currently throws an uncaught exception
+        // TODO: remove this
+        return false
+      })
+
       cy.visit('https://www.cypress.io')
       cy.visit('https://docs.cypress.io')
     })

--- a/packages/server/test/support/fixtures/projects/e2e/cypress/integration/stdout_passing_spec.js
+++ b/packages/server/test/support/fixtures/projects/e2e/cypress/integration/stdout_passing_spec.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 describe('stdout_passing_spec', () => {
   context('file', () => {
     it('visits file', () => {
@@ -8,7 +7,7 @@ describe('stdout_passing_spec', () => {
 
   context('google', () => {
     it('visits google', () => {
-      cy.visit('https://www.google.com')
+      cy.visit('https://www.google.com:1777')
     })
 
     it('google2', () => {})
@@ -18,7 +17,7 @@ describe('stdout_passing_spec', () => {
     it('apple1', () => {})
 
     it('visits apple', () => {
-      cy.visit('https://www.apple.com')
+      cy.visit('https://www.apple.com:1777')
     })
   })
 
@@ -26,14 +25,8 @@ describe('stdout_passing_spec', () => {
     it('cypress1', () => {})
 
     it('visits cypress', () => {
-      cy.on('uncaught:exception', () => {
-        // cypress.io currently throws an uncaught exception
-        // TODO: remove this
-        return false
-      })
-
-      cy.visit('https://www.cypress.io')
-      cy.visit('https://docs.cypress.io')
+      cy.visit('https://www.cypress.io:1777')
+      cy.visit('https://docs.cypress.io:1777')
     })
 
     it('cypress3', () => {})


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog

N/A

### Additional details

cypress.io is throwing an unhandled exception due to an error in the cookielaw sdk, breaking some of our e2e tests. visit with adblocker disabled to see. this PR suppresses the error.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
