### PR TITLE
fix: text events propagate out of shadow root.

### DIFF
--- a/packages/driver/cypress/fixtures/shadow-dom-type.html
+++ b/packages/driver/cypress/fixtures/shadow-dom-type.html
@@ -1,0 +1,25 @@
+<html>
+  <body>
+    <test-element id="element"></test-element>
+    <div id="result"></div>
+  </body>
+  <script>
+    class TestElement extends HTMLElement {
+      constructor() {
+        super();
+        this._shadow = this.attachShadow({mode: "open"});
+
+        const input = document.createElement("input");
+        this._shadow.appendChild(input);
+      }
+    }
+
+    customElements.define("test-element", TestElement);
+
+    const el = document.getElementById("element");
+
+    el.addEventListener('keydown', () =>{
+      document.getElementById('result').innerText = 'typed'
+    })
+  </script>
+</html>

--- a/packages/driver/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_spec.js
@@ -3592,5 +3592,16 @@ describe('src/cy/commands/actions/type - #type', () => {
       .find('input', { includeShadowDom: true })
       .type('foo')
     })
+
+    // https://github.com/cypress-io/cypress/issues/17531
+    it('text events propagate out of shadow root', () => {
+      cy.visit('fixtures/shadow-dom-type.html')
+
+      cy
+      .get('test-element').shadow()
+      .find('input').type('asdf')
+
+      cy.get('#result').should('have.text', 'typed')
+    })
   })
 })

--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -960,6 +960,9 @@ export class Keyboard {
       ..._.omitBy(
         {
           bubbles: true,
+          // allow propagation out of root of shadow-dom
+          // https://developer.mozilla.org/en-US/docs/Web/API/Event/composed
+          composed: true,
           cancelable,
           key,
           code,


### PR DESCRIPTION
- Closes #17531

### User facing changelog

Typing events now correctly propagate out of the shadow DOM.

### Additional details
- Why was this change necessary? => By default, text events don't propagate out of shadow root. This behavior sometimes causes some unexpected failures.
- What is affected by this change? => N/A
- Any implementation details to explain? => I followed the convention of `cy.click()` fixed at #3030. 

### How has the user experience changed?

**Before:** Text events don't propagate out of shadow root boundary. 
**After:** They do.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
