### PR TITLE
fix(unify): improve dev server config ergonomics

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3,7 +3,9 @@
 
 // The new Awaited type added in 4.5 would work here, but we seem to need to
 // support older versions of Typescript
-type AwaitedLike<T> = T extends PromiseLike<infer U> ? AwaitedLike<U> : T
+type AwaitedLike<T> = T extends PromiseLike<infer U>
+  ? { 0: AwaitedLike<U>; 1: U }[U extends PromiseLike<any> ? 0 : 1]
+  : T
 
 declare namespace Cypress {
   type FileContents = string | any[] | object

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1,6 +1,10 @@
 /// <reference path="./cypress-npm-api.d.ts" />
 /// <reference path="./cypress-eventemitter.d.ts" />
 
+// The new Awaited type added in 4.5 would work here, but we seem to need to
+// support older versions of Typescript
+type AwaitedLike<T> = T extends PromiseLike<infer U> ? AwaitedLike<U> : T
+
 declare namespace Cypress {
   type FileContents = string | any[] | object
   type HistoryDirection = 'back' | 'forward'
@@ -2988,7 +2992,7 @@ declare namespace Cypress {
   type DevServerFn<ComponentDevServerOpts = any> = (cypressConfig: DevServerConfig, devServerConfig: ComponentDevServerOpts) => ResolvedDevServerConfig | Promise<ResolvedDevServerConfig>
   interface ComponentConfigOptions<ComponentDevServerOpts = any> extends CoreConfigOptions {
     devServer: Promise<{ devServer: DevServerFn<ComponentDevServerOpts>}> | { devServer: DevServerFn<ComponentDevServerOpts> } | DevServerFn<ComponentDevServerOpts>
-    devServerConfig?: ComponentDevServerOpts | Awaited<Promise<ComponentDevServerOpts>>
+    devServerConfig?: ComponentDevServerOpts | AwaitedLike<Promise<ComponentDevServerOpts>>
   }
 
   /**

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2988,7 +2988,7 @@ declare namespace Cypress {
   type DevServerFn<ComponentDevServerOpts = any> = (cypressConfig: DevServerConfig, devServerConfig: ComponentDevServerOpts) => ResolvedDevServerConfig | Promise<ResolvedDevServerConfig>
   interface ComponentConfigOptions<ComponentDevServerOpts = any> extends CoreConfigOptions {
     devServer: Promise<{ devServer: DevServerFn<ComponentDevServerOpts>}> | { devServer: DevServerFn<ComponentDevServerOpts> } | DevServerFn<ComponentDevServerOpts>
-    devServerConfig?: ComponentDevServerOpts | Promise<ComponentDevServerOpts>
+    devServerConfig?: ComponentDevServerOpts | Awaited<Promise<ComponentDevServerOpts>>
   }
 
   /**

--- a/npm/react/plugins/babel/index.d.ts
+++ b/npm/react/plugins/babel/index.d.ts
@@ -1,6 +1,6 @@
 import { Configuration } from "webpack";
 
-declare namespace legacyDevServer {
+declare namespace CypressBabelDevServer {
   interface CypressBabelDevServerConfig {
     /**
      * Allows to adjust the webpackConfig that our dev-server will use
@@ -31,6 +31,6 @@ declare namespace legacyDevServer {
  * @param config comes from the argument of the `pluginsFile` function
  * @param devServerConfig additional config object (create an empty object it to see how to use it)
  */
-declare function legacyDevServer(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions, devServerConfig?: legacyDevServer.CypressBabelDevServerConfig): void
+declare function CypressBabelDevServer(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions, devServerConfig?: CypressBabelDevServer.CypressBabelDevServerConfig): void
 
-export = legacyDevServer;
+export = CypressBabelDevServer;

--- a/npm/react/plugins/craco/index.d.ts
+++ b/npm/react/plugins/craco/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace legacyDevServer {
+declare namespace CypressCracoDevServer {
   interface CypressCracoDevServerConfig {
     /**
      * The object exported of your craco.config.js file
@@ -27,6 +27,6 @@ declare namespace legacyDevServer {
  * @param config comes from the argument of the `pluginsFile` function
  * @param cracoConfig the object exported of your craco.config.js file
  */
-declare function legacyDevServer(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions, cracoConfig: any): void
+declare function CypressCracoDevServer(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions, cracoConfig: any): void
 
-export = legacyDevServer;
+export = CypressCracoDevServer;

--- a/npm/react/plugins/load-webpack/index.d.ts
+++ b/npm/react/plugins/load-webpack/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace legacyDevServer {
+declare namespace CypressWebpackDevServer {
   interface CypressWebpackDevServerConfig {
     /**
      * Location of the weppack.config Cypress should use
@@ -27,6 +27,6 @@ declare namespace legacyDevServer {
  * @param config comes from the argument of the `pluginsFile` function
  * @param devServerConfig additional config object (create an empty object to see how to use it)
  */
-declare function legacyDevServer(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions, devServerConfig?: legacyDevServer.CypressWebpackDevServerConfig): void
+declare function CypressWebpackDevServer(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions, devServerConfig?: CypressWebpackDevServer.CypressWebpackDevServerConfig): void
 
-export = legacyDevServer;
+export = CypressWebpackDevServer;

--- a/npm/react/plugins/next/index.d.ts
+++ b/npm/react/plugins/next/index.d.ts
@@ -1,10 +1,3 @@
-/**
- * Sets up a Cypress component testing environment for your NextJs application
- * @param on comes from the argument of the `pluginsFile` function
- * @param config comes from the argument of the `pluginsFile` function
- */
-declare function legacyDevServer(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions): void
-
 declare namespace legacyDevServer {
   interface CypressNextDevServerConfig {
     /**

--- a/npm/react/plugins/next/index.d.ts
+++ b/npm/react/plugins/next/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace legacyDevServer {
+declare namespace CypressNextDevServer {
   interface CypressNextDevServerConfig {
     /**
      * Path to an index.html file that will serve as the template in
@@ -21,6 +21,6 @@ declare namespace legacyDevServer {
  * @param config comes from the argument of the `pluginsFile` function
  * @param devServerConfig additional config object (create an empty object to see how to use it)
  */
-declare function legacyDevServer(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions, devServerConfig?: legacyDevServer.CypressNextDevServerConfig): void
+declare function CypressNextDevServer(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions, devServerConfig?: CypressNextDevServer.CypressNextDevServerConfig): void
 
-export = legacyDevServer;
+export = CypressNextDevServer;

--- a/npm/react/plugins/react-scripts/index.d.ts
+++ b/npm/react/plugins/react-scripts/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace legacyDevServer {
+declare namespace CypressCRADevServer {
   interface CypressCRADevServerConfig {
     /**
      * Location of the weppack.config Cypress should use
@@ -27,6 +27,6 @@ declare namespace legacyDevServer {
  * @param config comes from the argument of the `pluginsFile` function
  * @param devServerConfig additional config object (create an empty object to see how to use it)
  */
-declare function legacyDevServer(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions, devServerConfig?: legacyDevServer.CypressCRADevServerConfig): void
+declare function CypressCRADevServer(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions, devServerConfig?: CypressCRADevServer.CypressCRADevServerConfig): void
 
-export = legacyDevServer;
+export = CypressCRADevServer;


### PR DESCRIPTION
I noticed a few things while working on https://cypress-io.atlassian.net/browse/UDX-5.

Please LMK if these changes are going to cause any issues!

### Promise methods were appearing in the code completion for `devServerConfig`
Changed in afea2166d8ce8ef456a6e505b38e23140b2a0128
- Removed `Promise` methods from code completion suggestions using a [TypeScript 2.8+ compatible `Awaited` polyfill](https://stackoverflow.com/a/49889856/142339) which I named `AwaitedLike` due to a naming conflict with the [TypeScript 4.5 bulit-in `Awaited` type](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#the-awaited-type-and-promise-improvements)

Before
![Screen Shot 2022-01-28 at 11 39 44 AM](https://user-images.githubusercontent.com/54051/151590060-81ef859b-9e6d-4502-8240-3d82899931c3.png)
After
![Screen Shot 2022-01-28 at 11 40 21 AM](https://user-images.githubusercontent.com/54051/151590087-3a0ee177-9150-4256-a26b-5665e92a0d89.png)

### The ergonomics of the `legacyDevServer` type felt like it could be improved
Changed in 3a9100ad6b6d23853ab1f2351e85c04efaea4fba
- Replaced `legacyDevServer` with an appropriate name for each of the react-scripts plugins
- Also removed an unnecessary type definition

Before
![Screen Shot 2022-01-28 at 11 53 04 AM](https://user-images.githubusercontent.com/54051/151590338-5ca53b15-c15d-4cc6-b7d2-bf1fd6691988.png)
After
![Screen Shot 2022-01-28 at 11 53 30 AM](https://user-images.githubusercontent.com/54051/151590357-1fc2e157-2290-401e-8034-94094dc32bdb.png)

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
