### PR TITLE
feat: Add typings for new devServer config

### DIFF
--- a/cli/types/cypress-npm-api.d.ts
+++ b/cli/types/cypress-npm-api.d.ts
@@ -395,7 +395,7 @@ declare module 'cypress' {
      * @param {Cypress.ConfigOptions} config
      * @returns {Cypress.ConfigOptions} the configuration passed in parameter
      */
-    defineConfig(config: Cypress.ConfigOptions): Cypress.ConfigOptions
+    defineConfig<ComponentDevServerOpts = any>(config: Cypress.ConfigOptions<ComponentDevServerOpts>): Cypress.ConfigOptions
   }
 
   // export Cypress NPM module interface

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2895,7 +2895,21 @@ declare namespace Cypress {
    * All configuration items are optional.
    */
   type CoreConfigOptions = Partial<Omit<ResolvedConfigOptions, TestingType>>
-  type ConfigOptions = CoreConfigOptions & { e2e?: CoreConfigOptions, component?: CoreConfigOptions }
+
+  interface ComponentConfigOptions<ComponentDevServerOpts> extends CoreConfigOptions {
+    // TODO(tim): Keeping optional until we land the implementation
+    devServer?: (cypressConfig: DevServerConfig, devServerConfig: ComponentDevServerOpts) => ResolvedDevServerConfig | Promise<ResolvedDevServerConfig>
+    devServerConfig?: ComponentDevServerOpts
+  }
+
+  /**
+   * Takes ComponentDevServerOpts to track the signature of the devServerConfig for the provided `devServer`,
+   * so we have proper completion for `devServerConfig`
+   */
+  type ConfigOptions<ComponentDevServerOpts = any> = CoreConfigOptions & {
+    e2e?: CoreConfigOptions,
+    component?: ComponentConfigOptions<ComponentDevServerOpts>
+  }
 
   interface PluginConfigOptions extends ResolvedConfigOptions {
     /**


### PR DESCRIPTION
Part of UNIFY-340

Adds signatures for `devServer` and `devServerConfig`, as well as a generic which track the signature of the `devServer` so we can infer the proper type of the `devServerConfig` without using the `defineDevServerConfig` helper function.

![image](https://user-images.githubusercontent.com/154748/140416832-a7702f19-f6d9-4f7a-a40a-1bb8059e799a.png)

