### PR TITLE
fix: check resolvedNodePath for Next.js 12 guard

### DIFF
--- a/npm/react/plugins/next/checkSWC.ts
+++ b/npm/react/plugins/next/checkSWC.ts
@@ -10,9 +10,11 @@ export function checkSWC (
     )
   })
 
-  if (hasSWCLoader && cypressConfig.nodeVersion !== 'system') {
-    throw new Error(`Cypress requires "nodeVersion" to be set to "system" in order to run Next.js with SWC optimizations.
-Please add "nodeVersion": "system" to your Cypress configuration and try again.`)
+  // "resolvedNodePath" is only set when using the user's Node.js, which is required to compile Next.js with SWC optimizations
+  // If it is not set, they have either explicitly set "nodeVersion" to "bundled" or are are using Cypress < 9.0.0 where it was set to "bundled" by default
+  if (hasSWCLoader && !cypressConfig.resolvedNodePath) {
+    throw new Error(`Cannot compile Next.js application with configured Node.js.
+If you are on Cypress version >= \`9.0.0\`, remove the "nodeVersion" property from your Cypress config. Otherwise, please add "nodeVersion": "system" to your Cypress config and try again.`)
   }
 
   return false


### PR DESCRIPTION
- Closes [UNIFY-877](https://cypress-io.atlassian.net/browse/UNIFY-877)

### User facing changelog
Remove "nodeVersion": "system" requirement for Next.js v12 applications now that "nodeVersion": "system" is the default for users using Cypress >= 9.0.0

### Additional details
Next.js uses SWC to compile js and wasn't working with our plugin due to "nodeVersion": "bundled" (which was the default prior to Cypress 9.0.0) causing Rust to not be able to run. Since "nodeVersion": "system", this PR changes how we check the nodeVersion so as to remove the requirement of having this property set for the application to compile if a user is using Cypress >= 9.0.0.

How it works:

- If using Next.js >= 12 and Cypress < 9: Users need to set "nodeVersion": "system"
- If using Next.js >= 12 and Cypress >= 9: Works with no change, errors if "nodeVersion": "bundled"

### How has the user experience changed?
Users using Cypress >=9.0.0 and Next.js >= 12 no longer need "nodeVersion": "system" set in there Cypress config.

### How to test
Check out this branch and run `yarn workspace @cypress/react build`. Then, you can copy and paste the `dist` and `plugins` folder into a Next.js project.

Getting #19088 done would be great so we could properly test changes like this. I ran into an issue trying to write a system test trying to install a `@cypress` dependency due to our use of `0.0.0-development`.

### PR Tasks

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
