### PR TITLE
fix(app): correctly teardown reporter and event manager

### DIFF
--- a/.vscode/terminals.json
+++ b/.vscode/terminals.json
@@ -40,6 +40,20 @@
       "command": "yarn test [fileBasename]"
     },
     {
+      "name": "packages/app cypress open",
+      "focus": true,
+      "onlySingle": true,
+      "cwd": "[cwd]/packages/app",
+      "command": "yarn cypress:open"
+    },
+    {
+      "name": "packages/app dev",
+      "focus": true,
+      "onlySingle": true,
+      "cwd": "[cwd]/packages/app",
+      "command": "yarn dev"
+    },
+    {
       "name": "packages/server test-watch",
       "focus": true,
       "onlySingle": true,

--- a/packages/app/src/runner/SpecRunnerContainer.vue
+++ b/packages/app/src/runner/SpecRunnerContainer.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts" setup>
-import { onMounted, ref, watch } from 'vue'
+import { onMounted, ref, watch, onBeforeUnmount } from 'vue'
 import { useRoute } from 'vue-router'
 import type { SpecRunnerFragment } from '../generated/graphql'
 import { getAutIframeModel, UnifiedRunnerAPI } from '../runner'
@@ -28,6 +28,10 @@ const route = useRoute()
 onMounted(async () => {
   await UnifiedRunnerAPI.initialize()
   initialized.value = true
+})
+
+onBeforeUnmount(() => {
+  UnifiedRunnerAPI.teardown()
 })
 
 const props = defineProps<{

--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -592,7 +592,7 @@ export class EventManager {
     this.selectorPlaygroundModel.setOpen(false)
   }
 
-  teardownReporter () {
+  resetReporter () {
     return new Promise((resolve) => {
       this.reporterBus.once('reporter:restarted', resolve)
       this.reporterBus.emit('reporter:restart:test:run')
@@ -600,7 +600,7 @@ export class EventManager {
   }
 
   async _rerun () {
-    await this.teardownReporter()
+    await this.resetReporter()
 
     // this probably isn't 100% necessary
     // since Cypress will fall out of scope

--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -1,5 +1,5 @@
+import Bluebird from 'bluebird'
 import { EventEmitter } from 'events'
-import Promise from 'bluebird'
 import type { BaseStore } from '@packages/runner-shared/src/store'
 import type { RunState } from '@packages/types/src/driver'
 import type MobX from 'mobx'
@@ -448,10 +448,10 @@ export class EventManager {
 
     Cypress.on('collect:run:state', () => {
       if (Cypress.env('NO_COMMAND_LOG')) {
-        return Promise.resolve()
+        return Bluebird.resolve()
       }
 
-      return new Promise((resolve) => {
+      return new Bluebird((resolve) => {
         this.reporterBus.emit('reporter:collect:run:state', (reporterState) => {
           resolve({
             ...reporterState,
@@ -593,7 +593,7 @@ export class EventManager {
   }
 
   resetReporter () {
-    return new Promise((resolve) => {
+    return new Bluebird((resolve) => {
       this.reporterBus.once('reporter:restarted', resolve)
       this.reporterBus.emit('reporter:restart:test:run')
     })

--- a/packages/app/src/runner/index.ts
+++ b/packages/app/src/runner/index.ts
@@ -144,6 +144,10 @@ function teardownSpec () {
   return getEventManager().teardown(getMobxRunnerStore())
 }
 
+export function teardown () {
+  UnifiedReporterAPI.setInitializedReporter(false)
+}
+
 /**
  * Set up a spec by creating a fresh AUT and initializing
  * Cypress on it.
@@ -268,13 +272,14 @@ async function initialize () {
  *    description for more information.
  */
 async function executeSpec (spec: BaseSpec) {
+  await teardownSpec()
+
   const mobxRunnerStore = getMobxRunnerStore()
 
   mobxRunnerStore.setSpec(spec)
 
   await UnifiedReporterAPI.resetReporter()
 
-  await teardownSpec()
   UnifiedReporterAPI.setupReporter()
 
   if (window.UnifiedRunner.config.testingType === 'e2e') {
@@ -291,4 +296,5 @@ async function executeSpec (spec: BaseSpec) {
 export const UnifiedRunnerAPI = {
   initialize,
   executeSpec,
+  teardown,
 }

--- a/packages/app/src/runner/index.ts
+++ b/packages/app/src/runner/index.ts
@@ -148,14 +148,14 @@ let isTorndown = false
 
 /**
  * Called when navigating away from the runner page.
- * This will teardown the reporter, event maanger, and
+ * This will teardown the reporter, event manager, and
  * any associated events.
  */
-export function teardown () {
+export async function teardown () {
   UnifiedReporterAPI.setInitializedReporter(false)
   _eventManager?.stop()
   _eventManager?.teardown(getMobxRunnerStore())
-  _eventManager?.resetReporter()
+  await _eventManager?.resetReporter()
   _eventManager = undefined
   isTorndown = true
 }
@@ -279,10 +279,12 @@ async function initialize () {
   // find out if we need to continue managing viewportWidth/viewportHeight in MobX at all.
   autStore.updateDimensions(config.viewportWidth, config.viewportHeight)
 
+  // just stick config on window until we figure out how we are
+  // going to manage it
   window.UnifiedRunner.config = config
 
   // window.UnifiedRunner exists now, since the Webpack bundle with
-  // the UnifiedRunner namespace was injected.
+  // the UnifiedRunner namespace was injected by `injectBundle`.
   initializeEventManager(window.UnifiedRunner)
 
   window.UnifiedRunner.MobX.runInAction(() => {

--- a/packages/app/src/runner/injectBundle.ts
+++ b/packages/app/src/runner/injectBundle.ts
@@ -21,10 +21,6 @@ export async function injectBundle () {
   document.head.appendChild(link)
 
   return new Promise<void>((resolve) => {
-    script.onload = () => {
-      // just stick config on window until we figure out how we are
-      // going to manage it
-      resolve()
-    }
+    script.onload = () => resolve()
   })
 }

--- a/packages/app/src/runner/injectBundle.ts
+++ b/packages/app/src/runner/injectBundle.ts
@@ -1,6 +1,3 @@
-import { initializeEventManager } from '.'
-import { initializeMobxStore, useAutStore } from '../store'
-
 export async function injectBundle () {
   const src = '/__cypress/runner/cypress_runner.js'
 
@@ -10,8 +7,6 @@ export async function injectBundle () {
     return
   }
 
-  const response = await window.fetch('/api')
-  const data = await response.json()
   const script = document.createElement('script')
 
   script.src = src
@@ -29,26 +24,6 @@ export async function injectBundle () {
     script.onload = () => {
       // just stick config on window until we figure out how we are
       // going to manage it
-      const config = window.UnifiedRunner.decodeBase64(data.base64Config) as any
-      const autStore = useAutStore()
-
-      // TODO(lachlan): use GraphQL to get the viewport dimensions
-      // once it is more practical to do so
-      // find out if we need to continue managing viewportWidth/viewportHeight in MobX at all.
-      autStore.updateDimensions(config.viewportWidth, config.viewportHeight)
-
-      window.UnifiedRunner.config = config
-
-      // window.UnifiedRunner exists now, since the Webpack bundle with
-      // the UnifiedRunner namespace was injected.
-      initializeEventManager(window.UnifiedRunner)
-
-      window.UnifiedRunner.MobX.runInAction(() => {
-        const store = initializeMobxStore(window.UnifiedRunner.config.testingType)
-
-        store.updateDimensions(config.viewportWidth, config.viewportHeight)
-      })
-
       resolve()
     }
   })

--- a/packages/app/src/runner/reporter.ts
+++ b/packages/app/src/runner/reporter.ts
@@ -3,7 +3,12 @@ import { getReporterElement } from './utils'
 import { getEventManager } from '.'
 import type { EventManager } from './event-manager'
 import { useRunnerUiStore } from '../store/runner-ui-store'
+
 let hasInitializeReporter = false
+
+export function setInitializedReporter (val: boolean) {
+  hasInitializeReporter = val
+}
 
 async function unmountReporter () {
   // We do not need to unmount the reporter at any point right now,
@@ -13,14 +18,17 @@ async function unmountReporter () {
 
 async function resetReporter () {
   if (hasInitializeReporter) {
-    await getEventManager().teardownReporter()
+    await getEventManager().resetReporter()
   }
 }
 
 function setupReporter () {
   const $reporterRoot = getReporterElement()
 
+  if (hasInitializeReporter) return
+
   renderReporter($reporterRoot, getMobxRunnerStore(), getEventManager())
+
   hasInitializeReporter = true
 }
 
@@ -52,4 +60,5 @@ export const UnifiedReporterAPI = {
   setupReporter,
   hasInitializeReporter,
   resetReporter,
+  setInitializedReporter,
 }

--- a/packages/reporter/src/main.tsx
+++ b/packages/reporter/src/main.tsx
@@ -19,8 +19,6 @@ import Header, { ReporterHeaderProps } from './header/header'
 import Runnables from './runnables/runnables'
 import TestingPreferences from './preferences/testing-preferences'
 
-let runnerListenersAdded = false
-
 interface BaseReporterProps {
   appState?: AppState
   className?: string
@@ -120,10 +118,7 @@ class Reporter extends Component<SingleReporterProps> {
       statsStore,
     })
 
-    if (!runnerListenersAdded) {
-      this.props.events.listen(runner)
-      runnerListenersAdded = true
-    }
+    this.props.events.listen(runner)
 
     shortcuts.start()
     EQ.init()

--- a/packages/runner-ct/package.json
+++ b/packages/runner-ct/package.json
@@ -41,6 +41,7 @@
     "fuzzysort": "^1.1.4",
     "hotkeys-js": "3.8.2",
     "html-webpack-plugin": "^4.5.0",
+    "ifdef-loader": "2.3.2",
     "koa": "^2.13.0",
     "mobx": "5.15.4",
     "mobx-react": "6.1.8",

--- a/packages/runner-ct/src/index.js
+++ b/packages/runner-ct/src/index.js
@@ -1,2 +1,12 @@
 import '@packages/runner/src/main.scss'
-import './main.tsx'
+
+// in CI we want to continue to use the full (legacy) runner-ct instead of main-lite
+// main-lite does not import everything, but until we get run mode working with the
+// new unification code, we need CI to use the legacy runner-ct
+// new DefinePlugin({ WEBPACK_MAIN_ENTRY: process.env.CI ? './main' : './main-lite' }),
+//
+/// #if process.env.CI
+import './main'
+/// #else
+import './main-lite'
+/// #endif

--- a/packages/runner-ct/src/main-lite.tsx
+++ b/packages/runner-ct/src/main-lite.tsx
@@ -1,0 +1,59 @@
+import 'regenerator-runtime/runtime'
+import _ from 'lodash'
+import * as MobX from 'mobx'
+import React from 'react'
+import ReactDOM from 'react-dom'
+import $Cypress from '@packages/driver'
+import defaultEvents from '@packages/reporter/src/lib/events'
+import shortcuts from '@packages/reporter/src/lib/shortcuts'
+import { Reporter } from '@packages/reporter/src/main'
+import {
+  blankContents, dom, logger, selectorPlaygroundModel, visitFailure, AutIframe, StudioRecorder,
+} from '@packages/runner-shared'
+
+const driverUtils = $Cypress.utils
+
+const UnifiedRunner = {
+  _,
+
+  CypressJQuery: $Cypress.$,
+
+  CypressDriver: $Cypress,
+
+  logger,
+
+  dom,
+
+  blankContents,
+
+  StudioRecorder,
+
+  selectorPlaygroundModel,
+
+  shortcuts,
+
+  visitFailure,
+
+  React,
+
+  MobX,
+
+  ReactDOM,
+
+  Reporter,
+
+  AutIframe,
+
+  defaultEvents,
+
+  decodeBase64: (base64: string) => {
+    return JSON.parse(driverUtils.decodeBase64Unicode(base64))
+  },
+
+  emit (evt: string, ...args: unknown[]) {
+    defaultEvents.emit(evt, ...args)
+  },
+}
+
+// @ts-ignore
+window.UnifiedRunner = UnifiedRunner

--- a/packages/runner-ct/webpack.config.ts
+++ b/packages/runner-ct/webpack.config.ts
@@ -60,6 +60,17 @@ const config: webpack.Configuration = {
     rules: [
       ...nonPngRules,
       pngRule,
+      {
+        test: /index\.js/,
+        exclude: /node_modules/,
+        use: [{
+          loader: 'ifdef-loader',
+          options: {
+            DEBUG: true,
+            'ifdef-verbose': true,
+          },
+        }],
+      },
     ],
   },
   entry: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23715,6 +23715,13 @@ ieee754@^1.1.13, ieee754@^1.1.4:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
+ifdef-loader@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/ifdef-loader/-/ifdef-loader-2.3.2.tgz#d08972f53c32e90dce6722b6efb9b3a91717cfef"
+  integrity sha512-kH9bHPrfIFxLpq3XEruJqSlHXch2nOljKIDRS/6MU5LDZTyHeaSWVf04wNYX+8RT+NDmeS8Vm5HwZ7akkXo8ig==
+  dependencies:
+    loader-utils "^1.1.0"
+
 iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
@@ -28896,6 +28903,7 @@ minipass-fetch@^1.3.0, minipass-fetch@^1.3.2:
   resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-1.3.3.tgz#34c7cea038c817a8658461bf35174551dce17a0a"
   integrity sha512-akCrLDWfbdAWkMLBxJEeWTdNsjML+dt5YgOI4gJ53vuO0vrmYQkUPxa6j6V65s9CcePIr2SSWqjT2EcrNseryQ==
   dependencies:
+    encoding "^0.1.12"
     minipass "^3.1.0"
     minipass-sized "^1.0.3"
     minizlib "^2.0.0"
@@ -42259,8 +42267,10 @@ watchpack@^1.6.0, watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
Some small but important tweaks to the lifecycle of the runner:

- fixes potential race condition 
- ensure reporter and event manager are torn down correctly
- adds conditional to `runner-ct` bundle to make injected bundle slightly smaller

These will also be useful for when we implement "cypress in cypress", aka e2e testing open mode in open mode, which is what sparked this PR.

Testing: just make sure open mode still works as expected. I added some notes explaining what's going on, happy to do a sync if anyone wants more details on this.