### PR TITLE
chore: add unique id to docs menu links

### DIFF
--- a/packages/desktop-gui/src/app/docs-menu.jsx
+++ b/packages/desktop-gui/src/app/docs-menu.jsx
@@ -50,6 +50,7 @@ const DocsMenu = observer(() => {
         utm_medium: 'Nav',
         utm_campaign: 'Docs',
       },
+      machineId: true,
     })
   }
 
@@ -88,6 +89,7 @@ const DocsMenu = observer(() => {
             utm_medium,
             utm_content: 'First Test',
           },
+          machineId: true,
         },
       }, {
         text: 'Testing your app',
@@ -97,6 +99,7 @@ const DocsMenu = observer(() => {
             utm_medium,
             utm_content: 'Testing Your App',
           },
+          machineId: true,
         },
       }],
     }, {
@@ -109,6 +112,7 @@ const DocsMenu = observer(() => {
             utm_medium,
             utm_content: 'Best Practices',
           },
+          machineId: true,
         },
       }, {
         text: 'Configuration',
@@ -118,6 +122,7 @@ const DocsMenu = observer(() => {
             utm_medium,
             utm_content: 'Configuration',
           },
+          machineId: true,
         },
       }, {
         text: 'API',
@@ -127,6 +132,7 @@ const DocsMenu = observer(() => {
             utm_medium,
             utm_content: 'API',
           },
+          machineId: true,
         },
       }],
     }, {
@@ -140,6 +146,7 @@ const DocsMenu = observer(() => {
             utm_medium,
             utm_content: 'Set Up CI',
           },
+          machineId: true,
         }),
       }, {
         text: 'Run tests faster',
@@ -149,6 +156,7 @@ const DocsMenu = observer(() => {
             utm_medium,
             utm_content: 'Parallelization',
           },
+          machineId: true,
         }),
       }],
     }]

--- a/packages/desktop-gui/src/prompts/prompts.jsx
+++ b/packages/desktop-gui/src/prompts/prompts.jsx
@@ -59,6 +59,7 @@ class CIPrompt1 extends Component {
             utm_campaign: 'Circle',
             utm_content: this.utm_content,
           },
+          machineId: true,
         },
       },
       {
@@ -71,6 +72,7 @@ class CIPrompt1 extends Component {
             utm_campaign: 'GitHub',
             utm_content: this.utm_content,
           },
+          machineId: true,
         },
       },
       {
@@ -83,6 +85,7 @@ class CIPrompt1 extends Component {
             utm_campaign: 'Bitbucket',
             utm_content: this.utm_content,
           },
+          machineId: true,
         },
       },
       {
@@ -95,6 +98,7 @@ class CIPrompt1 extends Component {
             utm_campaign: 'GitLab',
             utm_content: this.utm_content,
           },
+          machineId: true,
         },
       },
       {
@@ -107,6 +111,7 @@ class CIPrompt1 extends Component {
             utm_campaign: 'AWS',
             utm_content: this.utm_content,
           },
+          machineId: true,
         },
       },
     ]
@@ -129,6 +134,7 @@ class CIPrompt1 extends Component {
         utm_campaign: 'Other',
         utm_content: this.utm_content,
       },
+      machineId: true,
     })
   }
 
@@ -140,6 +146,7 @@ class CIPrompt1 extends Component {
         utm_campaign: 'Learn More',
         utm_content: this.utm_content,
       },
+      machineId: true,
     })
   }
 

--- a/packages/server/lib/gui/links.ts
+++ b/packages/server/lib/gui/links.ts
@@ -1,28 +1,36 @@
 import _ from 'lodash'
 import { shell } from 'electron'
+import { machineId } from '../util/machine_id'
 
 // NOTE: in order for query params to be passed through on links
 // forwardQueryParams: true must be set for that slug in the on package
 
 interface OpenExternalOptions {
   url: string
-  params: { [key: string]: string }
+  params?: { [key: string]: string }
+  machineId?: boolean
 }
 
