### PR TITLE
fix: set projectId in a custom config file

### DIFF
--- a/packages/desktop-gui/cypress/fixtures/config.json
+++ b/packages/desktop-gui/cypress/fixtures/config.json
@@ -147,6 +147,7 @@
   "requestTimeout": 5000,
   "resolvedNodePath": null,
   "resolvedNodeVersion": "1.2.3",
+  "configFile": "cypress.json",
   "hosts": {
     "*.foobar.com": "127.0.0.1"
   },

--- a/packages/desktop-gui/cypress/integration/settings_spec.js
+++ b/packages/desktop-gui/cypress/integration/settings_spec.js
@@ -326,9 +326,9 @@ describe('Settings', () => {
 
     context('when configFile is false', () => {
       beforeEach(function () {
-        this.openProject.resolve(Cypress._.assign({
+        this.openProject.resolve(Cypress._.assign(this.config, {
           configFile: false,
-        }, this.config))
+        }))
 
         this.goToSettings()
 
@@ -342,9 +342,9 @@ describe('Settings', () => {
 
     context('when configFile is set', function () {
       beforeEach(function () {
-        this.openProject.resolve(Cypress._.assign({
+        this.openProject.resolve(Cypress._.assign(this.config, {
           configFile: 'special-cypress.json',
-        }, this.config))
+        }))
 
         this.goToSettings()
 

--- a/packages/desktop-gui/cypress/integration/setup_project_spec.js
+++ b/packages/desktop-gui/cypress/integration/setup_project_spec.js
@@ -8,6 +8,7 @@ const onSubmitNewProject = function (orgId) {
         projectName: this.config.projectName,
         orgId,
         public: false,
+        configFile: undefined,
       })
     })
   })
@@ -25,6 +26,7 @@ const onSubmitNewProject = function (orgId) {
         projectRoot: '/foo/bar',
         orgId,
         public: true,
+        configFile: undefined,
       })
     })
   })
@@ -487,7 +489,7 @@ describe('Connect to Dashboard', function () {
             cy.get('.setup-project')
             .contains('.btn', 'Set up project').click()
             .then(() => {
-              expect(this.ipc.setProjectId).to.be.calledWith({ id: this.dashboardProjects[1].id, projectRoot: '/foo/bar' })
+              expect(this.ipc.setProjectId).to.be.calledWith({ id: this.dashboardProjects[1].id, projectRoot: '/foo/bar', configFile: undefined })
             })
           })
 

--- a/packages/desktop-gui/cypress/integration/setup_project_spec.js
+++ b/packages/desktop-gui/cypress/integration/setup_project_spec.js
@@ -8,7 +8,7 @@ const onSubmitNewProject = function (orgId) {
         projectName: this.config.projectName,
         orgId,
         public: false,
-        configFile: undefined,
+        configFile: 'cypress.json',
       })
     })
   })
@@ -26,7 +26,7 @@ const onSubmitNewProject = function (orgId) {
         projectRoot: '/foo/bar',
         orgId,
         public: true,
-        configFile: undefined,
+        configFile: 'cypress.json',
       })
     })
   })
@@ -489,7 +489,10 @@ describe('Connect to Dashboard', function () {
             cy.get('.setup-project')
             .contains('.btn', 'Set up project').click()
             .then(() => {
-              expect(this.ipc.setProjectId).to.be.calledWith({ id: this.dashboardProjects[1].id, projectRoot: '/foo/bar', configFile: undefined })
+              expect(this.ipc.setProjectId).to.be.calledWith({
+                id: this.dashboardProjects[1].id,
+                projectRoot: '/foo/bar',
+                configFile: 'cypress.json' })
             })
           })
 

--- a/packages/desktop-gui/src/dashboard-projects/dashboard-projects-api.js
+++ b/packages/desktop-gui/src/dashboard-projects/dashboard-projects-api.js
@@ -45,8 +45,8 @@ const setupDashboardProject = (projectDetails) => {
   .catch(ipc.isUnauthed, ipc.handleUnauthed)
 }
 
