### PR TITLE
fix: `change`, `input` events are not fired when the same option is selected again. 

### DIFF
--- a/packages/driver/cypress/fixtures/select-event-counter.html
+++ b/packages/driver/cypress/fixtures/select-event-counter.html
@@ -6,7 +6,7 @@
 <label>Choose an ice cream flavor:
   <select class='ice-cream' name='ice-cream'>
     <option value=''>Select One …</option>
-    <option value='chocolate'>Chocolate</option>
+    <option value='chocolate' selected>Chocolate</option>
     <option value='sardine'>Sardine</option>
     <option value='vanilla'>Vanilla</option>
   </select>

--- a/packages/driver/cypress/fixtures/select-event-counter.html
+++ b/packages/driver/cypress/fixtures/select-event-counter.html
@@ -1,0 +1,32 @@
+<html>
+<head>
+  <meta charset='utf-8'>
+  <title>Select event counter</title>
+</head>
+<label>Choose an ice cream flavor:
+  <select class='ice-cream' name='ice-cream'>
+    <option value=''>Select One …</option>
+    <option value='chocolate'>Chocolate</option>
+    <option value='sardine'>Sardine</option>
+    <option value='vanilla'>Vanilla</option>
+  </select>
+</label>
+
+<div id='change-result'></div>
+<div id='input-result'></div>
+
+<script>
+  const selectElement = document.querySelector('.ice-cream');
+  let numOfTimesOnChangeFired = 0;
+  selectElement.addEventListener('change', (event) => {
+    const result = document.querySelector('#change-result');
+    result.textContent = `Number of times onChange event fired: ${++numOfTimesOnChangeFired}`;
+  });
+
+  let numOfTimesInputFired = 0;
+  selectElement.addEventListener('input', (event) => {
+    const result = document.querySelector('#input-result');
+    result.textContent = `Number of times input event fired: ${++numOfTimesInputFired}`;
+  });
+</script>
+</html>

--- a/packages/driver/cypress/integration/commands/actions/select_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/select_spec.js
@@ -325,6 +325,19 @@ describe('src/cy/commands/actions/select', () => {
           expect(fired).to.deep.eq(events)
         })
       })
+
+      // https://github.com/cypress-io/cypress/issues/19494
+      it('does not fire `change`, `input` events when selecting the same option again', () => {
+        cy.visit('fixtures/select-event-counter.html')
+        cy.get('.ice-cream').select('Chocolate')
+        cy.get('#change-result').should('have.text', 'Number of times onChange event fired: 1')
+        cy.get('#input-result').should('have.text', 'Number of times input event fired: 1')
+
+        // Select the option that is already selected - `change`, `input` events should not fire.
+        cy.get('.ice-cream').select('Chocolate')
+        cy.get('#change-result').should('have.text', 'Number of times onChange event fired: 1')
+        cy.get('#input-result').should('have.text', 'Number of times input event fired: 1')
+      })
     })
 
     describe('errors', {

--- a/packages/driver/cypress/integration/commands/actions/select_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/select_spec.js
@@ -329,12 +329,18 @@ describe('src/cy/commands/actions/select', () => {
       // https://github.com/cypress-io/cypress/issues/19494
       it('does not fire `change`, `input` events when selecting the same option again', () => {
         cy.visit('fixtures/select-event-counter.html')
+
+        // Nothing happens when selecting the option with `selected` attribute
         cy.get('.ice-cream').select('Chocolate')
+        cy.get('#change-result').should('not.have.text', 'Number of times onChange event fired: 1')
+        cy.get('#input-result').should('not.have.text', 'Number of times input event fired: 1')
+
+        cy.get('.ice-cream').select('Sardine')
         cy.get('#change-result').should('have.text', 'Number of times onChange event fired: 1')
         cy.get('#input-result').should('have.text', 'Number of times input event fired: 1')
 
         // Select the option that is already selected - `change`, `input` events should not fire.
-        cy.get('.ice-cream').select('Chocolate')
+        cy.get('.ice-cream').select('Sardine')
         cy.get('#change-result').should('have.text', 'Number of times onChange event fired: 1')
         cy.get('#input-result').should('have.text', 'Number of times input event fired: 1')
       })
@@ -378,7 +384,7 @@ describe('src/cy/commands/actions/select', () => {
           done()
         })
 
-        cy.get('#select-maps').select('de_dust2').select('de_aztec')
+        cy.get('#select-maps').select('de_aztec').select('de_dust2')
       })
 
       it('throws when more than 1 element in the collection', (done) => {
@@ -660,7 +666,7 @@ describe('src/cy/commands/actions/select', () => {
           done()
         })
 
-        cy.get('#select-maps').select('de_dust2').then(($select) => { })
+        cy.get('#select-maps').select('de_aztec').then(($select) => { })
       })
 
       it('snapshots after clicking', () => {

--- a/packages/driver/src/cy/commands/actions/select.ts
+++ b/packages/driver/src/cy/commands/actions/select.ts
@@ -8,7 +8,7 @@ import $elements from '../../../dom/elements'
 
 const newLineRe = /\n/g
 
-export default (Commands, Cypress, cy, state) => {
+export default (Commands, Cypress, cy) => {
   Commands.addAll({ prevSubject: 'element' }, {
     // TODO: any -> Partial<Cypress.SelectOptions>
     select (subject, valueOrTextOrIndex, options: any = {}) {
@@ -201,24 +201,6 @@ export default (Commands, Cypress, cy, state) => {
         })
       }
 
-      const getOldValue = ($el) => {
-        const obj = state('select-old-value')
-
-        if (!obj) {
-          return null
-        }
-
-        return obj[$el]
-      }
-
-      const setOldValue = ($el, value) => {
-        const obj = state('select-old-value') || {}
-
-        obj[$el] = value
-
-        state('select-old-value', obj)
-      }
-
       return Promise
       .try(retryOptions)
       .then((obj = {}) => {
@@ -270,7 +252,7 @@ export default (Commands, Cypress, cy, state) => {
               interval: options.interval,
             })
           }).then(() => {
-            const oldValue = getOldValue(options.$el)
+            const oldValue = options.$el[0].selectedIndex
 
             // reset the selects value after we've
             // fired all the proper click events
@@ -301,12 +283,9 @@ export default (Commands, Cypress, cy, state) => {
 
             // https://github.com/cypress-io/cypress/issues/19494
             // When user selects the same option again, `input`, `change` events should not be fired.
-            // We're ignoring multiple select because it's physically impossible to select the same options again.
-            if (!options.$el.prop('multiple') && oldValue === values[0]) {
+            if (options.$el[0].selectedIndex === oldValue) {
               return
             }
-
-            setOldValue(options.$el, values[0])
 
             const input = new Event('input', {
               bubbles: true,


### PR DESCRIPTION
- Closes #19494

### User facing changelog

`change`, `input` events are not fired when the same option is selected again. 

### Additional details
- Why was this change necessary? => When the same `<option>` is selected, `change`, `input` events are not be fired in browsers, but Cypress does. 
- What is affected by this change? => N/A
- Any implementation details to explain? => I cache the selected old values and check them.

### How has the user experience changed?

**Before:** `cy.select` doesn't follow the browser behavior.
**After:** `cy.select` follows it. 

### PR Tasks
- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
