### PR TITLE
chore: minimal update to Vue and React READMEs to reference new examples

### DIFF
--- a/npm/react/README.md
+++ b/npm/react/README.md
@@ -108,6 +108,11 @@ module.exports = defineConfig({
 
 ## Examples
 
+### Note
+The most current 'Getting Started' examples for various kinds of React projects are located in the [Cypress Component Testing Examples](https://github.com/cypress-io/cypress-component-testing-examples) repo. That is a good place to see different ways to get component testing up and running with your setup.
+
+The examples contained in this repo, and the external examples linked below, are most useful when you are already up and running with component testing in your project. They cover details about how to achieve particular testing goals such as visual testing, adding styles, using hooks, and how to use component testing in various other scenarios.
+
 ```js
 import React from 'react'
 import { mount } from '@cypress/react'

--- a/npm/vue/README.md
+++ b/npm/vue/README.md
@@ -82,6 +82,11 @@ describe('Hello.vue', () => {
 
 ## Usage and Examples
 
+### Note
+The most current 'Getting Started' examples for various kinds of Vue projects are located in the [Cypress Component Testing Examples](https://github.com/cypress-io/cypress-component-testing-examples) repo. That is a good place to see different ways to get component testing up and running with your setup.
+
+The examples contained in this repo, and the external examples linked below, are most useful when you are already up and running with component testing in your project. They cover details about how to achieve particular testing goals, like mounting passing props, using slots, or handling user input.
+
 ```js
 // components/HelloWorld.spec.js
 import { mount } from '@cypress/vue'


### PR DESCRIPTION
This adds two notes explaining that the canonical examples are located in the cypress-component-testing-examples repo, and what the purpose is of the examples that remain in the Vue and React core packages.