### PR TITLE
fix: various style issues in launchpad and app

### DIFF
--- a/packages/app/src/main.scss
+++ b/packages/app/src/main.scss
@@ -1,5 +1,9 @@
 @use '@packages/frontend-shared/src/styles/shared.scss';
 
+html {
+  @apply h-screen overflow-hidden;
+}
+
 .fade-enter-active,
 .fade-leave-active {
   transition: opacity 0.15s ease;

--- a/packages/app/src/runner/SpecRunnerOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerOpenMode.vue
@@ -20,7 +20,7 @@
           v-if="props.gql.currentProject"
           v-show="runnerUiStore.isSpecsListOpen"
           id="inline-spec-list"
-          class="h-full bg-gray-1000 border-r-1 border-gray-900"
+          class="h-full bg-gray-1000 border-r-1 border-gray-900 force-dark"
           :class="{'pointer-events-none': isDragging}"
         >
           <InlineSpecList
@@ -42,7 +42,7 @@
           <div
             v-once
             :id="REPORTER_ID"
-            class="w-full"
+            class="w-full force-dark"
           />
         </HideDuringScreenshot>
       </template>

--- a/packages/app/src/runner/SpecRunnerRunMode.vue
+++ b/packages/app/src/runner/SpecRunnerRunMode.vue
@@ -17,7 +17,7 @@
         <HideDuringScreenshotOrRunMode
           v-show="runnerUiStore.isSpecsListOpen"
           id="inline-spec-list"
-          class="h-full bg-gray-1000 border-r-1 border-gray-900"
+          class="h-full bg-gray-1000 border-r-1 border-gray-900 force-dark"
           :class="{'pointer-events-none': isDragging}"
         />
       </template>
@@ -28,7 +28,7 @@
           <div
             v-once
             :id="REPORTER_ID"
-            class="w-full"
+            class="w-full force-dark"
           />
         </HideDuringScreenshot>
       </template>

--- a/packages/app/src/specs/InlineSpecListHeader.cy.tsx
+++ b/packages/app/src/specs/InlineSpecListHeader.cy.tsx
@@ -42,13 +42,13 @@ describe('InlineSpecListHeader', () => {
 
   it('exposes the result count correctly to assistive tech', () => {
     mountWithResultCount(0)
-    cy.contains(`0 ${ defaultMessages.specPage.matchPlural}`)
+    cy.contains('No Matches')
     .should('have.class', 'sr-only')
     .and('have.attr', 'aria-live', 'polite')
 
     mountWithResultCount(1)
-    cy.contains(`1 ${ defaultMessages.specPage.matchSingular}`).should('have.class', 'sr-only')
+    cy.contains('1 Match').should('have.class', 'sr-only')
     mountWithResultCount(100)
-    cy.contains(`100 ${ defaultMessages.specPage.matchPlural}`).should('have.class', 'sr-only')
+    cy.contains('100 Matches').should('have.class', 'sr-only')
   })
 })

--- a/packages/app/src/specs/InlineSpecListHeader.vue
+++ b/packages/app/src/specs/InlineSpecListHeader.vue
@@ -73,7 +73,7 @@
       class="sr-only"
       aria-live="polite"
     >
-      {{ resultCount }} {{ resultCount === 1 ? t('specPage.matchSingular') : t('specPage.matchPlural') }}
+      {{ t('components.fileSearch.matchesIndicatorEmptyFileSearch', { count: resultCount, denominator: resultCount}) }}
     </div>
   </div>
 </template>

--- a/packages/app/src/specs/InlineSpecListTree.vue
+++ b/packages/app/src/specs/InlineSpecListTree.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-bind="containerProps"
-    class="pt-8px specs-list-container overscroll-contain overflow-y-auto"
+    class="pt-8px specs-list-container overscroll-contain overflow-y-auto overflow-x-hidden"
   >
     <ul
       v-bind="wrapperProps"

--- a/packages/app/src/specs/SpecsListHeader.cy.tsx
+++ b/packages/app/src/specs/SpecsListHeader.cy.tsx
@@ -70,13 +70,13 @@ describe('<SpecsListHeader />', { keystrokeDelay: 0 }, () => {
     }
 
     mountWithResultCount(0)
-    cy.contains(`0 ${ defaultMessages.specPage.matchPlural}`)
+    cy.contains('No Matches')
     .should('be.visible')
     .and('have.attr', 'aria-live', 'polite')
 
     mountWithResultCount(1)
-    cy.contains(`1 ${ defaultMessages.specPage.matchSingular}`).should('be.visible')
+    cy.contains('1 Match').should('be.visible')
     mountWithResultCount(100)
-    cy.contains(`100 ${ defaultMessages.specPage.matchPlural}`).should('be.visible')
+    cy.contains('100 Matches').should('be.visible')
   })
 })

