### PR TITLE
fix: repair re-run of vite-dev-server issues

### DIFF
--- a/npm/vite-dev-server/src/makeCypressPlugin.ts
+++ b/npm/vite-dev-server/src/makeCypressPlugin.ts
@@ -122,11 +122,6 @@ export const makeCypressPlugin = (
             // there could be other spec files to re-run
             // see https://github.com/cypress-io/cypress/issues/17691
           }
-
-          // to avoid circular updates, keep track of what we updated
-          if (mod.file) {
-            exploredFiles.add(mod.file)
-          }
         }
 
         // get all the modules that import the current one
@@ -144,7 +139,10 @@ function getImporters (modules: Set<ModuleNode>, alreadyExploredFiles: Set<strin
 
   modules.forEach((m) => {
     if (m.file && !alreadyExploredFiles.has(m.file)) {
-      m.importers.forEach((imp) => allImporters.add(imp))
+      alreadyExploredFiles.add(m.file)
+      m.importers.forEach((imp) => {
+        allImporters.add(imp)
+      })
     }
   })
 

--- a/npm/vite-dev-server/src/makeCypressPlugin.ts
+++ b/npm/vite-dev-server/src/makeCypressPlugin.ts
@@ -134,6 +134,12 @@ export const makeCypressPlugin = (
   }
 }
 
+/**
+ * Gets all the modules that import the set of modules passed in parameters
+ * @param modules the set of module whose dependents to return
+ * @param alreadyExploredFiles set of files that have already been looked at and should be avoided in case of circular dependency
+ * @returns a set of ModuleMode that import directly the current modules
+ */
 function getImporters (modules: Set<ModuleNode>, alreadyExploredFiles: Set<string>): Set<ModuleNode> {
   const allImporters = new Set<ModuleNode>()
 


### PR DESCRIPTION
In vite-dev-server 2.0.7, when updating (saving) a component, the linked spec file was not re-running.
This error happened because vite-dev-server prevented circular references the wrong way. 
It added files to `analyzedDependencies` before they were analyzed.

With this PR the dependencies are added to the list after they are analyzed.

