### PR TITLE
feat(launchpad): adding the resolved config to the settings page

### DIFF
--- a/packages/launchpad/cypress/support/commands.ts
+++ b/packages/launchpad/cypress/support/commands.ts
@@ -14,7 +14,7 @@ import { createI18n } from '../../src/locales/i18n'
  * It has to be loaded run before initializing GraphQL
  * because graphql uses it.
  */
-(window as any).ipc = {
+;(window as any).ipc = {
   on: () => {},
   send: () => {},
 }

--- a/packages/launchpad/src/components/button/Button.vue
+++ b/packages/launchpad/src/components/button/Button.vue
@@ -32,7 +32,7 @@ import type { ButtonHTMLAttributes, FunctionalComponent, SVGAttributes } from "v
 
 const VariantClassesTable = {
   primary: "border-indigo-600 bg-indigo-600 text-white",
-  outline: "border-gray-200 text-indigo-600",
+  outline: "border-gray-200 text-indigo-600 bg-white",
   link: "border-transparent text-indigo-600",
 }
 

--- a/packages/launchpad/src/locales/en-US.json
+++ b/packages/launchpad/src/locales/en-US.json
@@ -11,6 +11,9 @@
     "copy": "Copy",
     "copied": "Copied"
   },
+  "file": {
+    "edit": "Edit"
+  },
   "status": {
     "enabled": "Enabled",
     "disabled": "Disabled"
@@ -32,15 +35,30 @@
     }
   },
   "settingsPage": {
-    "resolvedConfiguration": {
+    "config": {
       "title": "Resolved Configuration",
       "description": "Since the options in the {0} can be set dynamically by your development environment, please refer to the legend below to understand how the configuration options are resolved.",
       "legend": {
-        "environmentVariable": "Set from environment variables",
-        "defaultValue": "Default values",
-        "dynamic": "Set a runtime by the {0} function",
-        "cli": "Set from CLI arguments",
-        "config": "Set from {0}"
+        "env": {
+          "label": "env",
+          "description": "Set from environment variables"
+        },
+        "default": {
+          "label": "default",
+          "description": "Default values"
+        },
+        "dynamic": {
+          "label": "dynamic",
+          "description": "Set by the {0} function"
+        },
+        "cli": {
+          "label": "cli",
+          "description": "Set from CLI arguments"
+        },
+        "config": {
+          "label": "config",
+          "description": "Set from {0}"
+        }
       }
     },
     "proxy": {

--- a/packages/launchpad/src/locales/en-US.json
+++ b/packages/launchpad/src/locales/en-US.json
@@ -32,6 +32,17 @@
     }
   },
   "settingsPage": {
+    "resolvedConfiguration": {
+      "title": "Resolved Configuration",
+      "description": "Since the options in the {0} can be set dynamically by your development environment, please refer to the legend below to understand how the configuration options are resolved.",
+      "legend": {
+        "environmentVariable": "Set from environment variables",
+        "defaultValue": "Default values",
+        "dynamic": "Set a runtime by the {0} function",
+        "cli": "Set from CLI arguments",
+        "config": "Set from {0}"
+      }
+    },
     "proxy": {
       "title": "Proxy Settings",
       "description": "Cypress auto-detected the following proxy settings from your operating system.",

--- a/packages/launchpad/src/settings/device/ExternalEditorSettings.vue
+++ b/packages/launchpad/src/settings/device/ExternalEditorSettings.vue
@@ -68,5 +68,5 @@ const externalEditors = [
 ]
 
 const { t } = useI18n()
-const selectedEditor = ref(null)
+const selectedEditor = ref()
 </script>

--- a/packages/launchpad/src/settings/project/Config.spec.tsx
+++ b/packages/launchpad/src/settings/project/Config.spec.tsx
@@ -4,7 +4,7 @@ import { defaultMessages } from '../../locales/i18n'
 import { each } from 'lodash'
 
 describe('<Config/>', () => {
-  it('renders the title, description, code, and legend', { viewportHeight: 800, viewportWidth: 1200 }, () => {
+  it('renders the title, description, code, and legend', () => {
     cy.mount(() => <div class="p-12 resize-x overflow-auto"><Config /></div>)
     cy.get('[data-testid=config-code]').contains(jsonObject)
     cy.contains(defaultMessages.settingsPage.config.title)

--- a/packages/launchpad/src/settings/project/Config.spec.tsx
+++ b/packages/launchpad/src/settings/project/Config.spec.tsx
@@ -1,0 +1,17 @@
+import Config from './Config.vue'
+import jsonObject from '../../../cypress.json?raw'
+import { defaultMessages } from '../../locales/i18n'
+import { each } from 'lodash'
+
+describe('<Config/>', () => {
+  it('renders the title, description, code, and legend', { viewportHeight: 800, viewportWidth: 1200 }, () => {
+    cy.mount(() => <div class="p-12 resize-x overflow-auto"><Config /></div>)
+    cy.get('[data-testid=config-code]').contains(jsonObject)
+    cy.contains(defaultMessages.settingsPage.config.title)
+
+    // TODO: write a support file helper for ignoring the {0} values etc
+    each(defaultMessages.settingsPage.config.description.split('{0}'), (description) => {
+      cy.contains(description)
+    })
+  })
+})

--- a/packages/launchpad/src/settings/project/Config.vue
+++ b/packages/launchpad/src/settings/project/Config.vue
@@ -1,0 +1,32 @@
+<template>
+  <SettingsSection>
+    <template #title>{{ t('settingsPage.config.title') }}</template>
+    <template #description>
+      <i18n-t keypath="settingsPage.config.description">
+        <a href="https://docs.cypress.io" target="_blank">cypress.config.js</a>
+      </i18n-t>
+    </template>
+    <div class="flex w-full select-none">
+      <ConfigCode
+        data-testid="config-code"
+        :code="code"
+        class="relative grow-1 w-full hide-scrollbar rounded-bl-md rounded-tl-md mx-auto border-1 overflow-hidden"
+      />
+      <ConfigLegend
+        class="rounded-tr-md px-22px py-28px border-1 border-l-0 rounded-br-md min-w-280px"
+      />
+    </div>
+  </SettingsSection>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+import SettingsSection from '../SettingsSection.vue'
+import { useI18n } from '../../composables'
+import cypressJson from '../../../cypress.json?raw' // TODO: remove this
+import ConfigLegend from './ConfigLegend.vue'
+import ConfigCode from './ConfigCode.vue'
+
+const code = ref(JSON.parse(JSON.stringify(cypressJson, null, 2)))
+const { t } = useI18n()
+</script>

--- a/packages/launchpad/src/settings/project/ConfigBadge.spec.tsx
+++ b/packages/launchpad/src/settings/project/ConfigBadge.spec.tsx
@@ -1,0 +1,23 @@
+import ConfigBadge from './ConfigBadge.vue'
+
+describe('<ConfigBadge />', () => {
+  it('renders a badge with a label and description', () => {
+    const description = 'This is a pretty great badge'
+    const label = 'Wonderful'
+
+    cy.mount(() => {
+      return <ConfigBadge label="Wonderful" class="bg-fuchsia-100 text-fuchsia-600">This is a pretty <pre class="inline">great</pre> badge</ConfigBadge>
+    }).get('body').should('contain.text', description).and('contain.text', label)
+  })
+
+  it('playground', () => {
+    cy.mount(() => (
+      <div class="p-12 children:pb-4">
+        <ConfigBadge label="Superb" class="bg-gray-100 text-gray-600">This is a pretty <pre class="inline">great</pre> badge</ConfigBadge>
+        <ConfigBadge label="Sub-par" class="bg-yellow-100 text-yellow-600">A warning would probably go here</ConfigBadge>
+        <ConfigBadge label="So cool" class="bg-indigo-100 text-indigo-600">Populated by lorem ipsum</ConfigBadge>
+        <ConfigBadge label="...Super?" class="bg-rose-100 text-rose-600">...is <a>this</a> expected?</ConfigBadge>
+      </div>
+    ))
+  })
+})

--- a/packages/launchpad/src/settings/project/ConfigBadge.vue
+++ b/packages/launchpad/src/settings/project/ConfigBadge.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="text-sm">
+    <p class="font-mono whitespace-nowrap rounded px-2px w-min" data-testid="legend-label" v-bind="$attrs">{{ label }}</p>
+    <p class="text-gray-600 leading-snug font-light"><slot></slot></p>
+  </div>
+</template>
+
+<script lang="ts">
+export default {
+  inheritAttrs: false
+}
+</script>
+<script lang="ts" setup>
+defineProps<{
+  label: string;
+}>()
+</script>

--- a/packages/launchpad/src/settings/project/ConfigCode.spec.tsx
+++ b/packages/launchpad/src/settings/project/ConfigCode.spec.tsx
@@ -1,0 +1,35 @@
+import ConfigCode from './ConfigCode.vue'
+import jsonObject from '../../../cypress.json'
+import { defaultMessages } from '../../locales/i18n'
+
+const selector = '[data-testid=code]'
+const jsonString = JSON.stringify(jsonObject, null, 2)
+
+describe('<ConfigCode />', () => {
+  beforeEach(() => {
+    cy.mount(() => (<div class="p-12 max-w-full resize-x overflow-auto">
+      {
+        /* These classes and the tabindex are here to make this element focusable
+         * for testing the double click event.
+         * Arguably, we shouldn't need to use the `tabindex` prop
+         * but that would require making the Copy behavior accesible.
+         */
+      }
+      <ConfigCode data-testid="code" tab-index={0} class="focus:ring-0 focus:outline-none" code={jsonString} />
+    </div>))
+  })
+
+  it('renders the code passed in', () => {
+    cy.get(selector).should('contain.text', jsonString)
+  })
+
+  it('can be double clicked to copy the code', () => {
+    cy.findByText(defaultMessages.clipboard.copied).should('not.be.visible').get(selector).dblclick()
+    cy.findByText(defaultMessages.clipboard.copied).should('be.visible')
+    cy.findByText(defaultMessages.clipboard.copied).should('not.be.visible')
+  })
+
+  it('has an edit button', () => {
+    cy.findByText(defaultMessages.file.edit).should('be.visible').click()
+  })
+})

--- a/packages/launchpad/src/settings/project/ConfigCode.spec.tsx
+++ b/packages/launchpad/src/settings/project/ConfigCode.spec.tsx
@@ -7,7 +7,7 @@ const jsonString = JSON.stringify(jsonObject, null, 2)
 
 describe('<ConfigCode />', () => {
   beforeEach(() => {
-    cy.mount(() => (<div class="p-12 max-w-full resize-x overflow-auto">
+    cy.mount(() => (<div class="p-12 overflow-auto">
       {
         /* These classes and the tabindex are here to make this element focusable
          * for testing the double click event.
@@ -15,7 +15,7 @@ describe('<ConfigCode />', () => {
          * but that would require making the Copy behavior accesible.
          */
       }
-      <ConfigCode data-testid="code" tab-index={0} class="focus:ring-0 focus:outline-none" code={jsonString} />
+      <ConfigCode data-testid="code" tabindex={0} class="" code={jsonString} />
     </div>))
   })
 
@@ -23,8 +23,11 @@ describe('<ConfigCode />', () => {
     cy.get(selector).should('contain.text', jsonString)
   })
 
-  it('can be double clicked to copy the code', () => {
-    cy.findByText(defaultMessages.clipboard.copied).should('not.be.visible').get(selector).dblclick()
+  // This needs to be skipped because it cannot be tested unless "Emulate a focused page" is checked.
+  xit('can be double clicked to copy the code', () => {
+    cy.findByText(defaultMessages.clipboard.copied).should('not.be.visible').get(selector)
+    .focus().dblclick()
+
     cy.findByText(defaultMessages.clipboard.copied).should('be.visible')
     cy.findByText(defaultMessages.clipboard.copied).should('not.be.visible')
   })

--- a/packages/launchpad/src/settings/project/ConfigCode.spec.tsx
+++ b/packages/launchpad/src/settings/project/ConfigCode.spec.tsx
@@ -15,6 +15,7 @@ describe('<ConfigCode />', () => {
          * but that would require making the Copy behavior accesible.
          */
       }
+      { /* @ts-ignore */ }
       <ConfigCode data-testid="code" tabindex={0} class="" code={jsonString} />
     </div>))
   })
@@ -24,7 +25,7 @@ describe('<ConfigCode />', () => {
   })
 
   // This needs to be skipped because it cannot be tested unless "Emulate a focused page" is checked.
-  xit('can be double clicked to copy the code', () => {
+  it('can be double clicked to copy the code', () => {
     cy.findByText(defaultMessages.clipboard.copied).should('not.be.visible').get(selector)
     .focus().dblclick()
 

--- a/packages/launchpad/src/settings/project/ConfigCode.vue
+++ b/packages/launchpad/src/settings/project/ConfigCode.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="relative grow-1 w-full hide-scrollbar rounded-bl-md rounded-tl-md mx-auto border-1 overflow-hidden min-w-100px select-none">
+    <Button
+      variant="outline"
+      class="absolute top-4 right-4"
+      :prefixIcon="IconCode"
+      prefixIconClass="text-gray-500"
+    >{{ t('file.edit') }}</Button>
+    <pre @dblclick="copy(code)" class="p-2 font-mono text-gray-600 text-sm">{{ code }}</pre>
+    <div
+      aria-hidden="true"
+      class="pointer-events-none flex items-center text-center transition-opacity absolute top-0 left-0 w-full h-full"
+      :class="copied ? 'opacity-100' : 'opacity-0'"
+    >
+      <div class="w-full mb-80">
+        <span
+          class="px-2 rounded text-white bg-indigo-600 shadow-md py-1 text-sm"
+        >{{ t('clipboard.copied') }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import Button from '../../components/button/Button.vue'
+import IconCode from 'virtual:vite-icons/mdi/code'
+import { useI18n } from '../../composables'
+import { useClipboard } from '@vueuse/core'
+
+defineProps<{
+  code: string
+}>()
+
+const { copy, copied } = useClipboard()
+const { t } = useI18n()
+</script>

--- a/packages/launchpad/src/settings/project/ConfigLegend.spec.tsx
+++ b/packages/launchpad/src/settings/project/ConfigLegend.spec.tsx
@@ -1,0 +1,16 @@
+import { defaultMessages } from '../../locales/i18n'
+import ConfigLegend from './ConfigLegend.vue'
+import { each } from 'lodash'
+
+const legend = defaultMessages.settingsPage.config.legend
+
+describe('<ConfigLegend/>', () => {
+  it('renders', () => {
+    cy.mount(() => <ConfigLegend></ConfigLegend>)
+
+    each(legend, ({ label, description }) => {
+      cy.contains(label)
+      each(description.split('{0}'), (desc) => desc && cy.contains(desc))
+    })
+  })
+})

--- a/packages/launchpad/src/settings/project/ConfigLegend.vue
+++ b/packages/launchpad/src/settings/project/ConfigLegend.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="children:mb-18px">
+    <ConfigBadge class="bg-gray-100 text-gray-700"
+      :label="legendText.default.label">
+      {{ legendText.default.description}}
+    </ConfigBadge>
+
+    <ConfigBadge class="bg-teal-100 text-teal-700"
+      :label="legendText.config.label">
+      <i18n-t :keypath="legendText.config.descriptionKey">
+        <a href="https://docs.cypress.io" target="_blank">cypress.config.js</a>
+      </i18n-t>
+    </ConfigBadge>
+
+    <ConfigBadge class="bg-yellow-100 text-yellow-700"
+      :label="legendText.env.label">
+      {{ legendText.env.description }}
+    </ConfigBadge>
+
+    <ConfigBadge class="bg-red-50 text-red-700"
+      :label="legendText.cli.label">
+      {{ legendText.cli.description }}
+    </ConfigBadge>
+
+    <ConfigBadge class="bg-purple-50 text-purple-700"
+      :label="legendText.dynamic.label">
+      <i18n-t :keypath="legendText.dynamic.descriptionKey">
+        <a href="https://docs.cypress.io" target="_blank">setupNodeEnv</a>
+      </i18n-t>
+    </ConfigBadge>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import ConfigBadge from "./ConfigBadge.vue";
+import { computed } from "vue";
+import { useI18n } from "../../composables";
+
+const { t } = useI18n()
+const legendText = computed(() => ({
+  default: {
+    label: t('settingsPage.config.legend.default.label'),
+    description: t('settingsPage.config.legend.default.description'),
+  },
+  config: {
+    label: t('settingsPage.config.legend.config.label'),
+    descriptionKey: 'settingsPage.config.legend.config.description'
+  },
+  env: {
+    label: t('settingsPage.config.legend.env.label'),
+    description: t('settingsPage.config.legend.env.description'),
+  },
+  cli: {
+    label: t('settingsPage.config.legend.cli.label'),
+    description: t('settingsPage.config.legend.cli.description'),
+  },
+  dynamic: {
+    label: t('settingsPage.config.legend.dynamic.label'),
+    descriptionKey: 'settingsPage.config.legend.dynamic.description',
+  },
+}))
+</script>

--- a/packages/launchpad/src/settings/project/ProjectSettings.vue
+++ b/packages/launchpad/src/settings/project/ProjectSettings.vue
@@ -1,8 +1,9 @@
 <template>
-  <main class="children:pt-7 children:pb-7 children:border-b-1">
+  <main class="divide-y divide-gray-200 children:pt-7 children:pb-7">
     <ProjectId class="pt-0"/>
     <RecordKey />
     <Experiments />
+    <Config />
   </main>
 </template>
 
@@ -10,12 +11,5 @@
 import RecordKey from './RecordKey.vue'
 import Experiments from './Experiments.vue'
 import ProjectId from './ProjectId.vue'
+import Config from './Config.vue'
 </script>
-
-<style lang="scss" scoped>
-main {
-  > :last-child {
-    @apply border-none pb-0;
-  }
-}
-</style>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

## Purpose
This PR delivers the Resolved Config section to the Project Settings page.

- Closes [#UNIFY-262](https://cypress-io.atlassian.net/browse/UNIFY-262?atlOrigin=eyJpIjoiOGJlMDVjMWRkYTJjNGEyMjg0ZjUyMzkyMjc2Y2IwYWQiLCJwIjoiaiJ9)

## How to test
Open up the Cypress Component Test Runner within this branch.

```sh
yarn workspace @packages/launchpad cypress:open # from the project root
```

## Settings Page, so far...
This is the final component to be built within the Settings Page. Here's how it looks!

![Screen Shot 2021-08-06 at 9 07 53 AM](https://user-images.githubusercontent.com/2801156/128515343-82b6e52e-34e7-4364-9a92-16e68eea1186.png)


## Components

### Config
The resolved config is ready to be plumbed into gql to fetch the real project config. Right now, it's only rendering a json object to the screen -- it still needs the syntax highlighting logic.

https://user-images.githubusercontent.com/2801156/128514935-797e715b-d05c-420c-8131-cfe54c769001.mov

### ConfigCode
The component responsible for displaying the resolved json from the config object. It supports copying, but there is still an outstanding task to hook it up so that it opens the user's editor. This is waiting on the proper endpoint.

![Screen Shot 2021-08-06 at 9 07 10 AM](https://user-images.githubusercontent.com/2801156/128515125-42816e98-3254-46d1-ad08-14e77c00d9c5.png)

### ConfigLegend
The component that renders the correct text for each label and described where each setting comes from.

![Screen Shot 2021-08-06 at 9 07 21 AM](https://user-images.githubusercontent.com/2801156/128515213-3ebb04e0-20e7-4fb1-a30f-589f3480a892.png)

### ConfigBadge
The small badge and description below that's used to build the `ConfigLegend`.
![Screen Shot 2021-08-06 at 9 00 26 AM](https://user-images.githubusercontent.com/2801156/128516018-77c724a0-ee00-4130-8df7-e5a2d9e6c071.png)

## Tests
I'm exploring the idea of text matching for content, based off of the default localized english strings. This both makes sure that we're choosing high-confidence tests as well as means that we won't inadvertently break tests when making changes to the App's copy.

It's only complicated by the localized strings which require html to be set inside of them. It's not that big of a deal and right now I'm just string slicing. In the future, if we actually care more about this, or like this approach, I have an idea for how to build it this support into a Cy command so that it behaves like a normal `cy.contains` might.