### PR TITLE
fix: make switching testing types work

### DIFF
--- a/packages/app/src/navigation/SwitchTestingTypeModal.vue
+++ b/packages/app/src/navigation/SwitchTestingTypeModal.vue
@@ -1,6 +1,6 @@
 <template>
   <StandardModal
-    class="transition duration-200 transition-all"
+    class="transition-all transition duration-200"
     :click-outside="false"
     variant="bare"
     :title="t('testingType.modalTitle')"
@@ -31,7 +31,10 @@ fragment SwitchTestingTypeModal on Query {
 `
 
 gql`
-mutation SwitchTestingType_ReconfigureProject {
+mutation SwitchTestingType_ReconfigureProject($testingType: TestingTypeEnum!) {
+  setCurrentTestingType(testingType: $testingType) {
+    currentTestingType
+  }
   reconfigureProject
 }
 `
@@ -47,7 +50,7 @@ const emits = defineEmits<{
 
 const openElectron = useMutation(SwitchTestingType_ReconfigureProjectDocument)
 
-function reconfigure () {
-  openElectron.executeMutation({})
+function reconfigure (testingType: 'component' | 'e2e') {
+  openElectron.executeMutation({ testingType })
 }
 </script>

--- a/packages/data-context/src/actions/ProjectActions.ts
+++ b/packages/data-context/src/actions/ProjectActions.ts
@@ -390,7 +390,8 @@ export class ProjectActions {
     }
   }
 
-  reconfigureProject () {
+  async reconfigureProject () {
+    await this.api.closeActiveProject()
     this.ctx.actions.wizard.resetWizard()
     this.ctx.actions.electron.refreshBrowserWindow()
     this.ctx.actions.electron.showBrowserWindow()

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Mutation.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Mutation.ts
@@ -307,8 +307,8 @@ export const mutation = mutationType({
     t.nonNull.field('reconfigureProject', {
       type: 'Boolean',
       description: 'show the launchpad windows',
-      resolve: (_, args, ctx) => {
-        ctx.actions.project.reconfigureProject()
+      resolve: async (_, args, ctx) => {
+        await ctx.actions.project.reconfigureProject()
 
         return true
       },


### PR DESCRIPTION
- Closes [UNIFY-868](https://cypress-io.atlassian.net/browse/UNIFY-868)

### User facing changelog
Switching testing types works

### Additional details
With some recent changes, switching testing types broke. Previously, when choosing "Switching Testing Types", the Launchpad would take you to the "Choose Testing Type". Now, it takes you to the browser launch page, causing the testing type to not change. This is fixed by setting the testing type with a mutation on the frontend.

Another issue was that the open project was never being recreated, so even if you could switch it would still show you the wrong specs and nothing could execute. This is fixed by closing the active project whenever you choose to reconfigure.

A consequence of this fix is that the browser is closed immediately when reconfiguring, but this was a bug anyway so 2 birds 1 stone.

### How has the user experience changed?
Before

https://user-images.githubusercontent.com/25158820/148123251-c4a77c9d-430f-4e7a-8780-58f6046a4a93.mov

After

https://user-images.githubusercontent.com/25158820/148123278-1ed3441d-c2db-4bc4-9a1b-264a355a894c.mov

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
