### PR TITLE
fix: Remove mention of Cypress Studio from Experimental Project Settings

### DIFF
--- a/packages/config/lib/options.ts
+++ b/packages/config/lib/options.ts
@@ -177,12 +177,6 @@ const resolvedOptions: Array<ResolvedConfigOption> = [
     isExperimental: true,
     canUpdateDuringTestTime: false,
   }, {
-    name: 'experimentalStudio',
-    defaultValue: false,
-    validation: validate.isBoolean,
-    isExperimental: true,
-    canUpdateDuringTestTime: false,
-  }, {
     name: 'fileServerFolder',
     defaultValue: '',
     validation: validate.isString,

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -390,10 +390,6 @@
       "experimentalSourceRewriting": {
         "name": "Source Rewriting",
         "description": "Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm. See [#5273](https://github.com/cypress-io/cypress/issues/5273) for details."
-      },
-      "experimentalStudio": {
-        "name": "Studio",
-        "description": "Generate and save commands directly to your test suite by interacting with your app as an end user would. See [Cypress Studio](https://on.cypress.io/studio) for more details."
       }
     },
     "device": {


### PR DESCRIPTION
https://cypress-io.atlassian.net/jira/software/projects/UNIFY/boards/20?assignee=61df49aa326554006c70cdd2&selectedIssue=UNIFY-1067

### User facing changelog
Cypress Studio isn't something that'll be included in the 10.0.0 release. This row should be removed from the experimental project settings.

### How has the user experience changed?
Updated experimental project settings page:
<img width="1792" alt="Screenshot 2022-02-11 at 1 54 35 PM" src="https://user-images.githubusercontent.com/27690333/153652695-4e315dcf-b61a-4e4a-a755-b96acc64fbc9.png">

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
