### PR TITLE
fix(server): do not add electron when running as node

### DIFF
--- a/packages/config/__snapshots__/validation_spec.js
+++ b/packages/config/__snapshots__/validation_spec.js
@@ -2,10 +2,6 @@ exports['undefined browsers'] = `
 Missing browsers list
 `
 
-exports['empty list of browsers'] = `
-Expected at least one browser
-`
-
 exports['browsers list with a string'] = `
 Found an error while validating the \`browsers\` list. Expected \`name\` to be a non-empty string. Instead the value was: \`"foo"\`
 `

--- a/packages/config/lib/validation.js
+++ b/packages/config/lib/validation.js
@@ -86,10 +86,6 @@ const isValidBrowserList = (key, browsers) => {
     return 'Browsers should be an array'
   }
 
-  if (!browsers.length) {
-    return 'Expected at least one browser'
-  }
-
   for (let k = 0; k < browsers.length; k += 1) {
     const err = isValidBrowser(browsers[k])
 

--- a/packages/config/test/unit/validation_spec.js
+++ b/packages/config/test/unit/validation_spec.js
@@ -89,9 +89,8 @@ describe('src/validation', () => {
   })
 
   describe('.isValidBrowserList', () => {
-    it('does not allow empty or not browsers', () => {
+    it('does not allow non-array value for browsers', () => {
       snapshot('undefined browsers', validation.isValidBrowserList('browsers'))
-      snapshot('empty list of browsers', validation.isValidBrowserList('browsers', []))
 
       return snapshot('browsers list with a string', validation.isValidBrowserList('browsers', ['foo']))
     })

--- a/packages/server/lib/browsers/utils.ts
+++ b/packages/server/lib/browsers/utils.ts
@@ -257,21 +257,25 @@ export = {
         majorVersion = getMajorVersion(version)
       }
 
-      const electronBrowser: FoundBrowser = {
-        name: 'electron',
-        channel: 'stable',
-        family: 'chromium',
-        displayName: 'Electron',
-        version,
-        path: '',
-        majorVersion,
-        info: 'Electron is the default browser that comes with Cypress. This is the default browser that runs in headless mode. Selecting this browser is useful when debugging. The version number indicates the underlying Chromium version that Electron uses.',
+      if (!process.env.ELECTRON_RUN_AS_NODE) {
+        const electronBrowser: FoundBrowser = {
+          name: 'electron',
+          channel: 'stable',
+          family: 'chromium',
+          displayName: 'Electron',
+          version,
+          path: '',
+          majorVersion,
+          info: 'Electron is the default browser that comes with Cypress. This is the default browser that runs in headless mode. Selecting this browser is useful when debugging. The version number indicates the underlying Chromium version that Electron uses.',
+        }
+
+        // the internal version of Electron, which won't be detected by `launcher`
+        debug('adding Electron browser %o', electronBrowser)
+
+        return browsers.concat(electronBrowser)
       }
 
-      // the internal version of Electron, which won't be detected by `launcher`
-      debug('adding Electron browser %o', electronBrowser)
-
-      return browsers.concat(electronBrowser)
+      return browsers
     })
   },
 }

--- a/system-tests/__snapshots__/plugins_spec.js
+++ b/system-tests/__snapshots__/plugins_spec.js
@@ -118,13 +118,6 @@ exports['e2e plugins can modify config from plugins 1'] = `
 
 `
 
-exports['e2e plugins catches invalid browsers list returned from plugins 1'] = `
-An invalid configuration value returned from the plugins file: \`cypress/plugins/index.js\`
-
-Expected at least one browser
-
-`
-
 exports['e2e plugins catches invalid browser returned from plugins 1'] = `
 An invalid configuration value returned from the plugins file: \`cypress/plugins/index.js\`
 

--- a/system-tests/test/plugins_spec.js
+++ b/system-tests/test/plugins_spec.js
@@ -64,11 +64,11 @@ describe('e2e plugins', function () {
     })
   })
 
-  it('catches invalid browsers list returned from plugins', function () {
+  it('allows for an empty browsers list if browser set via command line', function () {
     return systemTests.exec(this, {
       project: 'plugin-returns-empty-browsers-list',
-      expectedExitCode: 1,
-      snapshot: true,
+      expectedExitCode: 0,
+      snapshot: false,
     })
   })
 


### PR DESCRIPTION
When running the cypress server as a node process
(via the environment variable ELECTRON_RUN_AS_NODE) the electron browser
is no longer valid for use. However, cypress server automatically
appends this invalid browser to the browsers list and then crashes
during validation. This change fixes that behavior.

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/17412

### User facing changelog
None

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
