### PR TITLE
refactor: remove connection use for specs list

### DIFF
--- a/packages/app/src/pages/Specs/Index.vue
+++ b/packages/app/src/pages/Specs/Index.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="query.data.value">
     <SpecsList
-      v-if="query.data.value.currentProject?.specs?.edges.length"
+      v-if="query.data.value.currentProject?.specs?.length"
       :gql="query.data.value"
     />
     <NoSpecsPage

--- a/packages/app/src/runner/SpecRunnerContainer.vue
+++ b/packages/app/src/runner/SpecRunnerContainer.vue
@@ -39,7 +39,7 @@ const props = defineProps<{
 }>()
 
 watch(() => route.query.file, (queryParam) => {
-  const spec = props.gql.currentProject?.specs?.edges.find((x) => x.node.relative === queryParam)?.node
+  const spec = props.gql.currentProject?.specs?.find((x) => x?.relative === queryParam)
 
   if (selectorPlaygroundStore.show) {
     const autIframe = getAutIframeModel()

--- a/packages/app/src/specs/InlineSpecList.spec.tsx
+++ b/packages/app/src/specs/InlineSpecList.spec.tsx
@@ -15,8 +15,8 @@ describe('InlineSpecList', () => {
         return ctx
       }
 
-      ctx.currentProject.specs.edges = specs.map((spec) => ({ __typename: 'SpecEdge', node: { __typename: 'Spec', ...spec, id: spec.relative } }))
-      specs = ctx.currentProject?.specs?.edges || []
+      ctx.currentProject.specs = specs.map((spec) => ({ __typename: 'Spec', ...spec, id: spec.relative }))
+      specs = ctx.currentProject?.specs || []
 
       return ctx
     },
@@ -66,8 +66,8 @@ describe('InlineSpecList', () => {
 
     cy.mountFragment(Specs_InlineSpecListFragmentDoc, {
       onResult (ctx) {
-        if (ctx.currentProject?.specs?.edges) {
-          ctx.currentProject.specs.edges = ctx.currentProject.specs.edges.slice(0, 50)
+        if (ctx.currentProject?.specs) {
+          ctx.currentProject.specs = ctx.currentProject.specs.slice(0, 50)
         }
 
         return ctx
@@ -82,7 +82,7 @@ describe('InlineSpecList', () => {
         )
       },
     }).then(() => {
-      const sortedSpecs = _gqlValue?.currentProject?.specs?.edges.sort((a, b) => a.node.relative < b.node.relative ? -1 : 1) || []
+      const sortedSpecs = _gqlValue?.currentProject?.specs.sort((a, b) => a.node.relative < b.node.relative ? -1 : 1) || []
       const firstSpec = sortedSpecs[0]
       const lastSpec = sortedSpecs[sortedSpecs.length - 1]
 
@@ -91,8 +91,8 @@ describe('InlineSpecList', () => {
       cy.contains(lastSpec.node.fileName).should('be.visible')
       cy.then(() => {
         // Emulating a gql update that shouldn't cause a scroll snap
-        if (_gqlValue.currentProject?.specs?.edges) {
-          _gqlValue.currentProject.specs.edges = [..._gqlValue.currentProject.specs.edges]
+        if (_gqlValue.currentProject?.specs) {
+          _gqlValue.currentProject.specs = [..._gqlValue.currentProject.specs]
         }
       })
 
@@ -102,8 +102,8 @@ describe('InlineSpecList', () => {
 
       cy.then(() => {
         // Checking that specs list refreshes when spec is added
-        if (_gqlValue.currentProject?.specs?.edges) {
-          _gqlValue.currentProject.specs.edges = _gqlValue.currentProject.specs.edges.concat(newSpec)
+        if (_gqlValue.currentProject?.specs) {
+          _gqlValue.currentProject.specs = _gqlValue.currentProject.specs.concat(newSpec)
         }
       })
 
@@ -113,8 +113,8 @@ describe('InlineSpecList', () => {
 
       cy.then(() => {
         // Checking that specs list refreshes when spec is deleted
-        if (_gqlValue.currentProject?.specs?.edges) {
-          _gqlValue.currentProject.specs.edges = _gqlValue.currentProject.specs.edges.filter(((spec) => spec.node.relative !== newSpec.node.relative))
+        if (_gqlValue.currentProject?.specs) {
+          _gqlValue.currentProject.specs = _gqlValue.currentProject.specs.filter(((spec) => spec.node.relative !== newSpec.node.relative))
         }
       })
 

--- a/packages/app/src/specs/InlineSpecList.vue
+++ b/packages/app/src/specs/InlineSpecList.vue
@@ -31,18 +31,16 @@ import CreateSpecModal from './CreateSpecModal.vue'
 import { FuzzyFoundSpec, fuzzySortSpecs, makeFuzzyFoundSpec, useCachedSpecs } from '@packages/frontend-shared/src/utils/spec-utils'
 
 gql`
-fragment SpecNode_InlineSpecList on SpecEdge {
-  node {
-    id
-    name
-    specType
-    absolute
-    baseName
-    fileName
-    specFileExtension
-    fileExtension
-    relative
-  }
+fragment SpecNode_InlineSpecList on Spec {
+  id
+  name
+  specType
+  absolute
+  baseName
+  fileName
+  specFileExtension
+  fileExtension
+  relative
 }
 `
 
@@ -53,10 +51,9 @@ fragment Specs_InlineSpecList on Query {
     id
     projectRoot
     currentTestingType
-    specs: specs(first: 1000) {
-      edges {
-        ...SpecNode_InlineSpecList
-      }
+    specs {
+      id
+      ...SpecNode_InlineSpecList
     }
   }
 }
@@ -68,10 +65,10 @@ const props = defineProps<{
 
 const showModal = ref(false)
 const search = ref('')
-const cachedSpecs = useCachedSpecs(computed(() => (props.gql.currentProject?.specs?.edges) || []))
+const cachedSpecs = useCachedSpecs(computed(() => props.gql.currentProject?.specs || []))
 
 const specs = computed<FuzzyFoundSpec[]>(() => {
-  const specs = cachedSpecs.value.map((x) => makeFuzzyFoundSpec(x.node))
+  const specs = cachedSpecs.value.map((x) => makeFuzzyFoundSpec(x))
 
   if (!search.value) return specs
 

--- a/packages/app/src/specs/SpecsList.spec.tsx
+++ b/packages/app/src/specs/SpecsList.spec.tsx
@@ -26,7 +26,7 @@ describe('<SpecsList />', { keystrokeDelay: 0 }, () => {
     beforeEach(() => {
       cy.mountFragment(Specs_SpecsListFragmentDoc, {
         onResult: (ctx) => {
-          specs = ctx.currentProject?.specs?.edges || []
+          specs = ctx.currentProject?.specs ?? []
 
           return ctx
         },
@@ -38,8 +38,8 @@ describe('<SpecsList />', { keystrokeDelay: 0 }, () => {
 
     it('should filter specs', () => {
       const longestSpec = specs.reduce((acc, spec) =>
-        acc.node.relative.length < spec.node.relative.length ? spec : acc
-      , specs[0]).node
+        acc.relative.length < spec.relative.length ? spec : acc
+      , specs[0])
 
       cy.get(inputSelector).type('garbage 🗑', { delay: 0 })
       .get(rowSelector)

--- a/packages/app/src/specs/SpecsList.vue
+++ b/packages/app/src/specs/SpecsList.vue
@@ -92,20 +92,18 @@ import { useVirtualList } from '@packages/frontend-shared/src/composables/useVir
 const { t } = useI18n()
 
 gql`
-fragment SpecNode_SpecsList on SpecEdge {
-  node {
-    id
-    name
-    specType
-    absolute
-    baseName
-    fileName
-    specFileExtension
-    fileExtension
-    relative
-    gitInfo {
-      ...SpecListRow
-    }
+fragment SpecNode_SpecsList on Spec {
+  id
+  name
+  specType
+  absolute
+  baseName
+  fileName
+  specFileExtension
+  fileExtension
+  relative
+  gitInfo {
+    ...SpecListRow
   }
 }
 `
@@ -117,10 +115,9 @@ fragment Specs_SpecsList on Query {
     id
     projectRoot
     currentTestingType
-    specs: specs(first: 100) {
-      edges {
-        ...SpecNode_SpecsList
-      }
+    specs {
+      id
+      ...SpecNode_SpecsList
     }
   }
 }
@@ -132,10 +129,10 @@ const props = defineProps<{
 
 const showModal = ref(false)
 const search = ref('')
-const cachedSpecs = useCachedSpecs(computed(() => props.gql.currentProject?.specs?.edges || []))
+const cachedSpecs = useCachedSpecs(computed(() => props.gql.currentProject?.specs || []))
 
 const specs = computed(() => {
-  const specs = cachedSpecs.value.map((x) => makeFuzzyFoundSpec(x.node))
+  const specs = cachedSpecs.value.map((x) => makeFuzzyFoundSpec(x))
 
   if (!search.value) {
     return specs

--- a/packages/frontend-shared/cypress/support/mock-graphql/stubgql-Project.ts
+++ b/packages/frontend-shared/cypress/support/mock-graphql/stubgql-Project.ts
@@ -32,26 +32,14 @@ export const createTestCurrentProject = (title: string, currentProject: Partial<
     isE2EConfigured: true,
     currentTestingType: 'e2e',
     projectId: `${globalProject.title}-id`,
-    specs: {
-      pageInfo: {
-        __typename: 'PageInfo',
-        hasNextPage: true,
-        hasPreviousPage: false,
-      },
-      __typename: 'SpecConnection' as const,
-      edges: [
-        ...randomComponents(200, 'Spec').map((c) => {
-          return {
-            __typename: 'SpecEdge' as const,
-            cursor: 'eoifjew',
-            node: {
-              ...c,
-              id: c.absolute,
-            },
-          }
-        }),
-      ],
-    },
+    specs: [
+      ...randomComponents(200, 'Spec').map((c) => {
+        return {
+          ...c,
+          id: c.absolute,
+        }
+      }),
+    ],
     config,
     cloudProject: CloudProjectStubs.componentProject,
     codeGenGlobs: {

--- a/packages/frontend-shared/src/utils/spec-utils.ts
+++ b/packages/frontend-shared/src/utils/spec-utils.ts
@@ -116,7 +116,7 @@ export function makeFuzzyFoundSpec (spec: FoundSpec): FuzzyFoundSpec {
   }
 }
 
-type SpecEdges = { node: FoundSpec }[]
+type SpecEdges = FoundSpec[]
 
 export function useCachedSpecs (specs) {
   const cachedSpecs = ref<SpecEdges>([])
@@ -125,7 +125,7 @@ export function useCachedSpecs (specs) {
     const specsAreDifferent =
         currentSpecs.length !== prevSpecs.length ||
         currentSpecs.some(
-          (spec, idx) => spec.node.absolute !== prevSpecs[idx]?.node?.absolute,
+          (spec, idx) => spec.absolute !== prevSpecs[idx]?.absolute,
         )
 
     if (specsAreDifferent) {

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -417,19 +417,7 @@ type CurrentProject implements Node & ProjectLike {
   projectRoot: String!
 
   """Specs for a project conforming to Relay Connection specification"""
-  specs(
-    """Returns the elements in the list that come after the specified cursor"""
-    after: String
-
-    """Returns the elements in the list that come before the specified cursor"""
-    before: String
-
-    """Returns the first n elements from the list."""
-    first: Int
-
-    """Returns the last n elements from the list."""
-    last: Int
-  ): SpecConnection
+  specs: [Spec!]
   storybook: Storybook
   title: String!
 }
@@ -854,26 +842,6 @@ type Spec implements Node {
 
   """Type of spec (e.g. component | integration)"""
   specType: SpecType!
-}
-
-type SpecConnection {
-  """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
-  """
-  edges: [SpecEdge!]!
-
-  """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
-  """
-  pageInfo: PageInfo!
-}
-
-type SpecEdge {
-  """https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor"""
-  cursor: String!
-
-  """https://facebook.github.io/relay/graphql/connections.htm#sec-Node"""
-  node: Spec!
 }
 
 enum SpecType {

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-CurrentProject.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-CurrentProject.ts
@@ -3,11 +3,13 @@ import path from 'path'
 import { BaseError } from '.'
 import { cloudProjectBySlug } from '../../stitching/remoteGraphQLCalls'
 import { TestingTypeEnum } from '../enumTypes/gql-WizardEnums'
+
 import { Browser } from './gql-Browser'
 import { CodeGenGlobs } from './gql-CodeGenGlobs'
 import { FileParts } from './gql-FileParts'
 import { ProjectPreferences } from './gql-ProjectPreferences'
 import { Storybook } from './gql-Storybook'
+import { Spec } from './gql-Spec'
 
 export const CurrentProject = objectType({
   name: 'CurrentProject',
@@ -97,10 +99,10 @@ export const CurrentProject = objectType({
     //   type: TestingTypeInfo,
     // })
 
-    t.connectionField('specs', {
+    t.list.nonNull.field('specs', {
       description: 'Specs for a project conforming to Relay Connection specification',
-      type: 'Spec',
-      nodes: (source, args, ctx) => {
+      type: Spec,
+      resolve: (source, args, ctx) => {
         return ctx.project.specs
       },
     })


### PR DESCRIPTION
Changes `connection` -> `list`, for the `specs` field, which simplifies usage, especially since we don't have a method of paginating for specs. Shouldn't matter, since the spec list is local - if we do need to add this in the future (paginated specs) we can change this.