### PR TITLE
chore: Remove desktop-gui tests from CI, update generated code

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ branches:
     - master
     - develop
     - windows-code-signing
-    - 9.0-release
+    - 10.0-release
     - /win*/
 
 # https://www.appveyor.com/docs/lang/nodejs-iojs/

--- a/circle.yml
+++ b/circle.yml
@@ -1026,8 +1026,6 @@ jobs:
             fi
       - wait-on-circle-jobs:
           job-names: >
-            desktop-gui-integration-tests-7x,
-            desktop-gui-component-tests,
             cli-visual-tests,
             runner-integration-tests-chrome,
             runner-ct-integration-tests-chrome,
@@ -1308,51 +1306,50 @@ jobs:
       - run-driver-integration-tests:
           browser: electron
 
-  desktop-gui-integration-tests-7x:
-    <<: *defaults
-    parallelism: 7
-    steps:
-      - restore_cached_workspace
-      - run:
-          command: yarn build-prod
-          working_directory: packages/desktop-gui
-      - run:
-          command: |
-            CYPRESS_KONFIG_ENV=production \
-            CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-            PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_ID \
-            PERCY_ENABLE=${PERCY_TOKEN:-0} \
-            PERCY_PARALLEL_TOTAL=-1 \
-            yarn percy exec --parallel -- -- \
-            yarn cypress:run --record --parallel --group 2x-desktop-gui
-          working_directory: packages/desktop-gui
-      - verify-mocha-results
-      - store_test_results:
-          path: /tmp/cypress
-      - store_artifacts:
-          path: /tmp/artifacts
-      - store-npm-logs
+  # desktop-gui-integration-tests-7x:
+  #   <<: *defaults
+  #   parallelism: 7
+  #   steps:
+  #     - restore_cached_workspace
+  #     - run:
+  #         command: yarn build-prod
+  #         working_directory: packages/desktop-gui
+  #     - run:
+  #         command: |
+  #           CYPRESS_KONFIG_ENV=production \
+  #           CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
+  #           PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_ID \
+  #           PERCY_ENABLE=${PERCY_TOKEN:-0} \
+  #           PERCY_PARALLEL_TOTAL=-1 \
+  #           yarn percy exec --parallel -- -- \
+  #           yarn cypress:run --record --parallel --group 2x-desktop-gui
+  #         working_directory: packages/desktop-gui
+  #     - verify-mocha-results
+  #     - store_test_results:
+  #         path: /tmp/cypress
+  #     - store_artifacts:
+  #         path: /tmp/artifacts
+  #     - store-npm-logs
 
-
-  desktop-gui-component-tests:
-    <<: *defaults
-    resource_class: medium
-    parallelism: 1
-    steps:
-      - restore_cached_workspace
-      - run:
-          # will use PERCY_TOKEN environment variable if available
-          command: |
-            CYPRESS_KONFIG_ENV=production \
-            PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_ID \
-            PERCY_ENABLE=${PERCY_TOKEN:-0} \
-            PERCY_PARALLEL_TOTAL=-1 \
-            yarn percy exec --parallel -- -- \
-            yarn cypress:run:ct
-          working_directory: packages/desktop-gui
-      - verify-mocha-results
-      # we don't really need any artifacts - we are only interested in visual screenshots
-      - store-npm-logs
+  # desktop-gui-component-tests:
+  #   <<: *defaults
+  #   resource_class: medium
+  #   parallelism: 1
+  #   steps:
+  #     - restore_cached_workspace
+  #     - run:
+  #         # will use PERCY_TOKEN environment variable if available
+  #         command: |
+  #           CYPRESS_KONFIG_ENV=production \
+  #           PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_ID \
+  #           PERCY_ENABLE=${PERCY_TOKEN:-0} \
+  #           PERCY_PARALLEL_TOTAL=-1 \
+  #           yarn percy exec --parallel -- -- \
+  #           yarn cypress:run:ct
+  #         working_directory: packages/desktop-gui
+  #     - verify-mocha-results
+  #     # we don't really need any artifacts - we are only interested in visual screenshots
+  #     - store-npm-logs
 
   reporter-integration-tests:
     <<: *defaults
@@ -2239,12 +2236,12 @@ linux-workflow: &linux-workflow
     #     context: test-runner:launchpad-tests
     #     requires:
     #       - build
-    - desktop-gui-integration-tests-7x:
-        requires:
-          - build
-    - desktop-gui-component-tests:
-        requires:
-          - build
+    # - desktop-gui-integration-tests-7x:
+    #     requires:
+    #       - build
+    # - desktop-gui-component-tests:
+    #     requires:
+    #       - build
     - reporter-integration-tests:
         requires:
           - build
@@ -2309,8 +2306,8 @@ linux-workflow: &linux-workflow
           - ui-components-integration-tests
           - reporter-integration-tests
           - Linux lint
-          - desktop-gui-component-tests
-          - desktop-gui-integration-tests-7x
+          # - desktop-gui-component-tests
+          # - desktop-gui-integration-tests-7x
           - runner-ct-integration-tests-chrome
           - runner-integration-tests-firefox
           - runner-integration-tests-chrome

--- a/packages/frontend-shared/cypress/e2e/support/e2eProjectDirs.ts
+++ b/packages/frontend-shared/cypress/e2e/support/e2eProjectDirs.ts
@@ -65,6 +65,7 @@ export const e2eProjectDirs = [
   'screen-size',
   'shadow-dom-global-inclusion',
   'spec-generation',
+  'spec-name-special-characters',
   'studio',
   'studio-no-source-maps',
   'system-node',

--- a/scripts/gulp/monorepoPaths.ts
+++ b/scripts/gulp/monorepoPaths.ts
@@ -5,6 +5,7 @@ export const monorepoPaths = {
   root: path.join(__dirname, '../..'),
   pkgDir: path.join(__dirname, '../../packages'),
   pkgApp: path.join(__dirname, '../../packages/app'),
+  pkgConfig: path.join(__dirname, '../../packages/config'),
   pkgDataContext: path.join(__dirname, '../../packages/data-context'),
   pkgDesktopGui: path.join(__dirname, '../../packages/desktop-gui'),
   pkgDriver: path.join(__dirname, '../../packages/driver'),


### PR DESCRIPTION
- Removes `desktop-gui` tests from CI jobs, since we are no longer using them
- Updates the codegen when `yarn dev` is run