### PR TITLE
chore: fix initial installation on windows

### DIFF
--- a/npm/create-cypress-tests/package.json
+++ b/npm/create-cypress-tests/package.json
@@ -5,7 +5,7 @@
   "private": false,
   "main": "index.js",
   "scripts": {
-    "build": "yarn prepare-example && tsc -p ./tsconfig.json && node scripts/example copy-to ./dist/initial-template && yarn copy \"./src/**/*.template.js\" \"./dist/src\"",
+    "build": "yarn prepare-example && tsc -p ./tsconfig.json && node scripts/example copy-to ./dist/initial-template && copy \"./src/**/*.template.js\" \"./dist/src\"",
     "build-prod": "yarn build",
     "prepare-example": "node scripts/example copy-to ./initial-template",
     "test": "cross-env TS_NODE_PROJECT=./tsconfig.test.json mocha --config .mocharc.json './src/**/*.test.ts'",

--- a/npm/create-cypress-tests/package.json
+++ b/npm/create-cypress-tests/package.json
@@ -5,7 +5,7 @@
   "private": false,
   "main": "index.js",
   "scripts": {
-    "build": "yarn prepare-example && tsc -p ./tsconfig.json && node scripts/example copy-to ./dist/initial-template && copy \"./src/**/*.template.js\" \"./dist/src\"",
+    "build": "yarn prepare-example && tsc -p ./tsconfig.json && node scripts/example copy-to ./dist/initial-template && copy ./src/**/*.template.js ./dist/src",
     "build-prod": "yarn build",
     "prepare-example": "node scripts/example copy-to ./initial-template",
     "test": "cross-env TS_NODE_PROJECT=./tsconfig.test.json mocha --config .mocharc.json './src/**/*.test.ts'",

--- a/npm/create-cypress-tests/package.json
+++ b/npm/create-cypress-tests/package.json
@@ -5,9 +5,10 @@
   "private": false,
   "main": "index.js",
   "scripts": {
-    "build": "yarn prepare-example && tsc -p ./tsconfig.json && node scripts/example copy-to ./dist/initial-template && copy ./src/**/*.template.js ./dist/src",
+    "build": "yarn prepare-example && tsc -p ./tsconfig.json && node scripts/example copy-to ./dist/initial-template && yarn prepare-copy-templates",
     "build-prod": "yarn build",
     "prepare-example": "node scripts/example copy-to ./initial-template",
+    "prepare-copy-templates": "node scripts/copy-templates copy-to ./dist/src",
     "test": "cross-env TS_NODE_PROJECT=./tsconfig.test.json mocha --config .mocharc.json './src/**/*.test.ts'",
     "test:watch": "yarn test -w"
   },
@@ -20,6 +21,7 @@
     "chalk": "4.1.0",
     "cli-highlight": "2.1.10",
     "commander": "6.1.0",
+    "fast-glob": "3.2.7",
     "find-up": "5.0.0",
     "fs-extra": "^9.0.1",
     "glob": "^7.1.6",

--- a/npm/create-cypress-tests/scripts/copy-templates.js
+++ b/npm/create-cypress-tests/scripts/copy-templates.js
@@ -1,0 +1,38 @@
+const fg = require('fast-glob')
+const fs = require('fs-extra')
+const chalk = require('chalk')
+const path = require('path')
+const program = require('commander')
+
+program
+.command('copy-to [destination]')
+.description('copy ./src/**/*.template.js into destination')
+.action(async (destination) => {
+  const srcPath = path.resolve(__dirname, '..', 'src')
+  const destinationPath = path.resolve(process.cwd(), destination)
+
+  const templates = await fg('**/*.template.js', {
+    cwd: srcPath,
+    onlyFiles: true,
+    unique: true,
+  })
+
+  const relativizeOutput = (template, dir) => {
+    dir = dir.replace('/\\/g', '/')
+    if (!dir.endsWith('/')) {
+      dir += '/'
+    }
+
+    return `${dir}${template}`
+  }
+
+  const result = await Promise.all(templates.map(async (template) => {
+    await fs.copy(path.join(srcPath, template), path.join(destinationPath, template))
+
+    return () => console.log(`✅ ${relativizeOutput(template, './src/')} successfully copied to ${chalk.cyan(relativizeOutput(template, destination))}`)
+  }))
+
+  result.forEach((r) => r())
+})
+
+program.parse(process.argv)

--- a/npm/create-cypress-tests/scripts/copy-templates.js
+++ b/npm/create-cypress-tests/scripts/copy-templates.js
@@ -17,19 +17,21 @@ program
     unique: true,
   })
 
