### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -1,7 +1,7 @@
 name: Update Browser Versions
 on:
   schedule:
-    - cron: '0 8 * * *' #  every day at 8am UTC (3/4am EST/EDT)
+    - cron: "0 8 * * *" #  every day at 8am UTC (3/4am EST/EDT)
 jobs:
   update-browser-versions:
     runs-on: ubuntu-latest
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
       - name: Check for new Chrome versions
         id: get-versions
         uses: actions/github-script@v4


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
