### PR TITLE
build: allow work with local dashboard

### DIFF
--- a/npm/vite-dev-server/src/startServer.ts
+++ b/npm/vite-dev-server/src/startServer.ts
@@ -52,7 +52,11 @@ const resolveServerConfig = async ({ viteConfig, options, indexHtml }: StartDevS
 
   finalConfig.server = finalConfig.server || {}
 
-  finalConfig.server.port = await getPort({ port: finalConfig.server.port || 3000, host: 'localhost' }),
+  finalConfig.server.port = await getPort({
+    port: finalConfig.server.port || 4000,
+    host: 'localhost',
+    exclusive: true,
+  }),
 
   // Ask vite to pre-optimize all dependencies of the specs
   finalConfig.optimizeDeps = finalConfig.optimizeDeps || {}

--- a/npm/vite-dev-server/src/startServer.ts
+++ b/npm/vite-dev-server/src/startServer.ts
@@ -54,8 +54,6 @@ const resolveServerConfig = async ({ viteConfig, options, indexHtml }: StartDevS
 
   finalConfig.server.port = await getPort({
     port: finalConfig.server.port || 4000,
-    host: 'localhost',
-    exclusive: true,
   }),
 
   // Ask vite to pre-optimize all dependencies of the specs

--- a/npm/vite-dev-server/src/startServer.ts
+++ b/npm/vite-dev-server/src/startServer.ts
@@ -52,9 +52,7 @@ const resolveServerConfig = async ({ viteConfig, options, indexHtml }: StartDevS
 
   finalConfig.server = finalConfig.server || {}
 
-  finalConfig.server.port = await getPort({
-    port: finalConfig.server.port || 4000,
-  }),
+  finalConfig.server.port = await getPort({ port: finalConfig.server.port || 3000 }),
 
   // Ask vite to pre-optimize all dependencies of the specs
   finalConfig.optimizeDeps = finalConfig.optimizeDeps || {}

--- a/scripts/gulp/gulpConstants.ts
+++ b/scripts/gulp/gulpConstants.ts
@@ -1,6 +1,6 @@
 // Where to fetch the remote "federated" schema. If you have a long-running branch
 // against a development schema, it's probably easiest to set this manually to "develop"
-export const DEFAULT_INTERNAL_CLOUD_ENV = 'staging'
+export const DEFAULT_INTERNAL_CLOUD_ENV = process.env.CYPRESS_INTERNAL_ENV || 'staging'
 
 export type MODES = 'dev' | 'devWatch' | 'test'
 


### PR DESCRIPTION
To work more easily with dashboard integration, we should be able to change the target of the remote server.

- This enables it using the `CYPRESS_INTERNAL_ENV=development` environment variable set
- This PR also fixes the conflict between vite-dev-server default port and the dashboards