### PR TITLE
fix: Fix for pages disallowing unsafe-eval in their content-security-policy

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -349,6 +349,11 @@ declare namespace Cypress {
     backend: Backend
 
     /**
+     * Bridge function to ensure proper binding of events to application window.
+     */
+    bridgeContentWindowListener(...args: any[]): any
+
+    /**
      * Returns all configuration objects.
      * @see https://on.cypress.io/config
      * @example

--- a/npm/vite-dev-server/client/initCypressTests.js
+++ b/npm/vite-dev-server/client/initCypressTests.js
@@ -18,16 +18,6 @@ if (!CypressInstance) {
   throw new Error('Tests cannot run without a reference to Cypress!')
 }
 
-/**
- * When we create a listener from the runner for the AUT, we need to ensure the function
- * is sourced from the AUT, otherwise the event will not be associated correctly.
- *
- * We do this by creating a function from the AUT window, keeping in state to ensure we
- * only have a single fn
- *
- * https://github.com/cypress-io/cypress/pull/15995
- * https://github.com/cypress-io/cypress/issues/19697
- */
 CypressInstance.bridgeContentWindowListener = function (fn) {
   return function (...args) {
     fn.apply(this, args)

--- a/npm/vite-dev-server/client/initCypressTests.js
+++ b/npm/vite-dev-server/client/initCypressTests.js
@@ -18,6 +18,22 @@ if (!CypressInstance) {
   throw new Error('Tests cannot run without a reference to Cypress!')
 }
 
+/**
+ * When we create a listener from the runner for the AUT, we need to ensure the function
+ * is sourced from the AUT, otherwise the event will not be associated correctly.
+ *
+ * We do this by creating a function from the AUT window, keeping in state to ensure we
+ * only have a single fn
+ *
+ * https://github.com/cypress-io/cypress/pull/15995
+ * https://github.com/cypress-io/cypress/issues/19697
+ */
+CypressInstance.bridgeContentWindowListener = function (fn) {
+  return function (...args) {
+    fn.apply(this, args)
+  }
+}
+
 // load the support and spec
 CypressInstance.onSpecWindow(window, importsToLoad)
 

--- a/npm/vite-dev-server/client/initCypressTests.js
+++ b/npm/vite-dev-server/client/initCypressTests.js
@@ -29,8 +29,8 @@ if (!CypressInstance) {
  * https://github.com/cypress-io/cypress/issues/19697
  */
 CypressInstance.bridgeContentWindowListener = function (fn) {
-  return function () {
-    fn.apply(this, arguments)
+  return function (...args) {
+    fn.apply(this, args)
   }
 }
 

--- a/npm/vite-dev-server/client/initCypressTests.js
+++ b/npm/vite-dev-server/client/initCypressTests.js
@@ -18,22 +18,6 @@ if (!CypressInstance) {
   throw new Error('Tests cannot run without a reference to Cypress!')
 }
 
-/**
- * When we create a listener from the runner for the AUT, we need to ensure the function
- * is sourced from the AUT, otherwise the event will not be associated correctly.
- *
- * We do this by creating a function from the AUT window, keeping in state to ensure we
- * only have a single fn
- *
- * https://github.com/cypress-io/cypress/pull/15995
- * https://github.com/cypress-io/cypress/issues/19697
- */
-CypressInstance.bridgeContentWindowListener = function (fn) {
-  return function (...args) {
-    fn.apply(this, args)
-  }
-}
-
 // load the support and spec
 CypressInstance.onSpecWindow(window, importsToLoad)
 

--- a/npm/vite-dev-server/client/initCypressTests.js
+++ b/npm/vite-dev-server/client/initCypressTests.js
@@ -18,6 +18,22 @@ if (!CypressInstance) {
   throw new Error('Tests cannot run without a reference to Cypress!')
 }
 
+/**
+ * When we create a listener from the runner for the AUT, we need to ensure the function
+ * is sourced from the AUT, otherwise the event will not be associated correctly.
+ *
+ * We do this by creating a function from the AUT window, keeping in state to ensure we
+ * only have a single fn
+ *
+ * https://github.com/cypress-io/cypress/pull/15995
+ * https://github.com/cypress-io/cypress/issues/19697
+ */
+CypressInstance.bridgeContentWindowListener = function (fn) {
+  return function () {
+    fn.apply(this, arguments)
+  }
+}
+
 // load the support and spec
 CypressInstance.onSpecWindow(window, importsToLoad)
 

--- a/npm/webpack-dev-server/src/aut-runner.ts
+++ b/npm/webpack-dev-server/src/aut-runner.ts
@@ -7,16 +7,6 @@ export function init (importPromises: Array<() => Promise<void>>, parent: Window
     throw new Error('Tests cannot run without a reference to Cypress!')
   }
 
-  /**
-   * When we create a listener from the runner for the AUT, we need to ensure the function
-   * is sourced from the AUT, otherwise the event will not be associated correctly.
-   *
-   * We do this by creating a function from the AUT window, keeping in state to ensure we
-   * only have a single fn
-   *
-   * https://github.com/cypress-io/cypress/pull/15995
-   * https://github.com/cypress-io/cypress/issues/19697
-   */
   Cypress.bridgeContentWindowListener = function (fn) {
     return function () {
       // @ts-ignore

--- a/npm/webpack-dev-server/src/aut-runner.ts
+++ b/npm/webpack-dev-server/src/aut-runner.ts
@@ -19,7 +19,7 @@ export function init (importPromises: Array<() => Promise<void>>, parent: Window
    */
   Cypress.bridgeContentWindowListener = function (fn) {
     return function () {
-      fn.apply(this, arguments)
+      fn.apply(this as any, arguments)
     }
   }
 

--- a/npm/webpack-dev-server/src/aut-runner.ts
+++ b/npm/webpack-dev-server/src/aut-runner.ts
@@ -7,23 +7,6 @@ export function init (importPromises: Array<() => Promise<void>>, parent: Window
     throw new Error('Tests cannot run without a reference to Cypress!')
   }
 
-  /**
-   * When we create a listener from the runner for the AUT, we need to ensure the function
-   * is sourced from the AUT, otherwise the event will not be associated correctly.
-   *
-   * We do this by creating a function from the AUT window, keeping in state to ensure we
-   * only have a single fn
-   *
-   * https://github.com/cypress-io/cypress/pull/15995
-   * https://github.com/cypress-io/cypress/issues/19697
-   */
-  Cypress.bridgeContentWindowListener = function (fn) {
-    return function () {
-      // @ts-ignore
-      fn.apply(this, arguments)
-    }
-  }
-
   Cypress.onSpecWindow(window, importPromises)
   Cypress.action('app:window:before:load', window)
 }

--- a/npm/webpack-dev-server/src/aut-runner.ts
+++ b/npm/webpack-dev-server/src/aut-runner.ts
@@ -19,7 +19,8 @@ export function init (importPromises: Array<() => Promise<void>>, parent: Window
    */
   Cypress.bridgeContentWindowListener = function (fn) {
     return function () {
-      fn.apply(this as any, arguments)
+      // @ts-ignore
+      fn.apply(this, arguments)
     }
   }
 

--- a/npm/webpack-dev-server/src/aut-runner.ts
+++ b/npm/webpack-dev-server/src/aut-runner.ts
@@ -7,6 +7,23 @@ export function init (importPromises: Array<() => Promise<void>>, parent: Window
     throw new Error('Tests cannot run without a reference to Cypress!')
   }
 
+  /**
+   * When we create a listener from the runner for the AUT, we need to ensure the function
+   * is sourced from the AUT, otherwise the event will not be associated correctly.
+   *
+   * We do this by creating a function from the AUT window, keeping in state to ensure we
+   * only have a single fn
+   *
+   * https://github.com/cypress-io/cypress/pull/15995
+   * https://github.com/cypress-io/cypress/issues/19697
+   */
+  Cypress.bridgeContentWindowListener = function (fn) {
+    return function () {
+      // @ts-ignore
+      fn.apply(this, arguments)
+    }
+  }
+
   Cypress.onSpecWindow(window, importPromises)
   Cypress.action('app:window:before:load', window)
 }

--- a/npm/webpack-dev-server/src/aut-runner.ts
+++ b/npm/webpack-dev-server/src/aut-runner.ts
@@ -7,6 +7,22 @@ export function init (importPromises: Array<() => Promise<void>>, parent: Window
     throw new Error('Tests cannot run without a reference to Cypress!')
   }
 
+  /**
+   * When we create a listener from the runner for the AUT, we need to ensure the function
+   * is sourced from the AUT, otherwise the event will not be associated correctly.
+   *
+   * We do this by creating a function from the AUT window, keeping in state to ensure we
+   * only have a single fn
+   *
+   * https://github.com/cypress-io/cypress/pull/15995
+   * https://github.com/cypress-io/cypress/issues/19697
+   */
+  Cypress.bridgeContentWindowListener = function (fn) {
+    return function () {
+      fn.apply(this, arguments)
+    }
+  }
+
   Cypress.onSpecWindow(window, importPromises)
   Cypress.action('app:window:before:load', window)
 }

--- a/packages/driver/cypress/fixtures/nested/3975_a.html
+++ b/packages/driver/cypress/fixtures/nested/3975_a.html
@@ -1,4 +1,14 @@
 <html>
+  <head>
+    <meta charset="utf-8" />
+    <!--
+      Our initial attempts to fix issue 3785 caused issues on pages Disallowing 'unsafe-eval'.
+      Including this meta tag ensures that #3785 remains fixed without reintroducing #19697.
+
+      https://github.com/cypress-io/cypress/issues/19697
+    !-->
+    <meta http-equiv="Content-Security-Policy" content="script-src 'unsafe-inline'" />
+  </head>
   <script>
     var x = new XMLHttpRequest()
     x.onload = function() {

--- a/packages/driver/src/cypress/events.ts
+++ b/packages/driver/src/cypress/events.ts
@@ -119,16 +119,3 @@ export function extend (obj): Events {
   // return the events object
   return events as Events
 }
-
-/**
- * When we create a listener from the runner for the AUT, we need to ensure the function
- * is sourced from the AUT, otherwise the event will not be associated correctly.
- *
- * We do this by creating a function from the AUT window, keeping in state to ensure we
- * only have a single fn
- */
-export function makeContentWindowListener (fnName, contentWindow) {
-  return new contentWindow.Function(fnName, `return function() {
-    return ${fnName}.apply(this, arguments)
-  }`)
-}

--- a/packages/driver/src/cypress/server.ts
+++ b/packages/driver/src/cypress/server.ts
@@ -4,7 +4,6 @@ import minimatch from 'minimatch'
 
 import $errUtils from './error_utils'
 import $XHR from './xml_http_request'
-import { makeContentWindowListener } from './events'
 
 const regularResourcesRe = /\.(jsx?|coffee|html|less|s?css|svg)(\?.*)?$/
 const needsDashRe = /([a-z][A-Z])/g
@@ -400,8 +399,6 @@ export class Server {
     const { send, open, abort } = XHR.prototype
     const srh = XHR.prototype.setRequestHeader
 
-    const bridgeContentWindowListener = makeContentWindowListener('cypressXhrBridge', contentWindow)
-
     this.restoreFn = () => {
       // restore the property back on the window
       return _.each(
@@ -559,9 +556,9 @@ export class Server {
 
       // bail if eventhandlers have already been called to prevent
       // infinite recursion
-      overrides.onload = bridgeContentWindowListener(bailIfRecursive(onLoadFn))
-      overrides.onerror = bridgeContentWindowListener(bailIfRecursive(onErrorFn))
-      overrides.onreadystatechange = bridgeContentWindowListener(bailIfRecursive(onReadyStateFn))
+      overrides.onload = Cypress.bridgeContentWindowListener(bailIfRecursive(onLoadFn))
+      overrides.onerror = Cypress.bridgeContentWindowListener(bailIfRecursive(onErrorFn))
+      overrides.onreadystatechange = Cypress.bridgeContentWindowListener(bailIfRecursive(onReadyStateFn))
 
       props.forEach((prop) => {
         // if we currently have one of these properties then

--- a/packages/driver/src/cypress/server.ts
+++ b/packages/driver/src/cypress/server.ts
@@ -554,6 +554,17 @@ export class Server {
         }
       }
 
+      /**
+       * When we create a listener from the runner for the AUT, we need to ensure the function
+       * is sourced from the AUT, otherwise the event will not be associated correctly.
+       *
+       * We do this by creating a function from the AUT window, keeping in state to ensure we
+       * only have a single fn
+       *
+       * https://github.com/cypress-io/cypress/pull/15995
+       * https://github.com/cypress-io/cypress/issues/19697
+       */
+
       // bail if eventhandlers have already been called to prevent
       // infinite recursion
       overrides.onload = Cypress.bridgeContentWindowListener(bailIfRecursive(onLoadFn))

--- a/packages/runner/cypress/support/verify-failures.js
+++ b/packages/runner/cypress/support/verify-failures.js
@@ -170,6 +170,12 @@ const createVerifyTest = (modifier) => {
       return runIsolatedCypress(`cypress/fixtures/errors/${props.file}`, {
         visitUrl: props.visitUrl,
         onBeforeRun ({ specWindow, win, autCypress }) {
+          autCypress.bridgeContentWindowListener = function (fn) {
+            return function (...args) {
+              fn.apply(win, args)
+            }
+          }
+
           specWindow.testToRun = title
           specWindow.autWindow = win
           specWindow.autCypress = autCypress

--- a/packages/runner/injection/index.js
+++ b/packages/runner/injection/index.js
@@ -30,20 +30,4 @@ Cypress.on('app:timers:pause', timers.pause)
 
 timers.wrap()
 
-/**
- * When we create a listener from the runner for the AUT, we need to ensure the function
- * is sourced from the AUT, otherwise the event will not be associated correctly.
- *
- * We do this by creating a function from the AUT window, keeping in state to ensure we
- * only have a single fn
- *
- * https://github.com/cypress-io/cypress/pull/15995
- * https://github.com/cypress-io/cypress/issues/19697
- */
-Cypress.bridgeContentWindowListener = function (fn) {
-  return function () {
-    fn.apply(this, arguments)
-  }
-}
-
 Cypress.action('app:window:before:load', window)

--- a/packages/runner/injection/index.js
+++ b/packages/runner/injection/index.js
@@ -30,4 +30,20 @@ Cypress.on('app:timers:pause', timers.pause)
 
 timers.wrap()
 
+/**
+ * When we create a listener from the runner for the AUT, we need to ensure the function
+ * is sourced from the AUT, otherwise the event will not be associated correctly.
+ *
+ * We do this by creating a function from the AUT window, keeping in state to ensure we
+ * only have a single fn
+ *
+ * https://github.com/cypress-io/cypress/pull/15995
+ * https://github.com/cypress-io/cypress/issues/19697
+ */
+Cypress.bridgeContentWindowListener = function (fn) {
+  return function () {
+    fn.apply(this, arguments)
+  }
+}
+
 Cypress.action('app:window:before:load', window)

--- a/packages/server/lib/html/iframe.html
+++ b/packages/server/lib/html/iframe.html
@@ -13,6 +13,24 @@
         if (!Cypress) {
           throw new Error("Tests cannot run without a reference to Cypress!");
         }
+
+        /**
+         * When we create a listener from the runner for the AUT, we need to ensure the function
+         * is sourced from the AUT, otherwise the event will not be associated correctly.
+         *
+         * We do this by creating a function from the AUT window, keeping in state to ensure we
+         * only have a single fn
+         *
+         * https://github.com/cypress-io/cypress/pull/15995
+         * https://github.com/cypress-io/cypress/issues/19697
+         */
+        Cypress.bridgeContentWindowListener = function (fn) {
+          return function () {
+            // @ts-ignore
+            fn.apply(this, arguments)
+          }
+        }
+
         return Cypress.onSpecWindow(window, {{scripts | safe}});
       })(window.opener || window.parent);
     </script>

--- a/packages/server/lib/html/iframe.html
+++ b/packages/server/lib/html/iframe.html
@@ -14,21 +14,8 @@
           throw new Error("Tests cannot run without a reference to Cypress!");
         }
 
-        /**
-         * When we create a listener from the runner for the AUT, we need to ensure the function
-         * is sourced from the AUT, otherwise the event will not be associated correctly.
-         *
-         * We do this by creating a function from the AUT window, keeping in state to ensure we
-         * only have a single fn
-         *
-         * https://github.com/cypress-io/cypress/pull/15995
-         * https://github.com/cypress-io/cypress/issues/19697
-         */
         Cypress.bridgeContentWindowListener = function (fn) {
-          return function () {
-            // @ts-ignore
-            fn.apply(this, arguments)
-          }
+          return function () { fn.apply(this, arguments) }
         }
 
         return Cypress.onSpecWindow(window, {{scripts | safe}});

--- a/packages/server/test/support/fixtures/server/absolute_url_expected.html
+++ b/packages/server/test/support/fixtures/server/absolute_url_expected.html
@@ -9,6 +9,10 @@
         throw new Error('Something went terribly wrong and we cannot proceed. We expected to find the global Cypress in the parent window but it is missing!. This should never happen and likely is a bug. Please open an issue!');
       };
 
+      Cypress.bridgeContentWindowListener = function (fn) {
+        return function () { fn.apply(this, arguments) }
+      }
+
       window.onerror = function(){
         Cypress.onUncaughtException.apply(Cypress, arguments);
       }

--- a/packages/server/test/support/fixtures/server/absolute_url_expected.html
+++ b/packages/server/test/support/fixtures/server/absolute_url_expected.html
@@ -14,12 +14,6 @@
       }
     </script>
     <script type='text/javascript'>
-      Cypress.bridgeContentWindowListener = function (fn) {
-        return function () {
-          fn.apply(this, arguments)
-        }
-      }
-
       Cypress.action('app:window:before:load', window);
     </script>
     <meta charset="utf-8">

--- a/packages/server/test/support/fixtures/server/absolute_url_expected.html
+++ b/packages/server/test/support/fixtures/server/absolute_url_expected.html
@@ -14,6 +14,12 @@
       }
     </script>
     <script type='text/javascript'>
+      Cypress.bridgeContentWindowListener = function (fn) {
+        return function () {
+          fn.apply(this, arguments)
+        }
+      }
+
       Cypress.action('app:window:before:load', window);
     </script>
     <meta charset="utf-8">

--- a/packages/server/test/support/fixtures/server/expected_e2e_iframe.html
+++ b/packages/server/test/support/fixtures/server/expected_e2e_iframe.html
@@ -13,6 +13,11 @@
         if (!Cypress) {
           throw new Error("Tests cannot run without a reference to Cypress!");
         }
+
+        Cypress.bridgeContentWindowListener = function (fn) {
+          return function () { fn.apply(this, arguments) }
+        }
+
         return Cypress.onSpecWindow(window, [{"absolute":"/<path-to-project>/e2e/cypress/support/commands.js","relative":"cypress/support/commands.js","relativeUrl":"/__cypress/tests?p=cypress/support/commands.js"},{"absolute":"/<path-to-project>/e2e/cypress/integration/app_spec.coffee","relative":"cypress/integration/app_spec.coffee","relativeUrl":"/__cypress/tests?p=cypress/integration/app_spec.coffee"}]);
       })(window.opener || window.parent);
     </script>

--- a/packages/server/test/support/fixtures/server/expected_ids_all_tests_iframe.html
+++ b/packages/server/test/support/fixtures/server/expected_ids_all_tests_iframe.html
@@ -13,6 +13,11 @@
         if (!Cypress) {
           throw new Error("Tests cannot run without a reference to Cypress!");
         }
+
+        Cypress.bridgeContentWindowListener = function (fn) {
+          return function () { fn.apply(this, arguments) }
+        }
+
         return Cypress.onSpecWindow(window, [{"absolute":"/<path-to-project>/ids/cypress/support/index.js","relative":"cypress/support/index.js","relativeUrl":"/__cypress/tests?p=cypress/support/index.js"},{"absolute":"/<path-to-project>/ids/cypress/integration/bar.js","relative":"cypress/integration/bar.js","relativeUrl":"/__cypress/tests?p=cypress/integration/bar.js"},{"absolute":"/<path-to-project>/ids/cypress/integration/baz.js","relative":"cypress/integration/baz.js","relativeUrl":"/__cypress/tests?p=cypress/integration/baz.js"},{"absolute":"/<path-to-project>/ids/cypress/integration/dom.jsx","relative":"cypress/integration/dom.jsx","relativeUrl":"/__cypress/tests?p=cypress/integration/dom.jsx"},{"absolute":"/<path-to-project>/ids/cypress/integration/es6.js","relative":"cypress/integration/es6.js","relativeUrl":"/__cypress/tests?p=cypress/integration/es6.js"},{"absolute":"/<path-to-project>/ids/cypress/integration/foo.coffee","relative":"cypress/integration/foo.coffee","relativeUrl":"/__cypress/tests?p=cypress/integration/foo.coffee"},{"absolute":"/<path-to-project>/ids/cypress/integration/nested/tmp.js","relative":"cypress/integration/nested/tmp.js","relativeUrl":"/__cypress/tests?p=cypress/integration/nested/tmp.js"},{"absolute":"/<path-to-project>/ids/cypress/integration/noop.coffee","relative":"cypress/integration/noop.coffee","relativeUrl":"/__cypress/tests?p=cypress/integration/noop.coffee"}]);
       })(window.opener || window.parent);
     </script>

--- a/packages/server/test/support/fixtures/server/expected_ids_iframe.html
+++ b/packages/server/test/support/fixtures/server/expected_ids_iframe.html
@@ -13,6 +13,11 @@
         if (!Cypress) {
           throw new Error("Tests cannot run without a reference to Cypress!");
         }
+
+        Cypress.bridgeContentWindowListener = function (fn) {
+          return function () { fn.apply(this, arguments) }
+        }
+
         return Cypress.onSpecWindow(window, [{"absolute":"/<path-to-project>/ids/cypress/support/index.js","relative":"cypress/support/index.js","relativeUrl":"/__cypress/tests?p=cypress/support/index.js"},{"absolute":"/<path-to-project>/ids/cypress/integration/foo.coffee","relative":"cypress/integration/foo.coffee","relativeUrl":"/__cypress/tests?p=cypress/integration/foo.coffee"}]);
       })(window.opener || window.parent);
     </script>

--- a/packages/server/test/support/fixtures/server/expected_no_server_iframe.html
+++ b/packages/server/test/support/fixtures/server/expected_no_server_iframe.html
@@ -13,6 +13,11 @@
         if (!Cypress) {
           throw new Error("Tests cannot run without a reference to Cypress!");
         }
+
+        Cypress.bridgeContentWindowListener = function (fn) {
+          return function () { fn.apply(this, arguments) }
+        }
+
         return Cypress.onSpecWindow(window, [{"absolute":"/<path-to-project>/no-server/helpers/includes.js","relative":"helpers/includes.js","relativeUrl":"/__cypress/tests?p=helpers/includes.js"},{"absolute":"/<path-to-project>/no-server/my-tests/test1.js","relative":"my-tests/test1.js","relativeUrl":"/__cypress/tests?p=my-tests/test1.js"}]);
       })(window.opener || window.parent);
     </script>

--- a/packages/server/test/support/fixtures/server/expected_no_server_no_support_iframe.html
+++ b/packages/server/test/support/fixtures/server/expected_no_server_no_support_iframe.html
@@ -13,6 +13,11 @@
         if (!Cypress) {
           throw new Error("Tests cannot run without a reference to Cypress!");
         }
+
+        Cypress.bridgeContentWindowListener = function (fn) {
+          return function () { fn.apply(this, arguments) }
+        }
+
         return Cypress.onSpecWindow(window, [{"absolute":"/<path-to-project>/no-server/my-tests/test1.js","relative":"my-tests/test1.js","relativeUrl":"/__cypress/tests?p=my-tests/test1.js"}]);
       })(window.opener || window.parent);
     </script>


### PR DESCRIPTION
- Closes #19697 

### User facing changelog
Cypress tests will no longer error on pages including a CSP <meta> tag that disallows unsafe-eval.

### Additional details
In Cypress versions between 7.1.0 and 9.3.1, the following tag included in a document's <head> would cause Cypress to throw an error:
```
<meta http-equiv="Content-Security-Policy" content="script-src ''" />
```

This now functions as expected; Cypress no longer requires the application to allow `'unsafe-eval'`.

### How has the user experience changed?
No change for most users.

### PR Tasks
- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
