### PR TITLE
fix: Use CYPRESS_VERIFY_TIMEOUT as integer

### DIFF
--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -15,7 +15,7 @@ const logger = require('../logger')
 const xvfb = require('../exec/xvfb')
 const state = require('./state')
 
-const VERIFY_TEST_RUNNER_TIMEOUT_MS = process.env.CYPRESS_VERIFY_TIMEOUT || 30000
+const VERIFY_TEST_RUNNER_TIMEOUT_MS = +process.env.CYPRESS_VERIFY_TIMEOUT || 30000
 
 const checkExecutable = (binaryDir) => {
   const executable = state.getPathToExecutable(binaryDir)

--- a/cli/test/lib/tasks/verify_spec.js
+++ b/cli/test/lib/tasks/verify_spec.js
@@ -26,6 +26,7 @@ const packageVersion = '1.2.3'
 const cacheDir = '/cache/Cypress'
 const executablePath = '/cache/Cypress/1.2.3/Cypress.app/Contents/MacOS/Cypress'
 const binaryStatePath = '/cache/Cypress/1.2.3/binary_state.json'
+const DEFAULT_VERIFY_TIMEOUT = 30000
 
 let stdout
 let spawnedProcess
@@ -69,7 +70,7 @@ context('lib/tasks/verify', () => {
   })
 
   it('has verify task timeout', () => {
-    expect(verify.VERIFY_TEST_RUNNER_TIMEOUT_MS).to.be.gt(10000)
+    expect(verify.VERIFY_TEST_RUNNER_TIMEOUT_MS).to.eql(DEFAULT_VERIFY_TIMEOUT)
   })
 
   it('accepts custom verify task timeout', () => {
@@ -77,7 +78,15 @@ context('lib/tasks/verify', () => {
     delete require.cache[require.resolve(`${lib}/tasks/verify`)]
     const newVerifyInstance = require(`${lib}/tasks/verify`)
 
-    expect(newVerifyInstance.VERIFY_TEST_RUNNER_TIMEOUT_MS).to.be.gte(500000)
+    expect(newVerifyInstance.VERIFY_TEST_RUNNER_TIMEOUT_MS).to.eql(500000)
+  })
+
+  it('falls back to default verify task timeout if custom value is invalid', () => {
+    process.env.CYPRESS_VERIFY_TIMEOUT = 'foobar'
+    delete require.cache[require.resolve(`${lib}/tasks/verify`)]
+    const newVerifyInstance = require(`${lib}/tasks/verify`)
+
+    expect(newVerifyInstance.VERIFY_TEST_RUNNER_TIMEOUT_MS).to.eql(DEFAULT_VERIFY_TIMEOUT)
   })
 
   it('logs error and exits when no version of Cypress is installed', () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #19476 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

- CYPRESS_VERIFY_TIMEOUT is now used as an integer rather than a string

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This change allows the CYPRESS_VERIFY_TIMEOUT environment variable to work appropriately when set by the user. The test cases were also updated to be more strict in their assertions.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [X] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
