### PR TITLE
fix(launchpad): add a11y support to Settings Card

### DIFF
--- a/packages/launchpad/src/settings/SettingsCard.spec.tsx
+++ b/packages/launchpad/src/settings/SettingsCard.spec.tsx
@@ -25,5 +25,18 @@ describe('<SettingsCard />', () => {
     .get(contentSelector).should('be.visible')
     .get(headerSelector).click()
     .get(contentSelector).should('not.exist')
+
+    // expected aria and keyboard behavior with space and enter keys:
+    cy.get(headerSelector).should('be.focused')
+    .get('body').type(' ')
+    .get(contentSelector).should('be.visible')
+    .get(headerSelector).should('have.attr', 'aria-expanded', 'true')
+    .get('body').type(' ')
+    .get(contentSelector).should('not.exist')
+    .get(headerSelector).should('have.attr', 'aria-expanded', 'false')
+    .get('body').type('{enter}')
+    .get(contentSelector).should('be.visible')
+    .get('body').type('{enter}')
+    .get(contentSelector).should('not.exist')
   })
 })

--- a/packages/launchpad/src/settings/SettingsCard.vue
+++ b/packages/launchpad/src/settings/SettingsCard.vue
@@ -1,16 +1,30 @@
 <template>
   <div class="p-4 min-w-650px mx-auto my-0">
-    <Disclosure as="section" class="border-1 border-gray-300 rounded" v-slot="{ open }">
-      <DisclosureButton data-testid="settings-card-header" class="settings-card-header bg-cool-gray-100 py-4 pl-6 pr-3 select-none cursor-pointer grid gap-4">
+    <Disclosure 
+      as="section" 
+      #="{ open }"
+      class="border-1 border-gray-300 rounded">
+      <DisclosureButton 
+        data-testid="settings-card-header" 
+        class="settings-card-header bg-cool-gray-100 py-4 pl-6 pr-3 select-none cursor-pointer grid gap-4">
         <span class="grid self-center h-full">
           <Icon :icon="icon" class="self-center text-indigo-600 text-xl"/>
         </span>
         <div class="w-0.5px bg-gray-300 h-full"/>
         <div>
-          <h2 data-testid="settings-card-title" class="col-start-3 text-xl text-indigo-600">{{ title }}</h2>
-          <p data-testid="settings-card-description" class="text-gray-500 text-sm">{{ description }}</p>
+          <h2 
+            data-testid="settings-card-title" 
+            class="col-start-3 text-xl text-indigo-600">
+            {{ title }}
+          </h2>
+          <p data-testid="settings-card-description" class="text-gray-500 text-sm">
+            {{ description }}
+          </p>
         </div>
-        <Icon :icon="IconCaret" class="transform transition-transform col-start-4 self-center text-xl text-gray-500" :class="{ 'rotate-90': !open, 'rotate-180': open }"/>
+        <Icon 
+          :icon="IconCaret" 
+          class="transform transition-transform col-start-4 self-center text-xl text-gray-500" 
+          :class="{ 'rotate-90': !open, 'rotate-180': open }"/>
       </DisclosureButton>
 
       <!-- Content of the Settings Card -->

--- a/packages/launchpad/src/settings/SettingsCard.vue
+++ b/packages/launchpad/src/settings/SettingsCard.vue
@@ -1,9 +1,7 @@
 <template>
   <div class="p-4 min-w-650px mx-auto my-0">
-    <section class="border-1 border-gray-300 rounded">
-
-      <!-- The Settings Card Header -->
-      <header @click="toggleOpen()" data-testid="settings-card-header" class="bg-cool-gray-100 py-4 pl-6 pr-3 select-none cursor-pointer grid gap-4">
+    <Disclosure as="div" class="border-1 border-gray-300 rounded" v-slot="{ open }">
+      <DisclosureButton data-testid="settings-card-header" class="settings-card-header bg-cool-gray-100 py-4 pl-6 pr-3 select-none cursor-pointer grid gap-4">
         <span class="grid self-center h-full">
           <Icon :icon="icon" class="self-center text-indigo-600 text-xl"/>
         </span>
@@ -12,36 +10,34 @@
           <h2 data-testid="settings-card-title" class="col-start-3 text-xl text-indigo-600">{{ title }}</h2>
           <p data-testid="settings-card-description" class="text-gray-500 text-sm">{{ description }}</p>
         </div>
