### PR TITLE
fix: Add support for system node 17

### DIFF
--- a/packages/server/lib/plugins/index.js
+++ b/packages/server/lib/plugins/index.js
@@ -8,6 +8,7 @@ const inspector = require('inspector')
 const errors = require('../errors')
 const util = require('./util')
 const pkg = require('@packages/root')
+const semver = require('semver')
 
 let pluginsProcess = null
 let registeredEvents = {}
@@ -35,6 +36,43 @@ const getPluginPid = () => {
 
 const registerHandler = (handler) => {
   handlers.push(handler)
+}
+
+const getChildOptions = (config) => {
+  const childOptions = {
+    stdio: 'pipe',
+    env: {
+      ...process.env,
+      NODE_OPTIONS: process.env.ORIGINAL_NODE_OPTIONS || '',
+    },
+  }
+
+  if (config.resolvedNodePath) {
+    debug('launching using custom node version %o', _.pick(config, ['resolvedNodePath', 'resolvedNodeVersion']))
+    childOptions.execPath = config.resolvedNodePath
+  }
+
+  // https://github.com/cypress-io/cypress/issues/18914
+  // If we're on node version 17 or higher, we need the
+  // NODE_ENV --openssl-legacy-provider so that webpack can continue to use
+  // the md4 hash function. This would cause an error prior to node 17
+  // though, so we have to detect node's major version before spawning the
+  // plugins process.
+
+  // To be removed on update to webpack >= 5.61, which no longer relies on
+  // node's builtin crypto.hash function.
+  if (semver.satisfies(config.resolvedNodeVersion, '>=17.0.0')) {
+    childOptions.env.NODE_OPTIONS += ' --openssl-legacy-provider'
+  }
+
+  if (inspector.url()) {
+    childOptions.execArgv = _.chain(process.execArgv.slice(0))
+    .remove('--inspect-brk')
+    .push(`--inspect=${process.debugPort + 1}`)
+    .value()
+  }
+
+  return childOptions
 }
 
 const init = (config, options) => {
@@ -82,28 +120,9 @@ const init = (config, options) => {
     const pluginsFile = config.pluginsFile || path.join(__dirname, 'child', 'default_plugins_file.js')
     const childIndexFilename = path.join(__dirname, 'child', 'index.js')
     const childArguments = ['--file', pluginsFile, '--projectRoot', options.projectRoot]
-    const childOptions = {
-      stdio: 'pipe',
-      env: {
-        ...process.env,
-        NODE_OPTIONS: process.env.ORIGINAL_NODE_OPTIONS || '',
-      },
-    }
-
-    if (config.resolvedNodePath) {
-      debug('launching using custom node version %o', _.pick(config, ['resolvedNodePath', 'resolvedNodeVersion']))
-      childOptions.execPath = config.resolvedNodePath
-    }
+    const childOptions = getChildOptions(config)
 
     debug('forking to run %s', childIndexFilename)
-
-    if (inspector.url()) {
-      childOptions.execArgv = _.chain(process.execArgv.slice(0))
-      .remove('--inspect-brk')
-      .push(`--inspect=${process.debugPort + 1}`)
-      .value()
-    }
-
     pluginsProcess = cp.fork(childIndexFilename, childArguments, childOptions)
 
     if (pluginsProcess.stdout && pluginsProcess.stderr) {
@@ -241,6 +260,7 @@ const _setPluginsProcess = (_pluginsProcess) => {
 }
 
 module.exports = {
+  getChildOptions,
   getPluginPid,
   execute,
   has,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11062,7 +11062,7 @@ awesome-typescript-loader@5.2.1:
     source-map-support "^0.5.3"
     webpack-log "^1.2.0"
 
-aws-sdk@2.814.0:
+aws-sdk@2.814.0, aws-sdk@^2.389.0:
   version "2.814.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.814.0.tgz#7a1c36006e0b5826f14bd2511b1d229ef6814bb0"
   integrity sha512-empd1m/J/MAkL6d9OeRpmg9thobULu0wk4v8W3JToaxGi2TD7PIdvE6yliZKyOVAdJINhBWEBhxR4OUIHhcGbQ==
@@ -11070,21 +11070,6 @@ aws-sdk@2.814.0:
     buffer "4.9.2"
     events "1.1.1"
     ieee754 "1.1.13"
-    jmespath "0.15.0"
-    querystring "0.2.0"
-    sax "1.2.1"
-    url "0.10.3"
-    uuid "3.3.2"
-    xml2js "0.4.19"
-
-aws-sdk@^2.389.0:
-  version "2.447.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.447.0.tgz#9a483157e537663b1835698f9d5806679c04a9f7"
-  integrity sha512-bAnNeYJx8U/SGb0zo13YbYvOmHhN3h+3eagP+X7uVG5kmpJMsEpn1EqZJ/Jby7qEB/DQXFGFUzg5kLt//C37/g==
-  dependencies:
-    buffer "4.9.1"
-    events "1.1.1"
-    ieee754 "1.1.8"
     jmespath "0.15.0"
     querystring "0.2.0"
     sax "1.2.1"
@@ -12983,15 +12968,6 @@ buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
-
-buffer@4.9.1:
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
-  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-    isarray "^1.0.0"
 
 buffer@4.9.2, buffer@^4.3.0:
   version "4.9.2"
@@ -22172,11 +22148,6 @@ ieee754@1.1.13:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
-
-ieee754@1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
-  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
 
 ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"


### PR DESCRIPTION
- Closes #18914

### User facing changelog
When using the default configuratation of `"nodeVersion": "system"` with an installed system node >=17, cypress will now work properly rather than throw an error incorrectly pointing to the user's plugin file.

### Additional details
Previously, users could work around this by setting `NODE_OPTIONS=--openssl-legacy-provider`. We now apply this workaround by default when detecting system node version 17.

### How has the user experience changed?
![image](https://user-images.githubusercontent.com/3003404/143140796-bd9c7821-a8fe-48d7-aa05-0d34a4e8de64.png)

This error no longer occurs when attempting to run spec files. It incorrectly points to the user's plugin file as the cause, while this was actually a bug with Cypress' bundled webpack.

### PR Tasks
- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? N/A
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? N/A
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)? N/A