### PR TITLE
fix: remove close handler when req stream ends

### DIFF
--- a/packages/proxy/lib/http/request-middleware.ts
+++ b/packages/proxy/lib/http/request-middleware.ts
@@ -176,7 +176,8 @@ const SendRequestOutgoing: RequestMiddleware = function () {
 
   req.on('error', this.onError)
   req.on('response', (incomingRes) => this.onResponse(incomingRes, req))
-  req.once('finish', () => {
+
+  this.req.res?.on('finish', () => {
     socket.removeListener('close', onSocketClose)
   })
 


### PR DESCRIPTION
Getting a bunch of `MaxListenersExceededWarning` in the network layer without this