### PR TITLE
fix: Do not crash when a ill formed URL request is proxied

### DIFF
--- a/packages/https-proxy/lib/server.js
+++ b/packages/https-proxy/lib/server.js
@@ -34,6 +34,16 @@ class Server {
   }
 
   connect (req, browserSocket, head, options = {}) {
+    // the SNI server requires a hostname, so if the hostname is blank,
+    // destroy the socket and fail fast
+    const { hostname } = url.parse(`https://${req.url}`)
+
+    if (!hostname) {
+      browserSocket.destroy()
+
+      return debug(`Invalid hostname for request url ${req.url}`)
+    }
+
     // don't buffer writes - thanks a lot, Nagle
     // https://github.com/cypress-io/cypress/issues/3192
     browserSocket.setNoDelay(true)
@@ -198,6 +208,17 @@ class Server {
         leave()
 
         return makeConnection(port)
+      })
+      .catch((err) => {
+        debug('Error making connection %o', { err })
+
+        browserSocket.destroy(err)
+
+        leave()
+
+        if (this._onError) {
+          return this._onError(err, browserSocket, head)
+        }
       })
     })
   }

--- a/packages/https-proxy/test/integration/proxy_spec.js
+++ b/packages/https-proxy/test/integration/proxy_spec.js
@@ -215,6 +215,25 @@ describe('Proxy', () => {
         expect(this.proxy._generateMissingCertificates).to.be.calledTwice
       })
     })
+
+    // https://github.com/cypress-io/cypress/issues/9220
+    it('handles errors with addContext', async function () {
+      this.sandbox.spy(this.proxy, 'connect')
+      this.sandbox.stub(this.proxy._sniServer, 'addContext').throws(new Error('error adding context'))
+
+      return request({
+        strictSSL: false,
+        url: 'https://localhost:8443/',
+        proxy: 'http://localhost:3333',
+      }).catch(() => {
+        // This scenario will cause an error but we should clean
+        // ensure the outgoing socket created for this connection was destroyed
+        expect(this.proxy.connect).calledOnce
+        const socket = this.proxy.connect.getCalls()[0].args[1]
+
+        expect(socket.destroyed).to.be.true
+      })
+    })
   })
 
   context('closing', () => {
@@ -229,7 +248,7 @@ describe('Proxy', () => {
       }).then(() => {
         return proxy.start(3333)
       }).then(() => {
-      // force this to reject if its called
+        // force this to reject if its called
         this.sandbox.stub(this.proxy, '_generateMissingCertificates').rejects(new Error('should not call'))
 
         return request({

--- a/packages/https-proxy/test/unit/server_spec.js
+++ b/packages/https-proxy/test/unit/server_spec.js
@@ -92,5 +92,21 @@ describe('lib/server', () => {
         srv._makeConnection(socket, head, '443', '%7Balgolia_application_id%7D-dsn.algolia.net')
       })
     })
+
+    // https://github.com/cypress-io/cypress/issues/9220
+    it('does not crash when a blank URL is parsed and instead only destroys the socket', function (done) {
+      const socket = new EE()
+
+      socket.destroy = this.sandbox.stub()
+      const head = {}
+
+      this.setup()
+      .then((srv) => {
+        srv.connect({ url: '%20:443' }, socket, head)
+        expect(socket.destroy).to.be.calledOnce
+
+        done()
+      })
+    })
   })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #9220 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

The Cypress App will no longer crash when proxying an ill formed request. For example, if the application under test has a resource of "http: //localhost/asset.js" (notice the extraneous space) the Cypress App will no longer crash. Instead, a debug message will be logged and the asset will fail to load.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

The goal here is to treat these ill-formed requests just like any other requests that are problematic (e.g. not found resources).  Thus, we don't attempt to stop the tests outright, but instead just fail the individual request.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Before:

Terminal:

![image](https://user-images.githubusercontent.com/4873279/144344749-911b7b20-d2b1-4982-8ee5-b245060d3d69.png)

After:

Terminal:

![image](https://user-images.githubusercontent.com/4873279/144344273-91b3a7a3-4f04-41a1-9340-8c5a2bed8508.png)

Browser Console:

![image](https://user-images.githubusercontent.com/4873279/144344317-f44045a6-1628-4ec2-8a49-97ec2bccf38b.png)

Network:

![image](https://user-images.githubusercontent.com/4873279/144344505-d18aac0d-2c40-4b16-a3fa-3ea8214181a5.png)

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [X] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
