### PR TITLE
chore: fix ci build process by pinning helper dep versions

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -258,7 +258,7 @@ commands:
           # Deps needed by circle-cache.js, before we "yarn" or unpack cached node_modules
           name: Cache Helper Deps
           working_directory: ~/
-          command: npm i globby@10.0.4 fs-extra@10.0.0 minimist@1.2.5 fast-json-stable-stringify@2.1.0
+          command: npm i globby@11.0.4 fs-extra@10.0.0 minimist@1.2.5 fast-json-stable-stringify@2.1.0
 
   install-required-node:
     # https://discuss.circleci.com/t/switch-nodejs-version-on-machine-executor-solved/26675/2

--- a/circle.yml
+++ b/circle.yml
@@ -258,7 +258,7 @@ commands:
           # Deps needed by circle-cache.js, before we "yarn" or unpack cached node_modules
           name: Cache Helper Deps
           working_directory: ~/
-          command: npm i globby fs-extra minimist fast-json-stable-stringify
+          command: npm i globby@10.0.4 fs-extra@10.0.0 minimist@1.2.5 fast-json-stable-stringify@2.1.0
 
   install-required-node:
     # https://discuss.circleci.com/t/switch-nodejs-version-on-machine-executor-solved/26675/2


### PR DESCRIPTION
Looks like `globby` released a breaking change in version `12.0.0` that's been breaking our CI build process - this should fix that and hopefully prevent this issue from arising again in the future