### PR TITLE
fix: refactor function getFilesByGlob to use concat instead of isArray

### DIFF
--- a/packages/data-context/src/sources/FileDataSource.ts
+++ b/packages/data-context/src/sources/FileDataSource.ts
@@ -33,7 +33,7 @@ export class FileDataSource {
   async getFilesByGlob (cwd: string, glob: string | string[], globOptions?: GlobbyOptions) {
     const globs = ([] as string[]).concat(glob)
 
-    const ignoreGlob = globOptions && Array.isArray(globOptions?.ignore) ? globOptions.ignore.concat('**/node_modules/**') : ['**/node_modules/**']
+    const ignoreGlob = (globOptions?.ignore ?? []).concat('**/node_modules/**')
 
     if (process.platform === 'win32') {
       // globby can't work with backwards slashes

--- a/packages/data-context/src/sources/FileDataSource.ts
+++ b/packages/data-context/src/sources/FileDataSource.ts
@@ -31,7 +31,7 @@ export class FileDataSource {
   }
 
   async getFilesByGlob (cwd: string, glob: string | string[], globOptions?: GlobbyOptions) {
-    const globs = Array.isArray(glob) ? glob : [glob]
+    const globs = ([] as string[]).concat(glob)
 
     const ignoreGlob = globOptions && Array.isArray(globOptions?.ignore) ? globOptions.ignore.concat('**/node_modules/**') : ['**/node_modules/**']
 

--- a/packages/data-context/src/sources/migration/shouldShowSteps.ts
+++ b/packages/data-context/src/sources/migration/shouldShowSteps.ts
@@ -10,12 +10,8 @@ function getTestFilesGlobs (config: OldCypressConfig, type: 'component' | 'integ
 
   const glob = config[k]?.testFiles ?? config.testFiles
 
-  if (glob && Array.isArray(glob)) {
-    return glob
-  }
-
-  if (glob && typeof glob === 'string') {
-    return [glob]
+  if (glob) {
+    return ([] as string[]).concat(glob)
   }
 
   return ['**/*']


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes UNIFY-1009

### User facing changelog
None

### Additional details
Used `concat` instead of `isArray` to simplify the code
