### PR TITLE
fix: fixed implementation & types mismatch for `Cypress.dom.getWindowByElement`

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -493,7 +493,7 @@ declare namespace Cypress {
       getElements(element: JQuery): JQuery | HTMLElement[]
       getContainsSelector(text: string, filter?: string): JQuery.Selector
       getFirstDeepestElement(elements: HTMLElement[], index?: number): HTMLElement
-      getWindowByElement(element: JQuery | HTMLElement): JQuery | HTMLElement
+      getWindowByElement(element: JQuery | HTMLElement): Window & typeof globalThis
       getReasonIsHidden(element: JQuery | HTMLElement, options?: object): string
       getFirstScrollableParent(element: JQuery | HTMLElement): JQuery | HTMLElement
       getFirstFixedOrStickyPositionParent(element: JQuery | HTMLElement): JQuery | HTMLElement

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -530,7 +530,7 @@ namespace CypressDomTests {
   Cypress.dom.getElements(jel) // $ExpectType JQuery<HTMLElement> | HTMLElement[]
   Cypress.dom.getContainsSelector('foo', 'bar') // $ExpectType string
   Cypress.dom.getFirstDeepestElement([el], 1) // $ExpectType HTMLElement
-  Cypress.dom.getWindowByElement(el) // $ExpectType HTMLElement | JQuery<HTMLElement>
+  Cypress.dom.getWindowByElement(el) // $ExpectType Window & typeof globalThis
   Cypress.dom.getReasonIsHidden(el) // $ExpectType string
   Cypress.dom.getFirstScrollableParent(el) // $ExpectType HTMLElement | JQuery<HTMLElement>
   Cypress.dom.getFirstFixedOrStickyPositionParent(el) // $ExpectType HTMLElement | JQuery<HTMLElement>

--- a/packages/driver/src/dom/window.js
+++ b/packages/driver/src/dom/window.js
@@ -1,11 +1,14 @@
 const $jquery = require('./jquery')
 const $document = require('./document')
+const jquery = require('./jquery')
 
 /**
- * @param {HTMLElement} el
+ * @param {JQuery<HTMLElement> | HTMLElement} $el
  * @returns {Window & typeof globalThis}
  */
-const getWindowByElement = function (el) {
+const getWindowByElement = function ($el) {
+  const el = jquery.isJquery($el) ? $el[0] : $el
+
   if (isWindow(el)) {
     return el
   }


### PR DESCRIPTION
When implementing a custom `isInViewport` I've noticed this mismatch along with this one: https://github.com/cypress-io/cypress/pull/17914

### User facing changelog

Fixed an issue with `Cypress.dom.getWindowByElement` crashing when receiving a jQuery element and improved its declared return type to be `Window & typeof globalThis`.

### Additional details
- Why was this change necessary?

Fixed an issue with `Cypress.dom.getWindowByElement` crashing when receiving a jQuery element. The return type of this function was also suboptimal.

- What is affected by this change?

The implementation of the `Cypress.dom.getWindowByElement` and the declared types for it.


### How has the user experience changed?

It has been improved because it will now be easier to work with this function.

### PR Tasks
- [ ] Have tests been added/updated?
