### PR TITLE
fix: `times` option of `cy.intercept` doesn't work with `req.reply`

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -2127,6 +2127,61 @@ describe('network stubbing', { retries: 2 }, function () {
             cy.get('#request').click()
             cy.get('#result').should('contain', 'client')
           })
+
+          it('works with reply', () => {
+            cy.intercept({
+              method: 'POST',
+              times: 1,
+              url: '/post-only',
+            },
+            (req) => {
+              req.reply('stubbed data')
+            }).as('interceptor')
+
+            cy.visit('fixtures/request.html')
+
+            cy.get('#request').click()
+            cy.get('#result').should('contain', 'stubbed data')
+
+            cy.get('#request').click()
+            cy.get('#result').should('contain', 'client') // Fail
+          })
+
+          it('works with reply and fallthrough', () => {
+            let times = 0
+
+            cy.intercept({
+              method: 'POST',
+              times: 3,
+              url: '/post-only',
+            },
+            (req) => {
+              req.reply(`${req.body === 'foo' ? 'foo' : 'nothing'} stubbed data ${times++}`)
+            })
+
+            cy.intercept({
+              method: 'POST',
+              times: 2,
+              url: '/post-only',
+            },
+            (req) => {
+              req.body = 'foo'
+            })
+
+            cy.visit('fixtures/request.html')
+
+            cy.get('#request').click()
+            cy.get('#result').should('contain', 'foo stubbed data 0')
+
+            cy.get('#request').click()
+            cy.get('#result').should('contain', 'foo stubbed data 1')
+
+            cy.get('#request').click()
+            cy.get('#result').should('contain', 'nothing stubbed data 2')
+
+            cy.get('#request').click()
+            cy.get('#result').should('contain', 'client') // Fail
+          })
         })
       })
     })

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -2144,7 +2144,7 @@ describe('network stubbing', { retries: 2 }, function () {
             cy.get('#result').should('contain', 'stubbed data')
 
             cy.get('#request').click()
-            cy.get('#result').should('contain', 'client') // Fail
+            cy.get('#result').should('contain', 'client')
           })
 
           it('works with reply and fallthrough', () => {
@@ -2180,7 +2180,7 @@ describe('network stubbing', { retries: 2 }, function () {
             cy.get('#result').should('contain', 'nothing stubbed data 2')
 
             cy.get('#request').click()
-            cy.get('#result').should('contain', 'client') // Fail
+            cy.get('#result').should('contain', 'client')
           })
         })
       })


### PR DESCRIPTION
- Closes #17139

### User facing changelog

`times` option of `cy.intercept` works with `req.reply`

### Additional details
- Why was this change necessary? => `times` option of `cy.intercept` doesn't work with `req.reply`. It's not an expected behavior.
- What is affected by this change? => N/A
- Any implementation details to explain? => I've left a long comment about the implementation decision in the code.

### How has the user experience changed?

N/A

### PR Tasks
- [x] Have tests been added/updated?
