### PR TITLE
chore(server): simplify util/specs, types

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2876,7 +2876,7 @@ declare namespace Cypress {
     socketId: null | string
     socketIoCookie: string
     socketIoRoute: string
-    spec: Cypress['spec']
+    spec: Cypress['spec'] | null
     specs: Array<Cypress['spec']>
     xhrRoute: string
     xhrUrl: string

--- a/packages/server/lib/controllers/files.js
+++ b/packages/server/lib/controllers/files.js
@@ -15,7 +15,7 @@ module.exports = {
   handleFiles (req, res, config) {
     debug('handle files')
 
-    return specsUtil.find(config)
+    return specsUtil.default.findSpecs(config)
     .then((files) => {
       return res.json({
         integration: files,
@@ -67,7 +67,6 @@ module.exports = {
     }
 
     const specFilter = _.get(extraOptions, 'specFilter')
-    const specTypeFilter = _.get(extraOptions, 'specType', 'integration')
 
     debug('specFilter %o', { specFilter })
     const specFilterContains = (spec) => {
@@ -85,17 +84,15 @@ module.exports = {
       if (spec === '__all') {
         debug('returning all specs')
 
-        return specsUtil.find(config)
+        return specsUtil.default.findSpecs(config)
         .then(R.tap((specs) => {
           return debug('found __all specs %o', specs)
         }))
         .filter(specFilterFn)
         .filter((foundSpec) => {
-          if (componentTestingEnabled) {
-            return foundSpec.specType === specTypeFilter
-          }
-
-          return true
+          return componentTestingEnabled
+            ? foundSpec.specType === 'component'
+            : foundSpec.specType === 'integration'
         }).then(R.tap((specs) => {
           return debug('filtered __all specs %o', specs)
         })).map((spec) => {

--- a/packages/server/lib/controllers/runner.ts
+++ b/packages/server/lib/controllers/runner.ts
@@ -69,7 +69,7 @@ export const runner = {
     config.version = pkg.version
     config.platform = os.platform() as PlatformName
     config.arch = os.arch()
-    config.spec = getSpec() ?? undefined
+    config.spec = getSpec() ?? null
     config.specs = specsStore.specFiles
     config.browser = getCurrentBrowser()
 

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1472,8 +1472,8 @@ module.exports = {
   },
 
   findSpecs (config, specPattern) {
-    return specsUtil
-    .find(config, specPattern)
+    return specsUtil.default
+    .findSpecs(config, specPattern)
     .tap((specs = []) => {
       if (debug.enabled) {
         const names = _.map(specs, 'name')
@@ -1549,8 +1549,14 @@ module.exports = {
         .spread((sys = {}, browser = {}, specs = []) => {
           // return only what is return to the specPattern
           if (specPattern) {
-            specPattern = specsUtil.getPatternRelativeToProjectRoot(specPattern, projectRoot)
+            specPattern = specsUtil.default.getPatternRelativeToProjectRoot(specPattern, projectRoot)
           }
+
+          specs = specs.filter((spec) => {
+            return options.testingType === 'component'
+              ? spec.specType === 'component'
+              : spec.specType === 'integration'
+          })
 
           if (!specs.length) {
             // did we use the spec pattern?
@@ -1568,12 +1574,6 @@ module.exports = {
 
           if (browser.family === 'chromium') {
             chromePolicyCheck.run(onWarning)
-          }
-
-          if (options.testingType === 'component') {
-            specs = specs.filter((spec) => {
-              return spec.specType === 'component'
-            })
           }
 
           const runAllSpecs = ({ beforeSpecRun, afterSpecRun, runUrl, parallel }) => {

--- a/packages/server/lib/open_project.ts
+++ b/packages/server/lib/open_project.ts
@@ -25,6 +25,11 @@ interface LaunchOpts {
   onError?: (err: Error) => void
 }
 
+interface SpecsByType {
+  component: Cypress.Spec[]
+  integration: Cypress.Spec[]
+}
+
 export interface LaunchArgs {
   _: [string] // Cypress App binary location
   config: Record<string, unknown>
@@ -231,8 +236,8 @@ export class OpenProject {
   }
 
   getSpecs (cfg) {
-    return specsUtil.find(cfg)
-    .then((specs: Cypress.Cypress['spec'][] = []) => {
+    return specsUtil.findSpecs(cfg)
+    .then((specs: Cypress.Spec[] = []) => {
       // TODO merge logic with "run.js"
       if (debug.enabled) {
         const names = _.map(specs, 'name')
@@ -260,20 +265,21 @@ export class OpenProject {
 
       // assumes all specs are integration specs
       return {
-        integration: specs,
+        integration: specs.filter((x) => x.specType === 'integration'),
+        component: [],
       }
     })
   }
 
   getSpecChanges (options: OpenProjectLaunchOptions = {}) {
-    let currentSpecs: Cypress.Cypress['spec'][]
+    let currentSpecs: SpecsByType
 
     _.defaults(options, {
       onChange: () => { },
       onError: () => { },
     })
 
-    const sendIfChanged = (specs = []) => {
+    const sendIfChanged = (specs: SpecsByType = { component: [], integration: [] }) => {
       // dont do anything if the specs haven't changed
       if (_.isEqual(specs, currentSpecs)) {
         return
@@ -332,9 +338,12 @@ export class OpenProject {
       }
     }
 
-    const get = () => {
+    const get = (): Bluebird<SpecsByType> => {
       if (!this.openProject) {
-        return
+        return Bluebird.resolve({
+          component: [],
+          integration: [],
+        })
       }
 
       const cfg = this.openProject.getConfig()

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -37,8 +37,8 @@ import type { LaunchArgs } from './open_project'
 // Instead, this is an interface of values that have been manually validated to exist
 // and are required when creating a project.
 type ReceivedCypressOptions =
-  Partial<Pick<Cypress.RuntimeConfigOptions, 'hosts' | 'projectName' | 'clientRoute' | 'devServerPublicPathRoute' | 'namespace' | 'report' | 'socketIoCookie' | 'configFile' | 'isTextTerminal' | 'isNewProject' | 'proxyUrl' | 'browsers' | 'browserUrl' | 'socketIoRoute' | 'arch' | 'platform' | 'spec' | 'specs' | 'browser' | 'version' | 'remote'>>
-  & Partial<Pick<Cypress.ResolvedConfigOptions, 'chromeWebSecurity' | 'supportFolder' | 'experimentalSourceRewriting' | 'fixturesFolder' | 'reporter' | 'reporterOptions' | 'screenshotsFolder' | 'pluginsFile' | 'supportFile' | 'integrationFolder' | 'baseUrl' | 'viewportHeight' | 'viewportWidth' | 'port' | 'experimentalInteractiveRunEvents' | 'componentFolder' | 'userAgent' | 'downloadsFolder' | 'env'>>// TODO: Figure out how to type this better.
+  Pick<Cypress.RuntimeConfigOptions, 'hosts' | 'projectName' | 'clientRoute' | 'devServerPublicPathRoute' | 'namespace' | 'report' | 'socketIoCookie' | 'configFile' | 'isTextTerminal' | 'isNewProject' | 'proxyUrl' | 'browsers' | 'browserUrl' | 'socketIoRoute' | 'arch' | 'platform' | 'spec' | 'specs' | 'browser' | 'version' | 'remote'>
+  & Pick<Cypress.ResolvedConfigOptions, 'chromeWebSecurity' | 'supportFolder' | 'experimentalSourceRewriting' | 'fixturesFolder' | 'reporter' | 'reporterOptions' | 'screenshotsFolder' | 'pluginsFile' | 'supportFile' | 'integrationFolder' | 'baseUrl' | 'viewportHeight' | 'viewportWidth' | 'port' | 'experimentalInteractiveRunEvents' | 'componentFolder' | 'userAgent' | 'downloadsFolder' | 'env' | 'testFiles' | 'ignoreTestFiles'> // TODO: Figure out how to type this better.
 
 export interface Cfg extends ReceivedCypressOptions {
   projectRoot: string
@@ -370,7 +370,15 @@ export class ProjectBase<TServer extends ServerE2E | ServerCt> extends EE {
     ctDevServerPort: number | undefined
     startSpecWatcher: () => void
   }> {
-    const allSpecs = await specsUtil.find(updatedConfig)
+    const allSpecs = await specsUtil.findSpecs({
+      projectRoot: updatedConfig.projectRoot,
+      fixturesFolder: updatedConfig.fixturesFolder,
+      supportFile: updatedConfig.supportFile,
+      testFiles: updatedConfig.testFiles,
+      ignoreTestFiles: updatedConfig.ignoreTestFiles,
+      componentFolder: updatedConfig.componentFolder,
+      integrationFolder: updatedConfig.integrationFolder,
+    })
     const specs = allSpecs.filter((spec: Cypress.Cypress['spec']) => {
       if (this.testingType === 'component') {
         return spec.specType === 'component'

--- a/packages/server/lib/specs-store.ts
+++ b/packages/server/lib/specs-store.ts
@@ -1,7 +1,9 @@
 import type Bluebird from 'bluebird'
 import chokidar, { FSWatcher } from 'chokidar'
 import _ from 'lodash'
-import { findSpecsOfType } from './util/specs'
+import specsUtil from './util/specs'
+/* eslint-disable no-duplicate-imports */
+import type { CommonSearchOptions } from './util/specs'
 
 type SpecFile = Cypress.Cypress['spec']
 type SpecFiles = SpecFile[]
@@ -9,8 +11,6 @@ type SpecFiles = SpecFile[]
 interface SpecsWatcherOptions {
   onSpecsChanged: (specFiles: SpecFiles) => void
 }
-
-const COMMON_SEARCH_OPTIONS = ['fixturesFolder', 'supportFile', 'projectRoot', 'testFiles', 'ignoreTestFiles']
 
 // TODO: shouldn't this be on the trailing edge, not leading?
 const debounce = (fn) => _.debounce(fn, 250, { leading: true })
@@ -54,12 +54,17 @@ export class SpecsStore {
   }
 
   getSpecFiles (): Bluebird<SpecFiles> {
-    const searchOptions = _.pick(this.cypressConfig, COMMON_SEARCH_OPTIONS)
+    const searchOptions: CommonSearchOptions = {
+      projectRoot: this.cypressConfig.projectRoot,
+      fixturesFolder: this.cypressConfig.fixturesFolder,
+      supportFile: this.cypressConfig.supportFile,
+      testFiles: this.cypressConfig.testFiles,
+      ignoreTestFiles: this.cypressConfig.ignoreTestFiles,
+    }
 
-    searchOptions.searchFolder = this.specDirectory
     searchOptions.testFiles = this.testFiles
 
-    return findSpecsOfType(searchOptions)
+    return specsUtil.findSpecsOfType(this.specDirectory, searchOptions)
   }
 
   watch (options: SpecsWatcherOptions) {

--- a/packages/server/lib/util/specs.js
+++ b/packages/server/lib/util/specs.js
@@ -245,6 +245,4 @@ module.exports = {
   findSpecsOfType,
 
   getPatternRelativeToProjectRoot,
-
-  TEST_TYPES: SPEC_TYPES,
 }

--- a/packages/server/test/unit/modes/run_spec.js
+++ b/packages/server/test/unit/modes/run_spec.js
@@ -676,11 +676,12 @@ describe('lib/modes/run', () => {
       sinon.stub(openProject, 'getProject').resolves(this.projectInstance)
       sinon.spy(errors, 'warning')
 
-      sinon.stub(specsUtil, 'find').resolves([
+      sinon.stub(specsUtil.default, 'findSpecs').resolves([
         {
           name: 'foo_spec.js',
           path: 'cypress/integration/foo_spec.js',
           absolute: '/path/to/spec.js',
+          specType: 'integration',
         },
       ])
     })
@@ -758,11 +759,12 @@ describe('lib/modes/run', () => {
       sinon.spy(runMode, 'runSpecs')
       sinon.stub(openProject, 'launch').resolves()
       sinon.stub(openProject, 'getProject').resolves(this.projectInstance)
-      sinon.stub(specsUtil, 'find').resolves([
+      sinon.stub(specsUtil.default, 'findSpecs').resolves([
         {
           name: 'foo_spec.js',
           path: 'cypress/integration/foo_spec.js',
           absolute: '/path/to/spec.js',
+          specType: 'integration',
         },
       ])
     })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A
- Related (cypress internal team only): https://cypress-io.atlassian.net/browse/UNIFY-301

As part of the work on unified GUI, I'd like to get a list of all specs, then expose them. This would be useful for, for example, a page in the unified runner that shows all the recent specs runs (for e2e and/or ct, depending how the user is filtering the list). 

At the moment, `specUtils.find` returns either component *or* integration specs (which also have `specType` to identify their type; having two separate arrays isn't very meaningful, since we filter them afterwards anyway).

This PR changes it to return a list of all specs. Each spec has a `specType` to identify it. this PR also adds type definitions to the file. There is no user facing change. I kept the changes to a minimum.

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
