### PR TITLE
fix: add missing clientCertificate type to ResolvedConfigOptions

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2520,7 +2520,7 @@ declare namespace Cypress {
      */
     url: string
     /**
-     * Paths to one or more CA files to validate certs against, relative to project root. 
+     * Paths to one or more CA files to validate certs against, relative to project root.
      */
     ca?: string[]
     /**
@@ -2791,6 +2791,11 @@ declare namespace Cypress {
      * @default {}
      */
     e2e: Omit<ResolvedConfigOptions, TestingType>
+
+    /**
+     * An array of objects defining the certificates
+     */
+    clientCertificate: ClientCertificate[]
   }
 
   /**
@@ -2834,11 +2839,6 @@ declare namespace Cypress {
      * The Cypress version being used.
      */
     version: string
-
-    /**
-     * An array of objects defining the certificates
-     */
-    clientCertificate: ClientCertificate[]
 
     // Internal or Unlisted at server/lib/config_options
     autoOpen: boolean

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2795,7 +2795,7 @@ declare namespace Cypress {
     /**
      * An array of objects defining the certificates
      */
-    clientCertificate: ClientCertificate[]
+    clientCertificates: ClientCertificate[]
   }
 
   /**

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2488,6 +2488,47 @@ declare namespace Cypress {
     cmdKey: boolean
   }
 
+  interface PEMCert {
+    /**
+     * Path to the certificate file, relative to project root.
+     */
+    cert: string
+    /**
+     * Path to the private key file, relative to project root.
+     */
+    key: string
+    /**
+     * Path to a text file containing the passphrase, relative to project root.
+     */
+    passphrase?: string
+  }
+
+  interface PFXCert {
+    /**
+     * Path to the certificate container, relative to project root.
+     */
+    pfx: string
+    /**
+     * Path to a text file containing the passphrase, relative to project root.
+     */
+    passphrase?: string
+  }
+
+  interface ClientCertificate {
+    /**
+     * URL to match requests against. Wildcards following [minimatch](https://github.com/isaacs/minimatch) rules are supported.
+     */
+    url: string
+    /**
+     * Paths to one or more CA files to validate certs against, relative to project root. 
+     */
+    ca?: string[]
+    /**
+     * A PEM format certificate/private key pair or PFX certificate container
+     */
+    certs: PEMCert[] | PFXCert[]
+  }
+
   interface ResolvedConfigOptions {
     /**
      * Url used as prefix for [cy.visit()](https://on.cypress.io/visit) or [cy.request()](https://on.cypress.io/request) command’s url
@@ -2793,6 +2834,11 @@ declare namespace Cypress {
      * The Cypress version being used.
      */
     version: string
+
+    /**
+     * An array of objects defining the certificates
+     */
+    clientCertificate: ClientCertificate[]
 
     // Internal or Unlisted at server/lib/config_options
     autoOpen: boolean


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/17799

### User facing changelog
Add missing clientCertificate field type definition to ResolvedConfigOptions

### Additional details
Provides code completion for clientCertificate

### PR Tasks
- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [x] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
