### PR TITLE
fix: flaky redirect test

### DIFF
--- a/packages/driver/cypress/fixtures/meta-redirect-timeout.html
+++ b/packages/driver/cypress/fixtures/meta-redirect-timeout.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
   <head>
-    <meta http-equiv="refresh" content="0; url=/timeout?ms=100" />
+    <meta http-equiv="refresh" content="0; url=/redirect-timeout" />
     <title>Page Redirect</title>
   </head>
   <body>

--- a/packages/driver/cypress/plugins/server.js
+++ b/packages/driver/cypress/plugins/server.js
@@ -43,6 +43,14 @@ const createApp = (port) => {
     })
   })
 
+  app.get('/redirect-timeout', (req, res) => {
+    return Promise
+    .delay(100)
+    .then(() => {
+      return res.send('<html><body>timeout</body></html>')
+    })
+  })
+
   app.get('/custom-headers', (req, res) => {
     return res.set('x-foo', 'bar')
     .send('<html><body>hello there</body></html>')


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog -->

Change is not user facing.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This test is failing due to issue #19039. Previously failed XHR calls can be matched up with subsequent XHR calls inappropriately. Specifically the `/timeout?ms=100` call is matching up with a previously failed instance of this. This pr avoids this issue by specifying a new `/retry-timeout` route. Since the route is unique to this test it doesn't have the possibility of having a previously failed pre-request. This is not fixing the root issue, just providing flaky test relief. 

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [x] Have tests been added/updated?
