### PR TITLE
fix: Wait for child process to be ready

### DIFF
--- a/packages/server/lib/plugins/child/run_plugins.js
+++ b/packages/server/lib/plugins/child/run_plugins.js
@@ -201,6 +201,8 @@ const runPlugins = (ipc, pluginsFile, projectRoot) => {
   ipc.on('execute', (event, ids, args) => {
     execute(ipc, event, ids, args)
   })
+
+  ipc.send('ready')
 }
 
 // for testing purposes

--- a/packages/server/lib/plugins/index.js
+++ b/packages/server/lib/plugins/index.js
@@ -153,7 +153,9 @@ const init = (config, options) => {
     Object.keys(config).sort().forEach((key) => orderedConfig[key] = config[key])
     config = orderedConfig
 
-    ipc.send('load', config)
+    ipc.on('ready', () => {
+      ipc.send('load', config)
+    })
 
     ipc.on('loaded', (newCfg, registrations) => {
       _.omit(config, 'projectRoot', 'configFile')


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
Fixes an issue where Cypress did not start. It also adds support for node's [experimental --loader feature](https://nodejs.org/api/esm.html#loaders) for plugins.

### Additional details
This PR fixes an issue in the `server` package where the plugin function gets never executed, leaving Cypress stuck in the init phase. In thise case, the UI just shows the loading spinner (could be the cause for https://github.com/cypress-io/cypress/issues/19782, and probably more...) . I've created a minimal reproducible test case at: https://github.com/jhnns/cypress-test-tiny/tree/native-esm-with-ts

The original code `fork()`s the process and immediately sends the `load` event. There's the implicit assumption that the child process is ready as soon as `fork()` returns which is not guaranteed afaik. The issue becomes apparent when using node's [experimental --loader feature](https://nodejs.org/api/esm.html#loaders) which may defer the process initialization.

The [test case](https://github.com/jhnns/cypress-test-tiny/tree/native-esm-with-ts) also demonstrates how this fix could enable TypeScript + native ESM in Cypress plugins (using `NODE_OPTIONS='--loader ts-node/esm/transpile-only'`)

*Obviously, this PR is not finished yet. I couldn't get the setup running on my Mac M1. So, I just wanted to send you this PR to get some feedback and maybe support on how to get this merged.*

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
