### PR TITLE
fix: oom error in CI preventing checkTs from running

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -974,7 +974,7 @@ jobs:
       - install-required-node
       - run:
           name: Check TS Types
-          command: yarn gulp checkTs
+          command: NODE_OPTIONS=--max_old_space_size=4096 yarn gulp checkTs
 
 
   # a special job that keeps polling Circle and when all


### PR DESCRIPTION
Currently, `yarn gulp checkTs` is going OOM when running in CI. This fixes that and going OOM is apparently a common problem with TS projects. Amusingly there's an entire package dedicated to solving this. https://www.npmjs.com/package/increase-memory-limit