### PR TITLE
feat:issue-17710

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2738,6 +2738,11 @@ declare namespace Cypress {
      */
     experimentalSessionSupport: boolean
     /**
+     * Maintain the experimental session cache between spec files in run mode.
+     * @default false
+     */
+    experimentalSessionKeepCache: boolean
+    /**
      * Allows listening to the `before:run`, `after:run`, `before:spec`, and `after:spec` events in the plugins file during interactive mode.
      * @default false
      */

--- a/packages/config/lib/options.ts
+++ b/packages/config/lib/options.ts
@@ -136,6 +136,11 @@ const resolvedOptions: Array<ResolvedConfigOption> = [
     validation: validate.isBoolean,
     isExperimental: true,
   }, {
+    name: 'experimentalSessionKeepCache',
+    defaultValue: false,
+    validation: validate.isBoolean,
+    isExperimental: true,
+  }, {
     name: 'experimentalSourceRewriting',
     defaultValue: false,
     validation: validate.isBoolean,

--- a/packages/server/lib/open_project.ts
+++ b/packages/server/lib/open_project.ts
@@ -228,7 +228,9 @@ export class OpenProject {
         }
 
         // clear all session data before each spec
-        session.clearSessions()
+        if (!cfg.experimentalSessionKeepCache) {
+          session.clearSessions()
+        }
       })
       .then(() => {
         return browsers.open(browser, options, automation)

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -39,7 +39,7 @@ import type { LaunchArgs } from './open_project'
 // and are required when creating a project.
 type ReceivedCypressOptions =
   Pick<Cypress.RuntimeConfigOptions, 'hosts' | 'projectName' | 'clientRoute' | 'devServerPublicPathRoute' | 'namespace' | 'report' | 'socketIoCookie' | 'configFile' | 'isTextTerminal' | 'isNewProject' | 'proxyUrl' | 'browsers' | 'browserUrl' | 'socketIoRoute' | 'arch' | 'platform' | 'spec' | 'specs' | 'browser' | 'version' | 'remote'>
-  & Pick<Cypress.ResolvedConfigOptions, 'chromeWebSecurity' | 'supportFolder' | 'experimentalSourceRewriting' | 'fixturesFolder' | 'reporter' | 'reporterOptions' | 'screenshotsFolder' | 'pluginsFile' | 'supportFile' | 'integrationFolder' | 'baseUrl' | 'viewportHeight' | 'viewportWidth' | 'port' | 'experimentalInteractiveRunEvents' | 'componentFolder' | 'userAgent' | 'downloadsFolder' | 'env' | 'testFiles' | 'ignoreTestFiles'> // TODO: Figure out how to type this better.
+  & Pick<Cypress.ResolvedConfigOptions, 'chromeWebSecurity' | 'supportFolder' | 'experimentalSourceRewriting' | 'fixturesFolder' | 'reporter' | 'reporterOptions' | 'screenshotsFolder' | 'pluginsFile' | 'supportFile' | 'integrationFolder' | 'baseUrl' | 'viewportHeight' | 'viewportWidth' | 'port' | 'experimentalInteractiveRunEvents' | 'experimentalSessionKeepCache' | 'componentFolder' | 'userAgent' | 'downloadsFolder' | 'env' | 'testFiles' | 'ignoreTestFiles'> // TODO: Figure out how to type this better.
 
 export interface Cfg extends ReceivedCypressOptions {
   projectRoot: string


### PR DESCRIPTION
Do not clear session cache when new ExperimentalSessionKeepCache config value is true

This allows users to standardize behavior between testing in run and open mode
In open mode the session cache is kept between spec file runs
In run mode the session cache is cleared before each spec file
This divergence can degrade performance and fail test when running multiple spec files in run mode

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes [issue 17710](https://github.com/cypress-io/cypress/issues/17710)

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Adds a new boolean configuration setting, _ExperimentalSessionKeepCache_, which when true prevents the session cache from being cleared between spec files in _run_ mode. This matches the behavior when running multiple spec files in _open_ mode.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

#### Justification 

[Currently the session cache is maintained between spec file runs in _open_ mode, but not _run_ mode](https://docs.cypress.io/api/commands/session#Session-caching). This leads to unpredictable test development, particularly around authentication, where a suite of tests developed in _open_ mode will fail when deployed to a CI workflow or some other form of automation in _run_ mode. Additionally, there are performance benefits to maintaining the session cache as it prevents the setup function, which is potentially expensive, from being run again until the verification function, generally faster, has run.

Finally, it is unclear why the design decision was made to clear the cache only in run mode. If the intent of the session API was to allow for server state to be explicitly tracked and cached by the user, particularly authentication state, it seems defeated by clearing the cache between spec files. Spec files are often organized by site area or areas of functionality to be tested; it is non-obvious that they are generalizable to boundaries between states.

As an example from our codebase: most of our tests require an authenticated user. We manage this with the session cache, performing a single login at setup that is then not performed in subsequent tests because the verification script passes. However, as the cache is emptied before each spec file in _run_ mode, the setup function (the login) is run for the first usage of the session of that session id in each spec file. This leads to test failures as a fundamental security setting of our architecture is that a user cannot authenticate twice within a short period of time. If a test runs faster than this limit, all subsequent ones will fail to authenticate until the time limit is passed. 

#### Implementation
Added a configuration value to disable the session being cleared in the `open_project.launch()` function that is invoked by `run.launch_browser()`. **As an alternative**, the behavior may be removed as a default for the reasons given above. Users who rely on it could replicate the behavior by invoking [`Cypress.session.clearAllSavedSessions()`
](https://docs.cypress.io/api/cypress-api/session) in a [before:spec hook](https://docs.cypress.io/api/plugins/before-spec-api#Syntax). 

#### Necessary work
Tests need to be added for the new configuration option and for the session cache behavior. Will add if this is a route that the team wants to go down.  

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

When _ExperimentalSessionKeepCache_ is true the session cache is not emptied between spec files in run mode. 

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
