### PR TITLE
fix(app): do not cache graphql

### DIFF
--- a/packages/data-context/src/DataContextShell.ts
+++ b/packages/data-context/src/DataContextShell.ts
@@ -61,7 +61,7 @@ export class DataContextShell {
     return new DataEmitterActions(this)
   }
 
-  get graphql () {
+  graphqlClient () {
     return new GraphQLDataSource(this, this.shellConfig.schema)
   }
 

--- a/packages/data-context/src/DataContextShell.ts
+++ b/packages/data-context/src/DataContextShell.ts
@@ -61,7 +61,6 @@ export class DataContextShell {
     return new DataEmitterActions(this)
   }
 
-  @cached
   get graphql () {
     return new GraphQLDataSource(this, this.shellConfig.schema)
   }

--- a/packages/data-context/src/sources/HtmlDataSource.ts
+++ b/packages/data-context/src/sources/HtmlDataSource.ts
@@ -10,15 +10,17 @@ export class HtmlDataSource {
   constructor (private ctx: DataContextShell) {}
 
   async fetchAppInitialData () {
+    const graphql = this.ctx.graphql
+
     await Promise.all([
-      this.ctx.graphql.executeQuery('AppQueryDocument', {}),
-      this.ctx.graphql.executeQuery('NewSpec_NewSpecQueryDocument', {}),
-      this.ctx.graphql.executeQuery('ProjectSettingsDocument', {}),
-      this.ctx.graphql.executeQuery('SpecsPageContainerDocument', {}),
-      this.ctx.graphql.executeQuery('HeaderBar_HeaderBarQueryDocument', {}),
+      graphql.executeQuery('AppQueryDocument', {}),
+      graphql.executeQuery('NewSpec_NewSpecQueryDocument', {}),
+      graphql.executeQuery('ProjectSettingsDocument', {}),
+      graphql.executeQuery('SpecsPageContainerDocument', {}),
+      graphql.executeQuery('HeaderBar_HeaderBarQueryDocument', {}),
     ])
 
-    return this.ctx.graphql.getSSRData()
+    return graphql.getSSRData()
   }
 
   async fetchAppHtml () {

--- a/packages/data-context/src/sources/HtmlDataSource.ts
+++ b/packages/data-context/src/sources/HtmlDataSource.ts
@@ -10,7 +10,7 @@ export class HtmlDataSource {
   constructor (private ctx: DataContextShell) {}
 
   async fetchAppInitialData () {
-    const graphql = this.ctx.graphql
+    const graphql = this.ctx.graphqlClient()
 
     await Promise.all([
       graphql.executeQuery('AppQueryDocument', {}),


### PR DESCRIPTION
Fix a bug where the specs of the previous project are shown due to caching.

How to reproduce:

1. Open a project using global mode
2. Go to __vite__ URL, specs tab
3. Go back to launchpad and choose another project
4. Go to __vite__ URL, spec tab
5. Specs from previous project are shown due to cached graphql client

Not sure if there's a better way (eg some way to bust the cache when we change to a project). If there is, please suggest it and I'll update the PR.