### PR TITLE
fix: remove .json check from require_async, prevent child_process spawn

### DIFF
--- a/packages/server/lib/util/require_async.ts
+++ b/packages/server/lib/util/require_async.ts
@@ -4,7 +4,6 @@ import * as cp from 'child_process'
 import * as inspector from 'inspector'
 import * as util from '../plugins/util'
 import * as errors from '../errors'
-import { fs } from '../util/fs'
 import Debug from 'debug'
 
 const debug = Debug('cypress:server:require_async')
@@ -31,10 +30,6 @@ export async function requireAsync (filePath: string, options: RequireAsyncOptio
     if (requireProcess) {
       debug('kill existing config process')
       killChildProcess()
-    }
-
-    if (/\.json$/.test(filePath)) {
-      fs.readJson(path.resolve(options.projectRoot, filePath)).then((result) => resolve(result)).catch(reject)
     }
 
     const childOptions: ChildOptions = {

--- a/packages/server/lib/util/settings.ts
+++ b/packages/server/lib/util/settings.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 import Promise from 'bluebird'
 import path from 'path'
+
 import errors from '../errors'
 import { fs } from '../util/fs'
 import { requireAsync } from './require_async'
@@ -146,11 +147,12 @@ export function read (projectRoot, options: SettingsOptions = {}) {
 
   const file = pathToConfigFile(projectRoot, options)
 
-  return requireAsync(file,
-    {
-      projectRoot,
-      loadErrorCode: 'CONFIG_FILE_ERROR',
-    })
+  const readPromise = /\.json$/.test(file) ? fs.readJSON(path.resolve(projectRoot, file)) : requireAsync(file, {
+    projectRoot,
+    loadErrorCode: 'CONFIG_FILE_ERROR',
+  })
+
+  return readPromise
   .catch((err) => {
     if (err.type === 'MODULE_NOT_FOUND' || err.code === 'ENOENT') {
       if (options.args?.runProject) {


### PR DESCRIPTION
### Additional details

Because there is no `return` in the `fs.readJSON` line, it appears as though the child process will get spawned regardless, even though the `Promise` is resolved. 

Moved the `.json` check out of the `require_async` into `util/settings` & fixed the above.