### PR TITLE
fix(unify): cursor for Open in IDE button

### DIFF
--- a/packages/reporter/src/hooks/hooks.scss
+++ b/packages/reporter/src/hooks/hooks.scss
@@ -22,6 +22,7 @@
         }
 
         .hook-open-in-ide {
+          cursor: pointer;
           display: block;
         }
       }
@@ -53,7 +54,7 @@
         align-items: center;
         color: $gray-400;
         display: none;
-        padding: 4px 10px;
+        padding: 4px;
 
         &:hover, &:focus {
           background-color: rgba($gray-700, 0.2);

--- a/packages/reporter/src/lib/open-file-in-ide.tsx
+++ b/packages/reporter/src/lib/open-file-in-ide.tsx
@@ -14,7 +14,7 @@ interface Props {
 const OpenFileInIDE: React.FC<Props> = observer((props) => {
   return (
     <Tooltip title={'Open in IDE'} className='cy-tooltip'>
-      <span onClick={() => events.emit('open:file:unified', props.fileDetails)}>
+      <span className={props.className} onClick={() => events.emit('open:file:unified', props.fileDetails)}>
         {props.children}
       </span>
     </Tooltip>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

The "Open in IDE" button should have a pointer cursor.

- Closes [#20c6mwc](https://app.clickup.com/t/20c6mwc)

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
