### PR TITLE
chore: fix server performance flake

### DIFF
--- a/packages/server/lib/environment.js
+++ b/packages/server/lib/environment.js
@@ -62,6 +62,8 @@ try {
   // https://github.com/cypress-io/cypress/issues/15814
   app.commandLine.appendSwitch('disable-dev-shm-usage')
 
+  // prevent navigation throttling when navigating in the browser rapid fire
+  // https://github.com/cypress-io/cypress/pull/20271
   app.commandLine.appendSwitch('disable-ipc-flooding-protection')
 
   if (os.platform() === 'linux') {

--- a/packages/server/lib/environment.js
+++ b/packages/server/lib/environment.js
@@ -62,6 +62,8 @@ try {
   // https://github.com/cypress-io/cypress/issues/15814
   app.commandLine.appendSwitch('disable-dev-shm-usage')
 
+  app.commandLine.appendSwitch('disable-ipc-flooding-protection')
+
   if (os.platform() === 'linux') {
     app.disableHardwareAcceleration()
   }


### PR DESCRIPTION
### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Our cy.visit performance tests are locking up occasionally. When running locally in electron, I see the following message displayed:

```
[50160:0218/150228.534909:INFO:CONSOLE(7623)] "Throttling navigation to prevent the browser from hanging. See https://crbug.com/1038223. Command line switch --disable-ipc-flooding-protection can be used to bypass the protection", source: cypress:///../driver/node_modules/jquery/dist/jquery.js (7623)
```

Previously, we added the flag `--disable-ipc-flooding-protection` for [chrome](https://github.com/cypress-io/cypress/issues/5132). It looks like this is needed for electron as well. I tried adding it and running the tests through ci with no failures whereas previously it was failing fairly frequently. As mentioned [here](https://github.com/cypress-io/cypress/issues/3633) this is one of the flags that is used by puppeteer in its project.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
