### PR TITLE
chore: trigger downstream project tests for windows workflow

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1693,7 +1693,7 @@ jobs:
       - run:
           name: Verify Cypress binary
           working_directory: /tmp/testing
-          command: $(yarn bin)/cypress verify
+          command: $(yarn bin cypress) verify
       - run:
           name: Running other test projects with new NPM package and binary
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -1686,11 +1686,11 @@ jobs:
       - run:
           # install NPM from unique urls
           name: Install Cypress
-          working_directory: /tmp/testing
           command: |
             node scripts/test-unique-npm-and-binary.js \
               --npm npm-package-url.json \
-              --binary binary-url.json
+              --binary binary-url.json \
+              --cwd /tmp/testing
       - run:
           name: Verify Cypress binary
           working_directory: /tmp/testing

--- a/circle.yml
+++ b/circle.yml
@@ -37,7 +37,6 @@ macWorkflowFilters: &mac-workflow-filters
   when:
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
-    - equal: [ tgriesser/fix/patch-resolutions, << pipeline.git.branch >> ]
     - equal: [ renovate/cypress-request-2.x, << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
@@ -48,7 +47,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     or:
     - equal: [ master, << pipeline.git.branch >> ]
     - equal: [ develop, << pipeline.git.branch >> ]
-    - equal: [ tgriesser/fix/patch-resolutions, << pipeline.git.branch >> ]
+    - equal: [ test-binary-downstream-windows, << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -1588,7 +1587,7 @@ jobs:
       - run:
           name: Check current branch to persist artifacts
           command: |
-            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "tgriesser/fix/patch-resolutions" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "test-binary-downstream-windows" ]]; then
               echo "Not uploading artifacts or posting install comment for this branch."
               circleci-agent step halt
             fi
@@ -1664,7 +1663,12 @@ jobs:
 
   test-binary-and-npm-against-other-projects:
     <<: *defaults
-    resource_class: medium
+    parameters:
+      <<: *defaultsParameters
+      resource_class:
+        type: string
+        default: medium
+    resource_class: << parameters.resource_class >>
     steps:
       # needs uploaded NPM and test binary
       - restore_cached_workspace
@@ -2431,6 +2435,14 @@ windows-workflow: &windows-workflow
           - test-runner:commit-status-checks
         requires:
           - windows-build
+
+    - test-binary-and-npm-against-other-projects:
+        context: test-runner:trigger-test-jobs
+        name: windows-test-binary-and-npm-against-other-projects
+        executor: windows
+        resource_class: windows.medium
+        requires:
+          - windows-create-build-artifacts
 
 workflows:
   linux:

--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,7 @@ mainBuildFilters: &mainBuildFilters
       only:
         - develop
         - 10.0-release
+        - test-binary-downstream-windows
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -1685,11 +1686,11 @@ jobs:
       - run:
           # install NPM from unique urls
           name: Install Cypress
+          working_directory: /tmp/testing
           command: |
             node scripts/test-unique-npm-and-binary.js \
               --npm npm-package-url.json \
-              --binary binary-url.json \
-              --cwd /tmp/testing
+              --binary binary-url.json
       - run:
           name: Verify Cypress binary
           working_directory: /tmp/testing
@@ -1724,19 +1725,19 @@ jobs:
       - run:
           name: Cypress version
           working_directory: test-binary
-          command: $(yarn bin)/cypress version
+          command: $(yarn bin cypress) version
       - run:
           name: Verify Cypress binary
           working_directory: test-binary
-          command: $(yarn bin)/cypress verify
+          command: $(yarn bin cypress) verify
       - run:
           name: Cypress help
           working_directory: test-binary
-          command: $(yarn bin)/cypress help
+          command: $(yarn bin cypress) help
       - run:
           name: Cypress info
           working_directory: test-binary
-          command: $(yarn bin)/cypress info
+          command: $(yarn bin cypress) info
       - store-npm-logs
 
   test-npm-module-on-minimum-node-version:
