### PR TITLE
fix: set testing type so config is merged properly

### DIFF
--- a/packages/data-context/src/sources/ProjectConfigDataSource.ts
+++ b/packages/data-context/src/sources/ProjectConfigDataSource.ts
@@ -32,7 +32,10 @@ export class ProjectConfigDataSource {
       this.ctx.coreData.currentProject.config = Promise.resolve().then(async () => {
         const configFile = await this.ctx.config.getDefaultConfigBasename(projectRoot)
 
-        return this.ctx._apis.projectApi.getConfig(projectRoot, { configFile })
+        return this.ctx._apis.projectApi.getConfig(projectRoot, {
+          configFile,
+          testingType: this.ctx.wizardData.chosenTestingType ?? undefined,
+        })
       })
     }
 


### PR DESCRIPTION
### Details
The call to get the config was passing in an `undefined` testingType, causing the previously merged (and correct) config to be overwritten. The testingType is now being passed and the config is merged properly.

https://user-images.githubusercontent.com/25158820/142954976-5472321d-c74d-41db-a909-b4d9a36e6077.mov

Yes you can check out this branch here https://github.com/cypress-io/cypress-component-testing-examples/pull/58
I pointed latest 10.0-release at the project and reproduced locally

### How has the user experience changed?
Config options are merged properly

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
