### PR TITLE
chore: remove design system warnings

### DIFF
--- a/npm/design-system/src/components/Nav/LeftNav.cy.tsx
+++ b/npm/design-system/src/components/Nav/LeftNav.cy.tsx
@@ -97,8 +97,8 @@ describe('LeftNav', () => {
           icon: 'ad',
           interaction: {
             type: 'js',
-            onClick (idx) {
-              if (idx === activeIndex) {
+            onClick ({ index }) {
+              if (index === activeIndex) {
                 return setActiveIndex(undefined)
               }
 
@@ -111,8 +111,8 @@ describe('LeftNav', () => {
           itemClasses: 'second-item-button',
           interaction: {
             type: 'js',
-            onClick (idx) {
-              if (idx === activeIndex) {
+            onClick ({ index }) {
+              if (index === activeIndex) {
                 return setActiveIndex(undefined)
               }
 

--- a/npm/design-system/src/components/fileTree/FileTree.cy.tsx
+++ b/npm/design-system/src/components/fileTree/FileTree.cy.tsx
@@ -17,16 +17,19 @@ const files = [
 
 const assertSelectedBorder = ($els: JQuery<HTMLElement>) => {
   const win = $els[0].ownerDocument.defaultView
-  const after = win.getComputedStyle($els[0], 'after')
 
-  // Verify that we see at least some border, indicating it is highlighted
-  const leftStyle = after.getPropertyValue('border-left-style')
+  if (win) {
+    const after = win.getComputedStyle($els[0], 'after')
 
-  expect(leftStyle).to.eq('solid')
+    // Verify that we see at least some border, indicating it is highlighted
+    const leftStyle = after.getPropertyValue('border-left-style')
 
-  const leftWidth = after.getPropertyValue('border-left-width')
+    expect(leftStyle).to.eq('solid')
 
-  expect(leftWidth).to.eq('2px')
+    const leftWidth = after.getPropertyValue('border-left-width')
+
+    expect(leftWidth).to.eq('2px')
+  }
 }
 
 beforeEach(() => {

--- a/npm/design-system/src/core/icon/Icon.cy.tsx
+++ b/npm/design-system/src/core/icon/Icon.cy.tsx
@@ -21,7 +21,11 @@ describe('<Icon />', () => {
   })
 
   it('Icon lines', () => {
-    const Icons = () => iconLines(['text-xs', 'text-s', 'text-ms', 'text-m', 'text-ml', 'text-l', 'text-xl', 'text-2xl', 'text-3xl', 'text-4xl'])
+    const Icons = () => (
+      <>
+        {iconLines(['text-xs', 'text-s', 'text-ms', 'text-m', 'text-ml', 'text-l', 'text-xl', 'text-2xl', 'text-3xl', 'text-4xl'])}
+      </>
+    )
 
     mountAndSnapshot(<Icons />)
   })


### PR DESCRIPTION
When building 10.0-release a few warnings appear about types in the design-system:

```
@cypress/design-system: $ rimraf dist && rollup -c rollup.config.js
@cypress/design-system: src/index.ts → ./dist...
@cypress/design-system: Info: === tsc-alias starting ===
@cypress/design-system: Info: 9 files were affected!
@cypress/design-system: (!) Plugin typescript: @rollup/plugin-typescript TS2531: Object is possibly 'null'.
@cypress/design-system: src/components/fileTree/FileTree.cy.tsx: (20:17)
@cypress/design-system: 20   const after = win.getComputedStyle($els[0], 'after')
@cypress/design-system:                    ~~~
@cypress/design-system: (!) Plugin typescript: @rollup/plugin-typescript TS2367: This condition will always return 'false' since the types 'NavClick' and 'number | undefined' have no overlap.
@cypress/design-system: src/components/Nav/LeftNav.cy.tsx: (101:19)
@cypress/design-system: 101               if (idx === activeIndex) {
@cypress/design-system:                       ~~~~~~~~~~~~~~~~~~~
@cypress/design-system: src/components/Nav/LeftNav.cy.tsx: (115:19)
@cypress/design-system: 115               if (idx === activeIndex) {
@cypress/design-system:                       ~~~~~~~~~~~~~~~~~~~
@cypress/design-system: (!) Plugin typescript: @rollup/plugin-typescript TS2786: 'Icons' cannot be used as a JSX component.
@cypress/design-system:   Its return type 'Element[]' is not a valid JSX element.
@cypress/design-system:     Type 'Element[]' is missing the following properties from type 'ReactElement<any, any>': type, props, key
@cypress/design-system: src/core/icon/Icon.cy.tsx: (26:23)
@cypress/design-system: 26     mountAndSnapshot(<Icons />)
@cypress/design-system:                          ~~~~~
@cypress/design-system: created ./dist in 3.9s
```


It was bugging me so I fixed them.