@@ -1895,7 +1896,7 @@ jobs:
             CYPRESS_PROJECT_ID=$TEST_TINY_PROJECT_ID \
             CYPRESS_RECORD_KEY=$TEST_TINY_RECORD_KEY \
             CYPRESS_INTERNAL_ENV=staging \
-            $(yarn bin)/cypress run --record
+            $(yarn bin cypress) run --record
       - store-npm-logs
 
   test-binary-against-recipes-firefox:
@@ -2030,11 +2031,11 @@ jobs:
       - run:
           name: Cypress help
           working_directory: test-binary
-          command: $(yarn bin)/cypress help
+          command: $(yarn bin cypress) help
       - run:
           name: Cypress info
           working_directory: test-binary
-          command: $(yarn bin)/cypress info
+          command: $(yarn bin cypress) info
       - run:
           name: Add Cypress demo
           working_directory: test-binary
@@ -2042,11 +2043,11 @@ jobs:
       - run:
           name: Verify Cypress binary
           working_directory: test-binary
-          command: DEBUG=cypress:cli $(yarn bin)/cypress verify
+          command: DEBUG=cypress:cli $(yarn bin cypress) verify
       - run:
           name: Run Cypress binary
           working_directory: test-binary
-          command: DEBUG=cypress:cli $(yarn bin)/cypress run
+          command: DEBUG=cypress:cli $(yarn bin cypress) run
       - store-npm-logs
 
 linux-workflow: &linux-workflow

--- a/circle.yml
+++ b/circle.yml
@@ -1678,23 +1678,14 @@ jobs:
       - run: ls -la binary-url.json npm-package-url.json
       - run: cat binary-url.json
       - run: cat npm-package-url.json
-      - run: mkdir /tmp/testing
-      - run:
-          name: create dummy package
-          working_directory: /tmp/testing
-          command: npm init -y
       - run:
           # install NPM from unique urls
-          name: Install Cypress
+          name: Install Cypress Binary in Dummy Package
           command: |
             node scripts/test-unique-npm-and-binary.js \
               --npm npm-package-url.json \
               --binary binary-url.json \
               --cwd /tmp/testing
-      - run:
-          name: Verify Cypress binary
-          working_directory: /tmp/testing
-          command: $(yarn bin cypress) verify
       - run:
           name: Running other test projects with new NPM package and binary
           command: |

--- a/scripts/test-unique-npm-and-binary.js
+++ b/scripts/test-unique-npm-and-binary.js
@@ -1,5 +1,3 @@
-const minimist = require('minimist')
-const options = minimist(process.argv)
 const la = require('lazy-ass')
 const is = require('check-more-types')
 const execa = require('execa')
@@ -14,12 +12,9 @@ la(is.unemptyString(binary), 'missing binary url')
 
 console.log('testing NPM from', npm)
 console.log('and binary from', binary)
