### PR TITLE
fix: pin ua-parser-js to non compromised version

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,6 +247,7 @@
     "**/jquery": "3.1.1",
     "**/pretty-format": "26.4.0",
     "**/socket.io-parser": "4.0.4",
+    "**/ua-parser-js": "0.7.24",
     "vue-template-compiler": "2.6.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -38354,7 +38354,7 @@ typescript@^3.9.7:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
   integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
 
-ua-parser-js@^0.7.18:
+ua-parser-js@0.7.24, ua-parser-js@^0.7.18:
   version "0.7.24"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.24.tgz#8d3ecea46ed4f1f1d63ec25f17d8568105dc027c"
   integrity sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==


### PR DESCRIPTION
The ua-parser-js package was compromised and later versions install malware. Pin ua-parser-js to the version we use until things clear up

faisalman/ua-parser-js#536

### User facing changelog
Pinned ua-parser-js package to non compromised version

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