-export const openExternal = (opts: OpenExternalOptions | string) => {
+export const openExternal = async (opts: OpenExternalOptions | string) => {
   if (_.isString(opts)) {
     return shell.openExternal(opts)
   }
 
   const url = new URL(opts.url)
 
-  if (opts.params) {
+  const params = opts.params || {}
+
+  if (opts.machineId && url.hostname === 'on.cypress.io') {
+    params.machine_id = await machineId()
+  }
+
+  if (params) {
     // just add the utm_source here so we don't have to duplicate it on every link
-    if (_.find(opts.params, (_val, key) => _.includes(key, 'utm_'))) {
-      opts.params.utm_source = 'Test Runner'
+    if (_.find(params, (_val, key) => _.includes(key, 'utm_'))) {
+      params.utm_source = 'Test Runner'
     }
 
-    url.search = new URLSearchParams(opts.params).toString()
+    url.search = new URLSearchParams(params).toString()
   }
 
   return shell.openExternal(url.href)

--- a/packages/server/test/unit/gui/links_spec.ts
+++ b/packages/server/test/unit/gui/links_spec.ts
@@ -6,10 +6,13 @@ import 'sinon-chai'
 import { shell } from 'electron'
 
 import { openExternal } from '../../../lib/gui/links'
+import machineId from '../../../lib/util/machine_id'
 
 describe('lib/gui/links', () => {
   beforeEach(() => {
     shell.openExternal = sinon.stub()
+
+    sinon.stub(machineId, 'machineId').resolves('machine-id')
   })
 
   afterEach(() => {
@@ -17,30 +20,62 @@ describe('lib/gui/links', () => {
   })
 
   it('opens urls passed as strings', () => {
-    openExternal('https://on.cypress.io/string-link')
-    expect(shell.openExternal).to.be.calledWith('https://on.cypress.io/string-link')
+    return openExternal('https://on.cypress.io/string-link')
+    .then(() => {
+      expect(shell.openExternal).to.be.calledWith('https://on.cypress.io/string-link')
+    })
   })
 
   it('appends get parameters', () => {
-    openExternal({
+    return openExternal({
       url: 'https://on.cypress.io/string-link',
       params: {
         search: 'term',
       },
+    }).then(() => {
+      expect(shell.openExternal).to.be.calledWith('https://on.cypress.io/string-link?search=term')
     })
-
-    expect(shell.openExternal).to.be.calledWith('https://on.cypress.io/string-link?search=term')
   })
 
   it('automatically adds utm_source if utm params are present', () => {
-    openExternal({
+    return openExternal({
       url: 'https://on.cypress.io/string-link',
       params: {
         utm_medium: 'GUI Tab',
         utm_campaign: 'Learn More',
       },
+    }).then(() => {
+      expect(shell.openExternal).to.be.calledWith('https://on.cypress.io/string-link?utm_medium=GUI+Tab&utm_campaign=Learn+More&utm_source=Test+Runner')
     })
+  })
 
-    expect(shell.openExternal).to.be.calledWith('https://on.cypress.io/string-link?utm_medium=GUI+Tab&utm_campaign=Learn+More&utm_source=Test+Runner')
+  it('adds machine id on request', () => {
+    return openExternal({
+      url: 'https://on.cypress.io/string-link',
+      machineId: true,
+    }).then(() => {
+      expect(shell.openExternal).to.be.calledWith('https://on.cypress.io/string-link?machine_id=machine-id')
+    })
+  })
+
+  it('adds machine id to existing parameters on request', () => {
+    return openExternal({
+      url: 'https://on.cypress.io/string-link',
+      params: {
+        search: 'term',
+      },
+      machineId: true,
+    }).then(() => {
+      expect(shell.openExternal).to.be.calledWith('https://on.cypress.io/string-link?search=term&machine_id=machine-id')
+    })
+  })
+
+  it('does not add machine id on request if opening link other than on.cypress.io', () => {
+    return openExternal({
+      url: 'https://example.com/string-link',
+      machineId: true,
+    }).then(() => {
+      expect(shell.openExternal).to.be.calledWith('https://example.com/string-link')
+    })
   })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes GROW-230

**SHOULD NOT BE MERGED UNTIL https://github.com/cypress-io/cypress-services/pull/3903 IS RELEASED**

### User facing changelog
No user facing changelog

### Additional details
Adds machine id to links coming from the docs menu and related prompts

Ideally this would be sent in a header or something but we can't do that when the user is sent to visit a page

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->