### PR TITLE
feat(app): default to unified runner

### DIFF
--- a/packages/server/lib/controllers/runner.ts
+++ b/packages/server/lib/controllers/runner.ts
@@ -83,7 +83,9 @@ export const runner = {
   },
 
   handle (testingType, req, res) {
-    const pathToFile = getPathToDist(testingType === 'e2e' ? 'runner' : 'runner-ct', req.params[0])
+    const toServe = process.env.LAUNCHPAD || testingType === 'component' ? 'runner-ct' : 'runner'
+
+    const pathToFile = getPathToDist(toServe, req.params[0])
 
     return send(req, pathToFile)
     .pipe(res)

--- a/packages/server/lib/open_project.ts
+++ b/packages/server/lib/open_project.ts
@@ -124,14 +124,16 @@ export class OpenProject {
     // of potential domain changes, request buffers, etc
     this.openProject!.reset()
 
-    const url = getSpecUrl({
-      absoluteSpecPath: spec.absolute,
-      specType: spec.specType,
-      browserUrl: this.openProject.cfg.browserUrl,
-      integrationFolder: this.openProject.cfg.integrationFolder || 'integration',
-      componentFolder: this.openProject.cfg.componentFolder || 'component?',
-      projectRoot: this.openProject.projectRoot,
-    })
+    const url = process.env.LAUNCHPAD
+      ? `${this.openProject.cfg.browserUrl.replace('/__/', '/__vite__/')}`
+      : getSpecUrl({
+        absoluteSpecPath: spec.absolute,
+        specType: spec.specType,
+        browserUrl: this.openProject.cfg.browserUrl,
+        integrationFolder: this.openProject.cfg.integrationFolder || 'integration',
+        componentFolder: this.openProject.cfg.componentFolder || 'component?',
+        projectRoot: this.openProject.projectRoot,
+      })
 
     debug('open project url %s', url)
 

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -63,7 +63,9 @@ export const createCommonRoutes = ({
   router.get(clientRoute, (req, res) => {
     debug('Serving Cypress front-end by requested URL:', req.url)
 
-    runner.serve(req, res, testingType === 'e2e' ? 'runner' : 'runner-ct', {
+    const toServe = process.env.LAUNCHPAD || testingType === 'component' ? 'runner-ct' : 'runner'
+
+    runner.serve(req, res, toServe, {
       config,
       testingType,
       getSpec,


### PR DESCRIPTION
Closes https://cypress-io.atlassian.net/browse/UNIFY-356

Opens `__vite__` url by default if `process.env.LAUNCHPAD` is true. You can still access the existing runner by changing the URL manually.