-  const relativizeOutput = (template, dir) => {
-    dir = dir.replace('/\\/g', '/')
-    if (!dir.endsWith('/')) {
-      dir += '/'
-    }
+  const srcOuput = './src/'
+  let destinationOuput = destination.replace('/\\/g', '/')
 
-    return `${dir}${template}`
+  if (!destinationOuput.endsWith('/')) {
+    destinationOuput += '/'
+  }
+
+  const relOutput = (template, forSource) => {
+    return `${forSource ? srcOuput : destinationOuput}${template}`
   }
 
   const result = await Promise.all(templates.map(async (template) => {
     await fs.copy(path.join(srcPath, template), path.join(destinationPath, template))
 
-    return () => console.log(`✅ ${relativizeOutput(template, './src/')} successfully copied to ${chalk.cyan(relativizeOutput(template, destination))}`)
+    return () => console.log(`✅ ${relOutput(template, true)} successfully copied to ${chalk.cyan(relOutput(template, false))}`)
   }))
 
   result.forEach((r) => r())

--- a/npm/design-system/package.json
+++ b/npm/design-system/package.json
@@ -4,7 +4,7 @@
   "description": "Styles, standards, and components used throughout Cypress",
   "main": "dist/index.js",
   "scripts": {
-    "build": "rimraf dist && yarn rollup -c rollup.config.js",
+    "build": "rimraf dist && rollup -c rollup.config.js",
     "build-prod": "yarn build",
     "build-storybook": "build-storybook",
     "build-style-types": "tsm \"src/css/derived/*.scss\" --nameFormat none --exportType default",

--- a/npm/react/package.json
+++ b/npm/react/package.json
@@ -4,7 +4,7 @@
   "description": "Test React components using Cypress",
   "main": "dist/cypress-react.cjs.js",
   "scripts": {
-    "build": "rimraf dist && yarn transpile-plugins && yarn rollup -c rollup.config.js",
+    "build": "rimraf dist && yarn transpile-plugins && rollup -c rollup.config.js",
     "build-prod": "yarn build",
     "cy:open": "node ../../scripts/cypress.js open-ct",
     "cy:open:debug": "node --inspect-brk ../../scripts/start.js --component-testing --run-project ${PWD}",

--- a/npm/vue/package.json
+++ b/npm/vue/package.json
@@ -4,7 +4,7 @@
   "description": "Browser-based Component Testing for Vue.js with Cypress.io ✌️🌲",
   "main": "dist/cypress-vue.cjs.js",
   "scripts": {
-    "build": "rimraf dist && yarn rollup -c rollup.config.js",
+    "build": "rimraf dist && rollup -c rollup.config.js",
     "build-prod": "yarn build",
     "cy:open": "node ../../scripts/cypress.js open-ct --project ${PWD}",
     "cy:run": "node ../../scripts/cypress.js run-ct --project ${PWD}",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18875,6 +18875,17 @@ fast-glob@3.1.1:
     merge2 "^1.3.0"
     micromatch "^4.0.2"
 
+fast-glob@3.2.7, fast-glob@^3.0.3, fast-glob@^3.1.1, fast-glob@^3.2.4:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
+  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-glob@^2.0.2, fast-glob@^2.2.6:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
@@ -18886,18 +18897,6 @@ fast-glob@^2.0.2, fast-glob@^2.2.6:
     is-glob "^4.0.0"
     merge2 "^1.2.3"
     micromatch "^3.1.10"
-
-fast-glob@^3.0.3, fast-glob@^3.1.1, fast-glob@^3.2.4:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
-  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.0"
-    merge2 "^1.3.0"
-    micromatch "^4.0.2"
-    picomatch "^2.2.1"
 
 fast-json-parse@^1.0.3:
   version "1.0.3"
@@ -20397,7 +20396,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0, glob-parent@~5.1.2:
+glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@^5.1.2, glob-parent@~5.1.0, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==


### PR DESCRIPTION
### Context
After following the CONTRIBUTING.md guide, there are still errors running certain packages while developing in the Cypress repo on a Windows machine.

### How to test
1. Follow the CONTRIBUTING.md guide
2. Run `yarn` and install deps from the root directory of the project.

### Current Behavior
When running `yarn` from the root once installed `node` and `python` there are errors.

There are scripts running `yarn <node_modules/.bin/command> ...args` commands, and they will fail on windows since they resolve to `<node_modules/.bin/command>` instead `<node_modules/.bin/command.cmd>`.

For example, on `npm/vue` we got this error:
```shell
@packages/electron: Packaging app for platform win32 x64 using electron v13.2.0
cypress: exec babel index.js -o build/index.js
@cypress/vue: /usr/bin/bash: F:workprojectsquiniGitHubcypress-developmentnode_modules.binrollup: command not found
@cypress/vue: error Command failed with exit code 127.
@cypress/vue: error Command failed with exit code 127.
lerna ERR! yarn run build exited 127 in '@cypress/vue'
lerna WARN complete Waiting for 5 child processes to exit. CTRL-C to exit immediately.
```

### New Behavior
* It doesn't crash on windows.
* You can run the Cypress build tasks.

### Tests
N/A