### PR TITLE
fix: revert "fix: treat form-data bodies as binary"

### DIFF
--- a/packages/net-stubbing/lib/server/util.ts
+++ b/packages/net-stubbing/lib/server/util.ts
@@ -251,10 +251,6 @@ export function getBodyEncoding (req: CyHttpMessages.IncomingRequest): BodyEncod
     if (contentType.includes('charset=utf-8') || contentType.includes('charset="utf-8"')) {
       return 'utf8'
     }
-
-    if (contentType.includes('multipart/form-data')) {
-      return 'binary'
-    }
   }
 
   // with fallback to inspecting the buffer using

--- a/packages/net-stubbing/test/unit/util-spec.ts
+++ b/packages/net-stubbing/test/unit/util-spec.ts
@@ -69,19 +69,5 @@ describe('net-stubbing util', () => {
 
       expect(getBodyEncoding(req), 'image').to.equal('binary')
     })
-
-    it('returns binary for form-data bodies', () => {
-      const formDataRequest = {
-        body: Buffer.from('hello world'),
-        headers: {
-          'content-type': 'multipart/form-data',
-        },
-        method: 'POST',
-        url: 'somewhere',
-        httpVersion: '1.1',
-      }
-
-      expect(getBodyEncoding(formDataRequest)).to.equal('binary')
-    })
   })
 })


### PR DESCRIPTION
Reverts cypress-io/cypress#20144

Unreleased - not a user-facing change.

This is being reverted because it caused breakage in `cypress-example-recipes` that's indicative of real-world breakage for users of `cy.intercept()`: https://circleci.com/gh/cypress-io/cypress/1283292?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

The patch to `cypress-example-recipes` required for it to pass after #20144: https://github.com/cypress-io/cypress-example-recipes/pull/762/commits/149ad0ed5732052a3de108bfabb6dd6381c24f19

Discussion about how to fix the problem #20144 was meant to address can continue in the original issue, #20143