### PR TITLE
docs: Add readmes to packages that are missing Readmes

### DIFF
--- a/packages/resolve-dist/README.md
+++ b/packages/resolve-dist/README.md
@@ -1,0 +1,7 @@
+# Resolve Dist
+
+This packages...
+
+## Installing
+
+## Developing & Testing

--- a/packages/resolve-dist/README.md
+++ b/packages/resolve-dist/README.md
@@ -1,7 +1,3 @@
 # Resolve Dist
 
-This packages...
-
-## Installing
-
-## Developing & Testing
+This package centralizes the resolution of paths to compiled/static assets from server-side code.

--- a/packages/static/README.md
+++ b/packages/static/README.md
@@ -1,0 +1,7 @@
+# Static
+
+This packages...
+
+## Installing
+
+## Developing & Testing

--- a/packages/static/README.md
+++ b/packages/static/README.md
@@ -1,7 +1,0 @@
-# Static
-
-This packages...
-
-## Installing
-
-## Developing & Testing

--- a/packages/ts/README.md
+++ b/packages/ts/README.md
@@ -1,7 +1,9 @@
 # TS
 
-This packages...
+Internal package used to standardize this repo's version of `ts-node` used for development. In production we pre-transpile all of the typescript so this packages `register` export is a no-op
 
 ## Installing
+N/A - handled by the top level `yarn install`
 
 ## Developing & Testing
+N/A

--- a/packages/ts/README.md
+++ b/packages/ts/README.md
@@ -1,0 +1,7 @@
+# TS
+
+This packages...
+
+## Installing
+
+## Developing & Testing

--- a/packages/web-config/README.md
+++ b/packages/web-config/README.md
@@ -1,0 +1,7 @@
+# Web Config
+
+This packages...
+
+## Installing
+
+## Developing & Testing

--- a/packages/web-config/README.md
+++ b/packages/web-config/README.md
@@ -1,7 +1,14 @@
 # Web Config
 
-This packages...
+Internal package to standardize this repo's web-related configuration
+
+**includes:**
+- a base webpack config that we share and build upon between many projects
+- utilities for setting up nodejs unit testing in a mocked web environment. 
+- anything else that keeps web-related configuration common to multiple packages in-sync and DRY.
 
 ## Installing
+N/A - handled by the top level `yarn install`
 
 ## Developing & Testing
+N/A


### PR DESCRIPTION
In an effort to help onboard new developers, every package should have a readme explaining:

- The purpose of the package
- If applicable, how to install, develop, build, watch, test, etc in the package
