### PR TITLE
chore: Add 'Other' field to feature issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -36,7 +36,7 @@ body:
     validations:
       required: true
   - type: textarea
-    id: othter
+    id: other
     attributes:
       label: Other
       placeholder: Any other details?

--- a/.github/ISSUE_TEMPLATE/2-install-issue.yml
+++ b/.github/ISSUE_TEMPLATE/2-install-issue.yml
@@ -54,7 +54,7 @@ body:
     validations:
       required: true
   - type: textarea
-    id: othter
+    id: other
     attributes:
       label: Other
       placeholder: Any other details?

--- a/.github/ISSUE_TEMPLATE/3-feature.yml
+++ b/.github/ISSUE_TEMPLATE/3-feature.yml
@@ -20,7 +20,7 @@ body:
       description: Remember, we're not familiar with the app you're testing, so please provide a clear description of why this would be useful to your project. 
       placeholder: I want this because...
   - type: textarea
-    id: othter
+    id: other
     attributes:
       label: Other
       placeholder: Any other details?

--- a/.github/ISSUE_TEMPLATE/3-feature.yml
+++ b/.github/ISSUE_TEMPLATE/3-feature.yml
@@ -19,3 +19,8 @@ body:
       label: Why is this needed?
       description: Remember, we're not familiar with the app you're testing, so please provide a clear description of why this would be useful to your project. 
       placeholder: I want this because...
+  - type: textarea
+    id: othter
+    attributes:
+      label: Other
+      placeholder: Any other details?


### PR DESCRIPTION
I was adding a feature and I needed to add info that doesn’t really fit within the 2 textareas provided. 

All the other issue templates have an extra ‘Other’ field that’s likely good to add to the feature issue template also. 

Also it looks like I misspelled the ID field for all of the other fields, so that's fixed - not sure what this can even be used for, maybe GitHub actions.