### PR TITLE
feat: implement uncaught:exception and error in spec bridge

### DIFF
--- a/packages/driver/cypress/fixtures/multi-domain.html
+++ b/packages/driver/cypress/fixtures/multi-domain.html
@@ -17,6 +17,7 @@
     <a data-cy="request-link" href="http://www.foobar.com:3500/fixtures/request.html">http://www.foobar.com:3500/fixtures/request.html</a>
     <a data-cy="shadow-dom-link" href="http://www.foobar.com:3500/fixtures/shadow-dom.html">http://www.foobar.com:3500/fixtures/shadow-dom.html</a>
     <a data-cy="files-form-link" href="http://www.foobar.com:3500/fixtures/files-form.html">http://www.foobar.com:3500/fixtures/files-form.html</a>
+    <a data-cy="errors-link" href="http://www.foobar.com:3500/fixtures/errors.html">http://www.foobar.com:3500/fixtures/errors.html</a>
   </div>
 </body>
 </html>

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
@@ -154,9 +154,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
 
   it('does not fail if thrown custom error with readonly name', (done) => {
     cy.once('fail', (err) => {
-      // TODO: we cannot currently serialize custom user errors back to the primary
-      // ideally, we want the name of this error to be 'CustomError'
-      expect(err.name).to.include('Error')
+      expect(err.name).to.include('CustomError')
       expect(err.message).to.include('custom error')
 
       done()

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
@@ -1,0 +1,175 @@
+// @ts-ignore / session support is needed for visiting about:blank between tests
+describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+  beforeEach(() => {
+    cy.visit('/fixtures/multi-domain.html')
+    cy.get('a[data-cy="errors-link"]').click()
+  })
+
+  describe('uncaught errors', () => {
+    describe('sync errors', () => {
+      it('fails the current test/command if sync errors are thrown from the switchToDomain context', () => {
+        const uncaughtExceptionSpy = cy.spy()
+        const r = cy.state('runnable')
+
+        cy.on('uncaught:exception', uncaughtExceptionSpy)
+        cy.on('fail', (err, runnable) => {
+          // TODO: we likely need to change the messaging around this error to make it clear to multi-domain users that
+          // this behavior is configurable with 'uncaught:exception', but it MUST be declared inside the switchToDomain callback
+          // and that 'uncaught:exception' will NOT be triggered outside that callback (inside the primary domain)
+          expect(err.name).to.eq('Error')
+          expect(err.message).to.include('sync error')
+          expect(err.message).to.include('The following error originated from your application code, not from Cypress.')
+          expect(err.message).to.not.include('https://on.cypress.io/uncaught-exception-from-application')
+          expect(err.docsUrl).to.deep.eq(['https://on.cypress.io/uncaught-exception-from-application'])
+
+          // lastly, make sure the `uncaught:exception' handler is NOT called in the primary
+          expect(uncaughtExceptionSpy.notCalled).to.be.true
+          expect(runnable === r).to.be.true
+        })
+
+        cy.switchToDomain('foobar.com', () => {
+          cy.get('.trigger-sync-error').click()
+        })
+      })
+
+      it('returns false from cy.on(uncaught:exception), resulting in cy:fail to not be called in the primary and passes the test', () => {
+        const uncaughtExceptionSpy = cy.spy()
+        const failureSpy = cy.spy()
+
+        cy.on('uncaught:exception', uncaughtExceptionSpy)
+
+        cy.on('fail', failureSpy)
+
+        cy.switchToDomain('foobar.com', () => {
+          cy.on('uncaught:exception', () => false)
+          cy.get('.trigger-sync-error').click()
+        }).then(() => {
+          expect(uncaughtExceptionSpy.notCalled).to.be.true
+          expect(failureSpy.notCalled).to.be.true
+        })
+      })
+
+      it('returns true from cy.on(uncaught:exception), resulting in cy:fail to be called in the primary', (done) => {
+        cy.on('fail', () => {
+          done()
+        })
+
+        cy.switchToDomain('foobar.com', () => {
+          cy.once('uncaught:exception', () => true)
+          cy.get('.trigger-sync-error').click()
+        })
+      })
+
+      // if we mutate the error, the app's listeners for 'error' or
+      // 'unhandledrejection' will have our wrapped error instead of the original
+      it('original error is not mutated for "error" in the switchToDomain', () => {
+        cy.switchToDomain('foobar.com', () => {
+          cy.once('uncaught:exception', () => false)
+
+          cy.get('.trigger-sync-error').click()
+          cy.get('.error-one').invoke('text').should('equal', 'sync error')
+          cy.get('.error-two').invoke('text').should('equal', 'sync error')
+        })
+      })
+    })
+
+    describe('async errors', () => {
+      it('fails the current test/command if async errors are thrown from the switchToDomain context while the callback window is still open', () => {
+        const uncaughtExceptionSpy = cy.spy()
+        const r = cy.state('runnable')
+
+        cy.on('uncaught:exception', uncaughtExceptionSpy)
+
+        cy.on('fail', (err, runnable) => {
+          expect(err.name).to.eq('Error')
+          expect(err.message).to.include('async error')
+          expect(err.message).to.include('The following error originated from your application code, not from Cypress.')
+          expect(err.message).to.not.include('https://on.cypress.io/uncaught-exception-from-application')
+          expect(err.docsUrl).to.deep.eq(['https://on.cypress.io/uncaught-exception-from-application'])
+
+          expect(uncaughtExceptionSpy.notCalled).to.be.true
+          expect(runnable === r).to.be.true
+        })
+
+        cy.switchToDomain('foobar.com', () => {
+          cy.get('.trigger-async-error').click()
+
+          // add the cy.wait here to keep commands streaming in,
+          // forcing the switchToDomain callback window to be open long enough for an async error to occur
+          cy.wait(1000)
+        })
+      })
+
+      it('passes the current test/command if async errors are thrown from the switchToDomain context, but the callback window is now closed', () => {
+        const uncaughtExceptionSpy = cy.spy()
+        const failureSpy = cy.spy()
+
+        cy.on('uncaught:exception', uncaughtExceptionSpy)
+
+        cy.on('fail', failureSpy)
+
+        cy.switchToDomain('foobar.com', () => {
+          // the async error here should be thrown AFTER the current command and test has finished, resulting in a passed test with no fail being triggered in the primary
+          cy.get('.trigger-async-error').click()
+        }).then(() => {
+          expect(uncaughtExceptionSpy.notCalled).to.be.true
+          expect(failureSpy.notCalled).to.be.true
+        })
+      })
+    })
+
+    describe('unhandled rejections', () => {
+      it('unhandled rejection triggers uncaught:exception and has promise as third argument', (done) => {
+        cy.switchToDomain('foobar.com', done, () => {
+          const r = cy.state('runnable')
+
+          cy.once('uncaught:exception', (err, runnable, promise) => {
+            expect(err.stack).to.include('promise rejection')
+            expect(err.stack).to.include('one')
+            expect(err.stack).to.include('two')
+            expect(err.stack).to.include('three')
+            expect(runnable === r).to.be.true
+            expect(promise).to.be.a('promise')
+
+            done()
+
+            return false
+          })
+
+          cy.get('.trigger-unhandled-rejection').click()
+        })
+      })
+
+      it('original error is not mutated for "unhandledrejection"', () => {
+        cy.switchToDomain('foobar.com', () => {
+          cy.once('uncaught:exception', () => false)
+
+          cy.get('.trigger-unhandled-rejection').click()
+          cy.get('.error-one').invoke('text').should('equal', 'promise rejection')
+          cy.get('.error-two').invoke('text').should('equal', 'promise rejection')
+        })
+      })
+    })
+
+    it('does not fail if thrown custom error with readonly name', (done) => {
+      cy.once('fail', (err) => {
+        // TODO: we cannot currently serialize custom user errors back to the primary
+        // ideally, we want the name of this error to be 'CustomError'
+        expect(err.name).to.include('Error')
+        expect(err.message).to.include('custom error')
+
+        done()
+      })
+
+      cy.switchToDomain('foobar.com', () => {
+        cy.then(() => {
+          throw new class CustomError extends Error {
+            get name () {
+              return 'CustomError'
+            }
+          }('custom error')
+        })
+      })
+    })
+  })
+})

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
@@ -23,8 +23,8 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
         expect(err.docsUrl).to.deep.eq(['https://on.cypress.io/uncaught-exception-from-application'])
 
         // lastly, make sure the `uncaught:exception' handler is NOT called in the primary
-        expect(uncaughtExceptionSpy.notCalled).to.be.true
-        expect(runnable === r).to.be.true
+        expect(uncaughtExceptionSpy).not.to.be.called
+        expect(runnable).to.be.equal(r)
       })
 
       cy.switchToDomain('foobar.com', () => {
@@ -44,8 +44,8 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
         cy.on('uncaught:exception', () => false)
         cy.get('.trigger-sync-error').click()
       }).then(() => {
-        expect(uncaughtExceptionSpy.notCalled).to.be.true
-        expect(failureSpy.notCalled).to.be.true
+        expect(uncaughtExceptionSpy).not.to.be.called
+        expect(failureSpy).not.to.be.called
       })
     })
 
