### PR TITLE
fix: Handle cases where attempt error stack is undefined/falsy

### DIFF
--- a/packages/server/lib/reporter.js
+++ b/packages/server/lib/reporter.js
@@ -372,7 +372,7 @@ class Reporter {
         const err = attempt.err && {
           name: attempt.err.name,
           message: attempt.err.message,
-          stack: stackUtils.stackWithoutMessage(attempt.err.stack),
+          stack: attempt.err.stack && stackUtils.stackWithoutMessage(attempt.err.stack),
           codeFrame: attempt.err.codeFrame,
         }
 

--- a/packages/server/test/unit/reporter_spec.js
+++ b/packages/server/test/unit/reporter_spec.js
@@ -168,4 +168,53 @@ describe('lib/reporter', () => {
       expect(this.emit.getCall(0).args[1].tests.length).to.equal(2)
     })
   })
+
+  context('#normalizeTest', () => {
+    let reporter
+    let test
+
+    beforeEach(() => {
+      reporter = new Reporter()
+      test = {
+        prevAttempts: [
+          {
+            err: {
+              name: 'Error',
+              message: 'There was an error',
+            },
+          },
+        ],
+      }
+    })
+
+    // https://github.com/cypress-io/cypress/issues/17378
+    describe('attempt errors', () => {
+      it('is null when error is undefined', () => {
+        test.prevAttempts[0].err = undefined
+        const result = reporter.normalizeTest(test)
+
+        expect(result.attempts[0].error).to.be.null
+      })
+
+      it('stack is undefined when error is a string', () => {
+        test.prevAttempts[0].err = 'There was an error'
+        const result = reporter.normalizeTest(test)
+
+        expect(result.attempts[0].error.stack).to.be.undefined
+      })
+
+      it('stack is undefined when undefined', () => {
+        const result = reporter.normalizeTest(test)
+
+        expect(result.attempts[0].error.stack).to.be.undefined
+      })
+
+      it('stack is an empty string when an empty string', () => {
+        test.prevAttempts[0].err.stack = ''
+        const result = reporter.normalizeTest(test)
+
+        expect(result.attempts[0].error.stack).to.equal('')
+      })
+    })
+  })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #17378

### User facing changelog

- Cypress no longer throws the error "cannot read property split of undefined" in certain circumstances

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
