### PR TITLE
fix: Add link to whoops-cant-run-tests error documentation

### DIFF
--- a/packages/runner-shared/src/no-automation/index.jsx
+++ b/packages/runner-shared/src/no-automation/index.jsx
@@ -54,7 +54,7 @@ export const NoAutomation = ({ browsers, onLaunchBrowser }) => (
       <p>Whoops, we can't run your tests.</p>
       {browsers.length ? browserPicker(browsers, onLaunchBrowser) : noBrowsers()}
       <div className='helper-line'>
-        <a className='helper-docs-link' href='https://on.cypress.io/launching-browsers' target='_blank' rel='noreferrer'>
+        <a className='helper-docs-link' href='https://on.cypress.io/whoops-cant-run-tests' target='_blank' rel='noreferrer'>
           <i className='fas fa-question-circle'></i>
           {' Why am I seeing this message?'}
         </a>

--- a/packages/server/lib/html/non_proxied_error.html
+++ b/packages/server/lib/html/non_proxied_error.html
@@ -16,6 +16,12 @@
           <div>
             <p class="muted">This browser was not launched through Cypress. Tests cannot run.</p>
           </div>
+          <div className='helper-line'>
+            <a className='helper-docs-link' href='https://on.cypress.io/whoops-cant-run-tests' target='_blank' rel='noreferrer'>
+              <i className='fas fa-question-circle'></i>
+              Why am I seeing this message?
+            </a>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes DX-313

### User facing changelog
- Update "Whoops, we can't run your tests" error screens to link to updated documentation

### Related issues
- https://github.com/cypress-io/cypress-documentation/pull/4021
- https://github.com/cypress-io/cypress-services/pull/3901

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
