### PR TITLE
fix(npm/vue): do not register CT specific hook in E2E mode

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1339,8 +1339,12 @@ jobs:
           name: Build
           command: yarn workspace @cypress/vue build
       - run:
-          name: Run tests
-          command: yarn test-ci
+          name: Run component tests
+          command: yarn test-ci:ct
+          working_directory: npm/vue
+      - run:
+          name: Run e2e tests
+          command: yarn test:ci:e2e
           working_directory: npm/vue
       - store_test_results:
           path: npm/vue/test_results

--- a/circle.yml
+++ b/circle.yml
@@ -1340,7 +1340,7 @@ jobs:
           command: yarn workspace @cypress/vue build
       - run:
           name: Run component tests
-          command: yarn test-ci:ct
+          command: yarn test:ci:ct
           working_directory: npm/vue
       - run:
           name: Run e2e tests

--- a/circle.yml
+++ b/circle.yml
@@ -258,7 +258,7 @@ commands:
           # Deps needed by circle-cache.js, before we "yarn" or unpack cached node_modules
           name: Cache Helper Deps
           working_directory: ~/
-          command: npm i globby fs-extra minimist fast-json-stable-stringify
+          command: npm i globby@11.0.4 fs-extra@10.0.0 minimist@1.2.5 fast-json-stable-stringify@2.1.0
 
   install-required-node:
     # https://discuss.circleci.com/t/switch-nodejs-version-on-machine-executor-solved/26675/2

--- a/npm/vue/cypress/plugins/index.js
+++ b/npm/vue/cypress/plugins/index.js
@@ -7,7 +7,7 @@ const webpackConfig = require('../../webpack.config')
  */
 module.exports = (on, config) => {
   if (config.testingType !== 'component') {
-    throw Error(`This is a component testing project. testingType should be 'component'. Received ${config.testingType}`)
+    return config
   }
 
   if (!webpackConfig.resolve) {

--- a/npm/vue/cypress/support/commands.js
+++ b/npm/vue/cypress/support/commands.js
@@ -1,0 +1,6 @@
+/// <reference types="cypress" />
+import { mount } from '@cypress/vue'
+
+Cypress.Commands.add('mount', (comp) => {
+  return mount(comp)
+})

--- a/npm/vue/cypress/support/index.js
+++ b/npm/vue/cypress/support/index.js
@@ -1,1 +1,3 @@
 // created automatically when cy:open starts
+
+import './commands'

--- a/npm/vue/package.json
+++ b/npm/vue/package.json
@@ -8,6 +8,7 @@
     "build-prod": "yarn build",
     "cy:open": "node ../../scripts/cypress.js open-ct --project ${PWD}",
     "cy:run": "node ../../scripts/cypress.js run-ct --project ${PWD}",
+    "cy:run:e2e": "node ../../scripts/cypress.js run --project ${PWD}",
     "test": "yarn cy:run",
     "watch": "yarn build --watch --watch.exclude ./dist/**/*",
     "test-ci": "node ../../scripts/run-ct-examples.js --examplesList=./examples.env"

--- a/npm/vue/package.json
+++ b/npm/vue/package.json
@@ -8,10 +8,10 @@
     "build-prod": "yarn build",
     "cy:open": "node ../../scripts/cypress.js open-ct --project ${PWD}",
     "cy:run": "node ../../scripts/cypress.js run-ct --project ${PWD}",
-    "cy:run:e2e": "node ../../scripts/cypress.js run --project ${PWD}",
+    "test:ci:e2e": "node ../../scripts/cypress.js run --project ${PWD}",
     "test": "yarn cy:run",
     "watch": "yarn build --watch --watch.exclude ./dist/**/*",
-    "test-ci": "node ../../scripts/run-ct-examples.js --examplesList=./examples.env"
+    "test:ci:ct": "node ../../scripts/run-ct-examples.js --examplesList=./examples.env"
   },
   "dependencies": {
     "@cypress/mount-utils": "0.0.0-development",

--- a/npm/vue/src/index.ts
+++ b/npm/vue/src/index.ts
@@ -36,6 +36,16 @@ type CyMountOptions<Props> = Omit<MountingOptions<Props>, 'attachTo'> & {
 let initialInnerHtml = ''
 
 Cypress.on('run:start', () => {
+  // `mount` is designed to work with component testing only.
+  // it assumes ROOT_ID exists, which is not the case in e2e.
+  // if the user registers a custom command that imports `cypress/vue`,
+  // this event will be registered and cause an error when the user
+  // launches e2e (since it's common to use Cypress for both CT and E2E.
+  // https://github.com/cypress-io/cypress/issues/17438
+  if (Cypress.testingType !== 'component') {
+    return
+  }
+
   initialInnerHtml = document.head.innerHTML
   Cypress.on('test:before:run', () => {
     Cypress.vueWrapper?.unmount()


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/17438

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->

Do not register CT specific hook when importing `@cypress/vue` in E2E mode.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

See original issue for description of problem.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

N/A

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
