### PR TITLE
refactor: remove unused legacy 'rewriteRules'

### DIFF
--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -857,7 +857,7 @@ export class ProjectBase<TServer extends Server> extends EE {
       return readSettings.projectId
     }
 
-    errors.throw('NO_PROJECT_ID', settings.configFile(this.options), this.projectRoot)
+    throw errors.throw('NO_PROJECT_ID', settings.configFile(this.options), this.projectRoot)
   }
 
   async verifyExistence () {

--- a/packages/server/lib/util/settings.ts
+++ b/packages/server/lib/util/settings.ts
@@ -88,7 +88,7 @@ export function id (projectRoot, options = {}) {
 
 export function read (projectRoot, options: SettingsOptions = {}) {
   if (options.configFile === false) {
-    return Promise.resolve({})
+    return Promise.resolve({} as Partial<Cypress.ConfigOptions>)
   }
 
   const file = pathToConfigFile(projectRoot, options)
@@ -117,7 +117,7 @@ export function read (projectRoot, options: SettingsOptions = {}) {
       throw err
     }
 
-    return _logReadErr(file, err)
+    throw _logReadErr(file, err)
   })
 }
 

--- a/packages/server/lib/util/settings.ts
+++ b/packages/server/lib/util/settings.ts
@@ -9,8 +9,6 @@ import { getCtx } from '@packages/data-context'
 
 const debug = Debug('cypress:server:settings')
 
-type ChangedConfig = { projectId?: string, component?: {}, e2e?: {} }
-
 function configCode (obj, isTS?: boolean) {
   const objJSON = obj && !_.isEmpty(obj)
     ? JSON.stringify(_.omit(obj, 'configFile'), null, 2)
@@ -24,49 +22,6 @@ function configCode (obj, isTS?: boolean) {
 
   return `module.exports = ${objJSON}
 `
-}
-
-// TODO:
-// think about adding another PSemaphore
-// here since we can read + write the
-// settings at the same time something else
-// is potentially reading it
-
-const flattenCypress = (obj) => {
-  return obj.cypress ? obj.cypress : undefined
-}
-
-const renameVisitToPageLoad = (obj) => {
-  const v = obj.visitTimeout
-
-  if (v) {
-    obj = _.omit(obj, 'visitTimeout')
-    obj.pageLoadTimeout = v
-
-    return obj
-  }
-}
-
-const renameCommandTimeout = (obj) => {
-  const c = obj.commandTimeout
-
-  if (c) {
-    obj = _.omit(obj, 'commandTimeout')
-    obj.defaultCommandTimeout = c
-
-    return obj
-  }
-}
-
-const renameSupportFolder = (obj) => {
-  const sf = obj.supportFolder
-
-  if (sf) {
-    obj = _.omit(obj, 'supportFolder')
-    obj.supportFile = sf
-
-    return obj
-  }
 }
 
 function _pathToFile (projectRoot, file) {
@@ -113,14 +68,6 @@ function _write (file, obj: any = {}) {
   })
 }
 
-function _applyRewriteRules (obj = {}) {
-  return _.reduce([flattenCypress, renameVisitToPageLoad, renameCommandTimeout, renameSupportFolder], (memo, fn) => {
-    const ret = fn(memo)
-
-    return ret ? ret : memo
-  }, _.cloneDeep(obj))
-}
-
 export function isComponentTesting (options: SettingsOptions = {}) {
   return options.testingType === 'component'
 }
@@ -163,20 +110,7 @@ export function read (projectRoot, options: SettingsOptions = {}) {
       configObject = { ...configObject, ...configObject.e2e }
     }
 
-    debug('resolved configObject', configObject)
-    const changed: ChangedConfig = _applyRewriteRules(configObject)
-
-    // if our object is unchanged
-    // then just return it
-    if (_.isEqual(configObject, changed)) {
-      return configObject
-    }
-
-    // else write the new reduced obj and store the projectId on the cache
-    return _write(file, changed)
-    .then((config) => {
-      return config
-    })
+    return configObject
   }).catch((err) => {
     debug('an error occurred when reading config', err)
     if (errors.isCypressErr(err)) {

--- a/packages/server/test/unit/util/settings_spec.js
+++ b/packages/server/test/unit/util/settings_spec.js
@@ -30,21 +30,6 @@ describe('lib/util/settings', () => {
       return fs.removeAsync('cypress.config.js')
     })
 
-    context('nested cypress object', () => {
-      it('flattens object on read', function () {
-        return this.setup({ cypress: { foo: 'bar' } })
-        .then(() => {
-          return settings.read(projectRoot, defaultOptions)
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ foo: 'bar' })
-
-          return require(path.join(projectRoot, 'cypress.config.js'))
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ foo: 'bar' })
-        })
-      })
-    })
-
     context('.readEnv', () => {
       afterEach(() => {
         return fs.removeAsync('cypress.env.json')
@@ -135,42 +120,6 @@ describe('lib/util/settings', () => {
           return settings.read(projectRoot, defaultOptions)
         }).then((obj) => {
           expect(obj).to.deep.eq({ a: 'c', e2e: { a: 'c' } })
-        })
-      })
-
-      it('renames commandTimeout -> defaultCommandTimeout', function () {
-        return this.setup({ commandTimeout: 30000, foo: 'bar' })
-        .then(() => {
-          return settings.read(projectRoot, defaultOptions)
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ defaultCommandTimeout: 30000, foo: 'bar' })
-        })
-      })
-
-      it('renames supportFolder -> supportFile', function () {
-        return this.setup({ supportFolder: 'foo', foo: 'bar' })
-        .then(() => {
-          return settings.read(projectRoot, defaultOptions)
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ supportFile: 'foo', foo: 'bar' })
-        })
-      })
-
-      it('renames visitTimeout -> pageLoadTimeout', function () {
-        return this.setup({ visitTimeout: 30000, foo: 'bar' })
-        .then(() => {
-          return settings.read(projectRoot, defaultOptions)
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ pageLoadTimeout: 30000, foo: 'bar' })
-        })
-      })
-
-      it('renames visitTimeout -> pageLoadTimeout on nested cypress obj', function () {
-        return this.setup({ cypress: { visitTimeout: 30000, foo: 'bar' } })
-        .then(() => {
-          return settings.read(projectRoot, defaultOptions)
-        }).then((obj) => {
-          expect(obj).to.deep.eq({ pageLoadTimeout: 30000, foo: 'bar' })
         })
       })
 


### PR DESCRIPTION
The `_write` called within the `settings.read` is only needed if we're renaming config options that have been gone for years. Removing this as the config upgrade will have an entirely new flow.