### PR TITLE
fix: Ensuring browser 'Focus' button is safe if browser window has been closed

### DIFF
--- a/packages/server/lib/socket-base.ts
+++ b/packages/server/lib/socket-base.ts
@@ -163,8 +163,6 @@ export class SocketBase {
       onCaptureVideoFrames () {},
     })
 
-    let automationClient
-
     const { socketIoRoute, socketIoCookie } = config
 
     const io = this._io = this.createIo(server, socketIoRoute, socketIoCookie)
@@ -181,17 +179,19 @@ export class SocketBase {
       Object.keys(origins).forEach((key) => delete origins[key])
     }
 
-    const onAutomationClientRequestCallback = (message, data, id) => {
-      return this.onAutomation(automationClient, message, data, id)
-    }
-
-    const automationRequest = (message: string, data: Record<string, unknown>) => {
-      return automation.request(message, data, onAutomationClientRequestCallback)
-    }
-
     const getFixture = (path, opts) => fixture.get(config.fixturesFolder, path, opts)
 
     io.on('connection', (socket: Socket & { inReporterRoom?: boolean, inRunnerRoom?: boolean }) => {
+      let automationClient
+
+      const onAutomationClientRequestCallback = (message, data, id) => {
+        return this.onAutomation(automationClient, message, data, id)
+      }
+
+      const automationRequest = (message: string, data: Record<string, unknown>) => {
+        return socket && socket.connected && automation.request(message, data, onAutomationClientRequestCallback)
+      }
+
       debug('socket connected')
 
       socket.on('disconnecting', (reason) => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

There's a couple things going on here:

* With Chrome, we send a `focus:browser:window` automation event to refocus the window; if we do this after the automation client disconnects (i.e. the window is closed), it fails and triggers a reconnect attempt, which locks up more ore less all interactions in the launchpad. We can check the socket status prior to sending the event, resulting in a no-op when the Focus button is pressed.
* With Firefox, we execute a command through the launchpad to show the browser instance. However, this is failing even before closing the window; investigation is ongoing, this PR will be updated with findings.
* With Electron, the process is killed when the window is closed, so we have no problems currently (or after this PR).

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
