### PR TITLE
chore: Fix rerunning multidomain tests

### DIFF
--- a/packages/driver/cypress/integration/e2e/multidomain_rerun_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multidomain_rerun_spec.ts
@@ -1,0 +1,35 @@
+describe('multidomain - rerun', () => {
+  beforeEach(() => {
+    cy.visit('/fixtures/multidomain.html')
+    // @ts-ignore
+    cy.anticipateMultidomain()
+    cy.get('a').click()
+  })
+
+  // this test will hang without the fix for multidomain rerun
+  // https://github.com/cypress-io/cypress/issues/18043
+  it('successfully reruns tests', () => {
+    // @ts-ignore
+    cy.switchToDomain('127.0.0.1:3501', () => {
+      cy.get('[data-cy="dom-check"]')
+    })
+    .then(() => {
+      const top = window.top!
+      const { hash } = top.location
+
+      // @ts-ignore
+      if (!top.hasRunOnce) {
+        // @ts-ignore
+        top.hasRunOnce = true
+
+        // hashchange causes the test to rerun
+        top.location.hash = `${hash}?rerun`
+
+        return
+      }
+
+      // this only executes after the test has been rerun
+      expect(true).to.be.true
+    })
+  })
+})

--- a/packages/driver/src/cy/multidomain/index.ts
+++ b/packages/driver/src/cy/multidomain/index.ts
@@ -2,8 +2,6 @@ import Bluebird from 'bluebird'
 import $Log from '../../cypress/log'
 import { createDeferred } from '../../util/deferred'
 
-const readiedDomains = {}
-
 export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, state: Cypress.State) {
   Commands.addAll({
     // this is a stop-gap command temporarily in use until looking ahead for
@@ -14,17 +12,8 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
       state('anticipateMultidomain', true)
 
       return new Bluebird((resolve) => {
-        // the spec bridge iframe only loads once, and that's when it sends
-        // 'cross:domain:bridge:ready', so if we've already readied it,
-        // there's no need to wait
-        if (readiedDomains[domain]) {
-          return resolve()
-        }
-
         // @ts-ignore
         Cypress.once('cross:domain:bridge:ready', () => {
-          readiedDomains[domain] = true
-
           resolve()
         })
 

--- a/packages/runner-shared/src/event-manager.js
+++ b/packages/runner-shared/src/event-manager.js
@@ -623,6 +623,10 @@ export const eventManager = {
     ws.emit('spec:changed', specFile)
   },
 
+  notifyCrossDomainBridgeReady () {
+    Cypress.emit('cross:domain:bridge:ready')
+  },
+
   focusTests () {
     ws.emit('focus:tests')
   },

--- a/packages/runner/src/iframe/iframes.jsx
+++ b/packages/runner/src/iframe/iframes.jsx
@@ -172,7 +172,11 @@ export default class Iframes extends Component {
     const id = `Cypress (${domain})`
 
     // if it already exists, don't add another one
-    if (document.getElementById(id)) return
+    if (document.getElementById(id)) {
+      this.props.eventManager.notifyCrossDomainBridgeReady()
+
+      return
+    }
 
     this._addIframe({
       id,


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #18043 

### User facing changelog

N/A - Multidomain WIP

### Additional details

Issue was caused by the secondary domain bridge iframe not existing and not being re-created on rerun.

Previously kept state in the driver for which domains were visited and had their bridge iframes already loaded (so they're not needlessly re-created between tests), but the iframes get cleared out between test runs, so it's better to let the runner, which controls the iframes, essentially keep that state instead.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- N/A Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
