### PR TITLE
fix: close chrome when closing electron

### DIFF
--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -520,13 +520,11 @@ export = {
     const originalBrowserKill = launchedBrowser.kill
 
     /* @ts-expect-error */
-    launchedBrowser.kill = async (...args) => {
+    launchedBrowser.kill = (...args) => {
       debug('closing remote interface client')
-
-      await criClient.close()
       debug('closing chrome')
 
-      await originalBrowserKill.apply(launchedBrowser, args)
+      originalBrowserKill.apply(launchedBrowser, args)
     }
 
     await this._maybeRecordVideo(criClient, options, browser.majorVersion)

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -522,6 +522,8 @@ export = {
     /* @ts-expect-error */
     launchedBrowser.kill = (...args) => {
       debug('closing remote interface client')
+
+      criClient.close()
       debug('closing chrome')
 
       originalBrowserKill.apply(launchedBrowser, args)

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -64,6 +64,10 @@ interface CRIWrapper {
    * @see https://github.com/cyrus-and/chrome-remote-interface#class-cdp
    */
   on (eventName: CRI.EventName, cb: Function): void
+  /**
+   * Calls underlying remote interface client close
+  */
+  close (): Bluebird<void>
 }
 
 interface Version {
@@ -249,6 +253,11 @@ export const create = Bluebird.method((target: websocketUrl, onAsynchronousError
         debug('registering CDP on event %o', { eventName })
 
         return cri.on(eventName, cb)
+      },
+      close () {
+        closed = true
+
+        return cri.close()
       },
     }
 

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -64,10 +64,6 @@ interface CRIWrapper {
    * @see https://github.com/cyrus-and/chrome-remote-interface#class-cdp
    */
   on (eventName: CRI.EventName, cb: Function): void
-  /**
-   * Calls underlying remote interface client close
-  */
-  close (): Bluebird<void>
 }
 
 interface Version {
@@ -191,7 +187,6 @@ export const create = Bluebird.method((target: websocketUrl, onAsynchronousError
       maybeDebugCdpMessages(cri)
 
       cri.send = Bluebird.promisify(cri.send, { context: cri })
-      cri.close = Bluebird.promisify(cri.close, { context: cri })
 
       // @see https://github.com/cyrus-and/chrome-remote-interface/issues/72
       cri._notifier.on('disconnect', reconnect)
@@ -254,11 +249,6 @@ export const create = Bluebird.method((target: websocketUrl, onAsynchronousError
         debug('registering CDP on event %o', { eventName })
 
         return cri.on(eventName, cb)
-      },
-      close () {
-        closed = true
-
-        return cri.close()
       },
     }
 

--- a/packages/server/test/unit/browsers/chrome_spec.js
+++ b/packages/server/test/unit/browsers/chrome_spec.js
@@ -290,24 +290,6 @@ describe('lib/browsers/chrome', () => {
       })
     })
 
-    it('calls cri client close on kill', function () {
-      // need a reference here since the stub will be monkey-patched
-      const {
-        kill,
-      } = this.launchedBrowser
-
-      return chrome.open('chrome', 'http://', {}, this.automation)
-      .then(() => {
-        expect(this.launchedBrowser.kill).to.be.a('function')
-
-        return this.launchedBrowser.kill()
-      }).then(() => {
-        expect(this.criClient.close).to.be.calledOnce
-
-        expect(kill).to.be.calledOnce
-      })
-    })
-
     it('rejects if CDP version check fails', function () {
       this.criClient.ensureMinimumProtocolVersion.rejects()
 

--- a/packages/server/test/unit/browsers/chrome_spec.js
+++ b/packages/server/test/unit/browsers/chrome_spec.js
@@ -290,6 +290,24 @@ describe('lib/browsers/chrome', () => {
       })
     })
 
+    it('calls cri client close on kill', function () {
+      // need a reference here since the stub will be monkey-patched
+      const {
+        kill,
+      } = this.launchedBrowser
+
+      return chrome.open('chrome', 'http://', {}, this.automation)
+      .then(() => {
+        expect(this.launchedBrowser.kill).to.be.a('function')
+
+        return this.launchedBrowser.kill()
+      }).then(() => {
+        expect(this.criClient.close).to.be.calledOnce
+
+        expect(kill).to.be.calledOnce
+      })
+    })
+
     it('rejects if CDP version check fails', function () {
       this.criClient.ensureMinimumProtocolVersion.rejects()
 

--- a/packages/server/test/unit/browsers/chrome_spec.js
+++ b/packages/server/test/unit/browsers/chrome_spec.js
@@ -300,10 +300,9 @@ describe('lib/browsers/chrome', () => {
       .then(() => {
         expect(this.launchedBrowser.kill).to.be.a('function')
 
-        return this.launchedBrowser.kill()
-      }).then(() => {
-        expect(this.criClient.close).to.be.calledOnce
+        this.launchedBrowser.kill()
 
+        expect(this.criClient.close).to.be.calledOnce
         expect(kill).to.be.calledOnce
       })
     })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one --> https://github.com/cypress-io/cypress/issues/18827

### User facing changelog

Fixed an issue where Chromium-family browsers would stay open after closing `cypress open`.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

* If chrome is open, and electron is closed, the chrome process is not being killed
* This was broken before because process.on('exit') handlers have to be synchronous, and this was async

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
