### PR TITLE
fix: preserve runnable spec on browser change

### DIFF
--- a/packages/server/lib/project_utils.ts
+++ b/packages/server/lib/project_utils.ts
@@ -86,7 +86,7 @@ export const getSpecUrl = ({
   specType ??= 'integration'
   browserUrl ??= ''
 
-  // App routes to spec with convention {browserUrl}#/runner?file={relativeSpecPath}
+  // App routes to spec with convention {browserUrl}#/specs/runner?file={relativeSpecPath}
   if (process.env.LAUNCHPAD) {
     if (!absoluteSpecPath) {
       return browserUrl
@@ -95,7 +95,7 @@ export const getSpecUrl = ({
     const relativeSpecPath = path.relative(projectRoot, path.resolve(projectRoot, absoluteSpecPath))
     .replace(backSlashesRe, '/')
 
-    return `${browserUrl}/#/runner?file=${relativeSpecPath}`
+    return `${browserUrl}/#/specs/runner?file=${relativeSpecPath}`
     .replace(multipleForwardSlashesRe, multipleForwardSlashesReplacer)
   }
 


### PR DESCRIPTION
Fix for preserving the currently selected spec when switching browsers. The backend redirects the browser when switching types and thus requires the exact route that the frontend uses for running a spec.