### PR TITLE
chore(workflows): merge develop into 10.0-release on push

### DIFF
--- a/.github/workflows/merge-develop-into-10.0-release.yml
+++ b/.github/workflows/merge-develop-into-10.0-release.yml
@@ -1,0 +1,78 @@
+name: Merge develop into 10.0-release
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  merge-develop-into-10-0-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.DEVELOP_PUSH_TOKEN }}
+      - name: Set committer info
+        run: |
+          git config --local user.email "$(git log --format='%ae' HEAD^!)"
+          git config --local user.name "$(git log --format='%an' HEAD^!)"
+      - name: Checkout 10.0-release branch
+        run: git checkout 10.0-release
+      - name: Check for merge conflict
+        id: check-conflict
+        run: echo "::set-output name=merge_conflict::$(git merge-tree $(git merge-base HEAD develop) develop HEAD | egrep '<<<<<<<')"
+      - name: Merge develop into 10.0-release
+        id: merge-develop
+        run: git merge develop
+        if: ${{ !steps.check-conflict.outputs.merge_conflict }}
+      - name: Failed merge, set merged status as failed
+        run: echo "::set-output name=merge_conflict::'failed merge'"
+        if: ${{ steps.merge-develop.outcome != 'success' }}
+      - name: Push
+        run: git push
+        if: ${{ !steps.check-conflict.outputs.merge_conflict }}
+      - name: Checkout develop
+        run: git checkout develop
+        if: ${{ steps.check-conflict.outputs.merge_conflict }}
+      - name: Determine name of new branch
+        id: gen-names
+        run: |
+          echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+          echo "::set-output name=branch_name::$(git rev-parse --short HEAD)-develop-into-10.0-release"
+        if: ${{ steps.check-conflict.outputs.merge_conflict }}
+      - name: Create a copy of develop on a new branch
+        run: git checkout -b ${{ steps.gen-names.outputs.branch_name }} develop
+        if: ${{ steps.check-conflict.outputs.merge_conflict }}
+      - name: Push branch to remote
+        run: git push origin ${{ steps.gen-names.outputs.branch_name }}
+        if: ${{ steps.check-conflict.outputs.merge_conflict }}
+      - name: Create Pull Request
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const pull = await github.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: '10.0-release',
+              head: '${{ steps.gen-names.outputs.branch_name }}',
+              title: 'chore: merge develop (${{ steps.gen-names.outputs.sha }}) into 10.0-release',
+              body: `There was a merge conflict when trying to automatically merge develop into 10.0-release. Please resolve the conflict and complete the merge.
+
+              DO NOT SQUASH AND MERGE
+
+              @${context.actor}`,
+              maintainer_can_modify: true,
+            })
+            await github.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pull.data.number,
+              reviewers: [context.actor],
+            })
+            await github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pull.data.number,
+              labels: ['auto-merge'],
+            })
+        if: ${{ steps.check-conflict.outputs.merge_conflict }}


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog

n/a

### Additional details

- As discussed in yesterday's unification sync, merge develop into 10.0-release on push, the same way we do for master into develop
- Demo of this working: https://github.com/flotwig/cypress-workflow-test/pull/1

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