@@ -88,8 +88,8 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
         // @ts-ignore
         expect(err.docsUrl).to.deep.eq(['https://on.cypress.io/uncaught-exception-from-application'])
 
-        expect(uncaughtExceptionSpy.notCalled).to.be.true
-        expect(runnable === r).to.be.true
+        expect(uncaughtExceptionSpy).not.to.be.called
+        expect(runnable).to.be.equal(r)
       })
 
       cy.switchToDomain('foobar.com', () => {
@@ -113,8 +113,8 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
         // the async error here should be thrown AFTER the current command and test has finished, resulting in a passed test with no fail being triggered in the primary
         cy.get('.trigger-async-error').click()
       }).then(() => {
-        expect(uncaughtExceptionSpy.notCalled).to.be.true
-        expect(failureSpy.notCalled).to.be.true
+        expect(uncaughtExceptionSpy).not.to.be.called
+        expect(failureSpy).not.to.be.called
       })
     })
   })
@@ -129,7 +129,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
           expect(err.stack).to.include('one')
           expect(err.stack).to.include('two')
           expect(err.stack).to.include('three')
-          expect(runnable === r).to.be.true
+          expect(runnable).to.be.equal(r)
           expect(promise).to.be.a('promise')
 
           done()

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
@@ -49,9 +49,14 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
       })
     })
 
