### PR TITLE
fix: specs list extension was breaking test and styling was broken

### DIFF
--- a/packages/app/src/specs/SpecsList.spec.tsx
+++ b/packages/app/src/specs/SpecsList.spec.tsx
@@ -4,7 +4,7 @@ import { defaultMessages } from '@cy/i18n'
 
 const rowSelector = '[data-testid=specs-list-row]'
 const inputSelector = 'input'
-const fullFile = (s) => `${s.node.fileName}${s.node.specFileExtension}${s.node.fileExtension}`
+const fullFile = (s) => `${s.node.fileName}${s.node.specFileExtension}`
 const hasSpecText = (_node: JQuery<HTMLElement>, spec: SpecListRowFragment) => {
   const $node = _node as JQuery<HTMLDivElement>
 

--- a/packages/app/src/specs/SpecsListHeader.spec.tsx
+++ b/packages/app/src/specs/SpecsListHeader.spec.tsx
@@ -30,10 +30,10 @@ describe('<SpecsListHeader />', { keystrokeDelay: 0 }, () => {
     const onNewSpec = cy.spy().as('new-spec')
     const search = ref('')
 
-    cy.mount(<SpecsListHeader
+    cy.mount(<div class="max-w-800px p-12 resize overflow-auto"><SpecsListHeader
       modelValue={search.value}
       onNewSpec={onNewSpec}
-    />)
+    /></div>)
     .get(buttonSelector)
     .click()
     .get('@new-spec')

--- a/packages/app/src/specs/SpecsListRow.vue
+++ b/packages/app/src/specs/SpecsListRow.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="grid grid-cols-2 outline-none children:cursor-pointer group"
+    class="grid grid-cols-2 outline-none children:cursor-pointer group h-full"
     data-testid="specs-list-row"
     role="link"
     tabindex="0"

--- a/packages/frontend-shared/src/graphql/specs/testStubSpecs.ts
+++ b/packages/frontend-shared/src/graphql/specs/testStubSpecs.ts
@@ -140,7 +140,7 @@ export const randomComponents = (n = 200): FoundSpec[] => {
       relative: `${directories[d.directory](d)}/${name}`,
       absolute: `${faker.system.directoryPath()}/${directories[d.directory](d)}/${name}`,
       name: `${componentName}${d.specPattern}`,
-      specFileExtension: d.specPattern,
+      specFileExtension: `${d.specPattern}${d.fileExtension}`,
       fileExtension: d.fileExtension,
       specType: 'component',
       fileName: componentName,


### PR DESCRIPTION
During the merge of this branch, the div styling was broken and the SpecsListRow component was rendering the wrong file extension.