### PR TITLE
fix(launchpad): fix bugs introduced by urql/graphcache

### DIFF
--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -612,6 +612,9 @@ enum WizardNavigateDirection {
 type WizardNpmPackage {
   description: String!
 
+  """id"""
+  id: String!
+
   """The package name that you would npm install"""
   name: String!
 }

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -544,6 +544,9 @@ type Wizard {
   """
   canNavigateForward: Boolean!
 
+  """Whether the plugins for the selected testing type has been initialized"""
+  chosenTestingTypePluginsInitialized: Boolean
+
   """The title of the page, given the current step of the wizard"""
   description: String
   framework: WizardFrontendFramework

--- a/packages/graphql/src/entities/Wizard.ts
+++ b/packages/graphql/src/entities/Wizard.ts
@@ -219,6 +219,21 @@ export class Wizard {
     return true
   }
 
+  @nxs.field.boolean({
+    description: 'Whether the plugins for the selected testing type has been initialized',
+  })
+  chosenTestingTypePluginsInitialized (): NxsResult<'Wizard', 'chosenTestingTypePluginsInitialized'> {
+    if (this.chosenTestingType === 'component' && this._ctx.activeProject?.ctPluginsInitialized) {
+      return true
+    }
+
+    if (this.chosenTestingType === 'e2e' && this._ctx.activeProject?.e2ePluginsInitialized) {
+      return true
+    }
+
+    return false
+  }
+
   navigate (direction: WizardNavigateDirection): Wizard {
     debug(`_history is ${this._history.join(',')}`)
 
@@ -287,7 +302,21 @@ export class Wizard {
     }
 
     if (this.currentStep === 'createConfig') {
-      this.navigateToStep('initializePlugins')
+      if (this.chosenTestingType === 'component') {
+        if (this._ctx.activeProject?.ctPluginsInitialized) {
+          this.navigateToStep('setupComplete')
+        } else {
+          this.navigateToStep('initializePlugins')
+        }
+      }
+
+      if (this.chosenTestingType === 'e2e') {
+        if (this._ctx.activeProject?.e2ePluginsInitialized) {
+          this.navigateToStep('setupComplete')
+        } else {
+          this.navigateToStep('initializePlugins')
+        }
+      }
 
       return this
     }

--- a/packages/graphql/src/entities/Wizard.ts
+++ b/packages/graphql/src/entities/Wizard.ts
@@ -201,7 +201,7 @@ export class Wizard {
       return false
     }
 
-    if (this.currentStep === 'selectFramework' && !this.chosenBundler && !this.chosenFramework) {
+    if (this.currentStep === 'selectFramework' && (!this.chosenBundler || !this.chosenFramework)) {
       return false
     }
 

--- a/packages/graphql/src/entities/Wizard.ts
+++ b/packages/graphql/src/entities/Wizard.ts
@@ -272,8 +272,12 @@ export class Wizard {
     if (this.currentStep === 'welcome' && this.testingType === 'component') {
       if (this._ctx.activeProject?.isFirstTimeCT) {
         this.navigateToStep('selectFramework')
-      } else {
+      } else if (!this._ctx.activeProject?.ctPluginsInitialized) {
+        // not first time, and we haven't initialized plugins - initialize them
         this.navigateToStep('initializePlugins')
+      } else {
+        // not first time, have already initialized plugins - just move to open browser screen
+        this.navigateToStep('setupComplete')
       }
 
       return this
@@ -282,8 +286,12 @@ export class Wizard {
     if (this.currentStep === 'welcome' && this.testingType === 'e2e') {
       if (this._ctx.activeProject?.isFirstTimeE2E) {
         this.navigateToStep('createConfig')
-      } else {
+      } else if (!this._ctx.activeProject?.e2ePluginsInitialized) {
+        // not first time, and we haven't initialized plugins - initialize them
         this.navigateToStep('initializePlugins')
+      } else {
+        // not first time, have already initialized plugins - just move to open browser screen
+        this.navigateToStep('setupComplete')
       }
 
       return this

--- a/packages/graphql/src/entities/WizardNpmPackage.ts
+++ b/packages/graphql/src/entities/WizardNpmPackage.ts
@@ -8,6 +8,13 @@ export class WizardNpmPackage {
   constructor (private pkg: NpmPackages) {}
 
   @nxs.field.nonNull.string({
+    description: 'id',
+  })
+  id (): NxsResult<'WizardNpmPackage', 'id'> {
+    return this.pkg
+  }
+
+  @nxs.field.nonNull.string({
     description: 'The package name that you would npm install',
   })
   name (): NxsResult<'WizardNpmPackage', 'name'> {

--- a/packages/launchpad/cypress.json
+++ b/packages/launchpad/cypress.json
@@ -14,9 +14,6 @@
   "reporterOptions": {
     "configFile": "../../mocha-reporter-config.json"
   },
-  "component": {
-    "componentFolder": "src"
-  },
   "e2e": {
     "supportFile": false
   }

--- a/packages/launchpad/cypress.json
+++ b/packages/launchpad/cypress.json
@@ -14,6 +14,9 @@
   "reporterOptions": {
     "configFile": "../../mocha-reporter-config.json"
   },
+  "component": {
+    "componentFolder": "src"
+  },
   "e2e": {
     "supportFile": false
   }

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -25,6 +25,7 @@
     "@intlify/vite-plugin-vue-i18n": "2.4.0",
     "@testing-library/cypress": "8.0.0",
     "@urql/core": "2.3.1",
+    "@urql/devtools": "2.0.3",
     "@urql/vue": "0.4.3",
     "@vitejs/plugin-vue": "1.2.4",
     "@vitejs/plugin-vue-jsx": "1.1.6",

--- a/packages/launchpad/src/Main.vue
+++ b/packages/launchpad/src/Main.vue
@@ -34,6 +34,7 @@ query MainQuery {
   ...Wizard
 
   wizard {
+    canNavigateForward
     ...WizardHeader
   }
 

--- a/packages/launchpad/src/components/select/SelectFramework.vue
+++ b/packages/launchpad/src/components/select/SelectFramework.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="text-left relative">
     <label class="text-gray-800 text-sm my-3 block" :class="disabledClass">{{
-      name
+      props.name
     }}</label>
     <button
       class="
@@ -19,13 +19,13 @@
       "
       :class="disabledClass 
         + (isOpen ? ' border-indigo-600' : ' border-gray-200') 
-        + (disabled ? ' bg-gray-300 text-gray-600' : '')"
+        + (props.disabled ? ' bg-gray-300 text-gray-600' : '')"
       @click="
-        if (!disabled) {
+        if (!props.disabled) {
           isOpen = !isOpen;
         }
       "
-      :disabled="disabled"
+      :disabled="props.disabled"
       v-click-outside="() => (isOpen = false)"
     >
       <template v-if="selectedOptionObject">
@@ -44,7 +44,7 @@
         </span>
       </template>
       <span v-else class="text-gray-400">
-        {{ placeholder }}
+        {{ props.placeholder }}
       </span>
       <span class="flex-grow"></span>
       <i-fa-angle-down />
@@ -64,7 +64,7 @@
       style="margin-top: -3px"
     >
       <li
-        v-for="opt in options"
+        v-for="opt in props.options"
         :key="opt.id"
         @click="selectOption(opt)"
         focus="1"
@@ -85,9 +85,9 @@
   </div>
 </template>
 
-<script lang="ts">
-import { computed, defineComponent, PropType, ref } from "vue";
-import { ClickOutside } from '../../directives/ClickOutside'
+<script lang="ts" setup>
+import { computed, ref } from "vue";
+import { ClickOutside as vClickOutside } from '../../directives/ClickOutside'
 import { FrameworkBundlerLogos } from '../../utils/icons'
 
 export interface Option {
@@ -96,53 +96,30 @@ export interface Option {
   id: string;
 }
 
-export default defineComponent({
-  emits: { select: Object },
-  directives: { ClickOutside },
-  props: {
-    name: {
-      type: String,
-      required: true,
-    },
-    value: {
-      type: String,
-      default: undefined,
-    },
-    placeholder: {
-      type: String,
-      default: undefined,
-    },
-    options: {
-      type: Array as PropType<ReadonlyArray<Option>>,
-      required: true,
-    },
-    disabled: {
-      type: Boolean,
-      default: false,
-    },
-  },
-  setup(props, { emit }) {
-    const isOpen = ref(false);
+const emit = defineEmits<{
+  (event: 'select', id: string)
+}>()
 
-    const selectedOptionObject = computed(() => {
-      return props.options.find((opt) => opt.id === props.value);
-    });
+const props = withDefaults(defineProps<{
+  name: string
+  value?: string
+  placeholder?: string
+  options: Readonly<Option[]>
+  disabled?: boolean
+}>(), {
+  disabled: false
+})
 
-    const selectOption = (opt: Option) => {
-      emit("select", opt.id);
-    };
+const isOpen = ref(false);
 
-    const disabledClass = computed(() =>
-      props.disabled ? "opacity-50" : undefined
-    );
-
-    return {
-      isOpen,
-      selectedOptionObject,
-      selectOption,
-      disabledClass,
-      FrameworkBundlerLogos
-    };
-  },
+const selectedOptionObject = computed(() => {
+  return props.options.find((opt) => opt.id === props.value);
 });
+
+const selectOption = (opt: Option) => {
+  emit("select", opt.id);
+};
+
+const disabledClass = computed(() => props.disabled ? "opacity-50" : undefined)
+
 </script>

--- a/packages/launchpad/src/setup/ConfigFile.vue
+++ b/packages/launchpad/src/setup/ConfigFile.vue
@@ -42,7 +42,7 @@
     </nav>
     <div v-if="tsInstalled" class="relative">
       <PrismJs :key="language" :language="language">{{ code }}</PrismJs>
-      <CopyButton v-if="manualInstall && code" :text="code" />
+      <CopyButton v-if="manualCreate && code" :text="code" />
     </div>
   </WizardLayout>
 </template>
@@ -96,16 +96,16 @@ const props = defineProps<{
   gql: ConfigFileFragment 
 }>()
 
-const manualInstall = ref(false);
+const manualCreate = ref(false);
 
 const altFn = (val: boolean) => {
-  manualInstall.value = val
+  manualCreate.value = val
 }
 
 const tsInstalled = ref(false);
 const language = ref<"js" | "ts">("ts");
 const nextButtonName = computed(() =>
-  manualInstall.value ? "I've added this file" : "Create File"
+  manualCreate.value ? "I've added this file" : "Create File"
 );
 
 import("prismjs/components/prism-typescript").then(() => {
@@ -122,7 +122,7 @@ const code = computed(() => {
 })
 
 const createConfig = async () => {
-  if (manualInstall.value) {
+  if (manualCreate.value) {
     return
   }
 

--- a/packages/launchpad/src/setup/ConfigFile.vue
+++ b/packages/launchpad/src/setup/ConfigFile.vue
@@ -112,7 +112,6 @@ import("prismjs/components/prism-typescript").then(() => {
   tsInstalled.value = true;
 });
 
-
 const createConfigFile = useMutation(ConfigFile_AppCreateConfigFileDocument)
 
 const code = computed(() => {
@@ -123,6 +122,10 @@ const code = computed(() => {
 })
 
 const createConfig = async () => {
+  if (manualInstall.value) {
+    return
+  }
+
   if (!props.gql.app?.activeProject?.projectRoot) {
     throw Error(`Cannot find the active project's projectRoot. This should never happen.`)
   }

--- a/packages/launchpad/src/setup/ConfigFile.vue
+++ b/packages/launchpad/src/setup/ConfigFile.vue
@@ -68,10 +68,16 @@ fragment ConfigFile on Query {
     }
   }
   wizard {
-    canNavigateForward
-    sampleCodeJs: sampleCode(lang: js)
-    sampleCodeTs: sampleCode(lang: ts)
+    ...SampleCode
   }
+}
+`
+
+gql`
+fragment SampleCode on Wizard {
+  canNavigateForward
+  sampleCodeJs: sampleCode(lang: js)
+  sampleCodeTs: sampleCode(lang: ts)
 }
 `
 

--- a/packages/launchpad/src/setup/EnvironmentSetup.vue
+++ b/packages/launchpad/src/setup/EnvironmentSetup.vue
@@ -69,6 +69,9 @@ fragment EnvironmentSetup on Wizard {
     id
     name
   }
+
+  ...InstallDependencies
+  ...SampleCode
 }
 `
 

--- a/packages/launchpad/src/setup/InitializeConfig.vue
+++ b/packages/launchpad/src/setup/InitializeConfig.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-col items-center mx-auto my-10">
       <img src="../images/success.svg" class="my-2"/>
       <span class="my-2">
-        Loading...
+        {{ props.gql.chosenTestingTypePluginsInitialized ? 'Project initialized.' : 'Initializing...' }}
       </span>
     </div>
   </WizardLayout>
@@ -16,18 +16,17 @@ import { useMutation, gql } from "@urql/vue";
 import { InitializeConfigFragment, InitializeOpenProjectDocument } from "../generated/graphql"
 
 gql`
-fragment InitializeConfig on Query {
-  wizard {
-    canNavigateForward
-  }
+fragment InitializeConfig on Wizard {
+  canNavigateForward
+  chosenTestingTypePluginsInitialized
+  step
 }
 `
 
 gql`
 mutation InitializeOpenProject {
   initializeOpenProject {
-    step
-    canNavigateForward
+    ...InitializeConfig
   }
 }
 `
@@ -38,7 +37,7 @@ const props = defineProps<{
 
 const initializeOpenProject = useMutation(InitializeOpenProjectDocument)
 
-const canNavigateForward = computed(() => props.gql.wizard.canNavigateForward ?? false)
+const canNavigateForward = computed(() => props.gql.canNavigateForward ?? false)
 
 onMounted(async () => {
   await initializeOpenProject.executeMutation({})

--- a/packages/launchpad/src/setup/InstallDependencies.vue
+++ b/packages/launchpad/src/setup/InstallDependencies.vue
@@ -3,22 +3,22 @@
     :next="nextButtonName" 
     alt="Install manually" 
     :altFn="altFn"
-    :canNavigateForward="gql.canNavigateForward"
+    :canNavigateForward="props.gql.canNavigateForward"
   >
     <PackagesList
       v-if="!manualInstall" 
-      :gql="gql" 
+      :gql="props.gql" 
     />
     <ManualInstall 
       v-else 
       @back="manualInstall = false" 
-      :gql="gql || []" 
+      :gql="props.gql" 
     />
   </WizardLayout>
 </template>
 
-<script lang="ts">
-import { computed, defineComponent, PropType } from "vue";
+<script lang="ts" setup>
+import { computed } from "vue";
 import WizardLayout from "./WizardLayout.vue";
 import PackagesList from "./PackagesList.vue";
 import ManualInstall from "./ManualInstall.vue";
@@ -44,36 +44,21 @@ mutation InstallDependenciesManualInstall($isManual: Boolean!) {
 }
 `
 
+const props = defineProps<{
+  gql: InstallDependenciesFragment
+}>()
 
-export default defineComponent({
-  components: {
-    WizardLayout,
-    PackagesList,
-    ManualInstall,
-  },
-  props: {
-    gql: {
-      type: Object as PropType<InstallDependenciesFragment>,
-      required: true
-    }
-  },
-  setup(props) {
-    const { t } = useI18n()
-    const toggleManual = useMutation(InstallDependenciesManualInstallDocument)
-    const nextButtonName = computed(() =>
-      props.gql.isManualInstall ?
-        t('setupPage.install.confirmManualInstall') :
-        t('setupPage.install.startButton')
-    );
+const { t } = useI18n()
+const toggleManual = useMutation(InstallDependenciesManualInstallDocument)
+const nextButtonName = computed(() =>
+  props.gql.isManualInstall ?
+    t('setupPage.install.confirmManualInstall') :
+    t('setupPage.install.startButton')
+);
 
-    return { 
-      manualInstall: computed(() => props.gql.isManualInstall),
-      nextButtonName, 
-      gql: computed(() => props.gql),
-      altFn (val: boolean) {
-        toggleManual.executeMutation({ isManual: val })
-      }
-    };
-  },
-});
+const manualInstall = computed(() => props.gql.isManualInstall)
+
+const altFn = (val: boolean) => {
+  toggleManual.executeMutation({ isManual: val })
+}
 </script>

--- a/packages/launchpad/src/setup/ManualInstall.vue
+++ b/packages/launchpad/src/setup/ManualInstall.vue
@@ -34,6 +34,7 @@ import type { ManualInstallFragment } from "../generated/graphql";
 gql`
 fragment ManualInstall on Wizard {
   packagesToInstall {
+    id
     name
     description
   }

--- a/packages/launchpad/src/setup/PackagesList.vue
+++ b/packages/launchpad/src/setup/PackagesList.vue
@@ -1,19 +1,18 @@
 <template>
   <div
     :key="pkg.name"
-    v-for="(pkg, index) in packagesToInstall ?? []"
+    v-for="(pkg, index) in props.gql.packagesToInstall ?? []"
     class="flex text-left"
     :class="index > 0 ? 'border-t border-t-gray-200' : undefined"
   >
     <div class="p-5">
       <h2 class="text-indigo-600 font-normal">{{ pkg.name }}</h2>
-      <p class="text-gray-400 text-sm" v-html="pkg.description"/>
+      <p class="text-gray-400 text-sm" v-html="pkg.description" />
     </div>
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, computed } from "vue";
+<script lang="ts" setup>
 import { gql } from '@urql/core'
 import type { PackagesListFragment } from "../generated/graphql";
 
@@ -27,17 +26,7 @@ fragment PackagesList on Wizard {
 }
 `
 
-export default defineComponent({
-  props: {
-    gql: {
-      type: Object as PropType<PackagesListFragment>,
-      required: true
-    }
-  },
-  setup(props) {
-    return { 
-      packagesToInstall: computed(() => props.gql.packagesToInstall)
-    };
-  },
-});
+const props = defineProps<{
+  gql: PackagesListFragment
+}>()
 </script>

--- a/packages/launchpad/src/setup/PackagesList.vue
+++ b/packages/launchpad/src/setup/PackagesList.vue
@@ -20,6 +20,7 @@ import type { PackagesListFragment } from "../generated/graphql";
 gql`
 fragment PackagesList on Wizard {
   packagesToInstall {
+    id
     name
     description
   }

--- a/packages/launchpad/src/setup/TestingType.vue
+++ b/packages/launchpad/src/setup/TestingType.vue
@@ -2,12 +2,12 @@
   <div class="max-w-4xl mx-auto text-center">
     <button
       :key="type.id"
-      v-for="type in testingTypes"
+      v-for="type of props.gql.testingTypes"
       class="block h-45 border border-gray-200 m-5 p-2 rounded md:h-100 md:w-2/5 md:p-9 md:inline-block"
       @click="selectTestingType(type.id)"
     >
       <img
-        :src="icons[type.id]"
+        :src="TestingTypeIcons[type.id]"
         class="float-left m-5 md:mx-auto md:mb-10 md:float-none"
       />
       <p class="text-indigo-700 text-left mt-3 md:text-center">{{ type.title }}</p>
@@ -16,8 +16,7 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from "vue";
+<script lang="ts" setup>
 import { gql } from '@urql/core'
 import { useMutation } from '@urql/vue'
 import { TestingType_SelectDocument, TestingTypeFragment, TestingTypeEnum } from '../generated/graphql'
@@ -46,25 +45,13 @@ fragment TestingType on Wizard {
 }
 `
 
-export default defineComponent({
-  props: {
-    gql: {
-      type: Object as PropType<TestingTypeFragment>,
-      required: true,
-    }
-  },
-  setup(props) {
-    const mutation = useMutation(TestingType_SelectDocument)
+const props = defineProps<{
+  gql: TestingTypeFragment
+}>()
 
-    const selectTestingType = (testingType: TestingTypeEnum) => {
-      mutation.executeMutation({ testingType });
-    };
+const mutation = useMutation(TestingType_SelectDocument)
 
-    return { 
-      icons: TestingTypeIcons,
-      testingTypes: props.gql.testingTypes, 
-      selectTestingType 
-    };
-  },
-});
+const selectTestingType = (testingType: TestingTypeEnum) => {
+  mutation.executeMutation({ testingType });
+};
 </script>

--- a/packages/launchpad/src/setup/TestingType.vue
+++ b/packages/launchpad/src/setup/TestingType.vue
@@ -27,6 +27,7 @@ gql`
 mutation TestingType_Select($testingType: TestingTypeEnum!) {
   wizardSetTestingType(type: $testingType) {
     step
+    canNavigateForward
     testingType
     title
     description

--- a/packages/launchpad/src/setup/TestingTypeCards.vue
+++ b/packages/launchpad/src/setup/TestingTypeCards.vue
@@ -65,6 +65,7 @@ gql`
 mutation TestingTypeCardsNavigateForward {
   wizardNavigate(direction: forward) {
     step
+    chosenTestingTypePluginsInitialized
     canNavigateForward
     title
     description

--- a/packages/launchpad/src/setup/TestingTypeCards.vue
+++ b/packages/launchpad/src/setup/TestingTypeCards.vue
@@ -50,6 +50,8 @@ fragment TestingTypeCards on Query {
       description
     }
   }
+
+  ...ConfigFile
 }
 `
 

--- a/packages/launchpad/src/setup/TestingTypeCards.vue
+++ b/packages/launchpad/src/setup/TestingTypeCards.vue
@@ -56,10 +56,7 @@ fragment TestingTypeCards on Query {
 gql`
 mutation TestingTypeSelect($testingType: TestingTypeEnum!) {
   wizardSetTestingType(type: $testingType) {
-    step
     testingType
-    title
-    description
   }
 }
 `
@@ -68,6 +65,9 @@ gql`
 mutation TestingTypeCardsNavigateForward {
   wizardNavigate(direction: forward) {
     step
+    canNavigateForward
+    title
+    description
   }
 }
 `

--- a/packages/launchpad/src/setup/Wizard.vue
+++ b/packages/launchpad/src/setup/Wizard.vue
@@ -15,7 +15,7 @@
     />
     <InitializeConfig 
       v-if="props.gql.wizard.step === 'initializePlugins'" 
-      :gql="props.gql"
+      :gql="props.gql.wizard"
     />
     <OpenBrowser v-if="props.gql.wizard.step === 'setupComplete'" />
   </div>
@@ -40,9 +40,9 @@ fragment Wizard on Query {
     testingType
     ...EnvironmentSetup
     ...InstallDependencies
+    ...InitializeConfig
   }
   ...ConfigFile
-  ...InitializeConfig
 }`
 
 const props = defineProps<{

--- a/packages/launchpad/src/setup/WizardLayout.vue
+++ b/packages/launchpad/src/setup/WizardLayout.vue
@@ -30,6 +30,8 @@ import { useI18n } from "../composables"
 
 gql`
 fragment WizardLayout on Wizard {
+  title
+  description
   step
   canNavigateForward
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9500,6 +9500,13 @@
     "@graphql-typed-document-node/core" "^3.1.0"
     wonka "^4.0.14"
 
+"@urql/devtools@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@urql/devtools/-/devtools-2.0.3.tgz#780998c37386c72af9402a8f88c1b388e62f28cd"
+  integrity sha512-TktPLiBS9LcBPHD6qcnb8wqOVcg3Bx0iCtvQ80uPpfofwwBGJmqnQTjUdEFU6kwaLOFZULQ9+Uo4831G823mQw==
+  dependencies:
+    wonka ">= 4.0.9"
+
 "@urql/exchange-execute@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@urql/exchange-execute/-/exchange-execute-1.1.0.tgz#253ee9cdd3f9b16019cb1e6aa48ee4af11a1a0c2"
@@ -42396,7 +42403,7 @@ with@^7.0.0:
     assert-never "^1.2.1"
     babel-walk "3.0.0-canary-5"
 
-wonka@^4.0.14, wonka@^4.0.15:
+"wonka@>= 4.0.9", wonka@^4.0.14, wonka@^4.0.15:
   version "4.0.15"
   resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.15.tgz#9aa42046efa424565ab8f8f451fcca955bf80b89"
   integrity sha512-U0IUQHKXXn6PFo9nqsHphVCE5m3IntqZNB9Jjn7EB1lrR7YTDY3YWgFvEvwniTzXSvOH/XMzAZaIfJF/LvHYXg==


### PR DESCRIPTION
- Closes https://cypress-io.atlassian.net/browse/UNIFY-368

[This PR](https://github.com/cypress-io/cypress/pull/17875) made many changes, one of which was changing from the default [document cache](https://formidable.com/open-source/urql/docs/basics/document-caching/) to [graph cache](https://formidable.com/open-source/urql/docs/graphcache/).

This introduced some bugs relating to reactivity due to Graphcache's more aggressive caching policy.

I fixed the bugs by ensuring the mutations return the correct fields to update the cache. I also made some other small fixes:

- do not re-initializing the plugins if they were already initialized
- added urql devtools support
- do not create the config file is "create this manually" is selected
- use `<script setup>` 

Here's an example of a few of the bug fixed. It doesn't not create a new config file if I choose "create manually". It also only initializes the plugins once, even if you click "back" from the browser screen. Finally, if the plugins have already been initialized, it'll just skip the initializing and detecting screen, going straight to the browser launch screen.

https://user-images.githubusercontent.com/19196536/134284508-6976c46d-9ca1-4f8b-94ef-ef7adb6d7256.mov


