### PR TITLE
chore(tests): Remove flaky assertion that relies on png how compression

### DIFF
--- a/system-tests/test/screenshots_spec.js
+++ b/system-tests/test/screenshots_spec.js
@@ -97,9 +97,6 @@ describe('e2e screenshots', () => {
         .then((sizes) => {
           // make sure all of the values are unique
           expect(sizes).to.deep.eq(_.uniq(sizes))
-
-          // png1 should not be within 1k of png2
-          expect(sizes[0]).not.to.be.closeTo(sizes[1], 1000)
         }).then(() => {
           return Promise.all([
             sizeOf(screenshot1),


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/17721

This test fails frequently in circleci, roughly 20% of the time on `develop` branch in circleci. It fails fairly consistently for me locally. While it may seem odd to simply remove an assertion, it's merely the final step of a proud tradition.

- This was part of the original test, back in 2016, expecting a diff greater than 5000 in the file sizes.
- Back in 2020 (before the decafination PR - it took some digging) this was reduced to 3000, in order to - as the commit message says - reduce test flake.
- Then we again reduced it from 3000 to 1000 in 2021, with another commit message that it would reduce test flake.

This PR is the final step in the process, removing the assertion entirely.