### PR TITLE
fix: `Cypress.testingType` should not be `undefined`.

### DIFF
--- a/packages/driver/cypress/integration/cypress/cypress_spec.js
+++ b/packages/driver/cypress/integration/cypress/cypress_spec.js
@@ -126,6 +126,13 @@ describe('driver/src/cypress/index', () => {
     })
   })
 
+  context('.testingType', () => {
+    // https://github.com/cypress-io/cypress/issues/17664
+    it(`should be one of 'e2e' or 'component', not undefined`, () => {
+      expect(Cypress.testingType).to.be.oneOf(['e2e', 'component'])
+    })
+  })
+
   context('private command methods', () => {
     it('throws when using Cypress.addAssertionCommand', () => {
       const addAssertionCommand = () => Cypress.addAssertionCommand()

--- a/packages/server-ct/src/routes-ct.ts
+++ b/packages/server-ct/src/routes-ct.ts
@@ -22,7 +22,7 @@ export interface InitializeRoutes {
   networkProxy: NetworkProxy
   getRemoteState: () => any
   onError: (...args: unknown[]) => any
-  testingType: 'component' | 'e2e'
+  testingType: Cypress.Cypress['testingType']
 }
 
 export const createRoutes = ({

--- a/packages/server-ct/src/routes-ct.ts
+++ b/packages/server-ct/src/routes-ct.ts
@@ -22,6 +22,7 @@ export interface InitializeRoutes {
   networkProxy: NetworkProxy
   getRemoteState: () => any
   onError: (...args: unknown[]) => any
+  testingType: 'component' | 'e2e'
 }
 
 export const createRoutes = ({

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -25,6 +25,7 @@ export const createRoutes = ({
   getSpec,
   getCurrentBrowser,
   onError,
+  testingType,
 }: InitializeRoutes) => {
   // routing for the actual specs which are processed automatically
   // this could be just a regular .js file or a .coffee file
@@ -169,7 +170,8 @@ export const createRoutes = ({
     debug('Serving Cypress front-end by requested URL:', req.url)
 
     runner.serve(req, res, {
-      config,
+      // testingType should be passed below to send `testingType` to the client
+      config: { ...config, testingType },
       getSpec,
       getCurrentBrowser,
       getRemoteState,

--- a/packages/server/lib/server-base.ts
+++ b/packages/server/lib/server-base.ts
@@ -221,6 +221,7 @@ export abstract class ServerBase<TSocket extends SocketE2E | SocketCt> {
         onError,
         getSpec,
         getCurrentBrowser,
+        testingType,
       })
 
       return this.createServer(app, config, onWarning)


### PR DESCRIPTION
- Closes #17664

### User facing changelog

`Cypress.testingType` should be one of `'e2e'` or `'component'`. But it was `undefined` in `e2e` tests.

### Additional details
- Why was this change necessary? => `Cypress.testingType` wasn't working as defined.
- What is affected by this change? => N/A
- Any implementation details to explain? => `testingType` value wasn't passed from the server to the client.

### How has the user experience changed?

N/A

### PR Tasks
- [x] Have tests been added/updated?
