### PR TITLE
feat: expose story file parts

### DIFF
--- a/packages/app/src/pages/NewSpec.vue
+++ b/packages/app/src/pages/NewSpec.vue
@@ -27,7 +27,7 @@
 </route>
 <script lang="ts" setup>
 import { gql, useMutation, useQuery } from '@urql/vue'
-import { computed } from 'vue-demi'
+import { computed } from 'vue'
 import { NewSpecQueryDocument, NewSpec_GenerateSpecFromStoryDocument } from '../generated/graphql'
 
 gql`

--- a/packages/app/src/pages/NewSpec.vue
+++ b/packages/app/src/pages/NewSpec.vue
@@ -1,20 +1,18 @@
 <template>
-  <div v-if="query.data.value?.wizard.storybook">
+  <div v-if="query.data.value?.app.activeProject?.storybook">
     <h2>New Spec</h2>
-    <ul v-if="stories.length">
+    <ul>
       <li
         v-for="story of stories"
         :key="story.relative"
+        class="group"
         @click="storyClick(story.absolute)"
       >
         <span class="text-indigo-600 font-medium">{{ story.fileName }}</span>
         <span class="font-light text-gray-400">{{ story.fileExtension }}</span>
-        <span class="font-light text-gray-400 pl-16px show-on-hover">{{ story.relativeFromProjectRoot }}</span>
+        <span class="font-light text-gray-400 pl-16px hidden group-hover:inline">{{ story.relativeFromProjectRoot }}</span>
       </li>
     </ul>
-    <p v-else>
-      No Stories Detected
-    </p>
   </div>
   <div v-else>
     Storybook is not configured for this project
@@ -31,16 +29,29 @@ import { computed } from 'vue'
 import { NewSpecQueryDocument, NewSpec_GenerateSpecFromStoryDocument } from '../generated/graphql'
 
 gql`
