### PR TITLE
feat: (multi-domain) handle uncaught errors in the spec bridge

### DIFF
--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
@@ -142,6 +142,25 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
         expect(failureSpy).not.to.be.called
       })
     })
+
+    // FIXME: Remove skip once support is added for handling errors from switchToDomain after the callback windows closes
+    it.skip('fails the current test/command if async errors are thrown from the test code in switchToDomain while the callback window is now closed', (done) => {
+      cy.on('fail', (err) => {
+        expect(err.name).to.eq('Error')
+        expect(err.message).to.include('setTimeout error')
+        expect(err.message).to.include('The following error originated from your test code, not from Cypress.')
+
+        done()
+      })
+
+      cy.switchToDomain('foobar.com', () => {
+        setTimeout(() => {
+          throw new Error('setTimeout error')
+        }, 50)
+      })
+
+      cy.wait(250)
+    })
   })
 
   describe('unhandled rejections', () => {
@@ -193,6 +212,24 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
         // switchToDomain callback window to be open long enough for the error to occur
         cy.wait(250)
       })
+    })
+
+    // FIXME: Remove skip once support is added for handling errors from switchToDomain after the callback windows closes
+    it.skip('fails the current test/command if a promise is rejected from the test code in switchToDomain while the callback window is now closed', (done) => {
+      cy.on('fail', (err) => {
+        expect(err.name).to.eq('Error')
+        expect(err.message).to.include('rejected promise')
+        expect(err.message).to.include('The following error originated from your test code, not from Cypress. It was caused by an unhandled promise rejection.')
+        expect(err.message).to.not.include('https://on.cypress.io/uncaught-exception-from-application')
+
+        done()
+      })
+
+      cy.switchToDomain('foobar.com', () => {
+        Promise.reject(new Error('rejected promise'))
+      })
+
+      cy.wait(250)
     })
   })
 

