### PR TITLE
chore: fix typo in the spelling of skipPluginInitializeForTesting option

### DIFF
--- a/packages/frontend-shared/cypress/e2e/support/e2eSupport.ts
+++ b/packages/frontend-shared/cypress/e2e/support/e2eSupport.ts
@@ -106,7 +106,7 @@ function initializeApp (mode: 'component' | 'e2e' = 'e2e') {
   return cy.withCtx(async (ctx, o) => {
     ctx.actions.wizard.setTestingType(o.mode)
     await ctx.actions.project.initializeActiveProject({
-      skipPluginIntializeForTesting: true,
+      skipPluginInitializeForTesting: true,
     })
 
     await ctx.actions.project.launchProject(o.mode, {

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -200,7 +200,7 @@ export class ProjectBase<TServer extends Server> extends EE {
 
     this._server = this.createServer(this.testingType)
 
-    if (!this.options.skipPluginIntializeForTesting) {
+    if (!this.options.skipPluginInitializeForTesting) {
       cfg = await this.initializePlugins(cfg, this.options)
     }
 
@@ -470,7 +470,7 @@ export class ProjectBase<TServer extends Server> extends EE {
 
     let ctDevServerPort: number | undefined
 
-    if (this.testingType === 'component' && !this.options.skipPluginIntializeForTesting) {
+    if (this.testingType === 'component' && !this.options.skipPluginInitializeForTesting) {
       const { port } = await this.startCtDevServer(specs, config)
 
       ctDevServerPort = port

--- a/packages/types/src/server.ts
+++ b/packages/types/src/server.ts
@@ -62,7 +62,7 @@ export interface OpenProjectLaunchOptions {
    * Whether to skip the plugin initialization, useful when
    * we're using Cypress to test Cypress
    */
-  skipPluginIntializeForTesting?: boolean
+  skipPluginInitializeForTesting?: boolean
 
   configFile?: string | false
   browsers?: Cypress.Browser[]


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->
Added the missing `i` to fix the miss-spelling of Initialize.

### User facing changelog
n/a 

### How has the user experience changed?
n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [n/a ] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
