### PR TITLE
fix: Correctly parse single --spec globs containing a range

### DIFF
--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -250,7 +250,7 @@ const parseSpecArgv = (pattern) => {
   }
 
   if (!hasComma) {
-    return pattern
+    return [pattern]
   }
 
   // Get comma rules.

--- a/packages/server/test/unit/util/args_spec.js
+++ b/packages/server/test/unit/util/args_spec.js
@@ -177,6 +177,18 @@ describe('lib/util/args', () => {
       expect(options.spec[0]).to.eq(`${cwd}/cypress/integration/{[!a]*.spec.js,sub1,{sub2,sub3/sub4}}/*.js`)
       expect(options.spec[1]).to.eq(`${cwd}/cypress/integration/foo.spec.js`)
     })
+
+    it('should be correctly parsing single glob with range', function () {
+      const options = this.setup('--spec', 'cypress/integration/[a-c]*/**')
+
+      expect(options.spec[0]).to.eq(`${cwd}/cypress/integration/[a-c]*/**`)
+    })
+
+    it('should be correctly parsing single glob with list', function () {
+      const options = this.setup('--spec', 'cypress/integration/{a,b,c}/*.js')
+
+      expect(options.spec[0]).to.eq(`${cwd}/cypress/integration/{a,b,c}/*.js`)
+    })
   })
 
   context('--tag', () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #19783 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Corrects glob pattern matching for CLI parameter spec when glob contains a range. Fixes #19783 

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

When we detect range brackets within the glob, but no commas, we do not need to do any further parsing and can use the value directly. However, this branch of logic was returning a string and not the expected array, and an exception is thrown as a result. 

This change corrects that and adds additional tests for coverage.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [X] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
