### PR TITLE
chore: fix system-test-firefox screenshots_spec flake

### DIFF
--- a/system-tests/projects/e2e/cypress/integration/screenshots_spec.js
+++ b/system-tests/projects/e2e/cypress/integration/screenshots_spec.js
@@ -308,6 +308,7 @@ describe('taking screenshots', () => {
     cy.visit('http://localhost:3322/color/yellow')
     cy.screenshot('overwrite-test', {
       overwrite: false,
+      capture: 'viewport',
       clip: { x: 10, y: 10, width: 160, height: 80 },
     })
 
@@ -320,6 +321,7 @@ describe('taking screenshots', () => {
 
     cy.screenshot('overwrite-test', {
       overwrite: true,
+      capture: 'viewport',
       clip: { x: 10, y: 10, width: 100, height: 50 },
     })
 
@@ -342,6 +344,7 @@ describe('taking screenshots', () => {
     cy.viewport(600, 200)
     cy.visit('http://localhost:3322/color/yellow')
     cy.screenshot('overwrite-test', {
+      capture: 'viewport',
       clip: { x: 10, y: 10, width: 160, height: 80 },
     })
 
@@ -353,6 +356,7 @@ describe('taking screenshots', () => {
     })
 
     cy.screenshot('overwrite-test', {
+      capture: 'viewport',
       clip: { x: 10, y: 10, width: 100, height: 50 },
     })
 


### PR DESCRIPTION
### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

There is logic in our screenshots that, if the image is big enough, and thus multi-part, we compare each part to the previous part to make sure that we are truly getting new data and not just the previous data. If the parts are the same, we retry until they are different or a timeout is reached. In the system tests, we are taking pictures of pages that are purely one color. In the tests I've changed, we don't limit the size of the screenshot to the viewport, so we are receiving 10 parts that are all exactly the same. This triggers the retry logic. In the two tests I've updated, we do this 4 times and over time this is pressing on memory consumption which may cause firefox to crash. I'm fixing the tests as a part of this PR, but I think it's worth investigating if there's a less memory-intensive way of doing the retries (though this scenario may not occur too much outside of tests like this)

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