-        <Icon :icon="IconCaret" class="transform transition-transform col-start-4 self-center text-xl text-gray-500" :class="{ 'rotate-90': !isOpen, 'rotate-180': isOpen }"/>
-      </header>
+        <Icon :icon="IconCaret" class="transform transition-transform col-start-4 self-center text-xl text-gray-500" :class="{ 'rotate-90': !open, 'rotate-180': open }"/>
+      </DisclosureButton>
 
       <!-- Content of the Settings Card -->
-      <div class="pl-6 pr-10 pt-6 pb-6 border-t-width-1px border-gray-300" v-if="isOpen">
+      <DisclosurePanel class="pl-6 pr-10 pt-6 pb-6 border-t-width-1px border-gray-300">
         <slot/>
-      </div>
-    </section>
+      </DisclosurePanel>
+    </Disclosure>
   </div>
 </template>
 
 <script lang="ts" setup>
   import IconCaret from 'virtual:vite-icons/mdi/caret'
   import Icon from '../components/icon/Icon.vue'
-  import { useToggle } from '@vueuse/core'
   import type { FunctionalComponent, SVGAttributes } from 'vue'
+  import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
   
-
   defineProps<{
     title: string,
     description: string,
     icon: FunctionalComponent<SVGAttributes, {}>
   }>()
 
-  const [ isOpen, toggleOpen ] = useToggle(false)
-
 </script>
 
 <style lang="scss" scoped>
-header {
+.settings-card-header {
+  width: 100%;
   grid-template-columns: auto auto 1fr auto;
 }
 </style>

--- a/packages/launchpad/src/settings/SettingsCard.vue
+++ b/packages/launchpad/src/settings/SettingsCard.vue
@@ -6,7 +6,7 @@
       class="border-1 border-gray-300 rounded">
       <DisclosureButton 
         data-testid="settings-card-header" 
-        class="settings-card-header bg-cool-gray-100 py-4 pl-6 pr-3 select-none cursor-pointer grid gap-4">
+        class="settings-card-header w-full bg-cool-gray-100 py-4 pl-6 pr-3 select-none cursor-pointer grid gap-4">
         <span class="grid self-center h-full">
           <Icon :icon="icon" class="self-center text-indigo-600 text-xl"/>
         </span>
@@ -51,7 +51,6 @@
 
 <style lang="scss" scoped>
 .settings-card-header {
-  width: 100%;
   grid-template-columns: auto auto 1fr auto;
 }
 </style>

--- a/packages/launchpad/src/settings/SettingsCard.vue
+++ b/packages/launchpad/src/settings/SettingsCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="p-4 min-w-650px mx-auto my-0">
-    <Disclosure as="div" class="border-1 border-gray-300 rounded" v-slot="{ open }">
+    <Disclosure as="section" class="border-1 border-gray-300 rounded" v-slot="{ open }">
       <DisclosureButton data-testid="settings-card-header" class="settings-card-header bg-cool-gray-100 py-4 pl-6 pr-3 select-none cursor-pointer grid gap-4">
         <span class="grid self-center h-full">
           <Icon :icon="icon" class="self-center text-indigo-600 text-xl"/>


### PR DESCRIPTION
## Purpose
This PR addresses an accessibility issue with the Settings Card.

- Closes #UNIFY-311 https://cypress-io.atlassian.net/browse/UNIFY-311

### Additional details
By using the Headless UI `Disclosure` and related components to wrap the header and body content, we get the correct accessibility behavior built in, and no longer have to manage open/closed state of the card in the component itself.

### How has the user experience changed?
Now the card can be opened and closed with the keyboard and will announce state to screen readers.

The only visual change is that since the card header is keyboard-focusable it now has a focus outline when focused.

Old:
![card-no-focus](https://user-images.githubusercontent.com/8340719/132686514-b6d70fbe-6472-4fde-a07b-491d8c0fa0d7.png)

New:
![card focus](https://user-images.githubusercontent.com/8340719/132686518-83b9e23f-a042-46f5-bb39-877c0e55e778.png)

### How to Test
Using the keyboard, press tab to focus the card header, and use space and enter keys to toggle the component open and closed. With a screenreader like VoiceOver, verify that the open or closed state of the component is announced at the end of the card header content.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?

