### PR TITLE
fix(https-proxy): add error handling when using cached cert

### DIFF
--- a/packages/https-proxy/lib/server.js
+++ b/packages/https-proxy/lib/server.js
@@ -183,6 +183,15 @@ class Server {
       }
 
       return this._getPortFor(hostname)
+      .catch(async (err) => {
+        debug('Error adding context, deleting certs and regenning %o', { hostname, err })
+
+        // files on disk can be corrupted, so try again
+        // @see https://github.com/cypress-io/cypress/issues/8705
+        await this._ca.clearDataForHostname(hostname)
+
+        return this._getPortFor(hostname)
+      })
       .then((port) => {
         sslServers[hostname] = { port }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #8705 

### User facing changelog

- Fixed an issue that could cause intermittent OpenSSL errors when the local CA cert cache becomes corrupted.

### Additional details

- the first error from `addContext` is caught, and causes the existing certs for that hostname to be deleted, before trying one more time to generate certs.
- was not able to come up with an e2e test for this, only a unit test that i believe captures the issue

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
