### PR TITLE
fix: Add drone env for the url of the repo

### DIFF
--- a/packages/server/lib/util/ci_provider.js
+++ b/packages/server/lib/util/ci_provider.js
@@ -505,7 +505,7 @@ const _providerCommitParams = () => {
       message: env.DRONE_COMMIT_MESSAGE,
       authorName: env.DRONE_COMMIT_AUTHOR,
       authorEmail: env.DRONE_COMMIT_AUTHOR_EMAIL,
-      // remoteOrigin: ???
+      remoteOrigin: env.DRONE_GIT_HTTP_URL,
       defaultBranch: env.DRONE_REPO_BRANCH,
     },
     githubActions: {

--- a/packages/server/test/unit/ci_provider_spec.js
+++ b/packages/server/test/unit/ci_provider_spec.js
@@ -519,6 +519,7 @@ describe('lib/util/ci_provider', () => {
       DRONE_COMMIT_AUTHOR: 'droneCommitAuthor',
       DRONE_COMMIT_AUTHOR_EMAIL: 'droneCommitAuthorEmail',
       DRONE_REPO_BRANCH: 'droneRepoBranch',
+      DRONE_GIT_HTTP_URL: 'droneRemoteOrigin',
     }, { clear: true })
 
     expectsName('drone')
@@ -536,6 +537,7 @@ describe('lib/util/ci_provider', () => {
       authorName: 'droneCommitAuthor',
       authorEmail: 'droneCommitAuthorEmail',
       defaultBranch: 'droneRepoBranch',
+      remoteOrigin: 'droneRemoteOrigin',
     })
   })
 


### PR DESCRIPTION
Close #18210 

### User Facing Changelog

- Cypress now captures the repo url on Drone CI. 

### Additional Details

https://docs.drone.io/pipeline/environment/reference/drone-git-http-url/

