### PR TITLE
fix: add deprecation notice for win 32-bit

### DIFF
--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -991,10 +991,10 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
       return arg1
     case 'WIN32_DEPRECATION':
       return stripIndent`\
-        You are currently running a 32-bit build of Cypress. Cypress will remove Windows 32-bit support in a future release.
+        You are running a 32-bit build of Cypress. Cypress will remove Windows 32-bit support in a future release.
 
-        ${arg1 ? 'You are using Windows 64-bit, which will continue to support Cypress. Try installing Node.js 64-bit and reinstalling Cypress to use the 64-bit build.'
-        : 'You are on Windows 32-bit, which will be unable to run future releases of Cypress. Consider upgrading to a 64-bit OS to continue using Cypress.'}
+        ${arg1 ? 'Try installing Node.js 64-bit and reinstalling Cypress to use the 64-bit build.'
+        : 'Consider upgrading to a 64-bit OS to continue using Cypress in future releases.'}
 
         For more information, see: https://on.cypress.io/win32-removal
         `

--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -989,6 +989,15 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
         `
     case 'UNSUPPORTED_BROWSER_VERSION':
       return arg1
+    case 'WIN32_DEPRECATION':
+      return stripIndent`\
+        You are currently running a 32-bit build of Cypress. Cypress will remove Windows 32-bit support in a future release.
+
+        ${arg1 ? 'You are using Windows 64-bit, which will continue to support Cypress. Try installing Node.js 64-bit and reinstalling Cypress to use the 64-bit build.'
+        : 'You are on Windows 32-bit, which will be unable to run future releases of Cypress. Consider upgrading to a 64-bit OS to continue using Cypress.'}
+
+        For more information, see: https://on.cypress.io/win32-removal
+        `
     default:
   }
 }

--- a/packages/server/lib/open_project.ts
+++ b/packages/server/lib/open_project.ts
@@ -16,6 +16,7 @@ import type { Browser, FoundBrowser, PlatformName } from '@packages/launcher'
 import type { AutomationMiddleware } from './automation'
 import { fs } from './util/fs'
 import path from 'path'
+import os from 'os'
 
 const debug = Debug('cypress:server:open_project')
 
@@ -44,7 +45,7 @@ export interface LaunchArgs {
 
 // @see https://github.com/cypress-io/cypress/issues/18094
 async function win32BitWarning (onWarning) {
-  // if (process.platform !== 'win32' || process.arch !== 'ia32') return
+  if (os.platform() !== 'win32' || os.arch() !== 'ia32') return
 
   // adapted from https://github.com/feross/arch/blob/master/index.js
   let useEnv = false
@@ -61,7 +62,7 @@ async function win32BitWarning (onWarning) {
   let hasX64 = false
 
   try {
-    hasX64 = !!fs.statSync(path.join(sysRoot, 'sysnative'))
+    hasX64 = !!(await fs.stat(path.join(sysRoot, 'sysnative')))
   } catch (err) {
     // pass
   }

--- a/packages/server/lib/open_project.ts
+++ b/packages/server/lib/open_project.ts
@@ -44,7 +44,7 @@ export interface LaunchArgs {
 }
 
 // @see https://github.com/cypress-io/cypress/issues/18094
-async function win32BitWarning (onWarning) {
+async function win32BitWarning (onWarning: (error: Error) => void) {
   if (os.platform() !== 'win32' || os.arch() !== 'ia32') return
 
   // adapted from https://github.com/feross/arch/blob/master/index.js

--- a/packages/server/lib/open_project.ts
+++ b/packages/server/lib/open_project.ts
@@ -14,6 +14,8 @@ import { getSpecUrl } from './project_utils'
 import errors from './errors'
 import type { Browser, FoundBrowser, PlatformName } from '@packages/launcher'
 import type { AutomationMiddleware } from './automation'
+import { fs } from './util/fs'
+import path from 'path'
 
 const debug = Debug('cypress:server:open_project')
 
@@ -38,6 +40,33 @@ export interface LaunchArgs {
   os: PlatformName
 
   onFocusTests?: () => any
+}
+
+// @see https://github.com/cypress-io/cypress/issues/18094
+async function win32BitWarning (onWarning) {
+  // if (process.platform !== 'win32' || process.arch !== 'ia32') return
+
+  // adapted from https://github.com/feross/arch/blob/master/index.js
+  let useEnv = false
+
+  try {
+    useEnv = !!(process.env.SYSTEMROOT && await fs.stat(process.env.SYSTEMROOT))
+  } catch (err) {
+    // pass
+  }
+
+  const sysRoot = useEnv ? process.env.SYSTEMROOT! : 'C:\\Windows'
+
+  // If %SystemRoot%\SysNative exists, we are in a WOW64 FS Redirected application.
+  let hasX64 = false
+
+  try {
+    hasX64 = !!fs.statSync(path.join(sysRoot, 'sysnative'))
+  } catch (err) {
+    // pass
+  }
+
+  onWarning(errors.get('WIN32_DEPRECATION', hasX64))
 }
 
 export class OpenProject {
@@ -417,6 +446,8 @@ export class OpenProject {
         testingType: args.testingType,
       },
     })
+
+    await win32BitWarning(options.onWarning)
 
     try {
       await this.openProject.initializeConfig()

--- a/packages/server/test/unit/open_project_spec.js
+++ b/packages/server/test/unit/open_project_spec.js
@@ -1,6 +1,7 @@
 require('../spec_helper')
 
 const path = require('path')
+const os = require('os')
 const chokidar = require('chokidar')
 const browsers = require(`${root}lib/browsers`)
 const ProjectBase = require(`${root}lib/project-base`).ProjectBase
@@ -35,6 +36,18 @@ describe('lib/open_project', () => {
     sinon.stub(preprocessor, 'removeFile')
 
     return openProject.create('/project/root', {}, {})
+  })
+
+  context('#create', () => {
+    // @see https://github.com/cypress-io/cypress/issues/18094
+    it('warns on win 32bit', async () => {
+      sinon.stub(os, 'platform').returns('win32')
+      sinon.stub(os, 'arch').returns('ia32')
+      const onWarning = sinon.stub()
+
+      await openProject.create('/root', {}, { onWarning })
+      expect(onWarning.getCall(0).args[0].message).to.include('You are currently running a 32-bit build')
+    })
   })
 
   context('#launch', () => {

--- a/packages/server/test/unit/open_project_spec.js
+++ b/packages/server/test/unit/open_project_spec.js
@@ -46,7 +46,7 @@ describe('lib/open_project', () => {
       const onWarning = sinon.stub()
 
       await openProject.create('/root', {}, { onWarning })
-      expect(onWarning.getCall(0).args[0].message).to.include('You are currently running a 32-bit build')
+      expect(onWarning.getCall(0).args[0].message).to.include('You are running a 32-bit build')
     })
   })
 


### PR DESCRIPTION
- Closes #18094 

### User facing changelog

- Added a deprecation notice for Windows 32-bit users that support will be removed in a future release.

### Additional details

### How has the user experience changed?

warning for users on 32-bit windows:

![image](https://user-images.githubusercontent.com/1151760/133664066-1f19d273-3063-46e0-ac8e-fb8cf712e9a3.png)

warning for users on 64-bit windows:

![image](https://user-images.githubusercontent.com/1151760/133664185-b8f8649b-0fcc-4620-9baa-6d057223b55a.png)

same warning in runmode:

![image](https://user-images.githubusercontent.com/1151760/133664300-76932d44-1d57-4da6-9357-dd59247ee5a6.png)


### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
