### PR TITLE
fix: Add CYPRESS_VERIFY_TIMEOUT env variable

### DIFF
--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -15,7 +15,7 @@ const logger = require('../logger')
 const xvfb = require('../exec/xvfb')
 const state = require('./state')
 
-const VERIFY_TEST_RUNNER_TIMEOUT_MS = 30000
+const VERIFY_TEST_RUNNER_TIMEOUT_MS = process.env.CYPRESS_VERIFY_TIMEOUT || 30000
 
 const checkExecutable = (binaryDir) => {
   const executable = state.getPathToExecutable(binaryDir)


### PR DESCRIPTION
On slow machines (esp. with a virus checker installed), running install and verify can timeout.

People are working around this by editing this file as part of a script - https://github.com/cypress-io/cypress/issues/6082#issuecomment-861452454

For me, using the approach in the comment consistently works.

I would either like to raise this number significantly or introduce a environment variable, so my build scripts look less hacky

- Closes/Related to 6082

### User facing changelog

You can now override the verification timeout for slow machines with the environment variable `CYPRESS_VERIFY_TIMEOUT`.  It defaults to 30000 milliseconds but in some circumstances it can take up to 60000 milliseconds.

### Additional details
See the linked issue

### PR Tasks

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
