### PR TITLE
fix: wire up the step field and other migration fixes

### DIFF
--- a/packages/app/src/runs/RunsConnectSuccessAlert.vue
+++ b/packages/app/src/runs/RunsConnectSuccessAlert.vue
@@ -8,7 +8,10 @@
   >
     <p class="flex px-16px pt-16px leading-24px items-center">
       <i-cy-arrow-outline-right_x16 class="h-16px mr-8px w-16px inline align-middle icon-dark-jade-500" />
-      <i18n-t keypath="runs.connectSuccessAlert.item1">
+      <i18n-t
+        scope="global"
+        keypath="runs.connectSuccessAlert.item1"
+      >
         <template #projectId>
           <span class="font-normal m-4px text-jade-600">projectId</span>
         </template>
@@ -19,7 +22,10 @@
     </p>
     <p class="flex px-16px pt-16px pb-16px leading-24px items-center">
       <i-cy-arrow-outline-right_x16 class="h-16px mr-8px w-16px inline align-middle icon-dark-jade-500" />
-      <i18n-t keypath="runs.connectSuccessAlert.item2">
+      <i18n-t
+        scope="global"
+        keypath="runs.connectSuccessAlert.item2"
+      >
         <span class="font-normal m-4px text-jade-600">{{ configFilePath }}</span>
       </i18n-t>
     </p>

--- a/packages/app/src/runs/RunsErrorRenderer.vue
+++ b/packages/app/src/runs/RunsErrorRenderer.vue
@@ -7,7 +7,10 @@
     :message="t('runs.errors.notfound.title')"
     @button-click="showConnectDialog = true"
   >
-    <i18n-t keypath="runs.errors.notfound.description">
+    <i18n-t
+      scope="global"
+      keypath="runs.errors.notfound.description"
+    >
       <CodeTag
         bg
         class="bg-purple-50 text-purple-500"

--- a/packages/app/src/runs/modals/NeedManualUpdateModal.vue
+++ b/packages/app/src/runs/modals/NeedManualUpdateModal.vue
@@ -11,7 +11,10 @@
       icon-classes="icon-dark-orange-400"
     />
     <p class="mt-24px mb-16px text-16px leading-24px">
-      <i18n-t keypath="runs.connect.modal.connectManually.mainMessage">
+      <i18n-t
+        scope="global"
+        keypath="runs.connect.modal.connectManually.mainMessage"
+      >
         <template #projectId>
           <code class="border rounded border-gray-200 m-2px py-2px px-3px text-purple-500 text-16px">projectId</code>
         </template>

--- a/packages/data-context/__snapshots__/config-generator.spec.ts.js
+++ b/packages/data-context/__snapshots__/config-generator.spec.ts.js
@@ -2,9 +2,7 @@ exports['migration utils should create a string when passed only a global option
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
-  
-  visualViewport: 300
-,
+visualViewport: 300,
 })
 `
 
@@ -12,7 +10,6 @@ exports['migration utils should create a string when passed an empty object 1'] 
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
-  
 })
 `
 
@@ -20,14 +17,11 @@ exports['migration utils should create a string when passed only a e2e options 1
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
-  
   e2e: {
     setupNodeEvents(on, config) {
       return require('/cypress/plugins/index.js')
     },
-    
     baseUrl: 'localhost:3000'
-
   },
 })
 `
@@ -36,25 +30,19 @@ exports['migration utils should create a string for a config with global, compon
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
-  
-  visualViewport: 300
-,
+visualViewport: 300,
   e2e: {
     setupNodeEvents(on, config) {
       return require('/cypress/plugins/index.js')
     },
-    
     baseUrl: 'localhost:300',
     retries: 2
-
   },
   component: {
     setupNodeEvents(on, config) {
       return require('/cypress/plugins/index.js')
     },
-    
     retries: 1
-
   },
 })
 `
@@ -63,14 +51,11 @@ exports['migration utils should create a string when passed only a component opt
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
-  
   component: {
     setupNodeEvents(on, config) {
       return require('/cypress/plugins/index.js')
     },
-    
     retries: 2
-
   },
 })
 `
@@ -79,6 +64,5 @@ exports['migration utils should exclude fields that are no longer valid 1'] = `
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
-  
 })
 `

--- a/packages/data-context/__snapshots__/config-generator.spec.ts.js
+++ b/packages/data-context/__snapshots__/config-generator.spec.ts.js
@@ -2,7 +2,9 @@ exports['migration utils should create a string when passed only a global option
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
-  visualViewport: 300,
+  
+  visualViewport: 300
+,
 })
 `
 
@@ -23,7 +25,9 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       return require('/cypress/plugins/index.js')
     },
+    
     baseUrl: 'localhost:3000'
+
   },
 })
 `
@@ -32,19 +36,25 @@ exports['migration utils should create a string for a config with global, compon
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
-  visualViewport: 300,
+  
+  visualViewport: 300
+,
   e2e: {
     setupNodeEvents(on, config) {
       return require('/cypress/plugins/index.js')
     },
+    
     baseUrl: 'localhost:300',
     retries: 2
+
   },
   component: {
     setupNodeEvents(on, config) {
       return require('/cypress/plugins/index.js')
     },
+    
     retries: 1
+
   },
 })
 `
@@ -58,7 +68,9 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       return require('/cypress/plugins/index.js')
     },
+    
     retries: 2
+
   },
 })
 `

--- a/packages/data-context/__snapshots__/config-generator.spec.ts.js
+++ b/packages/data-context/__snapshots__/config-generator.spec.ts.js
@@ -1,7 +1,7 @@
 exports['migration utils should create a string when passed only a global option 1'] = `
 const { defineConfig } = require('cypress')
 
