### PR TITLE
fix: remove nullish coalescing in js files to support node 12

### DIFF
--- a/npm/react/plugins/utils/get-transpile-folders.js
+++ b/npm/react/plugins/utils/get-transpile-folders.js
@@ -2,7 +2,7 @@
 const path = require('path')
 
 function getTranspileFolders (config) {
-  const rawFolders = config.addTranspiledFolders ?? []
+  const rawFolders = config.addTranspiledFolders || []
   const folders = rawFolders.map((folder) => path.resolve(config.projectRoot, folder))
 
   // user can disable folders, so check first


### PR DESCRIPTION
- Closes [UNIFY-1060](https://cypress-io.atlassian.net/browse/UNIFY-1060)

### User facing changelog
Remove nullish coalescing operator in js files

### Additional details
`plugins/react-scripts` was failing on Node v12 due to the `??` operator. It's fine in typescript files since we transpile them, but not in javascript files.

### How has the user experience changed?
`@cypress/react/plugins/react-scripts` works with node v12

### Testing
I tested this by checkout out [cypress-component-testing-examples](https://github.com/cypress-io/cypress-component-testing-examples) and testing against `create-react-app` using nvm to switch to node v12. Running `npx cypress open-ct` throws:

```
The plugins file is missing or invalid.

Your `pluginsFile` is set to `/Users/zachjw/work/cypress-component-testing-examples/create-react-app/cypress/plugins/index.js`, but either the file is missing, it contains a syntax error, or threw an error when required. The `pluginsFile` must be a `.js`, `.ts`, or `.coffee` file.

Or you might have renamed the extension of your `pluginsFile`. If that's the case, restart the test runner.

Please fix this, or set `pluginsFile` to `false` if a plugins file is not necessary for your project.

 /Users/zachjw/work/cypress-component-testing-examples/create-react-app/node_modules/@cypress/react/plugins/utils/get-transpile-folders.js:5
  const rawFolders = config.addTranspiledFolders ?? []
                                                  ^

SyntaxError: Unexpected token '?'

...
```

Then, run `yarn workspace @cypress/react build` and copy and paste the `npm/react/plugins` and `npm/react/dist` folders into `~/<path-to-repo>/cypress-component-testing-examples/create-react-app/node_modules/@cypress/react` and run `npx cypress open-ct`. No failure!

### PR Tasks

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
