### PR TITLE
Support @typescript-eslint/no-unused-vars rule

### DIFF
--- a/packages/server/__snapshots__/scaffold_spec.js
+++ b/packages/server/__snapshots__/scaffold_spec.js
@@ -587,7 +587,7 @@ exports['lib/scaffold .plugins creates pluginsFile when pluginsFolder does not e
 /**
  * @type {Cypress.PluginConfig}
  */
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 module.exports = (on, config) => {
   // <backtick>on<backtick> is used to hook into various events Cypress emits
   // <backtick>config<backtick> is the resolved Cypress config


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->



### User facing changelog

This disables the ESLint [`@typescript-eslint/no-unused-vars`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md) rule (the typed counterpart to ESLint's built-in `no-unused-vars`)

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

The files scaffolded by Cypress create an error out of the box for those users who are using `@typescript-eslint/no-unused-vars` instead of `no-unused-vars`

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Before: Error out of the box

![Screen Shot 2021-07-21 at 22 02 48](https://user-images.githubusercontent.com/1935696/126552752-8f6c8e4a-71b5-464e-89cf-97e766f98e44.png)


After: No error

![Screen Shot 2021-07-21 at 22 03 34](https://user-images.githubusercontent.com/1935696/126552730-77dd872a-1a4b-4090-b462-88ad9ee1925b.png)


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

