### PR TITLE
chore: remove system test it.only and prevent CI from ever running onlys

### DIFF
--- a/system-tests/lib/system-tests.ts
+++ b/system-tests/lib/system-tests.ts
@@ -3,6 +3,8 @@ const snapshot = require('snap-shot-it')
 import { SpawnOptions } from 'child_process'
 import { expect } from './spec_helper'
 
+const isCi = require('is-ci')
+
 require('mocha-banner').register()
 const chalk = require('chalk').default
 const _ = require('lodash')
@@ -525,7 +527,7 @@ const copy = function () {
   }
 }
 
-const getMochaItFn = function (only, skip, browser, specifiedBrowser) {
+const getMochaItFn = function (title, only, skip, browser, specifiedBrowser) {
   // if we've been told to skip this test
   // or if we specified a particular browser and this
   // doesn't match the one we're currently trying to run...
@@ -535,6 +537,12 @@ const getMochaItFn = function (only, skip, browser, specifiedBrowser) {
   }
 
   if (only) {
+    if (isCi) {
+      // fixes the problem where systemTests can accidentally by skipped using systemTests.it.only(...)
+      // https://github.com/cypress-io/cypress/pull/20276
+      throw new Error(`the system test: "${chalk.yellow(title)}" has been set to run with an it.only() which is not allowed in CI environments.\n\nPlease remove the it.only()`)
+    }
+
     return it.only
   }
 
@@ -605,7 +613,7 @@ const localItFn = function (title: string, opts: ItOptions) {
   const browsersToTest = getBrowsers(options.browser)
 
   const browserToTest = function (browser) {
-    const mochaItFn = getMochaItFn(options.only, options.skip, browser, specifiedBrowser)
+    const mochaItFn = getMochaItFn(title, options.only, options.skip, browser, specifiedBrowser)
 
     const testTitle = `${title} [${browser}]`
 

--- a/system-tests/test/deprecated_spec.ts
+++ b/system-tests/test/deprecated_spec.ts
@@ -50,7 +50,7 @@ describe('deprecated before:browser:launch args', () => {
     psInclude: ['--foo', '--bar'],
   })
 
-  systemTests.it.only('concat return returns once', {
+  systemTests.it('concat return returns once', {
     // TODO: implement webPreferences.additionalArgs here
     // once we decide if/what we're going to make the implemenation
     // SUGGESTION: add this to Cypress.browser.args which will capture


### PR DESCRIPTION
### Changes
- Removes an incidental `systemTests.it.only` which would have prevented those CI groups from fully running.
- Throws an error in CI when `systemTests` are run exclusively

CC @jennifer-shehane and @ryanthemanuel and @tgriesser 

There was a PR merged in about a week ago (the PR that closes the browser tab) that inadvertently added this. That means that PR's into `10.0` that passed may not actually have been passing since the system test group that was set to run `deprecated_spec.ts`  were not running all the tests.

### TODO

We should update our custom `eslint` plugin which disallows `it.only()` to account for this situation: `systemTests.it.only(...)`. Right now listing is not catching this problem and it could occur again in the future.