### PR TITLE
chore: refactor `create` into class `$Cy`

### DIFF
--- a/packages/driver/cypress/integration/cy/snapshot_css_spec.js
+++ b/packages/driver/cypress/integration/cy/snapshot_css_spec.js
@@ -1,5 +1,5 @@
 const { $ } = Cypress
-const $SnapshotsCss = require('../../../src/cy/snapshots_css').default
+const { create } = require('../../../src/cy/snapshots_css')
 
 const normalizeStyles = (styles) => {
   return styles
@@ -17,7 +17,7 @@ describe('driver/src/cy/snapshots_css', () => {
   let snapshotCss
 
   beforeEach(() => {
-    snapshotCss = $SnapshotsCss.create(cy.$$, cy.state)
+    snapshotCss = create(cy.$$, cy.state)
 
     cy.viewport(400, 600)
     cy.visit('/fixtures/generic.html').then(() => {

--- a/packages/driver/cypress/integration/cy/timeouts_spec.js
+++ b/packages/driver/cypress/integration/cy/timeouts_spec.js
@@ -1,4 +1,4 @@
-import Timeouts from '@packages/driver/src/cy/timeouts'
+import { create } from '@packages/driver/src/cy/timeouts'
 
 describe('driver/src/cy/timeouts', () => {
   beforeEach(() => {
@@ -7,7 +7,7 @@ describe('driver/src/cy/timeouts', () => {
 
   it('creates timeout and clearTimeout props', () => {
     const state = cy.state('window')
-    const timeouts = Timeouts.create(state)
+    const timeouts = create(state)
 
     expect(timeouts).to.have.property('timeout')
     expect(timeouts).to.have.property('clearTimeout')
@@ -16,7 +16,7 @@ describe('driver/src/cy/timeouts', () => {
   context('timeout', () => {
     it('throws when no runnable', () => {
       const state = () => { }
-      const timeouts = Timeouts.create(state)
+      const timeouts = create(state)
 
       const fn = () => {
         return timeouts.timeout(0)
@@ -31,7 +31,7 @@ describe('driver/src/cy/timeouts', () => {
   context('clearTimeout', () => {
     it('throws when no runnable', () => {
       const state = () => { }
-      const timeouts = Timeouts.create(state)
+      const timeouts = create(state)
 
       const fn = () => {
         return timeouts.clearTimeout()

--- a/packages/driver/src/cy/aliases.ts
+++ b/packages/driver/src/cy/aliases.ts
@@ -12,133 +12,112 @@ const aliasDisplayName = (name) => {
   return name.replace(aliasDisplayRe, '')
 }
 
-const getXhrTypeByAlias = (alias) => {
-  if (requestXhrRe.test(alias)) {
-    return 'request'
-  }
+// eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
+export const create = (cy) => ({
+  addAlias (ctx, aliasObj) {
+    const { alias, subject } = aliasObj
 
-  return 'response'
-}
+    const aliases = cy.state('aliases') || {}
 
-const validateAlias = (alias: string) => {
-  if (!_.isString(alias)) {
-    $errUtils.throwErrByPath('as.invalid_type')
-  }
+    aliases[alias] = aliasObj
+    cy.state('aliases', aliases)
 
-  if (aliasDisplayRe.test(alias)) {
-    $errUtils.throwErrByPath('as.invalid_first_token', {
-      args: {
-        alias,
-        suggestedName: alias.replace(aliasDisplayRe, ''),
-      },
-    })
-  }
+    const remoteSubject = cy.getRemotejQueryInstance(subject)
 
-  if (_.isEmpty(alias)) {
-    $errUtils.throwErrByPath('as.empty_string')
-  }
+    ctx[alias] = remoteSubject ?? subject
+  },
 
-  if (reserved.includes(alias)) {
-    return $errUtils.throwErrByPath('as.reserved_word', { args: { alias } })
-  }
+  getAlias (name, cmd, log) {
+    const aliases = cy.state('aliases') || {}
 
-  return null
-}
-
-export default {
-  create: (cy) => {
-    const addAlias = (ctx, aliasObj) => {
-      const { alias, subject } = aliasObj
-
-      const aliases = cy.state('aliases') || {}
-
-      aliases[alias] = aliasObj
-      cy.state('aliases', aliases)
-
-      const remoteSubject = cy.getRemotejQueryInstance(subject)
-
-      ctx[alias] = remoteSubject ?? subject
+    // bail if the name doesnt reference an alias
+    if (!aliasRe.test(name)) {
+      return
     }
 
-    const getNextAlias = () => {
-      const next = cy.state('current').get('next')
+    const alias = aliases[name.slice(1)]
 
-      if (next && (next.get('name') === 'as')) {
-        return next.get('args')[0]
-      }
+    // slice off the '@'
+    if (!alias) {
+      this.aliasNotFoundFor(name, cmd, log)
     }
 
-    const getAlias = (name, cmd, log) => {
-      const aliases = cy.state('aliases') || {}
+    return alias
+  },
 
-      // bail if the name doesnt reference an alias
-      if (!aliasRe.test(name)) {
-        return
-      }
+  // below are public because its expected other commands
+  // know about them and are expected to call them
 
-      const alias = aliases[name.slice(1)]
+  getNextAlias () {
+    const next = cy.state('current').get('next')
 
-      // slice off the '@'
-      if (!alias) {
-        aliasNotFoundFor(name, cmd, log)
-      }
+    if (next && (next.get('name') === 'as')) {
+      return next.get('args')[0]
+    }
+  },
 
-      return alias
+  validateAlias (alias: string) {
+    if (!_.isString(alias)) {
+      $errUtils.throwErrByPath('as.invalid_type')
     }
 
-    const getAvailableAliases = () => {
-      const aliases = cy.state('aliases')
-
-      if (!aliases) {
-        return []
-      }
-
-      return _.keys(aliases)
-    }
-
-    const aliasNotFoundFor = (name, cmd, log) => {
-      let displayName
-      const availableAliases = getAvailableAliases()
-
-      // throw a very specific error if our alias isnt in the right
-      // format, but its word is found in the availableAliases
-      if (!aliasRe.test(name) && availableAliases.includes(name)) {
-        displayName = aliasDisplayName(name)
-        $errUtils.throwErrByPath('alias.invalid', {
-          onFail: log,
-          args: { name, displayName },
-        })
-      }
-
-      cmd = cmd ?? ((log && log.get('name')) || cy.state('current').get('name'))
-      displayName = aliasDisplayName(name)
-
-      const errPath = availableAliases.length
-        ? 'alias.not_registered_with_available'
-        : 'alias.not_registered_without_available'
-
-      return $errUtils.throwErrByPath(errPath, {
-        onFail: log,
-        args: { cmd, displayName, availableAliases: availableAliases.join(', ') },
+    if (aliasDisplayRe.test(alias)) {
+      $errUtils.throwErrByPath('as.invalid_first_token', {
+        args: {
+          alias,
+          suggestedName: alias.replace(aliasDisplayRe, ''),
+        },
       })
     }
 
-    return {
-      getAlias,
-
-      addAlias,
-
-      // these are public because its expected other commands
-      // know about them and are expected to call them
-      getNextAlias,
-
-      validateAlias,
-
-      aliasNotFoundFor,
-
-      getXhrTypeByAlias,
-
-      getAvailableAliases,
+    if (_.isEmpty(alias)) {
+      $errUtils.throwErrByPath('as.empty_string')
     }
+
+    if (reserved.includes(alias)) {
+      return $errUtils.throwErrByPath('as.reserved_word', { args: { alias } })
+    }
+
+    return null
   },
-}
+
+  aliasNotFoundFor (name, cmd, log) {
+    const availableAliases = cy.state('aliases')
+      ? _.keys(cy.state('aliases'))
+      : []
+
+    let displayName
+
+    // throw a very specific error if our alias isnt in the right
+    // format, but its word is found in the availableAliases
+    if (!aliasRe.test(name) && availableAliases.includes(name)) {
+      displayName = aliasDisplayName(name)
+      $errUtils.throwErrByPath('alias.invalid', {
+        onFail: log,
+        args: { name, displayName },
+      })
+    }
+
+    cmd = cmd ?? ((log && log.get('name')) || cy.state('current').get('name'))
+    displayName = aliasDisplayName(name)
+
+    const errPath = availableAliases.length
+      ? 'alias.not_registered_with_available'
+      : 'alias.not_registered_without_available'
+
+    return $errUtils.throwErrByPath(errPath, {
+      onFail: log,
+      args: { cmd, displayName, availableAliases: availableAliases.join(', ') },
+    })
+  },
+
+  getXhrTypeByAlias (alias) {
+    if (requestXhrRe.test(alias)) {
+      return 'request'
+    }
+
+    return 'response'
+  },
+})
+
+export interface IAliases extends ReturnType<typeof create> {}

--- a/packages/driver/src/cy/aliases.ts
+++ b/packages/driver/src/cy/aliases.ts
@@ -75,7 +75,7 @@ export const create = (cy) => ({
     }
 
     if (reserved.includes(alias)) {
-      return $errUtils.throwErrByPath('as.reserved_word', { args: { alias } })
+      $errUtils.throwErrByPath('as.reserved_word', { args: { alias } })
     }
 
     return null
@@ -105,7 +105,7 @@ export const create = (cy) => ({
       ? 'alias.not_registered_with_available'
       : 'alias.not_registered_without_available'
 
-    return $errUtils.throwErrByPath(errPath, {
+    $errUtils.throwErrByPath(errPath, {
       onFail: log,
       args: { cmd, displayName, availableAliases: availableAliases.join(', ') },
     })

--- a/packages/driver/src/cy/assertions.ts
+++ b/packages/driver/src/cy/assertions.ts
@@ -514,7 +514,7 @@ export const create = (Cypress, cy) => {
     },
 
     assert (...args) {
-      // if we've temporarily overriden assertions
+      // if we've temporarily overridden assertions
       // then just bail early with this function
       const fn = cy.state('overrideAssert') || assertFn
 

--- a/packages/driver/src/cy/assertions.ts
+++ b/packages/driver/src/cy/assertions.ts
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 import _ from 'lodash'
 import Promise from 'bluebird'
 
@@ -48,6 +50,8 @@ const isDomSubjectAndMatchesValue = (value, subject) => {
     // and that all the els are the same
     return isDomTypeFn(subject) && allElsAreTheSame()
   }
+
+  return false
 }
 
 // Rules:

--- a/packages/driver/src/cy/assertions.ts
+++ b/packages/driver/src/cy/assertions.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 import _ from 'lodash'
 import Promise from 'bluebird'
 
@@ -71,74 +69,153 @@ const parseValueActualAndExpected = (value, actual, expected) => {
   return obj
 }
 
-export default {
-  create (Cypress, cy) {
-    const getUpcomingAssertions = () => {
-      const index = cy.state('index') + 1
+export const create = (Cypress, cy) => {
+  const getUpcomingAssertions = () => {
+    const index = cy.state('index') + 1
 
-      const assertions = []
+    const assertions = []
 
-      // grab the rest of the queue'd commands
-      for (let cmd of cy.queue.slice(index)) {
-        // don't break on utilities, just skip over them
-        if (cmd.is('utility')) {
-          continue
-        }
-
-        // grab all of the queued commands which are
-        // assertions and match our current chainerId
-        if (cmd.is('assertion')) {
-          assertions.push(cmd)
-        } else {
-          break
-        }
+    // grab the rest of the queue'd commands
+    for (let cmd of cy.queue.slice(index)) {
+      // don't break on utilities, just skip over them
+      if (cmd.is('utility')) {
+        continue
       }
 
-      return assertions
+      // grab all of the queued commands which are
+      // assertions and match our current chainerId
+      if (cmd.is('assertion')) {
+        assertions.push(cmd)
+      } else {
+        break
+      }
     }
 
-    const injectAssertionFns = (cmds) => {
-      return _.map(cmds, injectAssertion)
+    return assertions
+  }
+
+  const injectAssertionFns = (cmds) => {
+    return _.map(cmds, injectAssertion)
+  }
+
+  const injectAssertion = (cmd) => {
+    return ((subject) => {
+      // set assertions to itself or empty array
+      if (!cmd.get('assertions')) {
+        cmd.set('assertions', [])
+      }
+
+      // reset the assertion index back to 0
+      // so we can track assertions and merge
+      // them up with existing ones
+      cmd.set('assertionIndex', 0)
+
+      if (cy.state('current') != null) {
+        cy.state('current').set('currentAssertionCommand', cmd)
+      }
+
+      return cmd.get('fn').originalFn.apply(
+        cy.state('ctx'),
+        [subject].concat(cmd.get('args')),
+      )
+    })
+  }
+
+  const assertFn = (passed, message, value, actual, expected, error, verifying = false) => {
+    // slice off everything after a ', but' or ' but ' for passing assertions, because
+    // otherwise it doesn't make sense:
+    // "expected <div> to have a an attribute 'href', but it was 'href'"
+    if (message && passed && butRe.test(message)) {
+      message = message.substring(0, message.search(butRe))
     }
 
-    const injectAssertion = (cmd) => {
-      return ((subject) => {
-        // set assertions to itself or empty array
-        if (!cmd.get('assertions')) {
-          cmd.set('assertions', [])
-        }
-
-        // reset the assertion index back to 0
-        // so we can track assertions and merge
-        // them up with existing ones
-        cmd.set('assertionIndex', 0)
-
-        if (cy.state('current') != null) {
-          cy.state('current').set('currentAssertionCommand', cmd)
-        }
-
-        return cmd.get('fn').originalFn.apply(
-          cy.state('ctx'),
-          [subject].concat(cmd.get('args')),
-        )
-      })
+    if (value && value.isSinonProxy) {
+      message = message.replace(stackTracesRe, '\n')
     }
 
-    const finishAssertions = (assertions) => {
-      return _.each(assertions, (log) => {
-        log.snapshot()
+    let obj = parseValueActualAndExpected(value, actual, expected)
 
-        const e = log.get('_error')
-
-        if (e) {
-          return log.error(e)
-        }
-
-        return log.end()
-      })
+    if ($dom.isElement(value)) {
+      obj.$el = $dom.wrap(value)
     }
 
-    const verifyUpcomingAssertions = function (subject, options = {}, callbacks = {}) {
+    // if we are simply verifying the upcoming
+    // assertions then do not immediately end or snapshot
+    // else do
+    if (verifying) {
+      obj._error = error
+    } else {
+      obj.end = true
+      obj.snapshot = true
+      obj.error = error
+    }
+
+    const isChildLike = (subject, current) => {
+      return (value === subject) ||
+        isDomSubjectAndMatchesValue(value, subject) ||
+        // if our current command is an assertion type
+        isAssertionType(current) ||
+        // are we currently verifying assertions?
+        (cy.state('upcomingAssertions') && cy.state('upcomingAssertions').length > 0) ||
+        // did the function have arguments
+        functionHadArguments(current)
+    }
+
+    _.extend(obj, {
+      name: 'assert',
+      // end:      true
+      // snapshot: true
+      message,
+      passed,
+      selector: value ? value.selector : undefined,
+      timeout: 0,
+      type (current, subject) {
+        // if our current command has arguments assume
+        // we are an assertion that's involving the current
+        // subject or our value is the current subject
+        return isChildLike(subject, current) ? 'child' : 'parent'
+      },
+
+      consoleProps: () => {
+        obj = { Command: 'assert' }
+
+        _.extend(obj, parseValueActualAndExpected(value, actual, expected))
+
+        return _.extend(obj,
+          { Message: message.replace(bTagOpen, '').replace(bTagClosed, '') })
+      },
+    })
+
+    // think about completely gutting the whole object toString
+    // which chai does by default, its so ugly and worthless
+
+    if (error) {
+      error.onFail = (err) => { }
+    }
+
+    Cypress.log(obj)
+
+    return null
+  }
+
+  const finishAssertions = (assertions) => {
+    return _.each(assertions, (log) => {
+      log.snapshot()
+
+      const e = log.get('_error')
+
+      if (e) {
+        return log.error(e)
+      }
+
+      return log.end()
+    })
+  }
+
+  return {
+    finishAssertions,
+
+    verifyUpcomingAssertions (subject, options = {}, callbacks = {}) {
       const cmds = getUpcomingAssertions()
 
       cy.state('upcomingAssertions', cmds)
@@ -430,99 +507,19 @@ export default {
         throw err
       })
       .catch(onFailFn)
-    }
+    },
 
-    const assertFn = (passed, message, value, actual, expected, error, verifying = false) => {
-      // slice off everything after a ', but' or ' but ' for passing assertions, because
-      // otherwise it doesn't make sense:
-      // "expected <div> to have a an attribute 'href', but it was 'href'"
-      if (message && passed && butRe.test(message)) {
-        message = message.substring(0, message.search(butRe))
-      }
-
-      if (value && value.isSinonProxy) {
-        message = message.replace(stackTracesRe, '\n')
-      }
-
-      let obj = parseValueActualAndExpected(value, actual, expected)
-
-      if ($dom.isElement(value)) {
-        obj.$el = $dom.wrap(value)
-      }
-
-      // if we are simply verifying the upcoming
-      // assertions then do not immediately end or snapshot
-      // else do
-      if (verifying) {
-        obj._error = error
-      } else {
-        obj.end = true
-        obj.snapshot = true
-        obj.error = error
-      }
-
-      const isChildLike = (subject, current) => {
-        return (value === subject) ||
-          isDomSubjectAndMatchesValue(value, subject) ||
-          // if our current command is an assertion type
-          isAssertionType(current) ||
-          // are we currently verifying assertions?
-          (cy.state('upcomingAssertions') && cy.state('upcomingAssertions').length > 0) ||
-          // did the function have arguments
-          functionHadArguments(current)
-      }
-
-      _.extend(obj, {
-        name: 'assert',
-        // end:      true
-        // snapshot: true
-        message,
-        passed,
-        selector: value ? value.selector : undefined,
-        timeout: 0,
-        type (current, subject) {
-          // if our current command has arguments assume
-          // we are an assertion that's involving the current
-          // subject or our value is the current subject
-          return isChildLike(subject, current) ? 'child' : 'parent'
-        },
-
-        consoleProps: () => {
-          obj = { Command: 'assert' }
-
-          _.extend(obj, parseValueActualAndExpected(value, actual, expected))
-
-          return _.extend(obj,
-            { Message: message.replace(bTagOpen, '').replace(bTagClosed, '') })
-        },
-      })
-
-      // think about completely gutting the whole object toString
-      // which chai does by default, its so ugly and worthless
-
-      if (error) {
-        error.onFail = (err) => { }
-      }
-
-      Cypress.log(obj)
-
-      return null
-    }
-
-    const assert = function (...args) {
-      // if we've temporarily overridden assertions
+    assert (...args) {
+      // if we've temporarily overriden assertions
       // then just bail early with this function
       const fn = cy.state('overrideAssert') || assertFn
 
       return fn.apply(this, args)
-    }
+    },
+  }
+}
 
-    return {
-      finishAssertions,
-
-      verifyUpcomingAssertions,
-
-      assert,
-    }
-  },
+export interface IAssertions {
+  verifyUpcomingAssertions: ReturnType<typeof create>['verifyUpcomingAssertions']
+  assert: ReturnType<typeof create>['assert']
 }

--- a/packages/driver/src/cy/chai.ts
+++ b/packages/driver/src/cy/chai.ts
@@ -38,13 +38,18 @@ let containProto = null
 let existProto = null
 let getMessage = null
 let chaiUtils = null
-let create = null
 let replaceArgMessages = null
 let removeOrKeepSingleQuotesBetweenStars = null
 let setSpecWindowGlobals = null
 let restoreAsserts = null
 let overrideExpect = null
 let overrideChaiAsserts = null
+
+export let create: ((specWindow, state, assertFn) => ({
+  chai: Chai.ChaiStatic
+  expect: (val: any, message?: string) => Chai.Assertion
+  assert: any
+})) | null = null
 
 chai.use(sinonChai)
 
@@ -543,8 +548,11 @@ chai.use((chai, u) => {
   }
 })
 
+export interface IChai {
+  expect: ReturnType<typeof create>['expect']
+}
+
 export default {
-  create,
   replaceArgMessages,
   removeOrKeepSingleQuotesBetweenStars,
   setSpecWindowGlobals,

--- a/packages/driver/src/cy/chai.ts
+++ b/packages/driver/src/cy/chai.ts
@@ -45,11 +45,12 @@ let restoreAsserts = null
 let overrideExpect = null
 let overrideChaiAsserts = null
 
-export let create: ((specWindow, state, assertFn) => ({
+type CreateFunc = ((specWindow, state, assertFn) => ({
   chai: Chai.ChaiStatic
   expect: (val: any, message?: string) => Chai.Assertion
   assert: any
-})) | null = null
+}))
+export let create: CreateFunc | null = null
 
 chai.use(sinonChai)
 
@@ -549,7 +550,7 @@ chai.use((chai, u) => {
 })
 
 export interface IChai {
-  expect: ReturnType<typeof create>['expect']
+  expect: ReturnType<CreateFunc>['expect']
 }
 
 export default {

--- a/packages/driver/src/cy/commands/window.ts
+++ b/packages/driver/src/cy/commands/window.ts
@@ -246,16 +246,18 @@ export default (Commands, Cypress, cy, state) => {
       if (_.isString(presetOrWidth) && _.isBlank(presetOrWidth)) {
         $errUtils.throwErrByPath('viewport.empty_string', { onFail: options._log })
       } else if (_.isString(presetOrWidth)) {
-        const getPresetDimensions = (preset) => {
+        const getPresetDimensions = (preset): number[] => {
           try {
             return _.map(viewports[presetOrWidth].split('x'), Number)
           } catch (e) {
             const presets = _.keys(viewports).join(', ')
 
-            return $errUtils.throwErrByPath('viewport.missing_preset', {
+            $errUtils.throwErrByPath('viewport.missing_preset', {
               onFail: options._log,
               args: { preset, presets },
             })
+
+            return [] // dummy code to silence TS
           }
         }
 

--- a/packages/driver/src/cy/ensures.ts
+++ b/packages/driver/src/cy/ensures.ts
@@ -12,6 +12,8 @@ const VALID_POSITIONS = 'topLeft top topRight left center right bottomLeft botto
 // they may need to work with both element arrays, or specific items
 // such as a single element, a single document, or single window
 
+let returnFalse = () => false
+
 export const create = (state, expect) => {
   // TODO: we should probably normalize all subjects
   // into an array and loop through each and verify
@@ -152,7 +154,9 @@ export const create = (state, expect) => {
   }
 
   const runVisibilityCheck = (subject, onFail, method) => {
-    const visibleSubjects = subject.filter(() => !method(this, 'isVisible()', { checkOpacity: false }))
+    const visibleSubjects = subject.filter(function () {
+      return !method(this, 'isVisible()', { checkOpacity: false })
+    })
 
     if (subject.length !== visibleSubjects.length) {
       const cmd = state('current').get('name')
@@ -240,7 +244,7 @@ export const create = (state, expect) => {
   }
 
   const ensureExistence = (subject) => {
-    const returnFalse = () => {
+    returnFalse = () => {
       cleanup()
 
       return false

--- a/packages/driver/src/cy/ensures.ts
+++ b/packages/driver/src/cy/ensures.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 import _ from 'lodash'
 import $dom from '../dom'
 import $utils from '../cypress/utils'
@@ -18,339 +16,325 @@ let returnFalse = () => {
   return false
 }
 
-export default {
-  create: (state, expect) => {
-    // TODO: we should probably normalize all subjects
-    // into an array and loop through each and verify
-    // each element in the array is valid. as it stands
-    // we only validate the first
-    const validateType = (subject, type, cmd) => {
-      const name = cmd.get('name')
+export const create = (state, expect) => {
+  // TODO: we should probably normalize all subjects
+  // into an array and loop through each and verify
+  // each element in the array is valid. as it stands
+  // we only validate the first
+  const validateType = (subject, type, cmd) => {
+    const name = cmd.get('name')
 
-      switch (type) {
-        case 'element':
-          // if this is an element then ensure its currently attached
-          // to its document context
-          if ($dom.isElement(subject)) {
-            ensureAttached(subject, name)
-          }
+    switch (type) {
+      case 'element':
+        // if this is an element then ensure its currently attached
+        // to its document context
+        if ($dom.isElement(subject)) {
+          ensureAttached(subject, name)
+        }
 
-          // always ensure this is an element
-          return ensureElement(subject, name)
+        // always ensure this is an element
+        return ensureElement(subject, name)
 
-        case 'document':
-          return ensureDocument(subject, name)
+      case 'document':
+        return ensureDocument(subject, name)
 
-        case 'window':
-          return ensureWindow(subject, name)
+      case 'window':
+        return ensureWindow(subject, name)
 
-        default:
-          return
+      default:
+        return
+    }
+  }
+
+  const ensureSubjectByType = (subject, type) => {
+    const current = state('current')
+
+    let types: string[] = [].concat(type)
+
+    // if we have an optional subject and nothing's
+    // here then just return cuz we good to go
+    if (types.includes('optional') && _.isUndefined(subject)) {
+      return
+    }
+
+    // okay we either have a subject and either way
+    // slice out optional so we can verify against
+    // the various types
+    types = _.without(types, 'optional')
+
+    // if we have no types then bail
+    if (types.length === 0) {
+      return
+    }
+
+    let err
+    const errors: Error[] = []
+
+    for (type of types) {
+      try {
+        validateType(subject, type, current)
+      } catch (error) {
+        err = error
+        errors.push(err)
       }
     }
 
-    const ensureSubjectByType = (subject, type) => {
+    // every validation failed and we had more than one validation
+    if (errors.length === types.length) {
+      err = errors[0]
+
+      if (types.length > 1) {
+        // append a nice error message telling the user this
+        const errProps = $errUtils.appendErrMsg(err, `All ${types.length} subject validations failed on this subject.`)
+
+        $errUtils.mergeErrProps(err, errProps)
+      }
+
+      throw err
+    }
+  }
+
+  const ensureRunnable = (name) => {
+    if (!state('runnable')) {
+      $errUtils.throwErrByPath('miscellaneous.outside_test_with_cmd', {
+        args: {
+          cmd: name,
+        },
+      })
+    }
+  }
+
+  const ensureElementIsNotAnimating = ($el, coords = [], threshold) => {
+    const lastTwo = coords.slice(-2)
+
+    // bail if we dont yet have two points
+    if (lastTwo.length !== 2) {
+      $errUtils.throwErrByPath('dom.animation_check_failed')
+    }
+
+    const [point1, point2] = lastTwo
+
+    // verify that there is not a distance
+    // greater than a default of '5' between
+    // the points
+    if ($utils.getDistanceBetween(point1, point2) > threshold) {
+      const cmd = state('current').get('name')
+      const node = $dom.stringify($el)
+
+      $errUtils.throwErrByPath('dom.animating', {
+        args: { cmd, node },
+      })
+    }
+  }
+
+  const ensureNotDisabled = (subject, onFail) => {
+    const cmd = state('current').get('name')
+
+    if (subject.prop('disabled')) {
+      const node = $dom.stringify(subject)
+
+      $errUtils.throwErrByPath('dom.disabled', {
+        onFail,
+        args: { cmd, node },
+      })
+    }
+  }
+
+  const ensureNotReadonly = (subject, onFail) => {
+    const cmd = state('current').get('name')
+
+    // readonly can only be applied to input/textarea
+    // not on checkboxes, radios, etc..
+    if ($dom.isTextLike(subject.get(0)) && subject.prop('readonly')) {
+      const node = $dom.stringify(subject)
+
+      $errUtils.throwErrByPath('dom.readonly', {
+        onFail,
+        args: { cmd, node },
+      })
+    }
+  }
+
+  const runVisibilityCheck = (subject, onFail, method) => {
+    if (subject.length !== subject.filter(function () {
+      return !method(this, 'isVisible()', { checkOpacity: false })
+    }).length) {
+      const cmd = state('current').get('name')
+      const reason = $dom.getReasonIsHidden(subject, { checkOpacity: false })
+      const node = $dom.stringify(subject)
+
+      $errUtils.throwErrByPath('dom.not_visible', {
+        onFail,
+        args: { cmd, node, reason },
+      })
+    }
+  }
+
+  const ensureVisibility = (subject, onFail) => {
+    return runVisibilityCheck(subject, onFail, $dom.isHidden)
+  }
+
+  const ensureStrictVisibility = (subject, onFail) => {
+    return runVisibilityCheck(subject, onFail, $dom.isStrictlyHidden)
+  }
+
+  const ensureNotHiddenByAncestors = (subject, onFail) => {
+    return runVisibilityCheck(subject, onFail, $dom.isHiddenByAncestors)
+  }
+
+  const ensureAttached = (subject, name, onFail?) => {
+    if ($dom.isDetached(subject)) {
       const current = state('current')
 
-      let types = [].concat(type)
+      const cmd = name ?? current.get('name')
 
-      // if we have an optional subject and nothing's
-      // here then just return cuz we good to go
-      if (types.includes('optional') && _.isUndefined(subject)) {
-        return
-      }
+      const prev = current.get('prev') ? current.get('prev').get('name') : current.get('name')
+      const node = $dom.stringify(subject)
 
-      // okay we either have a subject and either way
-      // slice out optional so we can verify against
-      // the various types
-      types = _.without(types, 'optional')
+      $errUtils.throwErrByPath('subject.not_attached', {
+        onFail,
+        args: { cmd, prev, node },
+      })
+    }
+  }
 
-      // if we have no types then bail
-      if (types.length === 0) {
-        return
-      }
+  const ensureElement = (subject, name, onFail?) => {
+    if (!$dom.isElement(subject)) {
+      const prev = state('current').get('prev')
 
-      let err
-      const errors = []
+      $errUtils.throwErrByPath('subject.not_element', {
+        onFail,
+        args: {
+          name,
+          subject: $utils.stringifyActual(subject),
+          previous: prev.get('name'),
+        },
+      })
+    }
+  }
 
-      for (type of types) {
-        try {
-          validateType(subject, type, current)
-        } catch (error) {
-          err = error
-          errors.push(err)
+  const ensureWindow = (subject, name) => {
+    if (!$dom.isWindow(subject)) {
+      const prev = state('current').get('prev')
+
+      $errUtils.throwErrByPath('subject.not_window_or_document', {
+        args: {
+          name,
+          type: 'window',
+          subject: $utils.stringifyActual(subject),
+          previous: prev.get('name'),
+        },
+      })
+    }
+  }
+
+  const ensureDocument = (subject, name) => {
+    if (!$dom.isDocument(subject)) {
+      const prev = state('current').get('prev')
+
+      $errUtils.throwErrByPath('subject.not_window_or_document', {
+        args: {
+          name,
+          type: 'document',
+          subject: $utils.stringifyActual(subject),
+          previous: prev.get('name'),
+        },
+      })
+    }
+  }
+
+  const ensureExistence = (subject) => {
+    returnFalse = () => {
+      cleanup()
+
+      return false
+    }
+
+    const cleanup = () => {
+      return state('onBeforeLog', null)
+    }
+
+    // prevent any additional logs this is an implicit assertion
+    state('onBeforeLog', returnFalse)
+
+    // verify the $el exists and use our default error messages
+    // TODO: always unbind if our expectation failed
+    try {
+      expect(subject).to.exist
+    } catch (err) {
+      cleanup()
+
+      throw err
+    }
+  }
+
+  const ensureElExistence = ($el) => {
+    // dont throw if this isnt even a DOM object
+    // return if not $dom.isJquery($el)
+
+    // ensure that we either had some assertions
+    // or that the element existed
+    if ($el && $el.length) {
+      return
+    }
+
+    // TODO: REFACTOR THIS TO CALL THE CHAI-OVERRIDES DIRECTLY
+    // OR GO THROUGH I18N
+
+    return ensureExistence($el)
+  }
+
+  const ensureElDoesNotHaveCSS = ($el, cssProperty, cssValue, onFail) => {
+    const cmd = state('current').get('name')
+    const el = $el[0]
+    const win = $dom.getWindowByElement(el)
+    const value = win.getComputedStyle(el)[cssProperty]
+
+    if (value === cssValue) {
+      const elInherited = $elements.findParent(el, (el, prevEl) => {
+        if (win.getComputedStyle(el)[cssProperty] !== cssValue) {
+          return prevEl
         }
+      })
+
+      const element = $dom.stringify(el)
+      const elementInherited = (el !== elInherited) && $dom.stringify(elInherited)
+
+      const consoleProps = {
+        'But it has CSS': `${cssProperty}: ${cssValue}`,
       }
 
-      // every validation failed and we had more than one validation
-      if (errors.length === types.length) {
-        err = errors[0]
-
-        if (types.length > 1) {
-          // append a nice error message telling the user this
-          const errProps = $errUtils.appendErrMsg(err, `All ${types.length} subject validations failed on this subject.`)
-
-          $errUtils.mergeErrProps(err, errProps)
-        }
-
-        throw err
-      }
-    }
-
-    const ensureRunnable = (name) => {
-      if (!state('runnable')) {
-        return $errUtils.throwErrByPath('miscellaneous.outside_test_with_cmd', {
-          args: {
-            cmd: name,
-          },
+      if (elementInherited) {
+        _.extend(consoleProps, {
+          'Inherited From': elInherited,
         })
       }
+
+      $errUtils.throwErrByPath('dom.pointer_events_none', {
+        onFail,
+        args: {
+          cmd,
+          element,
+          elementInherited,
+        },
+        errProps: {
+          consoleProps,
+        },
+      })
     }
+  }
 
-    const ensureElementIsNotAnimating = ($el, coords = [], threshold) => {
-      const lastTwo = coords.slice(-2)
+  const ensureDescendents = ($el1, $el2, onFail) => {
+    const cmd = state('current').get('name')
 
-      // bail if we dont yet have two points
-      if (lastTwo.length !== 2) {
-        $errUtils.throwErrByPath('dom.animation_check_failed')
-      }
+    if (!$dom.isDescendent($el1, $el2)) {
+      if ($el2) {
+        const element1 = $dom.stringify($el1)
+        const element2 = $dom.stringify($el2)
 
-      const [point1, point2] = lastTwo
-
-      // verify that there is not a distance
-      // greater than a default of '5' between
-      // the points
-      if ($utils.getDistanceBetween(point1, point2) > threshold) {
-        const cmd = state('current').get('name')
-        const node = $dom.stringify($el)
-
-        return $errUtils.throwErrByPath('dom.animating', {
-          args: { cmd, node },
-        })
-      }
-    }
-
-    const ensureNotDisabled = (subject, onFail) => {
-      const cmd = state('current').get('name')
-
-      if (subject.prop('disabled')) {
-        const node = $dom.stringify(subject)
-
-        return $errUtils.throwErrByPath('dom.disabled', {
+        $errUtils.throwErrByPath('dom.covered', {
           onFail,
-          args: { cmd, node },
-        })
-      }
-    }
-
-    const ensureNotReadonly = (subject, onFail) => {
-      const cmd = state('current').get('name')
-
-      // readonly can only be applied to input/textarea
-      // not on checkboxes, radios, etc..
-      if ($dom.isTextLike(subject.get(0)) && subject.prop('readonly')) {
-        const node = $dom.stringify(subject)
-
-        return $errUtils.throwErrByPath('dom.readonly', {
-          onFail,
-          args: { cmd, node },
-        })
-      }
-    }
-
-    const runVisibilityCheck = (subject, onFail, method) => {
-      if (subject.length !== subject.filter(function () {
-        return !method(this, 'isVisible()', { checkOpacity: false })
-      }).length) {
-        const cmd = state('current').get('name')
-        const reason = $dom.getReasonIsHidden(subject, { checkOpacity: false })
-        const node = $dom.stringify(subject)
-
-        return $errUtils.throwErrByPath('dom.not_visible', {
-          onFail,
-          args: { cmd, node, reason },
-        })
-      }
-    }
-
-    const ensureVisibility = (subject, onFail) => {
-      return runVisibilityCheck(subject, onFail, $dom.isHidden)
-    }
-
-    const ensureStrictVisibility = (subject, onFail) => {
-      return runVisibilityCheck(subject, onFail, $dom.isStrictlyHidden)
-    }
-
-    const ensureNotHiddenByAncestors = (subject, onFail) => {
-      return runVisibilityCheck(subject, onFail, $dom.isHiddenByAncestors)
-    }
-
-    const ensureAttached = (subject, name, onFail) => {
-      if ($dom.isDetached(subject)) {
-        const current = state('current')
-
-        const cmd = name ?? current.get('name')
-
-        const prev = current.get('prev') ? current.get('prev').get('name') : current.get('name')
-        const node = $dom.stringify(subject)
-
-        return $errUtils.throwErrByPath('subject.not_attached', {
-          onFail,
-          args: { cmd, prev, node },
-        })
-      }
-    }
-
-    const ensureElement = (subject, name, onFail) => {
-      if (!$dom.isElement(subject)) {
-        const prev = state('current').get('prev')
-
-        return $errUtils.throwErrByPath('subject.not_element', {
-          onFail,
-          args: {
-            name,
-            subject: $utils.stringifyActual(subject),
-            previous: prev.get('name'),
-          },
-        })
-      }
-    }
-
-    const ensureWindow = (subject, name) => {
-      if (!$dom.isWindow(subject)) {
-        const prev = state('current').get('prev')
-
-        return $errUtils.throwErrByPath('subject.not_window_or_document', {
-          args: {
-            name,
-            type: 'window',
-            subject: $utils.stringifyActual(subject),
-            previous: prev.get('name'),
-          },
-        })
-      }
-    }
-
-    const ensureDocument = (subject, name) => {
-      if (!$dom.isDocument(subject)) {
-        const prev = state('current').get('prev')
-
-        return $errUtils.throwErrByPath('subject.not_window_or_document', {
-          args: {
-            name,
-            type: 'document',
-            subject: $utils.stringifyActual(subject),
-            previous: prev.get('name'),
-          },
-        })
-      }
-    }
-
-    const ensureExistence = (subject) => {
-      returnFalse = () => {
-        cleanup()
-
-        return false
-      }
-
-      const cleanup = () => {
-        return state('onBeforeLog', null)
-      }
-
-      // prevent any additional logs this is an implicit assertion
-      state('onBeforeLog', returnFalse)
-
-      // verify the $el exists and use our default error messages
-      // TODO: always unbind if our expectation failed
-      try {
-        expect(subject).to.exist
-      } catch (err) {
-        cleanup()
-
-        throw err
-      }
-    }
-
-    const ensureElExistence = ($el) => {
-      // dont throw if this isnt even a DOM object
-      // return if not $dom.isJquery($el)
-
-      // ensure that we either had some assertions
-      // or that the element existed
-      if ($el && $el.length) {
-        return
-      }
-
-      // TODO: REFACTOR THIS TO CALL THE CHAI-OVERRIDES DIRECTLY
-      // OR GO THROUGH I18N
-
-      return ensureExistence($el)
-    }
-
-    const ensureElDoesNotHaveCSS = ($el, cssProperty, cssValue, onFail) => {
-      const cmd = state('current').get('name')
-      const el = $el[0]
-      const win = $dom.getWindowByElement(el)
-      const value = win.getComputedStyle(el)[cssProperty]
-
-      if (value === cssValue) {
-        const elInherited = $elements.findParent(el, (el, prevEl) => {
-          if (win.getComputedStyle(el)[cssProperty] !== cssValue) {
-            return prevEl
-          }
-        })
-
-        const element = $dom.stringify(el)
-        const elementInherited = (el !== elInherited) && $dom.stringify(elInherited)
-
-        const consoleProps = {
-          'But it has CSS': `${cssProperty}: ${cssValue}`,
-        }
-
-        if (elementInherited) {
-          _.extend(consoleProps, {
-            'Inherited From': elInherited,
-          })
-        }
-
-        return $errUtils.throwErrByPath('dom.pointer_events_none', {
-          onFail,
-          args: {
-            cmd,
-            element,
-            elementInherited,
-          },
-          errProps: {
-            consoleProps,
-          },
-        })
-      }
-    }
-
-    const ensureDescendents = ($el1, $el2, onFail) => {
-      const cmd = state('current').get('name')
-
-      if (!$dom.isDescendent($el1, $el2)) {
-        if ($el2) {
-          const element1 = $dom.stringify($el1)
-          const element2 = $dom.stringify($el2)
-
-          return $errUtils.throwErrByPath('dom.covered', {
-            onFail,
-            args: { cmd, element1, element2 },
-            errProps: {
-              consoleProps: {
-                'But its Covered By': $dom.getElements($el2),
-              },
-            },
-          })
-        }
-
-        const node = $dom.stringify($el1)
-
-        return $errUtils.throwErrByPath('dom.center_hidden', {
-          onFail,
-          args: { cmd, node },
+          args: { cmd, element1, element2 },
           errProps: {
             consoleProps: {
               'But its Covered By': $dom.getElements($el2),
@@ -358,74 +342,76 @@ export default {
           },
         })
       }
-    }
 
-    const ensureValidPosition = (position, log) => {
-      // make sure its valid first!
-      if (VALID_POSITIONS.includes(position)) {
-        return true
-      }
+      const node = $dom.stringify($el1)
 
-      return $errUtils.throwErrByPath('dom.invalid_position_argument', {
-        onFail: log,
-        args: {
-          position,
-          validPositions: VALID_POSITIONS.join(', '),
+      $errUtils.throwErrByPath('dom.center_hidden', {
+        onFail,
+        args: { cmd, node },
+        errProps: {
+          consoleProps: {
+            'But its Covered By': $dom.getElements($el2),
+          },
         },
       })
     }
+  }
 
-    const ensureScrollability = ($el, cmd) => {
-      if ($dom.isScrollable($el)) {
-        return true
-      }
-
-      // prep args to throw in error since we can't scroll
-      cmd = cmd ?? state('current').get('name')
-
-      const node = $dom.stringify($el)
-
-      return $errUtils.throwErrByPath('dom.not_scrollable', {
-        args: { cmd, node },
-      })
+  const ensureValidPosition = (position, log): true | void => {
+    // make sure its valid first!
+    if (VALID_POSITIONS.includes(position)) {
+      return true
     }
 
-    return {
-      ensureSubjectByType,
+    $errUtils.throwErrByPath('dom.invalid_position_argument', {
+      onFail: log,
+      args: {
+        position,
+        validPositions: VALID_POSITIONS.join(', '),
+      },
+    })
+  }
 
-      ensureElement,
-
-      ensureAttached,
-
-      ensureRunnable,
-
-      ensureWindow,
-
-      ensureDocument,
-
-      ensureElDoesNotHaveCSS,
-
-      ensureElementIsNotAnimating,
-
-      ensureNotDisabled,
-
-      ensureVisibility,
-
-      ensureStrictVisibility,
-
-      ensureNotHiddenByAncestors,
-
-      ensureExistence,
-
-      ensureElExistence,
-
-      ensureDescendents,
-
-      ensureValidPosition,
-
-      ensureScrollability,
-
-      ensureNotReadonly,
+  const ensureScrollability = ($el, cmd): true | void => {
+    if ($dom.isScrollable($el)) {
+      return true
     }
-  },
+
+    // prep args to throw in error since we can't scroll
+    cmd = cmd ?? state('current').get('name')
+
+    const node = $dom.stringify($el)
+
+    $errUtils.throwErrByPath('dom.not_scrollable', {
+      args: { cmd, node },
+    })
+  }
+
+  return {
+    ensureElement,
+    ensureAttached,
+    ensureWindow,
+    ensureDocument,
+    ensureElDoesNotHaveCSS,
+    ensureElementIsNotAnimating,
+    ensureNotDisabled,
+    ensureVisibility,
+    ensureStrictVisibility,
+    ensureNotHiddenByAncestors,
+    ensureExistence,
+    ensureElExistence,
+    ensureDescendents,
+    ensureValidPosition,
+    ensureScrollability,
+    ensureNotReadonly,
+
+    // internal functions
+    ensureSubjectByType,
+    ensureRunnable,
+  }
 }
+
+export interface IEnsures extends Omit<
+  ReturnType<typeof create>,
+  'ensureSubjectByType' | 'ensureRunnable'
+> {}

--- a/packages/driver/src/cy/ensures.ts
+++ b/packages/driver/src/cy/ensures.ts
@@ -12,10 +12,6 @@ const VALID_POSITIONS = 'topLeft top topRight left center right bottomLeft botto
 // they may need to work with both element arrays, or specific items
 // such as a single element, a single document, or single window
 
-let returnFalse = () => {
-  return false
-}
-
 export const create = (state, expect) => {
   // TODO: we should probably normalize all subjects
   // into an array and loop through each and verify
@@ -156,9 +152,9 @@ export const create = (state, expect) => {
   }
 
   const runVisibilityCheck = (subject, onFail, method) => {
-    if (subject.length !== subject.filter(function () {
-      return !method(this, 'isVisible()', { checkOpacity: false })
-    }).length) {
+    const visibleSubjects = subject.filter(() => !method(this, 'isVisible()', { checkOpacity: false }))
+
+    if (subject.length !== visibleSubjects.length) {
       const cmd = state('current').get('name')
       const reason = $dom.getReasonIsHidden(subject, { checkOpacity: false })
       const node = $dom.stringify(subject)
@@ -244,7 +240,7 @@ export const create = (state, expect) => {
   }
 
   const ensureExistence = (subject) => {
-    returnFalse = () => {
+    const returnFalse = () => {
       cleanup()
 
       return false

--- a/packages/driver/src/cy/focused.ts
+++ b/packages/driver/src/cy/focused.ts
@@ -3,253 +3,240 @@ import $window from '../dom/window'
 import $elements from '../dom/elements'
 import $actionability from './actionability'
 
-export default {
-  create: (state) => {
-    const documentHasFocus = () => {
-      // hardcode document has focus as true
-      // since the test should assume the window
-      // is in focus the entire time
-      return true
+const simulateBlurEvent = (el, win) => {
+  // todo handle relatedTarget's per the spec
+  const focusoutEvt = new FocusEvent('focusout', {
+    bubbles: true,
+    cancelable: false,
+    view: win,
+    relatedTarget: null,
+  })
+
+  const blurEvt = new FocusEvent('blur', {
+    // @ts-ignore // Bubble isn't available on FocusEvent?
+    bubble: false,
+    cancelable: false,
+    view: win,
+    relatedTarget: null,
+  })
+
+  el.dispatchEvent(blurEvt)
+
+  return el.dispatchEvent(focusoutEvt)
+}
+
+const simulateFocusEvent = (el, win) => {
+  // todo handle relatedTarget's per the spec
+  const focusinEvt = new FocusEvent('focusin', {
+    bubbles: true,
+    view: win,
+    relatedTarget: null,
+  })
+
+  const focusEvt = new FocusEvent('focus', {
+    view: win,
+    relatedTarget: null,
+  })
+
+  // not fired in the correct order per w3c spec
+  // because chrome chooses to fire focus before focusin
+  // and since we have a simulation fallback we end up
+  // doing it how chrome does it
+  // http://www.w3.org/TR/DOM-Level-3-Events/#h-events-focusevent-event-order
+  el.dispatchEvent(focusEvt)
+
+  return el.dispatchEvent(focusinEvt)
+}
+
+// eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
+export const create = (state) => ({
+  documentHasFocus () {
+    // hardcode document has focus as true
+    // since the test should assume the window
+    // is in focus the entire time
+    return true
+  },
+
+  fireBlur (el) {
+    const win = $window.getWindowByElement(el)
+
+    let hasBlurred = false
+
+    // we need to bind to the blur event here
+    // because some browsers will not ever fire
+    // the blur event if the window itself is not
+    // currently blured
+    const cleanup = () => {
+      return $elements.callNativeMethod(el, 'removeEventListener', 'blur', onBlur)
     }
 
-    const fireBlur = (el) => {
-      const win = $window.getWindowByElement(el)
-
-      let hasBlurred = false
-
-      // we need to bind to the blur event here
-      // because some browsers will not ever fire
-      // the blur event if the window itself is not
-      // currently blured
-      const cleanup = () => {
-        return $elements.callNativeMethod(el, 'removeEventListener', 'blur', onBlur)
-      }
-
-      const onBlur = () => {
-        return hasBlurred = true
-      }
-
-      // for simplicity we allow change events
-      // to be triggered by a manual blur
-      $actionability.dispatchPrimedChangeEvents(state)
-
-      $elements.callNativeMethod(el, 'addEventListener', 'blur', onBlur)
-
-      $elements.callNativeMethod(el, 'blur')
-
-      cleanup()
-
-      // body will never emit focus events
-      // so we avoid simulating this
-      if ($elements.isBody(el)) {
-        return
-      }
-
-      // fallback if our focus event never fires
-      // to simulate the focus + focusin
-      if (!hasBlurred) {
-        return simulateBlurEvent(el, win)
-      }
+    const onBlur = () => {
+      return hasBlurred = true
     }
 
-    const simulateBlurEvent = (el, win) => {
-      // todo handle relatedTarget's per the spec
-      const focusoutEvt = new FocusEvent('focusout', {
-        bubbles: true,
-        cancelable: false,
-        view: win,
-        relatedTarget: null,
-      })
+    // for simplicity we allow change events
+    // to be triggered by a manual blur
+    $actionability.dispatchPrimedChangeEvents(state)
 
-      const blurEvt = new FocusEvent('blur', {
-        // @ts-ignore // Bubble isn't available on FocusEvent?
-        bubble: false,
-        cancelable: false,
-        view: win,
-        relatedTarget: null,
-      })
+    $elements.callNativeMethod(el, 'addEventListener', 'blur', onBlur)
 
-      el.dispatchEvent(blurEvt)
+    $elements.callNativeMethod(el, 'blur')
 
-      return el.dispatchEvent(focusoutEvt)
+    cleanup()
+
+    // body will never emit focus events
+    // so we avoid simulating this
+    if ($elements.isBody(el)) {
+      return
     }
 
-    const fireFocus = (el, opts) => {
-      // body will never emit focus events (unless it's contenteditable)
-      // so we avoid simulating this
-      if ($elements.isBody(el) && !$elements.isContentEditable(el)) {
-        return
-      }
-
-      // if we are focusing a different element
-      // dispatch any primed change events
-      // we have to do this because our blur
-      // method might not get triggered if
-      // our window is in focus since the
-      // browser may fire blur events naturally
-      $actionability.dispatchPrimedChangeEvents(state)
-
-      const win = $window.getWindowByElement(el)
-
-      // store the current focused element, since it will change when we call .focus()
-      //
-      // need to pass in el.ownerDocument to get the correct focused element
-      // when el is in an iframe and the browser is not
-      // in focus (https://github.com/cypress-io/cypress/issues/8111)
-      const $focused = getFocused(el.ownerDocument)
-
-      let hasFocused = false
-
-      // we need to bind to the focus event here
-      // because some browsers will not ever fire
-      // the focus event if the window itself is not
-      // currently focused
-      const cleanup = () => {
-        return $elements.callNativeMethod(el, 'removeEventListener', 'focus', onFocus)
-      }
-
-      const onFocus = () => {
-        return hasFocused = true
-      }
-
-      $elements.callNativeMethod(el, 'addEventListener', 'focus', onFocus)
-
-      $elements.callNativeMethod(el, 'focus', opts)
-
-      cleanup()
-
-      // fallback if our focus event never fires
-      // to simulate the focus + focusin
-      if (!hasFocused) {
-        // only blur if we have a focused element AND its not
-        // currently ourselves!
-        if ($focused && $focused.get(0) !== el) {
-          // additionally make sure that this isnt
-          // the window, since that does not steal focus
-          // or actually change the activeElement
-          if (!$window.isWindow(el)) {
-            fireBlur($focused.get(0))
-          }
-        }
-
-        return simulateFocusEvent(el, win)
-      }
-    }
-
-    const simulateFocusEvent = (el, win) => {
-      // todo handle relatedTarget's per the spec
-      const focusinEvt = new FocusEvent('focusin', {
-        bubbles: true,
-        view: win,
-        relatedTarget: null,
-      })
-
-      const focusEvt = new FocusEvent('focus', {
-        view: win,
-        relatedTarget: null,
-      })
-
-      // not fired in the correct order per w3c spec
-      // because chrome chooses to fire focus before focusin
-      // and since we have a simulation fallback we end up
-      // doing it how chrome does it
-      // http://www.w3.org/TR/DOM-Level-3-Events/#h-events-focusevent-event-order
-      el.dispatchEvent(focusEvt)
-
-      return el.dispatchEvent(focusinEvt)
-    }
-
-    const interceptFocus = (el, win, opts) => {
-      // normally programmatic focus calls cause "primed" focus/blur
-      // events if the window is not in focus
-      // so we fire fake events to act as if the window
-      // is always in focus
-      const $focused = getFocused()
-
-      if ((!$focused || $focused[0] !== el) && $dom.isW3CFocusable(el)) {
-        fireFocus(el, opts)
-
-        return
-      }
-
-      $elements.callNativeMethod(el, 'focus', opts)
-    }
-
-    const interceptBlur = (el) => {
-      // normally programmatic blur calls cause "primed" focus/blur
-      // events if the window is not in focus
-      // so we fire fake events to act as if the window
-      // is always in focus.
-      const $focused = getFocused()
-
-      if ($focused && $focused[0] === el) {
-        fireBlur(el)
-
-        return
-      }
-
-      $elements.callNativeMethod(el, 'blur')
-    }
-
-    const needsFocus = ($elToFocus, $previouslyFocusedEl) => {
-      const $focused = getFocused()
-
-      // if we dont have a focused element
-      // we know we want to fire a focus event
-      if (!$focused) {
-        return true
-      }
-
-      // if we didnt have a previously focused el
-      // then always return true
-      if (!$previouslyFocusedEl) {
-        return true
-      }
-
-      // if we are attemping to focus a differnet element
-      // than the one we currently have, we know we want
-      // to fire a focus event
-      if ($focused.get(0) !== $elToFocus.get(0)) {
-        return true
-      }
-
-      // if our focused element isnt the same as the previously
-      // focused el then what probably happened is our mouse
-      // down event caused our element to receive focuse
-      // without the browser sending the focus event
-      // which happens when the window isnt in focus
-      if ($previouslyFocusedEl.get(0) !== $focused.get(0)) {
-        return true
-      }
-
-      return false
-    }
-
-    const getFocused = (document = state('document')) => {
-      const { activeElement } = document
-
-      if ($dom.isFocused(activeElement)) {
-        return $dom.wrap(activeElement)
-      }
-
-      return null
-    }
-
-    return {
-      fireBlur,
-
-      fireFocus,
-
-      needsFocus,
-
-      getFocused,
-
-      interceptFocus,
-
-      interceptBlur,
-
-      documentHasFocus,
+    // fallback if our focus event never fires
+    // to simulate the focus + focusin
+    if (!hasBlurred) {
+      return simulateBlurEvent(el, win)
     }
   },
 
-}
+  fireFocus (el, opts) {
+    // body will never emit focus events (unless it's contenteditable)
+    // so we avoid simulating this
+    if ($elements.isBody(el) && !$elements.isContentEditable(el)) {
+      return
+    }
+
+    // if we are focusing a different element
+    // dispatch any primed change events
+    // we have to do this because our blur
+    // method might not get triggered if
+    // our window is in focus since the
+    // browser may fire blur events naturally
+    $actionability.dispatchPrimedChangeEvents(state)
+
+    const win = $window.getWindowByElement(el)
+
+    // store the current focused element, since it will change when we call .focus()
+    //
+    // need to pass in el.ownerDocument to get the correct focused element
+    // when el is in an iframe and the browser is not
+    // in focus (https://github.com/cypress-io/cypress/issues/8111)
+    const $focused = this.getFocused(el.ownerDocument)
+
+    let hasFocused = false
+
+    // we need to bind to the focus event here
+    // because some browsers will not ever fire
+    // the focus event if the window itself is not
+    // currently focused
+    const cleanup = () => {
+      return $elements.callNativeMethod(el, 'removeEventListener', 'focus', onFocus)
+    }
+
+    const onFocus = () => {
+      return hasFocused = true
+    }
+
+    $elements.callNativeMethod(el, 'addEventListener', 'focus', onFocus)
+
+    $elements.callNativeMethod(el, 'focus', opts)
+
+    cleanup()
+
+    // fallback if our focus event never fires
+    // to simulate the focus + focusin
+    if (!hasFocused) {
+      // only blur if we have a focused element AND its not
+      // currently ourselves!
+      if ($focused && $focused.get(0) !== el) {
+        // additionally make sure that this isnt
+        // the window, since that does not steal focus
+        // or actually change the activeElement
+        if (!$window.isWindow(el)) {
+          this.fireBlur($focused.get(0))
+        }
+      }
+
+      return simulateFocusEvent(el, win)
+    }
+  },
+
+  interceptFocus (el, win, opts) {
+    // normally programmatic focus calls cause "primed" focus/blur
+    // events if the window is not in focus
+    // so we fire fake events to act as if the window
+    // is always in focus
+    const $focused = this.getFocused()
+
+    if ((!$focused || $focused[0] !== el) && $dom.isW3CFocusable(el)) {
+      this.fireFocus(el, opts)
+
+      return
+    }
+
+    $elements.callNativeMethod(el, 'focus', opts)
+  },
+
+  interceptBlur (el) {
+    // normally programmatic blur calls cause "primed" focus/blur
+    // events if the window is not in focus
+    // so we fire fake events to act as if the window
+    // is always in focus.
+    const $focused = this.getFocused()
+
+    if ($focused && $focused[0] === el) {
+      this.fireBlur(el)
+
+      return
+    }
+
+    $elements.callNativeMethod(el, 'blur')
+  },
+
+  needsFocus ($elToFocus, $previouslyFocusedEl) {
+    const $focused = this.getFocused()
+
+    // if we dont have a focused element
+    // we know we want to fire a focus event
+    if (!$focused) {
+      return true
+    }
+
+    // if we didnt have a previously focused el
+    // then always return true
+    if (!$previouslyFocusedEl) {
+      return true
+    }
+
+    // if we are attemping to focus a differnet element
+    // than the one we currently have, we know we want
+    // to fire a focus event
+    if ($focused.get(0) !== $elToFocus.get(0)) {
+      return true
+    }
+
+    // if our focused element isnt the same as the previously
+    // focused el then what probably happened is our mouse
+    // down event caused our element to receive focuse
+    // without the browser sending the focus event
+    // which happens when the window isnt in focus
+    if ($previouslyFocusedEl.get(0) !== $focused.get(0)) {
+      return true
+    }
+
+    return false
+  },
+
+  getFocused (document = state('document')) {
+    const { activeElement } = document
+
+    if ($dom.isFocused(activeElement)) {
+      return $dom.wrap(activeElement)
+    }
+
+    return null
+  },
+})
+
+export interface IFocused extends Omit<
+  ReturnType<typeof create>,
+  'documentHasFocus' | 'interceptFocus' | 'interceptBlur'
+> {}

--- a/packages/driver/src/cy/jquery.ts
+++ b/packages/driver/src/cy/jquery.ts
@@ -7,29 +7,24 @@ const remoteJQueryisNotSameAsGlobal = (remoteJQuery) => {
   return remoteJQuery && (remoteJQuery !== $)
 }
 
-export default {
-  create (state) {
-    const jquery = () => {
-      return state('jQuery') || state('window').$
-    }
+// eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
+export const create = (state) => ({
+  getRemotejQueryInstance (subject) {
+    // we make assumptions that you cannot have
+    // an array of mixed types, so we only look at
+    // the first item (if there's an array)
+    const firstSubject = $utils.unwrapFirst(subject)
 
-    return {
-      getRemotejQueryInstance (subject) {
-        // we make assumptions that you cannot have
-        // an array of mixed types, so we only look at
-        // the first item (if there's an array)
-        const firstSubject = $utils.unwrapFirst(subject)
+    if (!$dom.isElement(firstSubject)) return
 
-        if (!$dom.isElement(firstSubject)) return
+    const remoteJQuery = state('jQuery') || state('window').$
 
-        const remoteJQuery = jquery()
+    if (remoteJQueryisNotSameAsGlobal(remoteJQuery)) {
+      const remoteSubject = remoteJQuery(subject)
 
-        if (remoteJQueryisNotSameAsGlobal(remoteJQuery)) {
-          const remoteSubject = remoteJQuery(subject)
-
-          return remoteSubject
-        }
-      },
+      return remoteSubject
     }
   },
-}
+})
+
+export interface IJQuery extends ReturnType<typeof create> {}

--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -1312,10 +1312,6 @@ export class Keyboard {
   }
 }
 
-const create = (state) => {
-  return new Keyboard(state)
-}
-
 let _defaults
 
 const reset = () => {
@@ -1360,7 +1356,6 @@ const defaults = (props: Partial<Cypress.KeyboardDefaultsOptions>) => {
 }
 
 export default {
-  create,
   defaults,
   getConfig,
   getKeymap,

--- a/packages/driver/src/cy/location.ts
+++ b/packages/driver/src/cy/location.ts
@@ -1,25 +1,24 @@
 import { $Location } from '../cypress/location'
 import $utils from '../cypress/utils'
 
-export default {
-  create: (state) => {
-    return {
-      getRemoteLocation (key, win) {
-        try {
-          const remoteUrl = $utils.locToString(win ?? state('window'))
-          const location = $Location.create(remoteUrl)
+// eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
+export const create = (state) => ({
+  getRemoteLocation (key, win) {
+    try {
+      const remoteUrl = $utils.locToString(win ?? state('window'))
+      const location = $Location.create(remoteUrl)
 
-          if (key) {
-            return location[key]
-          }
+      if (key) {
+        return location[key]
+      }
 
-          return location
-        } catch (e) {
-          // it is possible we do not have access to the location
-          // for example, if the app has redirected to a 2nd domain
-          return ''
-        }
-      },
+      return location
+    } catch (e) {
+      // it is possible we do not have access to the location
+      // for example, if the app has redirected to a 2nd domain
+      return ''
     }
   },
-}
+})
+
+export interface ILocation extends ReturnType<typeof create> {}

--- a/packages/driver/src/cy/mouse.ts
+++ b/packages/driver/src/cy/mouse.ts
@@ -42,7 +42,7 @@ const getMouseCoords = (state) => {
   return state('mouseCoords')
 }
 
-const create = (state, keyboard, focused, Cypress) => {
+export const create = (state, keyboard, focused, Cypress) => {
   const isFirefox = Cypress.browser.family === 'firefox'
 
   const sendPointerEvent = (el, evtOptions, evtName, bubbles = false, cancelable = false) => {
@@ -707,6 +707,8 @@ const create = (state, keyboard, focused, Cypress) => {
   return mouse
 }
 
+export interface Mouse extends ReturnType<typeof create> {}
+
 const { stopPropagation } = window.MouseEvent.prototype
 
 const sendEvent = (evtName, el, evtOptions, bubbles = false, cancelable = false, Constructor, composed = false) => {
@@ -757,8 +759,4 @@ const toCoordsEventOptions = (x, y, win) => {
     layerX: x + scrollX,
     layerY: x + scrollY,
   }
-}
-
-export default {
-  create,
 }

--- a/packages/driver/src/cy/mouse.ts
+++ b/packages/driver/src/cy/mouse.ts
@@ -707,8 +707,6 @@ export const create = (state, keyboard, focused, Cypress) => {
   return mouse
 }
 
-export interface Mouse extends ReturnType<typeof create> {}
-
 const { stopPropagation } = window.MouseEvent.prototype
 
 const sendEvent = (evtName, el, evtOptions, bubbles = false, cancelable = false, Constructor, composed = false) => {
@@ -760,3 +758,5 @@ const toCoordsEventOptions = (x, y, win) => {
     layerY: x + scrollY,
   }
 }
+
+export interface Mouse extends ReturnType<typeof create> {}

--- a/packages/driver/src/cy/net-stubbing/add-command.ts
+++ b/packages/driver/src/cy/net-stubbing/add-command.ts
@@ -199,7 +199,7 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
       staticResponse = handler as StaticResponse
     } else if (!_.isUndefined(handler)) {
       // a handler was passed but we dunno what it's supposed to be
-      return $errUtils.throwErrByPath('net_stubbing.intercept.invalid_handler', { args: { handler } })
+      $errUtils.throwErrByPath('net_stubbing.intercept.invalid_handler', { args: { handler } })
     }
 
     const routeMatcher = annotateMatcherOptionsTypes(matcher)
@@ -211,7 +211,7 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
     }
 
     if (routeMatcher.middleware && !hasInterceptor) {
-      return $errUtils.throwErrByPath('net_stubbing.intercept.invalid_middleware_handler', { args: { handler } })
+      $errUtils.throwErrByPath('net_stubbing.intercept.invalid_middleware_handler', { args: { handler } })
     }
 
     const frame: NetEvent.ToServer.AddRoute<BackendStaticResponseWithArrayBuffer> = {
@@ -257,11 +257,11 @@ export function addCommand (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, 
         // url, mergeRouteMatcher, handler
         // @ts-ignore
         if (handler.url) {
-          return $errUtils.throwErrByPath('net_stubbing.intercept.no_duplicate_url')
+          $errUtils.throwErrByPath('net_stubbing.intercept.no_duplicate_url')
         }
 
         if (!arg2) {
-          return $errUtils.throwErrByPath('net_stubbing.intercept.handler_required')
+          $errUtils.throwErrByPath('net_stubbing.intercept.handler_required')
         }
 
         checkExtraArguments(['url', 'mergeRouteMatcher', 'handler'])

--- a/packages/driver/src/cy/net-stubbing/events/before-request.ts
+++ b/packages/driver/src/cy/net-stubbing/events/before-request.ts
@@ -167,7 +167,7 @@ export const onBeforeRequest: HandlerFn<CyHttpMessages.IncomingRequest> = (Cypre
     },
     on (eventName, handler) {
       if (!validEvents.includes(eventName)) {
-        return $errUtils.throwErrByPath('net_stubbing.request_handling.unknown_event', {
+        $errUtils.throwErrByPath('net_stubbing.request_handling.unknown_event', {
           args: {
             validEvents,
             eventName,
@@ -176,7 +176,7 @@ export const onBeforeRequest: HandlerFn<CyHttpMessages.IncomingRequest> = (Cypre
       }
 
       if (!_.isFunction(handler)) {
-        return $errUtils.throwErrByPath('net_stubbing.request_handling.event_needs_handler')
+        $errUtils.throwErrByPath('net_stubbing.request_handling.event_needs_handler')
       }
 
       subscribe(eventName, handler)

--- a/packages/driver/src/cy/retries.ts
+++ b/packages/driver/src/cy/retries.ts
@@ -99,7 +99,7 @@ export const create = (Cypress, state, timeout, clearTimeout, whenStable, finish
       // are not and the retry code is happening between
       // runnables which is bad likely due to the issue below
       //
-      // bug in bluebird with not propagating cancelations
+      // bug in bluebird with not propagating cancellations
       // fast enough in a series of promises
       // https://github.com/petkaantonov/bluebird/issues/1424
       return state('canceled') || state('error') || runnableHasChanged()

--- a/packages/driver/src/cy/retries.ts
+++ b/packages/driver/src/cy/retries.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import _ from 'lodash'
 import Promise from 'bluebird'
 
@@ -6,132 +5,131 @@ import $errUtils from '../cypress/error_utils'
 
 const { errByPath, modifyErrMsg, throwErr, mergeErrProps } = $errUtils
 
-export default {
-  create: (Cypress, state, timeout, clearTimeout, whenStable, finishAssertions) => {
-    return {
-      retry (fn, options, log) {
-        // remove the runnables timeout because we are now in retry
-        // mode and should be handling timing out ourselves and dont
-        // want to accidentally time out via mocha
-        let runnableTimeout
+// eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
+export const create = (Cypress, state, timeout, clearTimeout, whenStable, finishAssertions) => ({
+  retry (fn, options, log) {
+    // remove the runnables timeout because we are now in retry
+    // mode and should be handling timing out ourselves and dont
+    // want to accidentally time out via mocha
+    let runnableTimeout
 
-        if (!options._runnableTimeout) {
-          runnableTimeout = options.timeout ?? timeout()
-          clearTimeout()
-        }
-
-        const current = state('current')
-
-        // use the log if passed in, else fallback to options._log
-        // else fall back to just grabbing the last log per our current command
-        if (!log) {
-          log = options._log ?? current?.getLastLog()
-        }
-
-        _.defaults(options, {
-          _runnable: state('runnable'),
-          _runnableTimeout: runnableTimeout,
-          _interval: 16,
-          _retries: 0,
-          _start: new Date,
-          _name: current?.get('name'),
-        })
-
-        let { error } = options
-
-        const interval = options.interval ?? options._interval
-
-        // we calculate the total time we've been retrying
-        // so we dont exceed the runnables timeout
-        const total = Date.now() - options._start
-
-        options.total = total
-
-        // increment retries
-        options._retries += 1
-
-        // if our total exceeds the timeout OR the total + the interval
-        // exceed the runnables timeout, then bail
-        if ((total + interval) >= options._runnableTimeout) {
-          // snapshot the DOM since we are bailing
-          // so the user can see the state we're in
-          // when we fail
-          if (log) {
-            log.snapshot()
-          }
-
-          const assertions = options.assertions
-
-          if (assertions) {
-            finishAssertions(assertions)
-          }
-
-          let onFail
-
-          ({ error, onFail } = options)
-
-          const prependMsg = errByPath('miscellaneous.retry_timed_out', {
-            ms: options._runnableTimeout,
-          }).message
-
-          const retryErrProps = modifyErrMsg(error, prependMsg, (msg1, msg2) => {
-            return `${msg2}${msg1}`
-          })
-
-          const retryErr = mergeErrProps(error, retryErrProps)
-
-          throwErr(retryErr, {
-            onFail: onFail || log,
-          })
-        }
-
-        const runnableHasChanged = () => {
-          // if we've changed runnables don't retry!
-          return options._runnable !== state('runnable')
-        }
-
-        const ended = () => {
-          // we should NOT retry if
-          // 1. our promise has been canceled
-          // 2. or we have an error
-          // 3. or if the runnables has changed
-
-          // although bluebird SHOULD cancel these retries
-          // since they're all connected - apparently they
-          // are not and the retry code is happening between
-          // runnables which is bad likely due to the issue below
-          //
-          // bug in bluebird with not propagating cancellations
-          // fast enough in a series of promises
-          // https://github.com/petkaantonov/bluebird/issues/1424
-          return state('canceled') || state('error') || runnableHasChanged()
-        }
-
-        return Promise
-        .delay(interval)
-        .then(() => {
-          if (ended()) {
-            return
-          }
-
-          Cypress.action('cy:command:retry', options)
-
-          if (ended()) {
-            return
-          }
-
-          // if we are unstable then remove
-          // the start since we need to retry
-          // fresh once we become stable again!
-          if (state('isStable') === false) {
-            options._start = undefined
-          }
-
-          // invoke the passed in retry fn
-          // once we reach stability
-          return whenStable(fn)
-        })
-      },
+    if (!options._runnableTimeout) {
+      runnableTimeout = options.timeout ?? timeout()
+      clearTimeout()
     }
+
+    const current = state('current')
+
+    // use the log if passed in, else fallback to options._log
+    // else fall back to just grabbing the last log per our current command
+    if (!log) {
+      log = options._log ?? current?.getLastLog()
+    }
+
+    _.defaults(options, {
+      _runnable: state('runnable'),
+      _runnableTimeout: runnableTimeout,
+      _interval: 16,
+      _retries: 0,
+      _start: new Date,
+      _name: current?.get('name'),
+    })
+
+    let { error } = options
+
+    const interval = options.interval ?? options._interval
+
+    // we calculate the total time we've been retrying
+    // so we dont exceed the runnables timeout
+    const total = Date.now() - options._start
+
+    options.total = total
+
+    // increment retries
+    options._retries += 1
+
+    // if our total exceeds the timeout OR the total + the interval
+    // exceed the runnables timeout, then bail
+    if ((total + interval) >= options._runnableTimeout) {
+      // snapshot the DOM since we are bailing
+      // so the user can see the state we're in
+      // when we fail
+      if (log) {
+        log.snapshot()
+      }
+
+      const assertions = options.assertions
+
+      if (assertions) {
+        finishAssertions(assertions)
+      }
+
+      let onFail
+
+      ({ error, onFail } = options)
+
+      const prependMsg = errByPath('miscellaneous.retry_timed_out', {
+        ms: options._runnableTimeout,
+      }).message
+
+      const retryErrProps = modifyErrMsg(error, prependMsg, (msg1, msg2) => {
+        return `${msg2}${msg1}`
+      })
+
+      const retryErr = mergeErrProps(error, retryErrProps)
+
+      throwErr(retryErr, {
+        onFail: onFail || log,
+      })
+    }
+
+    const runnableHasChanged = () => {
+      // if we've changed runnables don't retry!
+      return options._runnable !== state('runnable')
+    }
+
+    const ended = () => {
+      // we should NOT retry if
+      // 1. our promise has been canceled
+      // 2. or we have an error
+      // 3. or if the runnables has changed
+
+      // although bluebird SHOULD cancel these retries
+      // since they're all connected - apparently they
+      // are not and the retry code is happening between
+      // runnables which is bad likely due to the issue below
+      //
+      // bug in bluebird with not propagating cancelations
+      // fast enough in a series of promises
+      // https://github.com/petkaantonov/bluebird/issues/1424
+      return state('canceled') || state('error') || runnableHasChanged()
+    }
+
+    return Promise
+    .delay(interval)
+    .then(() => {
+      if (ended()) {
+        return
+      }
+
+      Cypress.action('cy:command:retry', options)
+
+      if (ended()) {
+        return
+      }
+
+      // if we are unstable then remove
+      // the start since we need to retry
+      // fresh once we become stable again!
+      if (state('isStable') === false) {
+        options._start = undefined
+      }
+
+      // invoke the passed in retry fn
+      // once we reach stability
+      return whenStable(fn)
+    })
   },
-}
+})
+
+export interface IRetries extends ReturnType<typeof create> {}

--- a/packages/driver/src/cy/snapshots.ts
+++ b/packages/driver/src/cy/snapshots.ts
@@ -1,241 +1,240 @@
 import $ from 'jquery'
-// @ts-nocheck
 import _ from 'lodash'
 import $dom from '../dom'
-import $SnapshotsCss from './snapshots_css'
+import { create as createSnapshotsCSS } from './snapshots_css'
 
-const HIGHLIGHT_ATTR = 'data-cypress-el'
+export const HIGHLIGHT_ATTR = 'data-cypress-el'
 
-export default {
-  HIGHLIGHT_ATTR,
-  create: ($$, state) => {
-    const snapshotsCss = $SnapshotsCss.create($$, state)
-    const snapshotsMap = new WeakMap()
-    const snapshotDocument = new Document()
+export const create = ($$, state) => {
+  const snapshotsCss = createSnapshotsCSS($$, state)
+  const snapshotsMap = new WeakMap()
+  const snapshotDocument = new Document()
 
-    const getHtmlAttrs = function (htmlEl) {
-      const tmpHtmlEl = document.createElement('html')
+  const getHtmlAttrs = function (htmlEl) {
+    const tmpHtmlEl = document.createElement('html')
 
-      return _.transform(htmlEl?.attributes, (memo, attr) => {
-        if (!attr.specified) {
-          return
-        }
+    return _.transform(htmlEl?.attributes, (memo, attr) => {
+      if (!attr.specified) {
+        return
+      }
 
-        try {
-          // if we can successfully set the attributethen set it on memo
-          // because it's possible the attribute is completely invalid
-          tmpHtmlEl.setAttribute(attr.name, attr.value)
-          memo[attr.name] = attr.value
-        } catch (error) { } // eslint-disable-line no-empty
-      }, {})
-    }
+      try {
+        // if we can successfully set the attributethen set it on memo
+        // because it's possible the attribute is completely invalid
+        tmpHtmlEl.setAttribute(attr.name, attr.value)
+        memo[attr.name] = attr.value
+      } catch (error) { } // eslint-disable-line no-empty
+    }, {})
+  }
 
-    const replaceIframes = (body) => {
-      // remove iframes because we don't want extra requests made, JS run, etc
-      // when restoring a snapshot
-      // replace them so the lack of them doesn't cause layout issues
-      // use <iframe>s as the placeholders because iframes are inline, replaced
-      // elements (https://developer.mozilla.org/en-US/docs/Web/CSS/Replaced_element)
-      // so it's hard to simulate their box model
-      // attach class names and inline styles, so that CSS styles are applied
-      // as they would be on the user's page, but override some
-      // styles so it looks like a placeholder
+  const replaceIframes = (body) => {
+    // remove iframes because we don't want extra requests made, JS run, etc
+    // when restoring a snapshot
+    // replace them so the lack of them doesn't cause layout issues
+    // use <iframe>s as the placeholders because iframes are inline, replaced
+    // elements (https://developer.mozilla.org/en-US/docs/Web/CSS/Replaced_element)
+    // so it's hard to simulate their box model
+    // attach class names and inline styles, so that CSS styles are applied
+    // as they would be on the user's page, but override some
+    // styles so it looks like a placeholder
 
-      // need to only replace the iframes in the cloned body, so grab those
-      const $iframes = body.find('iframe')
-      // but query from the actual document, since the cloned body
-      // iframes don't have proper styles applied
+    // need to only replace the iframes in the cloned body, so grab those
+    const $iframes = body.find('iframe')
+    // but query from the actual document, since the cloned body
+    // iframes don't have proper styles applied
 
-      return $$('iframe').each((idx, iframe) => {
-        const $iframe = $(iframe)
+    return $$('iframe').each((idx, iframe) => {
+      const $iframe = $(iframe)
 
-        const remove = () => {
-          return $iframes.eq(idx).remove()
-        }
+      const remove = () => {
+        return $iframes.eq(idx).remove()
+      }
 
-        // if we don't have access to window
-        // then just remove this $iframe...
-        try {
-          if (!$iframe.prop('contentWindow')) {
-            return remove()
-          }
-        } catch (error) {
+      // if we don't have access to window
+      // then just remove this $iframe...
+      try {
+        if (!$iframe.prop('contentWindow')) {
           return remove()
         }
+      } catch (error) {
+        return remove()
+      }
 
-        const props = {
-          id: iframe.id,
-          class: iframe.className,
-          style: iframe.style.cssText,
+      const props = {
+        id: iframe.id,
+        class: iframe.className,
+        style: iframe.style.cssText,
+      }
+
+      const dimensions = (fn) => {
+        // jquery may throw here if we accidentally
+        // pass an old iframe reference where the
+        // document + window properties are unavailable
+        try {
+          return $iframe[fn]()
+        } catch (e) {
+          return 0
         }
+      }
 
-        const dimensions = (fn) => {
-          // jquery may throw here if we accidentally
-          // pass an old iframe reference where the
-          // document + window properties are unavailable
-          try {
-            return $iframe[fn]()
-          } catch (e) {
-            return 0
-          }
-        }
+      const $placeholder = $('<iframe />', props).css({
+        background: '#f8f8f8',
+        border: 'solid 1px #a3a3a3',
+        boxSizing: 'border-box',
+        padding: '20px',
+        width: dimensions('outerWidth'),
+        height: dimensions('outerHeight'),
+      }) as JQuery<HTMLIFrameElement>
 
-        const $placeholder = $('<iframe />', props).css({
-          background: '#f8f8f8',
-          border: 'solid 1px #a3a3a3',
-          boxSizing: 'border-box',
-          padding: '20px',
-          width: dimensions('outerWidth'),
-          height: dimensions('outerHeight'),
-        }) as JQuery<HTMLIFrameElement>
-
-        $iframes.eq(idx).replaceWith($placeholder)
-        const contents = `\
+      $iframes.eq(idx).replaceWith($placeholder)
+      const contents = `\
 <style>
   p { color: #888; font-family: sans-serif; line-height: 1.5; }
 </style>
 <p>&lt;iframe&gt; placeholder for ${iframe.src}</p>\
 `
 
-        $placeholder[0].src = `data:text/html;base64,${window.btoa(contents)}`
-      })
+      $placeholder[0].src = `data:text/html;base64,${window.btoa(contents)}`
+    })
+  }
+
+  const getStyles = (snapshot) => {
+    const styleIds = snapshotsMap.get(snapshot)
+
+    if (!styleIds) {
+      return {}
     }
 
-    const getStyles = (snapshot) => {
-      const styleIds = snapshotsMap.get(snapshot)
+    return {
+      headStyles: snapshotsCss.getStylesByIds(styleIds.headStyleIds),
+      bodyStyles: snapshotsCss.getStylesByIds(styleIds.bodyStyleIds),
+    }
+  }
 
-      if (!styleIds) {
-        return {}
-      }
+  const detachDom = (iframeContents) => {
+    const { headStyleIds, bodyStyleIds } = snapshotsCss.getStyleIds()
+    const htmlAttrs = getHtmlAttrs(iframeContents.find('html')[0])
+    const $body = iframeContents.find('body')
 
-      return {
-        headStyles: snapshotsCss.getStylesByIds(styleIds.headStyleIds),
-        bodyStyles: snapshotsCss.getStylesByIds(styleIds.bodyStyleIds),
-      }
+    $body.find('script,link[rel="stylesheet"],style').remove()
+
+    const snapshot = {
+      name: 'final state',
+      htmlAttrs,
+      body: {
+        get: () => $body.detach(),
+      },
     }
 
-    const detachDom = (iframeContents) => {
+    snapshotsMap.set(snapshot, { headStyleIds, bodyStyleIds })
+
+    return snapshot
+  }
+
+  const createSnapshot = (name, $elToHighlight) => {
+    // create a unique selector for this el
+    // but only IF the subject is truly an element. For example
+    // we might be wrapping a primitive like "$([1, 2]).first()"
+    // which arrives here as number 1
+    // jQuery v2 allowed to silently try setting 1[HIGHLIGHT_ATTR] doing nothing
+    // jQuery v3 runs in strict mode and throws an error if you attempt to set a property
+
+    // TODO: in firefox sometimes this throws a cross-origin access error
+    try {
+      const isJqueryElement = $dom.isElement($elToHighlight) && $dom.isJquery($elToHighlight)
+
+      if (isJqueryElement) {
+        // JQuery.attr doesn't support `true` as a value.
+        // @ts-ignore
+        ($elToHighlight as JQuery<HTMLElement>).attr(HIGHLIGHT_ATTR, true)
+      }
+
+      // TODO: throw error here if cy is undefined!
+
+      // cloneNode can actually trigger functions attached to custom elements
+      // so we have to use importNode to clone the element
+      // https://github.com/cypress-io/cypress/issues/7187
+      // https://github.com/cypress-io/cypress/issues/1068
+      // we import it to a transient document (snapshotDocument) so that there
+      // are no side effects from cloning it. see below for how we re-attach
+      // it to the AUT document
+      // https://github.com/cypress-io/cypress/issues/8679
+      // this can fail if snapshotting before the page has fully loaded,
+      // so we catch this below and return null for the snapshot
+      // https://github.com/cypress-io/cypress/issues/15816
+      const $body = $$(snapshotDocument.importNode($$('body')[0], true))
+
+      // for the head and body, get an array of all CSS,
+      // whether it's links or style tags
+      // if it's same-origin, it will get the actual styles as a string
+      // it it's cross-domain, it will get a reference to the link's href
       const { headStyleIds, bodyStyleIds } = snapshotsCss.getStyleIds()
-      const htmlAttrs = getHtmlAttrs(iframeContents.find('html')[0])
-      const $body = iframeContents.find('body')
 
-      $body.find('script,link[rel="stylesheet"],style').remove()
+      // replaces iframes with placeholders
+      replaceIframes($body)
+
+      // remove tags we don't want in body
+      $body.find('script,link[rel=\'stylesheet\'],style').remove()
+
+      // here we need to figure out if we're in a remote manual environment
+      // if so we need to stringify the DOM:
+      // 1. grab all inputs / textareas / options and set their value on the element
+      // 2. convert DOM to string: body.prop("outerHTML")
+      // 3. send this string via websocket to our server
+      // 4. server rebroadcasts this to our client and its stored as a property
+
+      // its also possible for us to store the DOM string completely on the server
+      // without ever sending it back to the browser (until its requests).
+      // we could just store it in memory and wipe it out intelligently.
+      // this would also prevent having to store the DOM structure on the client,
+      // which would reduce memory, and some CPU operations
+
+      // now remove it after we clone
+      if (isJqueryElement) {
+        ($elToHighlight as JQuery<HTMLElement>).removeAttr(HIGHLIGHT_ATTR)
+      }
+
+      // preserve attributes on the <html> tag
+      const htmlAttrs = getHtmlAttrs($$('html')[0])
+      // the body we clone via importNode above is attached to a transient document
+      // so that there are no side effects from cloning it. we only attach it back
+      // to the AUT document at the last moment (when restoring the snapshot)
+      // https://github.com/cypress-io/cypress/issues/8679
+      let attachedBody
+      const body = {
+        get: () => {
+          if (!attachedBody) {
+            attachedBody = $$(state('document').adoptNode($body[0]))
+          }
+
+          return attachedBody
+        },
+      }
 
       const snapshot = {
-        name: 'final state',
+        name,
         htmlAttrs,
-        body: {
-          get: () => $body.detach(),
-        },
+        body,
       }
 
       snapshotsMap.set(snapshot, { headStyleIds, bodyStyleIds })
 
       return snapshot
+    } catch (e) {
+      return null
     }
+  }
 
-    const createSnapshot = (name, $elToHighlight) => {
-      // create a unique selector for this el
-      // but only IF the subject is truly an element. For example
-      // we might be wrapping a primitive like "$([1, 2]).first()"
-      // which arrives here as number 1
-      // jQuery v2 allowed to silently try setting 1[HIGHLIGHT_ATTR] doing nothing
-      // jQuery v3 runs in strict mode and throws an error if you attempt to set a property
-
-      // TODO: in firefox sometimes this throws a cross-origin access error
-      try {
-        const isJqueryElement = $dom.isElement($elToHighlight) && $dom.isJquery($elToHighlight)
-
-        if (isJqueryElement) {
-          $elToHighlight.attr(HIGHLIGHT_ATTR, true)
-        }
-
-        // TODO: throw error here if cy is undefined!
-
-        // cloneNode can actually trigger functions attached to custom elements
-        // so we have to use importNode to clone the element
-        // https://github.com/cypress-io/cypress/issues/7187
-        // https://github.com/cypress-io/cypress/issues/1068
-        // we import it to a transient document (snapshotDocument) so that there
-        // are no side effects from cloning it. see below for how we re-attach
-        // it to the AUT document
-        // https://github.com/cypress-io/cypress/issues/8679
-        // this can fail if snapshotting before the page has fully loaded,
-        // so we catch this below and return null for the snapshot
-        // https://github.com/cypress-io/cypress/issues/15816
-        const $body = $$(snapshotDocument.importNode($$('body')[0], true))
-
-        // for the head and body, get an array of all CSS,
-        // whether it's links or style tags
-        // if it's same-origin, it will get the actual styles as a string
-        // it it's cross-domain, it will get a reference to the link's href
-        const { headStyleIds, bodyStyleIds } = snapshotsCss.getStyleIds()
-
-        // replaces iframes with placeholders
-        replaceIframes($body)
-
-        // remove tags we don't want in body
-        $body.find('script,link[rel=\'stylesheet\'],style').remove()
-
-        // here we need to figure out if we're in a remote manual environment
-        // if so we need to stringify the DOM:
-        // 1. grab all inputs / textareas / options and set their value on the element
-        // 2. convert DOM to string: body.prop("outerHTML")
-        // 3. send this string via websocket to our server
-        // 4. server rebroadcasts this to our client and its stored as a property
-
-        // its also possible for us to store the DOM string completely on the server
-        // without ever sending it back to the browser (until its requests).
-        // we could just store it in memory and wipe it out intelligently.
-        // this would also prevent having to store the DOM structure on the client,
-        // which would reduce memory, and some CPU operations
-
-        // now remove it after we clone
-        if (isJqueryElement) {
-          $elToHighlight.removeAttr(HIGHLIGHT_ATTR)
-        }
-
-        // preserve attributes on the <html> tag
-        const htmlAttrs = getHtmlAttrs($$('html')[0])
-        // the body we clone via importNode above is attached to a transient document
-        // so that there are no side effects from cloning it. we only attach it back
-        // to the AUT document at the last moment (when restoring the snapshot)
-        // https://github.com/cypress-io/cypress/issues/8679
-        let attachedBody
-        const body = {
-          get: () => {
-            if (!attachedBody) {
-              attachedBody = $$(state('document').adoptNode($body[0]))
-            }
-
-            return attachedBody
-          },
-        }
-
-        const snapshot = {
-          name,
-          htmlAttrs,
-          body,
-        }
-
-        snapshotsMap.set(snapshot, { headStyleIds, bodyStyleIds })
-
-        return snapshot
-      } catch (e) {
-        return null
-      }
-    }
-
-    return {
-      createSnapshot,
-
-      detachDom,
-
-      getStyles,
-
-      onCssModified: snapshotsCss.onCssModified,
-
-      onBeforeWindowLoad: snapshotsCss.onBeforeWindowLoad,
-    }
-  },
+  return {
+    createSnapshot,
+    detachDom,
+    getStyles,
+    onCssModified: snapshotsCss.onCssModified,
+    onBeforeWindowLoad: snapshotsCss.onBeforeWindowLoad,
+  }
 }
+
+export interface ISnapshots extends Omit<
+  ReturnType<typeof create>,
+  'onCssModified' | 'onBeforeWindowLoad'
+> {}

--- a/packages/driver/src/cy/snapshots_css.ts
+++ b/packages/driver/src/cy/snapshots_css.ts
@@ -89,125 +89,123 @@ const getInlineCssContents = (stylesheet, $$) => {
   })
 }
 
-export default {
-  create: ($$, state) => {
-    const cssIdToContentsMap = new WeakMap()
-    const cssHashedContentsToIdMap = new LimitedMap()
-    const cssHrefToIdMap = new LimitedMap()
-    const cssHrefToModifiedMap = new LimitedMap()
-    let newWindow = false
+export const create = ($$, state) => {
+  const cssIdToContentsMap = new WeakMap()
+  const cssHashedContentsToIdMap = new LimitedMap()
+  const cssHrefToIdMap = new LimitedMap()
+  const cssHrefToModifiedMap = new LimitedMap()
+  let newWindow = false
 
-    //// we invalidate the cache when css is modified by javascript
-    const onCssModified = (href) => {
-      cssHrefToModifiedMap.set(href, { modified: true })
+  //// we invalidate the cache when css is modified by javascript
+  const onCssModified = (href) => {
+    cssHrefToModifiedMap.set(href, { modified: true })
+  }
+
+  //// the lifecycle of a stylesheet is the lifecycle of the window
+  //// so track this to know when to re-evaluate the cache in case
+  //// of css being modified by javascript
+  const onBeforeWindowLoad = () => {
+    newWindow = true
+  }
+
+  const getStyleId = (href, stylesheet) => {
+    const hrefModified = cssHrefToModifiedMap.get(href) || {}
+    const existing = cssHrefToIdMap.get(href)
+
+    //// if we've loaded a new window and the css was invalidated due to javascript
+    //// we need to re-evaluate since this time around javascript might not change the css
+    if (existing && !hrefModified.modified && !(newWindow && hrefModified.modifiedLast)) {
+      return existing
     }
 
-    //// the lifecycle of a stylesheet is the lifecycle of the window
-    //// so track this to know when to re-evaluate the cache in case
-    //// of css being modified by javascript
-    const onBeforeWindowLoad = () => {
-      newWindow = true
+    const cssContents = getExternalCssContents(href, stylesheet)
+
+    if (cssContents == null) {
+      return
     }
 
-    const getStyleId = (href, stylesheet) => {
-      const hrefModified = cssHrefToModifiedMap.get(href) || {}
-      const existing = cssHrefToIdMap.get(href)
+    const hashedCssContents = md5(cssContents)
+    //// if we already have these css contents stored, don't store them again
+    const existingId = cssHashedContentsToIdMap.get(hashedCssContents)
 
-      //// if we've loaded a new window and the css was invalidated due to javascript
-      //// we need to re-evaluate since this time around javascript might not change the css
-      if (existing && !hrefModified.modified && !(newWindow && hrefModified.modifiedLast)) {
-        return existing
+    //// id just needs to be a new object reference
+    //// we add the href for debuggability
+    const id = existingId || { hrefId: href }
+
+    cssHrefToIdMap.set(href, id)
+
+    //// if we already have these css contents stored, don't store them again
+    if (!existingId) {
+      cssHashedContentsToIdMap.set(hashedCssContents, id)
+      cssIdToContentsMap.set(id, cssContents)
+    }
+
+    if (hrefModified.modified) {
+      hrefModified.modifiedLast = true
+    } else if (newWindow) {
+      hrefModified.modifiedLast = false
+    }
+
+    hrefModified.modified = false
+    cssHrefToModifiedMap.set(href, hrefModified)
+
+    return id
+  }
+
+  const getStyleIdsFor = (doc, $$, stylesheets, location) => {
+    let styles = $$(location).find('link[rel=\'stylesheet\'],style')
+
+    styles = _.filter(styles, isScreenStylesheet)
+
+    return _.map(styles, (stylesheet) => {
+      //// in cases where we can get the CSS as a string, make the paths
+      //// absolute so that when they're restored by appending them to the page
+      //// in <style> tags, background images and fonts still properly load
+      const href = stylesheet.href
+
+      //// if there's an href, it's a link tag
+      //// return the CSS rules as a string, or, if cross-domain,
+      //// a reference to the stylesheet's href
+      if (href) {
+        return getStyleId(href, stylesheets[href]) || { href }
       }
 
-      const cssContents = getExternalCssContents(href, stylesheet)
+      //// otherwise, it's a style tag, and we can just grab its content
+      const cssContents = getInlineCssContents(stylesheet, $$)
 
-      if (cssContents == null) {
-        return
+      return makePathsAbsoluteToDoc(cssContents, doc)
+    })
+  }
+
+  const getStyleIds = () => {
+    const doc = state('document')
+    const stylesheets = getDocumentStylesheets(doc)
+
+    const styleIds = {
+      headStyleIds: getStyleIdsFor(doc, $$, stylesheets, 'head'),
+      bodyStyleIds: getStyleIdsFor(doc, $$, stylesheets, 'body'),
+    }
+
+    //// after getting the all the styles on the page, it's no longer a new window
+    newWindow = false
+
+    return styleIds
+  }
+
+  const getStylesByIds = (ids) => {
+    return _.map(ids, (idOrCss) => {
+      if (_.isString(idOrCss)) {
+        return idOrCss
       }
 
-      const hashedCssContents = md5(cssContents)
-      //// if we already have these css contents stored, don't store them again
-      const existingId = cssHashedContentsToIdMap.get(hashedCssContents)
+      return cssIdToContentsMap.get(idOrCss) || { href: idOrCss.href }
+    })
+  }
 
-      //// id just needs to be a new object reference
-      //// we add the href for debuggability
-      const id = existingId || { hrefId: href }
-
-      cssHrefToIdMap.set(href, id)
-
-      //// if we already have these css contents stored, don't store them again
-      if (!existingId) {
-        cssHashedContentsToIdMap.set(hashedCssContents, id)
-        cssIdToContentsMap.set(id, cssContents)
-      }
-
-      if (hrefModified.modified) {
-        hrefModified.modifiedLast = true
-      } else if (newWindow) {
-        hrefModified.modifiedLast = false
-      }
-
-      hrefModified.modified = false
-      cssHrefToModifiedMap.set(href, hrefModified)
-
-      return id
-    }
-
-    const getStyleIdsFor = (doc, $$, stylesheets, location) => {
-      let styles = $$(location).find('link[rel=\'stylesheet\'],style')
-
-      styles = _.filter(styles, isScreenStylesheet)
-
-      return _.map(styles, (stylesheet) => {
-        //// in cases where we can get the CSS as a string, make the paths
-        //// absolute so that when they're restored by appending them to the page
-        //// in <style> tags, background images and fonts still properly load
-        const href = stylesheet.href
-
-        //// if there's an href, it's a link tag
-        //// return the CSS rules as a string, or, if cross-domain,
-        //// a reference to the stylesheet's href
-        if (href) {
-          return getStyleId(href, stylesheets[href]) || { href }
-        }
-
-        //// otherwise, it's a style tag, and we can just grab its content
-        const cssContents = getInlineCssContents(stylesheet, $$)
-
-        return makePathsAbsoluteToDoc(cssContents, doc)
-      })
-    }
-
-    const getStyleIds = () => {
-      const doc = state('document')
-      const stylesheets = getDocumentStylesheets(doc)
-
-      const styleIds = {
-        headStyleIds: getStyleIdsFor(doc, $$, stylesheets, 'head'),
-        bodyStyleIds: getStyleIdsFor(doc, $$, stylesheets, 'body'),
-      }
-
-      //// after getting the all the styles on the page, it's no longer a new window
-      newWindow = false
-
-      return styleIds
-    }
-
-    const getStylesByIds = (ids) => {
-      return _.map(ids, (idOrCss) => {
-        if (_.isString(idOrCss)) {
-          return idOrCss
-        }
-
-        return cssIdToContentsMap.get(idOrCss) || { href: idOrCss.href }
-      })
-    }
-
-    return {
-      getStyleIds,
-      getStylesByIds,
-      onCssModified,
-      onBeforeWindowLoad,
-    }
-  },
+  return {
+    getStyleIds,
+    getStylesByIds,
+    onCssModified,
+    onBeforeWindowLoad,
+  }
 }

--- a/packages/driver/src/cy/stability.ts
+++ b/packages/driver/src/cy/stability.ts
@@ -1,58 +1,48 @@
 import Promise from 'bluebird'
 
-const tryFn = (fn) => {
-  // promisify this function
-  return Promise.try(fn)
-}
-
-export default {
-  create: (Cypress, state) => {
-    const isStable = (stable = true, event) => {
-      if (state('isStable') === stable) {
-        return
-      }
-
-      const whenStable = state('whenStable')
-
-      // if we are going back to stable and we have
-      // a whenStable callback
-      if (stable && whenStable) {
-        // invoke it
-        whenStable()
-      }
-
-      state('isStable', stable)
-
-      // we notify the outside world because this is what the runner uses to
-      // show the 'loading spinner' during an app page loading transition event
-      return Cypress.action('cy:stability:changed', stable, event)
+// eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
+export const create = (Cypress, state) => ({
+  isStable: (stable = true, event) => {
+    if (state('isStable') === stable) {
+      return
     }
 
-    const whenStable = (fn) => {
-      // if we are not stable
-      if (state('isStable') === false) {
-        return new Promise((resolve, reject) => {
-          // then when we become stable
-          return state('whenStable', () => {
-            // reset this callback function
-            state('whenStable', null)
+    const whenStable = state('whenStable')
 
-            // and invoke the original function
-            return tryFn(fn)
-            .then(resolve)
-            .catch(reject)
-          })
-        })
-      }
-
-      // else invoke it right now
-      return tryFn(fn)
+    // if we are going back to stable and we have
+    // a whenStable callback
+    if (stable && whenStable) {
+      // invoke it
+      whenStable()
     }
 
-    return {
-      isStable,
+    state('isStable', stable)
 
-      whenStable,
-    }
+    // we notify the outside world because this is what the runner uses to
+    // show the 'loading spinner' during an app page loading transition event
+    return Cypress.action('cy:stability:changed', stable, event)
   },
-}
+
+  whenStable: (fn) => {
+    // if we are not stable
+    if (state('isStable') === false) {
+      return new Promise((resolve, reject) => {
+        // then when we become stable
+        return state('whenStable', () => {
+          // reset this callback function
+          state('whenStable', null)
+
+          // and invoke the original function
+          return Promise.try(fn)
+          .then(resolve)
+          .catch(reject)
+        })
+      })
+    }
+
+    // else invoke it right now
+    return Promise.try(fn)
+  },
+})
+
+export interface IStability extends ReturnType<typeof create> {}

--- a/packages/driver/src/cy/stability.ts
+++ b/packages/driver/src/cy/stability.ts
@@ -2,7 +2,7 @@ import Promise from 'bluebird'
 
 // eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
 export const create = (Cypress, state) => ({
-  isStable: (stable = true, event) => {
+  isStable: (stable: boolean = true, event: string) => {
     if (state('isStable') === stable) {
       return
     }
@@ -23,7 +23,7 @@ export const create = (Cypress, state) => ({
     return Cypress.action('cy:stability:changed', stable, event)
   },
 
-  whenStable: (fn) => {
+  whenStable: (fn: () => any) => {
     // if we are not stable
     if (state('isStable') === false) {
       return new Promise((resolve, reject) => {

--- a/packages/driver/src/cy/testConfigOverrides.ts
+++ b/packages/driver/src/cy/testConfigOverrides.ts
@@ -135,7 +135,7 @@ export function getResolvedTestConfigOverride (test): ResolvedTestConfigOverride
   return testConfig
 }
 
-class TestConfigOverride {
+export class TestConfigOverride {
   private restoreTestConfigFn: Nullable<() => void> = null
 
   restoreAndSetTestConfigOverrides (test, config, env) {
@@ -147,10 +147,4 @@ class TestConfigOverride {
       this.restoreTestConfigFn = mutateConfiguration(resolvedTestConfig, config, env)
     }
   }
-}
-
-export default {
-  create () {
-    return new TestConfigOverride()
-  },
 }

--- a/packages/driver/src/cy/timeouts.ts
+++ b/packages/driver/src/cy/timeouts.ts
@@ -1,39 +1,38 @@
 import _ from 'lodash'
 import $errUtils from '../cypress/error_utils'
 
-export const create = (state) => {
-  return {
-    timeout (ms: number, delta: boolean = false) {
-      const runnable = state('runnable')
+// eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
+export const create = (state) => ({
+  timeout (ms: number, delta: boolean = false) {
+    const runnable = state('runnable')
 
-      if (!runnable) {
-        $errUtils.throwErrByPath('miscellaneous.outside_test')
-      }
+    if (!runnable) {
+      $errUtils.throwErrByPath('miscellaneous.outside_test')
+    }
 
-      if (_.isFinite(ms)) {
-        // if delta is true then we add (or subtract) from the
-        // runnables current timeout instead of blanketingly setting it
-        ms = delta ? runnable.timeout() + ms : ms
-        runnable.timeout(ms)
-
-        return this
-      }
-
-      return runnable.timeout()
-    },
-
-    clearTimeout () {
-      const runnable = state('runnable')
-
-      if (!runnable) {
-        $errUtils.throwErrByPath('miscellaneous.outside_test')
-      }
-
-      runnable.clearTimeout()
+    if (_.isFinite(ms)) {
+      // if delta is true then we add (or subtract) from the
+      // runnables current timeout instead of blanketingly setting it
+      ms = delta ? runnable.timeout() + ms : ms
+      runnable.timeout(ms)
 
       return this
-    },
-  }
-}
+    }
+
+    return runnable.timeout()
+  },
+
+  clearTimeout () {
+    const runnable = state('runnable')
+
+    if (!runnable) {
+      $errUtils.throwErrByPath('miscellaneous.outside_test')
+    }
+
+    runnable.clearTimeout()
+
+    return this
+  },
+})
 
 export interface ITimeouts extends ReturnType<typeof create> { }

--- a/packages/driver/src/cy/timeouts.ts
+++ b/packages/driver/src/cy/timeouts.ts
@@ -1,39 +1,39 @@
 import _ from 'lodash'
 import $errUtils from '../cypress/error_utils'
 
-export default {
-  create: (state) => {
-    return {
-      timeout (ms, delta = false) {
-        const runnable = state('runnable')
+export const create = (state) => {
+  return {
+    timeout (ms: number, delta: boolean = false) {
+      const runnable = state('runnable')
 
-        if (!runnable) {
-          $errUtils.throwErrByPath('miscellaneous.outside_test')
-        }
+      if (!runnable) {
+        $errUtils.throwErrByPath('miscellaneous.outside_test')
+      }
 
-        if (_.isFinite(ms)) {
-          // if delta is true then we add (or subtract) from the
-          // runnables current timeout instead of blanketingly setting it
-          ms = delta ? runnable.timeout() + ms : ms
-          runnable.timeout(ms)
-
-          return this
-        }
-
-        return runnable.timeout()
-      },
-
-      clearTimeout () {
-        const runnable = state('runnable')
-
-        if (!runnable) {
-          $errUtils.throwErrByPath('miscellaneous.outside_test')
-        }
-
-        runnable.clearTimeout()
+      if (_.isFinite(ms)) {
+        // if delta is true then we add (or subtract) from the
+        // runnables current timeout instead of blanketingly setting it
+        ms = delta ? runnable.timeout() + ms : ms
+        runnable.timeout(ms)
 
         return this
-      },
-    }
-  },
+      }
+
+      return runnable.timeout()
+    },
+
+    clearTimeout () {
+      const runnable = state('runnable')
+
+      if (!runnable) {
+        $errUtils.throwErrByPath('miscellaneous.outside_test')
+      }
+
+      runnable.clearTimeout()
+
+      return this
+    },
+  }
 }
+
+export interface ITimeouts extends ReturnType<typeof create> { }

--- a/packages/driver/src/cy/timers.ts
+++ b/packages/driver/src/cy/timers.ts
@@ -1,17 +1,14 @@
-export default {
-  create: (Cypress) => {
-    const reset = () => {
-      return Cypress.action('app:timers:reset')
-    }
-
-    const pauseTimers = (shouldPause) => {
-      return Cypress.action('app:timers:pause', shouldPause)
-    }
-
-    return {
-      reset,
-
-      pauseTimers,
-    }
+// eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
+export const create = (Cypress) => ({
+  reset () {
+    return Cypress.action('app:timers:reset')
   },
+
+  pauseTimers (shouldPause) {
+    return Cypress.action('app:timers:pause', shouldPause)
+  },
+})
+
+export interface ITimer {
+  pauseTimers: ReturnType<typeof create>['pauseTimers']
 }

--- a/packages/driver/src/cy/video-recorder.ts
+++ b/packages/driver/src/cy/video-recorder.ts
@@ -1,39 +1,36 @@
-export default {
-  create (Cypress) {
-    // Only start recording with getUserMedia API if we're in firefox and video-enabled and run mode.
-    // TODO: this logic should be cleaned up or gotten from some video-specific config value
-    if (
-      Cypress.isBrowser('firefox')
+export const initVideoRecorder = (Cypress) => {
+  // Only start recording with getUserMedia API if we're in firefox and video-enabled and run mode.
+  // TODO: this logic should be cleaned up or gotten from some video-specific config value
+  if (
+    Cypress.isBrowser('firefox')
       && Cypress.config('video')
       && !Cypress.config('isInteractive')
       // navigator.mediaDevices will be undefined if the browser does not support display capture
       && window.navigator.mediaDevices
-    ) {
-      window.navigator.mediaDevices.getUserMedia({
-        audio: false,
-        video: {
-          // mediaSource "browser" is supported by a firefox user preference
-          // @ts-ignore
-          mediaSource: 'browser',
-          frameRate: {
-            exact: 30,
-          },
-        },
-      })
-      .then((stream) => {
-        const options = {
-          mimeType: 'video/webm',
-        }
-
+  ) {
+    window.navigator.mediaDevices.getUserMedia({
+      audio: false,
+      video: {
+        // mediaSource "browser" is supported by a firefox user preference
         // @ts-ignore
-        const mediaRecorder = new window.MediaRecorder(stream, options)
+        mediaSource: 'browser',
+        frameRate: {
+          exact: 30,
+        },
+      },
+    })
+    .then((stream) => {
+      const options = {
+        mimeType: 'video/webm',
+      }
 
-        mediaRecorder.start(200)
+      const mediaRecorder = new window.MediaRecorder(stream, options)
 
-        mediaRecorder.addEventListener('dataavailable', (e) => {
-          Cypress.action('recorder:frame', e.data)
-        })
+      mediaRecorder.start(200)
+
+      mediaRecorder.addEventListener('dataavailable', (e) => {
+        Cypress.action('recorder:frame', e.data)
       })
-    }
-  },
+    })
+  }
 }

--- a/packages/driver/src/cy/video-recorder.ts
+++ b/packages/driver/src/cy/video-recorder.ts
@@ -24,6 +24,8 @@ export const initVideoRecorder = (Cypress) => {
         mimeType: 'video/webm',
       }
 
+      // TODO: update TypeScript to 4.4+.
+      // @ts-ignore
       const mediaRecorder = new window.MediaRecorder(stream, options)
 
       mediaRecorder.start(200)

--- a/packages/driver/src/cy/xhrs.ts
+++ b/packages/driver/src/cy/xhrs.ts
@@ -25,85 +25,83 @@ const xhrNotWaitedOnByIndex = (state, alias, index, prop) => {
   }
 }
 
-export default {
-  create: (state) => {
-    return {
-      getIndexedXhrByAlias (alias, index) {
-        let prop
-        let str
+// eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
+export const create = (state) => ({
+  getIndexedXhrByAlias (alias, index) {
+    let prop
+    let str
 
-        if (_.indexOf(alias, '.') === -1) {
-          str = alias
-          prop = null
-        } else {
-          const allParts = _.split(alias, '.')
+    if (_.indexOf(alias, '.') === -1) {
+      str = alias
+      prop = null
+    } else {
+      const allParts = _.split(alias, '.')
 
-          str = _.join(_.dropRight(allParts, 1), '.')
-          prop = _.last(allParts)
-        }
-
-        if (prop) {
-          if (prop === 'request') {
-            return xhrNotWaitedOnByIndex(state, str, index, 'requests')
-          }
-
-          if (prop !== 'response') {
-            $errUtils.throwErrByPath('wait.alias_invalid', {
-              args: { prop, str },
-            })
-          }
-        }
-
-        return xhrNotWaitedOnByIndex(state, str, index, 'responses')
-      },
-
-      getRequestsByAlias (alias) {
-        let prop
-
-        if (_.indexOf(alias, '.') === -1 || _.keys(cy.state('aliases')).includes(alias)) {
-          prop = null
-        } else {
-          // potentially valid prop
-          const allParts = _.split(alias, '.')
-
-          alias = _.join(_.dropRight(allParts, 1), '.')
-          prop = _.last(allParts)
-        }
-
-        if (prop && !validAliasApiRe.test(prop)) {
-          $errUtils.throwErrByPath('get.alias_invalid', {
-            args: { prop },
-          })
-        }
-
-        if (prop === '0') {
-          $errUtils.throwErrByPath('get.alias_zero', {
-            args: { alias },
-          })
-        }
-
-        // return an array of xhrs
-        const matching = _
-        .chain(state('responses'))
-        .filter({ alias })
-        .map('xhr')
-        .value()
-
-        // return the whole array if prop is all
-        if (prop === 'all') {
-          return matching
-        }
-
-        // else if prop its a digit and we need to return
-        // the 1-based response from the array
-        if (prop) {
-          return matching[_.toNumber(prop) - 1]
-        }
-
-        // else return the last matching response
-        return _.last(matching)
-      },
+      str = _.join(_.dropRight(allParts, 1), '.')
+      prop = _.last(allParts)
     }
+
+    if (prop) {
+      if (prop === 'request') {
+        return xhrNotWaitedOnByIndex(state, str, index, 'requests')
+      }
+
+      if (prop !== 'response') {
+        $errUtils.throwErrByPath('wait.alias_invalid', {
+          args: { prop, str },
+        })
+      }
+    }
+
+    return xhrNotWaitedOnByIndex(state, str, index, 'responses')
   },
 
-}
+  getRequestsByAlias (alias) {
+    let prop
+
+    if (_.indexOf(alias, '.') === -1 || _.keys(cy.state('aliases')).includes(alias)) {
+      prop = null
+    } else {
+      // potentially valid prop
+      const allParts = _.split(alias, '.')
+
+      alias = _.join(_.dropRight(allParts, 1), '.')
+      prop = _.last(allParts)
+    }
+
+    if (prop && !validAliasApiRe.test(prop)) {
+      $errUtils.throwErrByPath('get.alias_invalid', {
+        args: { prop },
+      })
+    }
+
+    if (prop === '0') {
+      $errUtils.throwErrByPath('get.alias_zero', {
+        args: { alias },
+      })
+    }
+
+    // return an array of xhrs
+    const matching = _
+    .chain(state('responses'))
+    .filter({ alias })
+    .map('xhr')
+    .value()
+
+    // return the whole array if prop is all
+    if (prop === 'all') {
+      return matching
+    }
+
+    // else if prop its a digit and we need to return
+    // the 1-based response from the array
+    if (prop) {
+      return matching[_.toNumber(prop) - 1]
+    }
+
+    // else return the last matching response
+    return _.last(matching)
+  },
+})
+
+export interface IXhr extends ReturnType<typeof create> {}

--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -22,7 +22,7 @@ import $errUtils from './cypress/error_utils'
 import $Log from './cypress/log'
 import $LocalStorage from './cypress/local_storage'
 import $Mocha from './cypress/mocha'
-import $Mouse from './cy/mouse'
+import { create as createMouse } from './cy/mouse'
 import $Runner from './cypress/runner'
 import $Screenshot from './cypress/screenshot'
 import $SelectorPlayground from './cypress/selector_playground'
@@ -664,7 +664,10 @@ $Cypress.prototype.LocalStorage = $LocalStorage
 $Cypress.prototype.Mocha = $Mocha
 $Cypress.prototype.resolveWindowReference = resolvers.resolveWindowReference
 $Cypress.prototype.resolveLocationReference = resolvers.resolveLocationReference
-$Cypress.prototype.Mouse = $Mouse
+$Cypress.prototype.Mouse = {
+  create: createMouse,
+}
+
 $Cypress.prototype.Runner = $Runner
 $Cypress.prototype.Server = $Server
 $Cypress.prototype.Screenshot = $Screenshot

--- a/packages/driver/src/cypress/command_queue.ts
+++ b/packages/driver/src/cypress/command_queue.ts
@@ -61,7 +61,7 @@ const commandRunningFailed = (Cypress, state, err) => {
 }
 
 export default {
-  create: (state, timeouts, stability, cleanup, fail, isCy) => {
+  create: (state, timeout, whenStable, cleanup, fail, isCy) => {
     const queue = $queue.create()
 
     const { get, slice, at, reset, clear, stop } = queue
@@ -127,7 +127,7 @@ export default {
       state('current', command)
       state('chainerId', command.get('chainerId'))
 
-      return stability.whenStable(() => {
+      return whenStable(() => {
         state('nestedIndex', state('index'))
 
         return command.get('args')
@@ -281,7 +281,7 @@ export default {
           // finished running if the application under
           // test is no longer stable because we cannot
           // move onto the next test until its finished
-          return stability.whenStable(() => {
+          return whenStable(() => {
             Cypress.action('cy:command:queue:end')
 
             return null
@@ -289,7 +289,7 @@ export default {
         }
 
         // store the previous timeout
-        const prevTimeout = timeouts.timeout()
+        const prevTimeout = timeout()
 
         // store the current runnable
         const runnable = state('runnable')
@@ -307,7 +307,7 @@ export default {
           let fn
 
           if (!runnable.state) {
-            timeouts.timeout(prevTimeout)
+            timeout(prevTimeout)
           }
 
           // mutate index by incrementing it

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -192,6 +192,8 @@ class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILoc
     const { expect } = createChai!(specWindow, state, this.assert)
 
     this.expect = expect
+
+    this.$$ = this.$$.bind(this)
   }
 
   $$ (selector, context) {

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -127,8 +127,10 @@ class $Cy implements ITimeouts, IStability, IAssertions, IRetries {
   assert: IAssertions['assert']
   verifyUpcomingAssertions: IAssertions['verifyUpcomingAssertions']
   retry: IRetries['retry']
+  state: any
 
   constructor (specWindow, Cypress, Cookies, state, config) {
+    this.state = state
     initVideoRecorder(Cypress)
 
     const timeouts = createTimeouts(state)
@@ -141,7 +143,7 @@ class $Cy implements ITimeouts, IStability, IAssertions, IRetries {
     this.isStable = statility.isStable
     this.whenStable = statility.whenStable
 
-    const assertions = createAssertions(Cypress, state)
+    const assertions = createAssertions(Cypress, this)
 
     this.assert = assertions.assert
     this.verifyUpcomingAssertions = assertions.verifyUpcomingAssertions

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -25,7 +25,7 @@ import $Assertions from '../cy/assertions'
 import $Listeners from '../cy/listeners'
 import { $Chainer } from './chainer'
 import $Timers from '../cy/timers'
-import { Timeouts, ITimeouts } from '../cy/timeouts'
+import { create as createTimeouts, ITimeouts } from '../cy/timeouts'
 import $Retries from '../cy/retries'
 import $Stability from '../cy/stability'
 import $selection from '../dom/selection'
@@ -126,7 +126,7 @@ class $Cy implements ITimeouts {
   constructor (specWindow, Cypress, Cookies, state, config) {
     initVideoRecorder(Cypress)
 
-    const timeouts = new Timeouts(state)
+    const timeouts = createTimeouts(state)
 
     this.timeout = timeouts.timeout
     this.clearTimeout = timeouts.clearTimeout

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -819,10 +819,6 @@ export default {
           queue.reset()
           queue.clear()
           cy.resetTimer()
-
-          queue.reset()
-          queue.clear()
-          cy.resetTimer()
           testConfigOverride.restoreAndSetTestConfigOverrides(test, Cypress.config, Cypress.env)
 
           cy.removeAllListeners()

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -59,10 +59,12 @@ function __stackReplacementMarker (fn, ctx, args) {
   return fn.apply(ctx, args)
 }
 
+declare let top: WindowProxy & { __alreadySetErrorHandlers__: boolean } | null
+
 // We only set top.onerror once since we make it configurable:false
 // but we update cy instance every run (page reload or rerun button)
-let curCy = null
-const setTopOnError = function (Cypress, cy) {
+let curCy: $Cy | null = null
+const setTopOnError = function (Cypress, cy: $Cy) {
   if (curCy) {
     curCy = cy
 
@@ -86,7 +88,7 @@ const setTopOnError = function (Cypress, cy) {
     // but they came from the spec, so we need to differentiate them
     const isSpecError = $errUtils.isSpecError(Cypress.config('spec'), err)
 
-    const handled = curCy.onUncaughtException({
+    const handled = curCy!.onUncaughtException({
       err,
       promise,
       handlerType,

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -11,14 +11,14 @@ import $stackUtils from './stack_utils'
 
 import $Chai from '../cy/chai'
 import $Xhrs from '../cy/xhrs'
-import $jQuery from '../cy/jquery'
+import { create as createJQuery, IJQuery } from '../cy/jquery'
 import $Aliases from '../cy/aliases'
 import * as $Events from './events'
 import $Ensures from '../cy/ensures'
 import $Focused from '../cy/focused'
 import $Mouse from '../cy/mouse'
 import $Keyboard from '../cy/keyboard'
-import $Location from '../cy/location'
+import { create as createLocation, ILocation } from '../cy/location'
 import { create as createAssertions, IAssertions } from '../cy/assertions'
 import $Listeners from '../cy/listeners'
 import { $Chainer } from './chainer'
@@ -119,7 +119,7 @@ const setTopOnError = function (Cypress, cy: $Cy) {
 
 // NOTE: this makes the cy object an instance
 // TODO: refactor the 'create' method below into this class
-class $Cy implements ITimeouts, IStability, IAssertions, IRetries {
+class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILocation {
   timeout: ITimeouts['timeout']
   clearTimeout: ITimeouts['clearTimeout']
   isStable: IStability['isStable']
@@ -128,6 +128,8 @@ class $Cy implements ITimeouts, IStability, IAssertions, IRetries {
   verifyUpcomingAssertions: IAssertions['verifyUpcomingAssertions']
   retry: IRetries['retry']
   state: any
+  getRemotejQueryInstance: IJQuery['getRemotejQueryInstance']
+  getRemoteLocation: ILocation['getRemoteLocation']
 
   constructor (specWindow, Cypress, Cookies, state, config) {
     this.state = state
@@ -155,6 +157,14 @@ class $Cy implements ITimeouts, IStability, IAssertions, IRetries {
     const retries = createRetries(Cypress, state, this.timeout, this.clearTimeout, this.whenStable, onFinishAssertions)
 
     this.retry = retries.retry
+
+    const jquery = createJQuery(state)
+
+    this.getRemotejQueryInstance = jquery.getRemotejQueryInstance
+
+    const location = createLocation(state)
+
+    this.getRemoteLocation = location.getRemoteLocation
   }
 }
 
@@ -181,8 +191,6 @@ export default {
       return $dom.query(selector, context)
     }
 
-    const jquery = $jQuery.create(state)
-    const location = $Location.create(state)
     const focused = $Focused.create(state)
     const keyboard = $Keyboard.create(state)
     const mouse = $Mouse.create(state, keyboard, focused, Cypress)
@@ -598,12 +606,6 @@ export default {
       getNextAlias: aliases.getNextAlias,
       aliasNotFoundFor: aliases.aliasNotFoundFor,
       getXhrTypeByAlias: aliases.getXhrTypeByAlias,
-
-      // location sync methods
-      getRemoteLocation: location.getRemoteLocation,
-
-      // jquery sync methods
-      getRemotejQueryInstance: jquery.getRemotejQueryInstance,
 
       // focused sync methods
       getFocused: focused.getFocused,

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -10,6 +10,7 @@ import $dom from '../dom'
 import $utils from './utils'
 import $errUtils from './error_utils'
 import $stackUtils from './stack_utils'
+
 import { create as createChai, IChai } from '../cy/chai'
 import { create as createXhr, IXhr } from '../cy/xhrs'
 import { create as createJQuery, IJQuery } from '../cy/jquery'
@@ -33,8 +34,6 @@ import { $Command } from './command'
 import $CommandQueue from './command_queue'
 import { initVideoRecorder } from '../cy/video-recorder'
 import { TestConfigOverride } from '../cy/testConfigOverrides'
-import debugFn from 'debug'
-import { registerFetch } from 'unfetch'
 
 const debugErrors = debugFn('cypress:driver:errors')
 

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -8,8 +8,7 @@ import $dom from '../dom'
 import $utils from './utils'
 import $errUtils from './error_utils'
 import $stackUtils from './stack_utils'
-
-import $Chai from '../cy/chai'
+import { create as createChai, IChai } from '../cy/chai'
 import $Xhrs from '../cy/xhrs'
 import { create as createJQuery, IJQuery } from '../cy/jquery'
 import $Aliases from '../cy/aliases'
@@ -121,7 +120,7 @@ const setTopOnError = function (Cypress, cy: $Cy) {
 
 // NOTE: this makes the cy object an instance
 // TODO: refactor the 'create' method below into this class
-class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILocation, ITimer {
+class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILocation, ITimer, IChai {
   id: string
   state: any
 
@@ -141,6 +140,8 @@ class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILoc
   getRemoteLocation: ILocation['getRemoteLocation']
 
   pauseTimers: ITimer['pauseTimers']
+
+  expect: IChai['expect']
 
   // Private methods
   resetTimer: ReturnType<typeof createTimer>['reset']
@@ -187,6 +188,10 @@ class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILoc
 
     this.pauseTimers = timer.pauseTimers
     this.resetTimer = timer.reset
+
+    const { expect } = createChai!(specWindow, state, this.assert)
+
+    this.expect = expect
   }
 
   $$ (selector, context) {
@@ -225,12 +230,10 @@ export default {
     const keyboard = $Keyboard.create(state)
     const mouse = $Mouse.create(state, keyboard, focused, Cypress)
 
-    const { expect } = $Chai.create(specWindow, state, cy.assert)
-
     const xhrs = $Xhrs.create(state)
     const aliases = $Aliases.create(cy)
 
-    const ensures = $Ensures.create(state, expect)
+    const ensures = $Ensures.create(state, cy.expect)
 
     // TODO: for some reason, cy.$$ fails.
     const snapshots = $Snapshots.create($$, state)
@@ -609,9 +612,6 @@ export default {
 
       // errors sync methods
       fail,
-
-      // chai expect sync methods
-      expect,
 
       // is cy
       isCy,

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -162,7 +162,7 @@ export default {
 
     const stability = $Stability.create(Cypress, state)
 
-    const retries = $Retries.create(Cypress, state, timeouts.timeout, timeouts.clearTimeout, stability.whenStable, onFinishAssertions)
+    const retries = $Retries.create(Cypress, state, cy.timeout, cy.clearTimeout, stability.whenStable, onFinishAssertions)
     const assertions = $Assertions.create(Cypress, cy)
 
     const jquery = $jQuery.create(state)
@@ -547,7 +547,10 @@ export default {
       return finish(err)
     }
 
-    const queue = $CommandQueue.create(state, timeouts, stability, cleanup, fail, isCy)
+    const queue = $CommandQueue.create(state, {
+      timeout: cy.timeout,
+      clearTimeout: cy.clearTimeout,
+    }, stability, cleanup, fail, isCy)
 
     _.extend(cy, {
       id: _.uniqueId('cy'),
@@ -1029,7 +1032,7 @@ export default {
 
           // control timeouts on runnables ourselves
           if (_.isFinite(timeout)) {
-            timeouts.timeout(timeout)
+            cy.timeout(timeout)
           }
 
           // store the current length of our queue

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -11,7 +11,7 @@ import $stackUtils from './stack_utils'
 import { create as createChai, IChai } from '../cy/chai'
 import { create as createXhr, IXhr } from '../cy/xhrs'
 import { create as createJQuery, IJQuery } from '../cy/jquery'
-import $Aliases from '../cy/aliases'
+import { create as createAliases, IAliases } from '../cy/aliases'
 import * as $Events from './events'
 import $Ensures from '../cy/ensures'
 import $Focused from '../cy/focused'
@@ -120,7 +120,7 @@ const setTopOnError = function (Cypress, cy: $Cy) {
 
 // NOTE: this makes the cy object an instance
 // TODO: refactor the 'create' method below into this class
-class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILocation, ITimer, IChai, IXhr {
+class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILocation, ITimer, IChai, IXhr, IAliases {
   id: string
   state: any
 
@@ -147,6 +147,13 @@ class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILoc
 
   getIndexedXhrByAlias: IXhr['getIndexedXhrByAlias']
   getRequestsByAlias: IXhr['getRequestsByAlias']
+
+  addAlias: IAliases['addAlias']
+  getAlias: IAliases['getAlias']
+  getNextAlias: IAliases['getNextAlias']
+  validateAlias: IAliases['validateAlias']
+  aliasNotFoundFor: IAliases['aliasNotFoundFor']
+  getXhrTypeByAlias: IAliases['getXhrTypeByAlias']
 
   // Private methods
   resetTimer: ReturnType<typeof createTimer>['reset']
@@ -203,6 +210,16 @@ class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILoc
     this.getIndexedXhrByAlias = xhr.getIndexedXhrByAlias
     this.getRequestsByAlias = xhr.getRequestsByAlias
 
+    const aliases = createAliases(this)
+
+    this.addAlias = aliases.addAlias
+    this.getAlias = aliases.getAlias
+    this.getNextAlias = aliases.getNextAlias
+    this.validateAlias = aliases.validateAlias
+    this.aliasNotFoundFor = aliases.aliasNotFoundFor
+    this.getXhrTypeByAlias = aliases.getXhrTypeByAlias
+
+    // binded functions
     this.$$ = this.$$.bind(this)
   }
 
@@ -233,8 +250,6 @@ export default {
     const focused = $Focused.create(state)
     const keyboard = $Keyboard.create(state)
     const mouse = $Mouse.create(state, keyboard, focused, Cypress)
-
-    const aliases = $Aliases.create(cy)
 
     const ensures = $Ensures.create(state, cy.expect)
 
@@ -619,14 +634,6 @@ export default {
       isCy,
 
       isStopped,
-
-      // alias sync methods
-      getAlias: aliases.getAlias,
-      addAlias: aliases.addAlias,
-      validateAlias: aliases.validateAlias,
-      getNextAlias: aliases.getNextAlias,
-      aliasNotFoundFor: aliases.aliasNotFoundFor,
-      getXhrTypeByAlias: aliases.getXhrTypeByAlias,
 
       // focused sync methods
       getFocused: focused.getFocused,

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 /* eslint-disable prefer-rest-params */
 import _ from 'lodash'
 import Promise from 'bluebird'
@@ -196,9 +198,6 @@ class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILoc
   documentHasFocus: ReturnType<typeof createFocused>['documentHasFocus']
   interceptFocus: ReturnType<typeof createFocused>['interceptFocus']
   interceptBlur: ReturnType<typeof createFocused>['interceptBlur']
-
-  // temporary -> should be removed
-  focused: any
 
   constructor (specWindow, Cypress, Cookies, state, config) {
     this.id = _.uniqueId('cy')

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -32,7 +32,7 @@ import $selection from '../dom/selection'
 import $Snapshots from '../cy/snapshots'
 import { $Command } from './command'
 import $CommandQueue from './command_queue'
-import $VideoRecorder from '../cy/video-recorder'
+import { initVideoRecorder } from '../cy/video-recorder'
 import $TestConfigOverrides from '../cy/testConfigOverrides'
 
 const debugErrors = debugFn('cypress:driver:errors')
@@ -148,7 +148,7 @@ export default {
       return $dom.query(selector, context)
     }
 
-    $VideoRecorder.create(Cypress)
+    initVideoRecorder(Cypress)
     const timeouts = $Timeouts.create(state)
     const stability = $Stability.create(Cypress, state)
 

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -13,7 +13,7 @@ import { create as createXhr, IXhr } from '../cy/xhrs'
 import { create as createJQuery, IJQuery } from '../cy/jquery'
 import { create as createAliases, IAliases } from '../cy/aliases'
 import * as $Events from './events'
-import $Ensures from '../cy/ensures'
+import { create as createEnsures, IEnsures } from '../cy/ensures'
 import $Focused from '../cy/focused'
 import $Mouse from '../cy/mouse'
 import $Keyboard from '../cy/keyboard'
@@ -120,7 +120,7 @@ const setTopOnError = function (Cypress, cy: $Cy) {
 
 // NOTE: this makes the cy object an instance
 // TODO: refactor the 'create' method below into this class
-class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILocation, ITimer, IChai, IXhr, IAliases {
+class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILocation, ITimer, IChai, IXhr, IAliases, IEnsures {
   id: string
   state: any
 
@@ -155,8 +155,27 @@ class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILoc
   aliasNotFoundFor: IAliases['aliasNotFoundFor']
   getXhrTypeByAlias: IAliases['getXhrTypeByAlias']
 
+  ensureElement: IEnsures['ensureElement']
+  ensureAttached: IEnsures['ensureAttached']
+  ensureWindow: IEnsures['ensureWindow']
+  ensureDocument: IEnsures['ensureDocument']
+  ensureElDoesNotHaveCSS: IEnsures['ensureElDoesNotHaveCSS']
+  ensureElementIsNotAnimating: IEnsures['ensureElementIsNotAnimating']
+  ensureNotDisabled: IEnsures['ensureNotDisabled']
+  ensureVisibility: IEnsures['ensureVisibility']
+  ensureStrictVisibility: IEnsures['ensureStrictVisibility']
+  ensureNotHiddenByAncestors: IEnsures['ensureNotHiddenByAncestors']
+  ensureExistence: IEnsures['ensureExistence']
+  ensureElExistence: IEnsures['ensureElExistence']
+  ensureDescendents: IEnsures['ensureDescendents']
+  ensureValidPosition: IEnsures['ensureValidPosition']
+  ensureScrollability: IEnsures['ensureScrollability']
+  ensureNotReadonly: IEnsures['ensureNotReadonly']
+
   // Private methods
   resetTimer: ReturnType<typeof createTimer>['reset']
+  ensureSubjectByType: ReturnType<typeof createEnsures>['ensureSubjectByType']
+  ensureRunnable: ReturnType<typeof createEnsures>['ensureRunnable']
 
   constructor (specWindow, Cypress, Cookies, state, config) {
     this.id = _.uniqueId('cy')
@@ -219,6 +238,28 @@ class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILoc
     this.aliasNotFoundFor = aliases.aliasNotFoundFor
     this.getXhrTypeByAlias = aliases.getXhrTypeByAlias
 
+    const ensures = createEnsures(state, this.expect)
+
+    this.ensureElement = ensures.ensureElement
+    this.ensureAttached = ensures.ensureAttached
+    this.ensureWindow = ensures.ensureWindow
+    this.ensureDocument = ensures.ensureDocument
+    this.ensureElDoesNotHaveCSS = ensures.ensureElDoesNotHaveCSS
+    this.ensureElementIsNotAnimating = ensures.ensureElementIsNotAnimating
+    this.ensureNotDisabled = ensures.ensureNotDisabled
+    this.ensureVisibility = ensures.ensureVisibility
+    this.ensureStrictVisibility = ensures.ensureStrictVisibility
+    this.ensureNotHiddenByAncestors = ensures.ensureNotHiddenByAncestors
+    this.ensureExistence = ensures.ensureExistence
+    this.ensureElExistence = ensures.ensureElExistence
+    this.ensureDescendents = ensures.ensureDescendents
+    this.ensureValidPosition = ensures.ensureValidPosition
+    this.ensureScrollability = ensures.ensureScrollability
+    this.ensureNotReadonly = ensures.ensureNotReadonly
+
+    this.ensureSubjectByType = ensures.ensureSubjectByType
+    this.ensureRunnable = ensures.ensureRunnable
+
     // binded functions
     this.$$ = this.$$.bind(this)
   }
@@ -251,8 +292,6 @@ export default {
     const keyboard = $Keyboard.create(state)
     const mouse = $Mouse.create(state, keyboard, focused, Cypress)
 
-    const ensures = $Ensures.create(state, cy.expect)
-
     const snapshots = $Snapshots.create(cy.$$, state)
     const testConfigOverride = new TestConfigOverride()
 
@@ -265,7 +304,7 @@ export default {
     }
 
     const runnableCtx = function (name) {
-      ensures.ensureRunnable(name)
+      cy.ensureRunnable(name)
 
       return state('runnable').ctx
     }
@@ -471,7 +510,7 @@ export default {
       if (prevSubject) {
         // make sure our current subject is valid for
         // what we expect in this command
-        ensures.ensureSubjectByType(subject, prevSubject, name)
+        cy.ensureSubjectByType(subject, prevSubject, name)
       }
 
       args.unshift(subject)
@@ -649,24 +688,6 @@ export default {
       // snapshots sync methods
       createSnapshot: snapshots.createSnapshot,
 
-      // ensure sync methods
-      ensureWindow: ensures.ensureWindow,
-      ensureElement: ensures.ensureElement,
-      ensureDocument: ensures.ensureDocument,
-      ensureAttached: ensures.ensureAttached,
-      ensureExistence: ensures.ensureExistence,
-      ensureElExistence: ensures.ensureElExistence,
-      ensureElDoesNotHaveCSS: ensures.ensureElDoesNotHaveCSS,
-      ensureVisibility: ensures.ensureVisibility,
-      ensureStrictVisibility: ensures.ensureStrictVisibility,
-      ensureNotHiddenByAncestors: ensures.ensureNotHiddenByAncestors,
-      ensureDescendents: ensures.ensureDescendents,
-      ensureNotReadonly: ensures.ensureNotReadonly,
-      ensureNotDisabled: ensures.ensureNotDisabled,
-      ensureValidPosition: ensures.ensureValidPosition,
-      ensureScrollability: ensures.ensureScrollability,
-      ensureElementIsNotAnimating: ensures.ensureElementIsNotAnimating,
-
       initialize ($autIframe) {
         setRemoteIframeProps($autIframe, state)
 
@@ -822,7 +843,7 @@ export default {
 
           let ret
 
-          ensures.ensureRunnable(name)
+          cy.ensureRunnable(name)
 
           // this is the first call on cypress
           // so create a new chainer instance

--- a/packages/driver/src/cypress/error_utils.ts
+++ b/packages/driver/src/cypress/error_utils.ts
@@ -237,7 +237,7 @@ const throwErrByPath = (errPath, options = {}) => {
     Error.captureStackTrace(err, throwErrByPath)
   }
 
-  return throwErr(err, options)
+  throwErr(err, options)
 }
 
 const warnByPath = (errPath, options = {}) => {

--- a/packages/driver/src/cypress/log.ts
+++ b/packages/driver/src/cypress/log.ts
@@ -4,7 +4,7 @@ import _ from 'lodash'
 import $ from 'jquery'
 import clone from 'clone'
 
-import $Snapshots from '../cy/snapshots'
+import { HIGHLIGHT_ATTR } from '../cy/snapshots'
 import * as $Events from './events'
 import $dom from '../dom'
 import $utils from './utils'
@@ -19,8 +19,6 @@ const DISPLAY_PROPS = 'id alias aliasType callCount displayName end err event fu
 const BLACKLIST_PROPS = 'snapshots'.split(' ')
 
 let counter = 0
-
-const { HIGHLIGHT_ATTR } = $Snapshots
 
 // mutate attrs by nulling out
 // object properties


### PR DESCRIPTION
- Related with #18172

### User facing changelog

N/A

### Additional details
- Why was this change necessary? => `$Cy` class is dummy and all the definitions were done inside the `create` function and `_.extend`. We're moving the parts into it. 
- What is affected by this change? => N/A


### implementation details

* At first, I wanted to move everything in this PR, but decided not to. Because it's still really big (+1675/-1667). I decided to break the PR to 3 steps.
  1. Handle outside functions (this PR).
  2. Handle queue and the functions inside `_.extend` (next PR)
  3. Remove `// @ts-nocheck` in `cy.ts` and other outside functions.
* I moved `create` out of `export default` because it requires one more indentation. 
* There are many functions in `$Cy` that are defined outside `cy.ts` and merged into it by `_.extend`. I solved the problem by creating interfaces for them. In the code, you'll find many interfaces like `ITimeouts`, `IJQuery`, etc.

### How has the user experience changed?

N/A

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

N/A