### PR TITLE
feat: Encode URL if there is any non-latin character in `cy.visit`

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3181,6 +3181,13 @@ declare namespace Cypress {
     url: string
 
     /**
+     * If the URL contains non-latin characters, encode them. 
+     *
+     * @default false
+     */
+    encodeIfNecessary: boolean
+
+    /**
      * The HTTP method to use in the visit. Can be `GET` or `POST`.
      *
      * @default "GET"

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3181,7 +3181,7 @@ declare namespace Cypress {
     url: string
 
     /**
-     * If the URL contains non-latin characters, encode them. 
+     * If the URL contains non-latin characters, encode them.
      *
      * @default false
      */

--- a/packages/driver/cypress/integration/commands/navigation_spec.js
+++ b/packages/driver/cypress/integration/commands/navigation_spec.js
@@ -1019,6 +1019,45 @@ describe('src/cy/commands/navigation', () => {
       })
     })
 
+    // https://github.com/cypress-io/cypress/issues/19355
+    describe('encodeIfNecessary option', () => {
+      it('latin with encodeIfNecessary option => pass', () => {
+        cy.visit('/dump-method', {
+          encodeIfNecessary: true,
+        })
+      })
+
+      it('latin w/o encodeIfNecessary option => pass', () => {
+        cy.visit('/dump-method')
+      })
+
+      it('raw non-latin with encodeIfNecessary option => pass', () => {
+        cy.visit('/nón-latin', {
+          encodeIfNecessary: true,
+        })
+      })
+
+      it('raw non-latin w/o encodeIfNecessary option => fail', () => {
+        // Some servers return `Request path contains unescaped characters` message in this case.
+        // But `404: Not Found` is our closest replication.
+        cy.on('fail', (err) => {
+          expect(err.message).to.include(`404: Not Found`)
+        })
+
+        cy.visit('/nón-latin')
+      })
+
+      it('encoded non-latin with encodeIfNecessary option => pass', () => {
+        cy.visit(encodeURI('/nón-latin'), {
+          encodeIfNecessary: true,
+        })
+      })
+
+      it('encoded non-latin w/o encodeIfNecessary option => pass', () => {
+        cy.visit(encodeURI('/nón-latin'))
+      })
+    })
+
     describe('.log', () => {
       beforeEach(function () {
         cy.stub(Cypress.runner, 'getEmissions').returns([])

--- a/packages/driver/cypress/plugins/server.js
+++ b/packages/driver/cypress/plugins/server.js
@@ -188,6 +188,11 @@ const createApp = (port) => {
     .send('<html><body>server error</body></html>')
   })
 
+  // https://github.com/cypress-io/cypress/issues/19355
+  app.get('/n%C3%B3n-latin', (req, res) => {
+    return res.send('<html><body>nón-latin</body></html>')
+  })
+
   let _var = ''
 
   app.get('/set-var', (req, res) => {

--- a/packages/driver/src/cy/commands/navigation.ts
+++ b/packages/driver/src/cy/commands/navigation.ts
@@ -704,6 +704,11 @@ export default (Commands, Cypress, cy, state, config) => {
         $errUtils.throwErrByPath('visit.invalid_1st_arg')
       }
 
+      // https://github.com/cypress-io/cypress/issues/19355
+      if (userOptions.encodeIfNecessary && /[^A-Za-z0-9_.\-~%:/]/.test(url)) {
+        url = encodeURI(url)
+      }
+
       const consoleProps = {}
 
       if (!_.isEmpty(userOptions)) {
@@ -711,6 +716,7 @@ export default (Commands, Cypress, cy, state, config) => {
       }
 
       options = _.defaults({}, userOptions, {
+        encodeIfNecessary: false,
         auth: null,
         failOnStatusCode: true,
         retryOnNetworkFailure: true,

--- a/packages/driver/src/cy/commands/navigation.ts
+++ b/packages/driver/src/cy/commands/navigation.ts
@@ -14,6 +14,8 @@ import { $Location } from '../../cypress/location'
 import debugFn from 'debug'
 const debug = debugFn('cypress:driver:navigation')
 
+const urlChars = /[^A-Za-z0-9_.\-~%:/]/g
+
 let id = null
 let previousDomainVisited = null
 let hasVisitedAboutBlank = null
@@ -705,7 +707,7 @@ export default (Commands, Cypress, cy, state, config) => {
       }
 
       // https://github.com/cypress-io/cypress/issues/19355
-      if (userOptions.encodeIfNecessary && /[^A-Za-z0-9_.\-~%:/]/.test(url)) {
+      if (userOptions.encodeIfNecessary && urlChars.test(url)) {
         url = encodeURI(url)
       }
 


### PR DESCRIPTION
- Closes #19355

### User facing changelog

If there is any non-latin character in `cy.visit` URL, you can encode them with `encodeIfNecessary` option.

### Additional details
- Why was this change necessary? => For those who wants to test their pages with the URL with non-latin characters, they had to encode them manually. This solves that problem. 
- What is affected by this change? => N/A
- Any implementation details to explain? => This checks if the URL has the character that's not `[A-Za-z0-9_.\-~%:/]`.

### How has the user experience changed?

**Before:**

```js
it('t', () => {
  cy.visit(encodeURI('https://seototo.net/한글-도메인-사용해도-될까-한글-도메인의-장단점-소/amp/'))
})
```

It would fail if URL is already encoded like below:

```js
it('t', () => {
  cy.visit(encodeURI('https://seototo.net/%ED%95%9C%EA%B8%80-%EB%8F%84%EB%A9%94%EC%9D%B8-%EC%82%AC%EC%9A%A9%ED%95%B4%EB%8F%84-%EB%90%A0%EA%B9%8C-%ED%95%9C%EA%B8%80-%EB%8F%84%EB%A9%94%EC%9D%B8%EC%9D%98-%EC%9E%A5%EB%8B%A8%EC%A0%90-%EC%86%8C/amp/'))
}) // => fail.
```

**After:**

```js
it('t', () => {
  cy.visit('https://seototo.net/한글-도메인-사용해도-될까-한글-도메인의-장단점-소/amp/', {
    encodeIfNecessary: true,
  })
})
```

It passes even if it's already encoded:

```js
it('t', () => {
  cy.visit('https://seototo.net/%ED%95%9C%EA%B8%80-%EB%8F%84%EB%A9%94%EC%9D%B8-%EC%82%AC%EC%9A%A9%ED%95%B4%EB%8F%84-%EB%90%A0%EA%B9%8C-%ED%95%9C%EA%B8%80-%EB%8F%84%EB%A9%94%EC%9D%B8%EC%9D%98-%EC%9E%A5%EB%8B%A8%EC%A0%90-%EC%86%8C/amp/', {
    encodeIfNecessary: true,
  }) // => pass
})
```


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? => https://github.com/cypress-io/cypress-documentation/pull/4295
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
