### PR TITLE
fix: share urql cache keys between client & server

### DIFF
--- a/packages/data-context/src/sources/GraphQLDataSource.ts
+++ b/packages/data-context/src/sources/GraphQLDataSource.ts
@@ -4,6 +4,7 @@ import { executeExchange } from '@urql/exchange-execute'
 import type { GraphQLSchema } from 'graphql'
 import type { DataContext } from '../DataContext'
 import type * as allOperations from '../gen/all-operations.gen'
+import { urqlCacheKeys } from '../util/urqlCacheKeys'
 
 // Filter out non-Query shapes
 type AllQueries<T> = {
@@ -49,7 +50,7 @@ export class GraphQLDataSource {
       url: `__`,
       exchanges: [
         dedupExchange,
-        cacheExchange(),
+        cacheExchange(urqlCacheKeys),
         this._ssr,
         executeExchange({
           schema: this.schema,

--- a/packages/data-context/src/util/index.ts
+++ b/packages/data-context/src/util/index.ts
@@ -2,3 +2,4 @@
 // created by autobarrel, do not modify directly
 
 export * from './cached'
+export * from './urqlCacheKeys'

--- a/packages/data-context/src/util/urqlCacheKeys.ts
+++ b/packages/data-context/src/util/urqlCacheKeys.ts
@@ -1,0 +1,20 @@
+import type { CacheExchangeOpts } from '@urql/exchange-graphcache'
+
+/**
+ * These are located in data-context, because we use them in the
+ * both the server-side and client-side urql, since we cache & hydrate
+ * the page on load
+ *
+ * We want to to keep the key definitions in sync between the
+ * server & client so we only define them once
+ */
+export const urqlCacheKeys: Partial<CacheExchangeOpts> = {
+  keys: {
+    App: (data) => data.__typename,
+    DevState: (data) => data.__typename,
+    Wizard: (data) => data.__typename,
+    GitInfo: () => null,
+    BaseError: () => null,
+    ProjectPreferences: (data) => data.__typename,
+  },
+}

--- a/packages/frontend-shared/src/graphql/urqlClient.ts
+++ b/packages/frontend-shared/src/graphql/urqlClient.ts
@@ -13,6 +13,8 @@ import { useToast } from 'vue-toastification'
 import { client } from '@packages/socket/lib/browser'
 
 import { cacheExchange as graphcacheExchange } from '@urql/exchange-graphcache'
+import { urqlCacheKeys } from '@packages/data-context/src/util/urqlCacheKeys'
+
 import { pubSubExchange } from './urqlExchangePubsub'
 import { namedRouteExchange } from './urqlExchangeNamedRoute'
 import { latestMutationExchange } from './urqlExchangeLatestMutation'
@@ -23,16 +25,7 @@ const SERVER_PORT_MATCH = /serverPort=(\d+)/.exec(window.location.search)
 const toast = useToast()
 
 export function makeCacheExchange () {
-  return graphcacheExchange({
-    keys: {
-      App: (data) => data.__typename,
-      DevState: (data) => data.__typename,
-      Wizard: (data) => data.__typename,
-      GitInfo: () => null,
-      BaseError: () => null,
-      ProjectPreferences: (data) => data.__typename,
-    },
-  })
+  return graphcacheExchange(urqlCacheKeys)
 }
 
 declare global {


### PR DESCRIPTION
These are located in data-context, because we use them in the both the server-side and client-side urql, since we cache & hydrate the page on load

We want to to keep the key definitions in sync between the server & client so we only define them once