### PR TITLE
Allow listening for remote automation events

### DIFF
--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -154,7 +154,7 @@ const ffToStandardResourceTypeMap: { [ff: string]: ResourceType } = {
 }
 
 export class CdpAutomation {
-  constructor (private sendDebuggerCommandFn: SendDebuggerCommand, onFn: OnFn, private automation: Automation) {
+  constructor (private sendDebuggerCommandFn: SendDebuggerCommand, private onFn: OnFn, private automation: Automation) {
     onFn('Network.requestWillBeSent', this.onNetworkRequestWillBeSent)
     onFn('Network.responseReceived', this.onResponseReceived)
     sendDebuggerCommandFn('Network.enable', {
@@ -269,6 +269,8 @@ export class CdpAutomation {
         return true
       case 'remote:debugger:protocol':
         return this.sendDebuggerCommandFn(data.command, data.params)
+      case 'remote:debugger:event':
+        return this.onFn(data.event, data.callback)
       case 'take:screenshot':
         return this.sendDebuggerCommandFn('Page.captureScreenshot', { format: 'png' })
         .catch((err) => {


### PR DESCRIPTION
### User facing changelog

`Cypress.automation` accepts a new `remote:debugger:event'` command. This allows you to listen for remote automation events like [`Page.javascriptDialogOpening`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-javascriptDialogOpening).

### Additional details

I'd like to test stuff like native browser dialogs. It's impossible without being able to hook into an event like [`Page.javascriptDialogOpening`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-javascriptDialogOpening)

### How has the user experience changed?

This introduces a new capability for advanced users.

### PR Tasks

If this PR gets green light from your team then I could work on the remaining tasks.

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
