### PR TITLE
fix: do not allow image markdown in assertions and command log

### DIFF
--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -1197,6 +1197,20 @@ describe('src/cy/commands/assertions', () => {
         })
       })
     })
+
+    describe('escape markdown', () => {
+      // https://github.com/cypress-io/cypress/issues/17357
+      it('images', (done) => {
+        const text = 'hello world ![JSDoc example](/slides/img/jsdoc.png)'
+        const result = 'hello world ``![JSDoc example](/slides/img/jsdoc.png)``'
+
+        expectMarkdown(
+          () => expect(text).to.equal(text),
+          `expected **${result}** to equal **${result}**`,
+          done,
+        )
+      })
+    })
   })
 
   context('chai overrides', () => {

--- a/packages/driver/src/cy/chai.js
+++ b/packages/driver/src/cy/chai.js
@@ -28,6 +28,7 @@ const leadingWhitespaces = /\*\*'\s*/g
 const trailingWhitespaces = /\s*'\*\*/g
 const whitespace = /\s/g
 const valueHasLeadingOrTrailingWhitespaces = /\*\*'\s+|\s+'\*\*/g
+const imageMarkdown = /!\[.*?\]\(.*?\)/g
 
 let assertProto = null
 let matchProto = null
@@ -128,6 +129,10 @@ chai.use((chai, u) => {
       .replace(allSingleQuotes, '')
       .replace(allQuoteMarkers, '\'') // put escaped quotes back
     })
+  }
+
+  const escapeMarkdown = (message) => {
+    return message.replace(imageMarkdown, '``$&``')
   }
 
   const replaceArgMessages = (args, str) => {
@@ -447,6 +452,7 @@ chai.use((chai, u) => {
       const actual = chaiUtils.getActual(this, customArgs)
 
       message = removeOrKeepSingleQuotesBetweenStars(message)
+      message = escapeMarkdown(message)
 
       try {
         assertProto.apply(this, args)


### PR DESCRIPTION
- Closes #17357

### User facing changelog

Do not allow image markdown in assertions and command log

### Additional details
- Why was this change necessary? => Image markdowns are interpreted in command log and it makes it hard for us to understand the assertion message.
- What is affected by this change? => N/A
- Any implementation details to explain? => By escaping markdowns.

### How has the user experience changed?

Before:

![Screenshot from 2021-08-18 09-56-34](https://user-images.githubusercontent.com/8130013/129819683-4a8633b5-b38c-4986-927b-6907f8296abf.png)

After:

![Screenshot from 2021-08-18 09-58-07](https://user-images.githubusercontent.com/8130013/129819778-9de7af18-ff60-4175-a4cb-c0775e5a201f.png)


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
