### PR TITLE
fix(cy.intercept): allow fixtures to define null encoding when used in static response

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1319,8 +1319,8 @@ describe('network stubbing', function () {
         cy.contains('#result', '""').should('be.visible')
       })
 
-      // @see https://github.com/cypress-io/cypress/issues/8623
-      // @see https://github.com/cypress-io/cypress/issues/8623
+      // @see https://github.com/cypress-io/cypress/issues/19330
+      // @see https://github.com/cypress-io/cypress/issues/19344
       it('load fixture as Buffer when encoding is null', function () {
         // call through normally on everything
         cy.spy(Cypress, 'backend')

--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -1320,6 +1320,61 @@ describe('network stubbing', function () {
       })
 
       // @see https://github.com/cypress-io/cypress/issues/8623
+      // @see https://github.com/cypress-io/cypress/issues/8623
+      it('load fixture as Buffer when encoding is null', function () {
+        // call through normally on everything
+        cy.spy(Cypress, 'backend')
+
+        cy.intercept('/fixtures/media/small.mp4', {
+          fixture: 'media/small.mp4,null',
+        }).as('video')
+
+        cy.visit('/fixtures/video.html')
+        .then(() => {
+          // @ts-ignore .getCall is a Sinon spy command
+          expect(Cypress.backend.getCall(0)).to.be.calledWithMatch(
+            'net',
+            'route:added',
+            {
+              staticResponse: {
+                fixture: {
+                  filePath: 'media/small.mp4',
+                  encoding: null,
+                },
+              },
+            },
+          )
+        })
+      })
+
+      it('load fixture with specified encoding', function () {
+        // call through normally on everything
+        cy.spy(Cypress, 'backend')
+
+        cy.intercept('non-existing-image.png', {
+          headers: { 'content-type': 'image/jpeg' },
+          fixture: 'media/cypress.png,base64',
+        }).as('video')
+
+        cy.visit('/fixtures/img-embed.html')
+        .then(() => {
+          // @ts-ignore .getCall is a Sinon spy command
+          expect(Cypress.backend.getCall(0)).to.be.calledWithMatch(
+            'net',
+            'route:added',
+            {
+              staticResponse: {
+                fixture: {
+                  filePath: 'media/cypress.png',
+                  encoding: 'base64',
+                },
+              },
+            },
+          )
+        })
+      })
+
+      // @see https://github.com/cypress-io/cypress/issues/8623
       it('works with images', function () {
         cy.visit('/fixtures/img-embed.html')
         .contains('div', 'error loading image')

--- a/packages/driver/cypress/integration/cy/net-stubbing/static-response-utils-spec.ts
+++ b/packages/driver/cypress/integration/cy/net-stubbing/static-response-utils-spec.ts
@@ -2,7 +2,7 @@ const {
   getBackendStaticResponse,
 } = require('../../../../src/cy/net-stubbing/static-response-utils')
 
-describe('static-response-utils', () => {
+describe('driver/src/cy/net-stubbing/static-response-utils', () => {
   describe('.getBackendStaticResponse', () => {
     describe('delay', () => {
       it('does not set delay when delayMS is not provided', () => {

--- a/packages/driver/cypress/integration/cy/net-stubbing/static-response-utils-spec.ts
+++ b/packages/driver/cypress/integration/cy/net-stubbing/static-response-utils-spec.ts
@@ -26,16 +26,7 @@ describe('static-response-utils', () => {
       })
 
       it('parses fixture string without file encoding', () => {
-        let staticResponse = getBackendStaticResponse({ fixture: 'file.html' })
-
-        expect(staticResponse.fixture).to.deep.equal({
-          filePath: 'file.html',
-          encoding: undefined,
-        })
-
-        staticResponse = getBackendStaticResponse({ fixture: {
-          filePath: 'file.html',
-        } })
+        const staticResponse = getBackendStaticResponse({ fixture: 'file.html' })
 
         expect(staticResponse.fixture).to.deep.equal({
           filePath: 'file.html',
@@ -44,17 +35,7 @@ describe('static-response-utils', () => {
       })
 
       it('parses fixture string with file encoding', () => {
-        let staticResponse = getBackendStaticResponse({ fixture: 'file.html,utf8' })
-
-        expect(staticResponse.fixture).to.deep.equal({
-          filePath: 'file.html',
-          encoding: 'utf8',
-        })
-
-        staticResponse = getBackendStaticResponse({ fixture: {
-          filePath: 'file.html',
-          encoding: 'utf8',
-        } })
+        const staticResponse = getBackendStaticResponse({ fixture: 'file.html,utf8' })
 
         expect(staticResponse.fixture).to.deep.equal({
           filePath: 'file.html',
@@ -63,17 +44,7 @@ describe('static-response-utils', () => {
       })
 
       it('parses fixture string with file encoding set as null to indicate Buffer', () => {
-        let staticResponse = getBackendStaticResponse({ fixture: 'file.html,null' })
-
-        expect(staticResponse.fixture).to.deep.equal({
-          filePath: 'file.html',
-          encoding: null,
-        })
-
-        staticResponse = getBackendStaticResponse({ fixture: {
-          filePath: 'file.html',
-          encoding: null,
-        } })
+        const staticResponse = getBackendStaticResponse({ fixture: 'file.html,null' })
 
         expect(staticResponse.fixture).to.deep.equal({
           filePath: 'file.html',

--- a/packages/driver/cypress/integration/cy/net-stubbing/static-response-utils-spec.ts
+++ b/packages/driver/cypress/integration/cy/net-stubbing/static-response-utils-spec.ts
@@ -1,0 +1,107 @@
+const {
+  getBackendStaticResponse,
+} = require('../../../../src/cy/net-stubbing/static-response-utils')
+
+describe('static-response-utils', () => {
+  describe('.getBackendStaticResponse', () => {
+    describe('delay', () => {
+      it('does not set delay when delayMS is not provided', () => {
+        const staticResponse = getBackendStaticResponse({})
+
+        expect(staticResponse).to.not.have.property('delay')
+      })
+
+      it('sets delay', () => {
+        const staticResponse = getBackendStaticResponse({ delayMs: 200 })
+
+        expect(staticResponse).to.have.property('delay', 200)
+      })
+    })
+
+    describe('fixtures', () => {
+      it('does not set fixtures data when fixtures string is not provided', () => {
+        const staticResponse = getBackendStaticResponse({})
+
+        expect(staticResponse).to.not.have.property('fixtures')
+      })
+
+      it('parses fixture string without file encoding', () => {
+        let staticResponse = getBackendStaticResponse({ fixture: 'file.html' })
+
+        expect(staticResponse.fixture).to.deep.equal({
+          filePath: 'file.html',
+          encoding: undefined,
+        })
+
+        staticResponse = getBackendStaticResponse({ fixture: {
+          filePath: 'file.html',
+        } })
+
+        expect(staticResponse.fixture).to.deep.equal({
+          filePath: 'file.html',
+          encoding: undefined,
+        })
+      })
+
+      it('parses fixture string with file encoding', () => {
+        let staticResponse = getBackendStaticResponse({ fixture: 'file.html,utf8' })
+
+        expect(staticResponse.fixture).to.deep.equal({
+          filePath: 'file.html',
+          encoding: 'utf8',
+        })
+
+        staticResponse = getBackendStaticResponse({ fixture: {
+          filePath: 'file.html',
+          encoding: 'utf8',
+        } })
+
+        expect(staticResponse.fixture).to.deep.equal({
+          filePath: 'file.html',
+          encoding: 'utf8',
+        })
+      })
+
+      it('parses fixture string with file encoding set as null to indicate Buffer', () => {
+        let staticResponse = getBackendStaticResponse({ fixture: 'file.html,null' })
+
+        expect(staticResponse.fixture).to.deep.equal({
+          filePath: 'file.html',
+          encoding: null,
+        })
+
+        staticResponse = getBackendStaticResponse({ fixture: {
+          filePath: 'file.html',
+          encoding: null,
+        } })
+
+        expect(staticResponse.fixture).to.deep.equal({
+          filePath: 'file.html',
+          encoding: null,
+        })
+      })
+    })
+
+    describe('body', () => {
+      it('does not set body when body is undefined', () => {
+        const staticResponse = getBackendStaticResponse({})
+
+        expect(staticResponse).to.not.have.property('body')
+      })
+
+      it('sets body when body is provided as a string', () => {
+        const staticResponse = getBackendStaticResponse({ body: 'body' })
+
+        expect(staticResponse.body).to.eq('body')
+      })
+
+      it('sets body when body is provided as a ArrayBuffer', () => {
+        const buffer = new ArrayBuffer(8)
+        const staticResponse = getBackendStaticResponse({ body: buffer })
+
+        expect(staticResponse.body).to.be.a('arraybuffer')
+        expect(staticResponse.body).to.eq(buffer)
+      })
+    })
+  })
+})

--- a/packages/driver/src/cy/net-stubbing/static-response-utils.ts
+++ b/packages/driver/src/cy/net-stubbing/static-response-utils.ts
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import type {
   StaticResponse,
   BackendStaticResponseWithArrayBuffer,
-  Fixture,
+  FixtureOpts,
 } from '@packages/net-stubbing/lib/types'
 import {
   caseInsensitiveHas,
@@ -28,17 +28,8 @@ export function validateStaticResponse (cmd: string, staticResponse: StaticRespo
     err('`body` and `fixture` cannot both be set, pick one.')
   }
 
-  if (fixture) {
-    if (_.isObject(fixture)) {
-      if (_.isUndefined(fixture.filePath) || !_.isString(fixture.filePath)) {
-        err('`fixture` object must contain the filePath key set to a string containing a path (for example, {"filePath": "foo.txt" }).')
-      }
-    } else {
-      if (!_.isString(fixture)) {
-        err('`fixture` must be a string containing a path and, optionally, an encoding separated by a comma (for example, "foo.txt,ascii") or \
-      it can be an object with the keys `filePath` and `encoding` (for example, {"filePath": "foo.txt", encoding: "ascii" }).')
-      }
-    }
+  if (fixture && !_.isString(fixture)) {
+    err('`fixture` must be a string containing a path and, optionally, an encoding separated by a comma (for example, "foo.txt,ascii").')
   }
 
   // statusCode must be a three-digit integer
@@ -101,11 +92,7 @@ export function parseStaticResponseShorthand (statusCodeOrBody: number | string 
   return
 }
 
-function getFixtureOpts (fixture: string | Fixture): Fixture {
-  if (_.isObject(fixture)) {
-    return { ...{ encoding: undefined }, ...fixture }
-  }
-
+function getFixtureOpts (fixture: string): FixtureOpts {
   const [filePath, encoding] = fixture.split(',')
 
   return { filePath, encoding: encoding === 'null' ? null : encoding }

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -386,15 +386,10 @@ export type RouteHandlerController = HttpRequestInterceptor
 
 export type RouteHandler = string | StaticResponse | RouteHandlerController | object
 
-export type Fixture = {
-  encoding: string | null
-  filePath: string
-}
-
 /**
  * Describes a response that will be sent back to the browser to fulfill the request.
  */
-export type StaticResponse = GenericStaticResponse<string | Fixture, string | object | boolean | ArrayBuffer | null> & {
+export type StaticResponse = GenericStaticResponse<string, string | object | boolean | ArrayBuffer | null> & {
   /**
    * Milliseconds to delay before the response is sent.
    * @deprecated Use `delay` instead of `delayMs`.

--- a/packages/net-stubbing/lib/external-types.ts
+++ b/packages/net-stubbing/lib/external-types.ts
@@ -386,10 +386,15 @@ export type RouteHandlerController = HttpRequestInterceptor
 
 export type RouteHandler = string | StaticResponse | RouteHandlerController | object
 
+export type Fixture = {
+  encoding: string | null
+  filePath: string
+}
+
 /**
  * Describes a response that will be sent back to the browser to fulfill the request.
  */
-export type StaticResponse = GenericStaticResponse<string, string | object | boolean | ArrayBuffer | null> & {
+export type StaticResponse = GenericStaticResponse<string | Fixture, string | object | boolean | ArrayBuffer | null> & {
   /**
    * Milliseconds to delay before the response is sent.
    * @deprecated Use `delay` instead of `delayMs`.

--- a/packages/net-stubbing/lib/internal-types.ts
+++ b/packages/net-stubbing/lib/internal-types.ts
@@ -7,7 +7,7 @@ import type {
 } from './external-types'
 
 export type FixtureOpts = {
-  encoding: string
+  encoding: string | null
   filePath: string
 }
 

--- a/packages/net-stubbing/lib/internal-types.ts
+++ b/packages/net-stubbing/lib/internal-types.ts
@@ -4,16 +4,12 @@ import type {
   GenericStaticResponse,
   Subscription,
   CyHttpMessages,
+  Fixture,
 } from './external-types'
 
-export type FixtureOpts = {
-  encoding: string
-  filePath: string
-}
+export type BackendStaticResponse = GenericStaticResponse<Fixture, string>
 
-export type BackendStaticResponse = GenericStaticResponse<FixtureOpts, string>
-
-export type BackendStaticResponseWithArrayBuffer = GenericStaticResponse<FixtureOpts, string | ArrayBuffer>
+export type BackendStaticResponseWithArrayBuffer = GenericStaticResponse<Fixture, string | ArrayBuffer>
 
 export const SERIALIZABLE_REQ_PROPS = [
   'headers',

--- a/packages/net-stubbing/lib/internal-types.ts
+++ b/packages/net-stubbing/lib/internal-types.ts
@@ -4,12 +4,16 @@ import type {
   GenericStaticResponse,
   Subscription,
   CyHttpMessages,
-  Fixture,
 } from './external-types'
 
-export type BackendStaticResponse = GenericStaticResponse<Fixture, string>
+export type FixtureOpts = {
+  encoding: string
+  filePath: string
+}
 
-export type BackendStaticResponseWithArrayBuffer = GenericStaticResponse<Fixture, string | ArrayBuffer>
+export type BackendStaticResponse = GenericStaticResponse<FixtureOpts, string>
+
+export type BackendStaticResponseWithArrayBuffer = GenericStaticResponse<FixtureOpts, string | ArrayBuffer>
 
 export const SERIALIZABLE_REQ_PROPS = [
   'headers',

--- a/packages/server/lib/fixture.js
+++ b/packages/server/lib/fixture.js
@@ -165,7 +165,7 @@ module.exports = {
 
       return obj
     }).catch((err) => {
-      throw new Error(`'${fixture}' is not a valid JavaScript object.${err.toString()}`)
+      throw new Error(`'${fixture}' is not a valid JavaScript object.\n${err.toString()}`)
     })
   },
 
@@ -190,10 +190,16 @@ module.exports = {
   parseHtml (p, fixture) {
     return fs.readFileAsync(p, 'utf8')
     .bind(this)
+    .catch((err) => {
+      throw new Error(`Unable to parse '${fixture}'.\n${err.toString()}`)
+    })
   },
 
   parse (p, fixture, encoding) {
     return fs.readFileAsync(p, encoding)
     .bind(this)
+    .catch((err) => {
+      throw new Error(`Unable to parse '${fixture}'.\n${err.toString()}`)
+    })
   },
 }

--- a/packages/server/test/unit/fixture_spec.js
+++ b/packages/server/test/unit/fixture_spec.js
@@ -215,7 +215,7 @@ ParseError: Unterminated string constant\
       .then(() => {
         throw new Error('should have failed but did not')
       }).catch((err) => {
-        expect(err.message).to.eq(`'bad_js.js' is not a valid JavaScript object.\n${e}`)
+        expect(err.message).to.eq(`'bad_js.js' is not a valid JavaScript object.${e}`)
       })
     })
   })

--- a/packages/server/test/unit/fixture_spec.js
+++ b/packages/server/test/unit/fixture_spec.js
@@ -215,7 +215,7 @@ ParseError: Unterminated string constant\
       .then(() => {
         throw new Error('should have failed but did not')
       }).catch((err) => {
-        expect(err.message).to.eq(`'bad_js.js' is not a valid JavaScript object.${e}`)
+        expect(err.message).to.eq(`'bad_js.js' is not a valid JavaScript object.\n\n${e}`)
       })
     })
   })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #19330
- Closes #19344

This issue was introduced in Cypress 9.0.0. by #18534 which made changes such that

- when null is passed as the encoding to `cy.readFile()` or `cy.fixture()`, the file is treated as binary and read as a Buffer.
- when null passed as the encoding to `cy.writeFile()` allows direct writing of buffers.
- If the encoding is unspecified, the default remains ‘utf8’, matching the current behavior.

Before this changes, when a fixture path was specified in cy.intercept() without an encoding value, the encoding would assume to be null and the file extension would be used to determine the encoding type and eventually fallback be read a a Buffer.

#18534 unintentionally introduced a non-passive change such that when a fixture path was specified in cy.intercept() without an encoding value it would use the default `utf8` encoding option (instead of null). This change aligned the default encoding behavior to `cy.readFile()` and `cy.fixture()`. The miss was documenting this change as breaking and allowing a null string to be processed by cy.intercept() to allow the fixture to be read a Buffer.

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Fixed a regression in [9.0.0](https://docs.cypress.io/guides/references/changelog#9-0-0) where a fixture provided in a static response to `cy.intercept()` did not support passing null to encoding to read the fixture as a Buffer. This identified  the undocumented 9.0.0 Breaking Change where the default read behavior of a fixture changed from a Buffer to being read with `utf8` encoding.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
This change moves forward with the un-intentional non-passive change to keep the default behavior of `cy.intercept()`, `cy.readFile()` and `cy.fixture()` aligned. 

The Breaking Changes section of the 9.0.0 changelog will need to be updated with a note to this change of the new behavior.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

```diff
  it("should be able to mock an mp4", () => {
-    cy.intercept("video.mp4", { fixture: "video.mp4" }); // before 9.0.0 release
+    cy.intercept("video.mp4", { fixture: "video.mp4,null" });  // after 9.0.0 release

    cy.visit("http://localhost:3000/");

    cy.get("video").should("have.prop", "paused", false)
  });
```

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ x Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/4278
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
