### PR TITLE
fix: Do not screenshot or trigger the failed event when tests are skipped

### DIFF
--- a/packages/driver/cypress/integration/cy/skipping_async_spec.js
+++ b/packages/driver/cypress/integration/cy/skipping_async_spec.js
@@ -1,0 +1,62 @@
+const { Screenshot } = Cypress
+
+let failedEventFired = false
+
+Cypress.on('fail', (error) => {
+  failedEventFired = true
+  throw new Error(error)
+})
+
+let screenshotTaken = false
+
+Screenshot.defaults({ onAfterScreenshot: () => {
+  screenshotTaken = true
+} })
+
+const pendingTests = []
+const passedTests = []
+
+Cypress.on('test:after:run', (test) => {
+  if (test.state === 'pending') {
+    return pendingTests.push(test)
+  }
+
+  if (test.state === 'passed') {
+    return passedTests.push(test)
+  }
+})
+
+beforeEach(() => {
+  // Set isInteractive to false to ensure that screenshots will be
+  // triggered in both run and open mode
+  Cypress.config('isInteractive', false)
+})
+
+describe('skipped test', () => {
+  it('does not fail', function () {
+    cy.then(() => {
+      this.skip()
+    }).then(() => {
+      expect(true).to.be.false
+    })
+  })
+
+  it('does not prevent subsequent tests from running', () => {
+    expect(true).to.be.true
+  })
+})
+
+describe('skipped test side effects', () => {
+  it('does not have a screenshot taken', () => {
+    expect(screenshotTaken).to.be.false
+  })
+
+  it('does not fire failed event', () => {
+    expect(failedEventFired).to.be.false
+  })
+
+  it('does still mark all tests with the correct state', () => {
+    expect(pendingTests).to.have.length(1)
+    expect(passedTests).to.have.length(3)
+  })
+})

--- a/packages/driver/cypress/integration/cy/skipping_sync_spec.js
+++ b/packages/driver/cypress/integration/cy/skipping_sync_spec.js
@@ -1,0 +1,70 @@
+const { Screenshot } = Cypress
+
+let failedEventFired = false
+
+Cypress.on('fail', (error) => {
+  failedEventFired = true
+  throw new Error(error)
+})
+
+let screenshotTaken = false
+
+Screenshot.defaults({ onAfterScreenshot: () => {
+  screenshotTaken = true
+} })
+
+const pendingTests = []
+const passedTests = []
+
+Cypress.on('test:after:run', (test) => {
+  if (test.state === 'pending') {
+    return pendingTests.push(test)
+  }
+
+  if (test.state === 'passed') {
+    return passedTests.push(test)
+  }
+})
+
+beforeEach(() => {
+  // Set isInteractive to false to ensure that screenshots will be
+  // triggered in both run and open mode
+  Cypress.config('isInteractive', false)
+})
+
+describe('generally skipped test', () => {
+  before(function () {
+    this.skip()
+  })
+
+  it('does not fail', function () {
+    expect(true).to.be.false
+  })
+})
+
+describe('individually skipped tests', () => {
+  it('does not fail when using this.skip', function () {
+    this.skip()
+    expect(true).to.be.false
+  })
+
+  // NOTE: We are skipping this test in order to test skip functionality
+  it.skip('does not fail when using it.skip', () => {
+    expect(true).to.be.false
+  })
+})
+
+describe('skipped test side effects', () => {
+  it('does not have a screenshot taken', () => {
+    expect(screenshotTaken).to.be.false
+  })
+
+  it('does not fire failed event', () => {
+    expect(failedEventFired).to.be.false
+  })
+
+  it('does still mark all tests with the correct state', () => {
+    expect(pendingTests).to.have.length(3)
+    expect(passedTests).to.have.length(2)
+  })
+})

--- a/packages/driver/src/cypress/command_queue.ts
+++ b/packages/driver/src/cypress/command_queue.ts
@@ -343,6 +343,14 @@ export class CommandQueue extends Queue<Command> {
     }
 
     const onError = (err: Error | string) => {
+      // If the runnable was marked as pending, this test was skipped
+      // go ahead and just return
+      const runnable = this.state('runnable')
+
+      if (runnable.isPending()) {
+        return
+      }
+
       if (this.state('onCommandFailed')) {
         return this.state('onCommandFailed')(err, this, next)
       }

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -942,6 +942,12 @@ export class $Cy implements ITimeouts, IStability, IAssertions, IRetries, IJQuer
         // else just return ret
         return ret
       } catch (err) {
+        // If the runnable was marked as pending, this test was skipped
+        // go ahead and just return
+        if (runnable.isPending()) {
+          return
+        }
+
         // if runnable.fn threw synchronously, then it didnt fail from
         // a cypress command, but we should still teardown and handle
         // the error


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #17660 
- Closes #14867 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Skipped tests will no longer trigger the fail event or cause screenshots to be generated.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

When a test is skipped, mocha triggers a ["sync skip; aborting execution" error](https://github.com/mochajs/mocha/blob/ac43029d6a86150a48ccd59e50e89ca10c72a9c0/lib/runnable.js#L143). In investigating #17660, it was determined that #14867 had the same root cause. The main difference is that #17660 deals with synchronous tests and #14867 deals with asynchronous tests. In both cases, the fix is to update the failure handling to check if the test is pending (mocha's indicator that the test was skipped) and not fail in that scenario.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

#17660 Before:

![image](https://user-images.githubusercontent.com/4873279/144912588-b2b32b1b-4d51-4f7a-ac76-b1f6bc81263b.png)

#17660 After:

![image](https://user-images.githubusercontent.com/4873279/144912862-cf0de75f-f06e-4ed8-8f88-5217339c8dfb.png)

#14866 Before:

![image](https://user-images.githubusercontent.com/4873279/144913289-803b1629-b7f0-4c58-ba15-5f3b0807e0dc.png)

#14866 After:

![image](https://user-images.githubusercontent.com/4873279/144913636-fdfd5e2b-5877-45e2-8291-bf2139a160f5.png)

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [X] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
