### PR TITLE
fix: Improve heuristic for --openssl-legacy-provider (#19320)

### DIFF
--- a/packages/server/lib/plugins/index.js
+++ b/packages/server/lib/plugins/index.js
@@ -53,15 +53,17 @@ const getChildOptions = (config) => {
   }
 
   // https://github.com/cypress-io/cypress/issues/18914
-  // If we're on node version 17 or higher, we need the
-  // NODE_ENV --openssl-legacy-provider so that webpack can continue to use
-  // the md4 hash function. This would cause an error prior to node 17
-  // though, so we have to detect node's major version before spawning the
-  // plugins process.
+  // Node 17+ ships with OpenSSL 3 by default, so we may need the option
+  // --openssl-legacy-provider so that webpack@4 can use the legacy MD4 hash
+  // function. This option doesn't exist on Node <17 or when it is built
+  // against OpenSSL 1, so we have to detect Node's major version and check
+  // which version of OpenSSL it was built against before spawning the plugins
+  // process.
 
   // To be removed on update to webpack >= 5.61, which no longer relies on
-  // node's builtin crypto.hash function.
-  if (semver.satisfies(config.resolvedNodeVersion, '>=17.0.0')) {
+  // Node's builtin crypto.hash function.
+  if (semver.satisfies(config.resolvedNodeVersion, '>=17.0.0') &&
+      !process.versions.openssl.startsWith('1.')) {
     childOptions.env.NODE_OPTIONS += ' --openssl-legacy-provider'
   }
 

--- a/packages/server/test/unit/plugins/index_spec.js
+++ b/packages/server/test/unit/plugins/index_spec.js
@@ -66,16 +66,37 @@ describe('lib/plugins/index', () => {
     })
 
     // https://github.com/cypress-io/cypress/issues/18914
-    it('includes --openssl-legacy-provider in node 17+', () => {
+    it('includes --openssl-legacy-provider in Node 17+ w/ OpenSSL 3', () => {
+      const sandbox = sinon.createSandbox()
+
+      sandbox.stub(process.versions, 'openssl').value('3.0.0-quic')
+
       const childOptions = plugins.getChildOptions({
         resolvedNodeVersion: 'v17.1.0',
       })
 
       expect(childOptions.env.NODE_OPTIONS).to.contain('--openssl-legacy-provider')
+
+      sandbox.restore()
+    })
+
+    // https://github.com/cypress-io/cypress/issues/19320
+    it('does not include --openssl-legacy-provider in Node 17+ w/ OpenSSL 1', () => {
+      const sandbox = sinon.createSandbox()
+
+      sandbox.stub(process.versions, 'openssl').value('1.1.1m')
+
+      const childOptions = plugins.getChildOptions({
+        resolvedNodeVersion: 'v17.3.0',
+      })
+
+      expect(childOptions.env.NODE_OPTIONS).not.to.contain('--openssl-legacy-provider')
+
+      sandbox.restore()
     })
 
     // https://github.com/cypress-io/cypress/issues/18914
-    it('does not include --openssl-legacy-provider in node <=16', () => {
+    it('does not include --openssl-legacy-provider in Node <=16', () => {
       const childOptions = plugins.getChildOptions({
         resolvedNodeVersion: 'v16.31.0',
       })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #19320

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
* Improved the heuristic for detecting whether `--openssl-legacy-provider` is needed

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Node 17+ can still be built against OpenSSL version 1 with `--shared-openssl` build parameter. In this case the option `--openssl-legacy-provider` does not work (and is not needed). We cannot assume that all versions of Node 17 are built with OpenSSL 3.

### How has the user experience changed?

Native Node v17 as built by Arch Linux and Homebrew now works with Cypress again (after being broken in 9.1.1).

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
