### PR TITLE
chore: Fix server unit tests running on mac by using actual tmp dir

### DIFF
--- a/system-tests/lib/fixtures.ts
+++ b/system-tests/lib/fixtures.ts
@@ -1,15 +1,15 @@
 import fs from 'fs-extra'
 import _path from 'path'
 import chokidar from 'chokidar'
-import os from 'os'
 import cachedir from 'cachedir'
 import execa from 'execa'
+import tempDir from 'temp-dir'
 
 const root = _path.join(__dirname, '..')
 
 const serverRoot = _path.join(__dirname, '../../packages/server/')
 const projects = _path.join(root, 'projects')
-const tmpDir = _path.join(os.tmpdir(), 'cy-projects')
+const cyTmpDir = _path.join(tempDir, 'cy-projects')
 
 // copy contents instead of deleting+creating new file, which can cause
 // filewatchers to lose track of toFile.
@@ -27,9 +27,9 @@ const copyContents = (fromFile, toFile) => {
 }
 
 // copies all of the project fixtures
-// to the tmpDir .projects in the root
+// to the cyTmpDir .projects in the root
 export function scaffold () {
-  fs.copySync(projects, tmpDir)
+  fs.copySync(projects, cyTmpDir)
 }
 
 /**
@@ -37,7 +37,7 @@ export function scaffold () {
  */
 export function scaffoldProject (project: string): void {
   const from = _path.join(projects, project)
-  const to = _path.join(tmpDir, project)
+  const to = _path.join(cyTmpDir, project)
 
   fs.copySync(from, to)
 }
@@ -131,7 +131,7 @@ function getYarnCommand (opts: {
 
   // in CircleCI, this offline cache can be used
   if (opts.isCI) cmd += ` --cache-folder=~/.yarn-${process.platform} `
-  else cmd += ` --cache-folder=${_path.join(os.tmpdir(), 'cy-system-tests-yarn-cache', String(Date.now()))}`
+  else cmd += ` --cache-folder=${_path.join(tempDir, 'cy-system-tests-yarn-cache', String(Date.now()))}`
 
   return cmd
 }
@@ -291,7 +291,7 @@ export async function scaffoldCommonNodeModules () {
 }
 
 export async function symlinkNodeModule (pkg) {
-  const from = _path.join(tmpDir, 'node_modules', pkg)
+  const from = _path.join(cyTmpDir, 'node_modules', pkg)
   const to = pathToPackage(pkg)
 
   await fs.ensureDir(_path.dirname(from))
@@ -312,7 +312,7 @@ export function scaffoldWatch () {
   chokidar.watch(watchdir, {
   })
   .on('change', (srcFilepath, stats) => {
-    const tmpFilepath = _path.join(tmpDir, _path.relative(watchdir, srcFilepath))
+    const tmpFilepath = _path.join(cyTmpDir, _path.relative(watchdir, srcFilepath))
 
     return copyContents(srcFilepath, tmpFilepath)
   })
@@ -320,19 +320,19 @@ export function scaffoldWatch () {
 }
 
 // removes all of the project fixtures
-// from the tmpDir .projects in the root
+// from the cyTmpDir .projects in the root
 export function remove () {
-  return fs.removeSync(tmpDir)
+  return fs.removeSync(cyTmpDir)
 }
 
 // returns the path to project fixture
-// in the tmpDir
+// in the cyTmpDir
 export function project (...args) {
   return this.projectPath.apply(this, args)
 }
 
 export function projectPath (name) {
-  return _path.join(tmpDir, name)
+  return _path.join(cyTmpDir, name)
 }
 
 export function get (fixture, encoding: BufferEncoding = 'utf8') {

--- a/system-tests/package.json
+++ b/system-tests/package.json
@@ -73,6 +73,7 @@
     "ssestream": "1.0.1",
     "supertest": "4.0.2",
     "systeminformation": "5.6.4",
+    "temp-dir": "^2.0.0",
     "webpack": "4.43.0",
     "ws": "5.2.3"
   },


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog

N/A - affects internal tests only

### Additional details

Presumably since #18574, server unit tests fail on MacOS, because fixture projects are scaffolded using `os.tmpdir()`, [which is the symlinked temp directory and not the real one](https://github.com/nodejs/node/issues/11422). This causes a false positive in the [config logic](https://github.com/cypress-io/cypress/blob/32d59024fbffe9d30a93ee12599f7c8646725d2c/packages/server/lib/config.ts#L439), causing the support file not to be found and the following error to be thrown: 

![Screen Shot 2021-12-13 at 2 18 41 PM](https://user-images.githubusercontent.com/1157043/145874387-028d076a-a895-4a68-b6be-23d38e6c33b8.png)

This fix uses the `temp-dir` package instead of `os.tmpdir()` so that the correct temp directory is used and not the symlinked one.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
