### PR TITLE
fix: server cypress_spec permissions test now passes

### DIFF
--- a/packages/server/lib/errors.js
+++ b/packages/server/lib/errors.js
@@ -705,7 +705,7 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
       return stripIndent`
           There is both a \`${arg2}\` and a \`${arg3}\` at the location below:
           ${arg1}
-          
+
           Cypress does not know which one to read for config. Please remove one of the two and try again.
           `
     case 'CONFIG_FILE_NOT_FOUND':
@@ -988,7 +988,7 @@ const getMsgByType = function (type, arg1 = {}, arg2, arg3) {
       `
     case 'CT_NO_DEV_START_EVENT':
       return stripIndent`\
-        To run component-testing, cypress needs the \`dev-server:start\` event. 
+        To run component-testing, cypress needs the \`dev-server:start\` event.
 
         Implement it by adding a \`on('dev-server:start', () => startDevServer())\` call in your pluginsFile.
         ${arg1 ?

--- a/packages/server/lib/scaffold.js
+++ b/packages/server/lib/scaffold.js
@@ -256,9 +256,7 @@ module.exports = {
       return fs.copyAsync(src, dest)
     }).catch((error) => {
       if (error.code === 'EACCES') {
-        const err = errors.get('ERROR_WRITING_FILE', dest, error)
-
-        errors.log(err)
+        error = errors.get('ERROR_WRITING_FILE', dest, error)
       }
 
       throw error

--- a/packages/server/lib/scaffold.js
+++ b/packages/server/lib/scaffold.js
@@ -7,6 +7,7 @@ const { fs } = require('./util/fs')
 const glob = require('./util/glob')
 const cwd = require('./cwd')
 const debug = require('debug')('cypress:server:scaffold')
+const errors = require('./errors')
 const { isEmpty } = require('ramda')
 const { isDefault } = require('./util/config')
 
@@ -232,7 +233,6 @@ module.exports = {
 
   plugins (folder, config) {
     debug(`plugins folder ${folder}`)
-
     // skip if user has explicitly set pluginsFile
     if (!config.pluginsFile || !isDefault(config, 'pluginsFile')) {
       return Promise.resolve()
@@ -254,6 +254,14 @@ module.exports = {
     return this._assertInFileTree(dest, config)
     .then(() => {
       return fs.copyAsync(src, dest)
+    }).catch((error) => {
+      if (error.code === 'EACCES') {
+        const err = errors.get('ERROR_WRITING_FILE', dest, error)
+
+        errors.log(err)
+      }
+
+      throw error
     })
   },
 

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -840,8 +840,12 @@ describe('lib/cypress', () => {
     // also make sure we test the rest of the integration functionality
     // for headed errors! <-- not unit tests, but integration tests!
     it('logs error and exits when project folder has read permissions only and cannot write cypress.json', function () {
-      const permissionsPath = path.resolve('./permissions')
+      // test disabled if running as root (such as inside docker) - root can write all things at all times
+      if (process.geteuid() === 0) {
+        return
+      }
 
+      const permissionsPath = path.resolve('./permissions')
       const cypressJson = path.join(permissionsPath, 'cypress.json')
 
       return fs.mkdirAsync(permissionsPath)

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -108,6 +108,7 @@ describe('lib/cypress', () => {
   require('mocha-banner').register()
 
   beforeEach(function () {
+    process.chdir(previousCwd)
     this.timeout(8000)
 
     cache.__removeSync()
@@ -839,17 +840,14 @@ describe('lib/cypress', () => {
     // also make sure we test the rest of the integration functionality
     // for headed errors! <-- not unit tests, but integration tests!
     it('logs error and exits when project folder has read permissions only and cannot write cypress.json', function () {
-      // test disabled if running as root - root can write all things at all times
-      if (process.geteuid() === 0) {
-        return
-      }
-
       const permissionsPath = path.resolve('./permissions')
 
       const cypressJson = path.join(permissionsPath, 'cypress.json')
 
-      return fs.outputFileAsync(cypressJson, '{}')
+      return fs.mkdirAsync(permissionsPath)
       .then(() => {
+        return fs.outputFileAsync(cypressJson, '{}')
+      }).then(() => {
         // read only
         return fs.chmodAsync(permissionsPath, '555')
       }).then(() => {
@@ -857,9 +855,9 @@ describe('lib/cypress', () => {
       }).then(() => {
         return fs.chmodAsync(permissionsPath, '777')
       }).then(() => {
-        return fs.removeAsync(permissionsPath)
-      }).then(() => {
-        this.expectExitWithErr('ERROR_READING_FILE', path.join(permissionsPath, 'cypress.json'))
+        this.expectExitWithErr('ERROR_WRITING_FILE', permissionsPath)
+      }).finally(() => {
+        return fs.rmdir(permissionsPath, { recursive: true })
       })
     })
 


### PR DESCRIPTION
### User facing changelog
Bugfix for `yarn test-integration --scope @packages/server` when run with non-root permissions

### Additional details
- The `logs error and exits when project folder has read permissions only and cannot write cypress.json` test had a bug, causing it to fail when run as a non-root user (and to be skipped when run as root). No longer - the test now runs and passes regardless of environment.

### PR Tasks

- [x] Have tests been added/updated?