### PR TITLE
fix: Use app.quit instead of process.exit to prevent crash on close

### DIFF
--- a/packages/server/lib/modes/interactive-e2e.js
+++ b/packages/server/lib/modes/interactive-e2e.js
@@ -18,7 +18,7 @@ module.exports = {
     return os.platform() === 'darwin'
   },
 
-  getWindowArgs (state, options = {}) {
+  getWindowArgs (state) {
     const common = {
       backgroundColor: '#dfe2e4',
       width: state.appWidth || 800,
@@ -51,7 +51,7 @@ module.exports = {
         return Windows.showAll()
       },
       onClose () {
-        return process.exit()
+        app.quit()
       },
     }
 

--- a/packages/server/test/unit/modes/interactive_spec.js
+++ b/packages/server/test/unit/modes/interactive_spec.js
@@ -25,11 +25,11 @@ describe('gui/interactive', () => {
   })
 
   context('.getWindowArgs', () => {
-    it('exits process when onClose is called', () => {
-      sinon.stub(process, 'exit')
+    it('quits app when onClose is called', () => {
+      electron.app.quit = sinon.stub()
       interactiveMode.getWindowArgs({}).onClose()
 
-      expect(process.exit).to.be.called
+      expect(electron.app.quit).to.be.called
     })
 
     it('tracks state properties', () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #17766

### User facing changelog

- Cypress no longer causes a SIGSEGV error on Mac when closing the test runner

### Additional details

Using `process.exit()` doesn't allow time for other handlers and cleanup to run, causing the SIGSEGV error. [`app.quit()`](https://www.electronjs.org/docs/api/app#appquit) "guarantees that all beforeunload and unload event handlers are correctly executed."



### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated? _I updated the unit test, but I don't think there's any way to write an automated test for the actual crashing issue..._
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)--> 
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
