### PR TITLE
fix: changes from #19837 causing flake in e2e_cookies_spec

### DIFF
--- a/cli/scripts/post-install.js
+++ b/cli/scripts/post-install.js
@@ -85,13 +85,22 @@ const filesToUncomment = [
   'jquery/misc.d.ts',
 ]
 
+// Added to make the execution of the script idempotent,
+// currently if this is run twice, under certain circumstances,
+// it's possible to double un-comment and break the type definitions
+const marker = '// -- Cypress Patched Types --'
+
 filesToUncomment.forEach((file) => {
   const filePath = join(__dirname, '../types', file)
-  const str = fs.readFileSync(filePath).toString()
+  const str = fs.readFileSync(filePath, 'utf8')
+
+  if (str.includes(marker)) {
+    return
+  }
 
   const result = str.split('\n').map((line) => {
     return line.startsWith('// ') ? line.substring(3) : line
   }).join('\n')
 
-  fs.writeFileSync(filePath, result)
+  fs.writeFileSync(filePath, [marker, result].join('\n\n'))
 })

--- a/packages/driver/src/cy/commands/navigation.ts
+++ b/packages/driver/src/cy/commands/navigation.ts
@@ -13,10 +13,10 @@ import debugFn from 'debug'
 const debug = debugFn('cypress:driver:navigation')
 
 let id = null
-let previousDomainVisited: boolean = false
-let hasVisitedAboutBlank: boolean = false
-let currentlyVisitingAboutBlank: boolean = false
-let knownCommandCausedInstability: boolean = false
+let previousDomainVisited: boolean | null = null
+let hasVisitedAboutBlank: boolean | null = null
+let currentlyVisitingAboutBlank: boolean | null = null
+let knownCommandCausedInstability: boolean | null = null
 
 const REQUEST_URL_OPTS = 'auth failOnStatusCode retryOnNetworkFailure retryOnStatusCodeFailure retryIntervals method body headers'
 .split(' ')

--- a/yarn.lock
+++ b/yarn.lock
@@ -35559,19 +35559,10 @@ shell-quote@1.7.2, shell-quote@^1.4.2, shell-quote@^1.6.1:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
-shelljs@0.8.5:
+shelljs@0.8.5, shelljs@^0.8.4:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
   integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
-shelljs@^0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
-  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"


### PR DESCRIPTION
We are seeing flake in CI around the `e2e_cookies_spec`

https://app.circleci.com/pipelines/github/cypress-io/cypress/31590/workflows/9fdd5ccd-d68e-4b77-8388-404cc96d2948/jobs/1234911/tests#failed-test-0

Tracked it down to most likely being due to a change in #19837 which changed `null` -> `false` on some values which might have had some unintended consequences. (Not 100% sure on this though, was just the first thing I tried with open mode locally and it seemed to make a difference)

Also fixed up a pesky yarn install bug that comes up occasionally where our patched jQuery types are broken by the double uncommenting, requiring blowing away `node_modules`