### PR TITLE
feat: add firefox `beforeinput` event support

### DIFF
--- a/packages/driver/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_spec.js
@@ -24,8 +24,6 @@ const expectTextEndsWith = (expected) => {
   }
 }
 
-const isChromium = Cypress.isBrowser({ family: 'chromium' })
-
 describe('src/cy/commands/actions/type - #type', () => {
   beforeEach(() => {
     cy.visit('/fixtures/dom.html')
@@ -2028,12 +2026,8 @@ describe('src/cy/commands/actions/type - #type', () => {
         .type(' f\n{backspace}')
         .type('{moveToStart}{del}')
         .then(($el) => {
-          if (isChromium) {
-            expect(stub).callCount(5)
-            expect($el[0].value).eq('oo bar baz ')
-          } else {
-            expect(stub, 'should NOT send beforeinput unless in chromium based browser').not.called
-          }
+          expect(stub).callCount(5)
+          expect($el[0].value).eq('oo bar baz ')
         })
       })
 
@@ -2076,12 +2070,8 @@ describe('src/cy/commands/actions/type - #type', () => {
         .type(' f\n{backspace}')
         .type('{moveToStart}{del}')
         .then(($el) => {
-          if (isChromium) {
-            expect(stub).callCount(5)
-            expect($el[0].value).eq('oo bar baz f')
-          } else {
-            expect(stub, 'should NOT send beforeinput unless in chromium based browser').not.called
-          }
+          expect(stub).callCount(5)
+          expect($el[0].value).eq('oo bar baz f')
         })
       })
 
@@ -2124,12 +2114,8 @@ describe('src/cy/commands/actions/type - #type', () => {
         .type(' f\n{backspace}')
         .type('{moveToStart}{del}')
         .then(($el) => {
-          if (isChromium) {
-            expect(stub).callCount(5)
-            expect($el[0].textContent).eq('oo bar baz f')
-          } else {
-            expect(stub, 'should NOT send beforeinput unless in chromium based browser').not.called
-          }
+          expect(stub).callCount(5)
+          expect($el[0].textContent).eq('oo bar baz f')
         })
       })
 
@@ -2169,11 +2155,7 @@ describe('src/cy/commands/actions/type - #type', () => {
         .type('{ctrl}{backspace}')
         .type('{ctrl}{shift}{backspace}')
         .then(($el) => {
-          if (isChromium) {
-            expect(stub).callCount(4)
-          } else {
-            expect(stub, 'should NOT send beforeinput unless in chromium based browser').not.called
-          }
+          expect(stub).callCount(4)
         })
       })
 
@@ -2190,12 +2172,8 @@ describe('src/cy/commands/actions/type - #type', () => {
         })
         .type('foo')
         .then(($el) => {
-          if (isChromium) {
-            expect(callCount).eq(3)
-            expect($el[0].value).eq('foo bar baz')
-          } else {
-            expect(callCount, 'should NOT send beforeinput unless in chromium based browser').eq(0)
-          }
+          expect(callCount).eq(3)
+          expect($el[0].value).eq('foo bar baz')
         })
       })
     })
