### PR TITLE
fix: assign default chosen browser & plugin initialization

### DIFF
--- a/packages/data-context/src/actions/AppActions.ts
+++ b/packages/data-context/src/actions/AppActions.ts
@@ -10,9 +10,10 @@ export class AppActions {
 
   async setActiveBrowser (id: string) {
     const browserId = this.ctx.fromId(id, 'Browser')
-    const browser = this.ctx.appData.browsers?.find((b) => this.ctx.browser.idForBrowser(b) === browserId)
 
     // Ensure that this is a valid ID to set
+    const browser = this.ctx.appData.browsers?.find((b) => this.idForBrowser(b) === browserId)
+
     if (browser) {
       this.ctx.coreData.wizard.chosenBrowser = browser
     }
@@ -22,5 +23,28 @@ export class AppActions {
     const browsers = await this.ctx._apis.appApi.getBrowsers()
 
     this.ctx.coreData.app.browsers = browsers
+
+    // If we don't have a chosen browser, assign to the first one in the list
+    if (!this.hasValidChosenBrowser(browsers) && browsers[0]) {
+      this.ctx.coreData.wizard.chosenBrowser = browsers[0]
+    }
+  }
+
+  private idForBrowser (obj: FoundBrowser) {
+    return this.ctx.browser.idForBrowser(obj)
+  }
+
+  /**
+   * Check whether we have a current chosen browser, and it matches up to one of the
+   * ones we have selected
+   */
+  private hasValidChosenBrowser (browsers: FoundBrowser[]) {
+    const chosenBrowser = this.ctx.coreData.wizard.chosenBrowser
+
+    if (!chosenBrowser) {
+      return false
+    }
+
+    return browsers.some((b) => this.idForBrowser(b) === this.idForBrowser(chosenBrowser))
   }
 }

--- a/packages/data-context/src/actions/WizardActions.ts
+++ b/packages/data-context/src/actions/WizardActions.ts
@@ -36,12 +36,15 @@ export class WizardActions {
 
     await this.ctx.actions.project.initializeActiveProject()
 
+    // Cannot have both the e2e & component plugins initialized at the same time
     if (this.ctx.wizardData.chosenTestingType === 'e2e') {
       this.ctx.activeProject.e2ePluginsInitialized = true
+      this.ctx.activeProject.ctPluginsInitialized = false
     }
 
     if (this.ctx.wizardData.chosenTestingType === 'component') {
       this.ctx.activeProject.ctPluginsInitialized = true
+      this.ctx.activeProject.e2ePluginsInitialized = false
     }
 
     this.ctx.debug('finishing initializing project')


### PR DESCRIPTION
- Chooses first browser in the list if we haven't chosen one yet
- Only 1 of CT / E2E can be setup at once, this is necessary because openProject tears down the previously opened project