-const setProjectId = (id, projectRoot) => {
-  return ipc.setProjectId({ id, projectRoot })
+const setProjectId = (id, projectRoot, configFile) => {
+  return ipc.setProjectId({ id, projectRoot, configFile })
 }
 
 export default {

--- a/packages/desktop-gui/src/runs/project-not-setup.jsx
+++ b/packages/desktop-gui/src/runs/project-not-setup.jsx
@@ -8,11 +8,6 @@ import authStore from '../auth/auth-store'
 import LoginForm from '../auth/login-form'
 import DashboardBanner from './dashboard-banner'
 import WhatIsDashboard from './what-is-dashboard'
-import ErrorMessage from './error-message'
-
-function isConfigJSONFile (filePath) {
-  return /\.json$/.test(filePath)
-}
 
 @observer
 export default class ProjectNotSetup extends Component {
@@ -35,20 +30,15 @@ export default class ProjectNotSetup extends Component {
     return (
       <div className="empty">
         {
-          !isConfigJSONFile(this.props.project.configFile) ?
-            <ErrorMessage>
-              Cypress can only configure a project with a json config file
-            </ErrorMessage>
+          this.state.setupProjectOpen && authStore.isAuthenticated ?
+            this._projectSetup()
             :
-            this.state.setupProjectOpen && authStore.isAuthenticated ?
-              this._projectSetup()
+            this.props.isValid ? authStore.isAuthenticated ?
+              this._connectProject()
               :
-              this.props.isValid ? authStore.isAuthenticated ?
-                this._connectProject()
-                :
-                this._logIn()
-                :
-                this._invalidProject()
+              this._logIn()
+              :
+              this._invalidProject()
         }
       </div>
     )
@@ -107,6 +97,20 @@ export default class ProjectNotSetup extends Component {
         </p>
       </div>
     )
+  }
+
+  _errorJSONFileOnly (configFile) {
+    return (<div className='runs-list-error'>
+      <div className='empty'>
+        <h4>
+          <i className='fas fa-exclamation-triangle red'></i>{' '}
+          Cypress can only configure a project with a json config file
+        </h4>
+        Your config file <code>{configFile}</code> could be
+        <br />
+        too complicated to safely update.
+      </div>
+    </div>)
   }
 
   _projectSetup () {

--- a/packages/desktop-gui/src/runs/project-not-setup.jsx
+++ b/packages/desktop-gui/src/runs/project-not-setup.jsx
@@ -99,20 +99,6 @@ export default class ProjectNotSetup extends Component {
     )
   }
 
-  _errorJSONFileOnly (configFile) {
-    return (<div className='runs-list-error'>
-      <div className='empty'>
-        <h4>
-          <i className='fas fa-exclamation-triangle red'></i>{' '}
-          Cypress can only configure a project with a json config file
-        </h4>
-        Your config file <code>{configFile}</code> could be
-        <br />
-        too complicated to safely update.
-      </div>
-    </div>)
-  }
-
   _projectSetup () {
     return (
       <SetupProject

--- a/packages/desktop-gui/src/runs/project-not-setup.jsx
+++ b/packages/desktop-gui/src/runs/project-not-setup.jsx
@@ -8,6 +8,11 @@ import authStore from '../auth/auth-store'
 import LoginForm from '../auth/login-form'
 import DashboardBanner from './dashboard-banner'
 import WhatIsDashboard from './what-is-dashboard'
+import ErrorMessage from './error-message'
+
+function isConfigJSONFile (filePath) {
+  return /\.json$/.test(filePath)
+}
 
 @observer
 export default class ProjectNotSetup extends Component {
@@ -30,15 +35,20 @@ export default class ProjectNotSetup extends Component {
     return (
       <div className="empty">
         {
-          this.state.setupProjectOpen && authStore.isAuthenticated ?
-            this._projectSetup()
+          !isConfigJSONFile(this.props.project.configFile) ?
+            <ErrorMessage>
+              Cypress can only configure a project with a json config file
+            </ErrorMessage>
             :
-            this.props.isValid ? authStore.isAuthenticated ?
-              this._connectProject()
+            this.state.setupProjectOpen && authStore.isAuthenticated ?
+              this._projectSetup()
               :
-              this._logIn()
-              :
-              this._invalidProject()
+              this.props.isValid ? authStore.isAuthenticated ?
+                this._connectProject()
+                :
+                this._logIn()
+                :
+                this._invalidProject()
         }
       </div>
     )

--- a/packages/desktop-gui/src/runs/setup-project.jsx
+++ b/packages/desktop-gui/src/runs/setup-project.jsx
@@ -378,10 +378,13 @@ class SetupProject extends Component {
         projectRoot: this.props.project.path,
         orgId: this.state.selectedOrgId,
         public: this.state.public,
+        configFile: this.props.project.configFile,
       })
     }
 
-    return dashboardProjectsApi.setProjectId(this.state.selectedProjectId, this.props.project.path)
+    return dashboardProjectsApi.setProjectId(this.state.selectedProjectId,
+      this.props.project.path,
+      this.props.project.configFile)
     .then((id) => {
       const project = dashboardProjectsStore.getProjectById(id)
 

--- a/packages/server/lib/gui/events.js
+++ b/packages/server/lib/gui/events.js
@@ -337,7 +337,7 @@ const handleEvent = function (options, bus, event, id, type, arg) {
       .catch(sendErr)
 
     case 'set:project:id':
-      return ProjectStatic.writeProjectId(arg.id, arg.projectRoot)
+      return ProjectStatic.writeProjectId(arg)
       .then(send)
       .catch(sendErr)
 

--- a/packages/server/lib/project_static.ts
+++ b/packages/server/lib/project_static.ts
@@ -162,7 +162,13 @@ export function ensureExists (path, options) {
   return settings.exists(path, options)
 }
 
-export async function writeProjectId (id: string, projectRoot: string) {
+interface ProjectIdOptions{
+  id: string
+  projectRoot: string
+  configFile: string
+}
+
+export async function writeProjectId ({ id, projectRoot, configFile }: ProjectIdOptions) {
   const attrs = { projectId: id }
 
   logger.info('Writing Project ID', _.clone(attrs))
@@ -170,7 +176,7 @@ export async function writeProjectId (id: string, projectRoot: string) {
   // TODO: We need to set this
   // this.generatedProjectIdTimestamp = new Date()
 
-  await settings.write(projectRoot, attrs)
+  await settings.write(projectRoot, attrs, { configFile })
 
   return id
 }
@@ -180,10 +186,13 @@ interface ProjectDetails {
   projectRoot: string
   orgId: string | null
   public: boolean
+  configFile: string
 }
 
-export async function createCiProject (projectDetails: ProjectDetails, projectRoot: string) {
-  debug('create CI project with projectDetails %o projectRoot %s', projectDetails, projectRoot)
+export async function createCiProject (projectDetails: ProjectDetails) {
+  debug('create CI project with projectDetails %o projectRoot %s', projectDetails)
+
+  const { projectRoot } = projectDetails
 
   const authToken = await user.ensureAuthToken()
   const remoteOrigin = await commitInfo.getRemoteOrigin(projectRoot)
@@ -195,7 +204,7 @@ export async function createCiProject (projectDetails: ProjectDetails, projectRo
 
   const newProject = await api.createProject(projectDetails, remoteOrigin, authToken)
 
-  await writeProjectId(newProject.id, projectRoot)
+  await writeProjectId({ ...projectDetails, id: newProject.id })
 
   return newProject
 }

--- a/packages/server/lib/project_static.ts
+++ b/packages/server/lib/project_static.ts
@@ -189,10 +189,8 @@ interface ProjectDetails {
   configFile: string
 }
 
-export async function createCiProject (projectDetails: ProjectDetails) {
+export async function createCiProject ({ projectRoot, configFile, ...projectDetails }: ProjectDetails) {
   debug('create CI project with projectDetails %o projectRoot %s', projectDetails)
-
-  const { projectRoot } = projectDetails
 
   const authToken = await user.ensureAuthToken()
   const remoteOrigin = await commitInfo.getRemoteOrigin(projectRoot)
@@ -204,7 +202,11 @@ export async function createCiProject (projectDetails: ProjectDetails) {
 
   const newProject = await api.createProject(projectDetails, remoteOrigin, authToken)
 
-  await writeProjectId({ ...projectDetails, id: newProject.id })
+  await writeProjectId({
+    configFile,
+    projectRoot,
+    id: newProject.id,
+  })
 
   return newProject
 }

--- a/packages/server/test/unit/gui/events_spec.js
+++ b/packages/server/test/unit/gui/events_spec.js
@@ -927,11 +927,11 @@ describe('lib/gui/events', () => {
     describe('set:project:id', () => {
       it('calls writeProjectId with projectRoot', function () {
         const arg = { id: '1', projectRoot: '/project/root/', configFile: 'cypress.json' }
-        const stub = sinon.stub(ProjectStatic, 'writeProjectId').resolves()
+        const stubWriteProjectId = sinon.stub(ProjectStatic, 'writeProjectId').resolves()
 
         return this.handleEvent('set:project:id', arg)
         .then(() => {
-          expect(stub).to.be.calledWith(arg.id, arg.projectRoot)
+          expect(stubWriteProjectId).to.be.calledWith(arg)
           expect(this.send.firstCall.args[0]).to.eq('response')
           expect(this.send.firstCall.args[1].id).to.match(/set:project:id-/)
         })

--- a/packages/server/test/unit/gui/events_spec.js
+++ b/packages/server/test/unit/gui/events_spec.js
@@ -926,7 +926,7 @@ describe('lib/gui/events', () => {
 
     describe('set:project:id', () => {
       it('calls writeProjectId with projectRoot', function () {
-        const arg = { id: '1', projectRoot: '/project/root/' }
+        const arg = { id: '1', projectRoot: '/project/root/', configFile: 'cypress.json' }
         const stub = sinon.stub(ProjectStatic, 'writeProjectId').resolves()
 
         return this.handleEvent('set:project:id', arg)
@@ -940,12 +940,12 @@ describe('lib/gui/events', () => {
 
     describe('setup:dashboard:project', () => {
       it('returns result of ProjectStatic.createCiProject', function () {
-        const arg = { projectRoot: '/project/root/' }
-        const stub = sinon.stub(ProjectStatic, 'createCiProject').resolves()
+        const arg = { projectRoot: '/project/root/', configFile: 'cypress.json' }
+        const stubCreateCiProject = sinon.stub(ProjectStatic, 'createCiProject').resolves()
 
         return this.handleEvent('setup:dashboard:project', arg)
         .then(() => {
-          expect(stub).to.be.calledWith(arg, arg.projectRoot)
+          expect(stubCreateCiProject).to.be.calledWith(arg)
           expect(this.send.firstCall.args[0]).to.eq('response')
           expect(this.send.firstCall.args[1].id).to.match(/setup:dashboard:project-/)
         })

--- a/packages/server/test/unit/project_spec.js
+++ b/packages/server/test/unit/project_spec.js
@@ -1023,7 +1023,7 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
       this.newProject = { id: 'project-id-123' }
 
       sinon.stub(user, 'ensureAuthToken').resolves('auth-token-123')
-      sinon.stub(settings, 'write').resolves('project-id-123')
+      sinon.stub(settings, 'write').resolves()
       sinon.stub(commitInfo, 'getRemoteOrigin').resolves('remoteOrigin')
       sinon.stub(api, 'createProject')
       .withArgs({ foo: 'bar' }, 'remoteOrigin', 'auth-token-123')
@@ -1032,7 +1032,7 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
 
     it('calls api.createProject with user session', function () {
       return createCiProject({ foo: 'bar', projectRoot }).then(() => {
-        expect(api.createProject).to.be.calledWith({ foo: 'bar', projectRoot }, 'remoteOrigin', 'auth-token-123')
+        expect(api.createProject).to.be.calledWith({ foo: 'bar' }, 'remoteOrigin', 'auth-token-123')
       })
     })
 

--- a/packages/server/test/unit/project_spec.js
+++ b/packages/server/test/unit/project_spec.js
@@ -948,14 +948,14 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
     })
 
     it('calls Settings.write with projectRoot and attrs', function () {
-      return writeProjectId('id-123').then((id) => {
+      return writeProjectId({ id: 'id-123' }).then((id) => {
         expect(id).to.eq('id-123')
       })
     })
 
     // TODO: This
     xit('sets generatedProjectIdTimestamp', function () {
-      return writeProjectId('id-123').then(() => {
+      return writeProjectId({ id: 'id-123' }).then(() => {
         expect(this.project.generatedProjectIdTimestamp).to.be.a('date')
       })
     })
@@ -1016,6 +1016,7 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
 
   context('#createCiProject', () => {
     const projectRoot = '/_test-output/path/to/project-e2e'
+    const configFile = 'cypress.config.js'
 
     beforeEach(function () {
       this.project = new ProjectBase({ projectRoot, testingType: 'e2e' })
@@ -1030,19 +1031,19 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
     })
 
     it('calls api.createProject with user session', function () {
-      return createCiProject({ foo: 'bar' }, projectRoot).then(() => {
-        expect(api.createProject).to.be.calledWith({ foo: 'bar' }, 'remoteOrigin', 'auth-token-123')
+      return createCiProject({ foo: 'bar', projectRoot }).then(() => {
+        expect(api.createProject).to.be.calledWith({ foo: 'bar', projectRoot }, 'remoteOrigin', 'auth-token-123')
       })
     })
 
     it('calls writeProjectId with id', function () {
-      return createCiProject({ foo: 'bar' }, projectRoot).then(() => {
-        expect(settings.write).to.be.calledWith(projectRoot, { projectId: 'project-id-123' })
+      return createCiProject({ foo: 'bar', projectRoot, configFile }).then(() => {
+        expect(settings.write).to.be.calledWith(projectRoot, { projectId: 'project-id-123' }, { configFile })
       })
     })
 
     it('returns project id', function () {
-      return createCiProject({ foo: 'bar' }, projectRoot).then((projectId) => {
+      return createCiProject({ foo: 'bar', projectRoot }).then((projectId) => {
         expect(projectId).to.eql(this.newProject)
       })
     })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #5747

### User facing changelog

When using a custom config file and setting up its connection to the dashboard, Cypress now writes the `projectId` in the custom config file instead of `cypress.json`.

### To test

Create a project with a `custom.json` file as the configuration

```
yarn install
yarn start --project=/path/to/the/project --config-file=custom.json
```

Then open the runs tab

Finally, connect the current project with the Cypress cloud

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->