### PR TITLE
fix:  secondary domain error serialization in firefox

### DIFF
--- a/packages/driver/src/cy/multi-domain/index.ts
+++ b/packages/driver/src/cy/multi-domain/index.ts
@@ -3,6 +3,7 @@ import $errUtils from '../../cypress/error_utils'
 import { CommandsManager } from './commands_manager'
 import { LogsManager } from './logs_manager'
 import { Validator } from './validator'
+import { correctStackForCrossDomainError } from './util'
 import { failedToSerializeSubject } from './failedSerializeSubjectProxy'
 
 export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, state: Cypress.State, config: Cypress.InternalConfig) {
@@ -101,14 +102,14 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
         logsManager.cleanup()
       }
 
-      const doneAndCleanup = async (err) => {
+      const doneAndCleanup = async ({ err }) => {
         communicator.off('done:called', doneAndCleanup)
         // If done is called, immediately unbind command listeners to prevent
         // any commands from being enqueued, but wait for log updates to
         // trickle in before invoking done
         commandsManager.cleanup()
         await logsManager.cleanup()
-        done(err)
+        done(err ? correctStackForCrossDomainError(err, userInvocationStack) : err)
       }
 
       if (done) {

--- a/packages/driver/src/multi-domain/communicator.ts
+++ b/packages/driver/src/multi-domain/communicator.ts
@@ -183,4 +183,8 @@ export class SpecBridgeDomainCommunicator extends EventEmitter {
   toPrimaryRanDomainFn (data: { subject?: any, err?: any }) {
     this.handleSubjectAndErr('ran:domain:fn', data)
   }
+
+  toPrimaryError (event, data: { subject?: any, err?: any }) {
+    this.handleSubjectAndErr(event, data)
+  }
 }

--- a/packages/driver/src/multi-domain/domain_fn.ts
+++ b/packages/driver/src/multi-domain/domain_fn.ts
@@ -58,7 +58,7 @@ export const handleDomainFn = (cy: $Cy, specBridgeCommunicator: SpecBridgeDomain
         doneEarly()
 
         // signal to the primary domain that done has been called and to signal that the command queue is finished in the secondary domain
-        specBridgeCommunicator.toPrimary('done:called', err)
+        specBridgeCommunicator.toPrimaryError('done:called', { err })
         specBridgeCommunicator.toPrimary('queue:finished')
 
         return null
@@ -80,7 +80,7 @@ export const handleDomainFn = (cy: $Cy, specBridgeCommunicator: SpecBridgeDomain
 
       // If there isn't a current command, just reject to fail the test
       if (!command) {
-        return specBridgeCommunicator.toPrimary('reject', { err })
+        return specBridgeCommunicator.toPrimaryError('reject', { err })
       }
 
       const id = command.get('id')


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
n/a

### Additional details

Since we removed implicit preprocessing of errors before it is serialized with `postMessage` in #19936 , we need to explicitly preprocess errors in (for firefox) when errors are send back over to the primary domain. This should fix this [test](https://app.circleci.com/pipelines/github/cypress-io/cypress/31019/workflows/d99fccfd-d010-46e5-b510-ed96ea0e8aa0/jobs/1209163/tests#failed-test-0) as well as fix `done` being called with an error in the secondary domain. 

So the following code should result in the correct failure. ( NOTE: We currently do not have a test for this as it requires a 'cypress in cypress' type of test)

![](https://user-images.githubusercontent.com/3980464/152866358-d5f91763-e2f7-4043-bac8-dd8f4bd48720.png)

![](https://user-images.githubusercontent.com/3980464/152866372-d4e6a3b2-f62d-482a-b005-6ae2748d8b21.png)


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
