### PR TITLE
feat: (multi-domain) add initial support for cy.screenshot

### DIFF
--- a/packages/driver/cypress/fixtures/multi-domain.html
+++ b/packages/driver/cypress/fixtures/multi-domain.html
@@ -18,6 +18,7 @@
     <a data-cy="shadow-dom-link" href="http://www.foobar.com:3500/fixtures/shadow-dom.html">http://www.foobar.com:3500/fixtures/shadow-dom.html</a>
     <a data-cy="files-form-link" href="http://www.foobar.com:3500/fixtures/files-form.html">http://www.foobar.com:3500/fixtures/files-form.html</a>
     <a data-cy="errors-link" href="http://www.foobar.com:3500/fixtures/errors.html">http://www.foobar.com:3500/fixtures/errors.html</a>
+    <a data-cy="screenshots-link" href="http://www.foobar.com:3500/fixtures/screenshots.html">http://www.foobar.com:3500/fixtures/screenshots.html</a>
   </div>
 </body>
 </html>

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
@@ -39,13 +39,6 @@ context('multi-domain misc', { experimentalSessionSupport: true, experimentalMul
     })
   })
 
-  // FIXME: hanging, nothing in console
-  it.skip('.screenshot()', () => {
-    cy.switchToDomain('foobar.com', () => {
-      cy.screenshot('multi-domain-screenshot-command')
-    })
-  })
-
   it('.wrap()', () => {
     cy.switchToDomain('foobar.com', () => {
       cy.wrap({ foo: 'bar' }).should('deep.equal', { foo: 'bar' })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_screenshot.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_screenshot.spec.ts
@@ -1,0 +1,182 @@
+// @ts-ignore / session support is needed for visiting about:blank between tests
+context('screenshot specs', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+  beforeEach(() => {
+    cy.visit('/fixtures/multi-domain.html')
+    cy.get('a[data-cy="screenshots-link"]').click()
+
+    this.serverResult = {
+      path: '/path/to/screenshot',
+      size: 12,
+      dimensions: { width: 20, height: 20 },
+      multipart: false,
+      pixelRatio: 1,
+      takenAt: new Date().toISOString(),
+      name: 'name',
+      blackout: [],
+      testAttemptIndex: 0,
+      duration: 100,
+    }
+  })
+
+  afterEach(() => {
+    // FIXME: the stub is not getting restored on its own causing other tests to fail
+    cy.switchToDomain('foobar.com', () => {
+      //@ts-ignore
+      Cypress.automation.restore()
+    })
+  })
+
+  it('captures the fullPage', () => {
+    cy.viewport(600, 200)
+
+    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+      const automationStub = cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
+
+      cy.screenshot({ capture: 'fullPage' })
+      .then(() => {
+        expect(automationStub).to.be.calledThrice
+        expect(automationStub.args[0][1].capture).to.equal('fullPage')
+        expect(automationStub.args[1][1].capture).to.equal('fullPage')
+        expect(automationStub.args[2][1].capture).to.equal('fullPage')
+      })
+    })
+  })
+
+  it('captures the runner', () => {
+    cy.viewport(600, 200)
+
+    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+      const automationStub = cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
+
+      cy.screenshot({ capture: 'runner' })
+      .then(() => {
+        expect(automationStub).to.be.calledOnce
+        expect(automationStub.args[0][1].capture).to.equal('runner')
+      })
+    })
+  })
+
+  it('captures the viewport', () => {
+    cy.viewport(600, 200)
+
+    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+      const automationStub = cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
+
+      cy.screenshot({ capture: 'viewport' })
+      .then(() => {
+        expect(automationStub).to.be.calledOnce
+        expect(automationStub.args[0][1].capture).to.equal('viewport')
+      })
+    })
+  })
+
+  it('supports multiple titles', () => {
+    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+      const automationStub = cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
+
+      cy.screenshot()
+      .then(() => {
+        expect(automationStub.args[0][1].titles).to.deep.equal(['screenshot specs', 'supports multiple titles'])
+      })
+    })
+  })
+
+  // FIXME: Add support for blackout option. Has cross-domain issue due to the blackout logic
+  // being called from top instead of the spec bridge
+  it.skip('supports the blackout option', () => {
+    cy.switchToDomain('foobar.com', () => {
+      cy.screenshot({ blackout: ['a'] })
+    })
+  })
+
+  it('supports element screenshots', () => {
+    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+      const automationStub = cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
+
+      cy.get('.tall-element').screenshot()
+      .then(() => {
+        expect(automationStub.args[0][1].clip).to.deep.equal({ x: 20, y: 140, width: 850, height: 320 })
+      })
+    })
+  })
+
+  it('supports screenshot retrying with appropriate naming', () => {
+    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+      const automationStub = cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
+
+      cy.state('runnable')._currentRetry = 2
+
+      cy.screenshot()
+      .then(() => {
+        expect(automationStub.args[0][1].testAttemptIndex).to.equal(2)
+      })
+    })
+  })
+
+  it('calls the onBeforeScreenshot callback', () => {
+    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+      let called
+
+      cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
+
+      cy.screenshot({
+        onBeforeScreenshot () {
+          called = true
+        },
+      })
+      .then(() => {
+        return called
+      })
+    })
+    .then((called) => {
+      expect(called).to.be.true
+    })
+  })
+
+  it('calls the onAfterScreenshot callback', () => {
+    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+      let called
+
+      cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
+
+      cy.screenshot({
+        onAfterScreenshot () {
+          called = true
+        },
+      })
+      .then(() => {
+        return called
+      })
+    })
+    .then((called) => {
+      expect(called).to.be.true
+    })
+  })
+
+  it('supports the Cypress.screenshot callbacks', () => {
+    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+      cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
+
+      let beforeCalled
+      let afterCalled
+
+      Cypress.Screenshot.defaults({
+        onBeforeScreenshot () {
+          beforeCalled = true
+        },
+        onAfterScreenshot () {
+          afterCalled = true
+        },
+      })
+
+      cy.screenshot()
+      .then(() => {
+        return { beforeCalled, afterCalled }
+      })
+    })
+    .then(({ beforeCalled, afterCalled }) => {
+      expect(beforeCalled).to.be.true
+      expect(afterCalled).to.be.true
+    })
+  })
+})

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_spec.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash'
+import { nullifyUnserializableValues } from '../../../../src/cy/multi-domain/util'
 
 // @ts-ignore / session support is needed for visiting about:blank between tests
 describe('multi-domain', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
@@ -16,6 +17,33 @@ describe('multi-domain', { experimentalSessionSupport: true, experimentalMultiDo
     })
 
     cy.log('after switchToDomain')
+  })
+
+  it('passes runnable state to the secondary domain', () => {
+    const expectedRunnable = nullifyUnserializableValues(cy.state('runnable'))
+
+    cy.switchToDomain('foobar.com', [expectedRunnable], ([expectedRunnable]) => {
+      const actualRunnable = cy.state('runnable')
+
+      expect(actualRunnable.id).to.equal(expectedRunnable.id)
+      expect(actualRunnable.title).to.equal(expectedRunnable.title)
+    })
+  })
+
+  it('passes viewportWidth/Height state to the secondary domain', () => {
+    const expectedViewport = [320, 480]
+
+    cy.viewport(320, 480).then(() => {
+      const primaryViewport = [cy.state('viewportWidth'), cy.state('viewportHeight')]
+
+      expect(primaryViewport).to.deep.equal(expectedViewport)
+    })
+
+    cy.switchToDomain('foobar.com', [expectedViewport], ([expectedViewport]) => {
+      const secondaryViewport = [cy.state('viewportWidth'), cy.state('viewportHeight')]
+
+      expect(secondaryViewport).to.deep.equal(expectedViewport)
+    })
   })
 
   it('handles querying nested elements', () => {

--- a/packages/driver/src/cy/multi-domain/index.ts
+++ b/packages/driver/src/cy/multi-domain/index.ts
@@ -3,7 +3,7 @@ import $errUtils from '../../cypress/error_utils'
 import { CommandsManager } from './commands_manager'
 import { LogsManager } from './logs_manager'
 import { Validator } from './validator'
-import { correctStackForCrossDomainError } from './util'
+import { nullifyUnserializableValues, correctStackForCrossDomainError } from './util'
 import { failedToSerializeSubject } from './failedSerializeSubjectProxy'
 
 export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, state: Cypress.State, config: Cypress.InternalConfig) {
@@ -168,6 +168,11 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
               data,
               fn: callbackFn.toString(),
               isDoneFnAvailable: !!done,
+              state: {
+                viewportWidth: Cypress.state('viewportWidth'),
+                viewportHeight: Cypress.state('viewportHeight'),
+                runnable: nullifyUnserializableValues(Cypress.state('runnable')),
+              },
             })
           } catch (err: any) {
             const wrappedErr = $errUtils.errByPath('switchToDomain.run_domain_fn_errored', {

--- a/packages/driver/src/cy/multi-domain/util.ts
+++ b/packages/driver/src/cy/multi-domain/util.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 import { AssertionError } from 'chai'
 import $stackUtils from '../../cypress/stack_utils'
+import $dom from '../../dom'
 
 export const correctStackForCrossDomainError = (serializedError: any, userInvocationStack: string) => {
   //  Since Errors sent over postMessage need to be serialized to Objects, we need to serialize them back into Error instances
@@ -16,4 +17,15 @@ export const correctStackForCrossDomainError = (serializedError: any, userInvoca
   reifiedError.stack = $stackUtils.replacedStack(reifiedError, userInvocationStack)
 
   return reifiedError
+}
+
+export const nullifyUnserializableValues = (obj) => {
+  // nullify values that cannot be cloned
+  return _.cloneDeepWith(obj, (val, key) => {
+    if (_.isFunction(val) || $dom.isDom(val)) {
+      return null
+    }
+
+    return undefined
+  })
 }

--- a/packages/driver/src/multi-domain/cypress.ts
+++ b/packages/driver/src/multi-domain/cypress.ts
@@ -67,6 +67,22 @@ const setup = () => {
   handleSocketEvents(Cypress)
   handleSpecWindowEvents(cy)
 
+  let beforeScreenshotCallback
+
+  Cypress.on('before:screenshot', (config, cb) => {
+    beforeScreenshotCallback = cb
+
+    specBridgeCommunicator.toPrimary('before:screenshot', config)
+  })
+
+  specBridgeCommunicator.on('before:screenshot:end', () => {
+    beforeScreenshotCallback()
+  })
+
+  Cypress.on('after:screenshot', (config) => {
+    specBridgeCommunicator.toPrimary('after:screenshot', config)
+  })
+
   cy.onBeforeAppWindowLoad = onBeforeAppWindowLoad(Cypress, cy)
 
   specBridgeCommunicator.initialize(window)

--- a/packages/driver/src/multi-domain/domain_fn.ts
+++ b/packages/driver/src/multi-domain/domain_fn.ts
@@ -29,24 +29,29 @@ export const handleDomainFn = (cy: $Cy, specBridgeCommunicator: SpecBridgeDomain
     cy.state('nestedIndex', null)
   }
 
-  const reset = () => {
+  const reset = (state) => {
     cy.reset({})
 
-    const runnable = {
-      ctx: {},
-      clearTimeout () {},
-      resetTimeout () {},
-      timeout () {},
-      isPending () {},
+    const stateUpdates = {
+      ...state,
+      runnable: {
+        ...state.runnable,
+        clearTimeout () {},
+        resetTimeout () {},
+        timeout () {},
+        isPending () {},
+      },
     }
 
-    cy.state('runnable', runnable)
+    // Update the state with the necessary values from the primary domain
+    cy.state(stateUpdates)
+
     // Set the state ctx to the runnable ctx to ensure they remain in sync
-    cy.state('ctx', runnable.ctx)
+    cy.state('ctx', cy.state('runnable').ctx)
   }
 
-  specBridgeCommunicator.on('run:domain:fn', async ({ data, fn, isDoneFnAvailable = false }: { data: any[], fn: string, isDoneFnAvailable: boolean }) => {
-    reset()
+  specBridgeCommunicator.on('run:domain:fn', async ({ data, fn, state, isDoneFnAvailable = false }: { data: any[], fn: string, isDoneFnAvailable: boolean, state: {}}) => {
+    reset(state)
 
     let fnWrapper = `(${fn})`
 

--- a/packages/runner-shared/src/event-manager.js
+++ b/packages/runner-shared/src/event-manager.js
@@ -442,12 +442,13 @@ export const eventManager = {
       reporterBus.emit('reporter:log:state:changed', displayProps)
     })
 
-    Cypress.on('before:screenshot', (config, cb) => {
+    const handleBeforeScreenshot = (config, cb) => {
       const beforeThenCb = () => {
         localBus.emit('before:screenshot', config)
         cb()
       }
 
+      // TODO: Should this come from primary or secondary?
       if (Cypress.env('NO_COMMAND_LOG')) {
         return beforeThenCb()
       }
@@ -459,11 +460,15 @@ export const eventManager = {
       }
 
       if (!wait) beforeThenCb()
-    })
+    }
 
-    Cypress.on('after:screenshot', (config) => {
+    Cypress.on('before:screenshot', handleBeforeScreenshot)
+
+    const handleAfterScreenshot = (config) => {
       localBus.emit('after:screenshot', config)
-    })
+    }
+
+    Cypress.on('after:screenshot', handleAfterScreenshot)
 
     _.each(driverToReporterEvents, (event) => {
       Cypress.on(event, (...args) => {
@@ -514,6 +519,16 @@ export const eventManager = {
     Cypress.multiDomainCommunicator.on('expect:domain', (domain) => {
       localBus.emit('expect:domain', domain)
     })
+
+    Cypress.multiDomainCommunicator.on('before:screenshot', (config) => {
+      const callback = () => {
+        Cypress.multiDomainCommunicator.toSpecBridge('before:screenshot:end')
+      }
+
+      handleBeforeScreenshot(config, callback)
+    })
+
+    Cypress.multiDomainCommunicator.on('after:screenshot', handleAfterScreenshot)
   },
 
   _runDriver (state) {

--- a/packages/runner/src/iframe/iframe.scss
+++ b/packages/runner/src/iframe/iframe.scss
@@ -95,3 +95,11 @@
     width: 100%;
   }
 }
+
+.spec-bridge-iframe {
+  border: none;
+  height: 100%;
+  position: fixed;
+  visibility: hidden;
+  width: 100%;
+}

--- a/packages/runner/src/iframe/iframes.jsx
+++ b/packages/runner/src/iframe/iframes.jsx
@@ -162,6 +162,7 @@ export default class Iframes extends Component {
     this._addIframe({
       $container,
       id: `Your Spec: ${specSrc}`,
+      className: 'spec-iframe',
       src: specSrc,
     })
 
@@ -169,7 +170,7 @@ export default class Iframes extends Component {
   }
 
   _addCrossDomainIframe = (domain) => {
-    const id = `Cypress (${domain})`
+    const id = `Spec Bridge: ${domain}`
 
     // if it already exists, don't add another one
     if (document.getElementById(id)) {
@@ -180,15 +181,16 @@ export default class Iframes extends Component {
 
     this._addIframe({
       id,
-      $container: $(this.refs.container),
+      $container: $(document.body),
+      className: 'spec-bridge-iframe',
       src: `//${domain}/${this.props.config.namespace}/multi-domain-iframes/${encodeURIComponent(domain)}`,
     })
   }
 
-  _addIframe ({ $container, id, src }) {
+  _addIframe ({ $container, id, src, className }) {
     const $specIframe = $('<iframe />', {
       id,
-      class: 'spec-iframe',
+      class: className,
     }).appendTo($container)
 
     $specIframe.prop('src', src)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Partial implementation of #20060 

* No `blackout` support
* No `timer` support

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
* Updated secondary domain to listen for the `before:screenshot` and `after:screenshot` events and call the primary.
* When taking a screenshot, the size of the window is needed. Since our spec bridge has a size of `0, 0`, the screenshot fails. To resolve the issue, I am attaching the spec bridge iframe to the body with a size set to 100%.
* The current viewport size is also needed in the secondary when taking a screenshot. The viewport size is stored in the state in the primary. Thus, I am passing this state to the secondary when `run:domain:fn` is called.
* Multiple runnable state values (id, current retry count, current ctx, and all parent ctx titles) from the primary are also needed when taking a screenshot. I am cloning the runnable state and nullify'ing all function/dom values and passing that to the secondary when `run:domain:fn` is called.
* Changed the id of the spec bridge iframe from `Cypress (foobar.com)` to `Spec Bridge: (foobar.com)`. I think this more closely matches the other iframes which are `Your Spec:` and `Your App:`

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
fullPage screenshot:

![screenshot specs -- captures the fullPage](https://user-images.githubusercontent.com/2002044/153251443-518c495b-bf29-4c87-8a88-ff4b99178b13.png)


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
