### PR TITLE
fix: change symlinks to avoid conflict

### DIFF
--- a/packages/frontend-shared/cypress/e2e/support/e2eSupport.ts
+++ b/packages/frontend-shared/cypress/e2e/support/e2eSupport.ts
@@ -103,7 +103,7 @@ function visitApp () {
     throw new Error(`Missing serverPort - did you forget to call cy.initializeApp(...) ?`)
   }
 
-  return cy.visit(`dist-app/index.html?gqlPort=${e2e_gqlPort}&serverPort=${e2e_serverPort}`)
+  return cy.visit(`dist-app-e2e/index.html?gqlPort=${e2e_gqlPort}&serverPort=${e2e_serverPort}`)
 }
 
 function visitLaunchpad (hash?: string) {
@@ -113,7 +113,7 @@ function visitLaunchpad (hash?: string) {
     throw new Error(`Missing gqlPort - did you forget to call cy.setupE2E(...) ?`)
   }
 
-  cy.visit(`dist-launchpad/index.html?gqlPort=${e2e_gqlPort}`)
+  cy.visit(`dist-launchpad-e2e/index.html?gqlPort=${e2e_gqlPort}`)
 }
 
 const pageLoadId = `uid${Math.random()}`

--- a/scripts/gulp/tasks/gulpVite.ts
+++ b/scripts/gulp/tasks/gulpVite.ts
@@ -74,19 +74,19 @@ function spawnViteDevServer (
 
 export async function symlinkViteProjects () {
   await Promise.all([
-    spawned('cmd-symlink', 'ln -s ../app/dist dist-app', {
+    spawned('cmd-symlink', 'ln -s ../app/dist-app-e2e dist-app', {
       cwd: monorepoPaths.pkgLaunchpad,
       waitForExit: true,
     }).catch((e) => {}),
-    spawned('cmd-symlink', 'ln -s dist dist-app', {
+    spawned('cmd-symlink', 'ln -s dist-launchpad-e2e dist-app', {
       cwd: monorepoPaths.pkgApp,
       waitForExit: true,
     }).catch((e) => {}),
-    spawned('cmd-symlink', 'ln -s dist dist-launchpad', {
+    spawned('cmd-symlink', 'ln -s dist-app-e2e dist-launchpad', {
       cwd: monorepoPaths.pkgLaunchpad,
       waitForExit: true,
     }).catch((e) => {}),
-    spawned('cmd-symlink', 'ln -s ../launchpad/dist dist-launchpad', {
+    spawned('cmd-symlink', 'ln -s ../launchpad/dist-launchpad-e2e dist-launchpad', {
       cwd: monorepoPaths.pkgApp,
       waitForExit: true,
     }).catch((e) => {}),
@@ -94,7 +94,7 @@ export async function symlinkViteProjects () {
 }
 
 export function viteBuildApp () {
-  return spawned('vite:build-app', `yarn vite build`, {
+  return spawned('vite:build-app', `yarn vite build --outDir dist-app-e2e`, {
     cwd: monorepoPaths.pkgApp,
     waitForExit: true,
     env: {
@@ -115,7 +115,7 @@ export function viteBuildAndWatchApp () {
 }
 
 export function viteBuildLaunchpad () {
-  return spawned('vite:build-launchpad', `yarn vite build`, {
+  return spawned('vite:build-launchpad', `yarn vite build --outDir dist-launchpad-e2e`, {
     cwd: monorepoPaths.pkgLaunchpad,
     waitForExit: true,
   })


### PR DESCRIPTION
#18472 seems to have broken local development, specifically this part: https://github.com/cypress-io/cypress/pull/18472/files#r729542694

## Reproduction:

Get a fresh repo (or remove symlinks created via `symlinkViteProjects`). Run `yarn gulp symlinkViteProjects`.

```
$ /Users/lachlan/code/work/cypress6/node_modules/.bin/gulp symlinkViteProjects
[17:08:30] Using gulpfile ~/code/work/cypress6/gulpfile.js
[17:08:30] Starting 'symlinkViteProjects'...
[cmd-symlink:44014]:  Exit code: 0 => null
[cmd-symlink:44015]:  Exit code: 0 => null
[cmd-symlink:44016]:  Exit code: 0 => null
[cmd-symlink:44017]:  Exit code: 0 => null
```

Now we have some symlinks, as represented by `@` on the end

```
 ls packages/launchpad/
README.md        dist-app@        
cypress/         dist-launchpad@
```

Note contents of `ls packages/launchpad/dist/`

```
(unified-desktop-gui) $ ls packages/launchpad/dist/
assets		index.html
```

Now `cd packages/launchpad` and start Vite:

```
(unified-desktop-gui) $ yarn vite --port 3333 --base /__vite__/
yarn run v1.22.11
$ /Users/lachlan/code/work/cypress6/node_modules/.bin/vite --port 3333 --base /__vite__/
warn - `lightBlue` has been renamed to `sky`.
warn - Please update your color palette to eliminate this warning.

  vite v2.4.4 dev server running at:

  > Local: http://localhost:3333/__vite__/
  > Network: use `--host` to expose

  ready in 986ms.

(node:44401) UnhandledPromiseRejectionWarning: Error: ELOOP: too many symbolic links encountered, stat '/Users/lachlan/code/work/cypress6/packages/launchpad/dist/dist'
(Use `node --trace-warnings ...` to show where the warning was created)
(node:44401) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
```

Recursively symlink.

```
ln dist/dist
ln: dist/dist: Too many levels of symbolic links
(unified-desktop-gui) $ ln dist/dist
(unified-desktop-gui) $ ls -l dist/dist
lrwxr-xr-x  1 lachlan  staff  4 15 Oct 17:10 dist/dist -> dist
```

I guess Vite also uses a symlink for the dev server referencing `dist`? I think we can work around it by building to a different directory than `dist` and linking against that for E2E.

## Fix

Use different directory for when building for e2e tests and change symlinks.
