### PR TITLE
fix: treat form-data bodies as binary

### DIFF
--- a/packages/net-stubbing/lib/server/util.ts
+++ b/packages/net-stubbing/lib/server/util.ts
@@ -251,6 +251,10 @@ export function getBodyEncoding (req: CyHttpMessages.IncomingRequest): BodyEncod
     if (contentType.includes('charset=utf-8') || contentType.includes('charset="utf-8"')) {
       return 'utf8'
     }
+
+    if (contentType.includes('multipart/form-data')) {
+      return 'binary'
+    }
   }
 
   // with fallback to inspecting the buffer using

--- a/packages/net-stubbing/test/unit/util-spec.ts
+++ b/packages/net-stubbing/test/unit/util-spec.ts
@@ -72,7 +72,7 @@ describe('net-stubbing util', () => {
 
     it('returns binary for form-data bodies', () => {
       const formDataRequest = {
-        body: new FormData(),
+        body: Buffer.from('hello world'),
         headers: {
           'content-type': 'multipart/form-data',
         },

--- a/packages/net-stubbing/test/unit/util-spec.ts
+++ b/packages/net-stubbing/test/unit/util-spec.ts
@@ -69,5 +69,19 @@ describe('net-stubbing util', () => {
 
       expect(getBodyEncoding(req), 'image').to.equal('binary')
     })
+
+    it('returns binary for form-data bodies', () => {
+      const formDataRequest = {
+        body: new FormData(),
+        headers: {
+          'content-type': 'multipart/form-data',
+        },
+        method: 'POST',
+        url: 'somewhere',
+        httpVersion: '1.1',
+      }
+
+      expect(getBodyEncoding(formDataRequest)).to.equal('binary')
+    })
   })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/20143

### User facing changelog
Http-Requests with content-type `multipart/form-data` will no longer stringified when they are intercepted

### Additional details
This change is necessary to guarantee that form-data requests which contain a binary file and a certain amount of plain text will not be serialized when they are intercepted. The serialization breaks binary files (like PDFs).


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
