### PR TITLE
fix: don't reassign the error name if it already exists

### DIFF
--- a/packages/driver/cypress/integration/e2e/uncaught_errors_spec.js
+++ b/packages/driver/cypress/integration/e2e/uncaught_errors_spec.js
@@ -175,6 +175,23 @@ describe('uncaught errors', () => {
     }).get('button:first').click()
   })
 
+  it('does not fail if thrown custom error with readonly name', (done) => {
+    cy.once('fail', (err) => {
+      expect(err.name).to.include('CustomError')
+      expect(err.message).to.include('custom error')
+
+      done()
+    })
+
+    cy.then(() => {
+      throw new class CustomError extends Error {
+        get name () {
+          return 'CustomError'
+        }
+      }('custom error')
+    })
+  })
+
   it('fails test based on an uncaught error after last command and before completing', (done) => {
     cy.on('fail', () => {
       done()

--- a/packages/driver/src/cypress/command_queue.ts
+++ b/packages/driver/src/cypress/command_queue.ts
@@ -343,9 +343,10 @@ export default {
 
         // since this failed this means that a specific command failed
         // and we should highlight it in red or insert a new command
-        if (_.isObject(err)) {
+        // @ts-ignore
+        if (_.isObject(err) && !err.name) {
           // @ts-ignore
-          err.name = err.name || 'CypressError'
+          err.name = 'CypressError'
         }
 
         commandRunningFailed(Cypress, state, err)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
Don't reassign the error name if it already exists
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->

### Additional details
Throwing custom errors from the tests, those defined like this:
```js
MyCustomError extends Error {
  get name() { return 'MyCustomError' }
}
```
leads to failing Cypress with the error `TypeError: Cannot set property name of [object Object] which has only a getter`
Affected Cypress versions >= 8.3.0

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
