### PR TITLE
fix: Add Timeoutable to cy.document function typing

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -982,7 +982,7 @@ declare namespace Cypress {
      *      .its('contentType')
      *      .should('eq', 'text/html')
      */
-    document(options?: Partial<Loggable>): Chainable<Document>
+    document(options?: Partial<Loggable & Timeoutable>): Chainable<Document>
 
     /**
      * Iterate through an array like structure (arrays or objects with a length property).


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/17695

### User facing changelog
Fixes the missing `Timeoutable` typings on `cy.document()`

### Additional details
Fixes the 

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
