### PR TITLE
chore: make `hasBinary` of `socket.io-parser` work more like the original

### DIFF
--- a/packages/socket/patches/socket.io-parser+4.0.4.patch
+++ b/packages/socket/patches/socket.io-parser+4.0.4.patch
@@ -115,7 +115,7 @@ index 0ef9f80..4cd787e 100644
      catch (e) {
          return false;
 diff --git a/node_modules/socket.io-parser/dist/is-binary.js b/node_modules/socket.io-parser/dist/is-binary.js
-index 4b7c234..e444014 100644
+index 4b7c234..f588141 100644
 --- a/node_modules/socket.io-parser/dist/is-binary.js
 +++ b/node_modules/socket.io-parser/dist/is-binary.js
 @@ -1,6 +1,7 @@
@@ -126,10 +126,11 @@ index 4b7c234..e444014 100644
  const withNativeArrayBuffer = typeof ArrayBuffer === "function";
  const isView = (obj) => {
      return typeof ArrayBuffer.isView === "function"
-@@ -15,23 +16,37 @@ const withNativeFile = typeof File === "function" ||
+@@ -14,24 +15,38 @@ const withNativeBlob = typeof Blob === "function" ||
+ const withNativeFile = typeof File === "function" ||
      (typeof File !== "undefined" &&
          toString.call(File) === "[object FileConstructor]");
- /**
++/**
 + * Returns true if obj is an ArrayBuffer.
 + * This extra check is made because the "instanceof ArrayBuffer" check does not work
 + * across different execution contexts.
@@ -138,7 +139,7 @@ index 4b7c234..e444014 100644
 +function isArrayBuffer(obj) {
 +    return typeof obj === 'object' && obj !== null && toString.call(obj) === '[object ArrayBuffer]';
 +}
-+/**
+ /**
   * Returns true if obj is a Buffer, an ArrayBuffer, a Blob or a File.
   *
   * @private
@@ -153,7 +154,7 @@ index 4b7c234..e444014 100644
  }
  exports.isBinary = isBinary;
 -function hasBinary(obj, toJSON) {
-+function hasBinary(obj, known = []) {
++function hasBinary(obj, known = [], toJSON = false) {
      if (!obj || typeof obj !== "object") {
          return false;
      }
@@ -168,12 +169,14 @@ index 4b7c234..e444014 100644
                  return true;
              }
          }
-@@ -43,10 +58,10 @@ function hasBinary(obj, toJSON) {
+@@ -42,11 +57,11 @@ function hasBinary(obj, toJSON) {
+     }
      if (obj.toJSON &&
          typeof obj.toJSON === "function" &&
-         arguments.length === 1) {
+-        arguments.length === 1) {
 -        return hasBinary(obj.toJSON(), true);
-+        return hasBinary(obj.toJSON(), known);
++        arguments.length === 2) {
++        return hasBinary(obj.toJSON(), known, true);
      }
      for (const key in obj) {
 -        if (Object.prototype.hasOwnProperty.call(obj, key) && hasBinary(obj[key])) {

--- a/packages/socket/test/socket_spec.js
+++ b/packages/socket/test/socket_spec.js
@@ -3,6 +3,7 @@ const path = require('path')
 const server = require('socket.io')
 const client = require('socket.io-client')
 const parser = require('socket.io-parser')
+const { hasBinary } = require('socket.io-parser/dist/is-binary')
 const expect = require('chai').expect
 const pkg = require('../package.json')
 const lib = require('../index')
@@ -215,6 +216,20 @@ describe('Socket', function () {
       for (let i = 0; i < encodedPackets.length; i++) {
         decoder.add(encodedPackets[i])
       }
+    })
+  })
+
+  context('hasBinary', () => {
+    it('hasBinary handles binary data in toJSON()', () => {
+      const x = {
+        toJSON () {
+          return Buffer.from('123', 'utf8')
+        },
+      }
+
+      const data = ['a', x]
+
+      expect(hasBinary(data)).to.be.true
     })
   })
 })


### PR DESCRIPTION
- Related with [#16641 comments](https://github.com/cypress-io/cypress/pull/16641#discussion_r699651415)

### User facing changelog

N/A

### Additional details
- Why was this change necessary? => The patched `hasBinary` should work like the original

### Any implementation details to explain?

[The original `hasBinary`](https://github.com/socketio/socket.io-parser/blob/75530b4dcdced9138d51a0b7b782c8f89cdf3899/lib/is-binary.ts#L33-L66) detects binary data inside `toJSON()` functions. 

But the patched version doesn't do that because we don't have the `toJSON` argument. The `obj.toJSON &&  typeof obj.toJSON === "function" && arguments.length === 1` in the code is always false because `arguments.length` is *always* `true`.

This PR solves this problem.

### What is affected by this change?

I guess there are none of them. Even if binary objects are In `toJSON()`, it will be converted to `string` eventually when encoding them. So, the encoded result is the same. 

It might be useful when a developer use the patched `hasBinary` directly in their code. But it doesn't change anything for now.

### How has the user experience changed?

N/A

### PR Tasks
- [x] Have tests been added/updated?