### PR TITLE
feat: add `decode` option to `cy.url`

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2060,7 +2060,7 @@ declare namespace Cypress {
      * @alias cy.location('href')
      * @see https://on.cypress.io/url
      */
-    url(options?: Partial<Loggable & Timeoutable>): Chainable<string>
+    url(options?: Partial<UrlOptions>): Chainable<string>
 
     /**
      * Control the size and orientation of the screen for your application.
@@ -3171,6 +3171,18 @@ declare namespace Cypress {
      * @default 'Event'
      */
     eventConstructor: string
+  }
+
+  /**
+   * Options to change the default behavior of .url()
+   */
+  interface UrlOptions extends Loggable, Timeoutable {
+    /**
+     * Whether the url is decoded
+     *
+     * @default false
+     */
+    decode: boolean
   }
 
   /** Options to change the default behavior of .writeFile */

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -483,6 +483,11 @@ namespace CypressLocationTests {
   cy.location('pathname') // $ExpectType Chainable<string>
 }
 
+// https://github.com/cypress-io/cypress/issues/17399
+namespace CypressUrlTests {
+  cy.url({decode: true}).should('contain', '사랑')
+}
+
 namespace CypressBrowserTests {
   Cypress.isBrowser('chrome')// $ExpectType boolean
   Cypress.isBrowser('firefox')// $ExpectType boolean

--- a/packages/driver/cypress/integration/commands/location_spec.js
+++ b/packages/driver/cypress/integration/commands/location_spec.js
@@ -30,6 +30,15 @@ describe('src/cy/commands/location', () => {
       cy.url().should('include', '/baz.html')
     })
 
+    // https://github.com/cypress-io/cypress/issues/17399
+    it('url decode option', () => {
+      // encodeURI() is used below because we cannot visit the site without it.
+      // For the curious, 사랑 means "love" in Korean.
+      cy.visit(encodeURI('/custom-headers?x=사랑'))
+
+      cy.url({ decode: true }).should('contain', '사랑')
+    })
+
     describe('assertion verification', () => {
       beforeEach(function () {
         cy.on('log:added', (attrs, log) => {

--- a/packages/driver/src/cy/commands/location.js
+++ b/packages/driver/src/cy/commands/location.js
@@ -8,7 +8,10 @@ module.exports = (Commands, Cypress, cy) => {
     url (options = {}) {
       const userOptions = options
 
-      options = _.defaults({}, userOptions, { log: true })
+      options = _.defaults({}, userOptions, {
+        log: true,
+        decode: false,
+      })
 
       if (options.log !== false) {
         options._log = Cypress.log({
@@ -23,6 +26,10 @@ module.exports = (Commands, Cypress, cy) => {
 
       const resolveHref = () => {
         return Promise.try(getHref).then((href) => {
+          if (options.decode) {
+            href = decodeURI(href)
+          }
+
           return cy.verifyUpcomingAssertions(href, options, {
             onRetry: resolveHref,
           })


### PR DESCRIPTION
- Closes #17399

### User facing changelog

`cy.url()` will decode URL when `decode` option is given.

### Additional details
- Why was this change necessary? => Encoded non-ascii url components are hard to read. This helps users read and test URL eaiser.
- What is affected by this change? => N/A


### Any implementation details to explain?

I was thinking what is the best solution for this problem. 

First option was to just leave the [existing workaround](https://github.com/cypress-io/cypress/issues/17399#issuecomment-899263020) at [cy.url doc](https://docs.cypress.io/api/commands/url#Examples). But I felt the solution is less Cypress-ish. 

So I decided to add an option. 

### How has the user experience changed?

**Before:**

```js
it('t', () => {
  cy.visit('https://mozilla.org/?x=шеллы')

  cy.url().then((url) => {
    expect(decodeURI(url)).to.contain('шеллы')
  })
})
```

**After:**

```js
it('t', () => {
  cy.visit('https://mozilla.org/?x=шеллы')

  cy.url({decode: true}).should('contain', 'шеллы')
})
```

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? => https://github.com/cypress-io/cypress-documentation/pull/4077
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?