### PR TITLE
fix(@cypress/react): throw if using Next.js swc-loader without nodeVersion=system

### DIFF
--- a/npm/react/plugins/next/checkSWC.ts
+++ b/npm/react/plugins/next/checkSWC.ts
@@ -1,0 +1,19 @@
+import type { Configuration } from 'webpack'
+
+export function checkSWC (
+  webpackConfig: Configuration,
+  cypressConfig: Cypress.Config,
+) {
+  const hasSWCLoader = webpackConfig.module?.rules.some((rule) => {
+    return rule.oneOf?.some(
+      (oneOf) => (oneOf.use as any)?.loader === 'next-swc-loader'
+    )
+  })
+
+  if (hasSWCLoader && cypressConfig.nodeVersion !== 'system') {
+    throw new Error(`Cypress requires "nodeVersion" to be set to "system" in order to run Next.js with SWC optimizations.
+Please add "nodeVersion": "system" to your cypress config and try again.`)
+  }
+
+  return false
+}

--- a/npm/react/plugins/next/checkSWC.ts
+++ b/npm/react/plugins/next/checkSWC.ts
@@ -12,7 +12,7 @@ export function checkSWC (
 
   if (hasSWCLoader && cypressConfig.nodeVersion !== 'system') {
     throw new Error(`Cypress requires "nodeVersion" to be set to "system" in order to run Next.js with SWC optimizations.
-Please add "nodeVersion": "system" to your cypress config and try again.`)
+Please add "nodeVersion": "system" to your Cypress configuration and try again.`)
   }
 
   return false

--- a/npm/react/plugins/next/findNextWebpackConfig.js
+++ b/npm/react/plugins/next/findNextWebpackConfig.js
@@ -4,6 +4,7 @@ const debug = require('debug')('@cypress/react')
 const getNextJsBaseWebpackConfig = require('next/dist/build/webpack-config').default
 const { findPagesDir } = require('../../dist/next/findPagesDir')
 const { getRunWebpackSpan } = require('../../dist/next/getRunWebpackSpan')
+const { checkSWC } = require('../../dist/next/checkSWC')
 
 async function getNextWebpackConfig (config) {
   let loadConfig
@@ -37,6 +38,8 @@ async function getNextWebpackConfig (config) {
   )
 
   debug('resolved next.js webpack config %o', nextWebpackConfig)
+
+  checkSWC(nextWebpackConfig, config)
 
   return nextWebpackConfig
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->
`cypress/react/plugins/next` will throw if using Next.js 12 SWC optimizations without having `"nodeVersion": system` in cypress config

### Additional details
With Next.js v12, javascript/typescript is compiled with [SWC](https://github.com/swc-project/swc) by default. When compiling with Cypress, the build will fail unless `"nodeVersion": "system"` is configured due to how Cypress' version of node can't sign the swc package.
![Screen Shot 2021-10-27 at 1 05 26 PM](https://user-images.githubusercontent.com/25158820/139297534-c9635f9c-dec7-48a0-abed-8a89ad5facca.png)

This is a stop-gap until `"node-version": "system"` becomes the default. https://github.com/cypress-io/cypress/issues/18684

### How has the user experience changed?
Users that are using Next.js v12 with SCW optimizations that have not added `"nodeVersion": "system"` to their cypress config will have their build fail with a message telling the user how to fix the issue.

### Testing
I tested this by creating a fresh `create-next-app` and using the build result of `yarn workspace @cypress/react build`. Here is a branch within the [cypress-component-testing-examples](https://github.com/cypress-io/cypress-component-testing-examples/tree/next-12-error) repo. You have to copy the content of both `npm/react/dist` and `npm/react/plugins` into your local node_modules `@cypress/react` to test the new code. Rust optimizations can be enabled by deleting the `.babelrc`.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
