### PR TITLE
feat: (multi-domain) add support for pausing timers during screenshots

### DIFF
--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
@@ -13,7 +13,7 @@ context('multi-domain misc', { experimentalSessionSupport: true, experimentalMul
         'selectFile', 'submit', 'type', 'clear', 'trigger', 'as', 'ng', 'should', 'and', 'clock', 'tick', 'spread', 'each', 'then',
         'invoke', 'its', 'getCookie', 'getCookies', 'setCookie', 'clearCookie', 'clearCookies', 'pause', 'debug', 'exec', 'readFile',
         'writeFile', 'fixture', 'clearLocalStorage', 'url', 'hash', 'location', 'end', 'noop', 'log', 'wrap', 'reload', 'go', 'visit',
-        'focused', 'get', 'contains', 'shadow', 'root', 'within', 'request', 'session', 'screenshot', 'task', 'find', 'filter', 'not',
+        'focused', 'get', 'root', 'contains', 'shadow', 'within', 'request', 'session', 'screenshot', 'task', 'find', 'filter', 'not',
         'children', 'eq', 'closest', 'first', 'last', 'next', 'nextAll', 'nextUntil', 'parent', 'parents', 'parentsUntil', 'prev',
         'prevAll', 'prevUntil', 'siblings', 'wait', 'title', 'window', 'document', 'viewport', 'server', 'route', 'intercept', 'switchToDomain',
       ],

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
@@ -13,7 +13,7 @@ context('multi-domain misc', { experimentalSessionSupport: true, experimentalMul
         'selectFile', 'submit', 'type', 'clear', 'trigger', 'as', 'ng', 'should', 'and', 'clock', 'tick', 'spread', 'each', 'then',
         'invoke', 'its', 'getCookie', 'getCookies', 'setCookie', 'clearCookie', 'clearCookies', 'pause', 'debug', 'exec', 'readFile',
         'writeFile', 'fixture', 'clearLocalStorage', 'url', 'hash', 'location', 'end', 'noop', 'log', 'wrap', 'reload', 'go', 'visit',
-        'focused', 'get', 'root', 'contains', 'shadow', 'within', 'request', 'session', 'screenshot', 'task', 'find', 'filter', 'not',
+        'focused', 'get', 'contains', 'shadow', 'root', 'within', 'request', 'session', 'screenshot', 'task', 'find', 'filter', 'not',
         'children', 'eq', 'closest', 'first', 'last', 'next', 'nextAll', 'nextUntil', 'parent', 'parents', 'parentsUntil', 'prev',
         'prevAll', 'prevUntil', 'siblings', 'wait', 'title', 'window', 'document', 'viewport', 'server', 'route', 'intercept', 'switchToDomain',
       ],

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_screenshot.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_screenshot.spec.ts
@@ -163,20 +163,7 @@ context('screenshot specs', { experimentalSessionSupport: true, experimentalMult
 
   it('supports pausing timers', () => {
     cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
-      cy.stub(Cypress, 'automation').withArgs('take:screenshot').returns(
-        {
-          // TODO: A bluebird promise is expected but we can't require bluebird yet
-          // so mock the timeout function to return a promise that simulates how
-          // long it takes to take a screenshot
-          timeout: () => {
-            return new Promise((resolve) => {
-              setTimeout(() => {
-                resolve(serverResult)
-              }, 500)
-            })
-          },
-        },
-      )
+      cy.stub(Cypress, 'automation').withArgs('take:screenshot').returns(Cypress.Promise.delay(500, serverResult))
 
       cy.window().then((win) => {
         // Hide the element using setTimeout
@@ -209,20 +196,7 @@ context('screenshot specs', { experimentalSessionSupport: true, experimentalMult
 
   it('does not pause timers when disableTimersAndAnimations is false', () => {
     cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
-      cy.stub(Cypress, 'automation').withArgs('take:screenshot').returns(
-        {
-          // TODO: A bluebird promise is expected but we can't require bluebird yet
-          // so mock the timeout function to return a promise that simulates how
-          // long it takes to take a screenshot
-          timeout: () => {
-            return new Promise((resolve) => {
-              setTimeout(() => {
-                resolve(serverResult)
-              }, 500)
-            })
-          },
-        },
-      )
+      cy.stub(Cypress, 'automation').withArgs('take:screenshot').returns(Cypress.Promise.delay(500, serverResult))
 
       cy.window().then((win) => {
         // Hide the element using setTimeout
@@ -252,20 +226,7 @@ context('screenshot specs', { experimentalSessionSupport: true, experimentalMult
     })
 
     cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
-      cy.stub(Cypress, 'automation').withArgs('take:screenshot').returns(
-        {
-          // TODO: A bluebird promise is expected but we can't require bluebird yet
-          // so mock the timeout function to return a promise that simulates how
-          // long it takes to take a screenshot
-          timeout: () => {
-            return new Promise((resolve) => {
-              setTimeout(() => {
-                resolve(serverResult)
-              }, 100)
-            })
-          },
-        },
-      )
+      cy.stub(Cypress, 'automation').withArgs('take:screenshot').returns(Cypress.Promise.delay(100, serverResult))
 
       cy.window().then((win) => {
         // Add a timeout error
@@ -291,20 +252,7 @@ context('screenshot specs', { experimentalSessionSupport: true, experimentalMult
     })
 
     cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
-      cy.stub(Cypress, 'automation').withArgs('take:screenshot').returns(
-        {
-          // TODO: A bluebird promise is expected but we can't require bluebird yet
-          // so mock the timeout function to return a promise that simulates how
-          // long it takes to take a screenshot
-          timeout: () => {
-            return new Promise((resolve) => {
-              setTimeout(() => {
-                resolve(serverResult)
-              }, 100)
-            })
-          },
-        },
-      )
+      cy.stub(Cypress, 'automation').withArgs('take:screenshot').returns(Cypress.Promise.delay(100, serverResult))
 
       cy.window().then((win) => {
         // Add a timeout error

--- a/packages/driver/src/multi-domain/cypress.ts
+++ b/packages/driver/src/multi-domain/cypress.ts
@@ -121,7 +121,7 @@ const onBeforeAppWindowLoad = (Cypress: Cypress.Cypress, cy: $Cy) => (autWindow:
       // TODO: implement these commented out bits
       // Cookies.setInitial()
 
-      // timers.reset()
+      cy.resetTimer()
 
       Cypress.action('app:window:before:unload', e)
 

--- a/packages/runner/injection/main.js
+++ b/packages/runner/injection/main.js
@@ -12,7 +12,8 @@ import { createTimers } from './timers'
 const Cypress = window.Cypress = parent.Cypress
 
 if (!Cypress) {
-  throw new Error('Something went terribly wrong and we cannot proceed. We expected to find the global Cypress in the parent window but it is missing!. This should never happen and likely is a bug. Please open an issue!')
+  throw new Error('Something went terribly wrong and we cannot proceed. We expected to find the global \
+    Cypress in the parent window but it is missing. This should never happen and likely is a bug. Please open an issue.')
 }
 
 // We wrap timers in the injection code because if we do it in the driver (like

--- a/packages/runner/injection/multi-domain.js
+++ b/packages/runner/injection/multi-domain.js
@@ -18,7 +18,7 @@ const Cypress = cyBridgeFrame.Cypress
 
 if (!Cypress) {
   throw new Error('Something went terribly wrong and we cannot proceed. We expected to find the global \
-    Cypress in the spec bridge window but it is missing!. This should never happen and likely is a bug. Please open an issue!')
+    Cypress in the spec bridge window but it is missing. This should never happen and likely is a bug. Please open an issue.')
 }
 
 const timers = createTimers()

--- a/packages/runner/injection/multi-domain.js
+++ b/packages/runner/injection/multi-domain.js
@@ -7,31 +7,7 @@
  * dependencies.
  */
 
-// TODO: uncomment the following code once the timing is worked out to have
-// the sibling Cypress global available before this injection code runs
-
-//  import { createTimers } from './timers'
-
-//  const Cypress = window.Cypress = parent.Cypress
-
-//  if (!Cypress) {
-//    throw new Error('Something went terribly wrong and we cannot proceed. We expected to find the global Cypress in the parent window but it is missing!. This should never happen and likely is a bug. Please open an issue!')
-//  }
-
-//  // We wrap timers in the injection code because if we do it in the driver (like
-//  // we used to do), any uncaught errors thrown in the timer callbacks would
-//  // get picked up by the top frame's 'error' handler instead of the AUT's.
-//  // We need to wrap the timer callbacks in the AUT itself for errors to
-//  // propagate properly.
-//  const timers = createTimers()
-
-//  Cypress.removeAllListeners('app:timers:reset')
-//  Cypress.removeAllListeners('app:timers:pause')
-
-//  Cypress.on('app:timers:reset', timers.reset)
-//  Cypress.on('app:timers:pause', timers.pause)
-
-//  timers.wrap()
+import { createTimers } from './timers'
 
 // TODO: don't hard-code the index. need it to be predictable or need
 // to search for the right one somehow. will need to be fixed when we
@@ -39,5 +15,20 @@
 const cyBridgeFrame = window.parent.frames[2]
 
 const Cypress = cyBridgeFrame.Cypress
+
+if (!Cypress) {
+  throw new Error('Something went terribly wrong and we cannot proceed. We expected to find the global \
+    Cypress in the spec bridge window but it is missing!. This should never happen and likely is a bug. Please open an issue!')
+}
+
+const timers = createTimers()
+
+Cypress.removeAllListeners('app:timers:reset')
+Cypress.removeAllListeners('app:timers:pause')
+
+Cypress.on('app:timers:reset', timers.reset)
+Cypress.on('app:timers:pause', timers.pause)
+
+timers.wrap()
 
 Cypress.action('app:window:before:load', window)

--- a/packages/runner/injection/multi-domain.js
+++ b/packages/runner/injection/multi-domain.js
@@ -21,6 +21,7 @@ if (!Cypress) {
     Cypress in the spec bridge window but it is missing. This should never happen and likely is a bug. Please open an issue.')
 }
 
+// the timers are wrapped in the injection code similar to the primary domain
 const timers = createTimers()
 
 Cypress.removeAllListeners('app:timers:reset')

--- a/packages/server/test/support/fixtures/server/absolute_url_expected.html
+++ b/packages/server/test/support/fixtures/server/absolute_url_expected.html
@@ -6,7 +6,7 @@
       var Cypress = window.Cypress = parent.Cypress;
 
       if (!Cypress) {
-        throw new Error('Something went terribly wrong and we cannot proceed. We expected to find the global Cypress in the parent window but it is missing!. This should never happen and likely is a bug. Please open an issue!');
+        throw new Error('Something went terribly wrong and we cannot proceed. We expected to find the global Cypress in the parent window but it is missing. This should never happen and likely is a bug. Please open an issue.');
       };
 
       window.onerror = function(){


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #20060 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
When taking a screenshot the timers need to be paused so the screenshot is not affected by any changes from the timer code. After the screenshot finishes, the timers are unpaused and allowed to run. The logic for pausing/unpausing the timers already exists in multi-domain but we weren't listening to the events. Updated `injection/multi-domain.js` to listen for the events and call the appropriate methods in `injection/timers.js`.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Timers are now paused when a screenshot is being taken and unpaused afterwards.

<img width="1640" alt="Screen Shot 2022-02-15 at 3 20 17 PM" src="https://user-images.githubusercontent.com/2002044/154159338-ba9a2398-7989-4a7c-9678-1bc454aaf94d.png">

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
