### PR TITLE
feat: support alternative replace string for CYPRESS_DOWNLOAD_PATH_TEMPLATE 

### DIFF
--- a/cli/__snapshots__/download_spec.js
+++ b/cli/__snapshots__/download_spec.js
@@ -44,3 +44,7 @@ https://download.cypress.io/desktop/0.20.2?platform=OS&arch=ARCH
 exports['desktop url from template'] = `
 https://download.cypress.io/desktop/0.20.2/darwin-x64/cypress.zip
 `
+
+exports['desktop url from alternative template'] = `
+https://download.cypress.io/desktop/0.20.2/darwin-x64/cypress.zip
+`

--- a/cli/lib/tasks/download.js
+++ b/cli/lib/tasks/download.js
@@ -68,12 +68,12 @@ const prepend = (urlPath) => {
 
   return pathTemplate
     ? pathTemplate
-        .replace('${endpoint}', endpoint)
-        .replace('${platform}', platform)
-        .replace('${arch}', arch())
-        .replace('{endpoint}', endpoint)
-        .replace('{platform}', platform)
-        .replace('{arch}', arch())
+    .replace('${endpoint}', endpoint)
+    .replace('${platform}', platform)
+    .replace('${arch}', arch())
+    .replace('{endpoint}', endpoint)
+    .replace('{platform}', platform)
+    .replace('{arch}', arch())
     : `${endpoint}?platform=${platform}&arch=${arch()}`
 }
 

--- a/cli/lib/tasks/download.js
+++ b/cli/lib/tasks/download.js
@@ -67,7 +67,13 @@ const prepend = (urlPath) => {
   const pathTemplate = util.getEnv('CYPRESS_DOWNLOAD_PATH_TEMPLATE')
 
   return pathTemplate
-    ? pathTemplate.replace('${endpoint}', endpoint).replace('${platform}', platform).replace('${arch}', arch())
+    ? pathTemplate
+        .replace('${endpoint}', endpoint)
+        .replace('${platform}', platform)
+        .replace('${arch}', arch())
+        .replace('{endpoint}', endpoint)
+        .replace('{platform}', platform)
+        .replace('{arch}', arch())
     : `${endpoint}?platform=${platform}&arch=${arch()}`
 }
 

--- a/cli/test/lib/tasks/download_spec.js
+++ b/cli/test/lib/tasks/download_spec.js
@@ -72,6 +72,13 @@ describe('lib/tasks/download', function () {
       snapshot('desktop url from template', normalize(url))
     })
 
+    it('returns custom url from template 2', () => {
+      process.env.CYPRESS_DOWNLOAD_PATH_TEMPLATE = '{endpoint}/{platform}-{arch}/cypress.zip'
+      const url = download.getUrl('0.20.2')
+
+      snapshot('desktop url from alternative template', normalize(url))
+    })
+
     it('returns input if it is already an https link', () => {
       const url = 'https://somewhere.com'
       const result = download.getUrl(url)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
Now it is possible to use CYPRESS_DOWNLOAD_PATH_TEMPLATE in an .npmrc file using this syntax
CYPRESS_DOWNLOAD_PATH_TEMPLATE={endpoint}/{platform}-{arch}/cypress.zip

### Additional details
- Why was this change necessary? - When setting environment variables through .npmrc file, npm itself does string replacement and searches for ${variableName} from the file. Due to this it wasn't possible to use CYPRESS_DOWNLOAD_PATH_TEMPLATE=${endpoint}/${platform}-${arch}/cypress.zip in an .npmrc file. To prevent breaking change I added an alternative format (instead of replacing the previous one). 
Setting the environement variable through .npmrc helps us to configure cypress for the entire repository. .npmrc gets commited with the rest of the code and every dev can just run `npm i` and have Cypress downloaded from correct url.
- What is affected by this change? - Cypress CLI. Support for alternative string replacement format

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Before:
`CYPRESS_DOWNLOAD_PATH_TEMPLATE=${endpoint}/${platform}-${arch}/cypress.zip`
After:
`CYPRESS_DOWNLOAD_PATH_TEMPLATE=${endpoint}/${platform}-${arch}/cypress.zip` or
`CYPRESS_DOWNLOAD_PATH_TEMPLATE={endpoint}/{platform}-{arch}/cypress.zip`

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
