### PR TITLE
fix(launchpad): update wizard navigation

### DIFF
--- a/packages/graphql/schema.graphql
+++ b/packages/graphql/schema.graphql
@@ -362,6 +362,10 @@ type Wizard {
   """All of the bundlers to choose from"""
   allBundlers: [WizardBundler!]!
   bundler: WizardBundler
+
+  """
+  Given the current state, returns whether the user progress to the next step of the wizard
+  """
   canNavigateForward: Boolean!
 
   """The title of the page, given the current step of the wizard"""

--- a/packages/graphql/src/context/BaseContext.ts
+++ b/packages/graphql/src/context/BaseContext.ts
@@ -17,7 +17,7 @@ export abstract class BaseContext {
 
   constructor (private _launchArgs: LaunchArgs, private _launchOptions: OpenProjectLaunchOptions) {}
 
-  wizard = new Wizard()
+  wizard = new Wizard(this)
   navigationMenu = new NavigationMenu()
   app = new App(this)
 

--- a/packages/graphql/src/entities/Wizard.ts
+++ b/packages/graphql/src/entities/Wizard.ts
@@ -36,13 +36,17 @@ export class Wizard {
   private chosenBundler: Bundler | null
   private chosenFramework: FrontendFramework | null
   private chosenManualInstall: boolean
-  private history: WizardStep[] = ['welcome']
+  private _history: WizardStep[] = ['welcome']
 
   constructor (private _ctx: BaseContext) {
     this.chosenTestingType = null
     this.chosenBundler = null
     this.chosenFramework = null
     this.chosenManualInstall = false
+  }
+
+  get history (): WizardStep[] {
+    return this._history
   }
 
   @nxs.field.type(() => WizardFrontendFramework)
@@ -186,8 +190,14 @@ export class Wizard {
     return this
   }
 
-  @nxs.field.nonNull.boolean()
+  @nxs.field.nonNull.boolean({
+    description: 'Given the current state, returns whether the user progress to the next step of the wizard',
+  })
   canNavigateForward (): NxsResult<'Wizard', 'canNavigateForward'> {
+    if (this.currentStep === 'setupComplete') {
+      return false
+    }
+
     if (this.currentStep === 'selectFramework' && !this.chosenBundler && !this.chosenFramework) {
       return false
     }
@@ -197,12 +207,12 @@ export class Wizard {
   }
 
   navigate (direction: WizardNavigateDirection): Wizard {
-    debug(`history is ${this.history.join(',')}`)
+    debug(`_history is ${this._history.join(',')}`)
 
     if (direction === 'back') {
-      this.history.pop()
+      this._history.pop()
 
-      const previous = this.history[this.history.length - 1]
+      const previous = this._history[this._history.length - 1]
 
       if (previous) {
         debug(`navigating back from ${previous} to %s`, previous)
@@ -219,24 +229,24 @@ export class Wizard {
     return this.navigateForward()
   }
 
-  private get shouldLaunchCt (): boolean {
+  get shouldLaunchCt (): boolean {
     return this.chosenTestingType === 'component' && this._ctx.activeProject!.hasSetupComponentTesting
   }
 
-  private get shouldLaunchE2E (): boolean {
+  get shouldLaunchE2E (): boolean {
     return this.chosenTestingType === 'e2e' && this._ctx.activeProject!.hasSetupE2ETesting
   }
 
-  private get shouldSetupCt (): boolean {
+  get shouldSetupCt (): boolean {
     return this.chosenTestingType === 'component' && this._ctx.activeProject!.hasSetupComponentTesting === false
   }
 
-  private get shouldSetupE2E (): boolean {
+  get shouldSetupE2E (): boolean {
     return this.chosenTestingType === 'e2e' && this._ctx.activeProject!.hasSetupE2ETesting === false
   }
 
   private navigateToStep (step: WizardStep): void {
-    this.history.push(step)
+    this._history.push(step)
     this.currentStep = step
   }
 

--- a/packages/graphql/src/entities/Wizard.ts
+++ b/packages/graphql/src/entities/Wizard.ts
@@ -150,12 +150,15 @@ export class Wizard {
       })
     }
 
-    return wizardGetConfigCode({
-      type: 'e2e',
-      lang: args.lang,
-    })
-  }
+    if (this.chosenTestingType === 'e2e') {
+      return wizardGetConfigCode({
+        type: 'e2e',
+        lang: args.lang,
+      })
+    }
 
+    return null
+  }
   // Internal Setters:
 
   setTestingType (testingType: TestingType | null): Wizard {

--- a/packages/graphql/src/util/wizardGetConfigCode.ts
+++ b/packages/graphql/src/util/wizardGetConfigCode.ts
@@ -2,18 +2,46 @@ import { FRAMEWORK_CONFIG_FILE, WizardCodeLanguage } from '../constants/wizardCo
 import type { WizardBundler } from '../entities/WizardBundler'
 import type { WizardFrontendFramework } from '../entities/WizardFrontendFramework'
 
-interface GetCodeOpts {
+interface GetCodeOptsE2E {
+  type: 'e2e'
+  lang: WizardCodeLanguage
+}
+
+interface GetCodeOptsCt {
+  type: 'component'
   framework: WizardFrontendFramework
   bundler: WizardBundler
   lang: WizardCodeLanguage
 }
+
+type GetCodeOpts = GetCodeOptsCt | GetCodeOptsE2E
 
 const LanguageNames: Record<WizardCodeLanguage, string> = {
   js: 'JavaScript',
   ts: 'TypeScript',
 }
 
+export const wizardGetConfigCodeE2E = (opts: GetCodeOptsE2E): string | null => {
+  return `{
+  e2e: {
+    viewportHeight: 660,
+    viewportWidth: 1000,
+}`
+}
+
 export const wizardGetConfigCode = (opts: GetCodeOpts): string | null => {
+  if (opts.type === 'component') {
+    return wizardGetConfigCodeCt(opts)
+  }
+
+  if (opts.type === 'e2e') {
+    return wizardGetConfigCodeE2E(opts)
+  }
+
+  return null
+}
+
+export const wizardGetConfigCodeCt = (opts: GetCodeOptsCt): string | null => {
   const { framework, bundler, lang } = opts
 
   const comments = `Component testing, ${LanguageNames[opts.lang]}, ${framework.name}, ${bundler.name}`

--- a/packages/graphql/test/integration/Wizard.spec.ts
+++ b/packages/graphql/test/integration/Wizard.spec.ts
@@ -6,8 +6,9 @@ import { initGraphql, makeRequest, TestContext } from './utils'
 describe('Wizard', () => {
   describe('sampleCode', () => {
     it('returns null when bundler is set but framework is null', async () => {
-      const wizard = new Wizard()
+      const wizard = new Wizard(new TestContext())
 
+      wizard.setTestingType('component')
       wizard.setBundler('webpack')
 
       const context = new TestContext({ wizard })
@@ -25,8 +26,9 @@ describe('Wizard', () => {
     })
 
     it('returns null when framework is set but bundler is null', async () => {
-      const wizard = new Wizard()
+      const wizard = new Wizard(new TestContext())
 
+      wizard.setTestingType('component')
       wizard.setFramework('react')
 
       const context = new TestContext({ wizard })
@@ -44,8 +46,9 @@ describe('Wizard', () => {
     })
 
     it('returns sampleCode when framework and bundler is set', async () => {
-      const wizard = new Wizard()
+      const wizard = new Wizard(new TestContext())
 
+      wizard.setTestingType('component')
       wizard.setFramework('cra')
       wizard.setBundler('webpack')
 

--- a/packages/graphql/test/integration/utils.ts
+++ b/packages/graphql/test/integration/utils.ts
@@ -13,7 +13,7 @@ interface TestContextInjectionOptions {
 export class TestActions extends BaseActions {
   ctx: BaseContext
 
-  constructor (_ctx: BaseContext) {
+  constructor (_ctx: BaseContext, private cfg?: FullConfig) {
     super(_ctx)
     this.ctx = _ctx
   }
@@ -23,6 +23,10 @@ export class TestActions extends BaseActions {
 
   async launchOpenProject () {}
   resolveOpenProjectConfig (): FullConfig {
+    if (this.cfg) {
+      return this.cfg
+    }
+
     return {
       projectRoot: '/root/path',
       resolved: {},

--- a/packages/graphql/test/unit/entities/LocalProject.spec.ts
+++ b/packages/graphql/test/unit/entities/LocalProject.spec.ts
@@ -22,7 +22,7 @@ describe('LocalProject', () => {
 
       const project = new LocalProject('/foo/bar/', new TestContext({ Actions: MyActions }))
 
-      expect(project.hasSetupE2ETesting()).to.eq(false)
+      expect(project.hasSetupE2ETesting).to.eq(false)
     })
 
     it('returns true when resolved e2e key has one override', () => {
@@ -44,7 +44,7 @@ describe('LocalProject', () => {
 
       const project = new LocalProject('/foo/bar/', new TestContext({ Actions: MyActions }))
 
-      expect(project.hasSetupE2ETesting()).to.eq(true)
+      expect(project.hasSetupE2ETesting).to.eq(true)
     })
   })
 
@@ -66,7 +66,7 @@ describe('LocalProject', () => {
 
       const project = new LocalProject('/foo/bar/', new TestContext({ Actions: MyActions }))
 
-      expect(project.hasSetupComponentTesting()).to.eq(false)
+      expect(project.hasSetupComponentTesting).to.eq(false)
     })
 
     it('returns true when resolved component key has one override', () => {
@@ -88,7 +88,7 @@ describe('LocalProject', () => {
 
       const project = new LocalProject('/foo/bar/', new TestContext({ Actions: MyActions }))
 
-      expect(project.hasSetupComponentTesting()).to.eq(true)
+      expect(project.hasSetupComponentTesting).to.eq(true)
     })
   })
 })

--- a/packages/graphql/test/unit/entities/Wizard.spec.ts
+++ b/packages/graphql/test/unit/entities/Wizard.spec.ts
@@ -1,65 +1,228 @@
+import type { FullConfig } from '@packages/types'
 import { expect } from 'chai'
-import { Wizard, WIZARD_STEP } from '../../../src'
+import { LocalProject, Wizard } from '../../../src'
+import { TestActions, TestContext } from '../../integration/utils'
+
+const createActionsWithResolvedConfig = (cfg: FullConfig) => {
+  const Ctor = class Actions extends TestActions {
+    resolveOpenProjectConfig () {
+      return cfg
+    }
+  }
+
+  return Ctor
+}
 
 describe('Wizard', () => {
-  describe('#navigate', () => {
-    it('allows navigation forwards', () => {
-      const wizard = new Wizard()
+  describe('#shouldLaunchCt', () => {
+    it('returns true if active project is configured and selected testing type is component', () => {
+      const Actions = createActionsWithResolvedConfig({
+        resolved: {
+          component: {
+            from: 'config',
+            value: {
+              testFiles: {
+                value: '*',
+                from: 'config',
+              },
+            },
+          },
+        },
+      } as const)
 
-      wizard.navigate('forward')
-      expect(wizard.step).to.eq('selectFramework')
+      const ctx = new TestContext({ Actions })
+      const project = new LocalProject('/', ctx)
+
+      ctx.localProjects = [project]
+      const wizard = new Wizard(ctx)
+
+      wizard.setTestingType('component')
+
+      expect(wizard.shouldLaunchCt).to.be.true
+      expect(wizard.shouldSetupCt).to.be.false
     })
 
-    it('allows navigation backward', () => {
-      const wizard = new Wizard()
+    it('false if chosenTestingType is e2e', () => {
+      const Actions = createActionsWithResolvedConfig({
+        resolved: {
+          component: {
+            from: 'config',
+            value: {
+              testFiles: {
+                value: '*',
+                from: 'config',
+              },
+            },
+          },
+        },
+      } as const)
 
-      expect(wizard.step).to.eq('welcome')
-      wizard.navigate('forward')
-      wizard.navigate('back')
-      expect(wizard.step).to.eq('welcome')
+      const ctx = new TestContext({ Actions })
+      const project = new LocalProject('/', ctx)
+
+      ctx.localProjects = [project]
+      const wizard = new Wizard(ctx)
+
+      wizard.setTestingType('e2e')
+
+      expect(wizard.shouldLaunchCt).to.be.false
     })
 
-    it('disallows navigation backwards when on first step', () => {
-      const wizard = new Wizard()
+    // When cypress.config.ts is merged this will change to
+    // if not setupDevServer is present.
+    it('false if no ct specific config exists', () => {
+      const Actions = createActionsWithResolvedConfig({
+        resolved: {
+          component: {
+            from: 'config',
+            value: {},
+          },
+        },
+      } as const)
 
-      expect(wizard.step).to.eq('welcome')
-      wizard.navigate('back')
-      expect(wizard.step).to.eq('welcome')
-    })
+      const ctx = new TestContext({ Actions })
+      const project = new LocalProject('/', ctx)
 
-    it('disallows navigation forward when on first step', () => {
-      const wizard = new Wizard()
+      ctx.localProjects = [project]
+      const wizard = new Wizard(ctx)
 
-      // navigate to last step
-      wizard.setStep('setupComplete')
+      wizard.setTestingType('component')
 
-      expect(wizard.step).to.eq(WIZARD_STEP[WIZARD_STEP.length - 1])
-
-      // navigate some more, should be the same step
-      wizard.navigate('forward')
-      expect(wizard.step).to.eq(WIZARD_STEP[WIZARD_STEP.length - 1])
+      expect(wizard.shouldLaunchCt).to.be.false
+      expect(wizard.shouldSetupCt).to.be.true
     })
   })
 
-  describe('#canNavigateForward', () => {
-    it('allows navigation forward when framework/bundler set', () => {
-      const wizard = new Wizard()
+  describe('#shouldLaunchE2E', () => {
+    it('returns true if active project is configured and selected testing type is e2e', () => {
+      const Actions = createActionsWithResolvedConfig({
+        resolved: {
+          e2e: {
+            from: 'config',
+            value: {
+              testFiles: {
+                value: '*',
+                from: 'config',
+              },
+            },
+          },
+        },
+      } as const)
 
-      wizard.setBundler('webpack')
-      wizard.setFramework('react')
+      const ctx = new TestContext({ Actions })
+      const project = new LocalProject('/', ctx)
 
-      wizard.navigate('forward')
-      expect(wizard.canNavigateForward()).to.eq(true)
+      ctx.localProjects = [project]
+      const wizard = new Wizard(ctx)
+
+      wizard.setTestingType('e2e')
+
+      expect(wizard.shouldLaunchE2E).to.be.true
+      expect(wizard.shouldSetupE2E).to.be.false
     })
 
-    it('disallows navigation forward from selectFramework when framework/bundler not selected', () => {
-      const wizard = new Wizard()
+    it('false if chosenTestingType is component', () => {
+      const Actions = createActionsWithResolvedConfig({
+        resolved: {
+          e2e: {
+            from: 'config',
+            value: {
+              testFiles: {
+                value: '*',
+                from: 'config',
+              },
+            },
+          },
+        },
+      } as const)
 
-      wizard.setBundler(null)
-      wizard.setFramework(null)
+      const ctx = new TestContext({ Actions })
+      const project = new LocalProject('/', ctx)
 
-      wizard.navigate('forward')
-      expect(wizard.canNavigateForward()).to.eq(false)
+      ctx.localProjects = [project]
+      const wizard = new Wizard(ctx)
+
+      wizard.setTestingType('component')
+
+      expect(wizard.shouldLaunchE2E).to.be.false
+    })
+
+    // When cypress.config.ts is merged this will change to
+    // if not setupDevServer is present.
+    it('false if no e2e specific config exists', () => {
+      const Actions = createActionsWithResolvedConfig({
+        resolved: {
+          e2e: {
+            from: 'config',
+            value: {},
+          },
+        },
+      } as const)
+
+      const ctx = new TestContext({ Actions })
+      const project = new LocalProject('/', ctx)
+
+      ctx.localProjects = [project]
+      const wizard = new Wizard(ctx)
+
+      wizard.setTestingType('e2e')
+
+      expect(wizard.shouldLaunchE2E).to.be.false
+      expect(wizard.shouldSetupE2E).to.be.true
+    })
+  })
+
+  describe('#navigate', () => {
+    context('chosenTestingType is component, component testing is not configured', () => {
+      it('progresses through wizard steps', () => {
+        const Actions = createActionsWithResolvedConfig({
+          resolved: {
+            component: {
+              from: 'default',
+              value: {},
+            },
+          },
+        } as const)
+        const ctx = new TestContext({ Actions })
+        const project = new LocalProject('/', ctx)
+
+        ctx.localProjects = [project]
+        const wizard = new Wizard(ctx)
+
+        wizard.setTestingType('component')
+
+        wizard.navigate('forward')
+        expect(wizard.step).to.eq('selectFramework')
+        expect(wizard.history).to.eqls(['welcome', 'selectFramework'])
+
+        wizard.navigate('forward')
+        // no change - need to choose bundler/framework
+        expect(wizard.step).to.eq('selectFramework')
+        expect(wizard.history).to.eqls(['welcome', 'selectFramework'])
+
+        wizard.setBundler('webpack')
+        wizard.setFramework('react')
+        wizard.navigate('forward')
+        expect(wizard.step).to.eq('installDependencies')
+        expect(wizard.history).to.eqls(['welcome', 'selectFramework', 'installDependencies'])
+
+        wizard.navigate('forward')
+        expect(wizard.step).to.eq('createConfig')
+        expect(wizard.history).to.eqls(['welcome', 'selectFramework', 'installDependencies', 'createConfig'])
+
+        wizard.navigate('forward')
+        expect(wizard.step).to.eq('setupComplete')
+        expect(wizard.history).to.eqls(['welcome', 'selectFramework', 'installDependencies', 'createConfig', 'setupComplete'])
+
+        // cannot go forward again
+        wizard.navigate('forward')
+        expect(wizard.step).to.eq('setupComplete')
+        expect(wizard.history).to.eqls(['welcome', 'selectFramework', 'installDependencies', 'createConfig', 'setupComplete'])
+
+        wizard.navigate('back')
+        expect(wizard.step).to.eq('createConfig')
+        expect(wizard.history).to.eqls(['welcome', 'selectFramework', 'installDependencies', 'createConfig'])
+      })
     })
   })
 })

--- a/packages/launchpad/cypress/support/testUrqlClient.ts
+++ b/packages/launchpad/cypress/support/testUrqlClient.ts
@@ -1,4 +1,5 @@
-import { cacheExchange, Client, createClient, dedupExchange, errorExchange } from '@urql/core'
+import { Client, createClient, dedupExchange, errorExchange } from '@urql/core'
+import { cacheExchange } from '@urql/exchange-graphcache'
 import { executeExchange } from '@urql/exchange-execute'
 import { graphqlSchema } from '@packages/graphql'
 import type { ClientTestContext } from '../../src/graphql/ClientTestContext'
@@ -13,7 +14,7 @@ export function testUrqlClient (config: TestUrqlClientConfig): Client {
     url: '/graphql',
     exchanges: [
       dedupExchange,
-      cacheExchange,
+      cacheExchange({}),
       errorExchange({
         onError (error) {
           // eslint-disable-next-line

--- a/packages/launchpad/cypress/support/testUrqlClient.ts
+++ b/packages/launchpad/cypress/support/testUrqlClient.ts
@@ -1,5 +1,5 @@
-import { Client, createClient, dedupExchange, errorExchange } from '@urql/core'
-import { cacheExchange } from '@urql/exchange-graphcache'
+import { Client, createClient, dedupExchange, errorExchange, cacheExchange } from '@urql/core'
+// import { cacheExchange } from '@urql/exchange-graphcache'
 import { executeExchange } from '@urql/exchange-execute'
 import { graphqlSchema } from '@packages/graphql'
 import type { ClientTestContext } from '../../src/graphql/ClientTestContext'
@@ -14,7 +14,7 @@ export function testUrqlClient (config: TestUrqlClientConfig): Client {
     url: '/graphql',
     exchanges: [
       dedupExchange,
-      cacheExchange({}),
+      cacheExchange,
       errorExchange({
         onError (error) {
           // eslint-disable-next-line

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -40,6 +40,7 @@
     "@testing-library/cypress": "8.0.0",
     "@urql/core": "2.1.5",
     "@urql/exchange-execute": "^1.0.4",
+    "@urql/exchange-graphcache": "4.3.3",
     "@urql/vue": "0.4.3",
     "@vitejs/plugin-vue": "1.2.4",
     "@vitejs/plugin-vue-jsx": "1.1.6",

--- a/packages/launchpad/src/App.vue
+++ b/packages/launchpad/src/App.vue
@@ -21,7 +21,7 @@ query AppQuery {
   ...Wizard
   app {
     activeProject {
-      __typename
+      title
     }
   }
 }

--- a/packages/launchpad/src/App.vue
+++ b/packages/launchpad/src/App.vue
@@ -3,26 +3,16 @@
     Loading...
   </div>
 
-  <div v-else>
-    <Layout v-slot="{ item }">
-      <Wizard 
-        v-if="item === 'projectSetup'" 
-        :query="query.data.value"
-      />
-      <SettingsPage v-if="item === 'settings'" />
-      <RunsPage v-if="item === 'runs'" />
-    </Layout>
+  <div v-else class="bg-white h-full">
+    <Wizard :query="query.data.value" />
   </div>
 </template>
 
 <script lang="ts" setup>
 import { computed } from 'vue'
 import { gql, useQuery } from '@urql/vue'
-import Layout from "./layouts/Layout.vue"
-import SettingsPage from './settings/SettingsPage.vue'
 import Wizard from "./setup/Wizard.vue"
 import { AppQueryDocument } from './generated/graphql'
-import RunsPage from "./runs/RunsPage.vue"
 
 gql`
 query AppQuery {
@@ -64,3 +54,9 @@ interval = window.setInterval(poll, 200)
 
 const backendInitialized = computed(() => !!query.data?.value?.app?.activeProject)
 </script>
+
+<style lang="scss">
+html, body, #app {
+  @apply h-full;
+}
+</style>

--- a/packages/launchpad/src/App.vue
+++ b/packages/launchpad/src/App.vue
@@ -4,6 +4,7 @@
   </div>
 
   <div v-else class="bg-white h-full">
+    <HeaderBar :gql="query.data.value.app" />
     <Wizard :query="query.data.value" />
   </div>
 </template>
@@ -12,6 +13,7 @@
 import { computed } from 'vue'
 import { gql, useQuery } from '@urql/vue'
 import Wizard from "./setup/Wizard.vue"
+import HeaderBar from './layouts/HeaderBar.vue'
 import { AppQueryDocument } from './generated/graphql'
 
 gql`

--- a/packages/launchpad/src/graphql/urqlClient.ts
+++ b/packages/launchpad/src/graphql/urqlClient.ts
@@ -3,9 +3,10 @@ import {
   createClient,
   dedupExchange,
   errorExchange,
+  cacheExchange,
   fetchExchange,
 } from '@urql/core'
-import { cacheExchange } from '@urql/exchange-graphcache'
+// import { cacheExchange } from '@urql/exchange-graphcache'
 
 import { initGraphQLIPC } from './graphqlIpc'
 
@@ -17,7 +18,7 @@ export function makeUrqlClient (): Client {
     url: 'http://localhost:52159/graphql',
     exchanges: [
       dedupExchange,
-      cacheExchange({}),
+      cacheExchange,
       errorExchange({
         onError (error) {
           // eslint-disable-next-line

--- a/packages/launchpad/src/graphql/urqlClient.ts
+++ b/packages/launchpad/src/graphql/urqlClient.ts
@@ -2,10 +2,10 @@ import {
   Client,
   createClient,
   dedupExchange,
-  cacheExchange,
   errorExchange,
   fetchExchange,
 } from '@urql/core'
+import { cacheExchange } from '@urql/exchange-graphcache'
 
 import { initGraphQLIPC } from './graphqlIpc'
 
@@ -17,7 +17,7 @@ export function makeUrqlClient (): Client {
     url: 'http://localhost:52159/graphql',
     exchanges: [
       dedupExchange,
-      cacheExchange,
+      cacheExchange({}),
       errorExchange({
         onError (error) {
           // eslint-disable-next-line

--- a/packages/launchpad/src/layouts/HeaderBar.vue
+++ b/packages/launchpad/src/layouts/HeaderBar.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="bg-gray-100 flex items-center p-2 mb-8 justify-between">
+    <div class="flex items-center">
+      <img src="../images/cypress_s.png" class="p-2" />
+      Projects > {{ app.activeProject?.title }}
+    </div>
+    <div>
+      <Auth />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { gql } from '@urql/vue'
+import { computed } from 'vue-demi'
+import type { HeaderBarFragment } from '../generated/graphql'
+import Auth from '../setup/Auth.vue'
+
+gql`
+fragment HeaderBar on App {
+  activeProject {
+    title
+  }
+}
+`
+
+const props = defineProps<{
+  gql: HeaderBarFragment
+}>()
+
+const app = computed(() => props.gql)
+</script>

--- a/packages/launchpad/src/setup/ButtonBar.spec.tsx
+++ b/packages/launchpad/src/setup/ButtonBar.spec.tsx
@@ -14,7 +14,7 @@ describe('<ButtonBar />', () => {
   })
 
   it('should trigger the next function', () => {
-    cy.mount(() => <ButtonBar next="Next Step" back="Back" nextFn={nextFn} backFn={backFn} />)
+    cy.mount(() => <ButtonBar next="Next Step" back="Back" nextFn={nextFn} backFn={backFn} canNavigateForward={true} />)
     cy.contains('Next Step')
     .click()
     .then(() => {

--- a/packages/launchpad/src/setup/ButtonBar.vue
+++ b/packages/launchpad/src/setup/ButtonBar.vue
@@ -10,7 +10,7 @@
       rounded-b
     "
   >
-    <Button @click="nextFn" :disabled="!canNavigateForward">{{ next }}</Button>
+    <Button v-if="showNext" @click="nextFn" :disabled="!canNavigateForward">{{ next }}</Button>
     <Button @click="backFn" variant="outline">{{ back }}</Button>
     <div class="flex-grow" />
     <div v-if="altFn && alt" class="flex items-center px-3">
@@ -20,52 +20,30 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, ref } from "vue";
+<script lang="ts" setup>
+import { ref } from "vue";
 import Button from "../components/button/Button.vue";
 import Switch from "../components/switch/Switch.vue";
 
-export default defineComponent({
-  components: { Button, Switch },
-  props: {
-    next: {
-      type: String,
-      required: true,
-    },
-    nextFn: {
-      type: Function as PropType<() => void>,
-      required: true
-    },
-    back: {
-      type: String,
-      required: true,
-    },
-    backFn: {
-      type: Function as PropType<() => void>,
-      required: true
-    },
-    alt: {
-      type: String,
-      default: undefined,
-    },
-    altFn: {
-      type: Function as PropType<(value: boolean) => void>,
-      default: undefined,
-    },
-    canNavigateForward: {
-      type: Boolean,
-      default: true
-    }
-  },
-  setup(props) {
-    const altValue = ref(false);
+const props = withDefaults(
+  defineProps<{
+  next: string
+  back: string
+  nextFn: () => void
+  backFn: () => void
+  alt?: string
+  altFn?: (value: boolean) => void
+  canNavigateForward: boolean
+  showNext: boolean
+}>(), {
+  showNext: true 
+})
 
-    const handleAlt = () => {
-      altValue.value = !altValue.value
-      props.altFn?.(altValue.value);
-    };
+const altValue = ref(false);
 
-    return { altValue, handleAlt };
-  },
-});
+const handleAlt = () => {
+  altValue.value = !altValue.value
+  props.altFn?.(altValue.value);
+}
+
 </script>

--- a/packages/launchpad/src/setup/ButtonBar.vue
+++ b/packages/launchpad/src/setup/ButtonBar.vue
@@ -33,7 +33,7 @@ const props = withDefaults(
   backFn: () => void
   alt?: string
   altFn?: (value: boolean) => void
-  canNavigateForward: boolean
+  canNavigateForward?: boolean
   showNext: boolean
 }>(), {
   showNext: true 

--- a/packages/launchpad/src/setup/OpenBrowser.vue
+++ b/packages/launchpad/src/setup/OpenBrowser.vue
@@ -1,17 +1,36 @@
 <template>
+  <WizardLayout :canNavigateForward="false" :showNext="false">
     <img src="../images/success.svg" class="mx-auto my-10"/>
-    <div class="text-center">
-        <Button>Open Chrome</Button>
+    <div class="flex justify-center">
+      <Button
+        v-for="browser of props.app.browsers"
+        :key="browser.version"
+        class="m-2"
+      >
+        {{ `${browser.displayName} v${browser.version}.x` }}
+      </Button>
     </div>
+  </WizardLayout>
 </template>
 
-<script lang="ts">
-import { defineComponent } from "vue"
+<script lang="ts" setup>
+import { gql } from "@urql/core"
 import Button from "../components/button/Button.vue"
+import WizardLayout from "./WizardLayout.vue";
+import type { OpenBrowserFragment } from "../generated/graphql"
 
-export default defineComponent({
-    setup() {
-    },
-    components: { Button }
-})
+gql`
+fragment OpenBrowser on App {
+  browsers {
+    displayName
+    version
+    majorVersion
+    name
+  }
+}
+`
+
+const props = defineProps<{
+  app: OpenBrowserFragment
+}>()
 </script>

--- a/packages/launchpad/src/setup/OpenBrowser.vue
+++ b/packages/launchpad/src/setup/OpenBrowser.vue
@@ -2,10 +2,12 @@
   <WizardLayout :canNavigateForward="false" :showNext="false">
     <img src="../images/success.svg" class="mx-auto my-10"/>
     <div class="flex justify-center">
+      <h1 class="text-3xl">TODO: launch in selected browser. Right now they all launch chrome.</h1>
       <Button
         v-for="browser of props.app.browsers"
         :key="browser.version"
         class="m-2"
+        @click="launch"
       >
         {{ `${browser.displayName} v${browser.version}.x` }}
       </Button>
@@ -17,10 +19,11 @@
 import { gql } from "@urql/core"
 import Button from "../components/button/Button.vue"
 import WizardLayout from "./WizardLayout.vue";
-import type { OpenBrowserFragment } from "../generated/graphql"
+import { InitializeOpenProjectDocument, LaunchOpenProjectDocument, OpenBrowserWizardFragment, OpenBrowserAppFragment } from "../generated/graphql"
+import { useMutation } from "@urql/vue";
 
 gql`
-fragment OpenBrowser on App {
+fragment OpenBrowserApp on App {
   browsers {
     displayName
     version
@@ -30,7 +33,47 @@ fragment OpenBrowser on App {
 }
 `
 
+gql`
+fragment OpenBrowserWizard on Wizard {
+  testingType
+}
+`
+
+gql`
+mutation InitializeOpenProject ($testingType: TestingTypeEnum!) {
+  initializeOpenProject (testingType: $testingType) {
+    projects {
+      __typename # don't really care about result at this point
+    }
+  }
+}
+`
+
+gql`
+mutation LaunchOpenProject ($testingType: TestingTypeEnum!) {
+  launchOpenProject (testingType: $testingType) {
+    projects {
+      __typename # don't really care about result at this point
+    }
+  }
+}
+`
+
+
+const initializeOpenProject = useMutation(InitializeOpenProjectDocument)
+const launchOpenProject = useMutation(LaunchOpenProjectDocument)
+
 const props = defineProps<{
-  app: OpenBrowserFragment
+  app: OpenBrowserAppFragment
+  wizard: OpenBrowserWizardFragment 
 }>()
+
+const launch = async () => {
+  if (!props.wizard.testingType) {
+    return
+  }
+  
+  await initializeOpenProject.executeMutation({ testingType: props.wizard.testingType })
+  await launchOpenProject.executeMutation({ testingType: props.wizard.testingType })
+}
 </script>

--- a/packages/launchpad/src/setup/TestingTypeCards.spec.tsx
+++ b/packages/launchpad/src/setup/TestingTypeCards.spec.tsx
@@ -1,23 +1,16 @@
+import { Query } from '@packages/graphql'
 import {
-  TestingTypeCardsAppFragmentDoc,
-  TestingTypeCardsWizardFragmentDoc,
+  TestingTypeCardsFragmentDoc,
 } from '../generated/graphql'
 import TestingTypeCards from './TestingTypeCards.vue'
 
 describe('TestingTypeCards', () => {
   it('renders correct label depending if testingType has been configured', () => {
-    cy.mountFragmentList([
-      TestingTypeCardsAppFragmentDoc,
-      TestingTypeCardsWizardFragmentDoc,
-    ], {
+    cy.mountFragment(TestingTypeCardsFragmentDoc, {
       type: (ctx) => {
-        const { app, wizard } = ctx
-
-        return [app, wizard]
+        return new Query()
       },
       render: (gqlVal) => {
-        // @ts-ignore - type is inferred as Frag1 | Frag2,
-        // but in practice is { frag1: ..., frag2: ... }
         return <TestingTypeCards gql={gqlVal} />
       },
     }).then(() => {

--- a/packages/launchpad/src/setup/TestingTypeCards.vue
+++ b/packages/launchpad/src/setup/TestingTypeCards.vue
@@ -6,7 +6,7 @@
       :title="ct.title"
       description="LAUNCH"
       role="launch-component-testing"
-      @click="emit('launchCt')"
+      @click="ctNextStep"
     />
 
     <TestingTypeCard
@@ -15,7 +15,7 @@
       :title="ct.title"
       :description="ct.description"
       role="setup-component-testing"
-      @click="selectTestingType('component')"
+      @click="ctNextStep"
     />
 
     <TestingTypeCard
@@ -24,7 +24,7 @@
       :title="e2e.title"
       description="LAUNCH"
       role="launch-e2e-testing"
-      @click="emit('launchE2E')"
+      @click="e2eNextStep"
     />
 
     <TestingTypeCard
@@ -33,7 +33,7 @@
       :title="e2e.title"
       :description="e2e.description"
       role="setup-e2e-testing"
-      @click="selectTestingType('e2e')"
+      @click="e2eNextStep"
     />
   </div>
 </template>
@@ -46,7 +46,8 @@ import {
   TestingTypeEnum,
   TestingTypeCardsWizardFragment,
   TestingTypeCardsAppFragment,
-  TestingTypeSelectDocument
+  TestingTypeSelectDocument,
+  TestingTypeCardsNavigateForwardDocument
 } from "../generated/graphql";
 import TestingTypeCard from "./TestingTypeCard.vue";
 
@@ -80,18 +81,23 @@ mutation TestingTypeSelect($testingType: TestingTypeEnum!) {
 }
 `
 
+gql`
+mutation TestingTypeCardsNavigateForward {
+  wizardNavigate(direction: forward) {
+    step
+  }
+}
+`
+
+
 const mutation = useMutation(TestingTypeSelectDocument)
+const navigateForwardMutation = useMutation(TestingTypeCardsNavigateForwardDocument)
 
 const props = defineProps<{
   gql: {
     app: TestingTypeCardsAppFragment
     wizard: TestingTypeCardsWizardFragment
   }
-}>()
-
-const emit = defineEmits<{
-  (event: 'launchCt'): void
-  (event: 'launchE2E'): void
 }>()
 
 const ct = computed(() => {
@@ -102,8 +108,18 @@ const ct = computed(() => {
 })
 
 const selectTestingType = (testingType: TestingTypeEnum) => {
-  mutation.executeMutation({ testingType });
-};
+  return mutation.executeMutation({ testingType })
+}
+
+const ctNextStep = async () => {
+  await selectTestingType('component')
+  navigateForwardMutation.executeMutation({})
+}
+
+const e2eNextStep = async () => {
+  await selectTestingType('e2e')
+  navigateForwardMutation.executeMutation({})
+}
 
 const e2e = computed(() => {
   return {

--- a/packages/launchpad/src/setup/TestingTypeCards.vue
+++ b/packages/launchpad/src/setup/TestingTypeCards.vue
@@ -44,28 +44,26 @@ import { useMutation } from "@urql/vue";
 import { computed } from "vue";
 import { 
   TestingTypeEnum,
-  TestingTypeCardsWizardFragment,
-  TestingTypeCardsAppFragment,
   TestingTypeSelectDocument,
   TestingTypeCardsNavigateForwardDocument
 } from "../generated/graphql";
 import TestingTypeCard from "./TestingTypeCard.vue";
 
 gql`
-fragment TestingTypeCardsApp on App {
-  activeProject {
-    hasSetupComponentTesting
-    hasSetupE2ETesting
+fragment TestingTypeCards on Query {
+  app {
+    activeProject {
+      hasSetupComponentTesting
+      hasSetupE2ETesting
+    }
   }
-}
-`
-  
-gql`
-fragment TestingTypeCardsWizard on Wizard {
-  testingTypes {
-    id
-    title
-    description
+
+  wizard {
+    testingTypes {
+      id
+      title
+      description
+    }
   }
 }
 `

--- a/packages/launchpad/src/setup/TestingTypeCards.vue
+++ b/packages/launchpad/src/setup/TestingTypeCards.vue
@@ -45,7 +45,8 @@ import { computed } from "vue";
 import { 
   TestingTypeEnum,
   TestingTypeSelectDocument,
-  TestingTypeCardsNavigateForwardDocument
+  TestingTypeCardsNavigateForwardDocument,
+TestingTypeCardsFragment
 } from "../generated/graphql";
 import TestingTypeCard from "./TestingTypeCard.vue";
 
@@ -92,10 +93,7 @@ const mutation = useMutation(TestingTypeSelectDocument)
 const navigateForwardMutation = useMutation(TestingTypeCardsNavigateForwardDocument)
 
 const props = defineProps<{
-  gql: {
-    app: TestingTypeCardsAppFragment
-    wizard: TestingTypeCardsWizardFragment
-  }
+  gql: TestingTypeCardsFragment
 }>()
 
 const ct = computed(() => {

--- a/packages/launchpad/src/setup/Wizard.vue
+++ b/packages/launchpad/src/setup/Wizard.vue
@@ -42,37 +42,28 @@ import type {
 } from '../generated/graphql'
 
 gql`
-fragment WizardApp on App {
-  isFirstOpen
-  activeProject {
-    hasSetupComponentTesting
-    hasSetupE2ETesting
-  }
-  ...ProjectRoot
-  ...TestingTypeCardsApp
-  ...OpenBrowserApp
-
-}
-
-fragment WizardWizard on Wizard {
-  step
-  title
-  ...TestingTypeCardsWizard
-  description
-  testingType
-  ...TestingType
-  ...ConfigFile
-  ...InstallDependencies
-  ...EnvironmentSetup
-  ...OpenBrowserWizard
-}
-
 fragment Wizard on Query {
+  ...TestingTypeCards
   app {
-    ...WizardApp
+    isFirstOpen
+    activeProject {
+      hasSetupComponentTesting
+      hasSetupE2ETesting
+    }
+    ...ProjectRoot
+    ...OpenBrowserApp
   }
+
   wizard {
-    ...WizardWizard
+    step
+    title
+    description
+    testingType
+    ...TestingType
+    ...ConfigFile
+    ...InstallDependencies
+    ...EnvironmentSetup
+    ...OpenBrowserWizard
   }
 }
 `

--- a/packages/launchpad/src/setup/Wizard.vue
+++ b/packages/launchpad/src/setup/Wizard.vue
@@ -1,6 +1,6 @@
 <template>
   <template v-if="wizard && app">
-    <h1 class="text-3xl mt-12 text-center">{{ wizard.title }}</h1>
+    <h1 class="text-3xl pt-12 text-center">{{ wizard.title }}</h1>
     <p class="text-center text-gray-400 my-2 mx-10" v-html="wizard.description" />
     <div class="mx-5">
       <TestingTypeCards 

--- a/packages/launchpad/src/setup/Wizard.vue
+++ b/packages/launchpad/src/setup/Wizard.vue
@@ -23,6 +23,7 @@
       <OpenBrowser 
         v-if="wizard.step === 'setupComplete'" 
         :app="app"
+        :wizard="wizard"
       />
     </div>
   </template> 

--- a/packages/launchpad/src/setup/Wizard.vue
+++ b/packages/launchpad/src/setup/Wizard.vue
@@ -1,50 +1,34 @@
 <template>
   <template v-if="wizard && app">
-    <Auth />
-    <Button @click="launchCt">Launch CT in Chrome</Button>
-    <Button @click="launchE2E">Launch E2E in Chrome</Button>
     <h1 class="text-3xl mt-12 text-center">{{ wizard.title }}</h1>
     <p class="text-center text-gray-400 my-2 mx-10" v-html="wizard.description" />
     <div class="mx-5">
-      <template v-if="wizard.step === 'welcome'">
-        <TestingTypeCards 
-          :gql="query" 
-          @launchCt="launchCt"
-          @launchE2E="launchE2E"
-        />
-      </template> 
-      <template v-else-if="wizard.testingType === 'component'">
-        <EnvironmentSetup v-if="wizard.step === 'selectFramework'" :gql="wizard" />
-        <InstallDependencies v-else-if="wizard.step === 'installDependencies'" :gql="wizard" />
-        <ConfigFile v-else-if="wizard.step === 'createConfig'" :wizard="wizard" :app="app" />
-        <OpenBrowser v-else-if="wizard.step === 'setupComplete'" />
-      </template>
-      <template v-else>
-        <WizardLayout :canNavigateForward="wizard.canNavigateForward">
-          <div>Here be dragons</div>
-        </WizardLayout>
-      </template>
+      <TestingTypeCards 
+        v-if="wizard.step === 'welcome'"
+        :gql="query" 
+      />
+      <EnvironmentSetup v-if="wizard.step === 'selectFramework'" :gql="wizard" />
+      <InstallDependencies v-if="wizard.step === 'installDependencies'" :gql="wizard" />
+      <ConfigFile v-if="wizard.step === 'createConfig'" :wizard="wizard" :app="app" />
+      <OpenBrowser 
+        v-if="wizard.step === 'setupComplete'" 
+        :app="app"
+      />
     </div>
   </template> 
 </template>
 
 <script lang="ts" setup>
 import { computed } from "vue";
-import Auth from './Auth.vue'
 import TestingTypeCards from "./TestingTypeCards.vue";
 import EnvironmentSetup from "./EnvironmentSetup.vue";
 import InstallDependencies from "./InstallDependencies.vue";
 import ConfigFile from "./ConfigFile.vue";
 import OpenBrowser from "./OpenBrowser.vue";
-import WizardLayout from './WizardLayout.vue'
 import { gql } from '@urql/core'
-import { 
-  InitializeOpenProjectDocument,
-  LaunchOpenProjectDocument,
+import type { 
   WizardFragment,
 } from '../generated/graphql'
-import { useMutation } from "@urql/vue";
-import Button from '../components/button/Button.vue'
 
 gql`
 mutation InitializeOpenProject ($testingType: TestingTypeEnum!) {
@@ -75,6 +59,7 @@ fragment WizardApp on App {
   }
   ...ProjectRoot
   ...TestingTypeCardsApp
+  ...OpenBrowser
 }
 
 fragment WizardWizard on Wizard {
@@ -105,18 +90,4 @@ const props = defineProps<{
 
 const app = computed(() => props.query?.app)
 const wizard = computed(() => props.query?.wizard)
-
-const initializeOpenProject = useMutation(InitializeOpenProjectDocument)
-const launchOpenProject = useMutation(LaunchOpenProjectDocument)
-
-const launchCt = async () => {
-  const r1 = await initializeOpenProject.executeMutation({ testingType: 'component' })
-  console.log(r1.error)
-  await launchOpenProject.executeMutation({ testingType: 'component' })
-}
-
-const launchE2E = async () => {
-  await initializeOpenProject.executeMutation({ testingType: 'e2e' })
-  await launchOpenProject.executeMutation({ testingType: 'e2e' })
-}
 </script>

--- a/packages/launchpad/src/setup/Wizard.vue
+++ b/packages/launchpad/src/setup/Wizard.vue
@@ -7,9 +7,19 @@
         v-if="wizard.step === 'welcome'"
         :gql="query" 
       />
-      <EnvironmentSetup v-if="wizard.step === 'selectFramework'" :gql="wizard" />
-      <InstallDependencies v-if="wizard.step === 'installDependencies'" :gql="wizard" />
-      <ConfigFile v-if="wizard.step === 'createConfig'" :wizard="wizard" :app="app" />
+      <EnvironmentSetup 
+        v-if="wizard.step === 'selectFramework'" 
+        :gql="wizard" 
+      />
+      <InstallDependencies 
+        v-if="wizard.step === 'installDependencies'" 
+        :gql="wizard" 
+      />
+      <ConfigFile 
+        v-if="wizard.step === 'createConfig'" 
+        :wizard="wizard" 
+        :app="app" 
+      />
       <OpenBrowser 
         v-if="wizard.step === 'setupComplete'" 
         :app="app"
@@ -31,26 +41,6 @@ import type {
 } from '../generated/graphql'
 
 gql`
-mutation InitializeOpenProject ($testingType: TestingTypeEnum!) {
-  initializeOpenProject (testingType: $testingType) {
-    projects {
-      __typename # don't really care about result at this point
-    }
-  }
-}
-`
-
-gql`
-mutation LaunchOpenProject ($testingType: TestingTypeEnum!) {
-  launchOpenProject (testingType: $testingType) {
-    projects {
-      __typename # don't really care about result at this point
-    }
-  }
-}
-`
-
-gql`
 fragment WizardApp on App {
   isFirstOpen
   activeProject {
@@ -59,7 +49,8 @@ fragment WizardApp on App {
   }
   ...ProjectRoot
   ...TestingTypeCardsApp
-  ...OpenBrowser
+  ...OpenBrowserApp
+
 }
 
 fragment WizardWizard on Wizard {
@@ -72,6 +63,7 @@ fragment WizardWizard on Wizard {
   ...ConfigFile
   ...InstallDependencies
   ...EnvironmentSetup
+  ...OpenBrowserWizard
 }
 
 fragment Wizard on Query {

--- a/packages/launchpad/src/setup/WizardLayout.vue
+++ b/packages/launchpad/src/setup/WizardLayout.vue
@@ -57,7 +57,7 @@ const props = withDefaults(
     back?: string
     alt?: string
     showNext?: boolean
-    canNavigateForward: boolean
+    canNavigateForward?: boolean
     altFn?: (val: boolean) => void
     nextFn?: (...args: unknown[]) => any,
   }>(), {

--- a/packages/launchpad/src/setup/WizardLayout.vue
+++ b/packages/launchpad/src/setup/WizardLayout.vue
@@ -19,6 +19,7 @@
       :backFn="backFn" 
       :altFn="altFn" 
       :next="nextLabel" 
+      :showNext="showNext"
       :back="backLabel" 
       :alt="alt" 
     />
@@ -50,14 +51,18 @@ mutation WizardLayoutNavigate($direction: WizardNavigateDirection!) {
 
 const { t } = useI18n()
 
-const props = defineProps<{
+const props = withDefaults(
+  defineProps<{
     next?: string
     back?: string
     alt?: string
-    canNavigateForward?: boolean
+    showNext?: boolean
+    canNavigateForward: boolean
     altFn?: (val: boolean) => void
     nextFn?: (...args: unknown[]) => any,
-}>()
+  }>(), {
+  showNext: true
+})
 
 const nextLabel = computed(() => props.next || t('setupPage.step.next'))
 const backLabel = computed(() => props.back || t('setupPage.step.back'))

--- a/yarn.lock
+++ b/yarn.lock
@@ -9309,10 +9309,18 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@urql/core@2.1.5", "@urql/core@>=2.1.0", "@urql/core@^2.1.5":
+"@urql/core@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@urql/core/-/core-2.1.5.tgz#8fbc0846d6020cee89dadbee07ffb0a618ab29d8"
   integrity sha512-iX30xZ6exdJbajv2S4gxVP+1ZEh57x9gEuUrpOCLWZp84970XDSo82xoz+11I+NGWiQNZfbIs6LTLaie/iG3OQ==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.0"
+    wonka "^4.0.14"
+
+"@urql/core@>=2.1.0", "@urql/core@>=2.3.1", "@urql/core@^2.1.5":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@urql/core/-/core-2.3.1.tgz#1aa558b5aa6eca785062a3a768e6fec708aab6d2"
+  integrity sha512-M9gGz02+TH7buqkelVg+m0eTkLCKly9ZjuTp6NHMP7hXD/zpImPu/m3YluA+D4HbFqw3kofBtLCuVk67X9dxRw==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.0"
     wonka "^4.0.14"
@@ -9323,6 +9331,14 @@
   integrity sha512-Ig/5lmOiAkNrnO5ekV0iBlRXuMdsYl2eFpqC3erGNAV8YvxiXSjZpDIugOVvRMq9h34PQQbfHwDIgE5MiTRmTA==
   dependencies:
     "@urql/core" ">=2.1.0"
+    wonka "^4.0.14"
+
+"@urql/exchange-graphcache@4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@urql/exchange-graphcache/-/exchange-graphcache-4.3.3.tgz#5a4fee253458fd2faeb70a2bb1474d4f775f7846"
+  integrity sha512-30xFeagf1pJj+ilQeujY0J/qczFW6kQHMbK+WzLBjuomVkn/+D2ZCylMplaUMZ2gYKZ6hHIpkG4MWX1KUnmqhQ==
+  dependencies:
+    "@urql/core" ">=2.3.1"
     wonka "^4.0.14"
 
 "@urql/vue@0.4.3":


### PR DESCRIPTION
Jira: https://cypress-io.atlassian.net/browse/UNIFY-297

- simplified `<Wizard>`, moved more logic to the backend
- merged 2 fragments in 1 in some places
- removed sidebar (code still exists - it'll be used in the runner instead)
- fix some small bugs
- Updated the navigation to support all conditions:

1. CT not configured
2. CT configured
3. E2E not configured 
4. E2E configured

If you have not configured a testing type, it'll do the config workflow. If you have, it'll take you straight to the "launch browser" screen.

- added `OpenBrowser` page to show all the browsers 
- support launching CT and E2E from within launchpad from the last step (`<OpenBrowser>`)
- added a super basic header to match mocks (leaving UI stuff for Mark, who is our new UI guy 😎 )

Tried adding graphcache as discussed w/ Tim, which is a better fit for a non-content heavy GraphQL app, but needs more work. We need `id` for each entity. I'll look into this in a separate PR. Docs: https://formidable.com/open-source/urql/docs/graphcache/

Example UI:

- CT configured, so you can just hit launch
- E2E is not, so it says "configure" and you can go through the process of creating a new config file.

![image](https://user-images.githubusercontent.com/19196536/131658644-c6efe470-7696-4e2b-8dea-9327e12f869f.png)
