### PR TITLE
fix(unify): Updating reporter to use vue preferred editor dialog

### DIFF
--- a/packages/app/cypress/e2e/runner/reporter.errors.cy.ts
+++ b/packages/app/cypress/e2e/runner/reporter.errors.cy.ts
@@ -1,0 +1,90 @@
+import { verify } from './support/verify-helpers'
+
+describe('errors ui', {
+  viewportHeight: 768,
+  viewportWidth: 1024,
+}, () => {
+  describe('assertion failures', () => {
+    beforeEach(() => {
+      cy.scaffoldProject('runner-e2e-specs')
+      cy.openProject('runner-e2e-specs')
+
+      // set preferred editor to bypass IDE selection dialog
+      cy.withCtx((ctx) => {
+        ctx.coreData.localSettings.availableEditors = [
+          ...ctx.coreData.localSettings.availableEditors,
+          {
+            id: 'test-editor',
+            binary: '/usr/bin/test-editor',
+            name: 'Test editor',
+          },
+        ]
+
+        ctx.coreData.localSettings.preferences.preferredEditorBinary = 'test-editor'
+      })
+
+      cy.startAppServer()
+      cy.visitApp()
+
+      cy.contains('[data-cy=spec-item]', 'assertions.cy.js').click()
+
+      cy.location().should((location) => {
+        expect(location.hash).to.contain('assertions.cy.js')
+      })
+
+      // Wait for specs to complete
+      cy.findByLabelText('Stats').get('.failed', { timeout: 10000 }).should('have.text', 'Failed:3')
+    })
+
+    verify.it('with expect().<foo>', {
+      file: 'assertions.cy.js',
+      hasPreferredIde: true,
+      column: 25,
+      message: `expected 'actual' to equal 'expected'`,
+      codeFrameText: 'with expect().<foo>',
+    })
+
+    verify.it('with assert()', {
+      file: 'assertions.cy.js',
+      hasPreferredIde: true,
+      column: '(5|12)', // (chrome|firefox)
+      message: `should be true`,
+      codeFrameText: 'with assert()',
+    })
+
+    verify.it('with assert.<foo>()', {
+      file: 'assertions.cy.js',
+      hasPreferredIde: true,
+      column: 12,
+      message: `expected 'actual' to equal 'expected'`,
+      codeFrameText: 'with assert.<foo>()',
+    })
+  })
+
+  describe('assertion failures - no preferred IDE', () => {
+    beforeEach(() => {
+      cy.scaffoldProject('runner-e2e-specs')
+      cy.openProject('runner-e2e-specs')
+
+      cy.startAppServer()
+      cy.visitApp()
+
+      cy.contains('[data-cy=spec-item]', 'assertions.cy.js').click()
+
+      cy.location().should((location) => {
+        expect(location.hash).to.contain('assertions.cy.js')
+      })
+
+      // Wait for specs to complete
+      cy.findByLabelText('Stats').get('.failed', { timeout: 10000 }).should('have.text', 'Failed:3')
+    })
+
+    verify.it('with expect().<foo>', {
+      file: 'assertions.cy.js',
+      hasPreferredIde: false,
+      column: 25,
+      message: `expected 'actual' to equal 'expected'`,
+      codeFrameText: 'with expect().<foo>',
+    })
+  })
+})

