### PR TITLE
test: fix some windows tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ mainBuildFilters: &mainBuildFilters
       only:
         - develop
         - 10.0-release
-        - elevatebart/fix/windows-migration
+        - elevatebart/test/windows
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -48,7 +48,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
     - equal: [ '10.0-release', << pipeline.git.branch >> ]
-    - equal: [ 'elevatebart/fix/windows-migration', << pipeline.git.branch >> ]
+    - equal: [ 'elevatebart/test/windows', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -1586,7 +1586,7 @@ jobs:
       - run:
           name: Check current branch to persist artifacts
           command: |
-            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "elevatebart/fix/windows-migration" && "$CIRCLE_BRANCH" != "10.0-release" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "elevatebart/test/windows" && "$CIRCLE_BRANCH" != "10.0-release" ]]; then
               echo "Not uploading artifacts or posting install comment for this branch."
               circleci-agent step halt
             fi

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -2,7 +2,7 @@ import defaultMessages from '@packages/frontend-shared/src/locales/en-US.json'
 
 describe('Navigation', () => {
   before(() => {
-    cy.scaffoldProject('todos')
+    cy.scaffoldProject('todos', { timeout: 50 * 1000 })
   })
 
   it('External links trigger mutation to open in a new browser', () => {

--- a/packages/app/cypress/e2e/settings.cy.ts
+++ b/packages/app/cypress/e2e/settings.cy.ts
@@ -1,6 +1,6 @@
 describe('App: Settings', () => {
   before(() => {
-    cy.scaffoldProject('todos')
+    cy.scaffoldProject('todos', { timeout: 50 * 1000 })
   })
 
   beforeEach(() => {

--- a/packages/frontend-shared/cypress/e2e/support/e2eSupport.ts
+++ b/packages/frontend-shared/cypress/e2e/support/e2eSupport.ts
@@ -17,7 +17,7 @@ import type pDefer from 'p-defer'
 configure({ testIdAttribute: 'data-cy' })
 
 const NO_TIMEOUT = 1000 * 1000
-const TEN_SECONDS = 10 * 1000
+const TEN_SECONDS = 20 * 1000
 
 export type ProjectFixture = typeof e2eProjectDirs[number]
 

--- a/packages/frontend-shared/cypress/e2e/support/e2eSupport.ts
+++ b/packages/frontend-shared/cypress/e2e/support/e2eSupport.ts
@@ -17,7 +17,7 @@ import type pDefer from 'p-defer'
 configure({ testIdAttribute: 'data-cy' })
 
 const NO_TIMEOUT = 1000 * 1000
-const TEN_SECONDS = 20 * 1000
+const TEN_SECONDS = 50 * 1000
 
 export type ProjectFixture = typeof e2eProjectDirs[number]
 

--- a/packages/frontend-shared/cypress/e2e/support/e2eSupport.ts
+++ b/packages/frontend-shared/cypress/e2e/support/e2eSupport.ts
@@ -17,7 +17,7 @@ import type pDefer from 'p-defer'
 configure({ testIdAttribute: 'data-cy' })
 
 const NO_TIMEOUT = 1000 * 1000
-const TEN_SECONDS = 50 * 1000
+const TEN_SECONDS = 10 * 1000
 
 export type ProjectFixture = typeof e2eProjectDirs[number]
 
@@ -180,9 +180,9 @@ beforeEach(() => {
   taskInternal('__internal__beforeEach', undefined)
 })
 
-function scaffoldProject (projectName: ProjectFixture) {
+function scaffoldProject (projectName: ProjectFixture, options: { timeout?: number} = {}) {
   return logInternal({ name: 'scaffoldProject', message: projectName }, () => {
-    return taskInternal('__internal_scaffoldProject', projectName)
+    return taskInternal('__internal_scaffoldProject', projectName, options)
   })
 }
 
@@ -435,10 +435,10 @@ type Resolved<V> = V extends Promise<infer U> ? U : V
  * Run an internal task, as defined by e2ePluginSetup. Automatically tracks the types
  *
  */
-function taskInternal<T extends keyof E2ETaskMap> (name: T, arg: Parameters<E2ETaskMap[T]>[0]) {
+function taskInternal<T extends keyof E2ETaskMap> (name: T, arg: Parameters<E2ETaskMap[T]>[0], options: { timeout?: number } = {}): Cypress.Chainable<Resolved<ReturnType<E2ETaskMap[T]>>> {
   const isDebugging = Boolean(Cypress.env('e2e_isDebugging'))
 
-  return cy.task<Resolved<ReturnType<E2ETaskMap[T]>>>(name, arg, { log: isDebugging, timeout: isDebugging ? NO_TIMEOUT : TEN_SECONDS })
+  return cy.task<Resolved<ReturnType<E2ETaskMap[T]>>>(name, arg, { log: isDebugging, timeout: options.timeout ?? (isDebugging ? NO_TIMEOUT : TEN_SECONDS) })
 }
 
 function logInternal<T> (name: string | Partial<Cypress.LogConfig>, cb: (log: Cypress.Log) => Cypress.Chainable<T>, opts: Partial<Cypress.Loggable> = {}): Cypress.Chainable<T> {

--- a/packages/launcher/lib/windows/index.ts
+++ b/packages/launcher/lib/windows/index.ts
@@ -7,7 +7,6 @@ import { notInstalledErr } from '../errors'
 import { log } from '../log'
 import type { PathData } from '../types'
 import type { Browser, FoundBrowser } from '@packages/types'
-import Bluebird from 'bluebird'
 
 function formFullAppPath (name: string) {
   return [
@@ -169,7 +168,11 @@ export function getVersionString (path: string) {
   // on Windows using "--version" seems to always start the full
   // browser, no matter what one does.
 
-  return Bluebird.resolve(winVersionInfo(path).FileVersion)
+  try {
+    return Promise.resolve(winVersionInfo(path).FileVersion)
+  } catch (err) {
+    return Promise.reject(err)
+  }
 }
 
 export function getVersionNumber (version: string) {

--- a/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
+++ b/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
@@ -60,7 +60,6 @@ describe('Choose a Browser Page', () => {
       cy.get('[data-cy="alert-header"]').should('contain', 'Warning: Browser Not Found')
       cy.get('[data-cy="alert-body"]')
       .should('contain', 'We could not identify a known browser at the path you specified: /path/does/not/exist')
-      .should('contain', 'spawn /path/does/not/exist ENOENT')
       .validateExternalLink({
         name: 'how to troubleshoot launching browsers',
         href: 'https://on.cypress.io/troubleshooting-launching-browsers',


### PR DESCRIPTION
This PR fixes three tests on windows.
It also adds the possibility to add a timeout on `cy.scaffoldProject()`. This avoids flakes on windows when necessary but prevents the effects of a potential infinite loop.