--- a/packages/app/src/specs/SpecsListHeader.vue
+++ b/packages/app/src/specs/SpecsListHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative flex w-full gap-16px">
+  <div class="flex w-full gap-16px relative">
     <Input
       type="search"
       class="flex-grow h-full min-w-200px"
@@ -12,14 +12,14 @@
     >
       <template #suffix>
         <button
-          class="mr-[-0.75rem] h-40px outline-none hover:(bg-indigo-50 text-indigo-500) transition-all rounded-r-md group"
+          class="rounded-r-md outline-none h-40px mr-[-0.75rem] transition-all group"
           aria-live="polite"
           @click="emit('showSpecPatternModal')"
         >
           <span
-            class="block border-l h-24px px-16px border-l-gray-100 group-hover:border-none"
+            class="rounded-r flex mr-1px px-16px items-center matches-button  group-hocus:text-indigo-500"
           >
-            {{ resultCount }} {{ resultCount === 1 ? t('specPage.matchSingular') : t('specPage.matchPlural') }}
+            {{ t('components.fileSearch.matchesIndicatorEmptyFileSearch', { count: resultCount, denominator: resultCount}) }}
             <span class="sr-only">{{ t(`createSpec.viewSpecPatternButton`) }} </span>
           </span>
         </button>
@@ -69,3 +69,18 @@ const onInput = (e: Event) => {
   emit('update:modelValue', value)
 }
 </script>
+
+<style scoped>
+.matches-button {
+  @apply border-transparent h-full border-t-1 border-b-1 border-r-1 group-hocus:bg-indigo-50 group-hocus:border-indigo-300;
+}
+.matches-button:before {
+  @apply h-full bg-gray-100 transform transition ease-in w-1px
+  scale-y-50 duration-150 group-hocus:bg-indigo-300 group-hocus:scale-y-100;
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  content: '';
+}
+</style>

--- a/packages/app/src/specs/SpecsListHeader.vue
+++ b/packages/app/src/specs/SpecsListHeader.vue
@@ -17,7 +17,7 @@
           @click="emit('showSpecPatternModal')"
         >
           <span
-            class="rounded-r flex mr-1px px-16px items-center matches-button  group-hocus:text-indigo-500"
+            class="border-transparent rounded-r flex h-full border-t-1 border-b-1 border-r-1 mr-1px px-16px items-center matches-button group-hocus:bg-indigo-50 group-hocus:border-indigo-300  group-hocus:text-indigo-500"
           >
             {{ t('components.fileSearch.matchesIndicatorEmptyFileSearch', { count: resultCount, denominator: resultCount}) }}
             <span class="sr-only">{{ t(`createSpec.viewSpecPatternButton`) }} </span>
