### PR TITLE
fix: retrieve 'exit' from config instead of options

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -48,7 +48,7 @@ yarn test-watch /test/path/to/spec.js
 
 ### Running individual unit tests
 
-```bashtest-kitchensink
+```bash
 yarn test <path/to/test>
 yarn test test/unit/api_spec.js
 ## or
@@ -68,7 +68,7 @@ yarn test-integration cli_spec ## shorthand, uses globbing to find spec
 
 > With the addition of Component Testing, `e2e` tests have been renamed to `system-tests` and moved to the [`system-tests`](../../system-tests) directory.
 
-### Updating snaphots
+### Updating snapshots
 
 Prepend `SNAPSHOT_UPDATE=1` to any test command. See [`snap-shot-it` instructions](https://github.com/bahmutov/snap-shot-it#advanced-use) for more info.
 

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1428,7 +1428,6 @@ module.exports = {
     })
 
     if (browser.family !== 'chromium' && !options.config.chromeWebSecurity) {
-      console.log()
       errors.warning('CHROME_WEB_SECURITY_NOT_SUPPORTED', browser.family)
     }
 
@@ -1460,7 +1459,7 @@ module.exports = {
           compressedVideoName: videoRecordProps.compressedVideoName,
           endVideoCapture: videoRecordProps.endVideoCapture,
           startedVideoCapture: videoRecordProps.startedVideoCapture,
-          exit: options.exit,
+          exit: config.exit,
           videoCompression: options.videoCompression,
           videoUploadOnPasses: options.videoUploadOnPasses,
           quiet: options.quiet,
@@ -1608,7 +1607,6 @@ module.exports = {
               video: config.video,
               videoCompression: config.videoCompression,
               videoUploadOnPasses: config.videoUploadOnPasses,
-              exit: options.exit,
               headed: options.headed,
               quiet: options.quiet,
               outputPath: options.outputPath,

--- a/packages/server/test/unit/modes/run_spec.js
+++ b/packages/server/test/unit/modes/run_spec.js
@@ -810,6 +810,21 @@ describe('lib/modes/run', () => {
       })
     })
 
+    it('passes exit from config to waitForTestsToFinishRunning', function () {
+      this.projectInstance.getConfig.restore()
+      sinon.stub(this.projectInstance, 'getConfig').resolves({
+        proxyUrl: 'http://localhost:12345',
+        exit: false,
+      })
+
+      return runMode.run()
+      .then(() => {
+        expect(runMode.waitForTestsToFinishRunning).to.be.calledWithMatch({
+          exit: false,
+        })
+      })
+    })
+
     it('passes headed to openProject.launch', () => {
       const browser = { name: 'electron', family: 'chromium' }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -19746,12 +19746,7 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
-follow-redirects@^1.0.0:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.12.1.tgz#de54a6205311b93d60398ebc01cf7015682312b6"
-  integrity sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg==
-
-follow-redirects@^1.14.0:
+follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   version "1.14.5"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
   integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #19485<!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
Cypress remains open when the `--no-exit` option is used.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
See https://github.com/cypress-io/cypress/issues/19485#issuecomment-1004263526

> This was introduced by #18896. By adding 'exit' to the default config we elevated the exit key from being in the root options object (options.exit) to being nested in the config object (options.config.exit), preventing us from reading it in run.js. A fix could would be reading from reading the 'exit' option from config.exit instead of options.exit in the above file.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Before:
<img width="753" alt="Screen Shot 2022-01-05 at 9 28 07 AM" src="https://user-images.githubusercontent.com/2002044/148253019-e70bc01c-a395-433c-bac8-ca584e36ec29.png">

After:
<img width="410" alt="Screen Shot 2022-01-05 at 9 26 02 AM" src="https://user-images.githubusercontent.com/2002044/148252697-5b1b7a1c-19e6-4b47-ba65-198d22df4453.png">

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