-module.export = defineConfig({
+module.exports = defineConfig({
   visualViewport: 300,
 })
 `
@@ -9,7 +9,7 @@ module.export = defineConfig({
 exports['migration utils should create a string when passed an empty object 1'] = `
 const { defineConfig } = require('cypress')
 
-module.export = defineConfig({
+module.exports = defineConfig({
   
 })
 `
@@ -17,7 +17,7 @@ module.export = defineConfig({
 exports['migration utils should create a string when passed only a e2e options 1'] = `
 const { defineConfig } = require('cypress')
 
-module.export = defineConfig({
+module.exports = defineConfig({
   
   e2e: {
     setupNodeEvents(on, config) {
@@ -31,7 +31,7 @@ module.export = defineConfig({
 exports['migration utils should create a string for a config with global, component, and e2e options 1'] = `
 const { defineConfig } = require('cypress')
 
-module.export = defineConfig({
+module.exports = defineConfig({
   visualViewport: 300,
   e2e: {
     setupNodeEvents(on, config) {
@@ -52,7 +52,7 @@ module.export = defineConfig({
 exports['migration utils should create a string when passed only a component options 1'] = `
 const { defineConfig } = require('cypress')
 
-module.export = defineConfig({
+module.exports = defineConfig({
   
   component: {
     setupNodeEvents(on, config) {
@@ -66,7 +66,7 @@ module.export = defineConfig({
 exports['migration utils should exclude fields that are no longer valid 1'] = `
 const { defineConfig } = require('cypress')
 
-module.export = defineConfig({
+module.exports = defineConfig({
   
 })
 `

--- a/packages/data-context/package.json
+++ b/packages/data-context/package.json
@@ -38,6 +38,7 @@
     "lodash": "4.17.21",
     "p-defer": "^3.0.0",
     "randomstring": "1.1.5",
+    "stringify-object": "^3.0.0",
     "underscore.string": "^3.3.5",
     "wonka": "^4.0.15"
   },
@@ -50,6 +51,7 @@
     "@packages/types": "0.0.0-development",
     "@types/dedent": "^0.7.0",
     "@types/ejs": "^3.1.0",
+    "@types/stringify-object": "^3.0.0",
     "mocha": "7.0.1",
     "rimraf": "3.0.2",
     "tslint": "^6.1.3"

--- a/packages/data-context/src/actions/MigrationActions.ts
+++ b/packages/data-context/src/actions/MigrationActions.ts
@@ -1,4 +1,4 @@
-import type { MIGRATION_STEPS } from '@packages/types'
+import { MIGRATION_STEPS } from '@packages/types'
 import type { DataContext } from '..'
 
 type MIGRATION_STEP = typeof MIGRATION_STEPS[number]
@@ -19,6 +19,11 @@ export class MigrationActions {
     })
   }
 
+  initialize () {
+    // FIXME: stop watchers before migrating
+    this.setStep(MIGRATION_STEPS[0])
+  }
+
   async renameSpecFiles () {
     // TODO: implement the renaming of spec files here
   }
@@ -29,7 +34,7 @@ export class MigrationActions {
   }
 
   async startWizardReconfiguration () {
-    // TODO: implement reconfiguration of component testing
+    // TODO: start component testing config wizard here
   }
 
   setStep (step: MIGRATION_STEP) {

--- a/packages/data-context/src/actions/MigrationActions.ts
+++ b/packages/data-context/src/actions/MigrationActions.ts
@@ -12,8 +12,6 @@ export class MigrationActions {
       throw error
     })
 
-    this.ctx.lifecycleManager.refreshMetaState()
-
     await this.ctx.actions.file.removeFileInProject('cypress.json').catch((error) => {
       throw error
     })
@@ -34,7 +32,9 @@ export class MigrationActions {
   }
 
   async startWizardReconfiguration () {
-    // TODO: start component testing config wizard here
+    this.ctx.lifecycleManager.initializeConfigWatchers()
+    this.ctx.lifecycleManager.refreshMetaState()
+    this.ctx.lifecycleManager.setCurrentTestingType('component')
   }
 
   setStep (step: MIGRATION_STEP) {

--- a/packages/data-context/src/actions/MigrationActions.ts
+++ b/packages/data-context/src/actions/MigrationActions.ts
@@ -28,7 +28,7 @@ export class MigrationActions {
     return
   }
 
-  async reconfigureComponent () {
+  async startWizardReconfiguration () {
     // TODO: implement reconfiguration of component testing
   }
 

--- a/packages/data-context/src/actions/MigrationActions.ts
+++ b/packages/data-context/src/actions/MigrationActions.ts
@@ -1,5 +1,7 @@
+import type { MIGRATION_STEPS } from '@packages/types'
 import type { DataContext } from '..'
 
+type MIGRATION_STEP = typeof MIGRATION_STEPS[number]
 export class MigrationActions {
   constructor (private ctx: DataContext) { }
 
@@ -15,5 +17,14 @@ export class MigrationActions {
     await this.ctx.actions.file.removeFileInProject('cypress.json').catch((error) => {
       throw error
     })
+  }
+
+  async renameSpecFiles () {
+    // here be dragons
+    return
+  }
+
+  setStep (step: MIGRATION_STEP) {
+    this.ctx.migration.setStep(step)
   }
 }

--- a/packages/data-context/src/actions/MigrationActions.ts
+++ b/packages/data-context/src/actions/MigrationActions.ts
@@ -20,8 +20,16 @@ export class MigrationActions {
   }
 
   async renameSpecFiles () {
-    // here be dragons
+    // TODO: implement the renaming of spec files here
+  }
+
+  async renameSupportFile () {
+    // TODO: build rename of support file
     return
+  }
+
+  async reconfigureComponent () {
+    // TODO: implement reconfiguration of component testing
   }
 
   setStep (step: MIGRATION_STEP) {

--- a/packages/data-context/src/data/ProjectLifecycleManager.ts
+++ b/packages/data-context/src/data/ProjectLifecycleManager.ts
@@ -257,7 +257,7 @@ export class ProjectLifecycleManager {
       s.currentProject = projectRoot
     })
 
-    this.refreshMetaState()
+    const { needsCypressJsonMigration } = this.refreshMetaState()
 
     this.configFileWarningCheck()
 
@@ -274,7 +274,15 @@ export class ProjectLifecycleManager {
       this.setCurrentTestingType(this.ctx.coreData.currentTestingType)
     }
 
-    this.initializeConfigWatchers()
+    // If migration is needed only initialize the watchers
+    // when the migration is done.
+    //
+    // NOTE: If we watch the files while initializing,
+    // the config will be loaded before the migration is complete.
+    // The migration screen will disappear see `Main.vue` & `MigrationAction.ts`
+    if (!needsCypressJsonMigration) {
+      this.initializeConfigWatchers()
+    }
   }
 
   setRunModeExitEarly (exitEarly: ((err: Error) => void) | undefined) {
@@ -571,7 +579,7 @@ export class ProjectLifecycleManager {
    * Initializes the "watchers" for the current
    * config for "open" mode.
    */
-  private initializeConfigWatchers () {
+  initializeConfigWatchers () {
     if (this.ctx.isRunMode) {
       return
     }

--- a/packages/data-context/src/sources/MigrationDataSource.ts
+++ b/packages/data-context/src/sources/MigrationDataSource.ts
@@ -1,9 +1,13 @@
 import path from 'path'
+import type { MIGRATION_STEPS } from '@packages/types'
 import type { DataContext } from '..'
 import { createConfigString } from '../util/migration'
 
+type MIGRATION_STEP = typeof MIGRATION_STEPS[number]
+
 export class MigrationDataSource {
   private _config: Cypress.ConfigOptions | null = null
+  private _step: MIGRATION_STEP = 'renameAuto'
   constructor (private ctx: DataContext) { }
 
   async getConfig () {
@@ -60,5 +64,13 @@ export class MigrationDataSource {
     }
 
     return {}
+  }
+
+  get step (): MIGRATION_STEP {
+    return this._step
+  }
+
+  setStep (step: MIGRATION_STEP) {
+    this._step = step
   }
 }

--- a/packages/data-context/src/util/config-file-updater.ts
+++ b/packages/data-context/src/util/config-file-updater.ts
@@ -5,6 +5,7 @@ import { visit } from 'recast'
 import type { namedTypes } from 'ast-types'
 import Debug from 'debug'
 import * as fs from 'fs/promises'
+import stringify from 'stringify-object'
 
 const debug = Debug('cypress:data-context:config-file-updater')
 
@@ -19,7 +20,7 @@ export async function insertValuesInConfigFile (file: string, obj: {}, errors: E
 
   debug('transformedFileContents %s', transformedFileContents)
   await fs.writeFile(file, transformedFileContents).catch((e) => {
-    throw new Error(`Failed to update config file ${file} with ${JSON.stringify(obj)}: ${e.message}`)
+    throw new Error(`Failed to update config file ${file} with ${stringify(obj)}: ${e.message}`)
   })
 }
 
@@ -177,7 +178,7 @@ function setRootKeysSplicers (
   debug('keys to instert %O', keysToInsert)
 
   if (keysToInsert.length) {
-    const valuesInserted = `\n${lineStartSpacer}${ keysToInsert.map((key) => `${key}: ${JSON.stringify(obj[key])},`).join(`\n${lineStartSpacer}`)}`
+    const valuesInserted = `\n${lineStartSpacer}${ keysToInsert.map((key) => `${key}: ${stringify(obj[key])},`).join(`\n${lineStartSpacer}`)}`
 
     splicers.push({
       start: objectLiteralStartIndex,
@@ -231,7 +232,7 @@ function setSubKeysSplicers (
   for (const key in keysToInsertForSubKeys) {
     subvaluesInserted += `\n${parentLineStartSpacer}${key}: {`
     keysToInsertForSubKeys[key]?.forEach((subkey) => {
-      subvaluesInserted += `\n${parentLineStartSpacer}${lineStartSpacer}${subkey}: ${JSON.stringify(obj[key][subkey])},`
+      subvaluesInserted += `\n${parentLineStartSpacer}${lineStartSpacer}${subkey}: ${stringify(obj[key][subkey])},`
     })
 
     subvaluesInserted += `\n${parentLineStartSpacer}},`
@@ -270,7 +271,7 @@ function setSplicerToUpdateProperty (splicers: Splicer[],
     splicers.push({
       start: (propertyToUpdate.value as any).start,
       end: (propertyToUpdate.value as any).end,
-      replaceString: JSON.stringify(updatedValue),
+      replaceString: stringify(updatedValue),
     })
   } else {
     debug('error', propertyToUpdate?.value)

--- a/packages/data-context/src/util/migration.ts
+++ b/packages/data-context/src/util/migration.ts
@@ -51,14 +51,13 @@ function reduceConfig (cfg: Partial<Cypress.ConfigOptions>) {
 }
 
 function createCypressConfigJs (config: ConfigOptions, pluginPath: string) {
-  const globalString = Object.keys(config.global).length > 0 ? `${formatObjectForConfig(config.global, 2)},` : ''
+  const globalString = Object.keys(config.global).length > 0 ? `\n${formatObjectForConfig(config.global, 2)},` : ''
   const componentString = Object.keys(config.component).length > 0 ? createTestingTypeTemplate('component', pluginPath, config.component) : ''
   const e2eString = Object.keys(config.e2e).length > 0 ? createTestingTypeTemplate('e2e', pluginPath, config.e2e) : ''
 
   return `const { defineConfig } = require('cypress')
 
-module.exports = defineConfig({
-  ${globalString}${e2eString}${componentString}
+module.exports = defineConfig({${globalString}${e2eString}${componentString}
 })`
 }
 
@@ -66,6 +65,7 @@ function formatObjectForConfig (obj: Record<string, unknown>, spaces: number) {
   return stringify(obj, {
     indent: Array(spaces).fill(' ').join(''),
   }).replace(/^[{]|[}]$/g, '') // remove opening and closing {}
+  .trim() // remove trailing spaces
 }
 
 function createTestingTypeTemplate (testingType: 'e2e' | 'component', pluginPath: string, options: Record<string, unknown>) {

--- a/packages/data-context/src/util/migration.ts
+++ b/packages/data-context/src/util/migration.ts
@@ -1,4 +1,4 @@
-import dedent from 'dedent'
+import stringify from 'stringify-object'
 import path from 'path'
 
 type ConfigOptions = {
@@ -63,15 +63,13 @@ module.exports = defineConfig({
 }
 
 function formatObjectForConfig (obj: Record<string, unknown>, spaces: number) {
-  return JSON.stringify(obj, null, spaces)
-  .replace(/"([^"]+)":/g, '$1:') // remove quotes from fields
-  .replace(/^[{]|[}]$/g, '') // remove opening and closing {}
-  .replace(/"/g, '\'') // single quotes
-  .trim()
+  return stringify(obj, {
+    indent: Array(spaces).fill(' ').join(''),
+  }).replace(/^[{]|[}]$/g, '') // remove opening and closing {}
 }
 
 function createTestingTypeTemplate (testingType: 'e2e' | 'component', pluginPath: string, options: Record<string, unknown>) {
-  return dedent`
+  return `
   ${testingType}: {
     setupNodeEvents(on, config) {
       return require('${pluginPath}')

--- a/packages/data-context/src/util/migration.ts
+++ b/packages/data-context/src/util/migration.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent'
 import path from 'path'
 
 type ConfigOptions = {
@@ -56,7 +57,7 @@ function createCypressConfigJs (config: ConfigOptions, pluginPath: string) {
 
   return `const { defineConfig } = require('cypress')
 
-module.export = defineConfig({
+module.exports = defineConfig({
   ${globalString}${e2eString}${componentString}
 })`
 }
@@ -70,7 +71,7 @@ function formatObjectForConfig (obj: Record<string, unknown>, spaces: number) {
 }
 
 function createTestingTypeTemplate (testingType: 'e2e' | 'component', pluginPath: string, options: Record<string, unknown>) {
-  return `
+  return dedent`
   ${testingType}: {
     setupNodeEvents(on, config) {
       return require('${pluginPath}')

--- a/packages/data-context/test/unit/code-generator.spec.ts
+++ b/packages/data-context/test/unit/code-generator.spec.ts
@@ -95,12 +95,12 @@ describe('code-generator', () => {
     mTimesAfter.forEach((time, i) => expect(time > mTimesBefore[i]))
   })
 
-  it('should generate from integration template', async () => {
+  it('should generate from e2e template', async () => {
     const fileName = 'my-integration-file.js'
     const target = path.join(tmpPath, 'integration')
     const fileAbsolute = path.join(target, fileName)
     const action: Action = {
-      templateDir: templates.integration,
+      templateDir: templates.e2e,
       target,
     }
     const codeGenArgs = { fileName }
@@ -112,12 +112,12 @@ describe('code-generator', () => {
           type: 'text',
           status: 'add',
           file: fileAbsolute,
-          content: dedent`
+          content: `${dedent`
             describe('my-integration-file.js', () => {
               it('should visit', () => {
                 cy.visit('/')
               })
-            })`,
+            })` }\n`,
         },
       ],
       failed: [],

--- a/packages/data-context/test/unit/config-file-updater.spec.ts
+++ b/packages/data-context/test/unit/config-file-updater.spec.ts
@@ -25,7 +25,7 @@ describe('lib/util/config-file-updater', () => {
 
           const expectedOutput = stripIndent`\
             export default {
-              projectId: "id1234",
+              projectId: 'id1234',
               viewportWidth: 400,
               foo: 42,
             }
@@ -45,7 +45,7 @@ describe('lib/util/config-file-updater', () => {
 
           const expectedOutput = stripIndent`\
             module.exports = {
-              projectId: "id1234",
+              projectId: 'id1234',
               viewportWidth: 400,
               foo: 42,
             }
@@ -62,7 +62,7 @@ describe('lib/util/config-file-updater', () => {
             `
 
           const expectedOutput = stripIndent`\
-            module.exports = { 'projectId': "id1234"}
+            module.exports = { 'projectId': 'id1234'}
           `
 
           const output = await insertValueInJSString(src, { projectId: 'id1234' }, errors)
@@ -73,15 +73,15 @@ describe('lib/util/config-file-updater', () => {
         it('works with and without the quotes around keys', async () => {
           const src = stripIndent`\
               export default {
-                "foo": 42,
+                'foo': 42,
               }
             `
 
           const expectedOutput = stripIndent`\
               export default {
-                projectId: "id1234",
+                projectId: 'id1234',
                 viewportWidth: 400,
-                "foo": 42,
+                'foo': 42,
               }
             `
 
@@ -94,16 +94,16 @@ describe('lib/util/config-file-updater', () => {
       describe('defineConfig', () => {
         it('skips defineConfig and add to the object inside', async () => {
           const src = stripIndent`\
-              import { defineConfig } from "cypress"
+              import { defineConfig } from 'cypress'
               export default defineConfig({
                 foo: 42,
               })
             `
 
           const expectedOutput = stripIndent`\
-              import { defineConfig } from "cypress"
+              import { defineConfig } from 'cypress'
               export default defineConfig({
-                projectId: "id1234",
+                projectId: 'id1234',
                 viewportWidth: 400,
                 foo: 42,
               })
@@ -116,16 +116,16 @@ describe('lib/util/config-file-updater', () => {
 
         it('skips defineConfig even if it renamed in an import (es6)', async () => {
           const src = stripIndent`\
-              import { defineConfig as cy_defineConfig } from "cypress"
+              import { defineConfig as cy_defineConfig } from 'cypress'
               export default cy_defineConfig({
                 foo: 42,
               })
             `
 
           const expectedOutput = stripIndent`\
-              import { defineConfig as cy_defineConfig } from "cypress"
+              import { defineConfig as cy_defineConfig } from 'cypress'
               export default cy_defineConfig({
-                projectId: "id1234",
+                projectId: 'id1234',
                 viewportWidth: 400,
                 foo: 42,
               })
@@ -138,16 +138,16 @@ describe('lib/util/config-file-updater', () => {
 
         it('skips defineConfig even if it renamed in a require (es5)', async () => {
           const src = stripIndent`\
-              const { defineConfig: cy_defineConfig } = require("cypress")
+              const { defineConfig: cy_defineConfig } = require('cypress')
               module.exports = cy_defineConfig({
                 foo: 42,
               })
             `
 
           const expectedOutput = stripIndent`\
-              const { defineConfig: cy_defineConfig } = require("cypress")
+              const { defineConfig: cy_defineConfig } = require('cypress')
               module.exports = cy_defineConfig({
-                projectId: "id1234",
+                projectId: 'id1234',
                 viewportWidth: 400,
                 foo: 42,
               })
@@ -230,7 +230,7 @@ describe('lib/util/config-file-updater', () => {
 
           const expectedOutput = stripIndent`\
             export default {
-              projectId: "id1234",
+              projectId: 'id1234',
               foo: 1000,
               bar: 3000,
               'component': {
@@ -260,7 +260,7 @@ describe('lib/util/config-file-updater', () => {
           const expectedOutput = stripIndent`\
               module.exports = {
                 component: {
-                  specFilePattern: "src/**/*.spec.cy.js",
+                  specFilePattern: 'src/**/*.spec.cy.js',
                 },
                 foo: 42
               }
@@ -284,7 +284,7 @@ describe('lib/util/config-file-updater', () => {
           const expectedOutput = stripIndent`\
             module.exports = {
               'component': {
-                specFilePattern: "src/**/*.spec.cy.js",
+                specFilePattern: 'src/**/*.spec.cy.js',
                 viewportWidth: 800
               },
               foo: 42
@@ -310,7 +310,7 @@ describe('lib/util/config-file-updater', () => {
           module.exports = {
             foo: 42,
             component: {
-              specFilePattern: "src/**/*.spec.cy.js",
+              specFilePattern: 'src/**/*.spec.cy.js',
               foo: 82
             }
           }`

--- a/packages/frontend-shared/cypress/support/mock-graphql/stubgql-Migration.ts
+++ b/packages/frontend-shared/cypress/support/mock-graphql/stubgql-Migration.ts
@@ -49,4 +49,6 @@ export const stubMigration: MaybeResolver<Migration> = {
   })`,
   integrationFolder: 'cypress/integration',
   componentFolder: 'cypress/component',
+  supportFileBefore: 'cypress/support/index.js',
+  supportFileAfter: 'cypress/support/e2e.js',
 }

--- a/packages/frontend-shared/cypress/support/mock-graphql/stubgql-Migration.ts
+++ b/packages/frontend-shared/cypress/support/mock-graphql/stubgql-Migration.ts
@@ -3,7 +3,7 @@ import type { MaybeResolver } from './clientTestUtils'
 
 export const stubMigration: MaybeResolver<Migration> = {
   __typename: 'Migration',
-  step: `renameManual`,
+  step: `renameAuto`,
 
   specFilesBefore: [
     'cypress/integration/app_spec.js',

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -529,6 +529,13 @@
       "willConvert": "We'll automatically create a new {jsFile} file and seed it with your options from your existing {jsonFile}.",
       "removeJson": "We'll remove your existing {0} as part of this step."
     },
+    "setupComponent": {
+      "title": "You need to reconfigure Cypress for component testing",
+      "line1": "We've detected that you are currently using the experimental version of component testing.",
+      "line2": "Your existing configuration is no longer compatible with new component testing configuration options.",
+      "line3": "In a previous step, we renamed your component specs, but can't automatically migrate your existing component testing configuration.",
+      "line4": "In the next screen, you'll be able to reconfigure component testing in a new guided configuration wizard."
+    },
     "wizard": {
       "title": "Migration Helper",
       "description": "Complete the steps below to migrate your project to Cypress 10",

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -523,6 +523,11 @@
       "cannotAuto": "We can't automatically migrate your existing component spec files. We recommend that you move the following component spec files next to your source component files (e.g. {0})",
       "ifSkipNote": "If you skip this step, Cypress will still be able to find them, but any new specs that you create will automatically be created next to your component files."
     },
+    "renameSupport": {
+      "title": "We'll automatically rename your existing E2E support file in this step",
+      "serveDifferentTypes": "We now serve different support files for E2E and component testing.",
+      "changedSupportFile": "We've renamed the E2E support file from:"
+    },
     "configFile": {
       "title": "We need to move the Cypress configuration file",
       "changedTheFile": "We've removed {jsonFile} in favor of a {jsFile} file.",

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -535,7 +535,8 @@
       "step1": {
         "title": "Automatically rename existing specs",
         "description": "In this step, we'll automatically rename and move your existing spec files.",
-        "button": "Rename these specs for me"
+        "button": "Rename these specs for me",
+        "buttonSkip": "Skip renaming specs"
       },
       "step2": {
         "title": "Manually move your existing component specs",

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -545,9 +545,19 @@
         "button": "I'll do this later"
       },
       "step3": {
+        "title": "Rename the Cypress support file",
+        "description": "In this step, we'll automatically rename your existing support file.",
+        "button": "Rename the support file for me"
+      },
+      "step4": {
         "title": "Automatically migrate the Cypress configuration file",
         "description": "In this step, we'll automatically migrate your existing cypress configuration to the new Cypress configuration file.",
-        "button": "Migrate and continue"
+        "button": "Migrate the configuration for me"
+      },
+      "step5": {
+        "title": "Reconfigure component testing",
+        "description": "In this step, we'll explain how you will reconfigure Cypress for component testing.",
+        "button": "Finish migration and continue"
       }
     }
   },

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -628,6 +628,12 @@ type Mutation {
   """Transforms cypress.json file into cypress.config.js file"""
   migrateConfigFile: Boolean
 
+  """While migrating to 10+ renames files to match the new .cy pattern"""
+  migrateRenameSpecs(skip: Boolean): Query
+
+  """While migrating to 10+ skip manual rename step"""
+  migrateSkipManualRename: Query
+
   """Open a path in preferred IDE"""
   openDirectoryInIDE(path: String!): Boolean
   openExternal(url: String!): Boolean

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -634,10 +634,10 @@ type Mutation {
   matchesSpecPattern(specFile: String!): Boolean!
 
   """Merges the component testing config in cypress.config.{js,ts}"""
-  migrateComponentTesting: Boolean
+  migrateComponentTesting: Query
 
   """Transforms cypress.json file into cypress.config.js file"""
-  migrateConfigFile: Boolean
+  migrateConfigFile: Query
 
   """While migrating to 10+ renames files to match the new .cy pattern"""
   migrateRenameSpecs(skip: Boolean): Query
@@ -647,6 +647,9 @@ type Mutation {
 
   """While migrating to 10+ skip manual rename step"""
   migrateSkipManualRename: Query
+
+  """Initialize the migration wizard to the first step"""
+  migrateStart: Query
 
   """Open a path in preferred IDE"""
   openDirectoryInIDE(path: String!): Boolean

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -566,12 +566,20 @@ type Migration {
 
   """Step where the migration is right now"""
   step: MigrationStepEnum!
+
+  """Support files after rename"""
+  supportFileAfter: String!
+
+  """Support files needing automated rename"""
+  supportFileBefore: String!
 }
 
 enum MigrationStepEnum {
   configFile
   renameAuto
   renameManual
+  renameSupport
+  setupComponent
 }
 
 type Mutation {
@@ -625,11 +633,17 @@ type Mutation {
   """Check if a give spec file will match the project spec pattern"""
   matchesSpecPattern(specFile: String!): Boolean!
 
+  """Merges the component testing config in cypress.config.{js,ts}"""
+  migrateComponentTesting: Boolean
+
   """Transforms cypress.json file into cypress.config.js file"""
   migrateConfigFile: Boolean
 
   """While migrating to 10+ renames files to match the new .cy pattern"""
   migrateRenameSpecs(skip: Boolean): Query
+
+  """While migrating to 10+ launch renaming of support file"""
+  migrateRenameSupport: Query
 
   """While migrating to 10+ skip manual rename step"""
   migrateSkipManualRename: Query

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Migration.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Migration.ts
@@ -40,6 +40,20 @@ export const Migration = objectType({
       },
     })
 
+    t.nonNull.string('supportFileBefore', {
+      description: 'Support files needing automated rename',
+      resolve: () => {
+        return 'cypress/support/index.js'
+      },
+    })
+
+    t.nonNull.string('supportFileAfter', {
+      description: 'Support files after rename',
+      resolve: () => {
+        return 'cypress/support/e2e.js'
+      },
+    })
+
     t.nonNull.string('configBeforeCode', {
       description: 'contents of the cypress.json file before conversion',
       resolve: (source, args, ctx) => {

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Migration.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Migration.ts
@@ -14,7 +14,9 @@ export const Migration = objectType({
     t.nonNull.field('step', {
       type: MigrationStepEnum,
       description: 'Step where the migration is right now',
-      resolve: () => 'configFile',
+      resolve: (source, args, ctx) => {
+        return ctx.migration.step
+      },
     })
 
     t.nonNull.list.nonNull.string('specFilesBefore', {

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Mutation.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Mutation.ts
@@ -419,6 +419,38 @@ export const mutation = mutationType({
       },
     })
 
+    t.field('migrateRenameSpecs', {
+      description: 'While migrating to 10+ renames files to match the new .cy pattern',
+      type: Query,
+      args: {
+        skip: booleanArg(),
+      },
+      resolve: async (_, { skip }, ctx) => {
+        if (!skip) {
+          try {
+            await ctx.actions.migration.renameSpecFiles()
+          } catch (e) {
+            // add the error to an error stack
+            return {}
+          }
+        }
+
+        ctx.actions.migration.setStep('renameManual')
+
+        return {}
+      },
+    })
+
+    t.field('migrateSkipManualRename', {
+      description: 'While migrating to 10+ skip manual rename step',
+      type: Query,
+      resolve: async (_, args, ctx) => {
+        ctx.actions.migration.setStep('configFile')
+
+        return {}
+      },
+    })
+
     t.field('migrateConfigFile', {
       description: 'Transforms cypress.json file into cypress.config.js file',
       type: 'Boolean',

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Mutation.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Mutation.ts
@@ -419,6 +419,16 @@ export const mutation = mutationType({
       },
     })
 
+    t.field('migrateStart', {
+      description: 'Initialize the migration wizard to the first step',
+      type: Query,
+      resolve: async (_, args, ctx) => {
+        ctx.actions.migration.initialize()
+
+        return {}
+      },
+    })
+
     t.field('migrateRenameSpecs', {
       description: 'While migrating to 10+ renames files to match the new .cy pattern',
       type: Query,
@@ -469,30 +479,31 @@ export const mutation = mutationType({
 
     t.field('migrateConfigFile', {
       description: 'Transforms cypress.json file into cypress.config.js file',
-      type: 'Boolean',
+      type: Query,
       resolve: async (_, args, ctx) => {
         try {
           await ctx.actions.migration.createConfigFile()
-        } catch {
-          return false
+        } catch (e) {
+          // add the error to an error stack
+          return {}
         }
 
         ctx.actions.migration.setStep('setupComponent')
 
-        return true
+        return {}
       },
     })
 
     t.field('migrateComponentTesting', {
       description: 'Merges the component testing config in cypress.config.{js,ts}',
-      type: 'Boolean',
+      type: Query,
       resolve: async (_, args, ctx) => {
         try {
           await ctx.actions.migration.startWizardReconfiguration()
 
-          return true
+          return {}
         } catch {
-          return false
+          return {}
         }
       },
     })

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Mutation.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Mutation.ts
@@ -488,7 +488,7 @@ export const mutation = mutationType({
       type: 'Boolean',
       resolve: async (_, args, ctx) => {
         try {
-          await ctx.actions.migration.reconfigureComponent()
+          await ctx.actions.migration.startWizardReconfiguration()
 
           return true
         } catch {

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Mutation.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Mutation.ts
@@ -445,6 +445,22 @@ export const mutation = mutationType({
       description: 'While migrating to 10+ skip manual rename step',
       type: Query,
       resolve: async (_, args, ctx) => {
+        ctx.actions.migration.setStep('renameSupport')
+
+        return {}
+      },
+    })
+
+    t.field('migrateRenameSupport', {
+      description: 'While migrating to 10+ launch renaming of support file',
+      type: Query,
+      resolve: async (_, args, ctx) => {
+        try {
+          await ctx.actions.migration.renameSupportFile()
+        } catch (e) {
+          // add the error to an error stack
+          return {}
+        }
         ctx.actions.migration.setStep('configFile')
 
         return {}
@@ -457,6 +473,22 @@ export const mutation = mutationType({
       resolve: async (_, args, ctx) => {
         try {
           await ctx.actions.migration.createConfigFile()
+        } catch {
+          return false
+        }
+
+        ctx.actions.migration.setStep('setupComponent')
+
+        return true
+      },
+    })
+
+    t.field('migrateComponentTesting', {
+      description: 'Merges the component testing config in cypress.config.{js,ts}',
+      type: 'Boolean',
+      resolve: async (_, args, ctx) => {
+        try {
+          await ctx.actions.migration.reconfigureComponent()
 
           return true
         } catch {

--- a/packages/launchpad/cypress/e2e/error-handling.cy.ts
+++ b/packages/launchpad/cypress/e2e/error-handling.cy.ts
@@ -49,7 +49,7 @@ describe('Error handling', () => {
     cy.log('Fix error and validate it reloads configuration')
 
     cy.withCtx(async (ctx) => {
-      await ctx.actions.file.writeFileInProject('cypress.config.js', 'module.export = {}')
+      await ctx.actions.file.writeFileInProject('cypress.config.js', 'module.exports = {}')
     })
 
     cy.get('body')

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -52,8 +52,7 @@ describe('Migration', () => {
       cy.findByText(defaultMessages.migration.wizard.step2.button).click()
       cy.findByText(defaultMessages.migration.wizard.step3.button).click()
       cy.findByText(defaultMessages.migration.wizard.step4.button).click()
-      // FIXME: should work
-      // cy.findByText(defaultMessages.migration.wizard.step5.button).click()
+      cy.findByText(defaultMessages.migration.wizard.step5.button).click()
     })
   })
 })

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -1,14 +1,21 @@
+import defaultMessages from '@packages/frontend-shared/src/locales/en-US.json'
+
 describe('Migration', () => {
   beforeEach(() => {
     cy.scaffoldProject('migration')
     cy.openProject('migration')
-    cy.visitLaunchpad()
   })
 
   describe('Configuration', () => {
-    it('should create the cypress.config.js file and delete old config', () => {
-      cy.get('[data-cy="convertConfigButton"]').click()
+    beforeEach(() => {
+      cy.visitLaunchpad()
+      cy.findByText(defaultMessages.migration.wizard.step1.button).click()
+      cy.findByText(defaultMessages.migration.wizard.step2.button).click()
+      cy.findByText(defaultMessages.migration.wizard.step3.button).click()
+      cy.findByText(defaultMessages.migration.wizard.step4.button).click()
+    })
 
+    it('should create the cypress.config.js file and delete old config', () => {
       cy.withCtx(async (ctx) => {
         const stats = await ctx.actions.file.checkIfFileExists('cypress.config.js')
 
@@ -27,8 +34,6 @@ describe('Migration', () => {
     })
 
     it('should create a valid js file', () => {
-      cy.get('[data-cy="convertConfigButton"]').click()
-
       cy.withCtx(async (ctx) => {
         const configPath = ctx.path.join(ctx.lifecycleManager.projectRoot, 'cypress.config.js')
 
@@ -36,6 +41,19 @@ describe('Migration', () => {
 
         expect(isValidJsFile).to.be.true
       })
+    })
+  })
+
+  describe('Full flow', () => {
+    it('goes to each step', () => {
+      cy.visitLaunchpad()
+
+      cy.findByText(defaultMessages.migration.wizard.step1.button).click()
+      cy.findByText(defaultMessages.migration.wizard.step2.button).click()
+      cy.findByText(defaultMessages.migration.wizard.step3.button).click()
+      cy.findByText(defaultMessages.migration.wizard.step4.button).click()
+      // FIXME: should work
+      // cy.findByText(defaultMessages.migration.wizard.step5.button).click()
     })
   })
 })

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -53,6 +53,8 @@ describe('Migration', () => {
       cy.findByText(defaultMessages.migration.wizard.step3.button).click()
       cy.findByText(defaultMessages.migration.wizard.step4.button).click()
       cy.findByText(defaultMessages.migration.wizard.step5.button).click()
+
+      cy.findByText(defaultMessages.setupWizard.selectFramework.description).should('be.visible')
     })
   })
 })

--- a/packages/launchpad/src/migration/ConvertConfigFile.vue
+++ b/packages/launchpad/src/migration/ConvertConfigFile.vue
@@ -3,7 +3,10 @@
     <MigrationTitle :title="t('migration.configFile.title')" />
     <MigrationList>
       <template #line-1>
-        <i18n-t keypath="migration.configFile.changedTheFile">
+        <i18n-t
+          scope="global"
+          keypath="migration.configFile.changedTheFile"
+        >
           <template #jsonFile>
             <CodeTag class="text-red-500">
               cypress.json
@@ -17,7 +20,10 @@
         </i18n-t>
       </template>
       <template #line-2>
-        <i18n-t keypath="migration.configFile.willConvert">
+        <i18n-t
+          scope="global"
+          keypath="migration.configFile.willConvert"
+        >
           <template #jsonFile>
             <CodeTag class="text-red-500">
               cypress.json
@@ -31,7 +37,10 @@
         </i18n-t>
       </template>
       <template #line-3>
-        <i18n-t keypath="migration.configFile.removeJson">
+        <i18n-t
+          scope="global"
+          keypath="migration.configFile.removeJson"
+        >
           <CodeTag class="text-red-500">
             cypress.json
           </CodeTag>

--- a/packages/launchpad/src/migration/MigrationWizard.cy.tsx
+++ b/packages/launchpad/src/migration/MigrationWizard.cy.tsx
@@ -1,5 +1,7 @@
 import { MigrationWizardDataFragmentDoc } from '../generated/graphql-test'
 import MigrationWizard from './MigrationWizard.vue'
+import { defaultMessages } from '@cy/i18n'
+import dedent from 'dedent'
 
 describe('<MigrationWizard/>', { viewportWidth: 1280, viewportHeight: 1100 }, () => {
   it('renders Automatic rename', () => {
@@ -21,6 +23,35 @@ describe('<MigrationWizard/>', { viewportWidth: 1280, viewportHeight: 1100 }, ()
         </div>)
       },
     })
+
+    cy.findByText(defaultMessages.migration.wizard.step1.button).should('be.visible')
+  })
+
+  it('renders Automatic rename with skip', () => {
+    cy.mountFragment(MigrationWizardDataFragmentDoc, {
+      onResult (res) {
+        res.migration = {
+          __typename: 'Migration',
+          step: 'renameAuto',
+          specFilesAfter: ['test.cy.tsx'],
+          specFilesBefore: ['test.spec.tsx'],
+          manualFiles: ['test.cy.tsx'],
+          configAfterCode: '{}',
+          configBeforeCode: '{}',
+        }
+      },
+      render () {
+        return (<div class="p-16px">
+          <MigrationWizard />
+        </div>)
+      },
+    })
+
+    cy.findByText(defaultMessages.migration.renameAuto.changeButton).click()
+    cy.findByText(defaultMessages.migration.renameAuto.modals.step1.buttonProceed).click()
+    cy.findByText(defaultMessages.migration.renameAuto.modals.step2.option2).click()
+    cy.findByText(defaultMessages.migration.renameAuto.modals.step2.buttonSave).click()
+    cy.findByText(defaultMessages.migration.wizard.step1.buttonSkip).should('be.visible')
   })
 
   it('renders Manual rename', () => {
@@ -54,8 +85,14 @@ describe('<MigrationWizard/>', { viewportWidth: 1280, viewportHeight: 1100 }, ()
           specFilesAfter: ['test.cy.tsx'],
           specFilesBefore: ['test.spec.tsx'],
           manualFiles: ['test.cy.tsx'],
-          configAfterCode: '{}',
-          configBeforeCode: '{}',
+          configBeforeCode: dedent`{
+            "viewportWidth": 1280, 
+            "viewportHeight": 1100
+          }`,
+          configAfterCode: dedent`module.exports = {
+            viewportWidth: 1280, 
+            viewportHeight: 1100
+          }`,
         }
       },
       render () {

--- a/packages/launchpad/src/migration/MigrationWizard.cy.tsx
+++ b/packages/launchpad/src/migration/MigrationWizard.cy.tsx
@@ -3,18 +3,24 @@ import MigrationWizard from './MigrationWizard.vue'
 import { defaultMessages } from '@cy/i18n'
 import dedent from 'dedent'
 
+const migration = {
+  __typename: 'Migration' as const,
+  specFilesAfter: ['test.cy.tsx'],
+  specFilesBefore: ['test.spec.tsx'],
+  manualFiles: ['test.cy.tsx'],
+  configAfterCode: '{}',
+  configBeforeCode: '{}',
+  supportFileBefore: 'cypress/support/index.js',
+  supportFileAfter: 'cypress/support/e2e.js',
+}
+
 describe('<MigrationWizard/>', { viewportWidth: 1280, viewportHeight: 1100 }, () => {
   it('renders Automatic rename', () => {
     cy.mountFragment(MigrationWizardDataFragmentDoc, {
       onResult (res) {
         res.migration = {
-          __typename: 'Migration',
+          ...migration,
           step: 'renameAuto',
-          specFilesAfter: ['test.cy.tsx'],
-          specFilesBefore: ['test.spec.tsx'],
-          manualFiles: ['test.cy.tsx'],
-          configAfterCode: '{}',
-          configBeforeCode: '{}',
         }
       },
       render () {
@@ -31,13 +37,8 @@ describe('<MigrationWizard/>', { viewportWidth: 1280, viewportHeight: 1100 }, ()
     cy.mountFragment(MigrationWizardDataFragmentDoc, {
       onResult (res) {
         res.migration = {
-          __typename: 'Migration',
+          ...migration,
           step: 'renameAuto',
-          specFilesAfter: ['test.cy.tsx'],
-          specFilesBefore: ['test.spec.tsx'],
-          manualFiles: ['test.cy.tsx'],
-          configAfterCode: '{}',
-          configBeforeCode: '{}',
         }
       },
       render () {
@@ -58,13 +59,8 @@ describe('<MigrationWizard/>', { viewportWidth: 1280, viewportHeight: 1100 }, ()
     cy.mountFragment(MigrationWizardDataFragmentDoc, {
       onResult (res) {
         res.migration = {
-          __typename: 'Migration',
+          ...migration,
           step: 'renameManual',
-          specFilesAfter: ['test.cy.tsx'],
-          specFilesBefore: ['test.spec.tsx'],
-          manualFiles: ['test.cy.tsx'],
-          configAfterCode: '{}',
-          configBeforeCode: '{}',
         }
       },
       render () {
@@ -73,18 +69,34 @@ describe('<MigrationWizard/>', { viewportWidth: 1280, viewportHeight: 1100 }, ()
         </div>)
       },
     })
+
+    cy.findByText(defaultMessages.migration.wizard.step2.button).should('be.visible')
+  })
+
+  it('renders Support file rename', () => {
+    cy.mountFragment(MigrationWizardDataFragmentDoc, {
+      onResult (res) {
+        res.migration = {
+          ...migration,
+          step: 'renameSupport',
+        }
+      },
+      render () {
+        return (<div class="p-16px">
+          <MigrationWizard />
+        </div>)
+      },
+    })
+
+    cy.findByText(defaultMessages.migration.wizard.step3.button).should('be.visible')
   })
 
   it('renders Config File migration', () => {
     cy.mountFragment(MigrationWizardDataFragmentDoc, {
       onResult (res) {
         res.migration = {
-          ...res.migration,
-          __typename: 'Migration',
+          ...migration,
           step: 'configFile',
-          specFilesAfter: ['test.cy.tsx'],
-          specFilesBefore: ['test.spec.tsx'],
-          manualFiles: ['test.cy.tsx'],
           configBeforeCode: dedent`{
             "viewportWidth": 1280, 
             "viewportHeight": 1100
@@ -101,5 +113,25 @@ describe('<MigrationWizard/>', { viewportWidth: 1280, viewportHeight: 1100 }, ()
         </div>)
       },
     })
+
+    cy.findByText(defaultMessages.migration.wizard.step4.button).should('be.visible')
+  })
+
+  it('renders component reconfigure section', () => {
+    cy.mountFragment(MigrationWizardDataFragmentDoc, {
+      onResult (res) {
+        res.migration = {
+          ...migration,
+          step: 'setupComponent',
+        }
+      },
+      render () {
+        return (<div class="p-16px">
+          <MigrationWizard />
+        </div>)
+      },
+    })
+
+    cy.findByText(defaultMessages.migration.wizard.step5.button).should('be.visible')
   })
 })

--- a/packages/launchpad/src/migration/MigrationWizard.vue
+++ b/packages/launchpad/src/migration/MigrationWizard.vue
@@ -106,29 +106,60 @@ query MigrationWizardQuery {
 }
 `
 
+const query = useQuery({ query: MigrationWizardQueryDocument })
+
+const migration = computed(() => query.data.value?.migration ?? { step: 'renameAuto' })
+
+// specs rename
+
+const skipRename = ref(false)
+
+const renameSpecsMutation = gql`
+mutation MigrationWizard_RenameSpecs($skip: Boolean) {
+  migrateRenameSpecs(skip: $skip){
+    migration {
+      step
+    }
+  }
+}
+`
+
+const renameMutation = useMutation(renameSpecsMutation)
+
+function renameSpecs () {
+  renameMutation.executeMutation({ skip: skipRename.value })
+}
+
+// manual rename
+
+const skipManualRenameMutation = gql`
+mutation MigrationWizard_ConvertFile {
+  migrateSkipManualRename {
+    migration {
+      step
+    }
+  }
+}
+`
+
+const skipManualMutation = useMutation(skipManualRenameMutation)
+
+function skipStep2 () {
+  skipManualMutation.executeMutation({})
+}
+
+// config file migration
+
 const convertConfigMutation = gql`
 mutation MigrationWizard_ConvertFile {
   migrateConfigFile
 }
 `
 
-const query = useQuery({ query: MigrationWizardQueryDocument })
-
 const configMutation = useMutation(convertConfigMutation)
-
-const migration = computed(() => query.data.value?.migration ?? { step: 'renameAuto' })
-
-function renameSpecs () {
-
-}
-
-function skipStep2 () {
-
-}
 
 function convertConfig () {
   configMutation.executeMutation({})
 }
 
-const skipRename = ref(false)
 </script>

--- a/packages/launchpad/src/migration/MigrationWizard.vue
+++ b/packages/launchpad/src/migration/MigrationWizard.vue
@@ -15,12 +15,15 @@
       :title="t('migration.wizard.step1.title')"
       :description="t('migration.wizard.step1.description')"
     >
-      <RenameSpecsAuto :gql="query.data.value?.migration" />
+      <RenameSpecsAuto
+        :gql="query.data.value?.migration"
+        @skipChange="(newVal) => skipRename = newVal"
+      />
       <template #footer>
         <Button
           @click="renameSpecs"
         >
-          {{ t('migration.wizard.step1.button') }}
+          {{ skipRename ? t('migration.wizard.step1.buttonSkip') : t('migration.wizard.step1.button') }}
         </Button>
       </template>
     </MigrationStep>
@@ -83,7 +86,7 @@ import ConvertConfigFile from './ConvertConfigFile.vue'
 import { useI18n } from '@cy/i18n'
 import { gql, useMutation, useQuery } from '@urql/vue'
 import { MigrationWizardQueryDocument } from '../generated/graphql'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 const { t } = useI18n()
 
@@ -126,4 +129,6 @@ function skipStep2 () {
 function convertConfig () {
   configMutation.executeMutation({})
 }
+
+const skipRename = ref(false)
 </script>

--- a/packages/launchpad/src/migration/MigrationWizard.vue
+++ b/packages/launchpad/src/migration/MigrationWizard.vue
@@ -97,8 +97,8 @@
     <MigrationStep
       step="setupComponent"
       :current-step="migration.step"
-      :title="t('migration.wizard.step3.title')"
-      :description="t('migration.wizard.step3.description')"
+      :title="t('migration.wizard.step5.title')"
+      :description="t('migration.wizard.step5.description')"
     >
       <SetupComponentTesting />
       <template #footer>

--- a/packages/launchpad/src/migration/MigrationWizard.vue
+++ b/packages/launchpad/src/migration/MigrationWizard.vue
@@ -1,118 +1,120 @@
 <template>
-  <h1 class="font-medium text-center pt-20px text-32px text-body-gray-900">
-    {{ t('migration.wizard.title') }}
-  </h1>
-  <p
-    class="mx-42px mt-12px text-center mb-32px text-body-gray-600 text-18px"
-  >
-    {{ t('migration.wizard.description') }}
-  </p>
-  <template v-if="migration">
-    <MigrationStep
-      step="renameAuto"
-      :current-step="migration.step"
-      :title="t('migration.wizard.step1.title')"
-      :description="t('migration.wizard.step1.description')"
+  <div class="pb-8px">
+    <h1 class="font-medium text-center pt-20px text-32px text-body-gray-900">
+      {{ t('migration.wizard.title') }}
+    </h1>
+    <p
+      class="mx-42px mt-12px text-center mb-32px text-body-gray-600 text-18px"
     >
-      <RenameSpecsAuto
-        :gql="migration"
-        @skipChange="(newVal) => skipRename = newVal"
-      />
-      <template #footer>
-        <Button
-          :suffix-icon="ArrowRightIcon"
-          suffix-icon-class="w-16px h-16px icon-dark-white"
-          @click="renameSpecs"
-        >
-          {{ skipRename ? t('migration.wizard.step1.buttonSkip') : t('migration.wizard.step1.button') }}
-        </Button>
-      </template>
-    </MigrationStep>
-    <MigrationStep
-      step="renameManual"
-      :current-step="migration.step"
-      :title="t('migration.wizard.step2.title')"
-      :description="t('migration.wizard.step2.description')"
-    >
-      <RenameSpecsManual :gql="migration" />
-      <template #footer>
-        <div class="flex gap-16px">
+      {{ t('migration.wizard.description') }}
+    </p>
+    <template v-if="migration">
+      <MigrationStep
+        step="renameAuto"
+        :current-step="migration.step"
+        :title="t('migration.wizard.step1.title')"
+        :description="t('migration.wizard.step1.description')"
+      >
+        <RenameSpecsAuto
+          :gql="migration"
+          @skipChange="(newVal) => skipRename = newVal"
+        />
+        <template #footer>
           <Button
-            disabled
-            variant="pending"
+            :suffix-icon="ArrowRightIcon"
+            suffix-icon-class="w-16px h-16px icon-dark-white"
+            @click="renameSpecs"
           >
-            <template #prefix>
-              <i-cy-loading_x16
+            {{ skipRename ? t('migration.wizard.step1.buttonSkip') : t('migration.wizard.step1.button') }}
+          </Button>
+        </template>
+      </MigrationStep>
+      <MigrationStep
+        step="renameManual"
+        :current-step="migration.step"
+        :title="t('migration.wizard.step2.title')"
+        :description="t('migration.wizard.step2.description')"
+      >
+        <RenameSpecsManual :gql="migration" />
+        <template #footer>
+          <div class="flex gap-16px">
+            <Button
+              disabled
+              variant="pending"
+            >
+              <template #prefix>
+                <i-cy-loading_x16
 
-                class="animate-spin icon-dark-white icon-light-gray-400"
-              />
-            </template>
-            {{ t('migration.wizard.step2.buttonWait') }}
-          </Button>
+                  class="animate-spin icon-dark-white icon-light-gray-400"
+                />
+              </template>
+              {{ t('migration.wizard.step2.buttonWait') }}
+            </Button>
+            <Button
+              variant="outline"
+              @click="skipStep2"
+            >
+              {{ t('migration.wizard.step2.button') }}
+            </Button>
+          </div>
+        </template>
+      </MigrationStep>
+      <MigrationStep
+        step="renameSupport"
+        :current-step="migration.step"
+        :title="t('migration.wizard.step3.title')"
+        :description="t('migration.wizard.step3.description')"
+      >
+        <RenameSupport :gql="migration" />
+        <template #footer>
           <Button
-            variant="outline"
-            @click="skipStep2"
+            :suffix-icon="ArrowRightIcon"
+            suffix-icon-class="w-16px h-16px icon-dark-white"
+            data-cy="renameSupportButton"
+            @click="launchRenameSupportFile"
           >
-            {{ t('migration.wizard.step2.button') }}
+            {{ t('migration.wizard.step3.button') }}
           </Button>
-        </div>
-      </template>
-    </MigrationStep>
-    <MigrationStep
-      step="renameSupport"
-      :current-step="migration.step"
-      :title="t('migration.wizard.step3.title')"
-      :description="t('migration.wizard.step3.description')"
-    >
-      <RenameSupport :gql="migration" />
-      <template #footer>
-        <Button
-          :suffix-icon="ArrowRightIcon"
-          suffix-icon-class="w-16px h-16px icon-dark-white"
-          data-cy="renameSupportButton"
-          @click="launchRenameSupportFile"
-        >
-          {{ t('migration.wizard.step3.button') }}
-        </Button>
-      </template>
-    </MigrationStep>
-    <MigrationStep
-      step="configFile"
-      :current-step="migration.step"
-      :title="t('migration.wizard.step4.title')"
-      :description="t('migration.wizard.step4.description')"
-    >
-      <ConvertConfigFile :gql="migration" />
-      <template #footer>
-        <Button
-          :suffix-icon="ArrowRightIcon"
-          suffix-icon-class="w-16px h-16px icon-dark-white"
-          data-cy="convertConfigButton"
-          @click="convertConfig"
-        >
-          {{ t('migration.wizard.step4.button') }}
-        </Button>
-      </template>
-    </MigrationStep>
-    <MigrationStep
-      step="setupComponent"
-      :current-step="migration.step"
-      :title="t('migration.wizard.step5.title')"
-      :description="t('migration.wizard.step5.description')"
-    >
-      <SetupComponentTesting />
-      <template #footer>
-        <Button
-          :suffix-icon="ArrowRightIcon"
-          suffix-icon-class="w-16px h-16px icon-dark-white"
-          data-cy="launchReconfigureButton"
-          @click="launchReconfigureComponentTesting"
-        >
-          {{ t('migration.wizard.step5.button') }}
-        </Button>
-      </template>
-    </MigrationStep>
-  </template>
+        </template>
+      </MigrationStep>
+      <MigrationStep
+        step="configFile"
+        :current-step="migration.step"
+        :title="t('migration.wizard.step4.title')"
+        :description="t('migration.wizard.step4.description')"
+      >
+        <ConvertConfigFile :gql="migration" />
+        <template #footer>
+          <Button
+            :suffix-icon="ArrowRightIcon"
+            suffix-icon-class="w-16px h-16px icon-dark-white"
+            data-cy="convertConfigButton"
+            @click="convertConfig"
+          >
+            {{ t('migration.wizard.step4.button') }}
+          </Button>
+        </template>
+      </MigrationStep>
+      <MigrationStep
+        step="setupComponent"
+        :current-step="migration.step"
+        :title="t('migration.wizard.step5.title')"
+        :description="t('migration.wizard.step5.description')"
+      >
+        <SetupComponentTesting />
+        <template #footer>
+          <Button
+            :suffix-icon="ArrowRightIcon"
+            suffix-icon-class="w-16px h-16px icon-dark-white"
+            data-cy="launchReconfigureButton"
+            @click="launchReconfigureComponentTesting"
+          >
+            {{ t('migration.wizard.step5.button') }}
+          </Button>
+        </template>
+      </MigrationStep>
+    </template>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -253,6 +255,7 @@ mutation MigrationWizard_ReconfigureComponentTesting {
     currentProject {
       id
       currentTestingType
+      needsLegacyConfigMigration
     }
   }
 }

--- a/packages/launchpad/src/migration/MigrationWizard.vue
+++ b/packages/launchpad/src/migration/MigrationWizard.vue
@@ -184,8 +184,20 @@ function skipStep2 () {
 
 // rename support files
 
+const renameSupportFileMutation = gql`
+mutation MigrationWizard_RenameSupport {
+  migrateRenameSupport {
+    migration {
+      step
+    }
+  }
+}
+`
+
+const renameSupportMutation = useMutation(renameSupportFileMutation)
+
 function launchRenameSupportFile () {
-  // TODO: mutate the migration state here
+  renameSupportMutation.executeMutation({})
 }
 
 // config file migration
@@ -204,7 +216,15 @@ function convertConfig () {
 
 // launch reconfigure component testing
 
+const launchReconfigureCTMutation = gql`
+mutation MigrationWizard_ReconfigureComponentTesting {
+  migrateComponentTesting
+}
+`
+
+const launchReconfigureMutation = useMutation(launchReconfigureCTMutation)
+
 function launchReconfigureComponentTesting () {
-  // TODO: mutate things here
+  launchReconfigureMutation.executeMutation({})
 }
 </script>

--- a/packages/launchpad/src/migration/MigrationWizard.vue
+++ b/packages/launchpad/src/migration/MigrationWizard.vue
@@ -110,7 +110,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { gql, useMutation, useQuery } from '@urql/vue'
-import { MIGRATION_STEPS } from '@packages/types'
 import Button from '@cy/components/Button.vue'
 import MigrationStep from './fragments/MigrationStep.vue'
 import RenameSpecsAuto from './RenameSpecsAuto.vue'

--- a/packages/launchpad/src/migration/MigrationWizard.vue
+++ b/packages/launchpad/src/migration/MigrationWizard.vue
@@ -116,7 +116,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { gql, useMutation, useQuery } from '@urql/vue'
 import Button from '@cy/components/Button.vue'
 import ArrowRightIcon from '~icons/cy/arrow-right_x16.svg'
@@ -151,6 +151,24 @@ query MigrationWizardQuery {
 const query = useQuery({ query: MigrationWizardQueryDocument })
 
 const migration = computed(() => query.data.value?.migration)
+
+// start migration
+
+const migrateStartMutation = gql`
+mutation MigrationWizard_Start {
+  migrateStart {
+    migration {
+      step
+    }
+  }
+}
+`
+
+const start = useMutation(migrateStartMutation)
+
+onMounted(() => {
+  start.executeMutation({ })
+})
 
 // specs rename
 
@@ -212,7 +230,11 @@ function launchRenameSupportFile () {
 
 const convertConfigMutation = gql`
 mutation MigrationWizard_ConvertFile {
-  migrateConfigFile
+  migrateConfigFile {
+    migration {
+      step
+    }
+  }
 }
 `
 
@@ -226,7 +248,13 @@ function convertConfig () {
 
 const launchReconfigureCTMutation = gql`
 mutation MigrationWizard_ReconfigureComponentTesting {
-  migrateComponentTesting
+  migrateComponentTesting {
+    currentTestingType
+    currentProject {
+      id
+      currentTestingType
+    }
+  }
 }
 `
 

--- a/packages/launchpad/src/migration/MigrationWizard.vue
+++ b/packages/launchpad/src/migration/MigrationWizard.vue
@@ -20,6 +20,8 @@
       />
       <template #footer>
         <Button
+          :suffix-icon="ArrowRightIcon"
+          suffix-icon-class="w-16px h-16px icon-dark-white"
           @click="renameSpecs"
         >
           {{ skipRename ? t('migration.wizard.step1.buttonSkip') : t('migration.wizard.step1.button') }}
@@ -65,6 +67,8 @@
       <RenameSupport :gql="migration" />
       <template #footer>
         <Button
+          :suffix-icon="ArrowRightIcon"
+          suffix-icon-class="w-16px h-16px icon-dark-white"
           data-cy="renameSupportButton"
           @click="launchRenameSupportFile"
         >
@@ -81,6 +85,8 @@
       <ConvertConfigFile :gql="migration" />
       <template #footer>
         <Button
+          :suffix-icon="ArrowRightIcon"
+          suffix-icon-class="w-16px h-16px icon-dark-white"
           data-cy="convertConfigButton"
           @click="convertConfig"
         >
@@ -97,6 +103,8 @@
       <SetupComponentTesting />
       <template #footer>
         <Button
+          :suffix-icon="ArrowRightIcon"
+          suffix-icon-class="w-16px h-16px icon-dark-white"
           data-cy="launchReconfigureButton"
           @click="launchReconfigureComponentTesting"
         >
@@ -111,6 +119,7 @@
 import { computed, ref } from 'vue'
 import { gql, useMutation, useQuery } from '@urql/vue'
 import Button from '@cy/components/Button.vue'
+import ArrowRightIcon from '~icons/cy/arrow-right_x16.svg'
 import MigrationStep from './fragments/MigrationStep.vue'
 import RenameSpecsAuto from './RenameSpecsAuto.vue'
 import RenameSpecsManual from './RenameSpecsManual.vue'

--- a/packages/launchpad/src/migration/OptOutModalStep1.vue
+++ b/packages/launchpad/src/migration/OptOutModalStep1.vue
@@ -30,7 +30,10 @@
         {{ t('migration.renameAuto.modals.step1.line4') }}
       </template>
       <template #line-5>
-        <i18n-t keypath="migration.renameAuto.modals.step1.line5">
+        <i18n-t
+          scope="global"
+          keypath="migration.renameAuto.modals.step1.line5"
+        >
           <CodeTag class="text-jade-500">
             [filename].cy.[ext]
           </CodeTag>

--- a/packages/launchpad/src/migration/OptOutModalStep2.vue
+++ b/packages/launchpad/src/migration/OptOutModalStep2.vue
@@ -20,7 +20,10 @@
           v-if="option.value === 'rename'"
           class="text-jade-500"
         >
-          <i18n-t keypath="migration.renameAuto.modals.step2.option1">
+          <i18n-t
+            scope="global"
+            keypath="migration.renameAuto.modals.step2.option1"
+          >
             <CodeTag class="ml-0 text-jade-500">
               [filename].cy.[ext]
             </CodeTag>

--- a/packages/launchpad/src/migration/RenameSpecsAuto.vue
+++ b/packages/launchpad/src/migration/RenameSpecsAuto.vue
@@ -43,8 +43,14 @@
           {{ t('migration.renameAuto.changeButton') }}
         </a>
       </template>
-      <template #line-3>
-        <i18n-t keypath="migration.renameAuto.changedSpecPatternExplain">
+      <template
+        v-if="!skipRename"
+        #line-3
+      >
+        <i18n-t
+          scope="global"
+          keypath="migration.renameAuto.changedSpecPatternExplain"
+        >
           <CodeTag class="text-jade-500">
             [filename].cy.[ext]
           </CodeTag>
@@ -55,7 +61,7 @@
       <template #before>
         <HighlightedFilesList
           :files="props.gql.specFilesBefore"
-          :highlight-reg-exp="/(integration|[_,-,.]?spec)/gi"
+          :highlight-reg-exp="/(integration|[_,-,.]?(spec|test))/gi"
           highlight-class="text-red-500"
         />
       </template>
@@ -111,6 +117,10 @@ const props = defineProps<{
   gql: RenameSpecsAutoFragment
 }>()
 
+const emits = defineEmits<{
+  (eventName: 'skipChange', value: boolean): void
+  }>()
+
 const step1Modal = ref(false)
 const step2Modal = ref(false)
 
@@ -120,5 +130,6 @@ const skipRename = ref(false)
 function applySkipResult (val:string) {
   // TODO: add a GQL mutation here
   skipRename.value = val === 'skip'
+  emits('skipChange', skipRename.value)
 }
 </script>

--- a/packages/launchpad/src/migration/RenameSpecsManual.vue
+++ b/packages/launchpad/src/migration/RenameSpecsManual.vue
@@ -3,21 +3,30 @@
     <MigrationTitle :title="t('migration.renameManual.title')" />
     <MigrationList>
       <template #line-1>
-        <i18n-t keypath="migration.renameManual.componentFolderRemoved">
+        <i18n-t
+          scope="global"
+          keypath="migration.renameManual.componentFolderRemoved"
+        >
           <CodeTag class="text-red-500">
             componentFolder
           </CodeTag>
         </i18n-t>
       </template>
       <template #line-2>
-        <i18n-t keypath="migration.renameManual.cannotAuto">
+        <i18n-t
+          scope="global"
+          keypath="migration.renameManual.cannotAuto"
+        >
           <CodeTag class="text-jade-500">
             src/component/button/button.cy.js
           </CodeTag>
         </i18n-t>
       </template>
       <template #line-3>
-        <i18n-t keypath="migration.renameManual.ifSkipNote" />
+        <i18n-t
+          scope="global"
+          keypath="migration.renameManual.ifSkipNote"
+        />
       </template>
     </MigrationList>
     <div class="border rounded border-gray-100 mt-16px">

--- a/packages/launchpad/src/migration/RenameSupport.cy.tsx
+++ b/packages/launchpad/src/migration/RenameSupport.cy.tsx
@@ -1,0 +1,14 @@
+import { RenameSupportFragmentDoc } from '../generated/graphql-test'
+import RenameSupport from './RenameSupport.vue'
+
+describe('<RenameSpecsManual/>', { viewportWidth: 1119 }, () => {
+  it('renders expected content', () => {
+    cy.mountFragment(RenameSupportFragmentDoc, {
+      render (gql) {
+        return (<div class="p-16px">
+          <RenameSupport gql={gql} />
+        </div>)
+      },
+    })
+  })
+})

--- a/packages/launchpad/src/migration/RenameSupport.vue
+++ b/packages/launchpad/src/migration/RenameSupport.vue
@@ -1,0 +1,18 @@
+<template>
+  <div>SupportFile</div>
+</template>
+
+<script lang="ts" setup>
+import { gql } from '@urql/vue'
+import type { RenameSupportFragment } from '../generated/graphql'
+
+gql`
+fragment RenameSupport on Migration {
+  supportFileBefore
+  supportFileAfter
+}`
+
+defineProps<{
+  gql: RenameSupportFragment
+}>()
+</script>

--- a/packages/launchpad/src/migration/RenameSupport.vue
+++ b/packages/launchpad/src/migration/RenameSupport.vue
@@ -1,10 +1,49 @@
 <template>
-  <div>SupportFile</div>
+  <MigrationTitle :title="t('migration.renameSupport.title')" />
+  <MigrationList>
+    <template #line-1>
+      {{ t('migration.renameSupport.serveDifferentTypes') }}
+    </template>
+    <template #line-2>
+      {{ t('migration.renameSupport.changedSupportFile') }}
+      <CodeTag
+        class="text-red-500"
+      >cypress/support/index.js</CodeTag>
+      <i-cy-arrow-right_x16 class="h-16px w-16px inline-block icon-dark-gray-300" />
+      <CodeTag
+        class="text-jade-500"
+      >cypress/support/e2e.js</CodeTag>
+    </template>
+  </MigrationList>
+  <BeforeAfter>
+    <template #before>
+      <HighlightedFilesList
+        :files="[props.gql.supportFileBefore]"
+        :highlight-reg-exp="/index/gi"
+        highlight-class="text-red-500"
+      />
+    </template>
+    <template #after>
+      <HighlightedFilesList
+        :files="[props.gql.supportFileAfter]"
+        :highlight-reg-exp="/e2e/gi"
+        highlight-class="text-jade-500"
+      />
+    </template>
+  </BeforeAfter>
 </template>
 
 <script lang="ts" setup>
 import { gql } from '@urql/vue'
+import CodeTag from '@cy/components/CodeTag.vue'
+import MigrationTitle from './fragments/MigrationTitle.vue'
+import MigrationList from './fragments/MigrationList.vue'
+import HighlightedFilesList from './fragments/HighlightedFilesList.vue'
+import BeforeAfter from './fragments/BeforeAfter.vue'
 import type { RenameSupportFragment } from '../generated/graphql'
+import { useI18n } from '@cy/i18n'
+
+const { t } = useI18n()
 
 gql`
 fragment RenameSupport on Migration {
@@ -12,7 +51,7 @@ fragment RenameSupport on Migration {
   supportFileAfter
 }`
 
-defineProps<{
+const props = defineProps<{
   gql: RenameSupportFragment
 }>()
 </script>

--- a/packages/launchpad/src/migration/SetupComponentTesting.cy.tsx
+++ b/packages/launchpad/src/migration/SetupComponentTesting.cy.tsx
@@ -1,0 +1,9 @@
+import SetupComponentTesting from './SetupComponentTesting.vue'
+
+describe('<RenameSpecsManual/>', { viewportWidth: 1119 }, () => {
+  it('renders expected content', () => {
+    cy.mount(() => (<div class="p-16px">
+      <SetupComponentTesting />
+    </div>))
+  })
+})

--- a/packages/launchpad/src/migration/SetupComponentTesting.vue
+++ b/packages/launchpad/src/migration/SetupComponentTesting.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>SupportFile</div>
+</template>
+
+<script lang="ts" setup>
+import { useI18n } from '@cy/i18n'
+
+const t = useI18n()
+
+</script>

--- a/packages/launchpad/src/migration/SetupComponentTesting.vue
+++ b/packages/launchpad/src/migration/SetupComponentTesting.vue
@@ -1,10 +1,28 @@
 <template>
-  <div>Component testing</div>
+  <MigrationTitle
+    :title="t('migration.setupComponent.title')"
+  />
+  <MigrationList>
+    <template #line-1>
+      {{ t('migration.setupComponent.line1') }}
+    </template>
+    <template #line-2>
+      {{ t('migration.setupComponent.line2') }}
+    </template>
+    <template #line-3>
+      {{ t('migration.setupComponent.line3') }}
+    </template>
+    <template #line-4>
+      {{ t('migration.setupComponent.line4') }}
+    </template>
+  </MigrationList>
 </template>
 
 <script lang="ts" setup>
 import { useI18n } from '@cy/i18n'
+import MigrationList from './fragments/MigrationList.vue'
+import MigrationTitle from './fragments/MigrationTitle.vue'
 
-const t = useI18n()
+const { t } = useI18n()
 
 </script>

--- a/packages/launchpad/src/migration/SetupComponentTesting.vue
+++ b/packages/launchpad/src/migration/SetupComponentTesting.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>SupportFile</div>
+  <div>Component testing</div>
 </template>
 
 <script lang="ts" setup>

--- a/packages/launchpad/src/migration/fragments/MigrationList.vue
+++ b/packages/launchpad/src/migration/fragments/MigrationList.vue
@@ -13,13 +13,18 @@
 </template>
 
 <script lang="ts" setup>
-import { useSlots } from 'vue'
+import { computed, useSlots } from 'vue'
 
 const slots = useSlots()
-const slotNames:string[] = []
-let i = 0
+const slotNames = computed(() => {
+  const slotNamesTmp = [] as string[]
+  let i = 0
 
-while (slots[`line-${++i}`]) {
-  slotNames.push(`line-${i}`)
-}
+  while (slots[`line-${++i}`]?.()) {
+    slotNamesTmp.push(`line-${i}`)
+  }
+
+  return slotNamesTmp
+})
+
 </script>

--- a/packages/launchpad/src/migration/fragments/MigrationStep.vue
+++ b/packages/launchpad/src/migration/fragments/MigrationStep.vue
@@ -21,7 +21,7 @@
           v-else
           class="rounded-full bg-gray-100 h-24px text-center w-24px"
         >
-          {{ step }}
+          {{ stepNumber }}
         </div>
       </template>
       <template #header>
@@ -55,19 +55,20 @@
 </template>
 
 <script setup lang="ts">
-import { useSlots } from 'vue'
+import { computed } from 'vue'
 import ListRowHeader from '@cy/components/ListRowHeader.vue'
+import { MIGRATION_STEPS } from '@packages/types'
 
-withDefaults(defineProps<{
-  open?: boolean,
-  checked?: boolean,
-  step: number,
+const props = defineProps<{
+  currentStep: typeof MIGRATION_STEPS[number],
+  step: typeof MIGRATION_STEPS[number],
   title: string,
   description: string,
-}>(), {
-  open: false,
-  checked: false,
-})
+}>()
+
+const stepNumber = computed(() => MIGRATION_STEPS.indexOf(props.step) + 1)
+const open = computed(() => props.currentStep === props.step)
+const checked = computed(() => stepNumber.value <= MIGRATION_STEPS.indexOf(props.currentStep))
 
 const emit = defineEmits(['toggle'])
 </script>

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -112,7 +112,7 @@ export const CODE_LANGUAGES = [
 
 export type CodeLanguage = typeof CODE_LANGUAGES[number]
 
-export const MIGRATION_STEPS = ['renameAuto', 'renameManual', 'configFile'] as const
+export const MIGRATION_STEPS = ['renameAuto', 'renameManual', 'renameSupport', 'configFile', 'setupComponent'] as const
 
 export type AllPackages = FrontendFramework['package'] | Bundler['package'] | typeof STORYBOOK_DEPS[number]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9332,6 +9332,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/stringify-object@^3.0.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/stringify-object/-/stringify-object-3.3.1.tgz#9ee394931e63468de0412a8e19c9f021a7d1d24d"
+  integrity sha512-bpCBW0O+QrMLNFBY/+rkZtGzcYRmc2aTD8qYHOMNUmednqETfEZtFcGEA11l9xqbIeiT1PgXG0eq3zqayVzZSQ==
+
 "@types/strip-bom@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/strip-bom/-/strip-bom-3.0.0.tgz#14a8ec3956c2e81edb7520790aecf21c290aebd2"


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes UNIFY-959

### Changes

- `module.export` -> `module.exports`
- i18n was sending a warning because `scope="global"` was missing from a few tags
- setup migration step in gql and its mutations
- change the label of the first step's button to reflect the skipping
- hide the last comment of `renameAuto` when skipping