### PR TITLE
feat(BREAKING): Set DPR to 1 for Chrome headless browsers by default

### DIFF
--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -429,6 +429,10 @@ export = {
       // set default headless size to 1920x1080
       // https://github.com/cypress-io/cypress/issues/6210
       args.push('--window-size=1920,1080')
+
+      // set default headless DPR to 1
+      // https://github.com/cypress-io/cypress/issues/17375
+      args.push('--force-device-scale-factor=1')
     }
 
     // force ipv4

--- a/packages/server/test/e2e/5_headless_spec.ts
+++ b/packages/server/test/e2e/5_headless_spec.ts
@@ -84,4 +84,10 @@ describe('e2e headless', function () {
     project: Fixtures.projectPath('screen-size'),
     spec: 'default_size.spec.js',
   })
+
+  e2e.it('launches at DPR 1x', {
+    headed: false,
+    project: Fixtures.projectPath('screen-size'),
+    spec: 'device_pixel_ratio.spec.js',
+  })
 })

--- a/packages/server/test/support/fixtures/projects/screen-size/cypress/integration/device_pixel_ratio.spec.js
+++ b/packages/server/test/support/fixtures/projects/screen-size/cypress/integration/device_pixel_ratio.spec.js
@@ -1,0 +1,6 @@
+describe('devicePixelRatio', () => {
+  it('has DPR of 1', () => {
+    // assert the browser was spawned with DPR of 1
+    expect(window.devicePixelRatio).to.equal(1)
+  })
+})

--- a/packages/server/test/support/fixtures/projects/screen-size/cypress/plugins/index.js
+++ b/packages/server/test/support/fixtures/projects/screen-size/cypress/plugins/index.js
@@ -4,6 +4,7 @@
 module.exports = (on) => {
   on('before:browser:launch', (browser, options) => {
     // options.args.push('-width', '1280', '-height', '1024')
+    // options.args.push('--force-device-scale-factor=2')
 
     // return options
   })

--- a/packages/server/test/unit/browsers/chrome_spec.js
+++ b/packages/server/test/unit/browsers/chrome_spec.js
@@ -99,7 +99,7 @@ describe('lib/browsers/chrome', () => {
       })
     })
 
-    it('sets default window size in headless mode', function () {
+    it('sets default window size and DPR in headless mode', function () {
       chrome._writeExtension.restore()
 
       return chrome.open({ isHeadless: true, isHeaded: false }, 'http://', {}, this.automation)
@@ -109,6 +109,7 @@ describe('lib/browsers/chrome', () => {
         expect(args).to.include.members([
           '--headless',
           '--window-size=1920,1080',
+          '--force-device-scale-factor=1',
         ])
       })
     })


### PR DESCRIPTION
- close #17375 

### User facing changelog

- When running `—headless` Chromium based browsers via `cypress run`, the device pixel ratio will now be 1 by default, matching the behavior of all other browsers. This behavior can be overridden through the browser launch API [link to instructions on how to change this].

### Additional Details

- This didn’t end up being as difficult as first suspected because it turns out Chrome is the only browser that is using the DPR of the machine it’s run in instead of just 1x.

### User Experience

- People who were running in 2x machines (like a Mac retina) will see the resolution of their screenshots and videos reduced. This can be overridden.