### PR TITLE
fix: Adjust ffmpeg CLI args for performance

### DIFF
--- a/packages/server/lib/video_capture.ts
+++ b/packages/server/lib/video_capture.ts
@@ -321,10 +321,6 @@ export async function process (name, cname, videoCompression, ffmpegchaptersConf
       // https://en.wikipedia.org/wiki/Chroma_subsampling if you want the gritty details.
       // Short version: yuv420p is a standard video format supported everywhere.
       '-pix_fmt yuv420p',
-
-      // Limit the encoder to a single thread, so we aren't competing with the
-      // main cypress process for CPU time on low-resource machines.
-      '-threads 1',
     ]
 
     if (addChaptersMeta) {

--- a/packages/server/lib/video_capture.ts
+++ b/packages/server/lib/video_capture.ts
@@ -303,10 +303,6 @@ export async function process (name, cname, videoCompression, ffmpegchaptersConf
       '-threads 1',
     ]
 
-    if (os.cpus().length < 4) {
-      outputOptions.push()
-    }
-
     if (addChaptersMeta) {
       command.input(metaFileName)
       outputOptions.push('-map_metadata 1')

--- a/packages/server/lib/video_capture.ts
+++ b/packages/server/lib/video_capture.ts
@@ -278,7 +278,7 @@ export async function process (name, cname, videoCompression, ffmpegchaptersConf
   let total = null
 
   const metaFileName = `${name}.meta`
-  const addChaptersMeta = ffmpegchaptersConfig && await fs.writeFile(metaFileName, ffmpegchaptersConfig)
+  const addChaptersMeta = ffmpegchaptersConfig && await fs.writeFile(metaFileName, ffmpegchaptersConfig).then(() => true)
 
   return new Bluebird((resolve, reject) => {
     debug('processing video from %s to %s video compression %o',

--- a/packages/server/lib/video_capture.ts
+++ b/packages/server/lib/video_capture.ts
@@ -286,18 +286,42 @@ export async function process (name, cname, videoCompression, ffmpegchaptersConf
     const command = ffmpeg()
     .addOptions([
       // These flags all serve to reduce initial buffering, especially important
-      // when dealing with very short videos (such as during component tests)
+      // when dealing with very short videos (such as during component tests).
+      // See https://ffmpeg.org/ffmpeg-formats.html#Format-Options for details.
       '-avioflags direct',
-      '-fpsprobesize 0',
-      '-probesize 32',
-      '-analyzeduration 0',
 
+      // Because we're passing in a slideshow of still frames, there's no
+      // fps metadata to be found in the video stream. This ensures that ffmpeg
+      // isn't buffering a lot of data waiting for information that's not coming.
+      '-fpsprobesize 0',
+
+      // Tells ffmpeg to read only the first 32 bytes of the stream for information
+      // (resolution, stream format, etc).
+      // Some videos can have long metadata (eg, lots of chapters) or spread out,
+      // but our streams are always predictable; No need to wait / buffer data before
+      // starting encoding
+      '-probesize 32',
+
+      // By default ffmpeg buffers the first 5 seconds of video to analyze it before
+      // it starts encoding. We're basically telling it "there is no metadata coming,
+      // start encoding as soon as we give you frames."
+      '-analyzeduration 0',
     ])
 
+    // See https://trac.ffmpeg.org/wiki/Encode/H.264 for details about h264 options.
     const outputOptions = [
+      // Preset is a tradeoff between encoding speed and filesize. It does not determine video
+      // quality; It's just a tradeoff between CPU vs size.
       '-preset fast',
+      // Compression Rate Factor is essentially the quality dial; 0 would be lossless
+      // (big files), while 51 (the maximum) would lead to low quality (and small files).
       `-crf ${videoCompression}`,
+
+      // Discussion of pixel formats is beyond the scope of these comments. See
+      // https://en.wikipedia.org/wiki/Chroma_subsampling if you want the gritty details.
+      // Short version: yuv420p is a standard video format supported everywhere.
       '-pix_fmt yuv420p',
+
       // Limit the encoder to a single thread, so we aren't competing with the
       // main cypress process for CPU time on low-resource machines.
       '-threads 1',

--- a/packages/server/lib/video_capture.ts
+++ b/packages/server/lib/video_capture.ts
@@ -7,7 +7,6 @@ import Bluebird from 'bluebird'
 import { path as ffmpegPath } from '@ffmpeg-installer/ffmpeg'
 import BlackHoleStream from 'black-hole-stream'
 import { fs } from './util/fs'
-import os from 'os'
 
 const debug = Debug('cypress:server:video')
 // extra verbose logs for logging individual frames
@@ -299,13 +298,13 @@ export async function process (name, cname, videoCompression, ffmpegchaptersConf
       '-preset fast',
       `-crf ${videoCompression}`,
       '-pix_fmt yuv420p',
+      // Limit the encoder to a single thread, so we aren't competing with the
+      // main cypress process for CPU time on low-resource machines.
+      '-threads 1',
     ]
 
-    // On low-resource machines - estimated here by CPU count - limit the encoder
-    // to a single thread. While this can slow down video processing, it
-    // significantly reduces CPU contention, leading to a faster overall test time.
     if (os.cpus().length < 4) {
-      outputOptions.push('-threads 1')
+      outputOptions.push()
     }
 
     if (addChaptersMeta) {


### PR DESCRIPTION
### User facing changelog
Speeds up video recording on low-resourced machines (such as most CI docker containers).

### Additional details
ffmpeg is now limited to a single thread on machines with 2 or fewer CPUs, reducing resource contention with the main cypress project. Also adjusted ffmpeg probes to reduce buffering, especially impactful on short videos.

### How has the user experience changed?
No change. Video output remains unchanged in quality and filesize.

For Cypress' driver integration tests, this appears to save about 20 seconds for each container, from

![image](https://user-images.githubusercontent.com/3003404/151849478-de687daa-f0e1-484f-bc01-8ead818931ed.png)

to 

![image](https://user-images.githubusercontent.com/3003404/151849421-94d6af32-d4d5-4885-8a06-9a7eb42c4a3b.png)

Exact time saved depends on branch, test, load, and the phase of the moon, but seems to be generally improved.

### PR Tasks
- [N/A] Have tests been added/updated? Existing tests cover video recording functionality.
- [N/A] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
