### PR TITLE
fix: chain update all specs when changing child 

### DIFF
--- a/npm/vite-dev-server/cypress/components/vue/Hello/Hello.spec.js
+++ b/npm/vite-dev-server/cypress/components/vue/Hello/Hello.spec.js
@@ -4,7 +4,7 @@ import Hello from './Hello.vue'
 
 describe('Hello', () => {
   it('shows error for short text', () => {
-    cy.viewport(300, 200)
+    cy.viewport(500, 800)
     mount(Hello)
     // use the component like a real user
     cy.findByRole('textbox').type('abc')

--- a/npm/vite-dev-server/cypress/components/vue/Hello/Hello.vue
+++ b/npm/vite-dev-server/cypress/components/vue/Hello/Hello.vue
@@ -3,12 +3,16 @@
     <input v-model="username" />
     <div v-if="error" class="error">{{ error }}</div>
     <img src="./logo.png" />
+    <Card/>
   </div>
 </template>
 
 <script>
+import Card from "../Card/Card.vue"
+
 export default {
   name: "Hello",
+  components: { Card },
   data() {
     return {
       username: "",

--- a/npm/vite-dev-server/src/makeCypressPlugin.ts
+++ b/npm/vite-dev-server/src/makeCypressPlugin.ts
@@ -34,8 +34,8 @@ interface Spec{
 
 export const makeCypressPlugin = (
   projectRoot: string,
-  supportFilePath: string,
-  devServerEvents: EventEmitter,
+  supportFilePath: string | false,
+  devServerEvents: NodeJS.EventEmitter,
   specs: Spec[],
 ): Plugin => {
   let base = '/'

--- a/npm/vite-dev-server/src/makeCypressPlugin.ts
+++ b/npm/vite-dev-server/src/makeCypressPlugin.ts
@@ -93,8 +93,10 @@ export const makeCypressPlugin = (
       let moduleImporters = server.moduleGraph.fileToModulesMap.get(file)
       let iterationNumber = 0
 
+      const exploredFiles = new Set<string>()
+
       // until we reached a point where the current module is imported by no other
-      while (moduleImporters && moduleImporters.size) {
+      while (moduleImporters?.size) {
         if (iterationNumber > HMR_DEPENDENCY_LOOKUP_MAX_ITERATION) {
           debug(`max hmr iteration reached: ${HMR_DEPENDENCY_LOOKUP_MAX_ITERATION}; Rerun will not happen on this file change.`)
 
@@ -108,19 +110,27 @@ export const makeCypressPlugin = (
             debug('handleHotUpdate - support compile success')
             devServerEvents.emit('dev-server:compile:success')
 
+            // if we update support we know we have to re-run it all
+            // no need to ckeck further
             return []
           }
 
           if (mod.file && specsPathsSet.has(mod.file)) {
             debug('handleHotUpdate - spec compile success', mod.file)
             devServerEvents.emit('dev-server:compile:success', { specFile: mod.file })
+            // if we find one spec, does not mean we are done yet,
+            // there could be other spec files to re-run
+            // see https://github.com/cypress-io/cypress/issues/17691
+          }
 
-            return []
+          // to avoid circular updates, keep track of what we updated
+          if (mod.file) {
+            exploredFiles.add(mod.file)
           }
         }
 
         // get all the modules that import the current one
-        moduleImporters = getImporters(moduleImporters)
+        moduleImporters = getImporters(moduleImporters, exploredFiles)
         iterationNumber += 1
       }
 
@@ -129,11 +139,13 @@ export const makeCypressPlugin = (
   }
 }
 
-function getImporters (modules: Set<ModuleNode>): Set<ModuleNode> {
+function getImporters (modules: Set<ModuleNode>, alreadyExploredFiles: Set<string>): Set<ModuleNode> {
   const allImporters = new Set<ModuleNode>()
 
   modules.forEach((m) => {
-    m.importers.forEach((imp) => allImporters.add(imp))
+    if (m.file && !alreadyExploredFiles.has(m.file)) {
+      m.importers.forEach((imp) => allImporters.add(imp))
+    }
   })
 
   return allImporters

--- a/npm/vite-dev-server/src/startServer.ts
+++ b/npm/vite-dev-server/src/startServer.ts
@@ -6,18 +6,11 @@ import { makeCypressPlugin } from './makeCypressPlugin'
 
 const debug = Debug('cypress:vite-dev-server:start')
 
-interface Options {
-  specs: Cypress.Cypress['spec'][]
-  config: Record<string, string>
-  devServerEvents: EventEmitter
-  [key: string]: unknown
-}
-
 export interface StartDevServerOptions {
   /**
    * the Cypress options object
    */
-  options: Options
+  options: Cypress.DevServerOptions
   /**
    * By default, vite will use your vite.config file to
    * Start the server. If you need additional plugins or


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #17691

### User facing changelog
When requiring a component from a spec file, if a dependency component of this component is changed and this component has a spec too, both specs are re-run.

### Additional details
This issue was found while using the vite-dev-server in developing the launchpad
