### PR TITLE
fix: onUnmounted warning in topnav

### DIFF
--- a/packages/frontend-shared/src/gql-components/topnav/TopNav.vue
+++ b/packages/frontend-shared/src/gql-components/topnav/TopNav.vue
@@ -282,22 +282,31 @@ const props = defineProps<{
   showBrowsers?: boolean
 }>()
 
-const versions = computed(() => {
+const versions = (() => {
   if (!props.gql.versions) {
-    return null
+    return ref(null)
   }
 
-  return {
-    current: {
-      released: useTimeAgo(new Date(props.gql.versions.current.released)).value,
-      version: props.gql.versions.current.version,
-    },
-    latest: {
-      released: useTimeAgo(new Date(props.gql.versions.latest.released)).value,
-      version: props.gql.versions.latest.version,
-    },
-  }
-})
+  const currentReleased = useTimeAgo(new Date(props.gql.versions.current.released))
+  const latestReleased = useTimeAgo(new Date(props.gql.versions.latest.released))
+
+  return computed(() => {
+    if (!props.gql.versions) {
+      return null
+    }
+
+    return {
+      current: {
+        released: currentReleased.value,
+        version: props.gql.versions.current.version,
+      },
+      latest: {
+        released: latestReleased.value,
+        version: props.gql.versions.latest.version,
+      },
+    }
+  })
+})()
 
 const runningOldVersion = computed(() => {
   return props.gql.versions ? props.gql.versions.current.released < props.gql.versions.latest.released : false

--- a/packages/frontend-shared/src/gql-components/topnav/TopNav.vue
+++ b/packages/frontend-shared/src/gql-components/topnav/TopNav.vue
@@ -211,9 +211,7 @@ import { allBrowsersIcons } from '@packages/frontend-shared/src/assets/browserLo
 import { gql, useMutation } from '@urql/vue'
 import { TopNavFragment, TopNav_LaunchOpenProjectDocument, TopNav_SetBrowserDocument } from '../../generated/graphql'
 import { useI18n } from '@cy/i18n'
-import { computed, ref } from 'vue'
-// eslint-disable-next-line no-duplicate-imports
-import type { Ref } from 'vue'
+import { computed, ref, Ref } from 'vue'
 const { t } = useI18n()
 import { onClickOutside, onKeyStroke, useTimeAgo } from '@vueuse/core'
 import DocsMenuContent from './DocsMenuContent.vue'
@@ -284,13 +282,6 @@ const props = defineProps<{
   showBrowsers?: boolean
 }>()
 
-const docsMenuVariant: Ref<'main' | 'orchestration' | 'ci'> = ref('main')
-
-const promptsEl: Ref<HTMLElement | null> = ref(null)
-
-// reset docs menu if click or keyboard navigation happens outside
-// so it doesn't reopen on the one of the prompts
-
 const versions = computed(() => {
   if (!props.gql.versions) {
     return null
@@ -311,6 +302,13 @@ const versions = computed(() => {
 const runningOldVersion = computed(() => {
   return props.gql.versions ? props.gql.versions.current.released < props.gql.versions.latest.released : false
 })
+
+const docsMenuVariant: Ref<'main' | 'orchestration' | 'ci'> = ref('main')
+
+const promptsEl: Ref<HTMLElement | null> = ref(null)
+
+// reset docs menu if click or keyboard navigation happens outside
+// so it doesn't reopen on the one of the prompts
 
 onClickOutside(promptsEl, () => {
   setTimeout(() => {


### PR DESCRIPTION
When opening the launchpad I get warnings on the homepage

```log
[Vue warn]: onUnmounted is called when there is no active component instance to be associated with. Lifecycle injection APIs can only be used during execution of setup(). If you are using async setup(), make sure to register lifecycle hooks before the first await statement. 
  at <Anonymous gql= Object show-browsers=false > 
  at <Anonymous key=0 gql= Object show-browsers=false  ... > 
  at <Anonymous> 
  at <Anonymous> 
  at <App>
```

<img width="1248" alt="Screen Shot 2021-11-18 at 1 15 27 PM" src="https://user-images.githubusercontent.com/5592465/142487989-6376abfc-01d0-4d6f-8d0c-b599e88782ae.png">

### Fix

One cannot define a new computed inside of a computed property.
Don't use composables directly inside a computed.