### PR TITLE
fix: send click event with `cy.type('{enter}')`.

### DIFF
--- a/packages/driver/cypress/fixtures/type-enter.html
+++ b/packages/driver/cypress/fixtures/type-enter.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>type('{enter}') </title>
+    <meta charset="UTF-8" />
+  </head>
+
+  <body>
+    <button id="reset">clear log</button>
+    <button id="target-button-tag">click me then press enter</button>
+    <input id="target-input-button" type="button" value="click me then press enter" />
+    <input id="target-input-image" type="image" value="click me then press enter" />
+    <input id="target-input-reset" type="reset" value="click me then press enter" />
+    <input id="target-input-submit" type="submit" value="click me then press enter" />
+    <input id="target-input-checkbox" type="checkbox" value="click me then press enter" />
+    <input id="target-input-radio" type="radio" value="click me then press enter" />
+
+    <div id="log"></div>
+
+    <script>
+      const reset = document.getElementById("reset");
+
+      let log = [];
+
+      reset.addEventListener("click", () => {
+        log = [];
+        updateLog();
+      });
+
+      const updateLog = (msg) => {
+        if (msg) {
+          log.push(msg);
+        }
+
+        const ol = document.createElement("ol");
+
+        log.forEach((text) => {
+          const node = document.createTextNode(text);
+          const li = document.createElement("li");
+          li.appendChild(node);
+          ol.appendChild(li);
+        });
+
+        document.getElementById("log").replaceChildren(ol);
+      };
+
+      const targets = [
+        'target-button-tag',
+        'target-input-button',
+        'target-input-image',
+        'target-input-reset',
+        'target-input-submit',
+        'target-input-checkbox',
+        'target-input-radio',
+      ]
+
+      targets.forEach((targetId) => {
+        const target = document.getElementById(targetId);
+
+        target.addEventListener("keydown", () => {
+          updateLog("keydown");
+        });
+        target.addEventListener("keypress", () => {
+          updateLog("keypress");
+        });
+        target.addEventListener("click", () => {
+          updateLog("click");
+        });
+        target.addEventListener("keyup", () => {
+          updateLog("keyup");
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/packages/driver/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_spec.js
@@ -574,14 +574,13 @@ describe('src/cy/commands/actions/type - #type', () => {
 
       targets.forEach((targetId) => {
         it(`${targetId}`, () => {
-          cy.get(`#target-${targetId}`).click()
+          cy.get(`#target-${targetId}`).focus()
           cy.get(`#target-${targetId}`).type('{enter}')
 
-          cy.get('li').eq(0).should('have.text', 'click')
-          cy.get('li').eq(1).should('have.text', 'keydown')
-          cy.get('li').eq(2).should('have.text', 'keypress')
-          cy.get('li').eq(3).should('have.text', 'click')
-          cy.get('li').eq(4).should('have.text', 'keyup')
+          cy.get('li').eq(0).should('have.text', 'keydown')
+          cy.get('li').eq(1).should('have.text', 'keypress')
+          cy.get('li').eq(2).should('have.text', 'click')
+          cy.get('li').eq(3).should('have.text', 'keyup')
         })
       })
     })
@@ -594,13 +593,12 @@ describe('src/cy/commands/actions/type - #type', () => {
 
       targets.forEach((targetId) => {
         it(`${targetId}`, () => {
-          cy.get(`#target-${targetId}`).click()
+          cy.get(`#target-${targetId}`).focus()
           cy.get(`#target-${targetId}`).type('{enter}')
 
-          cy.get('li').eq(0).should('have.text', 'click')
-          cy.get('li').eq(1).should('have.text', 'keydown')
-          cy.get('li').eq(2).should('have.text', 'keypress')
-          cy.get('li').eq(3).should('have.text', 'keyup')
+          cy.get('li').eq(0).should('have.text', 'keydown')
+          cy.get('li').eq(1).should('have.text', 'keypress')
+          cy.get('li').eq(2).should('have.text', 'keyup')
         })
       })
     })

--- a/packages/driver/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_spec.js
@@ -557,6 +557,55 @@ describe('src/cy/commands/actions/type - #type', () => {
     })
   })
 
+  // https://github.com/cypress-io/cypress/issues/19541
+  describe(`type('{enter}') and click event on button-like elements`, () => {
+    beforeEach(() => {
+      cy.visit('fixtures/type-enter.html')
+    })
+
+    describe('triggers', () => {
+      const targets = [
+        'button-tag',
+        'input-button',
+        'input-image',
+        'input-reset',
+        'input-submit',
+      ]
+
+      targets.forEach((targetId) => {
+        it(`${targetId}`, () => {
+          cy.get(`#target-${targetId}`).click()
+          cy.get(`#target-${targetId}`).type('{enter}')
+
+          cy.get('li').eq(0).should('have.text', 'click')
+          cy.get('li').eq(1).should('have.text', 'keydown')
+          cy.get('li').eq(2).should('have.text', 'keypress')
+          cy.get('li').eq(3).should('have.text', 'click')
+          cy.get('li').eq(4).should('have.text', 'keyup')
+        })
+      })
+    })
+
+    describe('does not trigger', () => {
+      const targets = [
+        'input-checkbox',
+        'input-radio',
+      ]
+
+      targets.forEach((targetId) => {
+        it(`${targetId}`, () => {
+          cy.get(`#target-${targetId}`).click()
+          cy.get(`#target-${targetId}`).type('{enter}')
+
+          cy.get('li').eq(0).should('have.text', 'click')
+          cy.get('li').eq(1).should('have.text', 'keydown')
+          cy.get('li').eq(2).should('have.text', 'keypress')
+          cy.get('li').eq(3).should('have.text', 'keyup')
+        })
+      })
+    })
+  })
+
   describe('tabindex', () => {
     beforeEach(function () {
       this.$div = cy.$$('#tabindex')

--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -275,7 +275,7 @@ export default function (Commands, Cypress, cy, state, config) {
       // click event is only fired on button, image, submit, reset elements.
       // That's why we cannot use $elements.isButtonLike() here.
       const type = (type) => $elements.isInputType(options.$el.get(0), type)
-      const isButtonLike = type('button') || type('image') || type('submit') || type('reset')
+      const sendClickEvent = type('button') || type('image') || type('submit') || type('reset')
 
       return keyboard.type({
         $el: options.$el,
@@ -362,7 +362,7 @@ export default function (Commands, Cypress, cy, state, config) {
 
           // https://github.com/cypress-io/cypress/issues/19541
           // Send click event on type('{enter}')
-          if (isButtonLike) {
+          if (sendClickEvent) {
             // Firefox sends a click event automatically.
             if (!Cypress.isBrowser('firefox')) {
               const ctor = $dom.getDocumentFromElement(el).defaultView?.PointerEvent

--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -272,6 +272,11 @@ export default function (Commands, Cypress, cy, state, config) {
       const isContentEditable = $elements.isContentEditable(options.$el.get(0))
       const isTextarea = $elements.isTextarea(options.$el.get(0))
 
+      // click event is only fired on button, image, submit, reset elements.
+      // That's why we cannot use $elements.isButtonLike() here.
+      const type = (type) => $elements.isInputType(options.$el.get(0), type)
+      const isButtonLike = type('button') || type('image') || type('submit') || type('reset')
+
       return keyboard.type({
         $el: options.$el,
         chars,
@@ -347,13 +352,24 @@ export default function (Commands, Cypress, cy, state, config) {
           })
         },
 
-        onEnterPressed (id) {
+        onEnterPressed (el) {
           // dont dispatch change events or handle
           // submit event if we've pressed enter into
           // a textarea or contenteditable
-
           if (isTextarea || isContentEditable) {
             return
+          }
+
+          // https://github.com/cypress-io/cypress/issues/19541
+          // Send click event on type('{enter}')
+          if (isButtonLike) {
+            // Firefox sends a click event automatically.
+            if (!Cypress.isBrowser('firefox')) {
+              const ctor = $dom.getDocumentFromElement(el).defaultView?.PointerEvent
+              const event = new ctor('click')
+
+              el.dispatchEvent(event)
+            }
           }
 
           // if our value has changed since our
@@ -362,7 +378,7 @@ export default function (Commands, Cypress, cy, state, config) {
           const changeEvent = state('changeEvent')
 
           if (changeEvent) {
-            changeEvent(id)
+            changeEvent()
           }
 
           // handle submit event handler here

--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -582,7 +582,7 @@ const simulatedDefaultKeyMap: { [key: string]: SimulatedDefault } = {
       $selection.replaceSelectionContents(el, '\n')
     }
 
-    options.onEnterPressed && options.onEnterPressed()
+    options.onEnterPressed && options.onEnterPressed(el)
   },
   Delete: (el, key) => {
     key.events.input = $selection.deleteRightOfCursor(el)


### PR DESCRIPTION
- Closes #19541

### User facing changelog

Send click event with `cy.type('{enter}')` on some button-like elements(`<button>` element, `button`, `reset`, `image`, `submit` input elements)

### Additional details
- Why was this change necessary? => Cypress doesn't reflect the browser behavior.
- What is affected by this change? => N/A
- Any implementation details to explain? => Click event is programatically sent on Chrome only. Firefox automatically sends click events. 

### How has the user experience changed?

**Before:** click event is not sent. 
**After:** click event is sent. 

### PR Tasks
- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