+fragment StoryNode_NewSpec on FilePartsEdge {
+  node {
+    id
+    relative
+    fileName
+    baseName
+    absolute
+  }
+}
+`
+
+gql`
 query NewSpecQuery {
-  wizard {
-    storybook {
+  app {
+    activeProject {
       id
-      stories {
+      storybook {
         id
-        relative
-        fileName
-        baseName
-        absolute
+        stories: stories(first: 25) {
+          edges {
+            ...StoryNode_NewSpec
+          }
+        }
       }
     }
   }
@@ -71,7 +82,7 @@ async function storyClick (story: string) {
 }
 
 const stories = computed(() => {
-  return query.data.value?.wizard.storybook?.stories.map((story) => {
+  return query.data.value?.app.activeProject?.storybook?.stories?.edges.map(({ node: story }) => {
     return {
       ...story,
       fileExtension: story.baseName.replace(story.fileName, ''),
@@ -81,12 +92,3 @@ const stories = computed(() => {
 })
 
 </script>
-
-<style>
-.show-on-hover {
-  display: none;
-}
-li:hover .show-on-hover {
-  display: inline;
-}
-</style>

--- a/packages/data-context/src/actions/StorybookActions.ts
+++ b/packages/data-context/src/actions/StorybookActions.ts
@@ -1,12 +1,8 @@
 import type { FoundSpec, FullConfig } from '@packages/types'
 import { readCsfOrMdx } from '@storybook/csf-tools'
 import endent from 'endent'
-import glob from 'glob'
 import * as path from 'path'
-import { promisify } from 'util'
 import type { DataContext } from '..'
-
-const asyncGlob = promisify(glob)
 
 export class StorybookActions {
   constructor (private ctx: DataContext) {}

--- a/packages/data-context/src/actions/StorybookActions.ts
+++ b/packages/data-context/src/actions/StorybookActions.ts
@@ -1,8 +1,12 @@
 import type { FoundSpec, FullConfig } from '@packages/types'
 import { readCsfOrMdx } from '@storybook/csf-tools'
 import endent from 'endent'
+import glob from 'glob'
 import * as path from 'path'
+import { promisify } from 'util'
 import type { DataContext } from '..'
+
+const asyncGlob = promisify(glob)
 
 export class StorybookActions {
   constructor (private ctx: DataContext) {}

--- a/packages/data-context/src/sources/FileDataSource.ts
+++ b/packages/data-context/src/sources/FileDataSource.ts
@@ -1,4 +1,6 @@
 import type { DataContext } from '..'
+import * as path from 'path'
+import type { SpecFile } from '@packages/types'
 
 export class FileDataSource {
   private watchedFilePaths = new Set<string>()
@@ -17,6 +19,18 @@ export class FileDataSource {
       this.jsonFileLoader.clear(e)
       throw e
     }) as Promise<Result>
+  }
+
+  normalizeFileToSpec (absolute: string, projectRoot: string, searchFolder: string): SpecFile {
+    const parsed = path.parse(absolute)
+
+    return {
+      absolute,
+      name: path.relative(searchFolder, absolute),
+      relative: path.relative(projectRoot, absolute),
+      baseName: parsed.base,
+      fileName: parsed.base.split('.')[0] || '',
+    }
   }
 
   private trackFile () {

--- a/packages/data-context/src/sources/StorybookDataSource.ts
+++ b/packages/data-context/src/sources/StorybookDataSource.ts
@@ -1,7 +1,5 @@
-import glob from 'glob'
 import * as path from 'path'
 import type { DataContext } from '..'
-import { promisify } from 'util'
 import type { StorybookInfo } from '@packages/types'
 
 const STORYBOOK_FILES = [
@@ -34,7 +32,6 @@ export class StorybookDataSource {
       storybookRoot,
       files: [],
       storyGlobs: [],
-      getStories: this.getStories,
     }
 
     try {
@@ -75,18 +72,5 @@ export class StorybookDataSource {
     }
 
     return storybookInfo
-  }
-
-  private async getStories (storybookRoot: string, storyGlobs: string[]) {
-    const files: string[] = []
-
-    for (const storyPattern of storyGlobs) {
-      const res = await promisify(glob)(path.join(storybookRoot, storyPattern))
-
-      files.push(...res)
-    }
-
-    // Don't currently support mdx
-    return files.filter((file) => !file.endsWith('.mdx'))
   }
 }

--- a/packages/data-context/src/sources/WizardDataSource.ts
+++ b/packages/data-context/src/sources/WizardDataSource.ts
@@ -77,7 +77,7 @@ export class WizardDataSource {
 
   async sampleCode () {
     const data = this.ctx.wizardData
-    const storybookInfo = await this.ctx.storybook.storybookInfo
+    const storybookInfo = await this.ctx.storybook.loadStorybookInfo()
 
     if (!this.chosenLanguage) {
       return null
@@ -106,7 +106,7 @@ export class WizardDataSource {
   }
 
   async sampleTemplate () {
-    const storybookInfo = await this.ctx.storybook.storybookInfo
+    const storybookInfo = await this.ctx.storybook.loadStorybookInfo()
 
     if (!this.chosenFramework || !this.chosenBundler) {
       return null

--- a/packages/frontend-shared/cypress/support/mock-graphql/stubgql-Mutation.ts
+++ b/packages/frontend-shared/cypress/support/mock-graphql/stubgql-Mutation.ts
@@ -63,6 +63,10 @@ export const stubMutation: MaybeResolver<Mutation> = {
     return ctx.app.activeProject
   },
   generateSpecFromStory (source, args, ctx) {
-    return ctx.wizard
+    if (!ctx.app.activeProject) {
+      throw Error('Cannot set currentSpec without active project')
+    }
+
+    return ctx.app.activeProject
   },
 }

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -284,6 +284,26 @@ type FileParts implements Node {
   relative: String!
 }
 
+type FilePartsConnection {
+  """
+  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  """
+  edges: [FilePartsEdge!]!
+
+  """
+  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  """
+  pageInfo: PageInfo!
+}
+
+type FilePartsEdge {
+  """https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor"""
+  cursor: String!
+
+  """https://facebook.github.io/relay/graphql/connections.htm#sec-Node"""
+  node: FileParts!
+}
+
 enum FrontendFrameworkEnum {
   cra
   nextjs
@@ -331,7 +351,7 @@ type Mutation {
   devRelaunch(action: DevRelaunchAction!): Boolean
 
   """Generate spec from Storybook story"""
-  generateSpecFromStory(storyPath: String!): Wizard!
+  generateSpecFromStory(storyPath: String!): Project!
 
   """
   Initializes open_project global singleton to manager current project state
@@ -498,6 +518,7 @@ type Project implements Node {
     """Returns the last n elements from the list."""
     last: Int
   ): SpecConnection
+  storybook: Storybook
   title: String!
 }
 
@@ -606,7 +627,19 @@ type Storybook implements Node {
   id: ID!
 
   """List of all Storybook stories"""
-  stories: [FileParts!]!
+  stories(
+    """Returns the elements in the list that come after the specified cursor"""
+    after: String
+
+    """Returns the elements in the list that come before the specified cursor"""
+    before: String
+
+    """Returns the first n elements from the list."""
+    first: Int
+
+    """Returns the last n elements from the list."""
+    last: Int
+  ): FilePartsConnection
 
   """Folder containing storybook configuration files"""
   storybookRoot: String!
@@ -673,7 +706,6 @@ type Wizard {
   """IndexHtml file based on bundler and framework of choice"""
   sampleTemplate: String
   step: WizardStep!
-  storybook: Storybook
 
   """
   The testing type we are setting in the wizard, null if this has not been chosen

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -259,6 +259,31 @@ type DevState {
   needsRelaunch: Boolean
 }
 
+"""Represents a spec on the file system"""
+type FileParts implements Node {
+  """
+  Absolute path to spec (e.g. /Users/jess/my-project/src/component/MySpec.test.tsx)
+  """
+  absolute: String!
+
+  """
+  Full name of spec file (e.g. MySpec.test.tsx) without the spec extension
+  """
+  baseName: String!
+
+  """The first part of the file, without extensions (e.g. MySpec)"""
+  fileName: String!
+
+  """Relay style Node ID field for the FileParts field"""
+  id: ID!
+
+  """Full name of spec file (e.g. MySpec.test.tsx)"""
+  name: String!
+
+  """Relative path to spec (e.g. src/component/MySpec.test.tsx)"""
+  relative: String!
+}
+
 enum FrontendFrameworkEnum {
   cra
   nextjs
@@ -573,15 +598,18 @@ enum SpecType {
 }
 
 """Storybook"""
-type Storybook {
-  """Whether this is the selected framework bundler"""
-  configured: Boolean
-
+type Storybook implements Node {
   """Most recent generated spec"""
   generatedSpec: String
 
+  """Relay style Node ID field for the Storybook field"""
+  id: ID!
+
   """List of all Storybook stories"""
-  stories: [String!]!
+  stories: [FileParts!]!
+
+  """Folder containing storybook configuration files"""
+  storybookRoot: String!
 }
 
 """The bundlers that we can use with Cypress"""

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Mutation.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Mutation.ts
@@ -167,15 +167,19 @@ export const mutation = mutationType({
     })
 
     t.nonNull.field('generateSpecFromStory', {
-      type: 'Wizard',
+      type: 'Project',
       description: 'Generate spec from Storybook story',
       args: {
         storyPath: nonNull('String'),
       },
       async resolve (_root, args, ctx) {
+        if (!ctx.activeProject) {
+          throw Error(`Cannot set spec without active project!`)
+        }
+
         await ctx.actions.storybook.generateSpecFromStory(args.storyPath)
 
-        return ctx.wizardData
+        return ctx.activeProject
       },
     })
 

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Project.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Project.ts
@@ -72,5 +72,10 @@ export const Project = objectType({
         return ctx.project.getResolvedConfigFields(source.projectRoot)
       },
     })
+
+    t.field('storybook', {
+      type: 'Storybook',
+      resolve: (source, args, ctx) => ctx.storybook.loadStorybookInfo(),
+    })
   },
 })

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Storybook.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Storybook.ts
@@ -1,24 +1,46 @@
 import { objectType } from 'nexus'
 
+export const FileParts = objectType({
+  name: 'FileParts',
+  description: 'Represents a spec on the file system',
+  node: 'absolute',
+  definition (t) {
+    t.nonNull.string('absolute', {
+      description: 'Absolute path to spec (e.g. /Users/jess/my-project/src/component/MySpec.test.tsx)',
+    })
+
+    t.nonNull.string('relative', {
+      description: 'Relative path to spec (e.g. src/component/MySpec.test.tsx)',
+    })
+
+    t.nonNull.string('baseName', {
+      description: 'Full name of spec file (e.g. MySpec.test.tsx) without the spec extension',
+    })
+
+    t.nonNull.string('name', {
+      description: 'Full name of spec file (e.g. MySpec.test.tsx)',
+    })
+
+    t.nonNull.string('fileName', {
+      description: `The first part of the file, without extensions (e.g. MySpec)`,
+    })
+  },
+})
+
 export const Storybook = objectType({
   name: 'Storybook',
   description: 'Storybook',
+  node: 'storybookRoot',
   definition (t) {
-    t.boolean('configured', {
-      description: 'Whether this is the selected framework bundler',
-      resolve: async (source, args, ctx) => !!(await ctx.storybook.storybookInfo),
+    t.nonNull.string('storybookRoot', {
+      description: 'Folder containing storybook configuration files',
     })
 
-    t.nonNull.list.nonNull.string('stories', {
+    t.nonNull.list.nonNull.field('stories', {
+      type: FileParts,
       description: 'List of all Storybook stories',
       resolve: async (source, args, ctx) => {
-        const storybook = await ctx.storybook.storybookInfo
-
-        if (!storybook) {
-          return []
-        }
-
-        return storybook.getStories(storybook.storybookRoot, storybook.storyGlobs)
+        return ctx.actions.storybook.getStories()
       },
     })
 

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Storybook.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Storybook.ts
@@ -40,7 +40,7 @@ export const Storybook = objectType({
       type: FileParts,
       description: 'List of all Storybook stories',
       resolve: async (source, args, ctx) => {
-        return ctx.actions.storybook.getStories()
+        return ctx.storybook.getStories()
       },
     })
 

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Storybook.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Storybook.ts
@@ -36,10 +36,10 @@ export const Storybook = objectType({
       description: 'Folder containing storybook configuration files',
     })
 
-    t.nonNull.list.nonNull.field('stories', {
+    t.connectionField('stories', {
       type: FileParts,
       description: 'List of all Storybook stories',
-      resolve: async (source, args, ctx) => {
+      nodes: (source, args, ctx) => {
         return ctx.storybook.getStories()
       },
     })

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Wizard.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Wizard.ts
@@ -5,7 +5,6 @@ import { WizardNpmPackage } from './gql-WizardNpmPackage'
 import { objectType } from 'nexus'
 import { BUNDLERS, CODE_LANGUAGES, FRONTEND_FRAMEWORKS, TESTING_TYPES } from '@packages/types'
 import { TestingTypeEnum, WizardStepEnum } from '../enumTypes/gql-WizardEnums'
-import { Storybook } from './gql-Storybook'
 import { WizardCodeLanguage } from './gql-WizardCodeLanguage'
 
 export const Wizard = objectType({
@@ -102,11 +101,6 @@ export const Wizard = objectType({
     t.string('title', {
       description: 'The title of the page, given the current step of the wizard',
       resolve: (source, args, ctx) => ctx.wizard.title ?? null,
-    })
-
-    t.field('storybook', {
-      type: Storybook,
-      resolve: (source, args, ctx) => ctx.storybook.storybookInfo,
     })
   },
   sourceType: {

--- a/packages/types/src/storybook.ts
+++ b/packages/types/src/storybook.ts
@@ -9,8 +9,4 @@ export interface StorybookInfo {
   storybookRoot: string
   files: StorybookFile[]
   storyGlobs: string[]
-  getStories: (
-    storybookRoot: string,
-    storyGlobs: string[]
-  ) => Promise<string[]>
 }


### PR DESCRIPTION
This PR exposes detected stories similar to how specs are exposed. This logic will be reused when we implement spec generation from components.

[Here is a branch](https://github.com/cypress-io/cypress/tree/expose-story-parts-test) that has a create-react-app with Storybook installed that you can check out that will help in testing this feature. You can target the project by running `yarn dev -project npm/react/examples/cra-ts-storybook`.

I wanted to create a partial from `gql-Spec.ts` and do some type extension but I was having issues there so I duplicated the fields inside `gql-Storybook.ts`.

![Screen Shot 2021-10-12 at 1 57 07 PM](https://user-images.githubusercontent.com/25158820/137013892-0ebc5845-0383-4b9d-8788-7ef5980db231.png)


