### PR TITLE
Add 'slow' option to configure slow test threshold

### DIFF
--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -125,6 +125,7 @@ const descriptions = {
   record: 'records the run. sends test results, screenshots and videos to your Cypress Dashboard.',
   reporter: 'runs a specific mocha reporter. pass a path to use a custom reporter. defaults to "spec"',
   reporterOptions: 'options for the mocha reporter. defaults to "null"',
+  slow: '"slow" test threshold in milliseconds. defaults to 5000',
   spec: 'runs specific spec file(s). defaults to "all"',
   tag: 'named tag(s) for recorded runs in the Cypress Dashboard',
   version: 'prints Cypress version',
@@ -264,6 +265,7 @@ const addCypressRunCommand = (program) => {
   .option('-r, --reporter <reporter>', text('reporter'))
   .option('-o, --reporter-options <reporter-options>', text('reporterOptions'))
   .option('-s, --spec <spec>', text('spec'))
+  .option('-S, --slow <milliseconds>', text('slow'))
   .option('-t, --tag <tag>', text('tag'))
   .option('--dev', text('dev'), coerceFalse)
 }
@@ -451,6 +453,7 @@ module.exports = {
     .option('-r, --reporter <reporter>', text('reporter'))
     .option('-o, --reporter-options <reporter-options>', text('reporterOptions'))
     .option('-s, --spec <spec>', text('spec'))
+    .option('-S, --slow <milliseconds>', text('slow'))
     .option('-t, --tag <tag>', text('tag'))
     .option('--dev', text('dev'), coerceFalse)
     .action((opts) => {

--- a/cli/lib/exec/run.js
+++ b/cli/lib/exec/run.js
@@ -128,6 +128,10 @@ const processRunOptions = (options = {}) => {
     args.push('--reporter-options', options.reporterOptions)
   }
 
+  if (options.slow) {
+    args.push('--slow', options.slow)
+  }
+
   // if we have specific spec(s) push that into the args
   if (options.spec) {
     args.push('--spec', options.spec)

--- a/cli/lib/util.js
+++ b/cli/lib/util.js
@@ -220,6 +220,7 @@ const parseOpts = (opts) => {
     'reporterOptions',
     'record',
     'runProject',
+    'slow',
     'spec',
     'tag')
 

--- a/cli/schema/cypress.schema.json
+++ b/cli/schema/cypress.schema.json
@@ -44,6 +44,11 @@
           "default": null,
           "description": "The reporter options used. Supported options depend on the reporter. See https://on.cypress.io/reporters#Reporter-Options"
         },
+        "slow": {
+          "type": "number",
+          "default": 5000,
+          "description": "Slow test timeout passed to mocha. See See https://on.cypress.io/configuration#Global"
+        },
         "testFiles": {
           "type": [
             "string",

--- a/cli/types/cypress-npm-api.d.ts
+++ b/cli/types/cypress-npm-api.d.ts
@@ -92,6 +92,10 @@ declare namespace CypressCommandLine {
      */
     reporterOptions: any
     /**
+     * Specify a slow test threshold in milliseconds
+     */
+    slow: number
+    /**
      * Specify the specs to run
      */
     spec: string

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2573,6 +2573,11 @@ declare namespace Cypress {
      */
     reporterOptions: { [key: string]: any }
     /**
+     * A slow test threshold in milliseconds
+     * @default 5000
+     */
+    slow: number | null
+    /**
      * Whether Cypress will watch and restart tests on test file changes
      * @default true
      */

--- a/packages/server/lib/config_options.ts
+++ b/packages/server/lib/config_options.ts
@@ -217,6 +217,10 @@ export const options = [
     validation: v.isStringOrFalse,
     isFolder: true,
   }, {
+    name: 'slow',
+    defaultValue: 5000,
+    validation: v.isNumber,
+  }, {
     name: 'socketId',
     defaultValue: null,
     isInternal: true,

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -38,7 +38,7 @@ import type { LaunchArgs } from './open_project'
 // and are required when creating a project.
 type ReceivedCypressOptions =
   Pick<Cypress.RuntimeConfigOptions, 'hosts' | 'projectName' | 'clientRoute' | 'devServerPublicPathRoute' | 'namespace' | 'report' | 'socketIoCookie' | 'configFile' | 'isTextTerminal' | 'isNewProject' | 'proxyUrl' | 'browsers' | 'browserUrl' | 'socketIoRoute' | 'arch' | 'platform' | 'spec' | 'specs' | 'browser' | 'version' | 'remote'>
-  & Pick<Cypress.ResolvedConfigOptions, 'chromeWebSecurity' | 'supportFolder' | 'experimentalSourceRewriting' | 'fixturesFolder' | 'reporter' | 'reporterOptions' | 'screenshotsFolder' | 'pluginsFile' | 'supportFile' | 'integrationFolder' | 'baseUrl' | 'viewportHeight' | 'viewportWidth' | 'port' | 'experimentalInteractiveRunEvents' | 'componentFolder' | 'userAgent' | 'downloadsFolder' | 'env' | 'testFiles' | 'ignoreTestFiles'> // TODO: Figure out how to type this better.
+  & Pick<Cypress.ResolvedConfigOptions, 'chromeWebSecurity' | 'supportFolder' | 'experimentalSourceRewriting' | 'fixturesFolder' | 'reporter' | 'reporterOptions' | 'slow' | 'screenshotsFolder' | 'pluginsFile' | 'supportFile' | 'integrationFolder' | 'baseUrl' | 'viewportHeight' | 'viewportWidth' | 'port' | 'experimentalInteractiveRunEvents' | 'componentFolder' | 'userAgent' | 'downloadsFolder' | 'env' | 'testFiles' | 'ignoreTestFiles'> // TODO: Figure out how to type this better.
 
 export interface Cfg extends ReceivedCypressOptions {
   projectRoot: string
@@ -75,7 +75,7 @@ const localCwd = cwd()
 const debug = Debug('cypress:server:project')
 const debugScaffold = Debug('cypress:server:scaffold')
 
-type StartWebsocketOptions = Pick<Cfg, 'socketIoCookie' | 'namespace' | 'screenshotsFolder' | 'report' | 'reporter' | 'reporterOptions' | 'projectRoot'>
+type StartWebsocketOptions = Pick<Cfg, 'socketIoCookie' | 'namespace' | 'screenshotsFolder' | 'report' | 'reporter' | 'reporterOptions' | 'slow' | 'projectRoot'>
 
 export class ProjectBase<TServer extends ServerE2E | ServerCt> extends EE {
   protected watchers: Watchers
@@ -273,6 +273,7 @@ export class ProjectBase<TServer extends ServerE2E | ServerCt> extends EE {
       report: cfg.report,
       reporter: cfg.reporter,
       reporterOptions: cfg.reporterOptions,
+      slow: cfg.slow,
       projectRoot: this.projectRoot,
     })
 
@@ -554,7 +555,8 @@ export class ProjectBase<TServer extends ServerE2E | ServerCt> extends EE {
     reporter,
     projectRoot,
     reporterOptions,
-  }: Pick<Cfg, 'report' | 'reporter' | 'projectRoot' | 'reporterOptions'>) {
+    slow,
+  }: Pick<Cfg, 'report' | 'reporter' | 'projectRoot' | 'reporterOptions', 'slow'>) {
     if (!report) {
       return
     }
@@ -575,10 +577,10 @@ export class ProjectBase<TServer extends ServerE2E | ServerCt> extends EE {
       })
     }
 
-    return Reporter.create(reporter, reporterOptions, projectRoot)
+    return Reporter.create(reporter, reporterOptions, projectRoot, slow)
   }
 
-  startWebsockets (options: Omit<OpenProjectLaunchOptions, 'args'>, { socketIoCookie, namespace, screenshotsFolder, report, reporter, reporterOptions, projectRoot }: StartWebsocketOptions) {
+  startWebsockets (options: Omit<OpenProjectLaunchOptions, 'args'>, { socketIoCookie, namespace, screenshotsFolder, report, reporter, reporterOptions, slow, projectRoot }: StartWebsocketOptions) {
   // if we've passed down reporter
   // then record these via mocha reporter
     const reporterInstance = this.initializeReporter({
@@ -586,6 +588,7 @@ export class ProjectBase<TServer extends ServerE2E | ServerCt> extends EE {
       reporter,
       reporterOptions,
       projectRoot,
+      slow,
     })
 
     const onBrowserPreRequest = (browserPreRequest) => {

--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -13,7 +13,7 @@ const nestedObjectsInCurlyBracesRe = /\{(.+?)\}/g
 const nestedArraysInSquareBracketsRe = /\[(.+?)\]/g
 const everythingAfterFirstEqualRe = /=(.*)/
 
-const allowList = 'appPath apiKey browser ci ciBuildId clearLogs config configFile cwd env execPath exit exitWithCode group headed inspectBrk key logs mode outputPath parallel ping port project proxySource quiet record reporter reporterOptions returnPkg runMode runProject smokeTest spec tag updating version testingType'.split(' ')
+const allowList = 'appPath apiKey browser ci ciBuildId clearLogs config configFile cwd env execPath exit exitWithCode group headed inspectBrk key logs mode outputPath parallel ping port project proxySource quiet record reporter reporterOptions returnPkg runMode runProject slow smokeTest spec tag updating version testingType'.split(' ')
 // returns true if the given string has double quote character "
 // only at the last position.
 const hasStrayEndQuote = (s) => {

--- a/packages/server/test/support/helpers/e2e.ts
+++ b/packages/server/test/support/helpers/e2e.ts
@@ -605,6 +605,10 @@ const e2e = {
       args.push(`--reporter-options=${options.reporterOptions}`)
     }
 
+    if (options.slow) {
+      args.push(`--slow=${options.slow}`)
+    }
+
     if (options.browser) {
       args.push(`--browser=${options.browser}`)
     }

--- a/packages/server/test/unit/config_spec.js
+++ b/packages/server/test/unit/config_spec.js
@@ -1460,6 +1460,7 @@ describe('lib/config', () => {
             retries: { value: { runMode: 0, openMode: 0 }, from: 'default' },
             screenshotOnRunFailure: { value: true, from: 'default' },
             screenshotsFolder: { value: 'cypress/screenshots', from: 'default' },
+            slow: { value: 5000, from: 'default' },
             supportFile: { value: 'cypress/support', from: 'default' },
             taskTimeout: { value: 60000, from: 'default' },
             testFiles: { value: '**/*.*', from: 'default' },

--- a/packages/server/test/unit/reporter_spec.js
+++ b/packages/server/test/unit/reporter_spec.js
@@ -94,6 +94,18 @@ describe('lib/reporter', () => {
 
       expect(junitFn).to.be.calledWith(reporter.runner)
     })
+
+    it('passes the slow option through to mocha', function () {
+      const reporter = new Reporter('spec', {}, undefined, 2000)
+
+      reporter.setRunnables(this.root)
+
+      Object.values(reporter.runnables).forEach(function (v) {
+        expect(v._slow).to.eq(2000)
+      })
+
+      expect(reporter.mocha.suite._slow).to.eq(2000)
+    })
   })
 
   context('createSuite', () => {
@@ -111,7 +123,6 @@ describe('lib/reporter', () => {
     it('recursively creates suites for fullTitle', function () {
       const args = this.reporter.parseArgs('fail', [this.testObj])
 
-      console.log(args)
       expect(args[0]).to.eq('fail')
 
       const title = 'TodoMVC - React When page is initially opened should focus on the todo input field'


### PR DESCRIPTION
- Closes #447

### User facing changelog
- Changes the default slow test threshold from 75ms (mocha's default) to 5000ms
- Adds --slow CLI option and `slow` config option to customize slow test threshold

### Additional details
`cypress --slow 10000` overrides the default slow test threshold. A test that executes for half of the “slow” time will be highlighted in yellow with the default spec reporter; a test that executes for entire “slow” time will be highlighted in red. See https://mochajs.org/#-slow-ms-s-ms for more details.

Alternately, add `"slow": 10000` to your cypress.json configuration to affect all test runs.

### PR Tasks
- [ ] Have tests been added/updated? I have added some relevant unit tests, but welcome further suggestions.
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [x] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