--- a/packages/app/cypress/e2e/runner/support/verify-helpers.ts
+++ b/packages/app/cypress/e2e/runner/support/verify-helpers.ts
@@ -1,0 +1,205 @@
+import _ from 'lodash'
+import defaultMessages from '@packages/frontend-shared/src/locales/en-US.json'
+
+// Assert that either the the dialog is presented or the mutation is emitted, depending on
+// whether the test has a preferred IDE defined.
+const verifyIdeOpen = ({ file, action, hasPreferredIde }) => {
+  if (hasPreferredIde) {
+    cy.intercept('mutation-OpenFileInIDE', { data: { 'openFileInIDE': true } }).as('OpenIDE')
+
+    action()
+
+    cy.wait('@OpenIDE').then(({ request }) => {
+      expect(request.body.variables.input.absolute).to.include(file)
+    })
+  } else {
+    action()
+
+    cy.contains(defaultMessages.globalPage.selectPreferredEditor).should('be.visible')
+    cy.findByRole('button', { name: defaultMessages.actions.close }).click()
+  }
+}
+
+export const verifyFailure = (options) => {
+  const {
+    specTitle,
+    hasCodeFrame = true,
+    verifyOpenInIde = true,
+    hasPreferredIde,
+    column,
+    codeFrameText,
+    originalMessage,
+    message = [],
+    notInMessage = [],
+    command,
+    stack,
+    file,
+    uncaught = false,
+    uncaughtMessage,
+  } = options
+  let { regex, line } = options
+
+  regex = regex || new RegExp(`${file}:${line || '\\d+'}:${column}`)
+
+  cy.contains('.runnable-title', specTitle).closest('.runnable').as('Root')
+
+  cy.get('@Root').within(() => {
+    cy.contains('View stack trace').click()
+
+    const messageLines = [].concat(message)
+
+    if (messageLines.length) {
+      cy.log('message contains expected lines and stack does not include message')
+
+      _.each(messageLines, (msg) => {
+        cy.get('.runnable-err-message')
+        .should('include.text', msg)
+
+        cy.get('.runnable-err-stack-trace')
+        .should('not.include.text', msg)
+      })
+    }
+
+    if (originalMessage) {
+      cy.get('.runnable-err-message')
+      .should('include.text', originalMessage)
+    }
+
+    const notInMessageLines = [].concat(notInMessage)
+
+    if (notInMessageLines.length) {
+      cy.log('message does not contain the specified lines')
+
+      _.each(notInMessageLines, (msg) => {
+        cy.get('.runnable-err-message')
+        .should('not.include.text', msg)
+      })
+    }
+
+    cy.log('stack trace matches the specified pattern')
+    cy.get('.runnable-err-stack-trace')
+    .invoke('text')
+    .should('match', regex)
+
+    if (stack) {
+      const stackLines = [].concat(stack)
+
+      if (stackLines.length) {
+        cy.log('stack contains the expected lines')
+      }
+
+      _.each(stackLines, (stackLine) => {
+        cy.get('.runnable-err-stack-trace')
+        .should('include.text', stackLine)
+      })
+    }
+
+    cy.get('.runnable-err-stack-trace')
+    .invoke('text')
+    .should('not.include', '__stackReplacementMarker')
+    .should((stackTrace) => {
+      // if this stack trace has the 'From Your Spec Code' addendum,
+      // it should only appear once
+      const match = stackTrace.match(/From Your Spec Code/g)
+
+      if (match && match.length) {
+        expect(match.length, `'From Your Spec Code' should only be in the stack once, but found ${match.length} instances`).to.equal(1)
+      }
+    })
+  })
+
+  if (verifyOpenInIde) {
+    verifyIdeOpen({
+      file,
+      hasPreferredIde,
+      action: () => {
+        cy.get('@Root').contains('.runnable-err-stack-trace .runnable-err-file-path a', file)
+        .click('left')
+      },
+    })
+  }
+
+  cy.get('@Root').within(() => {
+    if (command) {
+      cy.log('the error is attributed to the correct command')
+      cy
+      .get('.command-state-failed')
+      .first()
+      .find('.command-method')
+      .invoke('text')
+      .should('equal', command)
+    }
+
+    if (uncaught) {
+      cy.log('uncaught error has an associated log for the original error')
+      cy.get('.command-name-uncaught-exception')
+      .should('have.length', 1)
+      .should('have.class', 'command-state-failed')
+      .find('.command-message-text')
+      .should('include.text', uncaughtMessage || originalMessage)
+    } else {
+      cy.log('"caught" error does not have an uncaught error log')
+      cy.get('.command-name-uncaught-exception').should('not.exist')
+    }
+
+    if (!hasCodeFrame) return
+
+    cy.log('code frame matches specified pattern')
+    cy
+    .get('.test-err-code-frame .runnable-err-file-path')
+    .invoke('text')
+    .should('match', regex)
+
+    cy.get('.test-err-code-frame pre span').should('include.text', codeFrameText)
+  })
+
+  if (verifyOpenInIde) {
+    verifyIdeOpen({
+      file,
+      hasPreferredIde,
+      action: () => {
+        cy.get('@Root').contains('.test-err-code-frame .runnable-err-file-path a', file)
+        .click()
+      },
+    })
+  }
+}
+
+const createVerifyTest = (modifier?: string) => {
+  return (title: string, opts: any, props?: any) => {
+    if (!props) {
+      props = opts
+      opts = null
+    }
+
+    props.specTitle ||= title
+
+    const verifyFn = props.verifyFn || verifyFailure.bind(null, props)
+
+    return (modifier ? it[modifier] : it)(title, verifyFn)
+  }
+}
+
+export const verify = {
+  it: createVerifyTest(),
+}
+
+verify.it['only'] = createVerifyTest('only')
+verify.it['skip'] = createVerifyTest('skip')
+
+export const verifyInternalFailure = (props) => {
+  const { method, stackMethod } = props
+
+  cy.get('.runnable-err-message')
+  .should('include.text', `thrown in ${method.replace(/\./g, '-')}`)
+
+  cy.get('.runnable-err-stack-expander > .collapsible-header').click()
+
+  cy.get('.runnable-err-stack-trace')
+  .should('include.text', stackMethod || method)
+
+  // this is an internal cypress error and we can only show code frames
+  // from specs, so it should not show the code frame
+  cy.get('.test-err-code-frame')
+  .should('not.exist')
+}

