### PR TITLE
fix: remove outdated npm registry links

### DIFF
--- a/npm/cypress-schematic/src/schematics/utility/index.ts
+++ b/npm/cypress-schematic/src/schematics/utility/index.ts
@@ -25,7 +25,7 @@ export function getLatestNodeVersion (packageName: string): Promise<NodePackage>
   const DEFAULT_VERSION = 'latest'
 
   return new Promise((resolve) => {
-    return get(`https://registry.npmjs.org/${packageName}`, (res) => {
+    return get(`http://registry.npmjs.org/${packageName}`, (res) => {
       let rawData = ''
 
       res.on('data', (chunk) => (rawData += chunk))

--- a/npm/cypress-schematic/src/schematics/utility/index.ts
+++ b/npm/cypress-schematic/src/schematics/utility/index.ts
@@ -25,7 +25,7 @@ export function getLatestNodeVersion (packageName: string): Promise<NodePackage>
   const DEFAULT_VERSION = 'latest'
 
   return new Promise((resolve) => {
-    return get(`http://registry.npmjs.org/${packageName}`, (res) => {
+    return get(`https://registry.npmjs.org/${packageName}`, (res) => {
       let rawData = ''
 
       res.on('data', (chunk) => (rawData += chunk))

--- a/npm/vue/.npmrc
+++ b/npm/vue/.npmrc
@@ -1,4 +1,3 @@
-registry=http://registry.npmjs.org/
 save-exact=true
 progress=false
 package-lock=true

--- a/npm/webpack-preprocessor/.npmrc
+++ b/npm/webpack-preprocessor/.npmrc
@@ -1,4 +1,3 @@
-registry=http://registry.npmjs.org/
 save-exact=true
 progress=false
 package-lock=false

--- a/scripts/unit/npm-release-spec.js
+++ b/scripts/unit/npm-release-spec.js
@@ -25,7 +25,7 @@ const semanticReleaseNoUpdate = (version) => {
 [semantic-release] › ⚠  Run automated release from branch master on repository https://github.com/cypress-io/cypress.git in dry-run mode
 [semantic-release] › ✔  Allowed to push to the Git repository
 [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/npm"
-[semantic-release] [@semantic-release/npm] › ℹ  Verify authentication for registry http://registry.npmjs.org/
+[semantic-release] [@semantic-release/npm] › ℹ  Verify authentication for registry https://registry.npmjs.org/
 [semantic-release] [@semantic-release/npm] › ℹ  Reading npm config from /cypress/npm/package/.npmrc
 [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/npm"
 [semantic-release] › ℹ  Found git tag @cypress/package-v${version} associated with version ${version} on branch master
@@ -66,7 +66,7 @@ const semanticReleaseUpdate = (oldVersion, newVersion) => {
 [semantic-release] › ⚠  Run automated release from branch master on repository https://github.com/cypress-io/cypress.git in dry-run mode
 [semantic-release] › ✔  Allowed to push to the Git repository
 [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/npm"
-[semantic-release] [@semantic-release/npm] › ℹ  Verify authentication for registry http://registry.npmjs.org/
+[semantic-release] [@semantic-release/npm] › ℹ  Verify authentication for registry https://registry.npmjs.org/
 [semantic-release] [@semantic-release/npm] › ℹ  Reading npm config from /cypress/npm/package/.npmrc
 [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/npm"
 [semantic-release] › ℹ  Found git tag @cypress/package-v${oldVersion} associated with version ${oldVersion} on branch master
@@ -150,7 +150,7 @@ const semanticReleaseNew = () => {
 [semantic-release] › ⚠  Run automated release from branch master on repository https://github.com/cypress-io/cypress.git in dry-run mode
 [semantic-release] › ✔  Allowed to push to the Git repository
 [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/npm"
-[semantic-release] [@semantic-release/npm] › ℹ  Verify authentication for registry http://registry.npmjs.org/
+[semantic-release] [@semantic-release/npm] › ℹ  Verify authentication for registry https://registry.npmjs.org/
 [semantic-release] [@semantic-release/npm] › ℹ  Reading npm config from /cypress/npm/package/.npmrc
 [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/npm"
 [semantic-release] › ℹ  No git tag version found on branch master


### PR DESCRIPTION
### User facing changelog
NA

### Additional details
Continuation of #18710. Missed a few outdated links.

[CI Build](https://app.circleci.com/pipelines/github/cypress-io/cypress/25779/workflows/fa61dfc5-8408-4528-80eb-e0bd233b4da6/jobs/968565) showing the `426 Upgrade required`. 
![Screen Shot 2021-11-01 at 10 09 59 AM](https://user-images.githubusercontent.com/25158820/139694263-551e2982-8d5f-4b8a-8267-2303e4fa8620.png)

### How has the user experience changed?
NA