### PR TITLE
fix: set the context when overwriting .clock command

### DIFF
--- a/packages/driver/cypress/integration/commands/clock_spec.js
+++ b/packages/driver/cypress/integration/commands/clock_spec.js
@@ -125,6 +125,14 @@ describe('src/cy/commands/clock', () => {
       })
     })
 
+    it('overwrite gracefully', () => {
+      Cypress.Commands.overwrite('clock', (originalCommand, ...args) => {
+        return originalCommand(...args)
+      })
+
+      cy.clock()
+    })
+
     context('errors', () => {
       it('throws if now is not a number (or options object)', (done) => {
         cy.on('fail', (err) => {

--- a/packages/driver/cypress/integration/commands/clock_spec.js
+++ b/packages/driver/cypress/integration/commands/clock_spec.js
@@ -125,7 +125,7 @@ describe('src/cy/commands/clock', () => {
       })
     })
 
-    it('overwrite gracefully', () => {
+    it('overwrites without crashing', () => {
       Cypress.Commands.overwrite('clock', (originalCommand, ...args) => {
         return originalCommand(...args)
       })

--- a/packages/driver/src/cy/commands/clock.ts
+++ b/packages/driver/src/cy/commands/clock.ts
@@ -39,7 +39,7 @@ export default function (Commands, Cypress, cy, state) {
   return Commands.addAll({ type: 'utility' }, {
     clock (subject, now, methods, options = {}) {
       let userOptions = options
-      const ctx = this
+      const ctx = state('ctx')
 
       if (clock) {
         return clock


### PR DESCRIPTION
### User facing changelog
Previously overwriting `.clock` command crashed because it did not preserve this context. Now the following works:

```js
Cypress.Commands.overwrite('clock', (originalCommand, ...args) => {
  return originalCommand(...args)
})

cy.clock()
```

### Additional details
This MR is vastly inspired from #9589

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? [Link](https://github.com/cypress-io/cypress-documentation/pull/4244)
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
