### PR TITLE
fix(driver): `cy.pause()` should not be ignored with `cypress run --headed --no-exit`

### DIFF
--- a/packages/driver/cypress/integration/commands/debugging_spec.js
+++ b/packages/driver/cypress/integration/commands/debugging_spec.js
@@ -5,6 +5,7 @@ describe('src/cy/commands/debugging', () => {
     })
 
     it('does not change the subject', () => {
+      cy.pause()
       cy.wrap({}).debug().then((subject) => {
         expect(subject).to.deep.eq({})
       })

--- a/packages/driver/cypress/integration/commands/debugging_spec.js
+++ b/packages/driver/cypress/integration/commands/debugging_spec.js
@@ -5,7 +5,6 @@ describe('src/cy/commands/debugging', () => {
     })
 
     it('does not change the subject', () => {
-      cy.pause()
       cy.wrap({}).debug().then((subject) => {
         expect(subject).to.deep.eq({})
       })
@@ -94,6 +93,33 @@ describe('src/cy/commands/debugging', () => {
 
         // should be pending
         expect(this.lastLog.get('state')).to.eq('passed')
+
+        // should no longer have onPaused
+        expect(cy.state('onPaused')).to.be.null
+      })
+    })
+
+    it('can pause in run mode with --headed and --no-exit', function () {
+      let didPause = false
+
+      Cypress.config('isInteractive', false)
+      Cypress.config('browser').isHeaded = true
+      Cypress.config('exit', false)
+
+      cy.once('paused', (name) => {
+        cy.once('paused', (name) => {
+          didPause = true
+
+          // resume the rest of the commands so this
+          // test ends
+          Cypress.emit('resume:all')
+        })
+
+        Cypress.emit('resume:next')
+      })
+
+      cy.pause().wrap({}).should('deep.eq', {}).then(function () {
+        expect(didPause).to.be.true
 
         // should no longer have onPaused
         expect(cy.state('onPaused')).to.be.null

--- a/packages/driver/src/cy/commands/debugging.ts
+++ b/packages/driver/src/cy/commands/debugging.ts
@@ -48,6 +48,7 @@ export default (Commands, Cypress, cy, state, config) => {
     // presses a key or clicks in the UI to continue
     pause (subject, options = {}) {
       // bail if we're headless
+      // console.log('isInteractive: ', config('isInteractive'))
       if (!config('isInteractive')) {
         return subject
       }

--- a/packages/driver/src/cy/commands/debugging.ts
+++ b/packages/driver/src/cy/commands/debugging.ts
@@ -47,9 +47,8 @@ export default (Commands, Cypress, cy, state, config) => {
     // pause should indefinitely pause until the user
     // presses a key or clicks in the UI to continue
     pause (subject, options = {}) {
-      // bail if we're headless
-      // console.log('isInteractive: ', config('isInteractive'))
-      if (!config('isInteractive')) {
+      // bail if we're in run mode, unless --headed and --no-exit flags are passed
+      if (!config('isInteractive') && (!config('browser').isHeaded || config('exit'))) {
         return subject
       }
 

--- a/packages/server/lib/controllers/runner.ts
+++ b/packages/server/lib/controllers/runner.ts
@@ -22,7 +22,7 @@ const _serveNonProxiedError = (res: Response) => {
   })
 }
 
-export interface ServeOptions extends Pick<InitializeRoutes, 'getSpec' | 'config' | 'getCurrentBrowser' | 'getRemoteState' | 'specsStore'> {
+export interface ServeOptions extends Pick<InitializeRoutes, 'getSpec' | 'config' | 'getCurrentBrowser' | 'getRemoteState' | 'specsStore' | 'exit'> {
   testingType: Cypress.TestingType
 }
 
@@ -47,7 +47,7 @@ export const runner = {
       return _serveNonProxiedError(res)
     }
 
-    let { config, getRemoteState, getCurrentBrowser, getSpec, specsStore } = options
+    let { config, getRemoteState, getCurrentBrowser, getSpec, specsStore, exit } = options
 
     config = _.clone(config)
     // at any given point, rather than just arbitrarily modifying it.
@@ -72,6 +72,7 @@ export const runner = {
     config.spec = getSpec() ?? null
     config.specs = specsStore.specFiles
     config.browser = getCurrentBrowser()
+    config.exit = exit
 
     debug('serving runner index.html with config %o',
       _.pick(config, 'version', 'platform', 'arch', 'projectName'))

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -43,6 +43,7 @@ type ReceivedCypressOptions =
 export interface Cfg extends ReceivedCypressOptions {
   projectRoot: string
   proxyServer?: Cypress.RuntimeConfigOptions['proxyUrl']
+  exit: boolean
   state?: {
     firstOpened?: number
     lastOpened?: number
@@ -213,6 +214,7 @@ export class ProjectBase<TServer extends ServerE2E | ServerCt> extends EE {
     const [port, warning] = await this._server.open(cfg, {
       getCurrentBrowser: () => this.browser,
       getSpec: () => this.spec,
+      exit: this.options.args.exit,
       onError: this.options.onError,
       onWarning: this.options.onWarning,
       shouldCorrelatePreRequests: this.shouldCorrelatePreRequests,

--- a/packages/server/lib/routes-ct.ts
+++ b/packages/server/lib/routes-ct.ts
@@ -21,6 +21,7 @@ export const createRoutesCT = ({
   testingType,
   getSpec,
   getRemoteState,
+  exit,
 }: InitializeRoutes) => {
   const routesCt = Router()
 
@@ -54,6 +55,7 @@ export const createRoutesCT = ({
       getCurrentBrowser,
       getRemoteState,
       specsStore,
+      exit,
     })
   })
 

--- a/packages/server/lib/routes-e2e.ts
+++ b/packages/server/lib/routes-e2e.ts
@@ -24,6 +24,7 @@ export const createRoutesE2E = ({
   getCurrentBrowser,
   onError,
   testingType,
+  exit,
 }: InitializeRoutes) => {
   const routesE2E = Router()
 
@@ -149,6 +150,7 @@ export const createRoutesE2E = ({
       getCurrentBrowser,
       getRemoteState,
       specsStore,
+      exit,
     })
   })
 

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -19,6 +19,7 @@ export interface InitializeRoutes {
   getRemoteState: () => Cypress.RemoteState
   onError: (...args: unknown[]) => any
   testingType: Cypress.TestingType
+  exit: boolean
 }
 
 export const createCommonRoutes = ({

--- a/packages/server/lib/server-base.ts
+++ b/packages/server/lib/server-base.ts
@@ -99,6 +99,7 @@ export interface OpenServerOptions {
   testingType: Cypress.TestingType
   onError: any
   onWarning: any
+  exit: boolean
   getCurrentBrowser: () => Browser
   getSpec: () => Cypress.Cypress['spec'] | null
   shouldCorrelatePreRequests: () => boolean
@@ -177,6 +178,7 @@ export abstract class ServerBase<TSocket extends SocketE2E | SocketCt> {
     specsStore,
     testingType,
     SocketCtor,
+    exit,
   }: OpenServerOptions) {
     debug('server open')
 
@@ -221,6 +223,7 @@ export abstract class ServerBase<TSocket extends SocketE2E | SocketCt> {
         getSpec,
         getCurrentBrowser,
         testingType,
+        exit,
       }
 
       const runnerSpecificRouter = testingType === 'e2e'


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/4044

### User facing changelog
Users will be able to use `cy.pause()` and observe that a test paused when using `cypress run --headed --no-exit`.

### Additional details
Previous behavior: `cy.pause()` was ignored when using `cypress run` even if `--headed` and `--no-exit` flags were passed.

New behavior: `cy.pause()` works as expected (i.e. the same as with `cypress open`) when `--headed` and `--no-exit` flags are passed to `cypress run`.

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
