### PR TITLE
feat: add cy.mount() runner error

### DIFF
--- a/packages/driver/cypress/e2e/commands/commands.cy.js
+++ b/packages/driver/cypress/e2e/commands/commands.cy.js
@@ -97,6 +97,24 @@ describe('src/cy/commands/commands', () => {
       })
     })
 
+    it('allows calling .add with hover / mount', () => {
+      let calls = 0
+
+      Cypress.Commands.add('hover', () => {
+        calls++
+      })
+
+      Cypress.Commands.add('mount', () => {
+        calls++
+      })
+
+      cy.mount()
+      cy.hover()
+      cy.then(() => {
+        expect(calls).to.eq(2)
+      })
+    })
+
     it('throws when attempting to add a command with the same name as an internal function', (done) => {
       cy.on('fail', (err) => {
         expect(err.message).to.eq('`Cypress.Commands.add()` cannot create a new command named `addChainer` because that name is reserved internally by Cypress.')

--- a/packages/driver/cypress/integration/commands/actions/mount_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/mount_spec.js
@@ -1,0 +1,30 @@
+const { $ } = Cypress
+
+describe('src/cy/commands/actions/mount', () => {
+  before(() => {
+    cy
+    .visit('/fixtures/dom.html')
+    .then(function (win) {
+      this.body = win.document.body.outerHTML
+    })
+  })
+
+  beforeEach(function () {
+    const doc = cy.state('document')
+
+    $(doc.body).empty().html(this.body)
+  })
+
+  context('#mount', () => {
+    it('throws when invoking', (done) => {
+      cy.on('fail', (err) => {
+        expect(err.message).to.include('`cy.mount()`')
+        expect(err.docsUrl).to.eq('https://on.cypress.io/mount')
+
+        done()
+      })
+
+      cy.mount()
+    })
+  })
+})

--- a/packages/driver/src/cy/commands/actions/index.ts
+++ b/packages/driver/src/cy/commands/actions/index.ts
@@ -8,6 +8,7 @@ import * as SelectFile from './selectFile'
 import * as Submit from './submit'
 import * as Type from './type'
 import * as Trigger from './trigger'
+import * as Mount from './mount'
 
 export {
   Check,
@@ -20,4 +21,5 @@ export {
   Submit,
   Type,
   Trigger,
+  Mount,
 }

--- a/packages/driver/src/cy/commands/actions/mount.ts
+++ b/packages/driver/src/cy/commands/actions/mount.ts
@@ -1,0 +1,9 @@
+import $errUtils from '../../../cypress/error_utils'
+
+export default (Commands) => {
+  return Commands.addAll({ prevSubject: 'element' }, {
+    mount () {
+      return $errUtils.throwErrByPath('mount.not_implemented')
+    },
+  })
+}

--- a/packages/driver/src/cy/commands/actions/mount.ts
+++ b/packages/driver/src/cy/commands/actions/mount.ts
@@ -1,7 +1,7 @@
 import $errUtils from '../../../cypress/error_utils'
 
 export default (Commands) => {
-  return Commands.addAll({ prevSubject: 'element' }, {
+  return Commands.addAll({
     mount () {
       return $errUtils.throwErrByPath('mount.not_implemented')
     },

--- a/packages/driver/src/cypress/commands.ts
+++ b/packages/driver/src/cypress/commands.ts
@@ -8,6 +8,8 @@ import $stackUtils from './stack_utils'
 import { allCommands } from '../cy/commands'
 import { addCommand } from '../cy/net-stubbing'
 
+const PLACEHOLDER_COMMANDS = ['mount', 'hover']
+
 const builtInCommands = [
   ..._.toArray(allCommands).map((c) => c.default || c),
   addCommand,
@@ -229,7 +231,7 @@ export default {
           })
         }
 
-        if (addingBuiltIns) {
+        if (addingBuiltIns && !PLACEHOLDER_COMMANDS.includes(name)) {
           builtInCommandNames[name] = true
         }
 

--- a/packages/driver/src/cypress/commands.ts
+++ b/packages/driver/src/cypress/commands.ts
@@ -231,6 +231,8 @@ export default {
           })
         }
 
+        // .hover & .mount are special case commands. allow as builtins so users
+        // may add them without throwing an error
         if (addingBuiltIns && !PLACEHOLDER_COMMANDS.includes(name)) {
           builtInCommandNames[name] = true
         }

--- a/packages/driver/src/cypress/error_messages.ts
+++ b/packages/driver/src/cypress/error_messages.ts
@@ -953,6 +953,16 @@ export default {
 
   },
 
+  mount: {
+    not_implemented: {
+      message: [
+        `${cmd('mount')} must be implemented by the user. There are`,
+        'full instructions for doing so at the following location.',
+      ].join('\n'),
+      docsUrl: 'https://on.cypress.io/mount',
+    },
+  },
+
   navigation: {
     cross_origin ({ message, originPolicy, configFile, projectRoot }) {
       return {


### PR DESCRIPTION
### User facing changelog
Using `cy.mount()` will provide a detailed error message with a link for writing a custom mount command.

### Additional details
- Users may import the `mount` function from their appropriate library of choice or author their own custom command. The documentation will show (and perhaps encourage) the use of `cy.mount()`.
- Calling `cy.mount()` before it has been overridden will now provide an error message and behave like `cy.hover()`
- the cypress 'on' link has been created to bring users to the right place, we just need that content which is WIP.  

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
