### PR TITLE
fix: transition eventManager errors

### DIFF
--- a/packages/app/src/pages/Specs/Runner.vue
+++ b/packages/app/src/pages/Specs/Runner.vue
@@ -1,25 +1,27 @@
 <template>
-  <!--
+  <div>
+    <!--
     Run Mode is a more minimal UI.
     It does not render things like the SpecList,
     Side and Top Nav, etc.
     It also has no GraphQL dependency.
   -->
-  <SpecRunnerContainerRunMode
-    v-if="isRunMode"
-    :run-mode-specs="specs"
-  />
+    <SpecRunnerContainerRunMode
+      v-if="isRunMode"
+      :run-mode-specs="specs"
+    />
 
-  <!--
+    <!--
     Open Mode is the full Cypress runner UI -
     including things like the SpecList,
     Side and Top Nav, Selector Playgroundn etc.
     It is driven by GraphQL and urql.
   -->
-  <SpecRunnerContainerOpenMode
-    v-else-if="query.data.value?.currentProject?.specs"
-    :gql="query.data.value"
-  />
+    <SpecRunnerContainerOpenMode
+      v-else-if="query.data.value?.currentProject?.specs"
+      :gql="query.data.value"
+    />
+  </div>
 </template>
 
 <script lang="ts" setup>

--- a/packages/app/src/pages/Specs/Runner.vue
+++ b/packages/app/src/pages/Specs/Runner.vue
@@ -1,22 +1,22 @@
 <template>
   <div>
     <!--
-    Run Mode is a more minimal UI.
-    It does not render things like the SpecList,
-    Side and Top Nav, etc.
-    It also has no GraphQL dependency.
-  -->
+      Run Mode is a more minimal UI.
+      It does not render things like the SpecList,
+      Side and Top Nav, etc.
+      It also has no GraphQL dependency.
+    -->
     <SpecRunnerContainerRunMode
       v-if="isRunMode"
       :run-mode-specs="specs"
     />
 
     <!--
-    Open Mode is the full Cypress runner UI -
-    including things like the SpecList,
-    Side and Top Nav, Selector Playgroundn etc.
-    It is driven by GraphQL and urql.
-  -->
+      Open Mode is the full Cypress runner UI -
+      including things like the SpecList,
+      Side and Top Nav, Selector Playgroundn etc.
+      It is driven by GraphQL and urql.
+    -->
     <SpecRunnerContainerOpenMode
       v-else-if="query.data.value?.currentProject?.specs"
       :gql="query.data.value"

--- a/packages/app/src/runner/unifiedRunner.ts
+++ b/packages/app/src/runner/unifiedRunner.ts
@@ -15,6 +15,7 @@ export function useUnifiedRunner () {
 
   onBeforeUnmount(() => {
     UnifiedRunnerAPI.teardown()
+    initialized.value = false
   })
 
   return {


### PR DESCRIPTION
Two small fixes:

1. Wrapper div in Runner.vue so there is a HTML root element for the transition. Navigation to other pages from Spec Runner works normally now.
1. Testing navigating from a spec, to the rest of the app, and then to another spec, I saw an event manager error and the new spec would not load. On the 2nd visit to the Spec Runner, we were trying to get the eventManager before it was initialized. Resetting the value of the `initialized` ref when we unmount the runner component fixes that, because the container component uses `v-if="initialized"` to decide when to render the runner itself, so if it stays true, we render too early on subsequent visits.