### PR TITLE
feat: Retain fileName when working with aliased fixtures and files

### DIFF
--- a/packages/driver/cypress/integration/commands/actions/selectFile_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/selectFile_spec.js
@@ -218,6 +218,10 @@ describe('src/cy/commands/actions/selectFile', () => {
         cy.fixture('valid.json').as('myFixture')
 
         cy.get('#basic').selectFile('@myFixture')
+        .then((input) => {
+          expect(input[0].files[0].name).to.eq('valid.json')
+          expect(input[0].files[0].type).to.eq('application/json')
+        })
         .then(getFileContents)
         .then((contents) => {
           // Because json files are loaded as objects, they get reencoded before
@@ -232,6 +236,10 @@ describe('src/cy/commands/actions/selectFile', () => {
         cy.readFile('cypress/fixtures/valid.json', { encoding: null }).as('myFile')
 
         cy.get('#basic').selectFile('@myFile')
+        .then((input) => {
+          expect(input[0].files[0].name).to.eq('valid.json')
+          expect(input[0].files[0].type).to.eq('application/json')
+        })
         .then(getFileContents)
         .then((contents) => {
           expect(contents[0]).to.eql(validJsonString)
@@ -251,6 +259,32 @@ describe('src/cy/commands/actions/selectFile', () => {
         .then((input) => {
           expect(input[0].files[0].name).to.eq('valid.json')
           expect(input[0].files[1].name).to.eq('app.js')
+          expect(input[0].files[0].type).to.eq('application/json')
+          expect(input[0].files[1].type).to.eq('application/javascript')
+        })
+      })
+
+      it('allows users to override the inferred filenames and mimetypes', () => {
+        cy.fixture('valid.json').as('myFixture')
+
+        cy.get('#multiple').selectFile([{
+          contents: 'cypress/fixtures/valid.json',
+          fileName: '1.png',
+        },
+        {
+          contents: '@myFixture',
+          fileName: '2.png',
+          mimeType: 'text/plain',
+        }])
+        .then((input) => {
+          expect(input[0].files[0].name).to.eq('1.png')
+          expect(input[0].files[1].name).to.eq('2.png')
+          // The mimetype should be inferred from the user-supplied filename,
+          // rather than the actual path
+          expect(input[0].files[0].type).to.eq('image/png')
+          // And ever if they supply a filename, explicit mimetype
+          // should always take precedent.
+          expect(input[0].files[1].type).to.eq('text/plain')
         })
       })
     })

--- a/packages/driver/src/cy/commands/actions/selectFile.ts
+++ b/packages/driver/src/cy/commands/actions/selectFile.ts
@@ -142,6 +142,7 @@ export default (Commands, Cypress, cy, state, config) => {
     }
 
     return {
+      fileName: aliasObj.fileName,
       ...file,
       contents: aliasObj.subject,
     }

--- a/packages/driver/src/cy/commands/aliasing.ts
+++ b/packages/driver/src/cy/commands/aliasing.ts
@@ -42,7 +42,7 @@ export default function (Commands, Cypress, cy, state) {
         }
       }
 
-      const fileName = prev.attributes.fileName
+      const fileName = prev.get('fileName')
 
       cy.addAlias(ctx, { subject, command: prev, alias: str, fileName })
 

--- a/packages/driver/src/cy/commands/aliasing.ts
+++ b/packages/driver/src/cy/commands/aliasing.ts
@@ -42,7 +42,9 @@ export default function (Commands, Cypress, cy, state) {
         }
       }
 
-      cy.addAlias(ctx, { subject, command: prev, alias: str })
+      const fileName = prev.attributes.fileName
+
+      cy.addAlias(ctx, { subject, command: prev, alias: str, fileName })
 
       return subject
     },

--- a/packages/driver/src/cy/commands/files.ts
+++ b/packages/driver/src/cy/commands/files.ts
@@ -80,7 +80,7 @@ export default (Commands, Cypress, cy, state) => {
           }
 
           // Add the filename as a symbol, in case we need it later (such as when storing an alias)
-          state('current').attributes.fileName = basename(filePath)
+          state('current').set('fileName', basename(filePath))
 
           consoleProps['File Path'] = filePath
           consoleProps['Contents'] = contents

--- a/packages/driver/src/cy/commands/files.ts
+++ b/packages/driver/src/cy/commands/files.ts
@@ -1,9 +1,10 @@
 // @ts-nocheck
 import _ from 'lodash'
+import { basename } from 'path'
 
 import $errUtils from '../../cypress/error_utils'
 
-export default (Commands, Cypress, cy) => {
+export default (Commands, Cypress, cy, state) => {
   Commands.addAll({
     readFile (file, encoding, options = {}) {
       let userOptions = options
@@ -77,6 +78,9 @@ export default (Commands, Cypress, cy) => {
           if (options.encoding === null) {
             contents = Buffer.from(contents)
           }
+
+          // Add the filename as a symbol, in case we need it later (such as when storing an alias)
+          state('current').attributes.fileName = basename(filePath)
 
           consoleProps['File Path'] = filePath
           consoleProps['Contents'] = contents

--- a/packages/driver/src/cy/commands/fixtures.ts
+++ b/packages/driver/src/cy/commands/fixtures.ts
@@ -2,6 +2,7 @@
 
 import _ from 'lodash'
 import Promise from 'bluebird'
+import { basename } from 'path'
 
 import $errUtils from '../../cypress/error_utils'
 
@@ -83,6 +84,9 @@ export default (Commands, Cypress, cy, state, config) => {
         // add the fixture to the cache
         // so it can just be returned next time
         cache[fixture] = response
+
+        // Add the filename as a symbol, in case we need it later (such as when storing an alias)
+        state('current').attributes.fileName = basename(fixture)
 
         // return the cloned response
         return clone(response)

--- a/packages/driver/src/cy/commands/fixtures.ts
+++ b/packages/driver/src/cy/commands/fixtures.ts
@@ -86,7 +86,7 @@ export default (Commands, Cypress, cy, state, config) => {
         cache[fixture] = response
 
         // Add the filename as a symbol, in case we need it later (such as when storing an alias)
-        state('current').attributes.fileName = basename(fixture)
+        state('current').set('fileName', basename(fixture))
 
         // return the cloned response
         return clone(response)


### PR DESCRIPTION
- Closes #19803 

### User facing changelog
`selectFile()` now retains the filename of files ready from disk when working with aliases.

### Additional details
```js
cy.fixture('example.json', { encoding: null }).as('exampleFile')
cy.get('input[type="file"]').selectFile('@exampleFile')
```

The input will have a filename of 'example.json', with the mimeType inferred from that. The filename and mimetype can still be specified manually.

### How has the user experience changed?

### PR Tasks
- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
