### PR TITLE
feat(app): AUT header, URL, viewport 

### DIFF
--- a/packages/app/cypress/e2e/integration/files.spec.ts
+++ b/packages/app/cypress/e2e/integration/files.spec.ts
@@ -11,7 +11,7 @@ describe('App', () => {
 
   it('resolves the home page', () => {
     cy.visitApp()
-    cy.wait(1000)
+    cy.wait(10000)
     cy.get('[href="#/runs"]').click()
     cy.get('[href="#/settings"]').click()
   })

--- a/packages/app/cypress/e2e/integration/files.spec.ts
+++ b/packages/app/cypress/e2e/integration/files.spec.ts
@@ -11,6 +11,7 @@ describe('App', () => {
 
   it('resolves the home page', () => {
     cy.visitApp()
+    cy.wait(1000)
     cy.get('[href="#/runs"]').click()
     cy.get('[href="#/settings"]').click()
   })

--- a/packages/app/cypress/e2e/integration/files.spec.ts
+++ b/packages/app/cypress/e2e/integration/files.spec.ts
@@ -11,7 +11,6 @@ describe('App', () => {
 
   it('resolves the home page', () => {
     cy.visitApp()
-    cy.wait(10000)
     cy.get('[href="#/runs"]').click()
     cy.get('[href="#/settings"]').click()
   })

--- a/packages/app/src/runner/iframe-model.ts
+++ b/packages/app/src/runner/iframe-model.ts
@@ -28,7 +28,6 @@ export class IframeModel {
     private restoreDom: (snapshot: any) => void,
     private highlightEl: ({ body }: any, opts: any) => void,
     private eventManager: any,
-    private MobX: any,
     private studio: {
       selectorPlaygroundModel: any
       recorder: any
@@ -42,11 +41,15 @@ export class IframeModel {
     this.eventManager.on('run:end', this._afterRun)
 
     this.eventManager.on('viewport:changed', this._updateViewport)
-    this.eventManager.on('config', this.MobX.action('config', (config: any) => {
+    // TODO(lachlan): verify this is called, and if it actually needs to be.
+    // in CT/E2E/unified, because `listen` is called **after** this $Cypress has been
+    // created and this event has been emitted, so right now in production
+    // I don't think this is actually doing anything.
+    this.eventManager.on('config', (config: { viewportHeight: number, viewportWidth: number }) => {
       const { viewportWidth, viewportHeight } = config
 
       return this._updateViewport({ viewportHeight, viewportWidth })
-    }))
+    })
 
     const autStore = useAutStore()
 

--- a/packages/app/src/runner/iframe-model.ts
+++ b/packages/app/src/runner/iframe-model.ts
@@ -1,5 +1,5 @@
 import { useSnapshotStore } from '../spec/snapshot-store'
-import { MobxRunnerStore, useAutStore } from '../store'
+import { useAutStore } from '../store'
 
 export interface AutSnapshot {
   id?: number
@@ -38,9 +38,7 @@ export class IframeModel {
   }
 
   listen () {
-    // this.eventManager.on('run:start', this.MobX.action('run:start', this._beforeRun))
     this.eventManager.on('run:start', this._beforeRun)
-    // this.eventManager.on('run:end', this.MobX.action('run:end', this._afterRun))
     this.eventManager.on('run:end', this._afterRun)
 
     this.eventManager.on('viewport:changed', this._updateViewport)
@@ -51,9 +49,11 @@ export class IframeModel {
     }))
 
     const autStore = useAutStore()
+
     this.eventManager.on('url:changed', (url: string) => {
       autStore.updateUrl(url)
     })
+
     this.eventManager.on('page:loading', this._updateLoadingUrl)
 
     this.eventManager.on('show:snapshot', this.setSnapshots)
@@ -78,11 +78,13 @@ export class IframeModel {
 
   _afterRun = () => {
     const autStore = useAutStore()
+
     autStore.setIsRunning(false)
   }
 
   _updateViewport = ({ viewportWidth, viewportHeight }, cb?: () => void) => {
     const autStore = useAutStore()
+
     autStore.updateDimensions(viewportWidth, viewportHeight)
 
     if (cb) {
@@ -92,6 +94,7 @@ export class IframeModel {
 
   _updateLoadingUrl = (isLoadingUrl: boolean) => {
     const autStore = useAutStore()
+
     autStore.setIsLoadingUrl(isLoadingUrl)
   }
 
@@ -231,9 +234,10 @@ export class IframeModel {
 
   _studioOpenError () {
     const snapshotStore = useSnapshotStore()
+
     snapshotStore.setMessage(
       'Cannot show Snapshot while creating commands in Studio',
-      'warning'
+      'warning',
     )
   }
 
@@ -254,7 +258,7 @@ export class IframeModel {
       // TODO: use same attr for both runner and runner-ct states.
       // these refer to the same thing - the viewport dimensions.
       viewportWidth: autStore.viewportWidth,
-      viewportHeight: autStore.viewportHeight
+      viewportHeight: autStore.viewportHeight,
     }
   }
 

--- a/packages/app/src/runner/iframe-model.ts
+++ b/packages/app/src/runner/iframe-model.ts
@@ -17,8 +17,6 @@ export interface AutSnapshot {
   }
 }
 
-type Fn = () => void
-
 export class IframeModel {
   isSnapshotPinned: boolean = false
   originalState?: AutSnapshot
@@ -26,7 +24,6 @@ export class IframeModel {
   intervalId?: number
 
   constructor (
-    private state: MobxRunnerStore,
     private detachDom: () => AutSnapshot,
     private restoreDom: (snapshot: any) => void,
     private highlightEl: ({ body }: any, opts: any) => void,
@@ -41,18 +38,23 @@ export class IframeModel {
   }
 
   listen () {
-    this.eventManager.on('run:start', this.MobX.action('run:start', this._beforeRun))
-    this.eventManager.on('run:end', this.MobX.action('run:end', this._afterRun))
+    // this.eventManager.on('run:start', this.MobX.action('run:start', this._beforeRun))
+    this.eventManager.on('run:start', this._beforeRun)
+    // this.eventManager.on('run:end', this.MobX.action('run:end', this._afterRun))
+    this.eventManager.on('run:end', this._afterRun)
 
-    this.eventManager.on('viewport:changed', this.MobX.action('viewport:changed', this._updateViewport))
+    this.eventManager.on('viewport:changed', this._updateViewport)
     this.eventManager.on('config', this.MobX.action('config', (config: any) => {
       const { viewportWidth, viewportHeight } = config
 
       return this._updateViewport({ viewportHeight, viewportWidth })
     }))
 
-    this.eventManager.on('url:changed', this.MobX.action('url:changed', this._updateUrl))
-    this.eventManager.on('page:loading', this.MobX.action('page:loading', this._updateLoadingUrl))
+    const autStore = useAutStore()
+    this.eventManager.on('url:changed', (url: string) => {
+      autStore.updateUrl(url)
+    })
+    this.eventManager.on('page:loading', this._updateLoadingUrl)
 
     this.eventManager.on('show:snapshot', this.setSnapshots)
     this.eventManager.on('hide:snapshot', this._clearSnapshots)
@@ -63,45 +65,46 @@ export class IframeModel {
 
   _beforeRun = () => {
     const snapshotStore = useSnapshotStore()
+    const autStore = useAutStore()
 
-    this.state.isLoading = false
-    this.state.isRunning = true
-    this.state.resetUrl()
+    autStore.setIsLoading(false)
+    autStore.setIsRunning(true)
+    autStore.resetUrl()
+
     this.studio.selectorPlaygroundModel.setEnabled(false)
     this._reset()
     snapshotStore.clearMessage()
   }
 
   _afterRun = () => {
-    this.state.isRunning = false
+    const autStore = useAutStore()
+    autStore.setIsRunning(false)
   }
 
-  _updateViewport = ({ viewportWidth, viewportHeight }, cb?: Fn) => {
-    this.state.updateDimensions(viewportWidth, viewportHeight)
+  _updateViewport = ({ viewportWidth, viewportHeight }, cb?: () => void) => {
+    const autStore = useAutStore()
+    autStore.updateDimensions(viewportWidth, viewportHeight)
 
     if (cb) {
-      this.state.setViewportUpdatedCallback(cb)
+      autStore.setViewportUpdatedCallback(cb)
     }
-  }
-
-  _updateUrl = (url: string) => {
-    this.state.url = url
   }
 
   _updateLoadingUrl = (isLoadingUrl: boolean) => {
-    this.state.isLoadingUrl = isLoadingUrl
+    const autStore = useAutStore()
+    autStore.setIsLoadingUrl(isLoadingUrl)
   }
 
   setSnapshots = (snapshotProps: AutSnapshot) => {
-    const store = useSnapshotStore()
+    const snapshotStore = useSnapshotStore()
     const autStore = useAutStore()
 
-    if (store.isSnapshotPinned) {
+    if (snapshotStore.isSnapshotPinned) {
       return
     }
 
-    if (this.state.isRunning) {
-      return store.setTestsRunningError()
+    if (autStore.isRunning) {
+      return snapshotStore.setTestsRunningError()
     }
 
     if (this.studio.recorder.isOpen) {
@@ -112,7 +115,7 @@ export class IframeModel {
 
     if (!snapshots || !snapshots.length) {
       this._clearSnapshots()
-      store.setMissingSnapshotMessage()
+      snapshotStore.setMissingSnapshotMessage()
 
       return
     }
@@ -150,9 +153,9 @@ export class IframeModel {
 
   /// todo(lachlan): figure out shape of these two args
   _showSnapshotVue = (snapshot: any, snapshotProps: AutSnapshot) => {
-    const store = useSnapshotStore()
+    const snapshotStore = useSnapshotStore()
 
-    store.showSnapshot(snapshot.name)
+    snapshotStore.showSnapshot(snapshot.name)
     this._restoreDom(snapshot, snapshotProps)
   }
 
@@ -227,11 +230,15 @@ export class IframeModel {
   }
 
   _studioOpenError () {
-    this.state.messageTitle = 'Cannot show Snapshot while creating commands in Studio'
-    this.state.messageType = 'warning'
+    const snapshotStore = useSnapshotStore()
+    snapshotStore.setMessage(
+      'Cannot show Snapshot while creating commands in Studio',
+      'warning'
+    )
   }
 
   _storeOriginalState () {
+    const autStore = useAutStore()
     const finalSnapshot = this.detachDom()
 
     if (!finalSnapshot) return
@@ -243,11 +250,11 @@ export class IframeModel {
       htmlAttrs,
       snapshot: finalSnapshot,
       snapshots: [],
-      url: this.state.url,
+      url: autStore.url || '',
       // TODO: use same attr for both runner and runner-ct states.
       // these refer to the same thing - the viewport dimensions.
-      viewportWidth: this.state.width,
-      viewportHeight: this.state.height,
+      viewportWidth: autStore.viewportWidth,
+      viewportHeight: autStore.viewportHeight
     }
   }
 
@@ -256,8 +263,8 @@ export class IframeModel {
     this.intervalId = undefined
     this.originalState = undefined
 
-    const store = useSnapshotStore()
+    const snapshotStore = useSnapshotStore()
 
-    store.setSnapshotPinned(false)
+    snapshotStore.setSnapshotPinned(false)
   }
 }

--- a/packages/app/src/runner/index.ts
+++ b/packages/app/src/runner/index.ts
@@ -92,13 +92,6 @@ function setupRunner () {
     autStore.viewportUpdateCallback?.()
   }, { flush: 'post' })
 
-  window.UnifiedRunner.MobX.reaction(
-    () => [mobxRunnerStore.height, mobxRunnerStore.width],
-    () => {
-      mobxRunnerStore.viewportUpdateCallback?.()
-    },
-  )
-
   _autIframeModel = new AutIframe(
     'Test Project',
     window.UnifiedRunner.eventManager,

--- a/packages/app/src/runner/index.ts
+++ b/packages/app/src/runner/index.ts
@@ -14,13 +14,14 @@
  * namespace there, and access it with `window.UnifiedRunner`.
  *
  */
-import { getMobxRunnerStore } from '../store'
+import { getMobxRunnerStore, useAutStore } from '../store'
 import { injectBundle } from './injectBundle'
 import type { BaseSpec } from '@packages/types/src/spec'
 import { UnifiedReporterAPI } from './reporter'
 import { getRunnerElement, empty } from './utils'
 import { IframeModel } from './iframe-model'
 import { AutIframe } from './aut-iframe'
+import { watchEffect } from 'vue'
 
 const randomString = `${Math.random()}`
 
@@ -52,7 +53,6 @@ function createIframeModel () {
   const autIframe = getAutIframeModel()
   // IFrame Model to manage snapshots, etc.
   const iframeModel = new IframeModel(
-    getMobxRunnerStore(),
     autIframe.detachDom,
     autIframe.restoreDom,
     autIframe.highlightEl,
@@ -86,6 +86,12 @@ function setupRunner () {
   })
 
   window.UnifiedRunner.eventManager.start(window.UnifiedRunner.config)
+
+  const autStore = useAutStore()
+
+  watchEffect(() => {
+    autStore.viewportUpdateCallback?.()
+  }, { flush: 'post' })
 
   window.UnifiedRunner.MobX.reaction(
     () => [mobxRunnerStore.height, mobxRunnerStore.width],

--- a/packages/app/src/runner/index.ts
+++ b/packages/app/src/runner/index.ts
@@ -57,7 +57,6 @@ function createIframeModel () {
     autIframe.restoreDom,
     autIframe.highlightEl,
     window.UnifiedRunner.eventManager,
-    window.UnifiedRunner.MobX,
     {
       recorder: window.UnifiedRunner.studioRecorder,
       selectorPlaygroundModel: window.UnifiedRunner.selectorPlaygroundModel,

--- a/packages/app/src/runner/injectBundle.ts
+++ b/packages/app/src/runner/injectBundle.ts
@@ -31,6 +31,9 @@ export async function injectBundle () {
       const config = window.UnifiedRunner.decodeBase64(data.base64Config) as any
       const autStore = useAutStore()
 
+      // TODO(lachlan): use GraphQL to get the viewport dimensions
+      // once it is more practical to do so
+      // find out if we need to continue managing viewportWidth/viewportHeight in MobX at all.
       autStore.updateDimensions(config.viewportWidth, config.viewportHeight)
 
       window.UnifiedRunner.config = config
@@ -38,9 +41,6 @@ export async function injectBundle () {
       window.UnifiedRunner.MobX.runInAction(() => {
         const store = initializeMobxStore(window.UnifiedRunner.config.testingType)
 
-        // TODO(lachlan): use GraphQL to get and set the configuration once
-        // it is more practical to do so
-        // find out if we need to continue managing viewportWidth/viewportHeight in MobX at all.
         store.updateDimensions(config.viewportWidth, config.viewportHeight)
       })
 

--- a/packages/app/src/runner/injectBundle.ts
+++ b/packages/app/src/runner/injectBundle.ts
@@ -1,4 +1,4 @@
-import { initializeMobxStore } from '../store'
+import { initializeMobxStore, useAutStore } from '../store'
 
 export async function injectBundle () {
   const src = '/__cypress/runner/cypress_runner.js'
@@ -29,12 +29,18 @@ export async function injectBundle () {
       // just stick config on window until we figure out how we are
       // going to manage it
       const config = window.UnifiedRunner.decodeBase64(data.base64Config) as any
+      const autStore = useAutStore()
+
+      autStore.updateDimensions(config.viewportWidth, config.viewportHeight)
 
       window.UnifiedRunner.config = config
 
       window.UnifiedRunner.MobX.runInAction(() => {
         const store = initializeMobxStore(window.UnifiedRunner.config.testingType)
 
+        // TODO(lachlan): use GraphQL to get and set the configuration once
+        // it is more practical to do so
+        // find out if we need to continue managing viewportWidth/viewportHeight in MobX at all.
         store.updateDimensions(config.viewportWidth, config.viewportHeight)
       })
 

--- a/packages/app/src/spec/SnapshotMessage.vue
+++ b/packages/app/src/spec/SnapshotMessage.vue
@@ -13,12 +13,12 @@
 
 <script lang="ts" setup>
 import { computed } from 'vue'
-import type { SnapshotMessageDescription } from './snapshot-store'
+import type { SnapshotMessageType } from './snapshot-store'
 
 const props = withDefaults(defineProps<{
   messageTitle?: string
   messageDescription?: string
-  messageType?: SnapshotMessageDescription
+  messageType?: SnapshotMessageType
 }>(), {
   messageTitle: undefined,
   messageDescription: undefined,

--- a/packages/app/src/spec/SpecRunner.vue
+++ b/packages/app/src/spec/SpecRunner.vue
@@ -7,18 +7,19 @@
       <InlineSpecList :gql="props.gql" />
     </div>
 
+
     <div
       id="runner"
       :style="`width: ${runnerColumnWidth}px`"
       class="relative"
     >
+      <SpecRunnerHeader :gql="props.gql" />
       <div
         :id="RUNNER_ID"
         class="viewport origin-top-left"
         :style="viewportStyle"
       />
       <SnapshotControls :event-manager="eventManager" />
-      <div>Viewport: {{ viewportDimensions.width }}px x {{ viewportDimensions.height }}px</div>
     </div>
 
     <div
@@ -29,45 +30,34 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onBeforeUnmount, onMounted, reactive, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, watch } from 'vue'
 import { REPORTER_ID, RUNNER_ID, getRunnerElement, getReporterElement, empty } from '../runner/utils'
 import { gql } from '@urql/core'
 import type { SpecRunnerFragment } from '../generated/graphql'
 import InlineSpecList from '../specs/InlineSpecList.vue'
-import { getMobxRunnerStore } from '../store'
+import { useAutStore } from '../store'
 import { UnifiedRunnerAPI } from '../runner'
 import type { BaseSpec } from '@packages/types'
 import SnapshotControls from './SnapshotControls.vue'
+import SpecRunnerHeader from './SpecRunnerHeader.vue'
 
 gql`
 fragment SpecRunner on App {
   ...Specs_InlineSpecList
+  ...SpecRunnerHeader
 }
 `
 
 const runnerColumnWidth = 400
 const eventManager = window.UnifiedRunner.eventManager
 
-const mobxRunnerStore = getMobxRunnerStore()
-
-const viewportDimensions = reactive({
-  height: mobxRunnerStore.height,
-  width: mobxRunnerStore.width,
-})
-
-window.UnifiedRunner.MobX.reaction(
-  () => [mobxRunnerStore.height, mobxRunnerStore.width],
-  ([height, width]) => {
-    viewportDimensions.height = height
-    viewportDimensions.width = width
-  },
-)
+const autStore = useAutStore()
 
 const viewportStyle = computed(() => {
   return `
-  width: ${viewportDimensions.width}px;
-  height: ${viewportDimensions.height}px;
-  transform: scale(${runnerColumnWidth / viewportDimensions.width});`
+  width: ${autStore.viewportDimensions.width}px;
+  height: ${autStore.viewportDimensions.height}px;
+  transform: scale(${runnerColumnWidth / autStore.viewportDimensions.width});`
 })
 
 const props = defineProps<{

--- a/packages/app/src/spec/SpecRunner.vue
+++ b/packages/app/src/spec/SpecRunner.vue
@@ -7,7 +7,6 @@
       <InlineSpecList :gql="props.gql" />
     </div>
 
-
     <div
       id="runner"
       :style="`width: ${runnerColumnWidth}px`"

--- a/packages/app/src/spec/SpecRunnerHeader.spec.tsx
+++ b/packages/app/src/spec/SpecRunnerHeader.spec.tsx
@@ -1,0 +1,15 @@
+import SpecRunnerHeader from './SpecRunnerHeader.vue'
+import { useAutStore } from '../store'
+import { SpecRunnerHeaderFragmentDoc } from '../generated/graphql-test'
+
+describe('SpecRunnerHeader', () => {
+  it('renders', () => {
+    const autStore = useAutStore()
+    autStore.updateUrl('http://localhost:4000')
+    cy.mountFragment(SpecRunnerHeaderFragmentDoc, {
+      render: (gqlVal) => {
+        return <SpecRunnerHeader gql={gqlVal} />
+      }
+    })
+  })
+})

--- a/packages/app/src/spec/SpecRunnerHeader.spec.tsx
+++ b/packages/app/src/spec/SpecRunnerHeader.spec.tsx
@@ -5,11 +5,103 @@ import { SpecRunnerHeaderFragmentDoc } from '../generated/graphql-test'
 describe('SpecRunnerHeader', () => {
   it('renders', () => {
     const autStore = useAutStore()
+
     autStore.updateUrl('http://localhost:4000')
     cy.mountFragment(SpecRunnerHeaderFragmentDoc, {
       render: (gqlVal) => {
         return <SpecRunnerHeader gql={gqlVal} />
-      }
+      },
     })
+  })
+
+  it('disabled selector playground and studio buttons when isRunning is true', () => {
+    const autStore = useAutStore()
+
+    autStore.setIsRunning(true)
+
+    cy.mountFragment(SpecRunnerHeaderFragmentDoc, {
+      render: (gqlVal) => {
+        return <SpecRunnerHeader gql={gqlVal} />
+      },
+    })
+
+    cy.get('[data-cy="header-studio"]').should('be.disabled')
+    cy.get('[data-cy="header-selector"]').should('be.disabled')
+  })
+
+  it('disabled selector playground and studio buttons when isLoading is true', () => {
+    const autStore = useAutStore()
+
+    autStore.setIsLoading(true)
+
+    cy.mountFragment(SpecRunnerHeaderFragmentDoc, {
+      render: (gqlVal) => {
+        return <SpecRunnerHeader gql={gqlVal} />
+      },
+    })
+
+    cy.get('[data-cy="header-studio"]').should('be.disabled')
+    cy.get('[data-cy="header-selector"]').should('be.disabled')
+  })
+
+  it('enables selector playground and studio buttons by default', () => {
+    cy.mountFragment(SpecRunnerHeaderFragmentDoc, {
+      render: (gqlVal) => {
+        return <SpecRunnerHeader gql={gqlVal} />
+      },
+    })
+
+    cy.get('[data-cy="header-studio"]').should('not.be.disabled')
+    cy.get('[data-cy="header-selector"]').should('not.be.disabled')
+  })
+
+  it('shows url section if activeTestingType is e2e', () => {
+    const autStore = useAutStore()
+
+    autStore.updateUrl('http://localhost:3000')
+
+    cy.mountFragment(SpecRunnerHeaderFragmentDoc, {
+      onResult: (gql) => {
+        gql.activeTestingType = 'e2e'
+      },
+      render: (gqlVal) => {
+        return <SpecRunnerHeader gql={gqlVal} />
+      },
+    })
+
+    cy.get('[data-cy="aut-url"]').should('exist')
+  })
+
+  it('does not show url section if activeTestingType is component', () => {
+    const autStore = useAutStore()
+
+    autStore.updateUrl('http://localhost:3000')
+
+    cy.mountFragment(SpecRunnerHeaderFragmentDoc, {
+      onResult: (gql) => {
+        gql.activeTestingType = 'component'
+      },
+      render: (gqlVal) => {
+        return <SpecRunnerHeader gql={gqlVal} />
+      },
+    })
+
+    cy.get('[data-cy="aut-url"]').should('not.exist')
+  })
+
+  it('shows current browser and viewport', () => {
+    const autStore = useAutStore()
+
+    autStore.updateDimensions(555, 777)
+    cy.mountFragment(SpecRunnerHeaderFragmentDoc, {
+      onResult: (ctx) => {
+        ctx.selectedBrowser = ctx.browsers?.find((x) => x.displayName === 'Chrome') ?? null
+      },
+      render: (gqlVal) => {
+        return <SpecRunnerHeader gql={gqlVal} />
+      },
+    })
+
+    cy.get('[data-cy="select-browser"]').contains('Chrome 555x777')
   })
 })

--- a/packages/app/src/spec/SpecRunnerHeader.vue
+++ b/packages/app/src/spec/SpecRunnerHeader.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="flex text-xs">
+    <button :disabled="isDisabled">
+      Studio
+    </button>
+
+    <button :disabled="isDisabled">
+      Selector
+    </button>
+
+    <div class="rounded-md bg-white flex shadow-md mx-2 url px-4">
+      URL: {{ autStore.url }}
+    </div>
+
+    <Select
+      v-model="browser"
+      :options="browsers"
+      item-value="name"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue';
+import { useAutStore } from '../store';
+import Select from '@packages/frontend-shared/src/components/Select.vue'
+import { gql } from '@urql/vue'
+import type { SpecRunnerHeaderFragment } from '../generated/graphql';
+
+gql`
+fragment SpecRunnerHeader on App {
+  selectedBrowser {
+    id
+    displayName
+  }
+  browsers {
+    id
+    name
+    displayName
+  }
+}
+`
+
+const props = defineProps<{
+  gql: SpecRunnerHeaderFragment
+}>()
+
+const browser = computed(() => {
+  if (!props.gql.selectedBrowser) {
+    return 
+  }
+
+  const dimensions = `${autStore.viewportDimensions.width}x${autStore.viewportDimensions.height}`
+
+  return {
+    id: props.gql.selectedBrowser.id,
+    name: `${props.gql.selectedBrowser.displayName} ${dimensions}`
+  }
+})
+
+const browsers = computed(() => props.gql.browsers?.slice() ?? [])
+
+const autStore = useAutStore()
+
+const isDisabled = computed(() => autStore.isRunning || autStore.isLoading)
+</script>
+
+<style scoped lang="scss">
+button, .url {
+  @apply rounded-md bg-white flex shadow-md ml-2;
+  @apply flex items-center justify-center;
+}
+
+button {
+  @apply w-20 hover:bg-gray-50;
+}
+</style>

--- a/packages/app/src/spec/SpecRunnerHeader.vue
+++ b/packages/app/src/spec/SpecRunnerHeader.vue
@@ -8,9 +8,19 @@
       Selector
     </button>
 
-    <div class="rounded-md bg-white flex shadow-md mx-2 url px-4">
-      URL: {{ autStore.url }}
+    <div
+      class="rounded-md flex shadow-md mx-2 url px-4"
+      :class="{
+        'bg-yellow-50': autStore.isLoadingUrl,
+        'bg-white': !autStore.isLoadingUrl,
+      }"
+    >
+      <div>
+        {{ autStore.url }}
+      </div>
     </div>
+
+    <div>Loading URL: {{ autStore.isLoadingUrl }}</div>
 
     <Select
       v-model="browser"
@@ -21,11 +31,11 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue';
-import { useAutStore } from '../store';
+import { computed } from 'vue'
+import { useAutStore } from '../store'
 import Select from '@packages/frontend-shared/src/components/Select.vue'
 import { gql } from '@urql/vue'
-import type { SpecRunnerHeaderFragment } from '../generated/graphql';
+import type { SpecRunnerHeaderFragment } from '../generated/graphql'
 
 gql`
 fragment SpecRunnerHeader on App {
@@ -47,14 +57,14 @@ const props = defineProps<{
 
 const browser = computed(() => {
   if (!props.gql.selectedBrowser) {
-    return 
+    return
   }
 
   const dimensions = `${autStore.viewportDimensions.width}x${autStore.viewportDimensions.height}`
 
   return {
     id: props.gql.selectedBrowser.id,
-    name: `${props.gql.selectedBrowser.displayName} ${dimensions}`
+    name: `${props.gql.selectedBrowser.displayName} ${dimensions}`,
   }
 })
 
@@ -67,11 +77,11 @@ const isDisabled = computed(() => autStore.isRunning || autStore.isLoading)
 
 <style scoped lang="scss">
 button, .url {
-  @apply rounded-md bg-white flex shadow-md ml-2;
   @apply flex items-center justify-center;
 }
 
 button {
+  @apply rounded-md bg-white flex shadow-md ml-2;
   @apply w-20 hover:bg-gray-50;
 }
 </style>

--- a/packages/app/src/spec/SpecRunnerHeader.vue
+++ b/packages/app/src/spec/SpecRunnerHeader.vue
@@ -1,14 +1,23 @@
 <template>
   <div class="flex text-xs">
-    <button :disabled="isDisabled">
+    <button
+      data-cy="header-studio"
+      :disabled="isDisabled"
+    >
       Studio
     </button>
 
-    <button :disabled="isDisabled">
+    <button
+      data-cy="header-selector"
+      :disabled="isDisabled"
+    >
       Selector
     </button>
 
-    <template v-if="props.gql.activeTestingType">
+    <div
+      v-if="props.gql.activeTestingType === 'e2e'"
+      data-cy="aut-url"
+    >
       <div
         class="rounded-md flex shadow-md mx-2 url px-4"
         :class="{
@@ -22,10 +31,11 @@
       </div>
 
       <div>Loading URL: {{ autStore.isLoadingUrl }}</div>
-    </template>
+    </div>
 
     <Select
       v-model="browser"
+      data-cy="select-browser"
       :options="browsers"
       item-value="name"
     />

--- a/packages/app/src/spec/SpecRunnerHeader.vue
+++ b/packages/app/src/spec/SpecRunnerHeader.vue
@@ -8,19 +8,21 @@
       Selector
     </button>
 
-    <div
-      class="rounded-md flex shadow-md mx-2 url px-4"
-      :class="{
-        'bg-yellow-50': autStore.isLoadingUrl,
-        'bg-white': !autStore.isLoadingUrl,
-      }"
-    >
-      <div>
-        {{ autStore.url }}
+    <template v-if="props.gql.activeTestingType">
+      <div
+        class="rounded-md flex shadow-md mx-2 url px-4"
+        :class="{
+          'bg-yellow-50': autStore.isLoadingUrl,
+          'bg-white': !autStore.isLoadingUrl,
+        }"
+      >
+        <div>
+          {{ autStore.url }}
+        </div>
       </div>
-    </div>
 
-    <div>Loading URL: {{ autStore.isLoadingUrl }}</div>
+      <div>Loading URL: {{ autStore.isLoadingUrl }}</div>
+    </template>
 
     <Select
       v-model="browser"
@@ -39,6 +41,8 @@ import type { SpecRunnerHeaderFragment } from '../generated/graphql'
 
 gql`
 fragment SpecRunnerHeader on App {
+  activeTestingType
+
   selectedBrowser {
     id
     displayName

--- a/packages/app/src/spec/snapshot-store.ts
+++ b/packages/app/src/spec/snapshot-store.ts
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia'
 import type { AutSnapshot } from '../runner/iframe-model'
 import { getAutIframeModel } from '../runner'
 
-export type SnapshotMessageDescription = 'info' | 'warning' | 'pinned'
+export type SnapshotMessageType = 'info' | 'warning'
 
 interface SnapshotStoreState {
   messageTitle?: string
@@ -110,6 +110,11 @@ export const useSnapshotStore = defineStore({
     setTestsRunningError () {
       this.messageTitle = 'Cannot show Snapshot while tests are running'
       this.messageType = 'warning'
+    },
+
+    setMessage (messageTitle: string, messageType: SnapshotMessageType) {
+      this.messageTitle = messageTitle
+      this.messageType = messageType
     },
 
     setMissingSnapshotMessage () {

--- a/packages/app/src/spec/snapshot-store.ts
+++ b/packages/app/src/spec/snapshot-store.ts
@@ -2,12 +2,12 @@ import { defineStore } from 'pinia'
 import type { AutSnapshot } from '../runner/iframe-model'
 import { getAutIframeModel } from '../runner'
 
-export type SnapshotMessageType = 'info' | 'warning'
+export type SnapshotMessageType = 'info' | 'warning' | 'pinned'
 
 interface SnapshotStoreState {
   messageTitle?: string
   messageDescription?: 'pinned' | string
-  messageType?: 'info' | 'warning'
+  messageType?: SnapshotMessageType
   snapshotProps?: AutSnapshot
   isSnapshotPinned: boolean
   snapshot?: {

--- a/packages/app/src/store/aut-store.ts
+++ b/packages/app/src/store/aut-store.ts
@@ -8,7 +8,7 @@ interface AutStoreState {
   isLoadingUrl: boolean
   isLoading: boolean
   isRunning: boolean
-  viewportUpdateCallback: (() => void)  | null
+  viewportUpdateCallback: (() => void) | null
 }
 
 export const useAutStore = defineStore({
@@ -23,7 +23,7 @@ export const useAutStore = defineStore({
       viewportWidth: 1000,
       isLoading: false,
       isRunning: false,
-      viewportUpdateCallback: null
+      viewportUpdateCallback: null,
     }
   },
 
@@ -61,7 +61,7 @@ export const useAutStore = defineStore({
       this.url = undefined
       this.highlightUrl = false
       this.isLoadingUrl = false
-    }
+    },
   },
 
   getters: {
@@ -70,6 +70,6 @@ export const useAutStore = defineStore({
         height: state.viewportHeight,
         width: state.viewportWidth,
       }
-    }
-  }
+    },
+  },
 })

--- a/packages/app/src/store/aut-store.ts
+++ b/packages/app/src/store/aut-store.ts
@@ -1,23 +1,75 @@
 import { defineStore } from 'pinia'
 
 interface AutStoreState {
-  highlightUrl: boolean
   url?: string
+  highlightUrl: boolean
+  viewportWidth: number
+  viewportHeight: number
+  isLoadingUrl: boolean
+  isLoading: boolean
+  isRunning: boolean
+  viewportUpdateCallback: (() => void)  | null
 }
 
 export const useAutStore = defineStore({
   id: 'aut-store',
   state: (): AutStoreState => {
+    // TODO(lachlan): depends on CT or E2E, should seed accordingly using `config`
     return {
+      isLoadingUrl: false,
       highlightUrl: false,
+      url: undefined,
+      viewportHeight: 660,
+      viewportWidth: 1000,
+      isLoading: false,
+      isRunning: false,
+      viewportUpdateCallback: null
     }
   },
+
   actions: {
     setHighlightUrl (highlightUrl: boolean) {
       this.highlightUrl = highlightUrl
     },
+
     updateUrl (url?: string) {
       this.url = url
     },
+
+    updateDimensions (viewportWidth: number, viewportHeight: number) {
+      this.viewportHeight = viewportHeight
+      this.viewportWidth = viewportWidth
+    },
+
+    setViewportUpdatedCallback (cb: () => void) {
+      this.viewportUpdateCallback = cb
+    },
+
+    setIsLoadingUrl (isLoadingUrl: boolean) {
+      this.isLoadingUrl = isLoadingUrl
+    },
+
+    setIsRunning (isRunning: boolean) {
+      this.isRunning = isRunning
+    },
+
+    setIsLoading (isLoading: boolean) {
+      this.isLoading = isLoading
+    },
+
+    resetUrl () {
+      this.url = undefined
+      this.highlightUrl = false
+      this.isLoadingUrl = false
+    }
   },
+
+  getters: {
+    viewportDimensions (state) {
+      return {
+        height: state.viewportHeight,
+        width: state.viewportWidth,
+      }
+    }
+  }
 })

--- a/packages/frontend-shared/src/components/Select.vue
+++ b/packages/frontend-shared/src/components/Select.vue
@@ -139,6 +139,12 @@
   </Listbox>
 </template>
 
+<script lang="ts">
+export default {
+  inheritAttrs: true,
+}
+</script>
+
 <script lang="ts" setup>
 import { Listbox, ListboxButton, ListboxLabel, ListboxOption, ListboxOptions } from '@headlessui/vue'
 import IconCheck from '~icons/mdi/check'


### PR DESCRIPTION
This PR creates a bare-bones header for the AUT IFrame, and hooks up the relevant events between the event manager, driver, and Vue layer. It eliminates much of the MobX/React layer.

It's not styled yet, that will be done separately. It updates the URL, load state and viewport depending as the tests run. It has some basic component tests, but full integration tests will need to wait until some infrastructure updates are in, namely the ability to have a test-by-test isolated event manager.

![image](https://user-images.githubusercontent.com/19196536/139186505-ffc63941-5847-45f2-818a-adec283469be.png)

If you want to try it out (be aware the unified runner is still a WIP):

- launch app or launchpad (e2e or CT)
- go to `/__vite__/` endpoint
- click "specs" on the side nav
- choose a spec

Done: 

- [x] Not using MobX in `iframe-model.ts`
- [x] Avoid need to listen to MobX Store in unified app, instead watch Pinia stores where needed
- [x] Should show button for selector playground
- [x] Should should url (e2e only)
- [x] Should set url loading state when loading (e2e only)
- [x] Should show current browser
- [x] Should show viewport height/width
- [x] Should have dropdown showing other browsers
- [ ] Show placeholder button for studio and selector playground

TODO in separate PR:

- [ ] Actually relaunch browser when selecting from dropdown
- [ ] Hook up Cypress Studio
- [ ] Hook up Selector playground
