### PR TITLE
chore: adding 10.0-release to the circle.yml build script

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ macBuildFilters: &macBuildFilters
     branches:
       only:
         - develop
+        - 10.0-release
         - tgriesser/chore/fix-release
 
 defaults: &defaults
@@ -42,6 +43,7 @@ onlyMainBranches: &onlyMainBranches
     branches:
       only:
         - develop
+        - 10.0-release
         - tgriesser/chore/fix-release
   requires:
     - create-build-artifacts
@@ -2310,6 +2312,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
+              - 10.0-release
               - tgriesser/chore/fix-release
         requires:
           - build
@@ -2322,6 +2325,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
+              - 10.0-release
               - tgriesser/chore/fix-release
         requires:
           - build
@@ -2372,6 +2376,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
+              - 10.0-release
               - tgriesser/chore/fix-release
         requires:
           - create-build-artifacts
@@ -2380,6 +2385,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
+              - 10.0-release
               - tgriesser/chore/fix-release
         requires:
           - create-build-artifacts
@@ -2389,6 +2395,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
+              - 10.0-release
               - tgriesser/chore/fix-release
         requires:
           - create-build-artifacts
@@ -2414,6 +2421,7 @@ linux-workflow: &linux-workflow
           branches:
             only:
               - develop
+              - 10.0-release
               - tgriesser/chore/fix-release
         requires:
           - create-build-artifacts
@@ -2486,6 +2494,7 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
+              - 10.0-release
               - tgriesser/chore/fix-release
         requires:
           - darwin-create-build-artifacts
@@ -2498,6 +2507,7 @@ mac-workflow: &mac-workflow
           branches:
             only:
               - develop
+              - 10.0-release
               - tgriesser/chore/fix-release
         requires:
           - darwin-create-build-artifacts


### PR DESCRIPTION
This PR enables the 10.0-release branch to release dmgs and build + test against the kitchen sink.