### PR TITLE
fix: poor outgoing network performance on Mac

### DIFF
--- a/packages/network/test/unit/connect_spec.ts
+++ b/packages/network/test/unit/connect_spec.ts
@@ -1,0 +1,19 @@
+import { connect } from '../..'
+import { expect } from 'chai'
+import sinon from 'sinon'
+import net from 'net'
+import tls from 'tls'
+
+describe('lib/connect', () => {
+  context('.byPortAndAddress', () => {
+    it('connects net/tls when depends on port used', () => {
+      sinon.spy(net, 'connect')
+      connect.byPortAndAddress('foo.bar', 1234, { address: '127.0.0.1' })
+      expect(net.connect).to.be.calledWith({ host: '127.0.0.1', port: 1234 })
+
+      sinon.spy(tls, 'connect')
+      connect.byPortAndAddress('foo.bar', 443, { address: '127.0.0.1' })
+      expect(tls.connect).to.be.calledWith({ host: '127.0.0.1', port: 443, servername: 'foo.bar' })
+    })
+  })
+})


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
Fixed poor network issue in MacOS on initial requests.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
I have been experiencing tests hangs when run cypress locally and always timed out. Digging into the issue, finally narrowed down `net.connect` makes super slow when http agent makes requests. 
This eventually turned out that NodeJS bug in MacOS. I have reported in https://github.com/nodejs/node/issues/41699 for more details.

In Cypress, when outgoing requests happen, http agent first lookup DNS records and find out the fasted IP family.
https://github.com/cypress-io/cypress/blob/develop/packages/network/lib/connect.ts#L24
When there are 4 hosts in a DNS record like www.google.com, it tries 4 net.connect() for the hosts which eventually makes 4x slower than usual request without net.connect() in my experiment.

Simplified sample code to reproduce the issue from https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/request.js#L434
```js
// test.js
let r = require('@cypress/request')
const { agent } = require("./packages/network");

const url = 'https://www.google.com'
const defaults = {
  agent,
  headers: {
    'Connection': 'keep-alive',
  },
  proxy: null, // upstream proxying is handled by CombinedAgent
}

console.time(url)
const reqStream = r({url, ...defaults});
reqStream.on('request', (req) => {
  console.timeLog(url, "on request")
})
reqStream.on('socket', socket => {
  console.timeLog(url, 'socket created')
  socket.on('lookup', () => {
    console.timeLog(url, 'socket lookup')
  })
  socket.on('connect', () => {
    console.timeLog(url, 'socket connected')
  })
})
reqStream.on('response', (incomingRes) => {
  incomingRes.on('data', data => {
    console.timeLog(url, 'data received')
  })
})
```

#### before fix
```bash
$ DEBUG=cypress:network:connect node test.js
cypress:network:connect beginning getAddress { hostname: 'www.google.com', port: 443 } +0ms
https://www.google.com: 9.085ms on request
cypress:network:connect got addresses { hostname: 'www.google.com', port: 443, addresses: [ { address: '172.253.62.103', family: 4 }, { address: '172.253.62.147', family: 4 }, { address: '172.253.62.104', family: 4 }, { address: '172.253.62.105', family: 4 }, { address: '172.253.62.106', family: 4 }, { address: '172.253.62.99', family: 4 }, { address: '2607:f8b0:4004:c07::63', family: 6 }, { address: '2607:f8b0:4004:c07::67', family: 6 }, { address: '2607:f8b0:4004:c07::69', family: 6 }, { address: '2607:f8b0:4004:c07::93', family: 6 } ] } +6ms
https://www.google.com: 95.359ms socket created
https://www.google.com: 96.893ms socket lookup
https://www.google.com: 2.167s socket connected
https://www.google.com: 10.292s data received
https://www.google.com: 10.293s data received
https://www.google.com: 10.293s data received
https://www.google.com: 10.293s data received
https://www.google.com: 10.293s data received
```

#### After fix
```bash
  cypress:network:connect beginning getAddress { hostname: 'www.google.com', port: 443 } +0ms
https://www.google.com: 10.707ms on request
  cypress:network:connect got addresses { hostname: 'www.google.com', port: 443, addresses: [ { address: '172.253.62.99', family: 4 }, { address: '172.253.62.103', family: 4 }, { address: '172.253.62.104', family: 4 }, { address: '172.253.62.105', family: 4 }, { address: '172.253.62.106', family: 4 }, { address: '172.253.62.147', family: 4 }, { address: '2607:f8b0:4004:835::2004', family: 6 } ] } +79ms
https://www.google.com: 247.343ms socket created
https://www.google.com: 256.244ms socket lookup
https://www.google.com: 325.534ms socket connected
https://www.google.com: 509.304ms data received
https://www.google.com: 509.633ms data received
https://www.google.com: 509.929ms data received
https://www.google.com: 510.103ms data received
https://www.google.com: 510.251ms data received
```

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
I have observed http requests hangs or pending status initially and randomly fails with timeout. Once the website has 3rd party dependencies such as Segment, Heap, Google Analytics etcs, it all goes slow for the net.connect issue and finally made the tests unreliable.
I verified with my colleagues that it works and this improves network performance significantly running tests in MacOS. This would solve most problem with timeouts or flakiness due to tests hang for Mac users.

Also verified the issue does not happen in Debian and Centos. Have not verified in Windows and Mac M1 chips.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
