### PR TITLE
fix: next trace error

### DIFF
--- a/npm/react/plugins/next/findNextWebpackConfig.js
+++ b/npm/react/plugins/next/findNextWebpackConfig.js
@@ -3,6 +3,7 @@
 const debug = require('debug')('@cypress/react')
 const getNextJsBaseWebpackConfig = require('next/dist/build/webpack-config').default
 const { findPagesDir } = require('../../dist/next/findPagesDir')
+const { getRunWebpackSpan } = require('../../dist/next/getRunWebpackSpan')
 
 async function getNextWebpackConfig (config) {
   let loadConfig
@@ -20,6 +21,7 @@ async function getNextWebpackConfig (config) {
     }
   }
   const nextConfig = await loadConfig('development', config.projectRoot)
+  const runWebpackSpan = await getRunWebpackSpan()
   const nextWebpackConfig = await getNextJsBaseWebpackConfig(
     config.projectRoot,
     {
@@ -30,6 +32,7 @@ async function getNextWebpackConfig (config) {
       pagesDir: findPagesDir(config.projectRoot),
       entrypoints: {},
       rewrites: { fallback: [], afterFiles: [], beforeFiles: [] },
+      ...runWebpackSpan,
     },
   )
 

--- a/npm/react/plugins/next/getRunWebpackSpan.ts
+++ b/npm/react/plugins/next/getRunWebpackSpan.ts
@@ -1,0 +1,16 @@
+import type { Span } from 'next/dist/telemetry/trace/trace'
+
+// Starting with v11.1.1, a trace is required.
+// 'next/dist/telemetry/trace/trace' only exists since v10.0.9
+// and our peerDeps support back to v8 so try-catch this import
+export async function getRunWebpackSpan (): Promise<{ runWebpackSpan?: Span }> {
+  let trace: (name: string) => Span
+
+  try {
+    trace = await import('next/dist/telemetry/trace/trace').then((m) => m.trace)
+
+    return { runWebpackSpan: trace('cypress') }
+  } catch (_) {
+    return {}
+  }
+}


### PR DESCRIPTION
- Closes #17992 

### User facing changelog
Fix webpack error with next >= 11.1.1

### Additional details
Next introduced tracing in v11.1.1. The trace is a required option for `getNextJsBaseWebpackConfig`, so this PR adds that. If trace doesn't exist, it's a no-op.

### How to test
I tested this by creating a branch inside `cypress-component-testing-examples` (the deps are slightly out of date so I updated most of them, plus `create-next-app` doesn't use Webpack 4 so I forced it). You can run:
```
// On this branch
yarn workspace @cypress/react build-prod

git clone https://github.com/cypress-io/cypress-component-testing-examples.git
git checkout next-trace-error
cd ./create-next-app-webpack-5 && yarn
npx cypress open-ct # Will error with traceChild
# Copy and paste dist and plugins folder from newly built @cypress/react into local node_modules (yarn add -D @cypress/react@file:path-to-react package was hanging so I don't have a better way to test this)
npx cypress open-ct # Will pass!
```

You can repeat the above inside of `create-next-app` which will test Webpack 4. Also, you can change the Next version to `11.1.0` and verify that this change isn't breaking previous versions.

### How has the user experience changed?
Next with Webpack 5 and Next >= 11.1.1 works

### PR Tasks
NA
