### PR TITLE
docs(data-context): explain concepts in data-context

### DIFF
--- a/packages/data-context/README.md
+++ b/packages/data-context/README.md
@@ -1,3 +1,160 @@
 ## @packages/data-context
 
 Centralized data access for the Cypress application
+
+## Directories & Concepts
+
+There are several directories in `src`:
+
+- `actions`
+- `codegen`
+- `data`
+- `gen`
+- `sources`
+- `util`
+
+The main ones you need to know about are `data`, `sources` and `actions`.
+
+Here are some general guidelines associated with each, and an example showing how they are used together.
+
+### Data
+
+This contains the interfaces that describe the top level data (called `coreData`) that is exposed and used by launchpad and app. Secondary data that isn't exposed to the outside world (temporary states, flags, etc) is usually in a Source. Sources are also used to derive data.
+
+If you want to update Data, you use an Action (see below).
+
+### Sources
+
+The sources directory contains what can be thought of as "read only" and "derived" data. Each one is namespaced based on the kind of data it's associated with, for example Project, Browser, Settings, etc. Sources can access the `ctx` (type `DataContext`, see [`DataContext.ts`](./DataContext.ts)), using `this.ctx`.
+
+If you want to update something in a Source, or in `coreData`, you want to do it using an Action.
+
+### Actions
+
+Actions are where mutative and destructive operations live. To make this predictable and changes each to track, updating `this.ctx.coreData` should be done via an Action and use `this.ctx.update`, which receives the current `coreData` as the first argument.
+
+## Example
+
+In this example, we will load some specs for a project and persist them. We will use a Source to derive any specs with the characters "foo" in the filename. This shows how Data, Sources and Actions are connected.
+
+### 1. Define Data [data/coreData](./data/coreDataShape.ts)
+
+First we define the type in `CoreDataShape` and set the initial value in `makeCoreData`.
+
+```ts
+export interface CoreDataShape {
+  specs: string[]
+}
+
+// ...
+
+export function makeCoreData (modeOptions: Partial<AllModeOptions> = {}): CoreDataShape {
+  return {
+    // ...
+    specs: [],
+  }
+}
+```
+
+This is where the actual value will be saved.
+
+### 2. Define Action to Update Specs
+
+We need some way to update the value. For this, we are defining a new `SpecActions` class inside of `actions` and updating the `coreData` with `this.ctx.update`.
+
+```ts
+import type { DataContext } from '..'
+import globby from 'globby'
+
+export class SpecActions {
+  constructor (private ctx: DataContext) {}
+
+  async findSpecs () {
+    const specs = await globby('./**/*.spec.js')
+    this.ctx.update(coreData => {
+      coreData.specs = specs
+    })
+  }
+}
+```
+
+**Note**: If you added a new Action file, you will also need to add it to [`DataActions.ts`](./DataActions.ts), although this isn't very common.
+
+```ts
+import type { DataContext } from '.'
+import {
+  // ...
+  SpecActions 
+} from './actions'
+import { cached } from './util'
+
+export class DataActions {
+  constructor (private ctx: DataContext) {}
+  
+  // ...
+
+  @cached
+  get specs () {
+    return new SpecActions(this.ctx)
+  }
+}
+```
+
+### 3. Derive the Data with a Source
+
+In this example we only want to expose specs with `foo` in the name. We can derive this using a Source. This will be a new Source call `SpecDataSource`, but you can use an existing one if it makes sense.
+
+```ts
+import type { DataContext } from '..'
+
+export class SpecDataSource {
+  constructor (private ctx: DataContext) {}
+
+  fooSpecs () {
+    return this.ctx.coreData.specs.find(spec => spec.includes('foo'))
+  }
+}
+```
+
+If you added a new Source, you need to add it to [`DataContext.ts`](./DataContext.ts). 
+
+```ts
+import { SpecDataSource } from './sources/SpecDataSource'
+
+export class DataContext {
+
+  // ...
+
+  @cached
+  get specs () {
+    return new SpecDataSource(this)
+  }
+}
+```
+
+### 4. (Bonus) Expose via GraphQL
+
+You might want to expose your new Data or Source via GraphQL. It's easy, since GraphQL also has access `ctx` as the third argument to the resolvers. For example, we can expose `specs` and `fooSpecs` in [`gql-Query.ts`](../graphql/src/schemaTypes/objectTypes/gql-Query.ts) like this:
+
+```ts
+export const Query = objectType({
+  definition (t) {
+
+    // ...
+
+    t.list.string('specs', {
+      description: 'A list of specs',
+      resolve: (source, args, ctx) => {
+        return ctx.coreData.specs
+      },
+    })
+
+    t.list.string('fooSpecs', {
+      description: 'A list of specs containing foo',
+      resolve: (source, args, ctx) => {
+        return ctx.specs.fooSpecs()
+      },
+    })
+  }
+})
+```


### PR DESCRIPTION
- Closes https://cypress-io.atlassian.net/browse/UNIFY-1016

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Explain interplay between `data`, `actions` and `sources` in `data-context` package. It's a work in progress; we should continue to update this as we go. I got this information [here](https://www.notion.so/cypressdx/TR-Unification-Development-0c9636f71d5748e6b8f0048f35114061), as well as my personal experience and looking at the patterns @tgriesser introduced.

I noticed a lot of our code doesn't actually adhere to these conventions, since they were not really set in stone when we started the unification project. Many Sources update `coreData` directly, not ideal. We should try to match these conventions as closely as possible.

### Discussion/Question

One thing that does not have a clear practice is data that does not live in `coreData`. For example we have a bunch of flags such as `hasComponentTesting`, which is used for the migration workflow. [It's currently on a Source](https://github.com/cypress-io/cypress/blob/703548e16ce436b0f23b6962348a43c68d2e0545/packages/data-context/src/sources/MigrationDataSource.ts#L58) and also updated by the Source, which goes against our rules. Should this data:

1. Go in `coreData.migration`? My concern is `coreData` will become a dumping ground for everything, kind of like `config` and `options` in server, where people just stick there variable on one of those so they can access it whenever they want.
2. Leave the data that does not need to be exposed on `coreData` in the Source? If so, should we update it using an Action? Eg `MigrationAction` should always up `MigrationSource`? It's a bit verbose to have these in different files, you need to keep switching back and forth, but if that's going to give us better separation of concerns (write vs read) it might be okay.
3. `this.ctx.update` is only used for `coreData` right now. I wonder if we want a similar pattern for Actions to update temp data in Sources.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Betters docs to enforce consistency.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
