### PR TITLE
chore: remove flaky ci jobs for main builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1884,17 +1884,6 @@ jobs:
           repo: cypress-example-todomvc
           browser: firefox
 
-  "test-binary-against-documentation-firefox":
-    <<: *defaults
-    resource_class: medium
-    steps:
-      - test-binary-against-repo:
-          repo: cypress-documentation
-          browser: firefox
-          command: "yarn cypress run"
-          wait-on: http://localhost:3000
-          server-start-command: yarn serve:dist
-
   "test-binary-against-conduit-chrome":
     <<: *defaults
     resource_class: medium
@@ -2233,15 +2222,15 @@ linux-workflow: &linux-workflow
 
     - test-binary-against-kitchensink-chrome:
         <<: *onlyMainBranches
-    - test-binary-against-conduit-chrome:
-        <<: *onlyMainBranches
+    # Re-enable when the cypress-example-conduit-app project is fixed.
+    # https://github.com/cypress-io/cypress-example-conduit-app/issues/346
+    # - test-binary-against-conduit-chrome:
+    #     <<: *onlyMainBranches
     - test-binary-against-recipes-firefox:
         <<: *onlyMainBranches
     - test-binary-against-kitchensink-firefox:
         <<: *onlyMainBranches
     - test-binary-against-todomvc-firefox:
-        <<: *onlyMainBranches
-    - test-binary-against-documentation-firefox:
         <<: *onlyMainBranches
     - test-binary-against-api-testing-firefox:
         <<: *onlyMainBranches


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Related to #17722
 
This change removes `test-binary-against-documentation-firefox` and disabled the `test-binary-against-documentation-firefox`  jobs in the linux-workflow. These run on the main branches (develop & master & release-*)

During this past few releases, these jobs have been failing consistently. We have discussed & opted to remove for the time being.

### User facing changelog
n/a

### How has the user experience changed?
n/a

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ n/a] Have tests been added/updated?
- [n/a ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
