### PR TITLE
feat: create a copy when selecting a pre-existing story

### DIFF
--- a/packages/data-context/src/actions/StorybookActions.ts
+++ b/packages/data-context/src/actions/StorybookActions.ts
@@ -61,7 +61,7 @@ export class StorybookActions {
         specFileExtension,
       )
 
-      await this.ctx.fs.outputFileSync(newSpecAbsolute, newSpecContent)
+      await this.ctx.fs.outputFile(newSpecAbsolute, newSpecContent)
     } catch (e) {
       return null
     }

--- a/packages/data-context/src/sources/WizardDataSource.ts
+++ b/packages/data-context/src/sources/WizardDataSource.ts
@@ -280,7 +280,7 @@ const getFrameworkConfigFile = (opts: GetCodeOptsCt) => {
 
         module.exports = defineConfig({
           component: {
-            testFiles: "**/*cy-spec.{js,jsx,ts,tsx}",
+            testFiles: "**/*.cy.{js,jsx,ts,tsx}",
             componentFolder: "src"
           }
         })
@@ -290,7 +290,7 @@ const getFrameworkConfigFile = (opts: GetCodeOptsCt) => {
 
         export default defineConfig({
           component: {
-            testFiles: "**/*cy-spec.{js,jsx,ts,tsx}",
+            testFiles: "**/*.cy.{js,jsx,ts,tsx}",
             componentFolder: "src"
           }
         })
@@ -302,7 +302,7 @@ const getFrameworkConfigFile = (opts: GetCodeOptsCt) => {
 
         module.exports = defineConfig({
           component: {
-            testFiles: "**/*cy-spec.{js,jsx,ts,tsx}",
+            testFiles: "**/*.cy.{js,jsx,ts,tsx}",
             componentFolder: "src"
           }
         })
@@ -312,7 +312,7 @@ const getFrameworkConfigFile = (opts: GetCodeOptsCt) => {
 
         export default defineConfig({
           component: {
-            testFiles: "**/*cy-spec.{js,jsx,ts,tsx}",
+            testFiles: "**/*.cy.{js,jsx,ts,tsx}",
             componentFolder: "src"
           }
         })


### PR DESCRIPTION
This PR changes the behavior of story generation such that when generating a spec from a story that already exists, a copy of the file will be created rather than a no-op. Also did some small refactoring so that the file generation and story parsing are separated which will be useful later on when file->spec generation is more generic.

Testing is still a bit of a chore, but you can follow the description from [this PR](https://github.com/cypress-io/cypress/pull/18242) to get Storybook setup for a create-react-app.

https://user-images.githubusercontent.com/25158820/136830264-0255b619-d4d0-4bee-8e27-4ccbc66bcb55.mov

