### PR TITLE
chore: refactor log function to class

### DIFF
--- a/packages/driver/cypress/integration/cypress/log_spec.js
+++ b/packages/driver/cypress/integration/cypress/log_spec.js
@@ -1,4 +1,4 @@
-const $Log = require('@packages/driver/src/cypress/log').default
+const { create } = require('@packages/driver/src/cypress/log')
 
 describe('src/cypress/log', function () {
   context('#snapshot', function () {
@@ -11,7 +11,7 @@ describe('src/cypress/log', function () {
       this.config = cy.stub()
       this.config.withArgs('isInteractive').returns(true)
       this.config.withArgs('numTestsKeptInMemory').returns(50)
-      this.log = $Log.create(Cypress, this.cy, this.state, this.config)
+      this.log = create(Cypress, this.cy, this.state, this.config)
     })
 
     it('creates a snapshot and returns the log', function () {

--- a/packages/driver/src/cy/commands/navigation.ts
+++ b/packages/driver/src/cy/commands/navigation.ts
@@ -5,7 +5,7 @@ import Promise from 'bluebird'
 
 import $utils from '../../cypress/utils'
 import $errUtils from '../../cypress/error_utils'
-import $Log from '../../cypress/log'
+import { LogUtils } from '../../cypress/log'
 import { bothUrlsMatchAndOneHasHash } from '../navigation'
 import { $Location } from '../../cypress/location'
 
@@ -1022,7 +1022,7 @@ export default (Commands, Cypress, cy, state, config) => {
           s.passed = Cypress.runner.countByTestState(s.tests, 'passed')
           s.failed = Cypress.runner.countByTestState(s.tests, 'failed')
           s.pending = Cypress.runner.countByTestState(s.tests, 'pending')
-          s.numLogs = $Log.countLogsByTests(s.tests)
+          s.numLogs = LogUtils.countLogsByTests(s.tests)
 
           return Cypress.action('cy:collect:run:state')
           .then((a = []) => {

--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -17,7 +17,7 @@ import $dom from './dom'
 import $Downloads from './cypress/downloads'
 import $errorMessages from './cypress/error_messages'
 import $errUtils from './cypress/error_utils'
-import $Log from './cypress/log'
+import { create as createLogFn, LogUtils } from './cypress/log'
 import $LocalStorage from './cypress/local_storage'
 import $Mocha from './cypress/mocha'
 import { create as createMouse } from './cy/mouse'
@@ -115,7 +115,7 @@ class $Cypress {
   errorMessages = $errorMessages
   Keyboard = $Keyboard
   Location = $Location
-  Log = $Log
+  Log = LogUtils
   LocalStorage = $LocalStorage
   Mocha = $Mocha
   resolveWindowReference = resolvers.resolveWindowReference
@@ -323,7 +323,7 @@ class $Cypress {
     this.cy = new $Cy(specWindow, this, this.Cookies, this.state, this.config)
     window.cy = this.cy
     this.isCy = this.cy.isCy
-    this.log = $Log.create(this, this.cy, this.state, this.config)
+    this.log = createLogFn(this, this.cy, this.state, this.config)
     this.mocha = $Mocha.create(specWindow, this, this.config)
     this.runner = $Runner.create(specWindow, this.mocha, this, this.cy, this.state)
     this.downloads = $Downloads.create(this)

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import dayjs from 'dayjs'
 import Promise from 'bluebird'
 
-import $Log from './log'
+import { LogUtils } from './log'
 import $utils from './utils'
 import $errUtils from './error_utils'
 import $stackUtils from './stack_utils'
@@ -1607,7 +1607,7 @@ export default {
       },
 
       setNumLogs (num) {
-        return $Log.setCounter(num)
+        return LogUtils.setCounter(num)
       },
 
       getEmissions () {
@@ -1662,13 +1662,13 @@ export default {
         _runner.removeAllListeners()
       },
 
-      getDisplayPropsForLog: $Log.getDisplayProps,
+      getDisplayPropsForLog: LogUtils.getDisplayProps,
 
       getConsolePropsForLogById (logId) {
         const attrs = _logsById[logId]
 
         if (attrs) {
-          return $Log.getConsoleProps(attrs)
+          return LogUtils.getConsoleProps(attrs)
         }
       },
 
@@ -1676,7 +1676,7 @@ export default {
         const attrs = _logsById[logId]
 
         if (attrs) {
-          return $Log.getSnapshotProps(attrs)
+          return LogUtils.getSnapshotProps(attrs)
         }
 
         return
@@ -1715,7 +1715,7 @@ export default {
                 // now, so lets store that
                 attrs._hasBeenCleanedUp = true
 
-                return $Log.reduceMemory(attrs)
+                return LogUtils.reduceMemory(attrs)
               })
             })
 
@@ -1791,7 +1791,7 @@ const mixinLogs = (test) => {
     const logs = test[type]
 
     if (logs) {
-      test[type] = _.map(logs, $Log.toSerializedJSON)
+      test[type] = _.map(logs, LogUtils.toSerializedJSON)
     }
   })
 }


### PR DESCRIPTION
- Related with [this comment](https://github.com/cypress-io/cypress/pull/20169#discussion_r813042620)

### User facing changelog

N/A. It's an internal refactoring

### Additional details
- Why was this change necessary? => Modernize the code.
- What is affected by this change? => N/A
- Any implementation details to explain? => Change the function/object to class.

### Summary of changes.

As it's a refactoring, the code change is hard to read. So, I left this.

* I organized the code into 3 parts: `LogUtils`, `LogManager`, `Log`. 
  * `LogUtils` are functions used in other files. They were exported with `export default`. I could remove them.
  * `LogManager`: Inside `create` function, `logs` variable exists and it manages logs created. But it makes us create `fireChangeEvent` function inside `create` function and attach it to `Log`. So, I created `LogManager` class and `Log` class reference it.
  * `Log`: It was a function that returns an object. I changed it to a class.
* I left some comments about other logic changes below.


### How has the user experience changed?

N/A

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
