### PR TITLE
fix: reorder electron launching sequence to eliminate timing issue

### DIFF
--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -444,9 +444,12 @@ export = {
 
     await options.onInitializeNewBrowserTab()
 
-    await this._maybeRecordVideo(pageCriClient, options, browser.majorVersion)
+    await Promise.all([
+      this._maybeRecordVideo(pageCriClient, options, browser.majorVersion),
+      this._handleDownloads(pageCriClient, options.downloadsFolder, automation),
+    ])
+
     await this._navigateUsingCRI(pageCriClient, options.url)
-    await this._handleDownloads(pageCriClient, options.downloadsFolder, automation)
   },
 
   async connectToExisting (browser: Browser, options: CypressConfiguration = {}, automation) {

--- a/packages/server/lib/browsers/electron.js
+++ b/packages/server/lib/browsers/electron.js
@@ -262,7 +262,10 @@ module.exports = {
       return win.loadURL('about:blank')
     })
     .then(() => this._getAutomation(win, options, automation).then((cdpAutomation) => automation.use(cdpAutomation)))
-    .then(() => Promise.all([_maybeRecordVideo(win.webContents, options), this._handleDownloads(win, options.downloadsFolder, automation)]))
+    .then(() => Promise.all([
+      _maybeRecordVideo(win.webContents, options),
+      this._handleDownloads(win, options.downloadsFolder, automation)
+    ]))
     .then(() => {
       // enabling can only happen once the window has loaded
       return this._enableDebugger(win.webContents)

--- a/packages/server/lib/browsers/electron.js
+++ b/packages/server/lib/browsers/electron.js
@@ -261,7 +261,8 @@ module.exports = {
     .then(() => {
       return win.loadURL('about:blank')
     })
-    .then(() => this._getAutomation(win, options, automation).then((cdpAutomation) => automation.use(cdpAutomation)))
+    .then(() => this._getAutomation(win, options, automation))
+    .then((cdpAutomation) => automation.use(cdpAutomation)))
     .then(() => Promise.all([
       _maybeRecordVideo(win.webContents, options),
       this._handleDownloads(win, options.downloadsFolder, automation)

--- a/packages/server/lib/browsers/electron.js
+++ b/packages/server/lib/browsers/electron.js
@@ -262,11 +262,13 @@ module.exports = {
       return win.loadURL('about:blank')
     })
     .then(() => this._getAutomation(win, options, automation))
-    .then((cdpAutomation) => automation.use(cdpAutomation)))
-    .then(() => Promise.all([
-      _maybeRecordVideo(win.webContents, options),
-      this._handleDownloads(win, options.downloadsFolder, automation)
-    ]))
+    .then((cdpAutomation) => automation.use(cdpAutomation))
+    .then(() => {
+      return Promise.all([
+        _maybeRecordVideo(win.webContents, options),
+        this._handleDownloads(win, options.downloadsFolder, automation),
+      ])
+    })
     .then(() => {
       // enabling can only happen once the window has loaded
       return this._enableDebugger(win.webContents)

--- a/packages/server/lib/browsers/electron.js
+++ b/packages/server/lib/browsers/electron.js
@@ -261,7 +261,7 @@ module.exports = {
     .then(() => {
       return win.loadURL('about:blank')
     })
-    .then(() => _getAutomation(win, options, automation).then((cdpAutomation) => automation.use(cdpAutomation)))
+    .then(() => this._getAutomation(win, options, automation).then((cdpAutomation) => automation.use(cdpAutomation)))
     .then(() => Promise.all([_maybeRecordVideo(win.webContents, options), this._handleDownloads(win, options.downloadsFolder, automation)]))
     .then(() => {
       // enabling can only happen once the window has loaded

--- a/packages/server/test/unit/browsers/electron_spec.js
+++ b/packages/server/test/unit/browsers/electron_spec.js
@@ -35,6 +35,8 @@ describe('lib/browsers/electron', () => {
       close: sinon.stub(),
       loadURL: sinon.stub(),
       focusOnWebView: sinon.stub(),
+      show: sinon.stub(),
+      destroy: sinon.stub(),
       webContents: {
         session: {
           cookies: {
@@ -290,6 +292,34 @@ describe('lib/browsers/electron', () => {
         })
       })
     })
+
+    it('registers onRequest automation middleware and calls show when requesting to be focused', function () {
+      sinon.spy(this.automation, 'use')
+
+      return electron._launch(this.win, this.url, this.automation, this.options)
+      .then(() => {
+        expect(this.automation.use).to.be.called
+        expect(this.automation.use.lastCall.args[0].onRequest).to.be.a('function')
+
+        this.automation.use.lastCall.args[0].onRequest('focus:browser:window')
+
+        expect(this.win.show).to.be.called
+      })
+    })
+
+    it('registers onRequest automation middleware and calls destroy when requesting to close the browser tabs', function () {
+      sinon.spy(this.automation, 'use')
+
+      return electron._launch(this.win, this.url, this.automation, this.options)
+      .then(() => {
+        expect(this.automation.use).to.be.called
+        expect(this.automation.use.lastCall.args[0].onRequest).to.be.a('function')
+
+        this.automation.use.lastCall.args[0].onRequest('close:browser:tabs')
+
+        expect(this.win.destroy).to.be.called
+      })
+    })
   })
 
   context('._render', () => {
@@ -346,38 +376,6 @@ describe('lib/browsers/electron', () => {
       return electron._render(this.url, this.automation, this.preferences, this.options)
       .then(() => {
         expect(this.newWin.maximize).not.to.be.called
-      })
-    })
-
-    it('registers onRequest automation middleware and calls show when requesting to be focused', function () {
-      sinon.spy(this.automation, 'use')
-
-      electron._render(this.url, this.automation, this.preferences, this.options)
-      .then(() => {
-        expect(Windows.create).to.be.calledWith(this.options.projectRoot, this.options)
-
-        expect(this.automation.use).to.be.called
-        expect(this.automation.use.lastCall.args[0].onRequest).to.be.a('function')
-
-        this.automation.use.lastCall.args[0].onRequest('focus:browser:window')
-
-        expect(this.newWin.show).to.be.called
-      })
-    })
-
-    it('registers onRequest automation middleware and calls destroy when requesting to close the browser tabs', function () {
-      sinon.spy(this.automation, 'use')
-
-      electron._render(this.url, this.automation, this.preferences, this.options)
-      .then(() => {
-        expect(Windows.create).to.be.calledWith(this.options.projectRoot, this.options)
-
-        expect(this.automation.use).to.be.called
-        expect(this.automation.use.lastCall.args[0].onRequest).to.be.a('function')
-
-        this.automation.use.lastCall.args[0].onRequest('close:browser:tabs')
-
-        expect(this.newWin.destroy).to.be.called
       })
     })
   })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Due to some changes in how we transition tests made on #19915 we are seeing a race condition with electron where the cdp automation is not set up in time to handle the events that get triggered from running tests. This PR will ensure that we have CDP loaded before we navigate to the new url (incidentally this is how chrome already works).

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
