### PR TITLE
fix: e2e select language highlight

### DIFF
--- a/packages/launchpad/src/setup/ScaffoldLanguageSelect.vue
+++ b/packages/launchpad/src/setup/ScaffoldLanguageSelect.vue
@@ -15,7 +15,7 @@
         <SelectLanguage
           :name="t('setupPage.projectSetup.configFileLanguageLabel')"
           :options="languages || []"
-          :value="props.gql.wizard.language?.id ?? 'js'"
+          :value="props.gql.wizard.language?.type ?? 'js'"
           @select="val => onLanguageSelect(val)"
         />
       </div>


### PR DESCRIPTION
Fixes the e2e select language not having a highlight

Before:
![Screen Shot 2022-02-08 at 1 56 56 PM](https://user-images.githubusercontent.com/25158820/153065673-efc41cc2-757a-480b-8c3d-e019a77296bf.png)

After:
![Screen Shot 2022-02-08 at 1 57 17 PM](https://user-images.githubusercontent.com/25158820/153065697-a5fbd840-4da4-4cb6-b984-6eabf075ada8.png)

