### PR TITLE
fix: add ignore scripts flag for WebpackDevServer 3 test

### DIFF
--- a/npm/webpack-dev-server/test-wds-3.js
+++ b/npm/webpack-dev-server/test-wds-3.js
@@ -16,7 +16,7 @@ const main = async () => {
 
   const resetPkg = async () => {
     fs.writeFileSync('package.json', originalPkg, 'utf8')
-    await execa('yarn', ['install'], { stdio: 'inherit' })
+    await execa('yarn', ['install', '--ignore-scripts'], { stdio: 'inherit' })
   }
 
   const checkExit = async ({ exitCode }) => {
@@ -36,7 +36,7 @@ const main = async () => {
 
   // eslint-disable-next-line no-console
   console.log('[@cypress/webpack-dev-server]: install dependencies...')
-  await execa('yarn', ['install'], { stdio: 'inherit' })
+  await execa('yarn', ['install', '--ignore-scripts'], { stdio: 'inherit' })
 
   const { exitCode } = await execa('yarn', ['test-all'], { stdio: 'inherit' })
 


### PR DESCRIPTION
Per Tim this is a potential fix for appveyor failure on 10.0-release branch