### PR TITLE
chore: Don't include tooltips in reporter percy snapshots

### DIFF
--- a/packages/reporter/cypress/support/index.ts
+++ b/packages/reporter/cypress/support/index.ts
@@ -8,5 +8,6 @@ installCustomPercyCommand({
   },
   elementOverrides: {
     '.command-progress': true,
+    '.cy-tooltip': true,
   },
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #17897 

### User facing changelog

N/A - Only affects internal tests

### Additional details

Tooltips are covered by the cypress tests themselves and are inconsistent in their rendering, so we're better off excluding them from percy snapshots. This is what we do in the desktop-gui as well.

### PR Tasks

N/A
