### PR TITLE
chore: fix npm/webpack-dev-server @ts-expect-error error

### DIFF
--- a/npm/webpack-dev-server/src/startServer.ts
+++ b/npm/webpack-dev-server/src/startServer.ts
@@ -63,7 +63,7 @@ export async function start ({ webpackConfig: userWebpackConfig, template, optio
       noInfo: false,
     }
 
-    return new WebpackDevServer(compiler, webpackDevServerConfig)
+    return new WebpackDevServer(webpackDevServerConfig, compiler)
   }
 
   if (webpackDevServerFacts.isV4()) {

--- a/npm/webpack-dev-server/src/startServer.ts
+++ b/npm/webpack-dev-server/src/startServer.ts
@@ -63,7 +63,6 @@ export async function start ({ webpackConfig: userWebpackConfig, template, optio
       noInfo: false,
     }
 
-    // @ts-expect-error ignore webpack-dev-server v3 type errors
     return new WebpackDevServer(compiler, webpackDevServerConfig)
   }
 
@@ -79,7 +78,6 @@ export async function start ({ webpackConfig: userWebpackConfig, template, optio
       hot: false,
     }
 
-    // @ts-expect-error Webpack types are clashing between Webpack and WebpackDevServer
     return new WebpackDevServer(webpackDevServerConfig, compiler)
   }
 


### PR DESCRIPTION
edit: not sure, this might only happen in my local environment

causing build process to fail:
```sh
@cypress/webpack-dev-server: src/startServer.ts(66,5): error TS2578: Unused '@ts-expect-error' directive.
@cypress/webpack-dev-server: src/startServer.ts(82,5): error TS2578: Unused '@ts-expect-error' directive.
@cypress/webpack-dev-server: error Command failed with exit code 2.
```
- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
