### PR TITLE
fix(driver): suppress ResizeObserver warning

### DIFF
--- a/packages/driver/cypress/fixtures/resize-observer.html
+++ b/packages/driver/cypress/fixtures/resize-observer.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+
+<!-- 
+  Minimal example to trigger ResizeObserver limit error in Chrome.
+  https://github.com/OliverJAsh/resize-observer-loop-tests/blob/master/simple.html
+-->
+
+<body></body>
+<script>
+  const createAndAppendElement = (tagName, parent) => {
+    if (!parent) {
+      parent = document.body;
+    }
+    const element = document.createElement(tagName);
+    parent.appendChild(element);
+    return element;
+  };
+
+  const t1 = createAndAppendElement("div");
+
+  const observer = new ResizeObserver((entries) => {
+    t1.style.width = "101px";
+
+    // give Cypress some time to capture and log the warning.
+    setTimeout(() => {
+      window.Cypress.emit('resize-observer-triggered')
+    }, 150)
+  });
+
+  observer.observe(t1);
+</script> 

--- a/packages/driver/cypress/integration/cypress/error_utils_spec.ts
+++ b/packages/driver/cypress/integration/cypress/error_utils_spec.ts
@@ -9,6 +9,19 @@ import $errUtils from '@packages/driver/src/cypress/error_utils'
 import $errorMessages from '@packages/driver/src/cypress/error_messages'
 
 describe('driver/src/cypress/error_utils', () => {
+  it('warns in console if ResizeObserver error is captured and suppressed', ({ browser: 'chrome' }), (done) => {
+    cy.spy(window.top.console, 'warn')
+    cy.visit('/fixtures/resize-observer.html')
+
+    window.Cypress.once('resize-observer-triggered', () => {
+      expect(window.top.console.warn).to.be.calledWith(
+        'Cypress is intentionally supressing and ignoring a unhandled ResizeObserver error. This can safely be ignored.',
+      )
+
+      done()
+    })
+  })
+
   context('.modifyErrMsg', () => {
     let originalErr
     let newErrMsg

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -6,7 +6,7 @@ import { registerFetch } from 'unfetch'
 
 import $dom from '../dom'
 import $utils from './utils'
-import $errUtils, { ErrorFromProjectRejectionEvent } from './error_utils'
+import $errUtils, { ErrorFromProjectRejectionEvent, shouldSuppressException } from './error_utils'
 import $stackUtils from './stack_utils'
 
 import { create as createChai, IChai } from '../cy/chai'
@@ -797,6 +797,16 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
     // AUT frame are the same
     if (frameType === 'app' || this.config('componentTesting')) {
       try {
+        const { suppress, warning } = shouldSuppressException(err)
+
+        if (suppress) {
+          // eslint-disable-next-line no-console
+          console.warn(warning)
+
+          // return undefined to skip logging the error and failing the test
+          return true
+        }
+
         const results = this.Cypress.action('app:uncaught:exception', err, runnable, promise)
 
         // dont do anything if any of our uncaught:exception

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -8,7 +8,7 @@ import Promise from 'bluebird'
 
 import $Log from './log'
 import $utils from './utils'
-import $errUtils from './error_utils'
+import $errUtils, { ErrorHandlerType } from './error_utils'
 import $stackUtils from './stack_utils'
 import { getResolvedTestConfigOverride } from '../cy/testConfigOverrides'
 import debugFn from 'debug'
@@ -1051,7 +1051,7 @@ export default {
     }
 
     // eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
-    const onSpecError = (handlerType) => (event) => {
+    const onSpecError = (handlerType: ErrorHandlerType) => (event: Event) => {
       let { originalErr, err } = $errUtils.errorFromUncaughtEvent(handlerType, event)
 
       debugErrors('uncaught spec error: %o', originalErr)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://cypress-io.atlassian.net/browse/UNIFY-940

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Suppress `ResizeObserver loop limit exceeded` error. 

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Since the early days, using `ResizeObserver` in your code often leads to `ResizeObserver loop limit exceeded` errors in Cypress when using Chrome. It's a Chrome specific error. 

It's generally understood as safe to ignore this error, as we recommend multiple times:

- Issue in Cypress repo: https://github.com/cypress-io/cypress/issues/8418
- Issue in Quasar w/ reply from us: https://github.com/quasarframework/quasar/issues/2233
- [Dicussion about error on Chromium bug tracker](https://bugs.chromium.org/p/chromium/issues/detail?id=809574) (not Cypress specific)
- [Most common result from Google noting it's safe to ignore](https://stackoverflow.com/a/50387233) with discussion

My understanding is this error triggers when `ResizeObsever#observe` is called more than once in a single `requestAnimationFrame`, which isn't really a fatal error that should cause a test failure.

This reason I added this into Cypress core is it's blocking some of our own CT examples, see [this issue](https://cypress-io.atlassian.net/browse/UNIFY-940).  Rather than telling people to "safely ignore it" and copy-paste a snippet, I figure it makes sense to include it, so they don't need to. Instead, we print a `console.warn`.

It's worth noting our own code base also intentionally ignores this - [this spec](https://github.com/cypress-io/cypress/blob/d4fa37e6528c5cbf3f65f2c4efaf1b5d1e1fb38d/packages/app/src/runner/selector-playground/SelectorPlayground.cy.tsx) cannot run due to `ResizeObserver` loop error, which is why we added the common [accepted work-around here](https://github.com/cypress-io/cypress/blob/d4fa37e6528c5cbf3f65f2c4efaf1b5d1e1fb38d/packages/app/cypress/component/support/index.ts#L40).

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

## Before (with work-around):

![image](https://user-images.githubusercontent.com/19196536/154626927-cb58c583-0599-4158-ae79-47b96760b96f.png)


## After:

![image](https://user-images.githubusercontent.com/19196536/154626395-9ec5efeb-0921-451a-84f7-7a07b324787b.png)


No need for copy-pasting 
```js
Cypress.on('uncaught:exception', (err) => !err.message.includes('ResizeObserver loop limit exceeded'))
``` 
in your support file.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
