### PR TITLE
fix: flaky settings_spec test

### DIFF
--- a/packages/desktop-gui/cypress/integration/settings_spec.js
+++ b/packages/desktop-gui/cypress/integration/settings_spec.js
@@ -818,12 +818,10 @@ describe('Settings', () => {
       })
     })
 
-    it('loads preferred editor and available editors', function () {
-      expect(this.ipc.getUserEditor).to.be.called
-    })
-
-    it('shows spinner', () => {
-      cy.get('.loading-editors')
+    it('loads preferred editor, available editors and shows spinner', () => {
+      cy.get('.loading-editors').then(function () {
+        expect(this.ipc.getUserEditor).to.be.called
+      })
     })
 
     describe('when editors load with preferred editor', () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->

No user facing changes

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This flaky test is caused by checking `expect(this.ipc.getUserEditor).to.be.called` before the [hook](https://github.com/cypress-io/cypress/blob/develop/packages/desktop-gui/src/settings/file-preference.jsx#L47-L57) has had a chance to be run. I corrected it by piggybacking on the implicit wait used in cy get to get the `.loading-editors` class. We simply check for `expect(this.ipc.getUserEditor).to.be.called` after we've checked the class.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
