### PR TITLE
feat(app): remove __vite__ route and default to unified runner

### DIFF
--- a/packages/app/cypress/e2e/integration/navigation.spec.ts
+++ b/packages/app/cypress/e2e/integration/navigation.spec.ts
@@ -13,8 +13,5 @@ describe('Navigation', () => {
     cy.wait('@OpenExternal').then((interception: Interception) => {
       expect(interception.request.body.variables.url).to.equal('https://on.cypress.io/writing-first-test?utm_medium=Docs+Menu&utm_content=First+Test')
     })
-
-    cy.get('[href="#/runs"]').click()
-    cy.contains(defaultMessages.runs.connect.title).should('be.visible')
   })
 })

--- a/packages/data-context/src/sources/HtmlDataSource.ts
+++ b/packages/data-context/src/sources/HtmlDataSource.ts
@@ -30,7 +30,7 @@ export class HtmlDataSource {
       return html
     }
 
-    return this.ctx.fs.readFile(getPathToDist('app'), 'utf8')
+    return this.ctx.fs.readFile(getPathToDist('app', 'index.html'), 'utf8')
   }
 
   /**

--- a/packages/driver/cypress.config.ts
+++ b/packages/driver/cypress.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from 'cypress'
 
 export default defineConfig({
   'projectId': 'ypt4pf',
-  'baseUrl': 'http://localhost:3500',
+  'e2e': {
+    'baseUrl': 'http://localhost:3500',
+  },
   'testFiles': '**/*',
   'hosts': {
     '*.foobar.com': '127.0.0.1',

--- a/packages/server/lib/project_utils.ts
+++ b/packages/server/lib/project_utils.ts
@@ -13,6 +13,10 @@ const multipleForwardSlashesRe = /[^:\/\/](\/{2,})/g
 const backSlashesRe = /\\/g
 
 const normalizeSpecUrl = (browserUrl: string, specUrl: string) => {
+  if (process.env.LAUNCHPAD) {
+    return browserUrl
+  }
+
   const replacer = (match: string) => match.replace('//', '/')
 
   return [

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -94,10 +94,6 @@ export const createCommonRoutes = ({
       target: `http://localhost:${process.env.CYPRESS_INTERNAL_VITE_APP_PORT}/`,
     })
 
-    // router.get('/__vite__/', (req, res) => {
-    //   ctx.html.appHtml().then((html) => res.send(html)).catch((e) => res.status(500).send({ stack: e.stack }))
-    // })
-
     // TODO: can namespace this onto a "unified" route like __app-unified__
     // make sure to update the generated routes inside of vite.config.ts
     router.get('/__vite__/*', (req, res) => {
@@ -147,7 +143,9 @@ export const createCommonRoutes = ({
     debug('Serving Cypress front-end by requested URL:', req.url)
 
     if (process.env.LAUNCHPAD) {
-      ctx.html.appHtml().then((html) => res.send(html)).catch((e) => res.status(500).send({ stack: e.stack }))
+      ctx.html.appHtml()
+      .then((html) => res.send(html))
+      .catch((e) => res.status(500).send({ stack: e.stack }))
     } else {
       runner.serve(req, res, testingType === 'e2e' ? 'runner' : 'runner-ct', {
         config,

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -159,7 +159,11 @@ export const createCommonRoutes = ({
     }
   })
 
-  router.get(`${clientRoute}assets/*`, (req, res) => {
+  // serve static assets from the dist'd Vite app
+  router.get([
+    `${clientRoute}assets/*`,
+    `${clientRoute}shiki/*`,
+  ], (req, res) => {
     debug('proxying static assets %s, params[0] %s', req.url, req.params[0])
     const pathToFile = getPathToDist('app', 'assets', req.params[0])
 

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -94,9 +94,9 @@ export const createCommonRoutes = ({
       target: `http://localhost:${process.env.CYPRESS_INTERNAL_VITE_APP_PORT}/`,
     })
 
-    router.get('/__vite__/', (req, res) => {
-      ctx.html.appHtml().then((html) => res.send(html)).catch((e) => res.status(500).send({ stack: e.stack }))
-    })
+    // router.get('/__vite__/', (req, res) => {
+    //   ctx.html.appHtml().then((html) => res.send(html)).catch((e) => res.status(500).send({ stack: e.stack }))
+    // })
 
     // TODO: can namespace this onto a "unified" route like __app-unified__
     // make sure to update the generated routes inside of vite.config.ts
@@ -146,15 +146,19 @@ export const createCommonRoutes = ({
   router.get(clientRoute, (req, res) => {
     debug('Serving Cypress front-end by requested URL:', req.url)
 
-    runner.serve(req, res, testingType === 'e2e' ? 'runner' : 'runner-ct', {
-      config,
-      testingType,
-      getSpec,
-      getCurrentBrowser,
-      getRemoteState,
-      specsStore,
-      exit,
-    })
+    if (process.env.LAUNCHPAD) {
+      ctx.html.appHtml().then((html) => res.send(html)).catch((e) => res.status(500).send({ stack: e.stack }))
+    } else {
+      runner.serve(req, res, testingType === 'e2e' ? 'runner' : 'runner-ct', {
+        config,
+        testingType,
+        getSpec,
+        getCurrentBrowser,
+        getRemoteState,
+        specsStore,
+        exit,
+      })
+    }
   })
 
   router.all('*', (req, res) => {

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -159,6 +159,13 @@ export const createCommonRoutes = ({
     }
   })
 
+  router.get(`${clientRoute}assets/*`, (req, res) => {
+    debug('proxying static assets %s, params[0] %s', req.url, req.params[0])
+    const pathToFile = getPathToDist('app', 'assets', req.params[0])
+
+    return send(req, pathToFile).pipe(res)
+  })
+
   router.all('*', (req, res) => {
     networkProxy.handleHttpRequest(req, res)
   })


### PR DESCRIPTION
It's time to say hello to the future. If you run `yarn dev` with `LAUNCHPAD=1`, we serve the unified runner. No more `__vite__` route.

This also fixes a bug where we did not correctly serve the statically build `packages/app`. So now you can do `cd packages/driver && LAUNCHPAD=1 yarn cypress:open` and it will work as expected (open mode with unified app, but not using a dev server - this is how things will work in production).

## Testing

- pull this
- yarn dev
- launch any project that are set up with cypress.config.ts. Good ones are `app`, `launchpad`, `driver`
- observe CT and E2E are working (no need to navigate to `__vite__`; no such route exists on the front-end)