### PR TITLE
feat: env to use path params in download url

### DIFF
--- a/cli/__snapshots__/download_spec.js
+++ b/cli/__snapshots__/download_spec.js
@@ -40,3 +40,7 @@ https://download.cypress.io/desktop?platform=OS&arch=ARCH
 exports['specific version desktop url 1'] = `
 https://download.cypress.io/desktop/0.20.2?platform=OS&arch=ARCH
 `
+
+exports['desktop url with path params'] = `
+https://download.cypress.io/desktop/0.20.2/OS-ARCH/cypress.zip
+`

--- a/cli/lib/tasks/download.js
+++ b/cli/lib/tasks/download.js
@@ -63,8 +63,9 @@ const getCA = () => {
 const prepend = (urlPath) => {
   const endpoint = url.resolve(getBaseUrl(), urlPath)
   const platform = os.platform()
+  const pathParams = util.getEnv('CYPRESS_DOWNLOAD_PATH_PARAMS')
 
-  return `${endpoint}?platform=${platform}&arch=${arch()}`
+  return pathParams ? `${endpoint}/${platform}-${arch()}/cypress.zip` : `${endpoint}?platform=${platform}&arch=${arch()}`;
 }
 
 const getUrl = (version) => {

--- a/cli/test/lib/tasks/download_spec.js
+++ b/cli/test/lib/tasks/download_spec.js
@@ -65,6 +65,13 @@ describe('lib/tasks/download', function () {
       snapshot('specific version desktop url 1', normalize(url))
     })
 
+    it('returns url with path params', () => {
+      process.env.CYPRESS_DOWNLOAD_PATH_PARAMS = 'true'
+      const url = download.getUrl('0.20.2')
+
+      snapshot('desktop url with path params', normalize(url))
+    })
+
     it('returns input if it is already an https link', () => {
       const url = 'https://somewhere.com'
       const result = download.getUrl(url)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->https://github.com/cypress-io/cypress/issues/15697

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
Add CYPRESS_DOWNLOAD_PATH_PARAMS env variable to use path based params instead of query based params in download url.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change? -> Cypress CLI. Support for new env variable
- Any implementation details to explain?
-->
- Why was this change necessary? - After https://github.com/cypress-io/cypress/issues/17291 was merged there was no way to switch the download url form query based parameters to path parameters.
- What is affected by this change? -> Cypress CLI. Support for new env variable

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
If the CYPRESS_DOWNLOAD_PATH_PARAMS is set to `true` then cypress is downloaded using path based params(https://download.cypress.io/desktop/0.20.2/OS-ARCH/cypress.zip)
If the new env variable is not used then download url doesn't change (uses query based params https://download.cypress.io/desktop/0.20.2?platform=OS&arch=ARCH)

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here --> https://github.com/cypress-io/cypress-documentation/pull/4298
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
