### PR TITLE
chore(multi-domain): add clock support in multi-domain

### DIFF
--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_spies_stubs_clocks.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_spies_stubs_clocks.spec.ts
@@ -25,9 +25,7 @@ context('multi-domain spies, stubs, and clock', { experimentalSessionSupport: tr
     })
   })
 
-  // FIXME: TypeError: Cannot set properties of undefined (setting 'clock')
-  // at Object.clock (webpack:///../driver/src/cy/commands/clock.ts?:170:17)
-  it.skip('clock() and tick()', () => {
+  it('clock() and tick()', () => {
     cy.switchToDomain('foobar.com', () => {
       const now = Date.UTC(2022, 0, 12)
 

--- a/packages/driver/src/multi-domain/index.ts
+++ b/packages/driver/src/multi-domain/index.ts
@@ -114,6 +114,9 @@ const setup = () => {
       isPending () {},
     })
 
+    // Set the state ctx to the runnable ctx to ensure they remain in sync
+    cy.state('ctx', cy.state('runnable').ctx)
+
     let fnWrapper = `(${fn})`
 
     if (isDoneFnAvailable) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -25214,20 +25214,12 @@ launch-editor-middleware@^2.2.1:
   dependencies:
     launch-editor "^2.2.1"
 
-launch-editor@2.3.0:
+launch-editor@2.3.0, launch-editor@^2.2.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.3.0.tgz#23b2081403b7eeaae2918bda510f3535ccab0ee4"
   integrity sha512-3QrsCXejlWYHjBPFXTyGNhPj4rrQdB+5+r5r3wArpLH201aR+nWUgw/zKKkTmilCfY/sv6u8qo98pNvtg8LUTA==
   dependencies:
     picocolors "^1.0.0"
-    shell-quote "^1.6.1"
-
-launch-editor@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.2.1.tgz#871b5a3ee39d6680fcc26d37930b6eeda89db0ca"
-  integrity sha512-On+V7K2uZK6wK7x691ycSUbLD/FyKKelArkbaAMSSJU8JmqmhwN2+mnJDNINuJWSrh2L0kDk+ZQtbC/gOWUwLw==
-  dependencies:
-    chalk "^2.3.0"
     shell-quote "^1.6.1"
 
 lazy-ass@1.6.0, lazy-ass@^1.6.0:


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #19846

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
The following error thrown when accessing `cy.clock()` or `cy.tick()`:
```
TypeError: Cannot set properties of undefined (setting 'clock')
  at Object.clock (webpack:///../driver/src/cy/commands/clock.ts?:170:17)
```

The [`state('ctx')`](https://github.com/cypress-io/cypress/blob/1f70b21bc4427ff99d20d8b67d201d98d71021fe/packages/driver/src/cy/commands/clock.ts#L48) object was not set in the secondary domain which caused the error. In the primary domain the `state('ctx')` is set to the [`runnable.ctx`](https://github.com/cypress-io/cypress/blob/1f70b21bc4427ff99d20d8b67d201d98d71021fe/packages/driver/src/cypress/cy.ts#L845) when the runnable is set. Thus, in the secondary domain, I'm setting the `state('ctx')` to the `runnable.ctx` when the `state('runnable')` is set.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Users are now able to use `.clock()` and `.tick()` in multi-domain.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