--- a/packages/frontend-shared/cypress/e2e/support/e2eProjectDirs.ts
+++ b/packages/frontend-shared/cypress/e2e/support/e2eProjectDirs.ts
@@ -78,6 +78,7 @@ export const e2eProjectDirs = [
   'remote-debugging-disconnect',
   'remote-debugging-port-removed',
   'retries-2',
+  'runner-e2e-specs',
   'same-fixtures-integration-folders',
   'screen-size',
   'selectFile',

--- a/packages/reporter/src/hooks/hooks.tsx
+++ b/packages/reporter/src/hooks/hooks.tsx
@@ -12,7 +12,6 @@ import HookModel, { HookName } from './hook-model'
 import ArrowRightIcon from '-!react-svg-loader!@packages/frontend-shared/src/assets/icons/arrow-right_x16.svg'
 import OpenIcon from '-!react-svg-loader!@packages/frontend-shared/src/assets/icons/technology-code-editor_x16.svg'
 import OpenFileInIDE from '../lib/open-file-in-ide'
-import FileOpener from '../lib/file-opener'
 
 export interface HookHeaderProps {
   model: HookModel
@@ -30,18 +29,10 @@ export interface HookOpenInIDEProps {
 }
 
 const HookOpenInIDE = ({ invocationDetails }: HookOpenInIDEProps) => {
-  if ('__vite__' in window) {
-    return (
-      <OpenFileInIDE fileDetails={invocationDetails} className='hook-open-in-ide'>
-        <OpenIcon viewBox="0 0 16 16" width="12" height="12" /> <span>Open in IDE</span>
-      </OpenFileInIDE>
-    )
-  }
-
   return (
-    <FileOpener fileDetails={invocationDetails} className='hook-open-in-ide'>
+    <OpenFileInIDE fileDetails={invocationDetails} className='hook-open-in-ide'>
       <OpenIcon viewBox="0 0 16 16" width="12" height="12" /> <span>Open in IDE</span>
-    </FileOpener>
+    </OpenFileInIDE>
   )
 }
 

--- a/packages/reporter/src/lib/file-name-opener.tsx
+++ b/packages/reporter/src/lib/file-name-opener.tsx
@@ -1,7 +1,5 @@
 import { observer } from 'mobx-react'
 import React from 'react'
-// @ts-ignore
-import Tooltip from '@cypress/react-tooltip'
 import { FileDetails } from '@packages/types'
 
 import FileOpener from './file-opener'
@@ -18,16 +16,12 @@ const FileNameOpener = observer((props: Props) => {
   const { displayFile, originalFile, line, column } = props.fileDetails
 
   return (
-    <Tooltip title={'Open in IDE'} wrapperClassName={props.className} className='cy-tooltip'>
-      <span>
-        <FileOpener fileDetails={props.fileDetails}>
-          {props.hasIcon && (
-            <TextIcon />
-          )}
-          {displayFile || originalFile}{!!line && `:${line}`}{!!column && `:${column}`}
-        </FileOpener>
-      </span>
-    </Tooltip>
+    <FileOpener fileDetails={props.fileDetails} className={props.className}>
+      {props.hasIcon && (
+        <TextIcon />
+      )}
+      {displayFile || originalFile}{!!line && `:${line}`}{!!column && `:${column}`}
+    </FileOpener>
   )
 })
 

--- a/packages/reporter/src/lib/file-opener.tsx
+++ b/packages/reporter/src/lib/file-opener.tsx
@@ -1,9 +1,7 @@
 import { observer } from 'mobx-react'
 import React, { ReactNode } from 'react'
 import type { FileDetails } from '@packages/types'
-import { GetUserEditorResult, Editor, FileOpener as Opener } from '@packages/ui-components'
-
-import events from './events'
+import OpenFileInIDE from './open-file-in-ide'
 
 interface Props {
   fileDetails: FileDetails
@@ -11,33 +9,15 @@ interface Props {
   className?: string
 }
 
-const openFile = (where: Editor, { absoluteFile: file, line, column }: FileDetails) => {
-  events.emit('open:file', {
-    where,
-    file,
-    line,
-    column,
-  })
-}
-
-const getUserEditor = (callback: (result: GetUserEditorResult) => any) => {
-  events.emit('get:user:editor', callback)
-}
-
-const setUserEditor = (editor: Editor) => {
-  events.emit('set:user:editor', editor)
-}
-
 const FileOpener = observer(({ fileDetails, children, className }: Props) => (
-  <Opener
-    openFile={openFile}
-    getUserEditor={getUserEditor}
-    setUserEditor={setUserEditor}
+  <OpenFileInIDE
     fileDetails={fileDetails}
     className={className}
   >
-    {children}
-  </Opener>
+    <a href="#" onClick={(e) => e.preventDefault()}>
+      {children}
+    </a>
+  </OpenFileInIDE>
 ))
 
 export default FileOpener

--- a/packages/reporter/src/runnables/runnable-header.tsx
+++ b/packages/reporter/src/runnables/runnable-header.tsx
@@ -3,11 +3,9 @@ import React, { Component, ReactElement } from 'react'
 
 import { StatsStore } from '../header/stats-store'
 import { formatDuration, getFilenameParts } from '../lib/util'
-import OpenFileInIDE from '../lib/open-file-in-ide'
 import FileNameOpener from '../lib/file-name-opener'
-import TextIcon from '-!react-svg-loader!@packages/frontend-shared/src/assets/icons/document-text_x16.svg'
 
-const renderRunnableHeader = (children: ReactElement) => <div className="runnable-header">{children}</div>
+const renderRunnableHeader = (children: ReactElement) => <div className="runnable-header" data-cy="runnable-header">{children}</div>
 
 interface RunnableHeaderProps {
   spec: Cypress.Cypress['spec']
@@ -52,22 +50,11 @@ class RunnableHeader extends Component<RunnableHeaderProps> {
       relativeFile: relativeSpecPath,
     }
 
-    const openInIde = '__vite__' in window
-      ? (
-        <OpenFileInIDE fileDetails={fileDetails}>
-          <a href="#" onClick={(e) => e.preventDefault()}>
-            <TextIcon />
-            {fileDetails.displayFile || fileDetails.originalFile}
-          </a>
-        </OpenFileInIDE>
-      )
-      : <FileNameOpener fileDetails={fileDetails} hasIcon />
-
     return renderRunnableHeader(
       <>
-        {openInIde}
+        <FileNameOpener fileDetails={fileDetails} hasIcon />
         {Boolean(statsStore.duration) && (
-          <span className='duration'>{formatDuration(statsStore.duration)}</span>
+          <span className='duration' data-cy="spec-duration">{formatDuration(statsStore.duration)}</span>
         )}
       </>,
     )

--- a/system-tests/projects/runner-e2e-specs/.babelrc
+++ b/system-tests/projects/runner-e2e-specs/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/system-tests/projects/runner-e2e-specs/.eslintrc.json
+++ b/system-tests/projects/runner-e2e-specs/.eslintrc.json
@@ -1,0 +1,58 @@
+{
+  "globals": {
+    "defineProps": "readonly",
+    "defineEmits": "readonly",
+    "defineExpose": "readonly",
+    "withDefaults": "readonly"
+  },
+  "plugins": [
+    "cypress",
+    "@cypress/dev"
+  ],
+  "extends": [
+    "../../../packages/frontend-shared/.eslintrc.json"
+  ],
+  "env": {
+    "cypress/globals": true
+  },
+  "overrides": [
+    {
+      "files": [
+        "*.ts"
+      ],
+      "rules": {
+        "no-dupe-class-members": "off",
+        "@typescript-eslint/no-dupe-class-members": "error"
+      }
+    },
+    {
+      "files": [
+        "lib/*"
+      ],
+      "rules": {
+        "no-console": 1
+      }
+    },
+    {
+      "files": [
+        "**/*.json"
+      ],
+      "rules": {
+        "quotes": "off",
+        "comma-dangle": "off"
+      }
+    },
+    {
+      "files": [
+        "*.tsx",
+        "*.jsx"
+      ],
+      "rules": {
+        "no-unused-vars": "off",
+        "react/jsx-no-bind": "off",
+        "react/react-in-jsx-scope": "off",
+        "react/no-unknown-property": "off"
+      }
+    }
+  ]
+}

--- a/system-tests/projects/runner-e2e-specs/cypress.config.js
+++ b/system-tests/projects/runner-e2e-specs/cypress.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  projectId: 'abc123',
+  e2e: {
+    supportFile: false,
+  },
+}

--- a/system-tests/projects/runner-e2e-specs/cypress/e2e/errors/assertions.cy.js
+++ b/system-tests/projects/runner-e2e-specs/cypress/e2e/errors/assertions.cy.js
@@ -1,0 +1,13 @@
+describe('assertion failures', () => {
+  it('with expect().<foo>', () => {
+    expect('actual').to.equal('expected')
+  })
+
+  it('with assert()', () => {
+    assert(false, 'should be true')
+  })
+
+  it('with assert.<foo>()', () => {
+    assert.equal('actual', 'expected')
+  })
+})

--- a/system-tests/projects/runner-e2e-specs/webpack.config.js
+++ b/system-tests/projects/runner-e2e-specs/webpack.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+        },
+      },
+    ],
+  },
+}


### PR DESCRIPTION
The reporter package had a few areas where the react-based dialog was still being used to manage IDE presentations. I updated these to emit the appropriate events so that the vue dialog (ChooseExternalEditorModal.vue) is used.

Also migrating helpers and initial tests to app from existing runner specs. More tests to come; I wanted to get some of the existing helper logic + the dialog fix in before inflating the PR size too much.

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
