### PR TITLE
fix: do not recreate iframe per spec

### DIFF
--- a/packages/runner-ct/src/iframe/iframes.tsx
+++ b/packages/runner-ct/src/iframe/iframes.tsx
@@ -90,8 +90,6 @@ export const Iframes = namedObserver('Iframes', ({
     }
 
     const specSrc = getSpecUrl({ namespace: config.namespace, spec })
-    // const $container = $Cypress.$(containerRef.current).empty()
-    // const $autIframe: JQuery<HTMLIFrameElement> = autIframe.create().appendTo($container)
 
     autIframe.showInitialBlankContents()
 


### PR DESCRIPTION
We have a memory leak in runner-ct where we create a new iframe per spec, and the previous specs' iframe is never cleaned up.

This never manifested in runner-e2e because we only ever run 1 spec at a time. Not sure if this is really the ideal fix, but one obvious way to solve this problem is to bring parity to the runner-ct and simply reuse the same AUT iframe for each spec. 

Edit: We actually need to destroy the iframe each spec, so this isn't really a fix, but it does demonstrate how the problem occurs. I will do some more exploration and push a real fix here.