### PR TITLE
fix: Typo in E2E Description

### DIFF
--- a/packages/frontend-shared/src/components/Card.cy.tsx
+++ b/packages/frontend-shared/src/components/Card.cy.tsx
@@ -7,7 +7,7 @@ import IconComponentSolid from '~icons/cy/testing-type-component-solid_x64.svg'
 describe('Card', { viewportHeight: 400 }, () => {
   it('renders with icons, text, and focus state', () => {
     const e2eTitle = 'E2E Testing'
-    const e2eDescription = 'Build and test the entire experience of your application from end-to-end to each ensure each flow matches your expectations.'
+    const e2eDescription = 'Build and test the entire experience of your application from end-to-end to ensure each flow matches your expectations.'
     const ctTitle = 'Component Testing'
     const ctDescription = 'Build and test your components from your design system in isolation in order to ensure each state matches your expectations.'
 

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -494,7 +494,7 @@
     "modalTitle": "Choose a testing type",
     "e2e": {
       "name": "E2E Testing",
-      "description": "Build and test the entire experience of your application from end-to-end to each ensure each flow matches your expectations."
+      "description": "Build and test the entire experience of your application from end-to-end to ensure each flow matches your expectations."
     },
     "component": {
       "name": "Component Testing",


### PR DESCRIPTION
- Closes https://cypress-io.atlassian.net/browse/UNIFY-1184

### User facing changelog
n/a

### Additional details
Fixed a typo in the description of E2E testing which said "each" twice.

Before:

![image](https://user-images.githubusercontent.com/27690333/155143190-703e03a8-17b1-4f9e-9924-fcf5c343ce20.png)

After:

<img width="424" alt="Screenshot 2022-02-22 at 8 33 25 AM" src="https://user-images.githubusercontent.com/27690333/155143139-de008037-d6f0-445b-a8d2-5adc14259c2a.png">

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
