### PR TITLE
fix: publish the types for vite-dev-server

### DIFF
--- a/npm/vite-dev-server/package.json
+++ b/npm/vite-dev-server/package.json
@@ -34,7 +34,8 @@
   "files": [
     "dist",
     "client",
-    "index.html"
+    "index.html",
+    "index.d.ts"
   ],
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
- Closes #17648

### User facing changelog
Publish the root types of vite-dev-server since they were forgotten prior to this PR 
