### PR TITLE
fix: compile npm packages for node 12

### DIFF
--- a/npm/vite-dev-server/tsconfig.json
+++ b/npm/vite-dev-server/tsconfig.json
@@ -1,14 +1,11 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "ESNEXT" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
+    "target": "ES2019" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "moduleResolution": "node",
     "skipLibCheck": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ] /* Specify library files to be included in the compilation:  */,
+    "lib": ["es2019", "es2020.bigint", "es2020.string", "es2020.symbol.wellknown"] /* Specify library files to be included in the compilation:  */,
     "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #18973 

### User facing changelog

- vite-dev-server now works with node v12
