### PR TITLE
chore: Increase paralleled machines for desktop-gui tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -960,7 +960,7 @@ jobs:
             fi
       - wait-on-circle-jobs:
           job-names: >
-            desktop-gui-integration-tests-2x,
+            desktop-gui-integration-tests-7x,
             desktop-gui-component-tests,
             cli-visual-tests,
             runner-integration-tests-chrome,
@@ -1189,7 +1189,7 @@ jobs:
       - run-driver-integration-tests:
           browser: electron
 
-  desktop-gui-integration-tests-2x:
+  desktop-gui-integration-tests-7x:
     <<: *defaults
     parallelism: 7
     steps:
@@ -2049,7 +2049,7 @@ linux-workflow: &linux-workflow
         requires:
           - build
 
-    - desktop-gui-integration-tests-2x:
+    - desktop-gui-integration-tests-7x:
         requires:
           - build
     - desktop-gui-component-tests:
@@ -2119,7 +2119,7 @@ linux-workflow: &linux-workflow
           - reporter-integration-tests
           - Linux lint
           - desktop-gui-component-tests
-          - desktop-gui-integration-tests-2x
+          - desktop-gui-integration-tests-7x
           - runner-ct-integration-tests-chrome
           - runner-integration-tests-firefox
           - runner-integration-tests-chrome

--- a/circle.yml
+++ b/circle.yml
@@ -966,7 +966,7 @@ jobs:
             runner-integration-tests-chrome,
             runner-ct-integration-tests-chrome
             reporter-integration-tests,
-      - run: yarn percy build:finalize
+      - run: DEBUG=* yarn percy build:finalize
 
   cli-visual-tests:
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -966,7 +966,7 @@ jobs:
             runner-integration-tests-chrome,
             runner-ct-integration-tests-chrome
             reporter-integration-tests,
-      - run: DEBUG=* yarn percy build:finalize
+      - run: yarn percy build:finalize
 
   cli-visual-tests:
     <<: *defaults
@@ -1191,7 +1191,7 @@ jobs:
 
   desktop-gui-integration-tests-2x:
     <<: *defaults
-    parallelism: 2
+    parallelism: 7
     steps:
       - restore_cached_workspace
       - run:


### PR DESCRIPTION
Our percy finalize job waits for other jobs in circle to finish, like the desktop-gui tests. This  was timing out lately because the desktop-gui tests are now taking longer than 10 mins to finish (about 12) and CircleCI exits any job when it gets no signal after 10 mins. 

This PR parallelizes the desktop-gui tests at the number of machines recommended by our dashboard (7). 

This should make our tests run faster and the percy-finalize job should no longer exit from no signal. 