### PR TITLE
feat(app): show upgrade modal when cypress out of date

### DIFF
--- a/packages/app/cypress/e2e/integration/index.spec.ts
+++ b/packages/app/cypress/e2e/integration/index.spec.ts
@@ -18,4 +18,49 @@ describe('Index', () => {
       cy.contains('Create your first spec')
     })
   })
+
+  it('shows update cypress version modal immediately when out of date', () => {
+    cy.visitApp()
+
+    cy.intercept('query-HeaderBar_HeaderBarQuery', (req) => {
+      req.continue((res) => {
+        res.body.data.versions.current.id = '9.0.0'
+        res.body.data.versions.current.version = '9.0.0'
+        res.body.data.versions.current.released = '2020-10-10T20:00:00.000Z'
+
+        res.body.data.versions.latest.id = '9.1.0'
+        res.body.data.versions.latest.version = '9.1.0'
+        res.body.data.versions.latest.released = '2021-12-12T20:00:00.000Z'
+
+        res.send(res.body)
+      })
+    }).as('Query')
+
+    cy.wait('@Query')
+
+    cy.get('[data-cy="update-cypress-modal"]').contains('Upgrade to Cypress')
+    cy.contains('You are currently running Version 9.0.0 of Cypress')
+  })
+
+  it('does not show update cypress version modal when up to date', () => {
+    cy.visitApp('')
+
+    cy.intercept('query-HeaderBar_HeaderBarQuery', (req) => {
+      req.continue((res) => {
+        res.body.data.versions.current.id = '9.1.0'
+        res.body.data.versions.current.version = '9.1.0'
+        res.body.data.versions.current.released = '2021-12-12T20:00:00.000Z'
+
+        res.body.data.versions.latest.id = '9.1.0'
+        res.body.data.versions.latest.version = '9.1.0'
+        res.body.data.versions.latest.released = '2021-12-12T20:00:00.000Z'
+
+        res.send(res.body)
+      })
+    }).as('Query')
+
+    cy.wait('@Query')
+
+    cy.get('[data-cy="update-cypress-modal"]').should('not.exist')
+  })
 })

--- a/packages/frontend-shared/src/gql-components/topnav/TopNav.vue
+++ b/packages/frontend-shared/src/gql-components/topnav/TopNav.vue
@@ -322,7 +322,7 @@ const runningOldVersion = computed(() => {
   return props.gql.versions ? props.gql.versions.current.released < props.gql.versions.latest.released : false
 })
 
-const showUpdateModal = ref(false)
+const showUpdateModal = ref(runningOldVersion.value)
 
 const docsMenuVariant: Ref<'main' | 'orchestration' | 'ci'> = ref('main')
 

--- a/packages/frontend-shared/src/gql-components/topnav/UpdateCypressModal.vue
+++ b/packages/frontend-shared/src/gql-components/topnav/UpdateCypressModal.vue
@@ -4,6 +4,7 @@
     variant="bare"
     :title="title"
     :model-value="show"
+    data-cy="update-cypress-modal"
     @update:model-value="emits('close')"
   >
     <div class="p-24px text-gray-700">


### PR DESCRIPTION
Show the Upgrade Modal if the current Cypress version on npm is newer than the one the user is using.