### PR TITLE
fix(vite-dev-server): windows `supportFile` + preserve optimize entries

### DIFF
--- a/npm/vite-dev-server/src/startServer.ts
+++ b/npm/vite-dev-server/src/startServer.ts
@@ -65,17 +65,8 @@ const resolveServerConfig = async ({ viteConfig, options }: StartDevServerOption
 
     // only optimize a supportFile is it is not false or undefined
     if (supportFile) {
-      if (process.platform === 'win32') {
-        if (isAbsolute(supportFile)) {
-          // fix: on windows we need to transform absolute paths to fast-glob pattern, also replace backslashes with slashes
-          finalConfig.optimizeDeps.entries.push(relative(process.cwd(), supportFile).replace(/\\/g, '/'))
-        } else {
-          // fix: on windows we need to replace backslashes with slashes
-          finalConfig.optimizeDeps.entries.push(supportFile.replace(/\\/g, '/'))
-        }
-      } else {
-        finalConfig.optimizeDeps.entries.push(supportFile)
-      }
+      // fix: on windows we need to replace backslashes with slashes
+      finalConfig.optimizeDeps.entries.push(supportFile.replace(/\\/g, '/'))
     }
   }
 

--- a/npm/vite-dev-server/src/startServer.ts
+++ b/npm/vite-dev-server/src/startServer.ts
@@ -1,6 +1,6 @@
 import Debug from 'debug'
 import { createServer, ViteDevServer, InlineConfig } from 'vite'
-import { dirname, resolve } from 'path'
+import { dirname, isAbsolute, relative, resolve } from 'path'
 import getPort from 'get-port'
 import { makeCypressPlugin } from './makeCypressPlugin'
 
@@ -52,12 +52,30 @@ const resolveServerConfig = async ({ viteConfig, options }: StartDevServerOption
   // Ask vite to pre-optimize all dependencies of the specs
   finalConfig.optimizeDeps = finalConfig.optimizeDeps || {}
 
-  // pre-optimizea all the specs
+  // pre-optimize all the specs
   if ((options.specs && options.specs.length)) {
-    finalConfig.optimizeDeps.entries = [...options.specs.map((spec) => spec.relative)]
+    // fix: we must preserve entries configured on target project
+    const existingOptimizeDepsEntries = finalConfig.optimizeDeps.entries
+
+    if (existingOptimizeDepsEntries) {
+      finalConfig.optimizeDeps.entries = [...existingOptimizeDepsEntries, ...options.specs.map((spec) => spec.relative)]
+    } else {
+      finalConfig.optimizeDeps.entries = [...options.specs.map((spec) => spec.relative)]
+    }
+
     // only optimize a supportFile is it is not false or undefined
     if (supportFile) {
-      finalConfig.optimizeDeps.entries.push(supportFile)
+      if (process.platform === 'win32') {
+        if (isAbsolute(supportFile)) {
+          // fix: on windows we need to transform absolute paths to fast-glob pattern, also replace backslashes with slashes
+          finalConfig.optimizeDeps.entries.push(relative(process.cwd(), supportFile).replace(/\\/g, '/'))
+        } else {
+          // fix: on windows we need to replace backslashes with slashes
+          finalConfig.optimizeDeps.entries.push(supportFile.replace(/\\/g, '/'))
+        }
+      } else {
+        finalConfig.optimizeDeps.entries.push(supportFile)
+      }
     }
   }
 

--- a/npm/vite-dev-server/src/startServer.ts
+++ b/npm/vite-dev-server/src/startServer.ts
@@ -1,6 +1,6 @@
 import Debug from 'debug'
 import { createServer, ViteDevServer, InlineConfig } from 'vite'
-import { dirname, isAbsolute, relative, resolve } from 'path'
+import { dirname, resolve } from 'path'
 import getPort from 'get-port'
 import { makeCypressPlugin } from './makeCypressPlugin'
 


### PR DESCRIPTION
### Context
This PR fix and closes #18261 

- preserve `optimizedDeps.entries` configured on target project
- ~~transform windows absolute paths to relative~~
- transform windows paths to use `/` to match fast glob patterns

### How to test
1. Follow the CONTRIBUTING.md guide
2. clone my branch, `yarn && yarn build --scope npm/vite-dev-server && cd npm/vite-dev-server && yarn link`.
3. clone the repo on #18261 , `yarn && yarn link "@cypress/vite-dev-server"`
4. edit `package.json` and change `"@cypress/vite-dev-server": "2.1.0"` with `"@cypress/vite-dev-server": "0.0.0-development"`
5.  run `yarn test:component:run`: the result should be the expected
6. if running `yarn test:component:run` from previous step again, delete `node_modules/.vite` directory before run it again

Once finished testing, unlink from `npm/vite-dev-server` package and from target project.

### Current Behavior
see #18261 

### New Behavior
* works on windows.
* target project `optimizeDeps.entries` entries  should be preserved

### Tests
PENDING (this is why is on draft)
