### PR TITLE
docs: Update npm README to remove notice about Node version 10.

### DIFF
--- a/cli/NPM_README.md
+++ b/cli/NPM_README.md
@@ -1,8 +1,10 @@
 # Cypress
 
+Fast, easy and reliable testing for anything that runs in a browser.
+
 ## What is this?
 
-Cypress comes packaged as an `npm` module, which is all you need to get started.
+[Cypress](https://www.cypress.io/) comes packaged as an `npm` module, which is all you need to get started testing.
 
 After installing you'll be able to:
 
@@ -12,7 +14,7 @@ After installing you'll be able to:
 
 ## Install
 
-Requires Node version >= 10.0.0
+Please check our [system requirements](https://on.cypress.io/installing-cypress).
 
 ```sh
 npm install --save-dev cypress


### PR DESCRIPTION
Our README on npm says that the minimum Node.js version for Cypress required is 10, which is incorrect. 

https://www.npmjs.com/package/cypress

- Updated to link out to system requirements from the docs. 
- Linked to our public site and explained what Cypress is :sweat_smile: 
- Going to try to ping someone from DX/marketing/? about taking a look at improving this Readme. 