### PR TITLE
fix: Backing out driver change for type

### DIFF
--- a/packages/app/src/runner/SpecRunnerHeader.cy.tsx
+++ b/packages/app/src/runner/SpecRunnerHeader.cy.tsx
@@ -151,10 +151,11 @@ describe('SpecRunnerHeader', { viewportHeight: 500 }, () => {
     cy.get('[data-cy="viewport"]').click()
     cy.contains('The viewport determines').should('be.visible')
     cy.get('[data-cy="viewport"]').click()
+    cy.contains('The viewport determines').should('be.hidden')
     // TODO: enable/remove with resolution of https://github.com/cypress-io/cypress/pull/20156
-    // cy.contains('The viewport determines').should('be.hidden')
     // cy.get('[data-cy="viewport"] button').focus().type(' ')
-    // cy.contains('The viewport determines').should('be.visible')
+    cy.get('[data-cy="viewport"] button').focus().type('{enter}')
+    cy.contains('The viewport determines').should('be.visible')
     cy.get('[data-cy="viewport"] button').focus().type('{enter}')
     cy.contains('The viewport determines').should('be.hidden')
   })

--- a/packages/app/src/runner/SpecRunnerHeader.cy.tsx
+++ b/packages/app/src/runner/SpecRunnerHeader.cy.tsx
@@ -151,9 +151,10 @@ describe('SpecRunnerHeader', { viewportHeight: 500 }, () => {
     cy.get('[data-cy="viewport"]').click()
     cy.contains('The viewport determines').should('be.visible')
     cy.get('[data-cy="viewport"]').click()
-    cy.contains('The viewport determines').should('be.hidden')
-    cy.get('[data-cy="viewport"] button').focus().type('{enter}')
-    cy.contains('The viewport determines').should('be.visible')
+    // TODO: enable/remove with resolution of https://github.com/cypress-io/cypress/pull/20156
+    // cy.contains('The viewport determines').should('be.hidden')
+    // cy.get('[data-cy="viewport"] button').focus().type(' ')
+    // cy.contains('The viewport determines').should('be.visible')
     cy.get('[data-cy="viewport"] button').focus().type('{enter}')
     cy.contains('The viewport determines').should('be.hidden')
   })

--- a/packages/app/src/runner/SpecRunnerHeader.cy.tsx
+++ b/packages/app/src/runner/SpecRunnerHeader.cy.tsx
@@ -137,7 +137,7 @@ describe('SpecRunnerHeader', { viewportHeight: 500 }, () => {
     cy.findByRole('list').within(() =>
       ['Chrome', 'Electron', 'Firefox'].forEach((browser) => cy.findAllByText(browser)))
 
-    cy.get('[data-cy="select-browser"] button[aria-controls]').focus().type(' ')
+    cy.get('[data-cy="select-browser"] button[aria-controls]').focus().type('{enter}')
     cy.contains('Firefox').should('be.hidden')
   })
 
@@ -152,7 +152,7 @@ describe('SpecRunnerHeader', { viewportHeight: 500 }, () => {
     cy.contains('The viewport determines').should('be.visible')
     cy.get('[data-cy="viewport"]').click()
     cy.contains('The viewport determines').should('be.hidden')
-    cy.get('[data-cy="viewport"] button').focus().type(' ')
+    cy.get('[data-cy="viewport"] button').focus().type('{enter}')
     cy.contains('The viewport determines').should('be.visible')
     cy.get('[data-cy="viewport"] button').focus().type('{enter}')
     cy.contains('The viewport determines').should('be.hidden')

--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -342,9 +342,7 @@ export default function (Commands, Cypress, cy, state, config) {
             // event.target is null when used with shadow DOM.
             (event.target && $elements.isButtonLike(event.target)) &&
             // When a space key is pressed for input radio elements, the click event is only fired when it's not checked.
-            !(event.target.tagName === 'INPUT' && event.target.type === 'radio' && event.target.checked === true) &&
-            // Click event should not be emitted if defaultPrevented
-            !event.defaultPrevented
+            !(event.target.tagName === 'INPUT' && event.target.type === 'radio' && event.target.checked === true)
           ) {
             fireClickEvent(event.target)
           }


### PR DESCRIPTION
### User facing changelog

Backing out hot-fix for type changes in develop until those changes can land in develop first.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
