### PR TITLE
fix: #15199: Increasing the default timeout values in cy.screenshot() for longer response time 

### DIFF
--- a/packages/driver/cypress/integration/commands/screenshot_spec.js
+++ b/packages/driver/cypress/integration/commands/screenshot_spec.js
@@ -73,7 +73,7 @@ describe('src/cy/commands/screenshot', () => {
         expect(Cypress.automation).not.to.be.called
       })
     })
- 
+
     it('is noop when screenshotOnRunFailure is false', () => {
       Cypress.config('isInteractive', false)
       cy.stub(Screenshot, 'getConfig').returns({

--- a/packages/driver/cypress/integration/commands/screenshot_spec.js
+++ b/packages/driver/cypress/integration/commands/screenshot_spec.js
@@ -73,7 +73,7 @@ describe('src/cy/commands/screenshot', () => {
         expect(Cypress.automation).not.to.be.called
       })
     })
-
+ 
     it('is noop when screenshotOnRunFailure is false', () => {
       Cypress.config('isInteractive', false)
       cy.stub(Screenshot, 'getConfig').returns({
@@ -818,20 +818,20 @@ describe('src/cy/commands/screenshot', () => {
       })
 
       it('sets timeout to Cypress.config(responseTimeout)', {
-        responseTimeout: 2500,
+        responseTimeout: 5000,
       }, () => {
         const timeout = cy.spy(Promise.prototype, 'timeout')
 
         cy.screenshot().then(() => {
-          expect(timeout).to.be.calledWith(2500)
+          expect(timeout).to.be.calledWith(5000)
         })
       })
 
       it('can override timeout', () => {
         const timeout = cy.spy(Promise.prototype, 'timeout')
 
-        cy.screenshot({ timeout: 1000 }).then(() => {
-          expect(timeout).to.be.calledWith(1000)
+        cy.screenshot({ timeout: 5000 }).then(() => {
+          expect(timeout).to.be.calledWith(5000)
         })
       })
 
@@ -1056,7 +1056,7 @@ describe('src/cy/commands/screenshot', () => {
       })
 
       it('throws after timing out', function (done) {
-        Cypress.automation.withArgs('take:screenshot').resolves(Promise.delay(1000))
+        Cypress.automation.withArgs('take:screenshot').resolves(Promise.delay(5000))
 
         cy.on('fail', (err) => {
           const { lastLog } = this
@@ -1066,13 +1066,13 @@ describe('src/cy/commands/screenshot', () => {
           expect(lastLog.get('state')).to.eq('failed')
           expect(lastLog.get('name')).to.eq('screenshot')
           expect(lastLog.get('message')).to.eq('foo')
-          expect(err.message).to.eq('`cy.screenshot()` timed out waiting `50ms` to complete.')
+          expect(err.message).to.eq('`cy.screenshot()` timed out waiting `100ms` to complete.')
           expect(err.docsUrl).to.eq('https://on.cypress.io/screenshot')
 
           done()
         })
 
-        cy.screenshot('foo', { timeout: 50 })
+        cy.screenshot('foo', { timeout: 100 })
       })
     })
 


### PR DESCRIPTION
- Closes #15199


### Additional details
--> There was an issue with cy.screenshot() while using the "fullPage" attribute for capturing long web pages. As the request was timing out due to the longer load time of the website. 
--> In this PR, added longer default wait timings for the website to load completely beforeScreenshot.

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