@@ -2573,17 +2551,15 @@ describe('src/cy/commands/actions/type - #type', () => {
         // eslint-disable-next-line
           console.table(table.data, table.columns)
 
-        const beforeinput = Cypress.isBrowser('firefox') ? '' : ' beforeinput,'
-
         expect(table.name).to.eq('Keyboard Events')
         const expectedTable = {
-          1: { 'Details': '{ code: KeyH, which: 72 }', Typed: 'h', 'Events Fired': `keydown, keypress,${beforeinput} textInput, input, keyup`, 'Active Modifiers': null, 'Prevented Default': null, 'Target Element': $input[0] },
+          1: { 'Details': '{ code: KeyH, which: 72 }', Typed: 'h', 'Events Fired': `keydown, keypress, beforeinput, textInput, input, keyup`, 'Active Modifiers': null, 'Prevented Default': null, 'Target Element': $input[0] },
           2: { 'Details': '{ code: ControlLeft, which: 17 }', Typed: '{ctrl}', 'Events Fired': 'keydown', 'Active Modifiers': 'ctrl', 'Prevented Default': null, 'Target Element': $input[0] },
           3: { 'Details': '{ code: AltLeft, which: 18 }', Typed: '{alt}', 'Events Fired': 'keydown', 'Active Modifiers': 'alt, ctrl', 'Prevented Default': null, 'Target Element': $input[0] },
           4: { 'Details': '{ code: Equal, which: 187 }', Typed: '+', 'Events Fired': 'keydown, keyup', 'Active Modifiers': 'alt, ctrl', 'Prevented Default': null, 'Target Element': $input[0] },
           5: { 'Details': '{ code: AltLeft, which: 18 }', Typed: '{alt}', 'Events Fired': 'keyup', 'Active Modifiers': 'ctrl', 'Prevented Default': null, 'Target Element': $input[0] },
           6: { 'Details': '{ code: ControlLeft, which: 17 }', Typed: '{ctrl}', 'Events Fired': 'keyup', 'Active Modifiers': null, 'Prevented Default': null, 'Target Element': $input[0] },
-          7: { 'Details': '{ code: KeyI, which: 73 }', Typed: 'i', 'Events Fired': `keydown, keypress,${beforeinput} textInput, input, keyup`, 'Active Modifiers': null, 'Prevented Default': null, 'Target Element': $input[0] },
+          7: { 'Details': '{ code: KeyI, which: 73 }', Typed: 'i', 'Events Fired': `keydown, keypress, beforeinput, textInput, input, keyup`, 'Active Modifiers': null, 'Prevented Default': null, 'Target Element': $input[0] },
         }
 
         // uncomment for debugging
@@ -3484,20 +3460,18 @@ describe('src/cy/commands/actions/type - #type', () => {
           // eslint-disable-next-line
             console.table(table.data, table.columns)
 
-          const beforeInput = isChromium ? 'beforeinput, ' : ''
-
           expect(table.name).to.eq('Keyboard Events')
           const expectedTable = {
             1: { 'Details': '{ code: MetaLeft, which: 91 }', Typed: '{cmd}', 'Events Fired': 'keydown', 'Active Modifiers': 'meta', 'Prevented Default': null, 'Target Element': $input[0] },
             2: { 'Details': '{ code: AltLeft, which: 18 }', Typed: '{option}', 'Events Fired': 'keydown', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
-            3: { 'Details': '{ code: KeyF, which: 70 }', Typed: 'f', 'Events Fired': `keydown, keypress, ${beforeInput}textInput, input, keyup`, 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
-            4: { 'Details': '{ code: KeyO, which: 79 }', Typed: 'o', 'Events Fired': `keydown, keypress, ${beforeInput}textInput, input, keyup`, 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
-            5: { 'Details': '{ code: KeyO, which: 79 }', Typed: 'o', 'Events Fired': `keydown, keypress, ${beforeInput}textInput, input, keyup`, 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
-            6: { 'Details': '{ code: Enter, which: 13 }', Typed: '{enter}', 'Events Fired': `keydown, keypress, ${beforeInput}keyup`, 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
-            7: { 'Details': '{ code: KeyB, which: 66 }', Typed: 'b', 'Events Fired': `keydown, keypress, ${beforeInput}textInput, input, keyup`, 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
+            3: { 'Details': '{ code: KeyF, which: 70 }', Typed: 'f', 'Events Fired': `keydown, keypress, beforeinput, textInput, input, keyup`, 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
+            4: { 'Details': '{ code: KeyO, which: 79 }', Typed: 'o', 'Events Fired': `keydown, keypress, beforeinput, textInput, input, keyup`, 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
+            5: { 'Details': '{ code: KeyO, which: 79 }', Typed: 'o', 'Events Fired': `keydown, keypress, beforeinput, textInput, input, keyup`, 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
+            6: { 'Details': '{ code: Enter, which: 13 }', Typed: '{enter}', 'Events Fired': `keydown, keypress, beforeinput, keyup`, 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
+            7: { 'Details': '{ code: KeyB, which: 66 }', Typed: 'b', 'Events Fired': `keydown, keypress, beforeinput, textInput, input, keyup`, 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
             8: { 'Details': '{ code: ArrowLeft, which: 37 }', Typed: '{leftarrow}', 'Events Fired': 'keydown, keyup', 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
-            9: { 'Details': '{ code: Delete, which: 46 }', Typed: '{del}', 'Events Fired': `keydown, ${beforeInput}input, keyup`, 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
-            10: { 'Details': '{ code: Enter, which: 13 }', Typed: '{enter}', 'Events Fired': `keydown, keypress, ${beforeInput}keyup`, 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
+            9: { 'Details': '{ code: Delete, which: 46 }', Typed: '{del}', 'Events Fired': `keydown, beforeinput, input, keyup`, 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
+            10: { 'Details': '{ code: Enter, which: 13 }', Typed: '{enter}', 'Events Fired': `keydown, keypress, beforeinput, keyup`, 'Active Modifiers': 'alt, meta', 'Prevented Default': null, 'Target Element': $input[0] },
             11: { 'Details': '{ code: MetaLeft, which: 91 }', Typed: '{cmd}', 'Events Fired': 'keyup', 'Active Modifiers': 'alt', 'Prevented Default': null, 'Target Element': $input[0] },
             12: { 'Details': '{ code: AltLeft, which: 18 }', Typed: '{option}', 'Events Fired': 'keyup', 'Active Modifiers': null, 'Prevented Default': null, 'Target Element': $input[0] },
           }
@@ -3513,10 +3487,8 @@ describe('src/cy/commands/actions/type - #type', () => {
         cy.get(':text:first').type('f').then(function ($el) {
           const table = this.lastLog.invoke('consoleProps').table[2]()
 
-          const beforeInput = isChromium ? 'beforeinput, ' : ''
-
           expect(table.data).to.deep.eq({
-            1: { Typed: 'f', 'Events Fired': `keydown, keypress, ${beforeInput}textInput, input, keyup`, 'Active Modifiers': null, Details: '{ code: KeyF, which: 70 }', 'Prevented Default': null, 'Target Element': $el[0] },
+            1: { Typed: 'f', 'Events Fired': `keydown, keypress, beforeinput, textInput, input, keyup`, 'Active Modifiers': null, Details: '{ code: KeyF, which: 70 }', 'Prevented Default': null, 'Target Element': $el[0] },
           })
         })
       })

--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -689,10 +689,8 @@ export interface typeOptions {
 }
 
 export class Keyboard {
-  private SUPPORTS_BEFOREINPUT_EVENT
-
-  constructor (private Cypress, private state: State) {
-    this.SUPPORTS_BEFOREINPUT_EVENT = Cypress.isBrowser({ family: 'chromium' })
+  constructor (private state: State) {
+    null
   }
 
   type (opts: typeOptions) {
@@ -1174,7 +1172,6 @@ export class Keyboard {
         this.fireSimulatedEvent(elToType, 'keypress', key, options)
       ) {
         if (
-          !this.SUPPORTS_BEFOREINPUT_EVENT ||
           shouldIgnoreEvent('beforeinput', key.events) ||
           this.fireSimulatedEvent(elToType, 'beforeinput', key, options)
         ) {
@@ -1317,8 +1314,8 @@ export class Keyboard {
   }
 }
 
-const create = (Cypress, state) => {
-  return new Keyboard(Cypress, state)
+const create = (state) => {
+  return new Keyboard(state)
 }
 
 let _defaults

--- a/packages/driver/src/cypress/cy.js
+++ b/packages/driver/src/cypress/cy.js
@@ -153,7 +153,7 @@ const create = function (specWindow, Cypress, Cookies, state, config, log) {
   const jquery = $jQuery.create(state)
   const location = $Location.create(state)
   const focused = $Focused.create(state)
-  const keyboard = $Keyboard.create(Cypress, state)
+  const keyboard = $Keyboard.create(state)
   const mouse = $Mouse.create(state, keyboard, focused, Cypress)
   const timers = $Timers.create(Cypress)
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/17583

### User facing changelog
[.type()](https://docs.cypress.io/api/commands/type) now fires the `beforeInput` event during typing in Firefox. _Note: Chromium support was added in [5.5.0](https://docs.cypress.io/guides/references/changelog#5-5-0)_ Addresses #17583.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Support for the `beforeinput` event was previously added for Chromium but at that time Firefox did not support it. However, Firefox added support for `beforeinput` in version 87. This PR updates the related browser checks to include both Chromium and Firefox. The `beforeInput event` tests in type_spec.js now pass for both Chrome and Firefox.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Users can now test the `type()` command on inputs that rely on the `beforeinput` event in Firefox.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/4070
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
