### PR TITLE
fix: update cli-table dependency to fix broken colors.js

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -33,7 +33,7 @@
     "chalk": "^4.1.0",
     "check-more-types": "^2.24.0",
     "cli-cursor": "^3.1.0",
-    "cli-table3": "~0.6.0",
+    "cli-table3": "~0.6.1",
     "commander": "^5.1.0",
     "common-tags": "^1.8.0",
     "dayjs": "^1.10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14067,7 +14067,7 @@ cli-table3@0.5.1, cli-table3@^0.5.0, cli-table3@^0.5.1:
   optionalDependencies:
     colors "^1.1.2"
 
-cli-table3@0.6.0, cli-table3@~0.6.0:
+cli-table3@0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.0.tgz#b7b1bc65ca8e7b5cef9124e13dc2b21e2ce4faee"
   integrity sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==
@@ -14076,6 +14076,15 @@ cli-table3@0.6.0, cli-table3@~0.6.0:
     string-width "^4.2.0"
   optionalDependencies:
     colors "^1.1.2"
+
+cli-table3@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.1.tgz#36ce9b7af4847f288d3cdd081fbd09bf7bd237b8"
+  integrity sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    colors "1.4.0"
 
 cli-table@^0.3.1:
   version "0.3.1"
@@ -14420,7 +14429,7 @@ colors@1.0.3, colors@1.0.x:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-colors@^1.1.2, colors@^1.3.3, colors@^1.4.0:
+colors@1.4.0, colors@^1.1.2, colors@^1.3.3, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==


### PR DESCRIPTION
Close #19624

By pinning a dependency to 1.4.0 see https://github.com/cli-table/cli-table3/pull/251/files https://github.com/Marak/colors.js/issues/285

### User facing changelog

Upgrade `cli-table3` to avoid problems with `colors.js` "bad" version

### Additional details

A non-working version of colors.js was uploaded and published by their owner. First-level dependencies are working through it.

### How has the user experience changed?

No change.

