### PR TITLE
chore: Update TypeScript to 4.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "terminal-banner": "1.1.0",
     "through": "2.3.8",
     "ts-node": "8.3.0",
-    "typescript": "^4.2.3",
+    "typescript": "^4.4.4",
     "yarn-deduplicate": "3.1.0"
   },
   "engines": {

--- a/packages/driver/cypress/integration/cy/snapshot_spec.js
+++ b/packages/driver/cypress/integration/cy/snapshot_spec.js
@@ -99,7 +99,7 @@ describe('driver/src/cy/snapshots', () => {
 
       cy.createSnapshot(null, this.$el)
 
-      expect(attr).to.be.calledWith('data-cypress-el', true)
+      expect(attr).to.be.calledWith('data-cypress-el', 'true')
     })
 
     it('removes data-cypress-el attr', function () {

--- a/packages/driver/src/cy/snapshots.ts
+++ b/packages/driver/src/cy/snapshots.ts
@@ -144,9 +144,7 @@ export const create = ($$, state) => {
       const isJqueryElement = $dom.isElement($elToHighlight) && $dom.isJquery($elToHighlight)
 
       if (isJqueryElement) {
-        // JQuery.attr doesn't support `true` as a value.
-        // @ts-ignore
-        ($elToHighlight as JQuery<HTMLElement>).attr(HIGHLIGHT_ATTR, true)
+        ($elToHighlight as JQuery<HTMLElement>).attr(HIGHLIGHT_ATTR, 'true')
       }
 
       // TODO: throw error here if cy is undefined!

--- a/packages/driver/src/cy/testConfigOverrides.ts
+++ b/packages/driver/src/cy/testConfigOverrides.ts
@@ -37,7 +37,7 @@ function setConfig (testConfigList: Array<TestConfig>, config, localConfigOverri
 
       try {
         config(testConfigOverride)
-      } catch (e) {
+      } catch (e: any) {
         let err = $errUtils.errByPath('config.invalid_test_override', {
           errMsg: e.message,
         })

--- a/packages/network/lib/client-certificates.ts
+++ b/packages/network/lib/client-certificates.ts
@@ -218,7 +218,7 @@ export function loadClientCertificateConfig (config) {
 
               try {
                 pki.certificateFromPem(caRaw)
-              } catch (error) {
+              } catch (error: any) {
                 throw new Error(`Cannot parse CA cert: ${error.message}`)
               }
 
@@ -251,7 +251,7 @@ export function loadClientCertificateConfig (config) {
 
             try {
               pemParsed = pki.certificateFromPem(pemRaw)
-            } catch (error) {
+            } catch (error: any) {
               throw new Error(`Cannot parse PEM cert: ${error.message}`)
             }
 
@@ -279,7 +279,7 @@ export function loadClientCertificateConfig (config) {
                   throw new Error('Cannot load PEM key')
                 }
               }
-            } catch (error) {
+            } catch (error: any) {
               throw new Error(`Cannot parse PEM key: ${error.message}`)
             }
 
@@ -332,7 +332,7 @@ export function loadClientCertificateConfig (config) {
         `loaded client certificates for ${clientCertificateStore.getCertCount()} URL(s)`,
       )
     }
-  } catch (e) {
+  } catch (e: any) {
     debug(
       `Failed to load client certificate for clientCertificates[${index}]: ${e.message} ${e.stack}`,
     )
@@ -363,7 +363,7 @@ function extractSubjectFromPem (pem): string {
     return pem.subject.attributes
     .map((attr) => [attr.shortName, attr.value].join('='))
     .join(', ')
-  } catch (e) {
+  } catch (e: any) {
     throw new Error(`Unable to extract subject from PEM file: ${e.message}`)
   }
 }
@@ -377,7 +377,7 @@ function loadPfx (pfx: Buffer, passphrase: string | undefined) {
     const certAsn1 = asn1.fromDer(certDer)
 
     return pkcs12.pkcs12FromAsn1(certAsn1, passphrase)
-  } catch (e) {
+  } catch (e: any) {
     debug(`loadPfx fail: ${e.message} ${e.stackTrace}`)
     throw new Error(`Unable to load PFX file: ${e.message}`)
   }
@@ -391,7 +391,7 @@ function extractSubjectFromPfx (pfx) {
     const certs = pfx.getBags({ bagType: pki.oids.certBag })[pki.oids.certBag].map((item) => item.cert)
 
     return certs[0].subject.attributes.map((attr) => [attr.shortName, attr.value].join('=')).join(', ')
-  } catch (e) {
+  } catch (e: any) {
     throw new Error(`Unable to extract subject from PFX file: ${e.message}`)
   }
 }

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -200,7 +200,7 @@ const PatchExpressSetHeader: ResponseMiddleware = function () {
     // set the header manually. this way we can retain Node's original error behavior
     try {
       return originalSetHeader.call(this, name, value)
-    } catch (err) {
+    } catch (err: any) {
       if (err.code !== 'ERR_INVALID_CHAR') {
         throw err
       }

--- a/packages/rewriter/lib/js.ts
+++ b/packages/rewriter/lib/js.ts
@@ -52,7 +52,7 @@ export function _rewriteJsUnsafe (url: string, js: string, deferSourceMapRewrite
 
   try {
     astTypes.visit(ast, jsRules)
-  } catch (err) {
+  } catch (err: any) {
     // if visiting fails, it points to a bug in our rewriting logic, so raise the error to the driver
     return _generateDriverError(url, err)
   }

--- a/packages/rewriter/lib/threads/worker.ts
+++ b/packages/rewriter/lib/threads/worker.ts
@@ -61,7 +61,7 @@ parentPort!.on('message', async (req: RewriteRequest) => {
     const output = await _getOutput()
 
     _reply({ output, threadMs: _getThreadMs() })
-  } catch (error) {
+  } catch (error: any) {
     _reply({ error, threadMs: _getThreadMs() })
   }
 

--- a/packages/runner-shared/src/header/index.tsx
+++ b/packages/runner-shared/src/header/index.tsx
@@ -263,7 +263,7 @@ export class Header extends Component<HeaderProps> {
     if (!this._studioNeedsUrl) return
 
     // Note: changes in TypeScript 4.4.4 made the code below fail the type check.
-    // @see https://github.com/cypress-io/cypress/pull/18930
+    // ts interprets visitUrl below as (url: null | undefined) => never
     // TODO: studio/studio-recorder.js should be converted to ts. And add proper type.
     // @ts-ignore
     studioRecorder.visitUrl(this.urlInput)

--- a/packages/runner-shared/src/header/index.tsx
+++ b/packages/runner-shared/src/header/index.tsx
@@ -262,6 +262,8 @@ export class Header extends Component<HeaderProps> {
 
     if (!this._studioNeedsUrl) return
 
+    // Note: changes in TypeScript 4.4.4 made the code below fail the type check.
+    // @see https://github.com/cypress-io/cypress/pull/18930
     // TODO: studio/studio-recorder.js should be converted to ts. And add proper type.
     // @ts-ignore
     studioRecorder.visitUrl(this.urlInput)

--- a/packages/runner-shared/src/header/index.tsx
+++ b/packages/runner-shared/src/header/index.tsx
@@ -262,6 +262,8 @@ export class Header extends Component<HeaderProps> {
 
     if (!this._studioNeedsUrl) return
 
+    // TODO: studio/studio-recorder.js should be converted to ts. And add proper type.
+    // @ts-ignore
     studioRecorder.visitUrl(this.urlInput)
 
     this.urlInput = ''

--- a/packages/server/lib/util/file-opener.ts
+++ b/packages/server/lib/util/file-opener.ts
@@ -11,7 +11,7 @@ export const openFile = (fileDetails) => {
   if (openerId === 'computer') {
     try {
       require('electron').shell.showItemInFolder(fileDetails.file)
-    } catch (err) {
+    } catch (err: any) {
       debug('error opening file: %s', err.stack)
     }
 

--- a/packages/web-config/package.json
+++ b/packages/web-config/package.json
@@ -11,7 +11,7 @@
     "@babel/preset-react": "7.9.4",
     "@babel/preset-typescript": "7.9.0",
     "@babel/register": "7.9.0",
-    "@types/jsdom": "12.2.4",
+    "@types/jsdom": "16.2.13",
     "@types/mock-require": "2.0.0",
     "@types/webpack": "4.41.0",
     "@types/webpack-dev-server": "^4.0.0",

--- a/patches/react-vtree+3.0.0-beta.1.patch
+++ b/patches/react-vtree+3.0.0-beta.1.patch
@@ -100,3 +100,30 @@ index bb27d60..a4f244f 100644
 +//     getRecordData: (index: number) => TNodePublicState;
 +//     treeData: any;
 +// }>) => string;
+diff --git a/node_modules/react-vtree/dist/lib/utils.d.ts b/node_modules/react-vtree/dist/lib/utils.d.ts
+index bb27d60..d5ac63c 100644
+--- a/node_modules/react-vtree/dist/lib/utils.d.ts
++++ b/node_modules/react-vtree/dist/lib/utils.d.ts
+@@ -12,14 +12,14 @@ export declare type RequestIdleCallbackDeadline = Readonly<{
+     didTimeout: boolean;
+     timeRemaining: () => number;
+ }>;
+-declare global {
+-    const requestIdleCallback: (callback: (deadline: RequestIdleCallbackDeadline) => void, opts?: RequestIdleCallbackOptions) => RequestIdleCallbackHandle;
+-    const cancelIdleCallback: (handle: RequestIdleCallbackHandle) => void;
+-    interface Window {
+-        requestIdleCallback: typeof requestIdleCallback;
+-        cancelIdleCallback: typeof cancelIdleCallback;
+-    }
+-}
++// declare global {
++//     const requestIdleCallback: (callback: (deadline: RequestIdleCallbackDeadline) => void, opts?: RequestIdleCallbackOptions) => RequestIdleCallbackHandle;
++//     const cancelIdleCallback: (handle: RequestIdleCallbackHandle) => void;
++//     interface Window {
++//         requestIdleCallback: typeof requestIdleCallback;
++//         cancelIdleCallback: typeof cancelIdleCallback;
++//     }
++// }
+ export declare type DefaultTreeProps = TreeProps<NodeData, NodePublicState<NodeData>, FixedSizeList>;
+ export declare type DefaultTreeState = TreeState<NodeData, NodePublicState<NodeData>, FixedSizeList>;
+ export declare type DefaultTreeCreatorOptions = TreeCreatorOptions<NodeData, NodePublicState<NodeData>, DefaultTreeState>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -38330,7 +38330,7 @@ typescript@4.1.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
   integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
-typescript@4.2.4, typescript@^4.2.3, typescript@~4.2.4:
+typescript@4.2.4, typescript@~4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
@@ -38339,6 +38339,11 @@ typescript@^3.9.7:
   version "3.9.9"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
   integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
+
+typescript@^4.2.3, typescript@^4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
 ua-parser-js@0.7.24, ua-parser-js@^0.7.18:
   version "0.7.24"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7958,14 +7958,14 @@
   dependencies:
     "@types/sizzle" "*"
 
-"@types/jsdom@12.2.4":
-  version "12.2.4"
-  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-12.2.4.tgz#845cd4d43f95b8406d9b724ec30c03edadcd9528"
-  integrity sha512-q+De3S/Ri6U9uPx89YA1XuC+QIBgndIfvBaaJG0pRT8Oqa75k4Mr7G9CRZjIvlbLGIukO/31DFGFJYlQBmXf/A==
+"@types/jsdom@16.2.13":
+  version "16.2.13"
+  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-16.2.13.tgz#126c8b7441b159d6234610a48de77b6066f1823f"
+  integrity sha512-8JQCjdeAidptSsOcRWk2iTm9wCcwn9l+kRG6k5bzUacrnm1ezV4forq0kWjUih/tumAeoG+OspOvQEbbRucBTw==
   dependencies:
     "@types/node" "*"
+    "@types/parse5" "*"
     "@types/tough-cookie" "*"
-    parse5 "^4.0.0"
 
 "@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8":
   version "7.0.9"
@@ -29821,7 +29821,7 @@ parse5-sax-parser@^6.0.1:
   dependencies:
     parse5 "^6.0.1"
 
-parse5@4.0.0, parse5@^4.0.0:
+parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
   integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7827,9 +7827,9 @@
     "@types/serve-static" "*"
 
 "@types/filesystem@*":
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.29.tgz#ee3748eb5be140dcf980c3bd35f11aec5f7a3748"
-  integrity sha512-85/1KfRedmfPGsbK8YzeaQUyV1FQAvMPMTuWFQ5EkLd2w7szhNO96bk3Rh/SKmOfd9co2rCLf0Voy4o7ECBOvw==
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.32.tgz#307df7cc084a2293c3c1a31151b178063e0a8edf"
+  integrity sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==
   dependencies:
     "@types/filewriter" "*"
 


### PR DESCRIPTION
- Closes 

### User facing changelog

N/A

### Additional details
- Why was this change necessary? => Fix some new type changes.
- What is affected by this change? => N/A


### Any implementation details to explain?

* As of 4.4.4, the default type of the thrown error is `unknown` from `any`. It caused some errors. For more info => https://github.com/microsoft/TypeScript/pull/41013
* I had to update `@types/jsdom` and `@types/filesystem` to avoid type conflicts. 
* Added a patch to `react-vtree`. It seems that some missing types are added to TypeScript. 

### How has the user experience changed?

N/A

### PR Tasks

N/A