### PR TITLE
chore: patch `winston` to suppress `padLevels` warning

### DIFF
--- a/patches/winston+2.4.4.patch
+++ b/patches/winston+2.4.4.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/winston/lib/winston/common.js b/node_modules/winston/lib/winston/common.js
+index 8ed9973..ecc59f8 100644
+--- a/node_modules/winston/lib/winston/common.js
++++ b/node_modules/winston/lib/winston/common.js
+@@ -32,7 +32,10 @@ exports.setLevels = function (target, past, current, isDefault) {
+   }
+ 
+   target.levels = current || config.npm.levels;
+-  if (target.padLevels) {
++  // Check if `padLevels` exists to suppress a warning about accessing
++  // a non-existing property on `exports`.
++  // @see https://github.com/winstonjs/winston/issues/1882
++  if (target.hasOwnProperty('padLevels') && target.padLevels) {
+     target.levelLength = exports.longestElement(Object.keys(target.levels));
+   }
+ 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog

n/a - not user facing since we hide warnings: https://github.com/cypress-io/cypress/blob/ab4ae0d48a992289346339d8e538e14944b16615/packages/server/lib/util/suppress_warnings.js#L37-L41

### Additional details

Fixes this warning:

```
(node:846252) Warning: Accessing non-existent property 'padLevels' of module exports inside circular dependency
(Use `Cypress --trace-warnings ...` to show where the warning was created)
```

See https://github.com/winstonjs/winston/issues/1882

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [na] Have tests been added/updated?
- [na] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
