### PR TITLE
fix: set correct default when using react-scripts plugin

### DIFF
--- a/npm/react/examples/react-scripts/cypress/plugins/index.js
+++ b/npm/react/examples/react-scripts/cypress/plugins/index.js
@@ -8,7 +8,7 @@ const devServer = require('@cypress/react/plugins/react-scripts')
  * @type {Cypress.PluginConfig}
  */
 module.exports = (on, config) => {
-  devServer(on, config)
+  devServer(on, config, {})
 
   // IMPORTANT to return the config object
   // with the any changed environment variables

--- a/npm/react/plugins/react-scripts/findReactScriptsWebpackConfig.js
+++ b/npm/react/plugins/react-scripts/findReactScriptsWebpackConfig.js
@@ -7,9 +7,11 @@ const { getTranspileFolders } = require('../utils/get-transpile-folders')
 const { addFolderToBabelLoaderTranspileInPlace } = require('../utils/babel-helpers')
 const { reactScriptsFiveModifications, isReactScripts5 } = require('../../dist/react-scripts/reactScriptsFive')
 
-module.exports = function findReactScriptsWebpackConfig (config, {
-  webpackConfigPath,
-} = { webpackConfigPath: 'react-scripts/config/webpack.config' }) {
+module.exports = function findReactScriptsWebpackConfig (config, devServerOptions) {
+  const webpackConfigPath = (devServerOptions && devServerOptions.webpackConfigPath)
+    ? devServerOptions.webpackConfigPath
+    : 'react-scripts/config/webpack.config'
+
   // this is required because
   // 1) we use our own HMR and we don't need react-refresh transpiling overhead
   // 2) it doesn't work with process.env=test @see https://github.com/cypress-io/cypress-realworld-app/pull/832


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://cypress-io.atlassian.net/browse/UNIFY-1085

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Correctly set default `webpackConfigPath` if the user passes an empty object of options to the react-script plugin.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

@JessicaSachs discovered that in Cypress 10, if you use the default of

```ts
component: {
  devServerConfig: {}
}
```

Then you will have a problem when setting up CT using our setup tool. This fixes it. The problem was if you pass an empty object, we would not set the default webpack config path correctly.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
