### PR TITLE
fix: create dummy request logs for intercepts w/o pre-requests

### DIFF
--- a/packages/driver/cypress/integration/cypress/proxy-logging-spec.ts
+++ b/packages/driver/cypress/integration/cypress/proxy-logging-spec.ts
@@ -414,4 +414,34 @@ describe('Proxy Logging', () => {
       })
     })
   })
+
+  context('Cypress.ProxyLogging', () => {
+    describe('.logInterception', () => {
+      it('creates a fake log for unmatched requests', () => {
+        const interception = {
+          id: 'request123',
+          request: {
+            url: 'http://foo',
+            method: 'GET',
+            headers: {},
+          },
+        }
+
+        const route = {}
+
+        const ret = Cypress.ProxyLogging.logInterception(interception, route)
+
+        expect(ret.preRequest).to.deep.eq({
+          requestId: 'request123',
+          resourceType: 'other',
+          originalResourceType: 'Request with no browser pre-request',
+          url: 'http://foo',
+          method: 'GET',
+          headers: {},
+        })
+
+        expect(ret.log.get('name')).to.eq('request')
+      })
+    })
+  })
 })

--- a/packages/driver/src/cypress/proxy-logging.ts
+++ b/packages/driver/src/cypress/proxy-logging.ts
@@ -270,7 +270,7 @@ export class ProxyLogging {
   /**
    * Update an existing proxy log with an interception, or create a new log if one was not created (like if shouldLog returned false)
    */
-  logInterception (interception: Interception, route: Route): ProxyRequest | undefined {
+  logInterception (interception: Interception, route: Route): ProxyRequest {
     const unloggedPreRequest = take(this.unloggedPreRequests, ({ requestId }) => requestId === interception.browserRequestId)
 
     if (unloggedPreRequest) {
@@ -278,10 +278,18 @@ export class ProxyLogging {
       this.createProxyRequestLog(unloggedPreRequest)
     }
 
-    const proxyRequest = _.find(this.proxyRequests, ({ preRequest }) => preRequest.requestId === interception.browserRequestId)
+    let proxyRequest = _.find(this.proxyRequests, ({ preRequest }) => preRequest.requestId === interception.browserRequestId)
 
     if (!proxyRequest) {
-      throw new Error(`Missing pre-request/proxy log for cy.intercept to ${interception.request.url}`)
+      // this can happen in a race condition, if user runs Network.disable, if the browser doesn't send pre-request for some reason...
+      debug(`Missing pre-request/proxy log for cy.intercept to ${interception.request.url} %o`, { interception, route })
+
+      proxyRequest = this.createProxyRequestLog({
+        requestId: interception.browserRequestId || interception.id,
+        resourceType: 'other',
+        originalResourceType: 'Request with no browser pre-request',
+        ..._.pick(interception.request, ['url', 'method', 'headers']),
+      })
     }
 
     proxyRequest.interceptions.push({ interception, route })
@@ -349,12 +357,14 @@ export class ProxyLogging {
     this.createProxyRequestLog(preRequest)
   }
 
-  private createProxyRequestLog (preRequest: BrowserPreRequest) {
+  private createProxyRequestLog (preRequest: BrowserPreRequest): ProxyRequest {
     const proxyRequest = new ProxyRequest(preRequest)
     const logConfig = getRequestLogConfig(proxyRequest as Omit<ProxyRequest, 'log'>)
 
     proxyRequest.log = this.Cypress.log(logConfig).snapshot('request')
 
     this.proxyRequests.push(proxyRequest as ProxyRequest)
+
+    return proxyRequest
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog

n/a - pre-release fix for #16730 

### Additional details

Occasionally it's possible for a request to not have a pre-request sent by the browser, in which case we wait 500ms before continuing the request. If the request is cy.intercepted, before this PR, it would fail. This could cause flake because requests can miss pre-requests for legitimate reasons. This PR creates a dummy log in such an event instead of erroring. This fixes the failures here: https://app.circleci.com/pipelines/github/cypress-io/cypress-test-example-repos/8257/workflows/84ef6df2-c864-4c27-9d52-8729f9b6981d/jobs/195214/parallel-runs/12?filterBy=FAILED

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
