### PR TITLE
chore: use latest kitchensink in example

### DIFF
--- a/packages/example/bin/build.js
+++ b/packages/example/bin/build.js
@@ -20,13 +20,6 @@ async function build() {
     fs.copy(join(resolvePkg('cypress-example-kitchensink'), 'app'), path.join(EXAMPLE_DIR, 'app')),
     fs.copy(join(resolvePkg('cypress-example-kitchensink'), 'cypress'), path.join(EXAMPLE_DIR, 'cypress')),
   ])
-  try {
-    await fs.move(path.join(EXAMPLE_DIR, 'cypress', 'support', 'index.js'), path.join(EXAMPLE_DIR, 'cypress', 'support', 'e2e.js'))
-  } catch (e) {
-    if (e.code !== 'ENOENT') {
-      throw e
-    }
-  }
   childProcess.execSync('node ./bin/convert.js', {
     cwd: EXAMPLE_DIR,
     stdio: 'inherit'

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "chai": "3.5.0",
     "cross-env": "6.0.3",
-    "cypress-example-kitchensink": "cypress-io/cypress-example-kitchensink#d4b6c4a898f87fa391fabef6dbbff8cd7bd11d2a",
+    "cypress-example-kitchensink": "cypress-io/cypress-example-kitchensink#8bd82de1729999cc0c1a6cb5dc2c9dd7ec2d2f0b",
     "gulp": "4.0.2",
     "gulp-clean": "0.4.0",
     "gulp-gh-pages": "0.6.0-6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17200,9 +17200,9 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress-example-kitchensink@cypress-io/cypress-example-kitchensink#d4b6c4a898f87fa391fabef6dbbff8cd7bd11d2a:
+cypress-example-kitchensink@cypress-io/cypress-example-kitchensink#8bd82de1729999cc0c1a6cb5dc2c9dd7ec2d2f0b:
   version "0.0.0-development"
-  resolved "https://codeload.github.com/cypress-io/cypress-example-kitchensink/tar.gz/d4b6c4a898f87fa391fabef6dbbff8cd7bd11d2a"
+  resolved "https://codeload.github.com/cypress-io/cypress-example-kitchensink/tar.gz/8bd82de1729999cc0c1a6cb5dc2c9dd7ec2d2f0b"
   dependencies:
     npm-run-all "^4.1.2"
     serve "11.3.0"


### PR DESCRIPTION
Seeing a bunch of failures here https://github.com/cypress-io/cypress/pull/20084 which are unrelated to the changes. For some reason, it's installing an older version of `cypress-kitchensink`. I don't know why. 

I tried using the latest commit (Feb 4). We were using second latest, Jan 5. With the latest one, it's working, at least locally, after a `yarn install`. Not sure if a circle caching issue, or what, but good to use the latest commit for the example project.

Also pushed this commit to #20084 to see if it fixes the problem there. We might just need to trick Circle into getting a new node_modules :thinking: 

Edit: this does not seem to fix #20084.

![image](https://user-images.githubusercontent.com/19196536/152992491-e309cf79-ad86-406b-8fab-fbc68f77d451.png)
