### PR TITLE
fix(unify): Support systems with node v17 installed

### DIFF
--- a/packages/data-context/src/actions/ProjectConfigDataActions.ts
+++ b/packages/data-context/src/actions/ProjectConfigDataActions.ts
@@ -64,6 +64,10 @@ export class ProjectConfigDataActions {
       execPath: this.ctx.nodePath ?? undefined,
     }
 
+    // https://github.com/cypress-io/cypress/issues/18914
+    // To be removed up update to webpack >= 5.61
+    childOptions.env.NODE_OPTIONS += ' --openssl-legacy-provider'
+
     if (inspector.url()) {
       childOptions.execArgv = _.chain(process.execArgv.slice(0))
       .remove('--inspect-brk')

--- a/packages/server/lib/util/run_require_async_child.js
+++ b/packages/server/lib/util/run_require_async_child.js
@@ -39,7 +39,7 @@ function run (ipc, requiredFile, projectRoot) {
   })
 
   process.on('unhandledRejection', (event) => {
-    const err = (event && event.reason) || event
+    const err = (event && event.reason && event.reason.message) ? event.reason : event
 
     debug('unhandled rejection:', util.serializeError(err))
     ipc.send('error', util.serializeError(err))


### PR DESCRIPTION
This does not close #18914 - there will be a separate backport PR to resolve the issue in `develop`.

### User facing changelog
When using the default configuratation of `"nodeVersion": "system"` with an installed system node >=17, cypress will now work properly rather than throw an error incorrectly pointing to the user's plugin file.

### Additional details
Previously, users could work around this by setting `NODE_OPTIONS=--openssl-legacy-provider`. We now apply this workaround by default when detecting system node version 17.

### How has the user experience changed?
![image](https://user-images.githubusercontent.com/3003404/143140796-bd9c7821-a8fe-48d7-aa05-0d34a4e8de64.png)

This error no longer occurs when attempting to run spec files. It incorrectly points to the user's plugin file as the cause, while this was actually a bug with Cypress' bundled webpack.

### PR Tasks
- [ ] Have tests been added/updated? If anyone has a good idea how to write a test this, I am all ears.
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? N/A
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? N/A
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)? N/A
