### PR TITLE
fix: type for Command.add with apending subject argument

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -175,6 +175,17 @@ declare namespace Cypress {
    */
   type Config = ResolvedConfigOptions & RuntimeConfigOptions
 
+  type AddSubjectArgument<
+    TPrevSubject extends CommandOptions['prevSubject'],
+    TFunction extends (...args: any) => any
+    > = (
+    prevSubject: TPrevSubject extends 'element' ? JQuery | HTMLElement
+      : TPrevSubject extends 'window' ? Window
+        : TPrevSubject extends 'document' ? Document
+          : any,
+    ...args: Parameters<TFunction>
+  ) => ReturnType<TFunction>
+
   /**
    * Several libraries are bundled with Cypress by default.
    *
@@ -421,7 +432,7 @@ declare namespace Cypress {
      */
     Commands: {
       add<T extends keyof Chainable>(name: T, fn: Chainable[T]): void
-      add<T extends keyof Chainable>(name: T, options: CommandOptions, fn: Chainable[T]): void
+      add<T extends keyof Chainable, TOptions extends CommandOptions>(name: T, options: TOptions, fn: Chainable[T] extends (...args: any) => any ? TOptions['prevSubject'] extends false ? Chainable[T] : AddSubjectArgument<TOptions['prevSubject'], Chainable[T]> : never): void
       overwrite<T extends keyof Chainable>(name: T, fn: Chainable[T]): void
     }
 

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -74,7 +74,37 @@ namespace CypressCommandsTests {
     arg
     return
   })
-  Cypress.Commands.add('newCommand', { prevSubject: true }, (arg) => {
+  Cypress.Commands.add('newCommand', { prevSubject: true }, (subject, arg) => {
+    // $ExpectType any
+    subject
+    // $ExpectType string
+    arg
+    return
+  })
+  Cypress.Commands.add('newCommand', { prevSubject: 'element' }, (subject, arg) => {
+    // $ExpectType HTMLElement | JQuery<HTMLElement>
+    subject
+    // $ExpectType string
+    arg
+    return
+  })
+  Cypress.Commands.add('newCommand', { prevSubject: 'window' }, (subject, arg) => {
+    // $ExpectType Window
+    subject
+    // $ExpectType string
+    arg
+    return
+  })
+  Cypress.Commands.add('newCommand', { prevSubject: 'document' }, (subject, arg) => {
+    // $ExpectType Document
+    subject
+    // $ExpectType string
+    arg
+    return
+  })
+  Cypress.Commands.add('newCommand', { prevSubject: 'optional' }, (subject, arg) => {
+    // $ExpectType any
+    subject
     // $ExpectType string
     arg
     return


### PR DESCRIPTION
- Closes #18879 

### User facing changelog
Updated type of Cypress.add with prevSubject option to add the subject argument to the function definition

### Additional details

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?