### PR TITLE
fix: UNIFY-1138, UNIFY-1130 loading unconfigured project

### DIFF
--- a/packages/data-context/src/DataContext.ts
+++ b/packages/data-context/src/DataContext.ts
@@ -463,12 +463,6 @@ export class DataContext {
     // load projects from cache on start
     toAwait.push(this.actions.project.loadProjects())
 
-    if (this.modeOptions.testingType) {
-      this.lifecycleManager.initializeConfig().catch((err) => {
-        this.coreData.baseError = err
-      })
-    }
-
     return Promise.all(toAwait)
   }
 }

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -70,6 +70,22 @@ function renameSupport (lang: 'js' | 'ts' = 'js') {
   }, { lang })
 }
 
+describe('Opening unmigrated project', () => {
+  it('legacy project with --e2e', () => {
+    cy.scaffoldProject('migration')
+    cy.openProject('migration', ['--e2e'])
+    cy.visitLaunchpad()
+    cy.get('h1').should('contain', 'Migration')
+  })
+
+  it('legacy project with --component', () => {
+    cy.scaffoldProject('migration-component-testing')
+    cy.openProject('migration-component-testing', ['--component'])
+    cy.visitLaunchpad()
+    cy.get('h1').should('contain', 'Migration')
+  })
+})
+
 describe('Full migration flow for each project', { retries: { openMode: 2, runMode: 2 } }, () => {
   it('completes journey for migration-component-testing', () => {
     startMigrationFor('migration-component-testing')

--- a/packages/launchpad/cypress/e2e/open-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/open-mode.cy.ts
@@ -18,34 +18,6 @@ describe('Launchpad: Open Mode', () => {
     })
   })
 
-  it('opens correctly in unconfigured project with --e2e', () => {
-    cy.scaffoldProject('pristine')
-    cy.openProject('pristine', ['--e2e'])
-    cy.visitLaunchpad()
-    cy.get('h1').should('contain', 'Project Setup')
-  })
-
-  it('opens correctly in unconfigured project with --component', () => {
-    cy.scaffoldProject('pristine')
-    cy.openProject('pristine', ['--component'])
-    cy.visitLaunchpad()
-    cy.get('h1').should('contain', 'Project Setup')
-  })
-
-  it('opens migration for legacy project with --e2e', () => {
-    cy.scaffoldProject('migration')
-    cy.openProject('migration', ['--e2e'])
-    cy.visitLaunchpad()
-    cy.get('h1').should('contain', 'Migration')
-  })
-
-  it('opens migration for legacy project with --component', () => {
-    cy.scaffoldProject('migration-component-testing')
-    cy.openProject('migration-component-testing', ['--component'])
-    cy.visitLaunchpad()
-    cy.get('h1').should('contain', 'Migration')
-  })
-
   it('goes directly to e2e tests when launched with --e2e', () => {
     cy.scaffoldProject('todos')
     cy.openProject('todos', ['--e2e'])

--- a/packages/launchpad/cypress/e2e/open-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/open-mode.cy.ts
@@ -18,6 +18,34 @@ describe('Launchpad: Open Mode', () => {
     })
   })
 
+  it('opens correctly in unconfigured project with --e2e', () => {
+    cy.scaffoldProject('pristine')
+    cy.openProject('pristine', ['--e2e'])
+    cy.visitLaunchpad()
+    cy.get('h1').should('contain', 'Project Setup')
+  })
+
+  it('opens correctly in unconfigured project with --component', () => {
+    cy.scaffoldProject('pristine')
+    cy.openProject('pristine', ['--component'])
+    cy.visitLaunchpad()
+    cy.get('h1').should('contain', 'Project Setup')
+  })
+
+  it('opens migration for legacy project with --e2e', () => {
+    cy.scaffoldProject('migration')
+    cy.openProject('migration', ['--e2e'])
+    cy.visitLaunchpad()
+    cy.get('h1').should('contain', 'Migration')
+  })
+
+  it('opens migration for legacy project with --component', () => {
+    cy.scaffoldProject('migration-component-testing')
+    cy.openProject('migration-component-testing', ['--component'])
+    cy.visitLaunchpad()
+    cy.get('h1').should('contain', 'Migration')
+  })
+
   it('goes directly to e2e tests when launched with --e2e', () => {
     cy.scaffoldProject('todos')
     cy.openProject('todos', ['--e2e'])

--- a/packages/launchpad/cypress/e2e/project-setup.cy.ts
+++ b/packages/launchpad/cypress/e2e/project-setup.cy.ts
@@ -19,6 +19,20 @@ describe('Launchpad: Setup Project', () => {
     verifyWelcomePage({ e2eIsConfigured: false, ctIsConfigured: false })
   })
 
+  it('opens correctly in unconfigured project with --e2e', () => {
+    cy.scaffoldProject('pristine')
+    cy.openProject('pristine', ['--e2e'])
+    cy.visitLaunchpad()
+    cy.get('h1').should('contain', 'Project Setup')
+  })
+
+  it('opens correctly in unconfigured project with --component', () => {
+    cy.scaffoldProject('pristine')
+    cy.openProject('pristine', ['--component'])
+    cy.visitLaunchpad()
+    cy.get('h1').should('contain', 'Project Setup')
+  })
+
   describe('"learn about testing types" modal', () => {
     beforeEach(() => {
       scaffoldAndOpenProject('pristine')

--- a/yarn.lock
+++ b/yarn.lock
@@ -41803,18 +41803,10 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@1.5.6:
+url-parse@1.5.6, url-parse@^1.4.3, url-parse@^1.4.7:
   version "1.5.6"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.6.tgz#b2a41d5a233645f3c31204cc8be60e76a15230a2"
   integrity sha512-xj3QdUJ1DttD1LeSfvJlU1eiF1RvBSBfUu8GplFGdUzSO28y5yUtEl7wb//PI4Af6qh0o/K8545vUmucRrfWsw==
-  dependencies:
-    querystringify "^2.1.1"
-    requires-port "^1.0.0"
-
-url-parse@^1.4.3, url-parse@^1.4.7:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.2.tgz#a4eff6fd5ff9fe6ab98ac1f79641819d13247cda"
-  integrity sha512-6bTUPERy1muxxYClbzoRo5qtQuyoGEbzbQvi0SW4/8U8UyVkAQhWFBlnigqJkRm4su4x1zDQfNbEzWkt+vchcg==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"


### PR DESCRIPTION
- Closes UNIFY-1138
- Closes UNIFY-1130

The `ProjectLifecycleManager` should be self-contained in managing the config loading based on state changes, we shouldn't be calling `initializeConfig` it `initializeOpenMode` as we might not have a configured project.