### PR TITLE
fix: rename spec.js to spec.cy.js

### DIFF
--- a/packages/data-context/src/sources/migration/autoRename.ts
+++ b/packages/data-context/src/sources/migration/autoRename.ts
@@ -27,7 +27,7 @@ interface GetSpecs {
 }
 
 export function substitute (part: FilePart): FilePart {
-  // nothing to substitite, just a regular
+  // nothing to substitute, just a regular
   // part of the file
   if (!('group' in part)) {
     return part

--- a/packages/data-context/src/sources/migration/format.ts
+++ b/packages/data-context/src/sources/migration/format.ts
@@ -31,8 +31,11 @@ export function formatMigrationFile (file: string, regexp: RegExp): FilePart[] {
 
   // sometimes `.` gets in here as the <ext> group
   // filter it out
-  const higlights = Object.values(match.groups).filter((x) => x.length > 1)
-  const delimiters = higlights.join('|')
+  const highlights = Object.values(match.groups)
+  .filter((x) => x.length > 0)
+  .map((d) => d === '.' ? `[${d}]` : d) // period is wildcard so surround with [] to use character
+
+  const delimiters = highlights.join('|')
   const re = new RegExp(`(${delimiters})`)
   const split = file.split(re)
 
@@ -45,7 +48,7 @@ export function formatMigrationFile (file: string, regexp: RegExp): FilePart[] {
           ? 'name'
           : undefined
 
-    const hasHighlight = higlights.includes(text)
+    const hasHighlight = text === '.' || highlights.includes(text)
 
     if (hasHighlight && group) {
       return {

--- a/packages/data-context/src/sources/migration/regexps.ts
+++ b/packages/data-context/src/sources/migration/regexps.ts
@@ -1,4 +1,4 @@
-const specExtRe = '[._-]?[s|S]pec.|[.])(?=[j|t]s[x]?'
+const specExtRe = '(?<!\/)[._-]?[s|S]pec.|[.])(?=[j|t]s[x]?'
 
 export const regexps = {
   e2e: {

--- a/packages/data-context/test/unit/sources/migration/autoRename.spec.ts
+++ b/packages/data-context/test/unit/sources/migration/autoRename.spec.ts
@@ -463,12 +463,6 @@ describe('applyMigrationTransform', () => {
 
       const result = applyMigrationTransform(input)
 
-      // console.log({ result: JSON.stringify(result, null, 2) })
-      // console.log('before: ', _.isEqual(result.before, expected.before))
-      // console.log('after: ', _.isEqual(result.after, expected.after))
-
-      // expect(result.before).to.eq(expected.before)
-
       expect(result.before).to.eql(expected.before)
       expect(result.after).to.eql(expected.after)
     })

--- a/packages/data-context/test/unit/sources/migration/autoRename.spec.ts
+++ b/packages/data-context/test/unit/sources/migration/autoRename.spec.ts
@@ -138,6 +138,12 @@ describe('getSpecs', () => {
         usesDefaultTestFiles: true,
         testingType: 'e2e',
       },
+      {
+        relative: 'cypress/integration/spec.ts',
+        usesDefaultFolder: true,
+        usesDefaultTestFiles: true,
+        testingType: 'e2e',
+      },
     ])
 
     expect(actual.component).to.eql([
@@ -332,6 +338,78 @@ describe('applyMigrationTransform', () => {
       expect(result.before).to.eql(expected.before)
       expect(result.after).to.eql(expected.after)
     })
+
+    it('handles a spec named spec', () => {
+      const input: MigrationSpec = {
+        relative: 'cypress/integration/spec.js',
+        usesDefaultFolder: true,
+        usesDefaultTestFiles: true,
+        testingType: 'e2e',
+      }
+
+      const expected: MigrationFile = {
+        testingType: 'e2e',
+        before: {
+          relative: 'cypress/integration/spec.js',
+          parts: [
+            {
+              'highlight': false,
+              'text': 'cypress/',
+            },
+            {
+              'highlight': true,
+              group: 'folder',
+              'text': 'integration',
+            },
+            {
+              'highlight': false,
+              'text': '/spec',
+            },
+            {
+              'highlight': true,
+              group: 'extension',
+              'text': '.',
+            },
+            {
+              'highlight': false,
+              'text': 'js',
+            },
+          ],
+        },
+        after: {
+          relative: 'cypress/e2e/spec.cy.js',
+          parts: [
+            {
+              'highlight': false,
+              'text': 'cypress/',
+            },
+            {
+              'highlight': true,
+              group: 'folder',
+              'text': 'e2e',
+            },
+            {
+              'highlight': false,
+              'text': '/spec',
+            },
+            {
+              'highlight': true,
+              group: 'extension',
+              'text': '.cy.',
+            },
+            {
+              'highlight': false,
+              'text': 'js',
+            },
+          ],
+        },
+      }
+
+      const result = applyMigrationTransform(input)
+
+      expect(result.before).to.eql(expected.before)
+      expect(result.after).to.eql(expected.after)
+    })
   })
 
   describe('component spec', () => {
@@ -384,6 +462,12 @@ describe('applyMigrationTransform', () => {
       }
 
       const result = applyMigrationTransform(input)
+
+      // console.log({ result: JSON.stringify(result, null, 2) })
+      // console.log('before: ', _.isEqual(result.before, expected.before))
+      // console.log('after: ', _.isEqual(result.after, expected.after))
+
+      // expect(result.before).to.eq(expected.before)
 
       expect(result.before).to.eql(expected.before)
       expect(result.after).to.eql(expected.after)

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -139,10 +139,12 @@ describe('Full migration flow for each project', () => {
     // Migration workflow
     // before auto migration
     cy.contains('cypress/integration/foo.spec.ts')
+    cy.contains('cypress/integration/spec.ts')
     cy.contains('cypress/component/button.spec.js')
 
     // after auto migration
     cy.contains('cypress/e2e/foo.cy.ts')
+    cy.contains('cypress/e2e/spec.cy.ts')
     cy.contains('cypress/component/button.cy.js')
 
     runAutoRename()

--- a/system-tests/projects/migration-e2e-component-default-everything/README.md
+++ b/system-tests/projects/migration-e2e-component-default-everything/README.md
@@ -17,6 +17,7 @@ Unless the user skips this step, after this step, the filesystem will be:
 | Before | After|
 |---|---|
 | `integration/foo.spec.ts` | `e2e/foo.cy.ts` |
+| `integration/spec.ts` | `e2e/spec.cy.ts` |
 | `component/button.spec.js` | `component/button.cy.js` |
 
 ## Manual Files


### PR DESCRIPTION
If a spec had the name spec.js it would rename it to .cy.js.

- Closes [UNIFY-1017](https://cypress-io.atlassian.net/browse/UNIFY-1017)

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
![Screen Shot 2022-02-02 at 3 51 26 PM](https://user-images.githubusercontent.com/8095629/152253102-bf4869a4-948a-4e0a-b253-0150a58c9185.png)


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
