### PR TITLE
fix: make vite re-run on supportFile change

### DIFF
--- a/npm/vite-dev-server/cypress/styles.css
+++ b/npm/vite-dev-server/cypress/styles.css
@@ -1,0 +1,3 @@
+body {
+	color: indigo;
+}

--- a/npm/vite-dev-server/cypress/support.js
+++ b/npm/vite-dev-server/cypress/support.js
@@ -1,4 +1,5 @@
 import '@testing-library/cypress/add-commands'
+import './styles.css'
 
 before(() => {
   window.supportFileWasLoaded = true

--- a/npm/vite-dev-server/src/index.ts
+++ b/npm/vite-dev-server/src/index.ts
@@ -1,8 +1,8 @@
 import { debug as debugFn } from 'debug'
-import { start as createDevServer, StartDevServer } from './startServer'
+import { start as createDevServer, StartDevServerOptions } from './startServer'
 const debug = debugFn('cypress:vite-dev-server:vite')
 
-export { StartDevServer }
+export { StartDevServerOptions as StartDevServer }
 
 type DoneCallback = () => unknown
 
@@ -11,7 +11,7 @@ export interface ResolvedDevServerConfig {
   close: (done?: DoneCallback) => void
 }
 
-export async function startDevServer (startDevServerArgs: StartDevServer): Promise<ResolvedDevServerConfig> {
+export async function startDevServer (startDevServerArgs: StartDevServerOptions): Promise<ResolvedDevServerConfig> {
   const viteDevServer = await createDevServer(startDevServerArgs)
 
   const app = await viteDevServer.listen()

--- a/npm/vite-dev-server/src/index.ts
+++ b/npm/vite-dev-server/src/index.ts
@@ -2,7 +2,7 @@ import { debug as debugFn } from 'debug'
 import { start as createDevServer, StartDevServerOptions } from './startServer'
 const debug = debugFn('cypress:vite-dev-server:vite')
 
-export { StartDevServerOptions as StartDevServer }
+export { StartDevServerOptions }
 
 type DoneCallback = () => unknown
 

--- a/npm/vite-dev-server/src/makeCypressPlugin.ts
+++ b/npm/vite-dev-server/src/makeCypressPlugin.ts
@@ -21,8 +21,12 @@ const INIT_FILEPATH = resolve(__dirname, '../client/initCypressTests.js')
 
 const HMR_DEPENDENCY_LOOKUP_MAX_ITERATION = 50
 
-function getSpecsPathsSet (specs: Spec[], supportFilePath) {
-  return new Set<string>([...specs.map((spec) => spec.absolute), supportFilePath])
+function getSpecsPathsSet (specs: Spec[], supportFile?: string | null) {
+  return new Set<string>(
+    supportFile
+      ? [...specs.map((spec) => spec.absolute), supportFile]
+      : specs.map((spec) => spec.absolute),
+  )
 }
 
 interface Spec{

--- a/npm/vite-dev-server/src/makeCypressPlugin.ts
+++ b/npm/vite-dev-server/src/makeCypressPlugin.ts
@@ -21,8 +21,8 @@ const INIT_FILEPATH = resolve(__dirname, '../client/initCypressTests.js')
 
 const HMR_DEPENDENCY_LOOKUP_MAX_ITERATION = 50
 
-function getSpecsSet (specs: Spec[]) {
-  return new Set<string>(specs.map((spec) => spec.absolute))
+function getSpecsPathsSet (specs: Spec[], supportFilePath) {
+  return new Set<string>([...specs.map((spec) => spec.absolute), supportFilePath])
 }
 
 interface Spec{
@@ -38,10 +38,10 @@ export const makeCypressPlugin = (
 ): Plugin => {
   let base = '/'
 
-  let specsPathsSet = getSpecsSet(specs)
+  let specsPathsSet = getSpecsPathsSet(specs, supportFilePath)
 
   devServerEvents.on('dev-server:specs:changed', (specs: Spec[]) => {
-    specsPathsSet = getSpecsSet(specs)
+    specsPathsSet = getSpecsPathsSet(specs, supportFilePath)
   })
 
   const posixSupportFilePath = supportFilePath ? convertPathToPosix(resolve(projectRoot, supportFilePath)) : undefined
@@ -101,6 +101,7 @@ export const makeCypressPlugin = (
 
         // as soon as we find one of the specs, we trigger the re-run of tests
         for (const mod of moduleImporters.values()) {
+          debug('handleHotUpdate - mod.file', mod.file)
           if (specsPathsSet.has(mod.file)) {
             debug('handleHotUpdate - compile success')
             devServerEvents.emit('dev-server:compile:success')

--- a/npm/vite-dev-server/src/startServer.ts
+++ b/npm/vite-dev-server/src/startServer.ts
@@ -13,7 +13,7 @@ interface Options {
   [key: string]: unknown
 }
 
-export interface StartDevServer {
+export interface StartDevServerOptions {
   /**
    * the Cypress options object
    */
@@ -27,7 +27,7 @@ export interface StartDevServer {
   viteConfig?: UserConfig
 }
 
-const resolveServerConfig = async ({ viteConfig, options }: StartDevServer): Promise<InlineConfig> => {
+const resolveServerConfig = async ({ viteConfig, options }: StartDevServerOptions): Promise<InlineConfig> => {
   const { projectRoot, supportFile } = options.config
 
   const requiredOptions: InlineConfig = {
@@ -66,7 +66,7 @@ const resolveServerConfig = async ({ viteConfig, options }: StartDevServer): Pro
   return finalConfig
 }
 
-export async function start (devServerOptions: StartDevServer): Promise<ViteDevServer> {
+export async function start (devServerOptions: StartDevServerOptions): Promise<ViteDevServer> {
   if (!devServerOptions.viteConfig) {
     debug('User did not pass in any Vite dev server configuration')
     devServerOptions.viteConfig = {}


### PR DESCRIPTION
### User facing changelog
Previously, when we changed a spec file, or any of it's dependencies, the current spec would re-run. But the `supportFile`, though impactful in the runs, would not be watched.

Now Cypress watches the `supportFile` for changes and re-runs the current spec if it changes.

### Additional details
To reproduce:
- `yarn workspace @cypress/vite-dev-server cy:open`
- navigate to the `hello-with-jsx` test
- open `npm/vite-dev-server/support.js` see the css file imported in it.
- open the imported file `npm/vite-dev-server/styles.css` 
- change the color to `hotpink` and save

The tests are not re-run before this PR
They are after the PR

