### PR TITLE
fix: make `have.text` work as the doc states.

### DIFF
--- a/packages/driver/cypress/fixtures/jquery.html
+++ b/packages/driver/cypress/fixtures/jquery.html
@@ -5,7 +5,7 @@
     <script type="text/javascript" src="/fixtures/jquery-3.2.1.js"></script>
   </head>
   <body>
-    <span id="foo">foo<span>
+    <span id="foo">foo</span>
     <div>div</div>
     <input id="input" />
     <button>button</button>

--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -1810,13 +1810,17 @@ describe('src/cy/commands/assertions', () => {
         })
       })
 
+      // https://github.com/cypress-io/cypress/issues/18097
+      it('matches the first', () => {
+        cy.get('span').should('have.text', 'foo')
+      })
+
       it('partial match', function () {
         expect(this.$div).to.have.text('foo')
         expect(this.$div).to.contain.text('o')
         expect(this.$div).to.include.text('o')
         cy.get('div').should('contain.text', 'iv').should('contain.text', 'd')
-
-        cy.get('div').should('not.contain.text', 'fizzbuzz').should('contain.text', 'Nest')
+        cy.get('div:nth-of-type(2)').should('not.contain.text', 'fizzbuzz').should('contain.text', 'Nest')
       })
 
       it('throws when obj is not DOM', function (done) {

--- a/packages/driver/src/cypress/chai_jquery.ts
+++ b/packages/driver/src/cypress/chai_jquery.ts
@@ -173,7 +173,11 @@ export const $chaiJquery = (chai, chaiUtils, callbacks = {}) => {
       text,
     )
 
-    const actual = wrap(this).text()
+    // https://github.com/cypress-io/cypress/issues/18097
+    // If there are multiple elements, use the first.
+    const wrapped = wrap(this)
+    const $el = wrapped.length > 1 ? wrapped.eq(0) : wrapped
+    const actual = $el.text()
 
     return assertPartial(
       this,


### PR DESCRIPTION
- Related with #18097

### User facing changelog

Make `have.text` work as the doc states.

### Additional details
- Why was this change necessary? => `have.text` doesn't work as the doc states.
- What is affected by this change? => It can break some tests if they use the previous behavior.

### Any implementation details to explain?

In [the document of `have.text`](https://github.com/chaijs/chai-jquery#texttext), it says:

> Assert that the text of the first element of the selection is equal to the given text

But the behavior is that it concatenates texts of the selected elements. 

And I learned that it's happening with the original `chai-jquery`. I think it's a bug and it caused confusion to a user at #18097. And I think it can cause more confusions to others. 

So, I fixed `have.text` to work like the doc definition.

### How has the user experience changed?

```html
<div>abc</div>
<div>def</div>
```

**Before:**

```js
cy.get('div').should('have.text', 'abc') // fail because it's 'abcdef'
cy.get('div').should('have.text', 'abcdef') // pass
```

**After:**

```js
cy.get('div').should('have.text', 'abc') // pass
cy.get('div').should('have.text', 'abcdef') // fail
```
If you want to check the second+ element, use `nth-of-type` or `get()`.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? => Maybe migration guide should be updated. <!-- Link to PR here -->
