### PR TITLE
feat(driver): {force: true} option to disable error checking on select and select options

### DIFF
--- a/packages/driver/cypress/integration/commands/actions/select_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/select_spec.js
@@ -123,6 +123,18 @@ describe('src/cy/commands/actions/select', () => {
       cy.get('#select-maps').select('de_train')
     })
 
+    it('can select disabled select with force', () => {
+      cy.get('select[name=disabled]').select('foo', { force: true })
+    })
+
+    it('can select disabled optgroup with force', () => {
+      cy.get('select[name=optgroup-disabled]').select('foo', { force: true })
+    })
+
+    it('can select disabled option with force', () => {
+      cy.get('select[name=opt-disabled]').select('bar', { force: true })
+    })
+
     it('can forcibly click even when being covered by another element', (done) => {
       const select = $('<select><option>foo</option></select>').attr('id', 'select-covered-in-span').prependTo(cy.$$('body'))
 
@@ -526,7 +538,7 @@ describe('src/cy/commands/actions/select', () => {
           done()
         })
 
-        cy.get('#select-maps').select('de_dust2').then(($select) => {})
+        cy.get('#select-maps').select('de_dust2').then(($select) => { })
       })
 
       it('snapshots after clicking', () => {

--- a/packages/driver/src/cy/commands/actions/select.ts
+++ b/packages/driver/src/cy/commands/actions/select.ts
@@ -148,7 +148,7 @@ export default (Commands, Cypress, cy) => {
         }
 
         _.each(optionEls, ($el) => {
-          if ($el.prop('disabled')) {
+          if (!options.force && $el.prop('disabled')) {
             node = $dom.stringify($el)
 
             $errUtils.throwErrByPath('select.option_disabled', {
@@ -158,7 +158,7 @@ export default (Commands, Cypress, cy) => {
         })
 
         _.each(optionEls, ($el) => {
-          if ($el.closest('optgroup').prop('disabled')) {
+          if (!options.force && $el.closest('optgroup').prop('disabled')) {
             node = $dom.stringify($el)
 
             $errUtils.throwErrByPath('select.optgroup_disabled', {


### PR DESCRIPTION
Closes https://github.com/cypress-io/cypress/issues/107

### User facing changelog
Users can pass the `{force: true}` option to the `.select()` command to disable error checking so that you can "select" a disabled select or option.

### Additional details
Added tests:
- Ability to select disabled select with {force: true}
- Ability to select disabled optgroup with {force: true}
- Ability to select disabled option with {force: true}

### How has the user experience changed?
Previously, users were unable to select disabled options or optgroups. This change allows the `{force: true}` option to be used to disable error checking so disabled options, optgroups, and selects can be selected.

### PR Tasks
- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
