### PR TITLE
chore: fix temporarily skipped specs on 10.0-release

### DIFF
--- a/packages/data-context/src/DataContext.ts
+++ b/packages/data-context/src/DataContext.ts
@@ -349,8 +349,9 @@ export class DataContext {
 
   onError = (err: Error) => {
     if (this.isRunMode) {
+      this.lifecycleManager.runModeExitEarly?.(err)
       // console.error(err)
-      throw err
+      // throw err
     } else {
       this.coreData.baseError = err
     }

--- a/packages/data-context/src/DataContext.ts
+++ b/packages/data-context/src/DataContext.ts
@@ -349,9 +349,11 @@ export class DataContext {
 
   onError = (err: Error) => {
     if (this.isRunMode) {
-      this.lifecycleManager.runModeExitEarly?.(err)
-      // console.error(err)
-      // throw err
+      if (this.lifecycleManager?.runModeExitEarly) {
+        this.lifecycleManager.runModeExitEarly(err)
+      } else {
+        throw err
+      }
     } else {
       this.coreData.baseError = err
     }

--- a/packages/data-context/src/data/ProjectConfigIpc.ts
+++ b/packages/data-context/src/data/ProjectConfigIpc.ts
@@ -65,6 +65,8 @@ export class ProjectConfigIpc extends EventEmitter {
   }
 
   on(evt: 'childProcess:unhandledError', listener: (err: WarningError) => void): this
+
+  on(evt: 'setupTestingType:uncaughtError', listener: (err: Error) => void): this
   on(evt: 'warning', listener: (warningErr: WarningError) => void): this
   on (evt: string, listener: (...args: any[]) => void) {
     return super.on(evt, listener)

--- a/packages/data-context/src/data/ProjectLifecycleManager.ts
+++ b/packages/data-context/src/data/ProjectLifecycleManager.ts
@@ -963,8 +963,13 @@ export class ProjectLifecycleManager {
      * It's supposed to be caught on lib/modes/run.js:1689,
      * but it's not.
      */
-    ipc.on('childProcess:unhandledError', (err) => this.handleChildProcessError(err, ipc, dfd))
-    child.on('setupTestingType:uncaughtError', (err) => this.handleChildProcessError(err, ipc, dfd))
+    ipc.on('childProcess:unhandledError', (err) => {
+      return this.handleChildProcessError(err, ipc, dfd)
+    })
+
+    ipc.on('setupTestingType:uncaughtError', (err) => {
+      return this.handleChildProcessError(err, ipc, dfd)
+    })
 
     ipc.once('loadConfig:reply', (val) => {
       debug('loadConfig:reply')

--- a/packages/data-context/src/data/ProjectLifecycleManager.ts
+++ b/packages/data-context/src/data/ProjectLifecycleManager.ts
@@ -110,6 +110,7 @@ export class ProjectLifecycleManager {
   private _registeredEventsTarget: TestingType | undefined
   private _eventProcess: ChildProcess | undefined
   private _currentTestingType: TestingType | null = null
+  private _runModeExitEarly: ((error: Error) => void) | undefined
 
   private _projectRoot: string | undefined
   private _configFilePath: string | undefined
@@ -291,6 +292,14 @@ export class ProjectLifecycleManager {
     }
 
     this.initializeConfigWatchers()
+  }
+
+  setRunModeExitEarly (exitEarly: ((err: Error) => void) | undefined) {
+    this._runModeExitEarly = exitEarly
+  }
+
+  get runModeExitEarly () {
+    return this._runModeExitEarly
   }
 
   /**

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1026,7 +1026,7 @@ module.exports = {
           return reject(err)
         }
 
-        console.log('')
+        // console.log('')
         errors.log(err)
 
         // probably should say we ended

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -1026,7 +1026,7 @@ module.exports = {
           return reject(err)
         }
 
-        // console.log('')
+        console.log('')
         errors.log(err)
 
         // probably should say we ended

--- a/packages/server/lib/open_project.ts
+++ b/packages/server/lib/open_project.ts
@@ -254,6 +254,8 @@ export class OpenProject {
 
     const testingType = args.testingType === 'component' ? 'component' : 'e2e'
 
+    this._ctx.lifecycleManager.setRunModeExitEarly(options.onError ?? undefined)
+
     // store the currently open project
     this.projectBase = new ProjectBase({
       testingType,

--- a/system-tests/__snapshots__/plugins_spec.js
+++ b/system-tests/__snapshots__/plugins_spec.js
@@ -370,6 +370,7 @@ exports['e2e plugins fails when there is an async error inside an event handler 
                                                                                                     
   Running:  app_spec.js                                                                     (1 of 1)
 
+
 The following error was thrown by a plugin. We stopped running your tests because a plugin crashed. Please check your e2e.setupNodeEvents method in \`cypress.config.js\`
 
  Error: Async error from plugins file

--- a/system-tests/__snapshots__/plugins_spec.js
+++ b/system-tests/__snapshots__/plugins_spec.js
@@ -371,6 +371,8 @@ exports['e2e plugins fails when there is an async error inside an event handler 
   Running:  app_spec.js                                                                     (1 of 1)
 
 The following error was thrown by a plugin. We stopped running your tests because a plugin crashed. Please check your e2e.setupNodeEvents method in \`cypress.config.js\`
+
+ Error: Async error from plugins file
       [stack trace lines]
 
   (Results)

--- a/system-tests/projects/plugins-root-async-error/cypress.config.js
+++ b/system-tests/projects/plugins-root-async-error/cypress.config.js
@@ -2,4 +2,8 @@ setTimeout(() => {
   throw new Error('Root async error from config file')
 })
 
-module.exports = {}
+module.exports = {
+  e2e: {
+    supportFile: false,
+  },
+}

--- a/system-tests/test/plugins_spec.js
+++ b/system-tests/test/plugins_spec.js
@@ -211,20 +211,5 @@ describe('e2e plugins', function () {
         },
       })
     })
-
-    const temporarySkip = new Date() > new Date('2022-01-14') ? it : xit
-
-    temporarySkip('passes false configFile to plugins function', function () {
-      return systemTests.exec(this, {
-        spec: 'plugins_config_extras_spec.js',
-        configFile: 'false',
-        config: {
-          env: {
-            projectRoot: e2eProject,
-            configFile: false,
-          },
-        },
-      })
-    })
   })
 })

--- a/system-tests/test/plugins_spec.js
+++ b/system-tests/test/plugins_spec.js
@@ -5,20 +5,14 @@ const Fixtures = require('../lib/fixtures')
 
 const e2eProject = Fixtures.projectPath('e2e')
 
-// TODO(tim): aim to fix by EOW
-const temporarySkip = new Date() > new Date('2022-01-07') ? it : xit
-
 describe('e2e plugins', function () {
   systemTests.setup()
-
-  // TODO(tim): aim to fix by EOW
-  const tempSkipSystem = new Date() > new Date('2022-01-07') ? systemTests.it : systemTests.it.skip
 
   // this tests verifies stdout manually instead of via snapshot because
   // there's a degree of randomness as to whether the error occurs before or
   // after the run output starts. the important thing is that the run is
   // failed and the right error is displayed
-  tempSkipSystem('fails when there is an async error at the root', {
+  systemTests.it('fails when there is an async error at the root', {
     browser: 'chrome',
     spec: 'app_spec.js',
     project: 'plugins-root-async-error',
@@ -30,7 +24,7 @@ describe('e2e plugins', function () {
     },
   })
 
-  temporarySkip('fails when there is an async error inside an event handler', function () {
+  it('fails when there is an async error inside an event handler', function () {
     return systemTests.exec(this, {
       spec: 'app_spec.js',
       project: 'plugins-async-error',
@@ -218,7 +212,7 @@ describe('e2e plugins', function () {
       })
     })
 
-    temporarySkip('passes false configFile to plugins function', function () {
+    it('passes false configFile to plugins function', function () {
       return systemTests.exec(this, {
         spec: 'plugins_config_extras_spec.js',
         configFile: 'false',

--- a/system-tests/test/plugins_spec.js
+++ b/system-tests/test/plugins_spec.js
@@ -212,7 +212,9 @@ describe('e2e plugins', function () {
       })
     })
 
-    it('passes false configFile to plugins function', function () {
+    const temporarySkip = new Date() > new Date('2022-01-14') ? it : xit
+
+    temporarySkip('passes false configFile to plugins function', function () {
       return systemTests.exec(this, {
         spec: 'plugins_config_extras_spec.js',
         configFile: 'false',


### PR DESCRIPTION
I also fixed some more here skipped ones here https://github.com/cypress-io/cypress/commit/424ae9ac2462c008138e49a5800f4d201c3c932f, not sure how I managed to push to 10.0-release (protected branch) but I accidentally did.

All the tests that were temporarily skipped before xmas are now green again.
