### PR TITLE
fix: remove outdated registry link

### DIFF
--- a/npm/cypress-schematic/package.json
+++ b/npm/cypress-schematic/package.json
@@ -50,8 +50,7 @@
     "testing"
   ],
   "publishConfig": {
-    "access": "public",
-    "registry": "http://registry.npmjs.org/"
+    "access": "public"
   },
   "builders": "./src/builders/builders.json",
   "ng-add": {

--- a/npm/react/package.json
+++ b/npm/react/package.json
@@ -178,8 +178,7 @@
     }
   },
   "publishConfig": {
-    "access": "public",
-    "registry": "http://registry.npmjs.org/"
+    "access": "public"
   },
   "standard": {
     "globals": [

--- a/npm/vue/package.json
+++ b/npm/vue/package.json
@@ -102,7 +102,6 @@
     }
   },
   "publishConfig": {
-    "access": "public",
-    "registry": "http://registry.npmjs.org/"
+    "access": "public"
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
NA

### Additional details
[NPM announcement](https://github.blog/2021-08-23-npm-registry-deprecating-tls-1-0-tls-1-1/)
Our recent [semantic-release build](https://app.circleci.com/pipelines/github/cypress-io/cypress/25624/workflows/007c84af-acfc-465f-b65c-b415215ce259/jobs/967757) failed (though it still shows as green...). Some of our packages were pointing to an outdated registry (`http`). The default registry is `https` so removing it will point to the updated registry.

![Screen Shot 2021-10-29 at 3 38 23 PM](https://user-images.githubusercontent.com/25158820/139498993-503d725d-68e6-4928-9ecd-93bf3d59cd79.png)

### How has the user experience changed?
NA

### PR Tasks
NA

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
