### PR TITLE
feat(driver): Unselect all selected options with cy.select([])

### DIFF
--- a/packages/driver/cypress/integration/commands/actions/select_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/select_spec.js
@@ -112,6 +112,14 @@ describe('src/cy/commands/actions/select', () => {
       })
     })
 
+    it('unselects all options if called with empty array', () => {
+      cy.get('select[name=movies]').select(['apoc', 'br'])
+
+      cy.get('select[name=movies]').select([]).then(($select) => {
+        expect($select.val()).to.deep.eq([])
+      })
+    })
+
     // readonly should only be limited to inputs, not checkboxes
     it('can select a readonly select', () => {
       cy.get('select[name=hunter]').select('gon').then(($select) => {
@@ -503,17 +511,6 @@ describe('src/cy/commands/actions/select', () => {
         })
 
         cy.get('select[name=foods]').select('')
-      })
-
-      it('throws invalid array argument error when called with empty array', (done) => {
-        cy.on('fail', (err) => {
-          expect(err.message).to.include('`cy.select()` must be passed an array containing only strings and/or numbers. You passed: `[]`')
-          expect(err.docsUrl).to.eq('https://on.cypress.io/select')
-
-          done()
-        })
-
-        cy.get('select[name=foods]').select([])
       })
 
       it('throws invalid array argument error when called with invalid array', (done) => {

--- a/packages/driver/src/cy/commands/actions/select.ts
+++ b/packages/driver/src/cy/commands/actions/select.ts
@@ -21,10 +21,8 @@ export default (Commands, Cypress, cy) => {
 
       if (
         _.isArray(valueOrTextOrIndex)
-        && (
-          valueOrTextOrIndex.length === 0
-          || !_.some(valueOrTextOrIndex, (val) => _.isNumber(val) || _.isString(val))
-        )
+        && valueOrTextOrIndex.length > 0
+        && !_.some(valueOrTextOrIndex, (val) => _.isNumber(val) || _.isString(val))
       ) {
         $errUtils.throwErrByPath('select.invalid_array_argument', { args: { value: JSON.stringify(valueOrTextOrIndex) } })
       }
@@ -163,7 +161,7 @@ export default (Commands, Cypress, cy) => {
           })
         }
 
-        if (!values.length) {
+        if (!values.length && !(_.isArray(valueOrTextOrIndex) && valueOrTextOrIndex.length === 0)) {
           $errUtils.throwErrByPath('select.no_matches', {
             args: { value: valueOrTextOrIndex.join(', ') },
           })


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/4318

### User facing changelog
Users can use `cy.select([])` to clear any selected options in a multi-value select.

### Additional details
This follows the existing pattern that passing an array into `cy.select()` will unselect the other options. For example, `cy.select(['Foo', 'Bar', 'Baz')` then `cy.select(['Foo'])` will only select 'Foo' and unselect the other options.
Previously, an error would be thrown if an empty array was passed into `cy.select()`, but this change allows the existing pattern to be extended to include clearing all selected options with `cy.select([])`.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/4134
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? --> N/A
- [x] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)? --> N/A
