### PR TITLE
fix: prevent error if project do not have git

### DIFF
--- a/packages/data-context/src/sources/GitDataSource.ts
+++ b/packages/data-context/src/sources/GitDataSource.ts
@@ -120,12 +120,18 @@ export class GitDataSource {
   }
 
   public async getBranch (absolutePath: string) {
-    const { stdout, exitCode = 0 } = await execa(GIT_BRANCH_COMMAND, { shell: true, cwd: absolutePath })
+    try {
+      const { stdout, exitCode = 0 } = await execa(GIT_BRANCH_COMMAND, { shell: true, cwd: absolutePath })
 
-    this.ctx.debug('executing command `%s`:', GIT_BRANCH_COMMAND)
-    this.ctx.debug('stdout for git branch', stdout)
-    this.ctx.debug('exitCode for git branch', exitCode)
+      this.ctx.debug('executing command `%s`:', GIT_BRANCH_COMMAND)
+      this.ctx.debug('stdout for git branch', stdout)
+      this.ctx.debug('exitCode for git branch', exitCode)
 
-    return exitCode === 0 ? stdout.trim() : null
+      return exitCode === 0 ? stdout.trim() : null
+    } catch (e) {
+      this.ctx.debug('Error getting git branch: %s', (e as Error).message)
+
+      return null
+    }
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

if the current project do not have git initialized, prevent throwing errors when getting the branch
<img width="1569" alt="Screen Shot 2021-12-02 at 12 55 42 PM" src="https://user-images.githubusercontent.com/15656860/144480225-a5e29082-a909-4b92-8ad9-d1b0a3e122fe.png">


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
