### PR TITLE
fix: the shadow root container element is ignored when clicking an element in it.

### DIFF
--- a/packages/driver/cypress/fixtures/shadow-dom-button.html
+++ b/packages/driver/cypress/fixtures/shadow-dom-button.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+    <head>
+      <title>Shadow DOM Button test</title>
+    </head>
+
+    <body>
+      <cy-test-element id='element'>Click me!</cy-test-element>
+      <script>
+        class CyTestElement extends HTMLElement {
+          constructor() {
+            super();
+
+            this.attachShadow({ mode: 'open' });
+            const button = document.createElement('button');
+            const slot = document.createElement('slot');
+
+            button.setAttribute('data-test-id', 'my-button')
+
+            button.appendChild(slot);
+
+            button.addEventListener('click', () => {
+              const div = document.createElement('div');
+              div.textContent = 'Clicked'
+
+              this.shadowRoot.appendChild(div);
+            });
+
+            this.shadowRoot.appendChild(
+                button
+            );
+          }
+        }
+
+        customElements.define('cy-test-element', CyTestElement);
+      </script>
+    </body>
+</html>

--- a/packages/driver/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/click_spec.js
@@ -3985,6 +3985,13 @@ describe('shadow dom', () => {
 
     cy.get('#shadow-element-1').click()
   })
+
+  // https://github.com/cypress-io/cypress/issues/18008
+  it('ignores the covering shadow host', () => {
+    cy.visit('/fixtures/shadow-dom-button.html')
+
+    cy.get('#element').shadow().find('[data-test-id="my-button"]').click()
+  })
 })
 
 describe('mouse state', () => {

--- a/packages/driver/cypress/integration/commands/actions/click_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/click_spec.js
@@ -3987,7 +3987,7 @@ describe('shadow dom', () => {
   })
 
   // https://github.com/cypress-io/cypress/issues/18008
-  it('ignores the covering shadow host', () => {
+  it('does not fail actionability check when element is covered by its shadow host', () => {
     cy.visit('/fixtures/shadow-dom-button.html')
 
     cy.get('#element').shadow().find('[data-test-id="my-button"]').click()

--- a/packages/driver/src/cy/ensures.ts
+++ b/packages/driver/src/cy/ensures.ts
@@ -328,11 +328,20 @@ export const create = (state, expect) => {
     const cmd = state('current').get('name')
 
     if (!$dom.isDescendent($el1, $el2)) {
+      // https://github.com/cypress-io/cypress/issues/18008
+      // when an element inside a shadow root is covered by its shadow host
+      if (
+        $dom.isWithinShadowRoot($el1.get(0)) &&
+          $el1.get(0).getRootNode() === $el2.get(0).shadowRoot
+      ) {
+        return
+      }
+
       if ($el2) {
         const element1 = $dom.stringify($el1)
         const element2 = $dom.stringify($el2)
 
-        $errUtils.throwErrByPath('dom.covered', {
+        return $errUtils.throwErrByPath('dom.covered', {
           onFail,
           args: { cmd, element1, element2 },
           errProps: {

--- a/packages/driver/src/cy/ensures.ts
+++ b/packages/driver/src/cy/ensures.ts
@@ -332,7 +332,7 @@ export const create = (state, expect) => {
       // when an element inside a shadow root is covered by its shadow host
       if (
         $dom.isWithinShadowRoot($el1.get(0)) &&
-          $el1.get(0).getRootNode() === $el2.get(0).shadowRoot
+          $el1.get(0).getRootNode() === $el2?.get(0).shadowRoot
       ) {
         return
       }
@@ -341,7 +341,7 @@ export const create = (state, expect) => {
         const element1 = $dom.stringify($el1)
         const element2 = $dom.stringify($el2)
 
-        return $errUtils.throwErrByPath('dom.covered', {
+        $errUtils.throwErrByPath('dom.covered', {
           onFail,
           args: { cmd, element1, element2 },
           errProps: {


### PR DESCRIPTION
- Closes #18008

### User facing changelog

- Shadow DOM elements are no longer falsely reported as hidden by their host

### Additional details
- Why was this change necessary? => When clicking an element inside a custom element, it shows the error message that it is covered by its custom element container. 
- What is affected by this change? => N/A

### Any implementation details to explain?
* I added a condition to bypass error when the element is inside a shadow root and covered by it.
* It fixes the "covering" problem. But it doesn't solve "event messages are not sent" problem (#17531). I added a new fixture for later tests. 

### How has the user experience changed?

**Before:**

![image](https://user-images.githubusercontent.com/8130013/141708985-775055d4-b91b-407a-b132-81e75faaa197.png)

**After:**

No Error.

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
