### PR TITLE
fix: Next.JS 12 components testing failing with ` TypeError: Cannot read property 'traceChild' of undefined`

### DIFF
--- a/npm/react/plugins/next/getRunWebpackSpan.ts
+++ b/npm/react/plugins/next/getRunWebpackSpan.ts
@@ -12,8 +12,8 @@ export async function getRunWebpackSpan (): Promise<{ runWebpackSpan?: Span }> {
       trace = await import('next/dist/telemetry/trace/trace').then((m) => m.trace)
 
       return { runWebpackSpan: trace('cypress') }
-    }
-    catch (_){
+    } catch (_) {
+      // @ts-ignore
       trace = await import('next/dist/trace/trace').then((m) => m.trace)
 
       return { runWebpackSpan: trace('cypress') }


### PR DESCRIPTION
### User facing changelog
Fix component testing errors for next 12.0

### Additional details
In Next.JS 12 the `trace` folder wass moved outside of `telemetry` folder. This code checks two locations now for the telemetry.js. If it doesn't find it anywhere then it's no-op.

### How has the user experience changed?
Component testing now works for both Next 11 and Next 12