-const cwd = options.cwd || process.cwd()
-
-console.log('in', cwd)
+console.log('in', process.cwd())
 
 execa(`npm install ${npm}`, {
-  cwd,
   shell: true,
   stdio: 'inherit',
   env: {

--- a/scripts/test-unique-npm-and-binary.js
+++ b/scripts/test-unique-npm-and-binary.js
@@ -18,39 +18,32 @@ const spawnOpts = {
   shell: os.platform() === 'win32' ? 'bash.exe' : '/bin/bash',
   stdio: 'inherit',
 }
-
-console.log('Create Dummy Project')
-execa('npm init -y', spawnOpts)
-.then(console.log)
-.catch((e) => {
-  console.error(e)
-  process.exit(1)
-})
-
 const { npm, binary } = getNameAndBinary(process.argv)
 
 la(is.unemptyString(npm), 'missing npm url')
 la(is.unemptyString(binary), 'missing binary url')
 
-console.log('testing NPM from', npm)
-console.log('and binary from', binary)
-console.log('in', cwd)
-
-execa(`npm install ${npm}`, {
-  ...spawnOpts,
-  env: {
-    CYPRESS_INSTALL_BINARY: binary,
-  },
-})
+console.log('Create Dummy Project')
+execa('npm init -y', spawnOpts)
 .then(console.log)
-.catch((e) => {
-  console.error(e)
-  process.exit(1)
-})
+.then(() => {
+  console.log('testing NPM from', npm)
+  console.log('and binary from', binary)
+  console.log('in', cwd)
 
-console.log('Verify Cypress binary')
-execa('$(yarn bin cypress) verify', spawnOpts)
-.then(console.log)
+  return execa(`npm install ${npm}`, {
+    ...spawnOpts,
+    env: {
+      CYPRESS_INSTALL_BINARY: binary,
+    },
+  }).then(console.log)
+})
+.then(() => {
+  console.log('Verify Cypress binary')
+
+  return execa('$(yarn bin cypress) verify', spawnOpts)
+  .then(console.log)
+})
 .catch((e) => {
   console.error(e)
   process.exit(1)

--- a/scripts/test-unique-npm-and-binary.js
+++ b/scripts/test-unique-npm-and-binary.js
@@ -1,11 +1,27 @@
+/* eslint-disable no-console */
 const minimist = require('minimist')
 const options = minimist(process.argv)
 const la = require('lazy-ass')
+const fs = require('fs-extra')
 const is = require('check-more-types')
 const execa = require('execa')
 const { getNameAndBinary } = require('./utils')
 
-/* eslint-disable no-console */
+const cwd = options.cwd || '/tmp/testing'
+
+fs.ensureDirSync(cwd)
+
+console.log('Create Dummy Project')
+execa('npm init -y', {
+  cwd,
+  shell: true,
+  stdio: 'inherit',
+})
+.then(console.log)
+.catch((e) => {
+  console.error(e)
+  process.exit(1)
+})
 
 const { npm, binary } = getNameAndBinary(process.argv)
 
@@ -14,10 +30,8 @@ la(is.unemptyString(binary), 'missing binary url')
 
 console.log('testing NPM from', npm)
 console.log('and binary from', binary)
-const cwd = options.cwd
 
-console.log('in (provided', cwd)
-console.log('in (node cwd)', process.cwd())
+console.log('in', cwd)
 
 execa(`npm install ${npm}`, {
   cwd,
@@ -34,7 +48,7 @@ execa(`npm install ${npm}`, {
 })
 
 console.log('Verify Cypress binary')
-execa(`$(yarn bin cypress) verify`, {
+execa('$(yarn bin cypress) verify', {
   cwd,
   shell: true,
   stdio: 'inherit',

--- a/scripts/test-unique-npm-and-binary.js
+++ b/scripts/test-unique-npm-and-binary.js
@@ -1,3 +1,5 @@
+const minimist = require('minimist')
+const options = minimist(process.argv)
 const la = require('lazy-ass')
 const is = require('check-more-types')
 const execa = require('execa')
@@ -12,14 +14,30 @@ la(is.unemptyString(binary), 'missing binary url')
 
 console.log('testing NPM from', npm)
 console.log('and binary from', binary)
-console.log('in', process.cwd())
+const cwd = options.cwd
+
+console.log('in (provided', cwd)
+console.log('in (node cwd)', process.cwd())
 
 execa(`npm install ${npm}`, {
+  cwd,
   shell: true,
   stdio: 'inherit',
   env: {
     CYPRESS_INSTALL_BINARY: binary,
   },
+})
+.then(console.log)
+.catch((e) => {
+  console.error(e)
+  process.exit(1)
+})
+
+console.log('Verify Cypress binary')
+execa(`$(yarn bin cypress) verify`, {
+  cwd,
+  shell: true,
+  stdio: 'inherit',
 })
 .then(console.log)
 .catch((e) => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

Trigger downstream tests for windows binary. The `test-binary-and-npm-against-other-projects` step triggers a new commit to [cypress-test-example-repos](https://github.com/cypress-io/cypress-test-example-repos) to test the project against the Cypress binary once it's been uploaded to the cdn.

For more info see: https://github.com/cypress-io/cypress/blob/develop/guides/testing-other-projects.md. 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
n/a

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
