### PR TITLE
fix: aut width in run mode

### DIFF
--- a/packages/app/src/runner/ResizablePanels.vue
+++ b/packages/app/src/runner/ResizablePanels.vue
@@ -45,6 +45,7 @@
     >
       <slot
         name="panel3"
+        :width="panel3width"
       />
     </div>
   </div>

--- a/packages/app/src/runner/ResizablePanels.vue
+++ b/packages/app/src/runner/ResizablePanels.vue
@@ -40,12 +40,11 @@
       class="flex-grow h-full relative"
       :class="{'pointer-events-none':panel2IsDragging}"
       :style="{
-        width: `${maxTotalWidth - panel1Width - panel2Width}px`
+        width: `${panel3width}px`
       }"
     >
       <slot
         name="panel3"
-        :width="maxTotalWidth - panel1Width - panel2Width"
       />
     </div>
   </div>
@@ -145,6 +144,10 @@ const maxPanel2Width = computed(() => {
   const unavailableWidth = panel1Width.value + props.minPanel3Width + props.offsetLeft
 
   return props.maxTotalWidth - unavailableWidth
+})
+
+const panel3width = computed(() => {
+  return props.maxTotalWidth - panel1Width.value - panel2Width.value
 })
 
 function handleResizeEnd (panel: DraggablePanel) {

--- a/packages/app/src/runner/SpecRunnerRunMode.vue
+++ b/packages/app/src/runner/SpecRunnerRunMode.vue
@@ -4,9 +4,8 @@
     class="flex border-gray-900 border-l-1"
   >
     <ResizablePanels
-      :offset-left="64"
-      :max-total-width="windowWidth - 64"
-      :initial-panel1-width="specListWidth"
+      :max-total-width="windowWidth"
+      :initial-panel1-width="0"
       :initial-panel2-width="reporterWidth"
       :show-panel1="false"
       :show-panel2="!screenshotStore.isScreenshotting"

--- a/packages/app/src/runner/useRunnerStyle.ts
+++ b/packages/app/src/runner/useRunnerStyle.ts
@@ -34,7 +34,11 @@ export const useRunnerStyle = ({
 
   const containerWidth = computed(() => {
     const miscBorders = 4
-    const nonAutWidth = reporterWidth.value + specListWidth.value + (autMargin * 2) + miscBorders + collapsedNavBarWidth
+    let nonAutWidth = reporterWidth.value + specListWidth.value + (autMargin * 2) + miscBorders
+
+    if (window.__CYPRESS_MODE__ !== 'run') {
+      nonAutWidth += collapsedNavBarWidth
+    }
 
     return windowWidth.value - nonAutWidth
   })
@@ -71,7 +75,13 @@ export const useRunnerStyle = ({
     specListWidth,
     containerHeight,
     containerWidth,
-    windowWidth: computed(() => windowWidth.value - collapsedNavBarWidth),
+    windowWidth: computed(() => {
+      if (window.__CYPRESS_MODE__ === 'run') {
+        return windowWidth.value
+      }
+
+      return windowWidth.value - collapsedNavBarWidth
+    }),
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://cypress-io.atlassian.net/browse/UNIFY-962

### User facing changelog

The width of the runner's AUT area is now correct in Run Mode. No more white area on the right hand side.

### Additional details

To account for the left nav in open mode, there are a few places we apply a 64px offset in calculations. This PR checks for run mode and avoids doing that if we're not in run mode, since we don't render the nav there.

A longer term solution will be to drive this kind of thing with detecting and measuring the nav bar element itself, but we are about to get right into some related stuff as the AUT header comes together, so let's do that then.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
