### PR TITLE
fix: Update `.type(' ')` to not emit clicks when the keyup event has been prevented

### DIFF
--- a/packages/driver/cypress/fixtures/click-event-by-type.html
+++ b/packages/driver/cypress/fixtures/click-event-by-type.html
@@ -8,6 +8,7 @@
   <body>
     <button id="reset">clear log</button>
     <button id="target-button-tag">button tag</button>
+    <button id="target-button-key-up-prevented">button tag key up prevented</button>
     <input id="target-input-button" type="button" value="input button" />
     <input id="target-input-image" type="image" value="input image" />
     <input id="target-input-reset" type="reset" value="input reset" />
@@ -46,6 +47,7 @@
 
       const targets = [
         'target-button-tag',
+        'target-button-key-up-prevented',
         'target-input-button',
         'target-input-image',
         'target-input-reset',
@@ -66,7 +68,10 @@
         target.addEventListener("click", () => {
           updateLog("click");
         });
-        target.addEventListener("keyup", () => {
+        target.addEventListener("keyup", (event) => {
+          if (targetId === 'target-button-key-up-prevented') {
+            event.preventDefault()
+          }
           updateLog("keyup");
         });
       });

--- a/packages/driver/cypress/fixtures/click-event-by-type.html
+++ b/packages/driver/cypress/fixtures/click-event-by-type.html
@@ -8,7 +8,6 @@
   <body>
     <button id="reset">clear log</button>
     <button id="target-button-tag">button tag</button>
-    <button id="target-button-key-up-prevented">button tag key up prevented</button>
     <input id="target-input-button" type="button" value="input button" />
     <input id="target-input-image" type="image" value="input image" />
     <input id="target-input-reset" type="reset" value="input reset" />
@@ -47,7 +46,6 @@
 
       const targets = [
         'target-button-tag',
-        'target-button-key-up-prevented',
         'target-input-button',
         'target-input-image',
         'target-input-reset',
@@ -69,9 +67,6 @@
           updateLog("click");
         });
         target.addEventListener("keyup", (event) => {
-          if (targetId === 'target-button-key-up-prevented') {
-            event.preventDefault()
-          }
           updateLog("keyup");
         });
       });

