### PR TITLE
feat: expose generated spec content and file parts

### DIFF
--- a/packages/app/src/pages/NewSpec.vue
+++ b/packages/app/src/pages/NewSpec.vue
@@ -81,7 +81,6 @@ mutation NewSpec_GenerateSpecFromStory($storyPath: String!) {
   generateSpecFromStory (storyPath: $storyPath) {
     storybook {
       generatedSpec {
-        id
         content
         spec {
           id
@@ -99,8 +98,8 @@ const mutation = useMutation(NewSpec_GenerateSpecFromStoryDocument)
 
 const generatedSpec = computed(() => mutation.data.value?.generateSpecFromStory.storybook?.generatedSpec)
 
-async function storyClick (story: string) {
-  await mutation.executeMutation({ storyPath: story })
+function storyClick (story: string) {
+  mutation.executeMutation({ storyPath: story })
 }
 
 function specClick () {

--- a/packages/app/src/pages/NewSpec.vue
+++ b/packages/app/src/pages/NewSpec.vue
@@ -1,18 +1,35 @@
 <template>
   <div v-if="query.data.value?.app.activeProject?.storybook">
     <h2>New Spec</h2>
-    <ul>
-      <li
-        v-for="story of stories"
-        :key="story.relative"
-        class="group"
-        @click="storyClick(story.absolute)"
+    <div>
+      <ul>
+        <li
+          v-for="story of stories"
+          :key="story.relative"
+          class="group"
+          @click="storyClick(story.absolute)"
+        >
+          <span class="text-indigo-600 font-medium">{{ story.fileName }}</span>
+          <span class="font-light text-gray-400">{{ story.fileExtension }}</span>
+          <span class="font-light text-gray-400 pl-16px hidden group-hover:inline">{{ story.relativeFromProjectRoot }}</span>
+        </li>
+      </ul>
+      <div
+        v-if="generatedSpec"
+        class="p-16px"
       >
-        <span class="text-indigo-600 font-medium">{{ story.fileName }}</span>
-        <span class="font-light text-gray-400">{{ story.fileExtension }}</span>
-        <span class="font-light text-gray-400 pl-16px hidden group-hover:inline">{{ story.relativeFromProjectRoot }}</span>
-      </li>
-    </ul>
+        <div class="flex">
+          <span>Generated Spec: </span>
+          <Button @click="specClick">
+            {{ generatedSpec.spec.relative }}
+          </Button>
+        </div>
+        <div>
+          <h2>Generated Spec Content:</h2>
+          <pre>{{ generatedSpec.content }}</pre>
+        </div>
+      </div>
+    </div>
   </div>
   <div v-else>
     Storybook is not configured for this project
@@ -24,6 +41,7 @@
 }
 </route>
 <script lang="ts" setup>
+import Button from '@cy/components/Button.vue'
 import { gql, useMutation, useQuery } from '@urql/vue'
 import { computed } from 'vue'
 import { NewSpecQueryDocument, NewSpec_GenerateSpecFromStoryDocument } from '../generated/graphql'
@@ -62,7 +80,15 @@ gql`
 mutation NewSpec_GenerateSpecFromStory($storyPath: String!) {
   generateSpecFromStory (storyPath: $storyPath) {
     storybook {
-      generatedSpec
+      generatedSpec {
+        id
+        content
+        spec {
+          id
+          name
+          relative
+        }
+      }
     }
   }
 } 
@@ -71,14 +97,14 @@ mutation NewSpec_GenerateSpecFromStory($storyPath: String!) {
 const query = useQuery({ query: NewSpecQueryDocument })
 const mutation = useMutation(NewSpec_GenerateSpecFromStoryDocument)
 
+const generatedSpec = computed(() => mutation.data.value?.generateSpecFromStory.storybook?.generatedSpec)
+
 async function storyClick (story: string) {
   await mutation.executeMutation({ storyPath: story })
-  const generatedSpec = mutation.data.value?.generateSpecFromStory.storybook?.generatedSpec
+}
 
-  // Runner doesn't pick up new file without timeout, I'm guessing a race condition between file watcher and runner starting
-  setTimeout(() => {
-    window.location.href = `${window.location.origin}/__/#/tests/component/${generatedSpec}`
-  }, 500)
+function specClick () {
+  window.location.href = `${window.location.origin}/__/#/tests/component/${generatedSpec.value?.spec.name}`
 }
 
 const stories = computed(() => {

--- a/packages/data-context/src/actions/ProjectActions.ts
+++ b/packages/data-context/src/actions/ProjectActions.ts
@@ -57,6 +57,7 @@ export class ProjectActions {
       isFirstTimeCT: await this.ctx.project.isFirstTimeAccessing(projectRoot, 'component'),
       isFirstTimeE2E: await this.ctx.project.isFirstTimeAccessing(projectRoot, 'e2e'),
       config: await this.ctx.project.getResolvedConfigFields(projectRoot),
+      generatedSpec: null,
     }
 
     return this

--- a/packages/data-context/src/actions/StorybookActions.ts
+++ b/packages/data-context/src/actions/StorybookActions.ts
@@ -22,7 +22,7 @@ export class StorybookActions {
       config.componentFolder,
     )
 
-    this.ctx.wizardData.generatedSpec = spec
+    project.generatedSpec = spec
   }
 
   private async generateSpec (

--- a/packages/data-context/src/actions/StorybookActions.ts
+++ b/packages/data-context/src/actions/StorybookActions.ts
@@ -1,4 +1,4 @@
-import type { FoundSpec, FullConfig } from '@packages/types'
+import type { FullConfig, GeneratedSpec } from '@packages/types'
 import { readCsfOrMdx } from '@storybook/csf-tools'
 import endent from 'endent'
 import * as path from 'path'
@@ -29,7 +29,7 @@ export class StorybookActions {
     storyPath: string,
     projectRoot: string,
     componentFolder: FullConfig['componentFolder'],
-  ): Promise<FoundSpec | null> {
+  ): Promise<GeneratedSpec | null> {
     const specFileExtension = '.cy'
     const parsedFile = path.parse(storyPath)
     const fileName = parsedFile.name.split('.')[0] as string
@@ -70,14 +70,17 @@ export class StorybookActions {
 
     // Can this be obtained from the spec watcher?
     return {
-      absolute: newSpecAbsolute,
-      baseName: parsedNewSpec.base,
-      fileExtension: parsedNewSpec.ext,
-      fileName,
-      name: path.relative(componentFolder || projectRoot, newSpecAbsolute),
-      relative: path.relative(projectRoot, newSpecAbsolute),
-      specFileExtension,
-      specType: 'component',
+      spec: {
+        absolute: newSpecAbsolute,
+        baseName: parsedNewSpec.base,
+        fileExtension: parsedNewSpec.ext,
+        fileName,
+        name: path.relative(componentFolder || projectRoot, newSpecAbsolute),
+        relative: path.relative(projectRoot, newSpecAbsolute),
+        specFileExtension,
+        specType: 'component',
+      },
+      content: newSpecContent,
     }
   }
 

--- a/packages/data-context/src/data/coreDataShape.ts
+++ b/packages/data-context/src/data/coreDataShape.ts
@@ -1,4 +1,4 @@
-import { BUNDLERS, FoundBrowser, FoundSpec, ResolvedFromConfig, StorybookFile } from '@packages/types'
+import { BUNDLERS, FoundBrowser, FoundSpec, ResolvedFromConfig, GeneratedSpec } from '@packages/types'
 import type { NexusGenEnums, TestingTypeEnum } from '@packages/graphql/src/gen/nxs.gen'
 
 export type Maybe<T> = T | null | undefined
@@ -48,7 +48,7 @@ export interface WizardDataShape {
   chosenLanguage: NexusGenEnums['CodeLanguageEnum']
   chosenManualInstall: boolean
   chosenBrowser: FoundBrowser | null
-  generatedSpec: Omit<StorybookFile, 'content'> | null
+  generatedSpec: GeneratedSpec | null
 }
 
 export interface CoreDataShape {

--- a/packages/data-context/src/data/coreDataShape.ts
+++ b/packages/data-context/src/data/coreDataShape.ts
@@ -26,6 +26,7 @@ export interface ActiveProjectShape extends ProjectShape {
   currentSpecId?: Maybe<string>
   specs?: FoundSpec[]
   config: ResolvedFromConfig[]
+  generatedSpec: GeneratedSpec | null
 }
 
 export interface AppDataShape {
@@ -48,7 +49,6 @@ export interface WizardDataShape {
   chosenLanguage: NexusGenEnums['CodeLanguageEnum']
   chosenManualInstall: boolean
   chosenBrowser: FoundBrowser | null
-  generatedSpec: GeneratedSpec | null
 }
 
 export interface CoreDataShape {
@@ -85,7 +85,6 @@ export function makeCoreData (): CoreDataShape {
       allBundlers: BUNDLERS,
       history: ['welcome'],
       chosenBrowser: null,
-      generatedSpec: null,
     },
     user: null,
   }

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -313,6 +313,15 @@ enum FrontendFrameworkEnum {
   vuecli
 }
 
+type GeneratedSpec implements Node {
+  """File content of most recently generated spec."""
+  content: String!
+
+  """Relay style Node ID field for the GeneratedSpec field"""
+  id: ID!
+  spec: FileParts!
+}
+
 """Git information about a spec file"""
 type GitInfo {
   """Last person to change the file in git"""
@@ -620,8 +629,7 @@ enum SpecType {
 
 """Storybook"""
 type Storybook implements Node {
-  """Most recent generated spec"""
-  generatedSpec: String
+  generatedSpec: GeneratedSpec
 
   """Relay style Node ID field for the Storybook field"""
   id: ID!

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -313,12 +313,9 @@ enum FrontendFrameworkEnum {
   vuecli
 }
 
-type GeneratedSpec implements Node {
+type GeneratedSpec {
   """File content of most recently generated spec."""
   content: String!
-
-  """Relay style Node ID field for the GeneratedSpec field"""
-  id: ID!
   spec: FileParts!
 }
 

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Storybook.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Storybook.ts
@@ -44,9 +44,21 @@ export const Storybook = objectType({
       },
     })
 
-    t.string('generatedSpec', {
-      description: 'Most recent generated spec',
-      resolve: (source, args, ctx) => ctx.wizardData.generatedSpec?.relative ?? null,
+    t.field('generatedSpec', {
+      type: objectType({
+        name: 'GeneratedSpec',
+        node: 'content',
+        definition (t) {
+          t.nonNull.string('content', {
+            description: 'File content of most recently generated spec.',
+          })
+
+          t.nonNull.field('spec', {
+            type: FileParts,
+          })
+        },
+      }),
+      resolve: (src, args, ctx) => ctx.wizardData.generatedSpec,
     })
   },
 })

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Storybook.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Storybook.ts
@@ -47,7 +47,6 @@ export const Storybook = objectType({
     t.field('generatedSpec', {
       type: objectType({
         name: 'GeneratedSpec',
-        node: 'content',
         definition (t) {
           t.nonNull.string('content', {
             description: 'File content of most recently generated spec.',
@@ -58,7 +57,15 @@ export const Storybook = objectType({
           })
         },
       }),
-      resolve: (src, args, ctx) => ctx.wizardData.generatedSpec,
+      resolve: (src, args, ctx) => {
+        const project = ctx.activeProject
+
+        if (!project) {
+          return null
+        }
+
+        return project.generatedSpec
+      },
     })
   },
 })

--- a/packages/types/src/storybook.ts
+++ b/packages/types/src/storybook.ts
@@ -1,3 +1,5 @@
+import type { FoundSpec } from './spec'
+
 export interface StorybookFile {
   name: string
   absolute: string
@@ -9,4 +11,9 @@ export interface StorybookInfo {
   storybookRoot: string
   files: StorybookFile[]
   storyGlobs: string[]
+}
+
+export interface GeneratedSpec {
+  spec: FoundSpec
+  content: string
 }


### PR DESCRIPTION
When generating a spec from a story, the frontend will need to know some file data from the generated spec as well as its content. This PR exposes this data in gql.

The `generatedSpec` was moved to `activeProject` since it doesn't make sense to be included on `wizard`.

Closes [UNIFY-438](https://cypress-io.atlassian.net/jira/software/projects/UNIFY/boards/20?selectedIssue=UNIFY-438)

https://user-images.githubusercontent.com/25158820/137215792-6e9953c0-05e9-403c-8cdc-ff570e43ba32.mov

## How to test
[storybook-test](https://github.com/cypress-io/cypress/tree/storybook-test) has `react-scripts-typescript` setup with storybook integration. You can run `yarn dev --project npm/react/examples/react-scripts-typescript`. Once in the app, the codegen screen is `__vite__/#/newspec`. Clicking on a spec from the list will codegen and the (rough) UI will show the generated file path and content.