@@ -71,9 +71,7 @@ const onInput = (e: Event) => {
 </script>
 
 <style scoped>
-.matches-button {
-  @apply border-transparent h-full border-t-1 border-b-1 border-r-1 group-hocus:bg-indigo-50 group-hocus:border-indigo-300;
-}
+
 .matches-button:before {
   @apply h-full bg-gray-100 transform transition ease-in w-1px
   scale-y-50 duration-150 group-hocus:bg-indigo-300 group-hocus:scale-y-100;

--- a/packages/frontend-shared/src/components/Card.vue
+++ b/packages/frontend-shared/src/components/Card.vue
@@ -32,7 +32,7 @@
     <!-- this button can be focused via tab key and allows card hocus styles to appear
     as well as allows a keyboard user to "activate" the card with spacebar or enter keys -->
     <button
-      class="m-8px text-indigo-500 text-18px leading-24px focus:outline-transparent"
+      class="font-medium mx-8px mb-8px text-indigo-500 text-18px leading-24px focus:outline-transparent"
       :class="{
         'text-gray-700': disabled
       }"

--- a/packages/frontend-shared/src/components/StandardModal.cy.tsx
+++ b/packages/frontend-shared/src/components/StandardModal.cy.tsx
@@ -5,7 +5,7 @@ import { ref } from 'vue'
 const title = 'Test Title'
 const body = 'Test body text'
 
-describe('<StandardModal />', { viewportWidth: 500, viewportHeight: 400 }, () => {
+describe('<StandardModal />', { viewportWidth: 800, viewportHeight: 400 }, () => {
   describe('default render and variations', () => {
     it('renders expected content in open state', () => {
       const isOpen = ref(true)
@@ -138,6 +138,11 @@ describe('<StandardModal />', { viewportWidth: 500, viewportHeight: 400 }, () =>
     it('closes with click-outside by default', () => {
       cy.get('body').click()
       cy.get('@updateSpy').should('have.been.calledOnceWith', false)
+    })
+
+    it('does not close w/ click-outside when viewport is xs', { viewportWidth: 400 }, () => {
+      cy.get('body').click()
+      cy.get('@updateSpy').should('not.have.been.called')
     })
 
     it('doesn\'t close with click inside', () => {

--- a/packages/frontend-shared/src/components/StandardModal.vue
+++ b/packages/frontend-shared/src/components/StandardModal.vue
@@ -9,7 +9,7 @@
         name="overlay"
         :classes="'fixed inset-0'"
       >
-        <DialogOverlay class="bg-gray-800 opacity-90 inset-0 fixed" />
+        <DialogOverlay class="bg-gray-800 opacity-90 fixed sm:inset-0" />
       </slot>
       <div
         data-cy="standard-modal"

--- a/packages/frontend-shared/src/components/StatusBadge.vue
+++ b/packages/frontend-shared/src/components/StatusBadge.vue
@@ -1,11 +1,11 @@
 <template>
   <span
-    class="inline-flex items-center border rounded-full p-5px pr-16px text-size-14px leading-20px"
+    class="border rounded-full font-medium p-5px pr-16px text-size-14px leading-20px inline-flex items-center"
     :class="status ? 'text-jade-500' : 'text-gray-600'"
   >
     <i-cy-grommet_x16
-      class="mx-4px h-16px w-16px"
-      :class="status ? 'icon-light-jade-500 icon-dark-jade-500' : 'icon-dark-gray-200 icon-dark-gray-50'"
+      class="h-16px mr-4px ml-4px w-16px"
+      :class="status ? 'icon-light-jade-400 icon-dark-jade-400' : 'icon-dark-gray-200 icon-dark-gray-50'"
     />
     {{ status ? titleOn : titleOff }}
   </span>

--- a/packages/frontend-shared/src/gql-components/HeaderBarContent.vue
+++ b/packages/frontend-shared/src/gql-components/HeaderBarContent.vue
@@ -9,24 +9,24 @@
       </div>
       <div
         v-else
-        class="flex items-center"
+        class="flex items-center children:font-medium children:leading-24px"
       >
         <img
           class="h-32px mr-18px w-32px"
           src="../assets/logos/cypress-dark.png"
         >
         <a
+          class="font-medium mr-2px hocus-link-default"
           :class="props.gql?.currentProject ? 'text-indigo-500' :
             'text-gray-700'"
           :href="props.gql?.currentProject ? 'global-mode' : undefined"
           @click.prevent="clearCurrentProject"
         >
-          Projects
+          {{ t('topNav.global.projects') }}
         </a>
-        <!-- TODO: Replace with a cy icon -->
-        <i-oi-chevron-right
+        <i-cy-chevron-right_x16
           v-if="props.gql?.currentProject"
-          class="h-8px text-gray-300"
+          class="h-16px mr-2px min-w-16px icon-dark-gray-200"
         />
         <span class="text-body-gray-700">{{ props.gql?.currentProject?.title }}</span>
       </div>
@@ -92,7 +92,7 @@
             <i-cy-profile_x16
               class="h-16px mr-8px w-16px block icon-dark-gray-500 icon-light-gray-100 group-hocus:icon-dark-indigo-500 group-hocus:icon-light-indigo-50"
             />
-            <span class="font-semibold whitespace-nowrap group-hocus:text-indigo-500">{{ t('topNav.login.actionLogin') }}</span>
+            <span class="font-medium whitespace-nowrap group-hocus:text-indigo-500">{{ t('topNav.login.actionLogin') }}</span>
           </button>
         </div>
       </div>

--- a/packages/frontend-shared/src/gql-components/topnav/DocsMenuContent.vue
+++ b/packages/frontend-shared/src/gql-components/topnav/DocsMenuContent.vue
@@ -4,7 +4,7 @@
     :key="list.title"
     class="min-w-164px"
   >
-    <h2 class="font-semibold text-gray-800">
+    <h2 class="font-medium text-gray-800">
       {{ list.title }}
     </h2>
     <hr class="border-gray-50 my-10px">

--- a/packages/frontend-shared/src/gql-components/topnav/TopNav.vue
+++ b/packages/frontend-shared/src/gql-components/topnav/TopNav.vue
@@ -9,7 +9,7 @@
       />
       <span
         data-cy="top-nav-version-list"
-        class="font-semibold text-indigo-500 whitespace-nowrap"
+        class="font-medium text-indigo-500 whitespace-nowrap"
       >v{{ versions.current.version }} <span
         class="text-indigo-300"
         aria-hidden="true"
@@ -20,7 +20,7 @@
       class="min-w-278px py-8px px-16px"
       data-cy="update-hint"
     >
-      <div class="font-semibold">
+      <div class="font-medium">
         <ExternalLink
           :href="`${releasesUrl}/tag/v${versions.latest.version}`"
           class="text-indigo-500"
@@ -59,7 +59,7 @@
       <div class="whitespace-nowrap">
         <ExternalLink
           :href="`${releasesUrl}/tag/v${versions.current.version}`"
-          class="font-semibold text-amber-800"
+          class="font-medium text-amber-800"
           data-cy="current-version"
         >
           {{ versions.current.version }}
@@ -89,7 +89,7 @@
   <ExternalLink
     v-else-if="versions"
     :href="`${releasesUrl}/tag/v${versions.latest.version}`"
-    class="flex font-semibold outline-transparent text-gray-600 gap-8px items-center group hocus:text-indigo-500 hocus:outline-0"
+    class="flex font-medium outline-transparent text-gray-600 gap-8px items-center group hocus:text-indigo-500 hocus:outline-0"
     :use-default-hocus="false"
     data-cy="top-nav-cypress-version-current-link"
   >
@@ -113,7 +113,7 @@
       >
       <span
         data-cy="top-nav-active-browser"
-        class="font-semibold whitespace-nowrap"
+        class="font-medium whitespace-nowrap"
       >{{ props.gql.currentProject?.currentBrowser?.displayName }} {{ props.gql.currentProject?.currentBrowser?.majorVersion }}</span>
     </template>
     <VerticalBrowserListItems
@@ -135,7 +135,7 @@
         :class="(open || props.forceOpenDocs) ? 'icon-dark-indigo-500 icon-light-indigo-50' : 'icon-dark-gray-500 icon-light-gray-100'"
       />
       <span
-        class="font-semibold"
+        class="font-medium"
         :class="{'text-indigo-600': open}"
       >{{ t('topNav.docsMenu.docsHeading') }}</span>
     </template>

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -290,14 +290,16 @@
     "review": "Review the differences between each testing type",
     "codeExample": "Code Example",
     "compareTypes": {
-      "e2eTitle": "End-to-end Tests",
-      "e2eBullet1": "Visit URLs via",
-      "e2eBullet2": "Test flows and functionality across multiple pages.",
-      "e2eBullet3": "Ideal for testing integrated flows in CD workflows.",
-      "componentTitle": "Component Tests",
-      "ctBullet1": "Import components via",
-      "ctBullet2": "Test individual components of a design system in isolation",
-      "ctBullet3": "Ideal for testing isolated flows and components in CI",
+      "content": {
+        "e2eTitle": "End-to-end Tests",
+        "e2eBullet1": "Visit URLs via",
+        "e2eBullet2": "Test flows and functionality across multiple pages.",
+        "e2eBullet3": "Ideal for testing integrated flows in CD workflows.",
+        "componentTitle": "Component Tests",
+        "ctBullet1": "Import components via",
+        "ctBullet2": "Test individual components of a design system in isolation",
+        "ctBullet3": "Ideal for testing isolated flows and components in CI"
+      },
       "modalTitle": "Key Differences"
     },
     "title": "Welcome to Cypress!"

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -125,8 +125,6 @@
     "pageTitle": "Specs",
     "newSpecButton": "New Spec",
     "searchPlaceholder": "Search Specs",
-    "matchPlural": "Matches",
-    "matchSingular": "Match",
     "componentSpecsHeader": "Component Specs",
     "e2eSpecsHeader": "E2E Specs",
     "gitStatusHeader": "Git Status",

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -216,7 +216,10 @@
       "pasteToUpgradeGlobal": "To upgrade to the latest version, first {0}, then paste the command below into your terminal:",
       "rememberToCloseInsert": "close this app"
     },
-    "upgradeText": "Upgrade"
+    "upgradeText": "Upgrade",
+    "global": {
+      "projects": "Projects"
+    }
   },
   "launchpadErrors": {
     "generic": {
@@ -294,8 +297,10 @@
       "componentTitle": "Component Tests",
       "ctBullet1": "Import components via",
       "ctBullet2": "Test individual components of a design system in isolation",
-      "ctBullet3": "Ideal for testing isolated flows and components in CI"
-    }
+      "ctBullet3": "Ideal for testing isolated flows and components in CI",
+      "modalTitle": "Key Differences"
+    },
+    "title": "Welcome to Cypress!"
   },
   "settingsPage": {
     "config": {

--- a/packages/frontend-shared/src/styles/shared.scss
+++ b/packages/frontend-shared/src/styles/shared.scss
@@ -45,6 +45,16 @@ body {
   }
 }
 
+// Dark scrollbars, anything with dark:
+.force-dark {
+  color-scheme: dark;
+}
+
+// Light scrollbars, anything with light:
+.force-light {
+  color-scheme: light;
+}
+
 /**
  * Common theming
  * -------------------------

--- a/packages/launchpad/src/Main.vue
+++ b/packages/launchpad/src/Main.vue
@@ -1,7 +1,7 @@
 <template>
   <template v-if="query.data.value">
     <HeaderBar
-      class="w-full z-30 fixed"
+      class="w-full z-10 fixed"
     />
     <div class="px-24px pt-86px">
       <BaseError
@@ -38,7 +38,7 @@
         </template>
         <template v-else-if="!currentProject?.currentTestingType">
           <LaunchpadHeader
-            title="Welcome to Cypress!"
+            :title="t('welcomePage.title')"
             description=""
           />
           <StandardModal
@@ -46,7 +46,7 @@
             class="h-full w-full sm:h-auto sm:mx-[5%] sm:w-auto"
           >
             <template #title>
-              Key Differences
+              {{ t('welcomePage.compareTypes.modalTitle') }}
             </template>
             <CompareTestingTypes />
           </StandardModal>

--- a/packages/launchpad/src/global/GlobalProjectCard.vue
+++ b/packages/launchpad/src/global/GlobalProjectCard.vue
@@ -35,6 +35,7 @@
     <Menu #="{ open }">
       <MenuButton
         aria-label="Project Actions"
+        tabindex="-1"
         class="flex h-32px text-white w-32px items-center
       justify-center focus:outline-transparent focus:text-gray-300"
         @click.stop
@@ -47,7 +48,7 @@
       <MenuItems
         data-cy="project-card-menu-items"
         class="rounded flex flex-col outline-transparent bg-gray-900 text-white
-      right-0 right-18px -bottom-104px z-40 absolute overflow-scroll"
+      right-0 right-18px -bottom-104px z-40 absolute"
       >
         <MenuItem
           v-for="item in menuItems"

--- a/packages/launchpad/src/setup/CompareTestingCard.vue
+++ b/packages/launchpad/src/setup/CompareTestingCard.vue
@@ -1,37 +1,37 @@
 <template>
-  <div class="w-full cursor-default px-24px mb-24px">
-    <h3 class="text-gray-900 mb-12px text-18px">
+  <div class="cursor-default w-full px-24px">
+    <h3 class="mb-12px text-gray-900 text-18px">
       {{ title }}
     </h3>
 
-    <ul class="text-gray-600 mb-10px">
-      <li class="relative mb-4px ml-12px">
+    <ul class="mb-10px text-gray-600">
+      <li class="mb-4px ml-12px relative">
         <div
-          class="absolute block border w-6px h-6px bg-jade-300 -left-11px top-9px rounded-10px border-jade-400"
+          class="border bg-jade-300 border-jade-400 rounded-10px h-6px top-9px -left-11px w-6px absolute block"
         />
         {{ listItems[0] }}
         <InlineCodeFragment class="text-14px">
           {{ codeFragment }}
         </InlineCodeFragment>
       </li>
-      <li class="relative mb-4px ml-12px">
+      <li class="mb-4px ml-12px relative">
         <div
-          class="absolute block border w-6px h-6px bg-jade-300 -left-11px top-9px rounded-10px border-jade-400"
+          class="border bg-jade-300 border-jade-400 rounded-10px h-6px top-9px -left-11px w-6px absolute block"
         />
         {{ listItems[1] }}
       </li>
-      <li class="relative mb-4px ml-12px">
+      <li class="mb-4px ml-12px relative">
         <div
-          class="absolute block border w-6px h-6px bg-jade-300 -left-11px top-9px rounded-10px border-jade-400"
+          class="border bg-jade-300 border-jade-400 rounded-10px h-6px top-9px -left-11px w-6px absolute block"
         />
         {{ listItems[2] }}
       </li>
     </ul>
-    <h3 class="text-gray-900 mb-8px">
+    <h3 class="mb-8px text-gray-900">
       Code Example
     </h3>
     <ShikiHighlight
-      class="border-1 rounded border-gray-100"
+      class="rounded border-1 border-gray-100"
       :code="localCode"
       lang="javascript"
       line-numbers

--- a/packages/launchpad/src/setup/CompareTestingTypes.cy.tsx
+++ b/packages/launchpad/src/setup/CompareTestingTypes.cy.tsx
@@ -4,7 +4,7 @@ import { defaultMessages } from '@cy/i18n'
 describe('TestingTypeCards', () => {
   it('renders expected content', () => {
     cy.mount(CompareTestingTypes)
-    Object.values(defaultMessages.welcomePage.compareTypes).forEach((pieceOfText) =>
+    Object.values(defaultMessages.welcomePage.compareTypes.content).forEach((pieceOfText) =>
       cy.contains(pieceOfText).should('be.visible'))
   })
 })

--- a/packages/launchpad/src/setup/CompareTestingTypes.vue
+++ b/packages/launchpad/src/setup/CompareTestingTypes.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sm:grid md:w-full grid-cols-2 pt-24px">
+  <div class="grid-cols-2 sm:grid md:w-full">
     <CompareTestingCard
       data-cy="end-to-end-comparison"
       class="border-r border-r-gray-100"

--- a/packages/launchpad/src/setup/CompareTestingTypes.vue
+++ b/packages/launchpad/src/setup/CompareTestingTypes.vue
@@ -3,14 +3,14 @@
     <CompareTestingCard
       data-cy="end-to-end-comparison"
       class="border-r border-r-gray-100"
-      title="End-to-end Tests:"
+      :title="t('welcomePage.compareTypes.content.e2eTitle') + ':'"
       :code="e2eCode"
       :list-items="e2eItems"
       code-fragment="cy.visit()"
     />
     <CompareTestingCard
       data-cy="component-comparison"
-      title="Component Tests:"
+      :title="t('welcomePage.compareTypes.content.componentTitle') + ':'"
       :code="ctCode"
       :list-items="ctItems"
       code-fragment="cy.mount()"
@@ -54,14 +54,14 @@ it('only shows a promotional modal on first visit', () => {
 `
 
 const e2eItems = [
-  t('welcomePage.compareTypes.e2eBullet1'),
-  t('welcomePage.compareTypes.e2eBullet2'),
-  t('welcomePage.compareTypes.e2eBullet3'),
+  t('welcomePage.compareTypes.content.e2eBullet1'),
+  t('welcomePage.compareTypes.content.e2eBullet2'),
+  t('welcomePage.compareTypes.content.e2eBullet3'),
 ]
 
 const ctItems = [
-  t('welcomePage.compareTypes.ctBullet1'),
-  t('welcomePage.compareTypes.ctBullet2'),
-  t('welcomePage.compareTypes.ctBullet3'),
+  t('welcomePage.compareTypes.content.ctBullet1'),
+  t('welcomePage.compareTypes.content.ctBullet2'),
+  t('welcomePage.compareTypes.content.ctBullet3'),
 ]
 </script>

--- a/packages/launchpad/src/setup/OpenBrowserList.vue
+++ b/packages/launchpad/src/setup/OpenBrowserList.vue
@@ -54,8 +54,8 @@
             >
           </div>
           <div
-            class="pt-2 text-indigo-600 text-18px leading-28px"
-            :class="{ 'text-jade-600': browser.isSelected, 'text-gray-500': browser.disabled || browser.isVersionSupported }"
+            class="font-medium pt-2 text-indigo-600 text-18px leading-28px"
+            :class="{ 'text-jade-600': browser.isSelected, 'text-gray-500': browser.disabled || !browser.isVersionSupported }"
           >
             {{ browser.displayName }}
           </div>
@@ -138,9 +138,9 @@
       <Button
         size="sm"
         variant="text"
-        :prefix-icon="ArrowLeftIcon"
-        prefix-icon-class="icon-dark-gray-500"
-        class="font-medium mx-auto text-gray-600 hover:text-indigo-500"
+        :prefix-icon="ArrowRightIcon"
+        prefix-icon-class="icon-dark-gray-500 transform transition-transform ease-in -translate-y-1px duration-200 inline-block group-hocus:icon-dark-indigo-500 rotate-180 group-hocus:translate-x-2px"
+        class="font-medium mx-auto text-gray-600 hocus-link-default group hocus:text-indigo-500"
         @click="emit('navigatedBack')"
       >
         {{ browserText.switchTestingType }}
@@ -160,7 +160,7 @@ import TestingTypeComponentIcon from '~icons/cy/testing-type-component_x16'
 import TestingTypeE2EIcon from '~icons/cy/testing-type-e2e_x16'
 import ExportIcon from '~icons/cy/export_x16'
 import PowerStandbyIcon from '~icons/cy/power-standby'
-import ArrowLeftIcon from '~icons/cy/arrow-left_x16'
+import ArrowRightIcon from '~icons/cy/arrow-right_x16'
 import StatusRunningIcon from '~icons/cy/status-running_x16'
 import { RadioGroup, RadioGroupOption, RadioGroupLabel } from '@headlessui/vue'
 import UnsupportedBrowserTooltip from '@packages/frontend-shared/src/gql-components/topnav/UnsupportedBrowserTooltip.vue'


### PR DESCRIPTION
1. Font weights (should've been using medium, not semibold)
2. Removed outline for Projects link in Launchpad, used hocus-link-default
3. Fixed spacing in Card.vue (Testing Type cards)
4. Fixed spacing in Testing Type overlay
5. Added a hocus state for "Switch testing type"
6. Added dark scrollbars for "dark mode" parts of the UI
7. Fixed the SpecListHeader "Matches" text to use the proper i18n counters
8. Fixed the SpecListHeader "Matches" focus/hover states
9. Added various hardcoded strings into i18n
10. Removed scrollbars from Menu in GlobalProjectCard.vue

https://user-images.githubusercontent.com/2801156/153143645-f44ea454-db00-45d5-8195-ca353c84572e.mov