### PR TITLE
fix: conditional E2E symlinks on CI only

### DIFF
--- a/packages/frontend-shared/cypress/e2e/support/e2eProjectDirs.ts
+++ b/packages/frontend-shared/cypress/e2e/support/e2eProjectDirs.ts
@@ -60,7 +60,6 @@ export const e2eProjectDirs = [
   'retries-2',
   'same-fixtures-integration-folders',
   'screen-size',
-  'server',
   'shadow-dom-global-inclusion',
   'studio',
   'studio-no-source-maps',

--- a/scripts/gulp/tasks/gulpVite.ts
+++ b/scripts/gulp/tasks/gulpVite.ts
@@ -73,6 +73,10 @@ function spawnViteDevServer (
  *------------------------------------------------------------------------**/
 
 export async function symlinkViteProjects () {
+  if (!process.env.CIRCLECI) {
+    return
+  }
+
   await Promise.all([
     spawned('cmd-symlink', 'ln -s ../app/dist dist-app', {
       cwd: monorepoPaths.pkgLaunchpad,


### PR DESCRIPTION
#18472 seems to have broken local development, specially this part: https://github.com/cypress-io/cypress/pull/18472/files#r729542694

I wrapped it in a conditional so that the symlinks are only done on CI.

Testing:

1. get this branch
2. run yarn
3. verify that the symlink error isn't shown ([see here]( https://github.com/cypress-io/cypress/pull/18472/files#r729542694))
4. `yarn dev` at top level
5. choose either `app` or `launchpad` for your project
6. select component testing
7. it should initialize the plugins and you should be able to open the runner



Repro

Get a fresh repo. Run `yarn gulp symlinkViteProjects`.

```
$ /Users/lachlan/code/work/cypress6/node_modules/.bin/gulp symlinkViteProjects
[17:08:30] Using gulpfile ~/code/work/cypress6/gulpfile.js
[17:08:30] Starting 'symlinkViteProjects'...
[cmd-symlink:44014]:  Exit code: 0 => null
[cmd-symlink:44015]:  Exit code: 0 => null
[cmd-symlink:44016]:  Exit code: 0 => null
[cmd-symlink:44017]:  Exit code: 0 => null
```

Now we have some symlinks, as represented by `@` on the end

```
 ls packages/launchpad/
README.md        dist-app@        
cypress/         dist-launchpad@
```

Note contents of `ls packages/launchpad/dist/`

```
(unified-desktop-gui) $ ls packages/launchpad/dist/
assets		index.html
```

Now `cd packages/launchpad` and start Vite:

```
(unified-desktop-gui) $ yarn vite --port 3333 --base /__vite__/
yarn run v1.22.11
$ /Users/lachlan/code/work/cypress6/node_modules/.bin/vite --port 3333 --base /__vite__/
warn - `lightBlue` has been renamed to `sky`.
warn - Please update your color palette to eliminate this warning.

  vite v2.4.4 dev server running at:

  > Local: http://localhost:3333/__vite__/
  > Network: use `--host` to expose

  ready in 986ms.

(node:44401) UnhandledPromiseRejectionWarning: Error: ELOOP: too many symbolic links encountered, stat '/Users/lachlan/code/work/cypress6/packages/launchpad/dist/dist'
(Use `node --trace-warnings ...` to show where the warning was created)
(node:44401) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
```

Recursively symlink.

```
ln dist/dist
ln: dist/dist: Too many levels of symbolic links
(unified-desktop-gui) $ ln dist/dist
(unified-desktop-gui) $ ls -l dist/dist
lrwxr-xr-x  1 lachlan  staff  4 15 Oct 17:10 dist/dist -> dist
```

I guess Vite also uses a symlink for the dev server referencing `dist`? I am not sure how to fix/work around this.