--- a/packages/driver/src/multi-domain/cypress.ts
+++ b/packages/driver/src/multi-domain/cypress.ts
@@ -84,7 +84,7 @@ const onBeforeAppWindowLoad = (Cypress: Cypress.Cypress, cy: $Cy) => (autWindow:
   cy.overrides.wrapNativeMethods(autWindow)
   // TODO: DRY this up with the mostly-the-same code in src/cypress/cy.js
   bindToListeners(autWindow, {
-    onError: handleErrorEvent(cy),
+    onError: handleErrorEvent(cy, 'app'),
     onHistoryNav () {},
     onSubmit (e) {
       return Cypress.action('app:form:submitted', e)

--- a/packages/driver/src/multi-domain/domain_fn.ts
+++ b/packages/driver/src/multi-domain/domain_fn.ts
@@ -75,6 +75,12 @@ export const handleDomainFn = (cy: $Cy, specBridgeCommunicator: SpecBridgeDomain
 
     cy.state('onFail', (err) => {
       const command = cy.state('current')
+
+      // If there isn't a current command, just reject to fail the test
+      if (!command) {
+        return specBridgeCommunicator.toPrimary('reject', { err })
+      }
+
       const id = command.get('id')
       const name = command.get('name')
       const logId = command.getLastLog()?.get('id')

--- a/packages/driver/src/multi-domain/errors.ts
+++ b/packages/driver/src/multi-domain/errors.ts
@@ -1,15 +1,15 @@
 import type { $Cy } from '../cypress/cy'
 import $errUtils, { ErrorFromProjectRejectionEvent } from '../cypress/error_utils'
 
-export const handleErrorEvent = (cy: $Cy) => {
-  return (handlerType: string, frameType?: string) => {
+export const handleErrorEvent = (cy: $Cy, frameType: 'spec' | 'app') => {
+  return (handlerType: string) => {
     return (event) => {
       const { originalErr, err, promise } = $errUtils.errorFromUncaughtEvent(handlerType, event) as ErrorFromProjectRejectionEvent
       const handled = cy.onUncaughtException({
         err,
         promise,
         handlerType,
-        frameType: frameType ?? 'app',
+        frameType,
       })
 
       $errUtils.logError(Cypress, handlerType, originalErr, handled)

--- a/packages/driver/src/multi-domain/errors.ts
+++ b/packages/driver/src/multi-domain/errors.ts
@@ -1,0 +1,31 @@
+import type { $Cy } from '../cypress/cy'
+import $errUtils, { ErrorFromProjectRejectionEvent } from '../cypress/error_utils'
+
+export const handleErrorEvent = (cy: $Cy) => {
+  return (handlerType: string, frameType?: string) => {
+    return (event) => {
+      const { originalErr, err, promise } = $errUtils.errorFromUncaughtEvent(handlerType, event) as ErrorFromProjectRejectionEvent
+      const handled = cy.onUncaughtException({
+        err,
+        promise,
+        handlerType,
+        frameType: frameType ?? 'app',
+      })
+
+      $errUtils.logError(Cypress, handlerType, originalErr, handled)
+
+      if (!handled) {
+        // if unhandled, fail the current command to fail the current test in the primary domain
+        // a current command may not exist if an error occurs in the spec bridge after the test is over
+        const command = cy.state('current')
+        const log = command?.getLastLog()
+
+        if (log) log.error(err)
+      }
+
+      // return undefined so the browser does its default
+      // uncaught exception behavior (logging to console)
+      return undefined
+    }
+  }
+}

--- a/packages/driver/src/multi-domain/spec_window_events.ts
+++ b/packages/driver/src/multi-domain/spec_window_events.ts
@@ -2,8 +2,8 @@ import type { $Cy } from '../cypress/cy'
 import { handleErrorEvent } from './errors'
 
 export const handleSpecWindowEvents = (cy: $Cy) => {
-  const handleWindowErrorEvent = handleErrorEvent(cy)('error', 'spec')
-  const handleWindowUnhandledRejectionEvent = handleErrorEvent(cy)('unhandledrejection', 'spec')
+  const handleWindowErrorEvent = handleErrorEvent(cy, 'spec')('error')
+  const handleWindowUnhandledRejectionEvent = handleErrorEvent(cy, 'spec')('unhandledrejection')
 
   const handleUnload = () => {
     window.removeEventListener('unload', handleUnload)

--- a/packages/driver/src/multi-domain/spec_window_events.ts
+++ b/packages/driver/src/multi-domain/spec_window_events.ts
@@ -1,0 +1,17 @@
+import type { $Cy } from '../cypress/cy'
+import { handleErrorEvent } from './errors'
+
+export const handleSpecWindowEvents = (cy: $Cy) => {
+  const handleWindowErrorEvent = handleErrorEvent(cy)('error', 'spec')
+  const handleWindowUnhandledRejectionEvent = handleErrorEvent(cy)('unhandledrejection', 'spec')
+
+  const handleUnload = () => {
+    window.removeEventListener('unload', handleUnload)
+    window.removeEventListener('error', handleWindowErrorEvent)
+    window.removeEventListener('unhandledrejection', handleWindowUnhandledRejectionEvent)
+  }
+
+  window.addEventListener('unload', handleUnload)
+  window.addEventListener('error', handleWindowErrorEvent)
+  window.addEventListener('unhandledrejection', handleWindowUnhandledRejectionEvent)
+}


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #19858 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
* Added window event listeners to spec bridge window on `error` and `unhandledrejection`
* Moved the error logic from the `onError` handler to it's own file to be shared with the spec bridge window handlers
* Updated the `onFail` handler to check if there is a current command and if not to just `reject`

Note, support for errors thrown after the `switchToDomain` call has ended are not currently supported. From other discussions, we are going to be looking into updating the commands and logs manager's to continue listening when the `switchToDomain` call ends. If this is done, then we shouldn't need to do anything additional for these errors.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

**setTimeout error:**

**before:**
<img width="990" alt="Screen Shot 2022-01-31 at 8 35 00 AM" src="https://user-images.githubusercontent.com/2002044/151823841-1ae850f1-51dd-4215-9889-2fe7752c961d.png">

**after:**
<img width="991" alt="Screen Shot 2022-01-31 at 8 36 53 AM" src="https://user-images.githubusercontent.com/2002044/151823911-11a33e0f-2fe6-409b-98a4-ab04c09a935f.png">

**Promise rejection:**

**before:**
<img width="992" alt="Screen Shot 2022-01-31 at 8 35 32 AM" src="https://user-images.githubusercontent.com/2002044/151824096-9ad15f2d-4c17-44a2-8a50-1fdce6f134f2.png">

**after:**
<img width="990" alt="Screen Shot 2022-01-31 at 8 37 49 AM" src="https://user-images.githubusercontent.com/2002044/151824193-183ad34d-621b-43e2-a6c8-3ceb784eacfd.png">

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
