### PR TITLE
chore: Percy nonce update

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -443,7 +443,7 @@ commands:
             cmd=$([[ <<parameters.percy>> == 'true' ]] && echo 'yarn percy exec --parallel -- --') || true
             CYPRESS_KONFIG_ENV=production \
             CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-            PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_ID \
+            PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
             PERCY_ENABLE=${PERCY_TOKEN:-0} \
             PERCY_PARALLEL_TOTAL=-1 \
             $cmd yarn workspace @packages/runner cypress:run --record --parallel --group runner-integration-<<parameters.browser>> --browser <<parameters.browser>>
@@ -484,7 +484,7 @@ commands:
             CYPRESS_INTERNAL_FORCE_BROWSER_RELAUNCH='true' \
             CYPRESS_KONFIG_ENV=production \
             CYPRESS_RECORD_KEY=$TEST_LAUNCHPAD_RECORD_KEY \
-            PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_ID \
+            PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
             PERCY_ENABLE=${PERCY_TOKEN:-0} \
             PERCY_PARALLEL_TOTAL=-1 \
             $cmd yarn workspace @packages/<<parameters.package>> cypress:run:<<parameters.type>> --browser <<parameters.browser>> --record --parallel --group <<parameters.package>>-<<parameters.type>>
@@ -508,14 +508,14 @@ commands:
       - run:
           command: |
             cmd=$([[ <<parameters.percy>> == 'true' ]] && echo 'yarn percy exec -- --') || true
-            PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_ID \
+            PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
             PERCY_ENABLE=${PERCY_TOKEN:-0} \
             PERCY_PARALLEL_TOTAL=-1 \
             $cmd yarn workspace @packages/runner-ct run cypress:run --browser <<parameters.browser>>
       - run:
           command: |
             if [[ <<parameters.percy>> == 'true' ]]; then
-              PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_ID \
+              PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
               PERCY_ENABLE=${PERCY_TOKEN:-0} \
               PERCY_PARALLEL_TOTAL=-1 \
               yarn percy upload packages/runner-ct/cypress/screenshots/screenshot.cy.tsx/percy
@@ -1102,7 +1102,7 @@ jobs:
               echo "This is an external PR, cannot access other services"
               circleci-agent step halt
             fi
-      - run: yarn percy build:finalize
+      - run: PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 yarn percy build:finalize
 
   cli-visual-tests:
     <<: *defaults
@@ -1123,7 +1123,7 @@ jobs:
       - run:
           name: Upload CLI snapshots for diffing
           command: |
-            PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_ID \
+            PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
             PERCY_ENABLE=${PERCY_TOKEN:-0} \
             PERCY_PARALLEL_TOTAL=-1 \
             yarn percy snapshot ./cli/visual-snapshots
@@ -1414,7 +1414,7 @@ jobs:
           command: |
             CYPRESS_KONFIG_ENV=production \
             CYPRESS_RECORD_KEY=$PACKAGES_RECORD_KEY \
-            PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_ID \
+            PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
             PERCY_ENABLE=${PERCY_TOKEN:-0} \
             PERCY_PARALLEL_TOTAL=-1 \
             yarn percy exec --parallel -- -- \
@@ -1556,7 +1556,7 @@ jobs:
           # will use PERCY_TOKEN environment variable if available
           command: |
             CYPRESS_KONFIG_ENV=production \
-            PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_ID \
+            PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
             PERCY_ENABLE=${PERCY_TOKEN:-0} \
             PERCY_PARALLEL_TOTAL=-1 \
             yarn percy exec --parallel -- -- \

--- a/circle.yml
+++ b/circle.yml
@@ -1080,8 +1080,7 @@ jobs:
           command: NODE_OPTIONS=--max_old_space_size=4096 yarn gulp checkTs
 
 
-  # a special job that keeps polling Circle and when all
-  # individual jobs are finished, it closes the Percy build
+# closes the Percy build when required jobs are passing
   percy-finalize:
     <<: *defaults
     parameters:
@@ -2193,8 +2192,7 @@ linux-workflow: &linux-workflow
           - run-frontend-shared-component-tests-chrome
           - run-launchpad-component-tests-chrome
           - run-launchpad-integration-tests-chrome
-          - runner-integration-tests-chrome
-          - runner-ct-integration-tests-chrome
+          - npm-design-system
     - lint-types:
         requires:
           - build


### PR DESCRIPTION
Percy builds created in parallel test runs are grouped together using a `PERCY_PARALLEL_NONCE` environment variable.

Right now we use `CIRCLE_WORKFLOW_ID` as the nonce. This causes a problem during "rerun from failed" in Circle CI. "Rerun from failed" creates a new workflow ID for the failed jobs, meaning that our earlier Percy builds become disconnected and `percy build:finalize` only applies to the snapshots taken during the last run that took place - the rerun that caused any outstanding required jobs to pass.

This PR changes the nonce we provide from `CIRCLE_WORKFLOW_ID` to `CIRCLE_SHA1`, the commit sha for the commit being built in CI. Using the commit sha for the nonce allows us to rerun flaky tests, and have the finalized Percy build include everything from that commit.

Merging this to 10.0-release should let us rerun any flaky tests on that branch to get full, clean Percy baselines that can be used for future PR diffs.