### PR TITLE
fix: no dev server ci

### DIFF
--- a/packages/resolve-dist/lib/index.ts
+++ b/packages/resolve-dist/lib/index.ts
@@ -19,7 +19,8 @@ export const getPathToIndex = (pkg: 'runner' | 'runner-ct') => {
 }
 
 export const getPathToDesktopIndex = (pkg: 'desktop-gui' | 'launchpad') => {
-  if (pkg === 'launchpad') return `http://localhost:3001`
+  // TODO: check if there's a better approach to fix here
+  if (pkg === 'launchpad' && !process.env.CI) return `http://localhost:3001`
 
   return `file://${path.join(__dirname, '..', '..', pkg, 'dist', 'index.html')}`
 }


### PR DESCRIPTION
Per discussion w/ @lmiller1990 & @JessicaSachs, in CI we should be serving the built files when we release.

There's probably a better way to do this conditionally, but this seemed like a quick fix to unblock CI in our unified branch