### PR TITLE
fix: overflow clip to prevent selector header from dissapearing

### DIFF
--- a/packages/runner/src/app/app.scss
+++ b/packages/runner/src/app/app.scss
@@ -45,7 +45,7 @@ $spec-list-width: 250px;
     bottom: 0;
     box-shadow: inset 0 0 10px #555;
     left: 33%;
-    overflow: hidden;
+    overflow: clip;
     position: absolute;
     right: 0;
     top: 0;


### PR DESCRIPTION
Fixes UNIFY-458

The header no longer disappears. Seemed to be caused by the auto-scrolling of the command log, I guess `clip` solves it - not sure if it breaks anything else though

`clip:`
> Similar to hidden, the content is clipped to the element's padding box. The difference between clip and hidden is that the clip keyword also forbids all scrolling, including programmatic scrolling. The box is not a scroll container, and does not start a new formatting context. If you wish to start a new formatting context, you can use display: flow-root to do so.