--- a/packages/driver/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_spec.js
@@ -574,8 +574,7 @@ describe('src/cy/commands/actions/type - #type', () => {
 
       targets.forEach((targetId) => {
         it(`${targetId}`, () => {
-          cy.get(`#target-${targetId}`).focus()
-          cy.get(`#target-${targetId}`).type('{enter}')
+          cy.get(`#target-${targetId}`).focus().type('{enter}')
 
           cy.get('li').eq(0).should('have.text', 'keydown')
           cy.get('li').eq(1).should('have.text', 'keypress')
@@ -593,8 +592,7 @@ describe('src/cy/commands/actions/type - #type', () => {
 
       targets.forEach((targetId) => {
         it(`${targetId}`, () => {
-          cy.get(`#target-${targetId}`).focus()
-          cy.get(`#target-${targetId}`).type('{enter}')
+          cy.get(`#target-${targetId}`).focus().type('{enter}')
 
           cy.get('li').eq(0).should('have.text', 'keydown')
           cy.get('li').eq(1).should('have.text', 'keypress')
@@ -610,17 +608,30 @@ describe('src/cy/commands/actions/type - #type', () => {
     })
 
     const targets = [
-      'button-tag',
-      'input-button',
-      'input-image',
-      'input-reset',
-      'input-submit',
+      '#target-button-tag',
+      '#target-input-button',
+      '#target-input-image',
+      '#target-input-reset',
+      '#target-input-submit',
     ]
 
     describe(`triggers with single space`, () => {
-      targets.forEach((targetId) => {
-        it(targetId, () => {
-          cy.get(`#target-${targetId}`).focus().type(' ')
+      targets.forEach((target) => {
+        it(target, () => {
+          const events = []
+
+          $(target).on('keydown keypress keyup click', (evt) => {
+            events.push(evt.type)
+          })
+
+          cy.get(target).focus().type(' ').then(() => {
+            expect(events).to.deep.eq([
+              'keydown',
+              'keypress',
+              'keyup',
+              'click',
+            ])
+          })
 
           cy.get('li').eq(0).should('have.text', 'keydown')
           cy.get('li').eq(1).should('have.text', 'keypress')
@@ -631,20 +642,60 @@ describe('src/cy/commands/actions/type - #type', () => {
     })
 
     describe(`does not trigger if keyup prevented`, () => {
-      it('target-button-key-up-prevented', () => {
-        cy.get(`#target-button-key-up-prevented`).focus().type(' ')
+      targets.forEach((target) => {
+        it(`${target} does not fire click event`, () => {
+          const events = []
 
-        cy.get('li').should('have.length', 3)
-        cy.get('li').eq(0).should('have.text', 'keydown')
-        cy.get('li').eq(1).should('have.text', 'keypress')
-        cy.get('li').eq(2).should('have.text', 'keyup')
+          $(target)
+          .on('keydown keypress keyup click', (evt) => {
+            events.push(evt.type)
+          })
+          .on('keyup', (evt) => {
+            evt.preventDefault()
+          })
+
+          cy.get(target).focus().type(' ').then(() => {
+            expect(events).to.deep.eq([
+              'keydown',
+              'keypress',
+              'keyup',
+            ])
+          })
+
+          cy.get('li').should('have.length', 3)
+          cy.get('li').eq(0).should('have.text', 'keydown')
+          cy.get('li').eq(1).should('have.text', 'keypress')
+          cy.get('li').eq(2).should('have.text', 'keyup')
+        })
       })
     })
 
     describe('triggers after other characters', () => {
-      targets.forEach((targetId) => {
-        it(targetId, () => {
-          cy.get(`#target-${targetId}`).focus().type('asd ')
+      targets.forEach((target) => {
+        it(target, () => {
+          const events = []
+
+          $(target).on('keydown keypress keyup click', (evt) => {
+            events.push(evt.type)
+          })
+
+          cy.get(target).focus().type('asd ').then(() => {
+            expect(events).to.deep.eq([
+              'keydown',
+              'keypress',
+              'keyup',
+              'keydown',
+              'keypress',
+              'keyup',
+              'keydown',
+              'keypress',
+              'keyup',
+              'keydown',
+              'keypress',
+              'keyup',
+              'click',
+            ])
+          })
 
           cy.get('li').eq(12).should('have.text', 'click')
         })

--- a/packages/driver/cypress/integration/commands/actions/type_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_spec.js
@@ -630,6 +630,17 @@ describe('src/cy/commands/actions/type - #type', () => {
       })
     })
 
+    describe(`does not trigger if keyup prevented`, () => {
+      it('target-button-key-up-prevented', () => {
+        cy.get(`#target-button-key-up-prevented`).focus().type(' ')
+
+        cy.get('li').should('have.length', 3)
+        cy.get('li').eq(0).should('have.text', 'keydown')
+        cy.get('li').eq(1).should('have.text', 'keypress')
+        cy.get('li').eq(2).should('have.text', 'keyup')
+      })
+    })
+
     describe('triggers after other characters', () => {
       targets.forEach((targetId) => {
         it(targetId, () => {

--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -342,7 +342,9 @@ export default function (Commands, Cypress, cy, state, config) {
             // event.target is null when used with shadow DOM.
             (event.target && $elements.isButtonLike(event.target)) &&
             // When a space key is pressed for input radio elements, the click event is only fired when it's not checked.
-            !(event.target.tagName === 'INPUT' && event.target.type === 'radio' && event.target.checked === true)
+            !(event.target.tagName === 'INPUT' && event.target.type === 'radio' && event.target.checked === true) &&
+            // When event is prevented, the click event should not be emitted
+            !event.defaultPrevented
           ) {
             fireClickEvent(event.target)
           }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog

Same as #20067, not yet released

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Buttons that call preventDefault on their keyUp events do not emit a click event when pressed with the Spacebar. This PR adds the defaultPrevented check to make sure we're not sending more events than we expect.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Came across this issue when Space was being used to toggle open a headless-ui Popover; you can see their logic here: https://github.com/tailwindlabs/headlessui/blob/main/packages/%40headlessui-vue/src/components/popover/popover.ts#L315-L320. The implementation in develop will emit the click event regardless of the prevention, causing the Popover to close and then immediately reopen (as it implements handlers for both).

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