-    it('returns true from cy.on(uncaught:exception), resulting in cy:fail to be called in the primary', (done) => {
-      cy.on('fail', () => {
-        done()
+    it('returns true from cy.on(uncaught:exception), resulting in cy:fail to be called in the primary', () => {
+      cy.on('fail', (err) => {
+        expect(err.name).to.eq('Error')
+        expect(err.message).to.include('sync error')
+        expect(err.message).to.include('The following error originated from your application code, not from Cypress.')
+        expect(err.message).to.not.include('https://on.cypress.io/uncaught-exception-from-application')
+        // @ts-ignore
+        expect(err.docsUrl).to.deep.eq(['https://on.cypress.io/uncaught-exception-from-application'])
       })
 
       cy.switchToDomain('foobar.com', () => {

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
@@ -5,172 +5,170 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
     cy.get('a[data-cy="errors-link"]').click()
   })
 
-  describe('uncaught errors', () => {
-    describe('sync errors', () => {
-      it('fails the current test/command if sync errors are thrown from the switchToDomain context', () => {
-        const uncaughtExceptionSpy = cy.spy()
-        const r = cy.state('runnable')
+  describe('sync errors', () => {
+    it('fails the current test/command if sync errors are thrown from the switchToDomain context', () => {
+      const uncaughtExceptionSpy = cy.spy()
+      const r = cy.state('runnable')
 
-        cy.on('uncaught:exception', uncaughtExceptionSpy)
-        cy.on('fail', (err, runnable) => {
-          // TODO: we likely need to change the messaging around this error to make it clear to multi-domain users that
-          // this behavior is configurable with 'uncaught:exception', but it MUST be declared inside the switchToDomain callback
-          // and that 'uncaught:exception' will NOT be triggered outside that callback (inside the primary domain)
-          expect(err.name).to.eq('Error')
-          expect(err.message).to.include('sync error')
-          expect(err.message).to.include('The following error originated from your application code, not from Cypress.')
-          expect(err.message).to.not.include('https://on.cypress.io/uncaught-exception-from-application')
-          // @ts-ignore
-          expect(err.docsUrl).to.deep.eq(['https://on.cypress.io/uncaught-exception-from-application'])
+      cy.on('uncaught:exception', uncaughtExceptionSpy)
+      cy.on('fail', (err, runnable) => {
+        // TODO: we likely need to change the messaging around this error to make it clear to multi-domain users that
+        // this behavior is configurable with 'uncaught:exception', but it MUST be declared inside the switchToDomain callback
+        // and that 'uncaught:exception' will NOT be triggered outside that callback (inside the primary domain)
+        expect(err.name).to.eq('Error')
+        expect(err.message).to.include('sync error')
+        expect(err.message).to.include('The following error originated from your application code, not from Cypress.')
+        expect(err.message).to.not.include('https://on.cypress.io/uncaught-exception-from-application')
+        // @ts-ignore
+        expect(err.docsUrl).to.deep.eq(['https://on.cypress.io/uncaught-exception-from-application'])
 
-          // lastly, make sure the `uncaught:exception' handler is NOT called in the primary
-          expect(uncaughtExceptionSpy.notCalled).to.be.true
-          expect(runnable === r).to.be.true
-        })
-
-        cy.switchToDomain('foobar.com', () => {
-          cy.get('.trigger-sync-error').click()
-        })
+        // lastly, make sure the `uncaught:exception' handler is NOT called in the primary
+        expect(uncaughtExceptionSpy.notCalled).to.be.true
+        expect(runnable === r).to.be.true
       })
 
-      it('returns false from cy.on(uncaught:exception), resulting in cy:fail to not be called in the primary and passes the test', () => {
-        const uncaughtExceptionSpy = cy.spy()
-        const failureSpy = cy.spy()
-
-        cy.on('uncaught:exception', uncaughtExceptionSpy)
-
-        cy.on('fail', failureSpy)
-
-        cy.switchToDomain('foobar.com', () => {
-          cy.on('uncaught:exception', () => false)
-          cy.get('.trigger-sync-error').click()
-        }).then(() => {
-          expect(uncaughtExceptionSpy.notCalled).to.be.true
-          expect(failureSpy.notCalled).to.be.true
-        })
-      })
-
-      it('returns true from cy.on(uncaught:exception), resulting in cy:fail to be called in the primary', (done) => {
-        cy.on('fail', () => {
-          done()
-        })
-
-        cy.switchToDomain('foobar.com', () => {
-          cy.once('uncaught:exception', () => true)
-          cy.get('.trigger-sync-error').click()
-        })
-      })
-
-      // if we mutate the error, the app's listeners for 'error' or
-      // 'unhandledrejection' will have our wrapped error instead of the original
-      it('original error is not mutated for "error" in the switchToDomain', () => {
-        cy.switchToDomain('foobar.com', () => {
-          cy.once('uncaught:exception', () => false)
-
-          cy.get('.trigger-sync-error').click()
-          cy.get('.error-one').invoke('text').should('equal', 'sync error')
-          cy.get('.error-two').invoke('text').should('equal', 'sync error')
-        })
+      cy.switchToDomain('foobar.com', () => {
+        cy.get('.trigger-sync-error').click()
       })
     })
 
-    describe('async errors', () => {
-      it('fails the current test/command if async errors are thrown from the switchToDomain context while the callback window is still open', () => {
-        const uncaughtExceptionSpy = cy.spy()
-        const r = cy.state('runnable')
+    it('returns false from cy.on(uncaught:exception), resulting in cy:fail to not be called in the primary and passes the test', () => {
+      const uncaughtExceptionSpy = cy.spy()
+      const failureSpy = cy.spy()
 
-        cy.on('uncaught:exception', uncaughtExceptionSpy)
+      cy.on('uncaught:exception', uncaughtExceptionSpy)
 
-        cy.on('fail', (err, runnable) => {
-          expect(err.name).to.eq('Error')
-          expect(err.message).to.include('async error')
-          expect(err.message).to.include('The following error originated from your application code, not from Cypress.')
-          expect(err.message).to.not.include('https://on.cypress.io/uncaught-exception-from-application')
-          // @ts-ignore
-          expect(err.docsUrl).to.deep.eq(['https://on.cypress.io/uncaught-exception-from-application'])
+      cy.on('fail', failureSpy)
 
-          expect(uncaughtExceptionSpy.notCalled).to.be.true
-          expect(runnable === r).to.be.true
-        })
-
-        cy.switchToDomain('foobar.com', () => {
-          cy.get('.trigger-async-error').click()
-
-          // add the cy.wait here to keep commands streaming in,
-          // forcing the switchToDomain callback window to be open long enough for an async error to occur
-          cy.wait(1000)
-        })
-      })
-
-      it('passes the current test/command if async errors are thrown from the switchToDomain context, but the callback window is now closed', () => {
-        const uncaughtExceptionSpy = cy.spy()
-        const failureSpy = cy.spy()
-
-        cy.on('uncaught:exception', uncaughtExceptionSpy)
-
-        cy.on('fail', failureSpy)
-
-        cy.switchToDomain('foobar.com', () => {
-          // the async error here should be thrown AFTER the current command and test has finished, resulting in a passed test with no fail being triggered in the primary
-          cy.get('.trigger-async-error').click()
-        }).then(() => {
-          expect(uncaughtExceptionSpy.notCalled).to.be.true
-          expect(failureSpy.notCalled).to.be.true
-        })
+      cy.switchToDomain('foobar.com', () => {
+        cy.on('uncaught:exception', () => false)
+        cy.get('.trigger-sync-error').click()
+      }).then(() => {
+        expect(uncaughtExceptionSpy.notCalled).to.be.true
+        expect(failureSpy.notCalled).to.be.true
       })
     })
 
-    describe('unhandled rejections', () => {
-      it('unhandled rejection triggers uncaught:exception and has promise as third argument', (done) => {
-        cy.switchToDomain('foobar.com', done, () => {
-          const r = cy.state('runnable')
-
-          cy.once('uncaught:exception', (err, runnable, promise) => {
-            expect(err.stack).to.include('promise rejection')
-            expect(err.stack).to.include('one')
-            expect(err.stack).to.include('two')
-            expect(err.stack).to.include('three')
-            expect(runnable === r).to.be.true
-            expect(promise).to.be.a('promise')
-
-            done()
-
-            return false
-          })
-
-          cy.get('.trigger-unhandled-rejection').click()
-        })
-      })
-
-      it('original error is not mutated for "unhandledrejection"', () => {
-        cy.switchToDomain('foobar.com', () => {
-          cy.once('uncaught:exception', () => false)
-
-          cy.get('.trigger-unhandled-rejection').click()
-          cy.get('.error-one').invoke('text').should('equal', 'promise rejection')
-          cy.get('.error-two').invoke('text').should('equal', 'promise rejection')
-        })
-      })
-    })
-
-    it('does not fail if thrown custom error with readonly name', (done) => {
-      cy.once('fail', (err) => {
-        // TODO: we cannot currently serialize custom user errors back to the primary
-        // ideally, we want the name of this error to be 'CustomError'
-        expect(err.name).to.include('Error')
-        expect(err.message).to.include('custom error')
-
+    it('returns true from cy.on(uncaught:exception), resulting in cy:fail to be called in the primary', (done) => {
+      cy.on('fail', () => {
         done()
       })
 
       cy.switchToDomain('foobar.com', () => {
-        cy.then(() => {
-          throw new class CustomError extends Error {
-            get name () {
-              return 'CustomError'
-            }
-          }('custom error')
+        cy.once('uncaught:exception', () => true)
+        cy.get('.trigger-sync-error').click()
+      })
+    })
+
+    // if we mutate the error, the app's listeners for 'error' or
+    // 'unhandledrejection' will have our wrapped error instead of the original
+    it('original error is not mutated for "error" in the switchToDomain', () => {
+      cy.switchToDomain('foobar.com', () => {
+        cy.once('uncaught:exception', () => false)
+
+        cy.get('.trigger-sync-error').click()
+        cy.get('.error-one').invoke('text').should('equal', 'sync error')
+        cy.get('.error-two').invoke('text').should('equal', 'sync error')
+      })
+    })
+  })
+
+  describe('async errors', () => {
+    it('fails the current test/command if async errors are thrown from the switchToDomain context while the callback window is still open', () => {
+      const uncaughtExceptionSpy = cy.spy()
+      const r = cy.state('runnable')
+
+      cy.on('uncaught:exception', uncaughtExceptionSpy)
+
+      cy.on('fail', (err, runnable) => {
+        expect(err.name).to.eq('Error')
+        expect(err.message).to.include('async error')
+        expect(err.message).to.include('The following error originated from your application code, not from Cypress.')
+        expect(err.message).to.not.include('https://on.cypress.io/uncaught-exception-from-application')
+        // @ts-ignore
+        expect(err.docsUrl).to.deep.eq(['https://on.cypress.io/uncaught-exception-from-application'])
+
+        expect(uncaughtExceptionSpy.notCalled).to.be.true
+        expect(runnable === r).to.be.true
+      })
+
+      cy.switchToDomain('foobar.com', () => {
+        cy.get('.trigger-async-error').click()
+
+        // add the cy.wait here to keep commands streaming in,
+        // forcing the switchToDomain callback window to be open long enough for an async error to occur
+        cy.wait(1000)
+      })
+    })
+
+    it('passes the current test/command if async errors are thrown from the switchToDomain context, but the callback window is now closed', () => {
+      const uncaughtExceptionSpy = cy.spy()
+      const failureSpy = cy.spy()
+
+      cy.on('uncaught:exception', uncaughtExceptionSpy)
+
+      cy.on('fail', failureSpy)
+
+      cy.switchToDomain('foobar.com', () => {
+        // the async error here should be thrown AFTER the current command and test has finished, resulting in a passed test with no fail being triggered in the primary
+        cy.get('.trigger-async-error').click()
+      }).then(() => {
+        expect(uncaughtExceptionSpy.notCalled).to.be.true
+        expect(failureSpy.notCalled).to.be.true
+      })
+    })
+  })
+
+  describe('unhandled rejections', () => {
+    it('unhandled rejection triggers uncaught:exception and has promise as third argument', (done) => {
+      cy.switchToDomain('foobar.com', done, () => {
+        const r = cy.state('runnable')
+
+        cy.once('uncaught:exception', (err, runnable, promise) => {
+          expect(err.stack).to.include('promise rejection')
+          expect(err.stack).to.include('one')
+          expect(err.stack).to.include('two')
+          expect(err.stack).to.include('three')
+          expect(runnable === r).to.be.true
+          expect(promise).to.be.a('promise')
+
+          done()
+
+          return false
         })
+
+        cy.get('.trigger-unhandled-rejection').click()
+      })
+    })
+
+    it('original error is not mutated for "unhandledrejection"', () => {
+      cy.switchToDomain('foobar.com', () => {
+        cy.once('uncaught:exception', () => false)
+
+        cy.get('.trigger-unhandled-rejection').click()
+        cy.get('.error-one').invoke('text').should('equal', 'promise rejection')
+        cy.get('.error-two').invoke('text').should('equal', 'promise rejection')
+      })
+    })
+  })
+
+  it('does not fail if thrown custom error with readonly name', (done) => {
+    cy.once('fail', (err) => {
+      // TODO: we cannot currently serialize custom user errors back to the primary
+      // ideally, we want the name of this error to be 'CustomError'
+      expect(err.name).to.include('Error')
+      expect(err.message).to.include('custom error')
+
+      done()
+    })
+
+    cy.switchToDomain('foobar.com', () => {
+      cy.then(() => {
+        throw new class CustomError extends Error {
+          get name () {
+            return 'CustomError'
+          }
+        }('custom error')
       })
     })
   })

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
@@ -20,6 +20,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
           expect(err.message).to.include('sync error')
           expect(err.message).to.include('The following error originated from your application code, not from Cypress.')
           expect(err.message).to.not.include('https://on.cypress.io/uncaught-exception-from-application')
+          // @ts-ignore
           expect(err.docsUrl).to.deep.eq(['https://on.cypress.io/uncaught-exception-from-application'])
 
           // lastly, make sure the `uncaught:exception' handler is NOT called in the primary
@@ -85,6 +86,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
           expect(err.message).to.include('async error')
           expect(err.message).to.include('The following error originated from your application code, not from Cypress.')
           expect(err.message).to.not.include('https://on.cypress.io/uncaught-exception-from-application')
+          // @ts-ignore
           expect(err.docsUrl).to.deep.eq(['https://on.cypress.io/uncaught-exception-from-application'])
 
           expect(uncaughtExceptionSpy.notCalled).to.be.true

--- a/packages/driver/src/cy/multi-domain/util.ts
+++ b/packages/driver/src/cy/multi-domain/util.ts
@@ -11,6 +11,8 @@ export const correctStackForCrossDomainError = (serializedError: any, userInvoca
     return _.isUndefined(objValue) ? srcValue : objValue
   })
 
+  reifiedError.name = serializedError?.name ?? reifiedError.name
+
   reifiedError.stack = $stackUtils.replacedStack(reifiedError, userInvocationStack)
 
   return reifiedError


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes  #19709

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
--> N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Extends off of #19805 to implement `uncaught:exception`s or application error events in `switchToDomain`.

When uncaught exceptions or errors occur in the secondary domain (SD), we want to fail the current command and test in the primary domain (PD) as long as the `switchToDomain` callback context is still 'open'. If a user wishes to bypass `uncaught:exception`s in the SD, a `cy.on('uncaught:exception')` handler can be defined in the `switchToDomain` callback and `false` can be returned just as described in the [docs](https://docs.cypress.io/api/events/catalog-of-events#Uncaught-Exceptions). However,  `uncaught:exception` events outside the `switchToDomain` context will NOT be called with errors occurring in the SD.  This is mainly due to difficulties serializing function arguments between domains to keep Cypress consistent with the way it works today. Here are a few examples as to how this is supposed to work:

#### Example 1
```js
cy.on('uncaught:exception', (err) => {
  // will NOT be called
})

cy.on('fail', (err, runnable) => {
  // will be called
})

cy.switchToDomain('foobar.com', () => {
  // throws an error
  cy.get('.trigger-sync-error').click()
})
```
#### Example 2
```js
cy.on('fail', (err, runnable) => {
  // will NOT be called
})

cy.switchToDomain('foobar.com', () => {
  cy.on('uncaught:exception', (err) => {
    // will be called
    return false
  })

  // throws an error
  cy.get('.trigger-sync-error').click()
})
```

In regards to the `switchToDomain` context still being open, the functionality should work as follows

#### Example 1
```js
cy.on('fail', (err, runnable) => {
  // Likely will NOT be called since the context window may be closed before the error actually throws
})

cy.switchToDomain('foobar.com', () => {
  cy.get('.trigger-async-error').click()
})
```

#### Example 2
```js
cy.on('fail', (err, runnable) => {
  // Likely will be called since the context window is still open by the time the error throws
})

cy.switchToDomain('foobar.com', () => {
  cy.get('.trigger-async-error').click()
  cy.wait(2000)
  // do some other cy commands
})
```


In the meantime, hopefully the added tests to exercise this behavior serve as documentation for how this functionality is supposed to work. Here are some code snippets followed by their test/runner outcome

#### sync error
```js
cy.switchToDomain('foobar.com', () => {
    cy.get('.trigger-sync-error').click()
  })
```
![](https://user-images.githubusercontent.com/3980464/151238894-14e4aae5-cb5b-4b2a-a2d8-f63ba9d18a3e.png)

#### async error
```js
cy.switchToDomain('foobar.com', () => {
    cy.get('.trigger-async-error').click()
    cy.wait(2000)
  })
```
![](https://user-images.githubusercontent.com/3980464/151238863-37e96bd2-a2f4-4607-9c50-dceed12828e9.png)

#### sync error expecting errors
```js
cy.on('fail', (err, runnable) => {
  done()
})

cy.switchToDomain('foobar.com', () => {
  cy.get('.trigger-sync-error').click()
})
```
![](https://user-images.githubusercontent.com/3980464/151245802-ac756810-effa-4b15-88db-e11dc144b812.png)

#### async error that doesn't get caught as the context window is closed
```js
cy.on('fail', (err, runnable) => {
  // does NOT get called and test passes
})

cy.switchToDomain('foobar.com', () => {
  cy.get('.trigger-async-error').click()
})
```
![](https://user-images.githubusercontent.com/3980464/151246121-c4047133-d12b-4ebd-8e34-2134bdadda03.png)

#### error thrown but `uncaught:exception` returns `false` in SD
```js
cy.on('fail', (err, runnable) => {
  // does NOT get called
})

cy.switchToDomain('foobar.com', () => {
  cy.on('uncaught:exception', () => false)
  cy.get('.trigger-sync-error').click()
})
```
![](https://user-images.githubusercontent.com/3980464/151246523-e5b95308-5d67-4981-b3f9-e6527740cb80.png)

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
