### PR TITLE
fix(driver): update wrapErr to ignore number and boolean values

### DIFF
--- a/packages/driver/cypress/integration/cypress/error_utils_spec.ts
+++ b/packages/driver/cypress/integration/cypress/error_utils_spec.ts
@@ -628,7 +628,7 @@ describe('driver/src/cypress/error_utils', () => {
       { value: undefined, label: 'undefined' },
       { value: null, label: 'null' },
       { value: '', label: 'empty string' },
-      { value: 'true', label: 'boolean' },
+      { value: true, label: 'boolean' },
       { value: 1, label: 'number' },
     ].forEach((err) => {
       it(`returns undefined if err is ${err.label}`, () => {

--- a/packages/driver/cypress/integration/cypress/error_utils_spec.ts
+++ b/packages/driver/cypress/integration/cypress/error_utils_spec.ts
@@ -622,4 +622,18 @@ describe('driver/src/cypress/error_utils', () => {
       expect(stack).not.to.include('removeMeAndAbove')
     })
   })
+
+  context('.wrapErr', () => {
+    [
+      { value: undefined, label: 'undefined' },
+      { value: null, label: 'null' },
+      { value: '', label: 'empty string' },
+      { value: 'true', label: 'boolean' },
+      { value: 1, label: 'number' },
+    ].forEach((err) => {
+      it(`returns undefined if err is ${err.label}`, () => {
+        expect($errUtils.wrapErr(err.value)).to.be.undefined
+      })
+    })
+  })
 })

--- a/packages/driver/src/cypress/error_utils.ts
+++ b/packages/driver/src/cypress/error_utils.ts
@@ -52,8 +52,14 @@ const prepareErrorForSerialization = (err) => {
   return err
 }
 
+// some errors, probably from user callbacks, might be boolean, number or falsy values
+// which means serializing will not provide any useful context
+const isSerializableError = (err) => {
+  !!err && (typeof err === 'object' || typeof err === 'string')
+}
+
 const wrapErr = (err) => {
-  if (!err) return
+  if (!isSerializableError(err)) return
 
   prepareErrorForSerialization(err)
 

--- a/packages/driver/src/cypress/error_utils.ts
+++ b/packages/driver/src/cypress/error_utils.ts
@@ -55,7 +55,7 @@ const prepareErrorForSerialization = (err) => {
 // some errors, probably from user callbacks, might be boolean, number or falsy values
 // which means serializing will not provide any useful context
 const isSerializableError = (err) => {
-  !!err && (typeof err === 'object' || typeof err === 'string')
+  return !!err && (typeof err === 'object' || typeof err === 'string')
 }
 
 const wrapErr = (err) => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #19561

### User facing changelog
Fixes an issue where Cypress throws an error when reporting/wrapping errors with type `boolean` or `number`.
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Cypress runner uses `wrapErr` to add and remove some props to error object. But it seems that some user modules/deps can throw/reject with type `bool` or `number`. But `wrapErr` covers only falsy values.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

* Errors with type `boolean` or `number` will be considered as empty/invalid errors.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
