### PR TITLE
fix: correct reference branch / commitSha in performance-reporter

### DIFF
--- a/system-tests/lib/performance-reporter.js
+++ b/system-tests/lib/performance-reporter.js
@@ -14,7 +14,8 @@ class StatsdReporter {
 
     console.log(chalk.green('Reporting to honeycomb'))
 
-    let branch; let commitSha
+    let branch
+    let commitSha
 
     this.honey = new Libhoney({
       dataset: 'systemtest-performance',
@@ -24,8 +25,8 @@ class StatsdReporter {
     commitInfo().then((commitInformation) => {
       const ciInformation = ciProvider.commitParams() || {}
 
-      this.branch = commitInformation.branch || ciInformation.branch
-      this.commitSha = commitInformation.sha || ciInformation.sha
+      branch = commitInformation.branch || ciInformation.branch
+      commitSha = commitInformation.sha || ciInformation.sha
     })
 
     runner.on('test', (test) => {


### PR DESCRIPTION
Minor fix, currently missing `branch` / `commitSha` in the logged metrics