### PR TITLE
fix: do not start spec watcher in run mode

### DIFF
--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -276,23 +276,25 @@ export class ProjectBase<TServer extends ServerE2E | ServerCt> extends EE {
       this.saveState(stateToSave),
     ])
 
-    // start watching specs
-    // whenever a spec file is added or removed, we notify the
-    // <SpecList>
-    // This is only used for CT right now, but it will be
-    // used for E2E eventually. Until then, do not watch
-    // the specs.
-    // do not start in run mode - only in interactive mode.
-    if (!cfg.isTextTerminal) {
-      startSpecWatcher()
-    }
-
     await Promise.all([
       checkSupportFile({ configFile: cfg.configFile, supportFile: cfg.supportFile }),
       this.watchPluginsFile(cfg, this.options),
     ])
 
-    if (cfg.isTextTerminal || !cfg.experimentalInteractiveRunEvents) return
+    if (cfg.isTextTerminal) {
+      return
+    }
+
+    // start watching specs
+    // whenever a spec file is added or removed, we notify the
+    // <SpecList>
+    // This is only used for CT right now by general users.
+    // It is is used with E2E if the CypressInternal_UseInlineSpecList flag is true.
+    startSpecWatcher()
+
+    if (cfg.experimentalInteractiveRunEvents) {
+      return
+    }
 
     const sys = await system.info()
     const beforeRunDetails = {

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -292,7 +292,7 @@ export class ProjectBase<TServer extends ServerE2E | ServerCt> extends EE {
     // It is is used with E2E if the CypressInternal_UseInlineSpecList flag is true.
     startSpecWatcher()
 
-    if (cfg.experimentalInteractiveRunEvents) {
+    if (!cfg.experimentalInteractiveRunEvents) {
       return
     }
 

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -282,7 +282,10 @@ export class ProjectBase<TServer extends ServerE2E | ServerCt> extends EE {
     // This is only used for CT right now, but it will be
     // used for E2E eventually. Until then, do not watch
     // the specs.
-    startSpecWatcher()
+    // do not start in run mode - only in interactive mode.
+    if (!cfg.isTextTerminal) {
+      startSpecWatcher()
+    }
 
     await Promise.all([
       checkSupportFile({ configFile: cfg.configFile, supportFile: cfg.supportFile }),

--- a/packages/server/test/unit/project_spec.js
+++ b/packages/server/test/unit/project_spec.js
@@ -406,6 +406,36 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
       })
     })
 
+    it('does not call startSpecWatcher if not in interactive mode', function () {
+      const startSpecWatcherStub = sinon.stub()
+
+      sinon.stub(ProjectBase.prototype, 'initializeSpecStore').resolves({
+        startSpecWatcher: startSpecWatcherStub,
+      })
+
+      this.config.isTextTerminal = true
+
+      return this.project.open()
+      .then(() => {
+        expect(startSpecWatcherStub).not.to.be.called
+      })
+    })
+
+    it('calls startSpecWatcher if in interactive mode', function () {
+      const startSpecWatcherStub = sinon.stub()
+
+      sinon.stub(ProjectBase.prototype, 'initializeSpecStore').resolves({
+        startSpecWatcher: startSpecWatcherStub,
+      })
+
+      this.config.isTextTerminal = false
+
+      return this.project.open()
+      .then(() => {
+        expect(startSpecWatcherStub).to.be.called
+      })
+    })
+
     it('does not get system info or execute before:run if experimental flag is not enabled', function () {
       sinon.stub(system, 'info')
       this.config.experimentalInteractiveRunEvents = false


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Related: https://github.com/cypress-io/cypress/issues/17173

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->

Do not start spec file watcher in run mode.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We should not call the `startSpecWatcher` function in run mode, since there's no need to watch any files - they won't change during run mode.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Fixes some specific problems relating to watching too many files when running Cypress in docker, primarily on GH actions. See [this comment](https://github.com/cypress-io/cypress/issues/17173#issuecomment-887257762) for a detailed write up of the problem and solution.

Prior to 7.7.0, this problem was only noticeable in component testing, but between 7.6.0 and 7.7.0 I removed a check that introduced this problem to e2e as well, [see here](https://github.com/cypress-io/cypress/compare/v7.6.0...v7.7.0#diff-a062d0b0db7bfd6f4a0d1785e9d83ee00e169d21dbb2cdcf7107ed0fab857e6aR252). The reason the check was removed was relating to the `CypressInternal_UseInlineSpecList` feature flag, which requires this to be enabled. I think it's fine to start the spec watcher in e2e, since we will need it eventually, just not in run mode, which is where users are encountering problems. I've added unit tests to make this this regressions doesn't occur in the future.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
