### PR TITLE
chore(tests): fix flake in proxy-logging-spec

### DIFF
--- a/packages/driver/cypress/integration/cypress/proxy-logging-spec.ts
+++ b/packages/driver/cypress/integration/cypress/proxy-logging-spec.ts
@@ -80,11 +80,8 @@ describe('Proxy Logging', () => {
         expect(log.consoleProps).to.not.have.property('Matched `cy.intercept()`')
 
         // trigger: .snapshot('request')
-        cy.once('log:changed', (log) => {
-          expect(log.snapshots.map((v) => v.name)).to.deep.eq(['request'])
-
-          // trigger: .snapshot('response')
-          cy.once('log:changed', (log) => {
+        cy.on('log:changed', (log) => {
+          try {
             expect(log.snapshots.map((v) => v.name)).to.deep.eq(['request', 'response'])
             expect(log.consoleProps['Response Headers']).to.include({
               'x-powered-by': 'Express',
@@ -101,7 +98,10 @@ describe('Proxy Logging', () => {
             )
 
             done()
-          })
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.log('assertion error, retrying', err)
+          }
         })
       })
     })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #17629 

### User facing changelog

n/a

### Additional details

There are 2 main reasons these tests were flaky after #16730:

1. It's possible for the log to update before or after the response is received (on the order of milliseconds). This means that tests that assert on the log after a response sometimes have to wait for the log to be updated.
2. XHR logs are created by the `xhr.js` code still since they can be totally stubbed by `cy.route()`, which will bypass #16730 entirely. But if the XHR does go out-of-browser, the XHR log will be updated with proxy logging metadata either before or after the XHR `onload` event fires. (similar to (1))

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [na] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
