### PR TITLE
chore(tests): typo for callback

### DIFF
--- a/packages/driver/cypress/integration/commands/waiting_spec.js
+++ b/packages/driver/cypress/integration/commands/waiting_spec.js
@@ -735,7 +735,7 @@ describe('src/cy/commands/waiting', () => {
           cy.wait('@foo', '@bar')
         })
 
-        it('throws when passed caallback function', (done) => {
+        it('throws when passed callback function', (done) => {
           cy.on('fail', (err) => {
             expect(err.message).to.eq('`cy.wait()` was passed invalid arguments. You cannot pass a function. If you would like to wait on the result of a `cy.wait()`, use `cy.then()`.')
             expect(err.docsUrl).to.eq('https://on.cypress.io/wait')


### PR DESCRIPTION
Fixing type for `callback` merged in - https://github.com/cypress-io/cypress/pull/17561/files