### PR TITLE
style: remove expanded folder arrows

### DIFF
--- a/packages/desktop-gui/cypress/integration/specs_list_spec.js
+++ b/packages/desktop-gui/cypress/integration/specs_list_spec.js
@@ -295,10 +295,8 @@ describe('Specs List', function () {
       context('collapsing specs', function () {
         it('sets folder collapsed when clicked with correct icon', () => {
           cy.get('.folder:first').should('have.class', 'folder-expanded')
-          cy.get('.folder-collapse-icon:first').should('have.class', 'fa-caret-down')
           cy.get('.folder .folder-name:first').click()
 
-          cy.get('.folder-collapse-icon:first').should('have.class', 'fa-caret-right')
           cy.get('.folder:first').should('have.class', 'folder-collapsed')
         })
 

--- a/packages/desktop-gui/src/specs/specs-list.jsx
+++ b/packages/desktop-gui/src/specs/specs-list.jsx
@@ -351,7 +351,6 @@ class SpecsList extends Component {
       <li key={spec.path} className={`folder level-${nestingLevel} ${isExpanded ? 'folder-expanded' : 'folder-collapsed'}`}>
         <div>
           <div tabIndex={tabIndex} className="folder-name" onKeyDown={this._openSpecFolder.bind(this, spec)} onClick={this._selectSpecFolder.bind(this, spec)}>
-            <i className={`folder-collapse-icon fas fa-fw ${isExpanded ? 'fa-caret-down' : 'fa-caret-right'}`} />
             {nestingLevel !== 0 ? <i className={`far fa-fw ${isExpanded ? 'fa-folder-open' : 'fa-folder'}`} /> : null}
             {
               nestingLevel === 0 ?


### PR DESCRIPTION
- Closes [6275](https://github.com/cypress-io/cypress/issues/6275)

### User facing changelog
Removed arrow icons for collapsed/expanded folders.

### Additional details
We're redesigning to make test list hierarchy to make it look less confusing.

### How has the user experience changed?
**Before changes:**

<img width="412" alt="Screen Shot 2021-11-18 at 6 33 15 PM" src="https://user-images.githubusercontent.com/32891808/142514004-18a957a2-7c91-4296-9640-1048eb0eb8cd.png">

**After changes:**

<img width="410" alt="Screen Shot 2021-11-18 at 6 36 40 PM" src="https://user-images.githubusercontent.com/32891808/142514104-c4d4dcc6-22cc-4029-bc30-3211d1aee177.png">

### Other designs ideas

**Arrows to the right of test's names:**

<img width="501" alt="Screen Shot 2021-11-18 at 6 43 57 PM" src="https://user-images.githubusercontent.com/32891808/142514366-dc18d19d-8166-430b-a4b4-2ef6d68f7fd7.png">

**Arrows between folder icon & test name:**

<img width="413" alt="Screen Shot 2021-11-18 at 6 44 25 PM" src="https://user-images.githubusercontent.com/32891808/142514406-5aa39459-0427-40a1-855e-0ec892b6272b.png">

### PR Tasks

- [ ] Have tests been added/updated?