### PR TITLE
fix: iframe feature policy for camera/microphone

### DIFF
--- a/packages/driver/cypress/integration/e2e/webcam_spec.js
+++ b/packages/driver/cypress/integration/e2e/webcam_spec.js
@@ -1,13 +1,4 @@
-// https://github.com/cypress-io/cypress/issues/2704
-
 describe('webcam support', () => {
-  if (Cypress.isBrowser('firefox')) {
-    // TODO: (firefox) allow auto-bypass webcam prompt
-    it.skip('navigator.mediaDevices.getUserMedia resolves with fake media stream')
-
-    return
-  }
-
   it('navigator.mediaDevices.getUserMedia resolves with fake media stream', () => {
     cy.visit('/fixtures/webcam.html')
     cy.window().then((win) => {

--- a/packages/runner-shared/src/iframe/aut-iframe.js
+++ b/packages/runner-shared/src/iframe/aut-iframe.js
@@ -20,6 +20,7 @@ export class AutIframe {
     this.$iframe = $('<iframe>', {
       id: `Your App: '${this.config.projectName}'`,
       class: 'aut-iframe',
+      allow: 'camera;microphone',
     })
 
     return this.$iframe

--- a/packages/server/lib/browsers/firefox.ts
+++ b/packages/server/lib/browsers/firefox.ts
@@ -291,6 +291,7 @@ const defaultPreferences = {
   // and auto-accept the permissions prompt
   'media.getusermedia.browser.enabled': true,
   'media.navigator.permission.disabled': true,
+  'media.navigator.streams.fake': true,
 
   'dom.min_background_timeout_value': 4,
   'dom.timeout.enable_budget_timer_throttling': false,


### PR DESCRIPTION
- Closes #8849 

### User facing changelog
Fixes `getUserMedia()` for Firefox 92+

### Additional details
Permissions must be specified to allow access to the (fake) camera and microphone from within the Cypress iframe.

### How has the user experience changed?
It has not, this is a bugfix.

### PR Tasks
None applicable.