### PR TITLE
fix: check the port is avail on all local hosts

### DIFF
--- a/npm/vite-dev-server/src/makeCypressPlugin.ts
+++ b/npm/vite-dev-server/src/makeCypressPlugin.ts
@@ -1,4 +1,4 @@
-import { resolve, posix, sep } from 'path'
+import { resolve, sep } from 'path'
 import { readFile } from 'fs'
 import { promisify } from 'util'
 import Debug from 'debug'

--- a/npm/vite-dev-server/src/startServer.ts
+++ b/npm/vite-dev-server/src/startServer.ts
@@ -47,7 +47,7 @@ const resolveServerConfig = async ({ viteConfig, options }: StartDevServerOption
 
   finalConfig.server = finalConfig.server || {}
 
-  finalConfig.server.port = await getPort({ port: finalConfig.server.port || 3000, host: 'localhost' }),
+  finalConfig.server.port = await getPort({ port: finalConfig.server.port || 3000 }),
 
   // Ask vite to pre-optimize all dependencies of the specs
   finalConfig.optimizeDeps = finalConfig.optimizeDeps || {}


### PR DESCRIPTION
If the port was taken by say a docker engine that did not respond to `localhost` but only to `127.0.0.1` vite-dev-server would still use that port and fail.

Once this fix is in, we check this port properly.