### PR TITLE
chore: remove eslint-plugin from runner-ct

### DIFF
--- a/packages/app/src/runs/CloudConnectButton.vue
+++ b/packages/app/src/runs/CloudConnectButton.vue
@@ -45,7 +45,7 @@ const emit = defineEmits<{
 }>()
 
 const props = defineProps<{
-  gql: CloudConnectButtonFragment,
+  gql: CloudConnectButtonFragment
   class?: string
 }>()
 

--- a/packages/runner-ct/package.json
+++ b/packages/runner-ct/package.json
@@ -34,7 +34,6 @@
     "clean-webpack-plugin": "^3.0.0",
     "cypress-real-events": "1.6.0",
     "eslint-plugin-mocha": "^8.0.0",
-    "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "express": "^4.17.1",
     "fuzzysort": "^1.1.4",


### PR DESCRIPTION
Linting is failing on `release-10.0` with

```sh
ESLint couldn't determine the plugin "react" uniquely.

- /Users/lachlan/code/work/cypress6/packages/runner-ct/node_modules/eslint-plugin-react/index.js (loaded in "packages/runner-ct/.eslintrc.json » ../reporter/src/.eslintrc.json » plugin:@cypress/dev/tests#overrides[0]")
- /Users/lachlan/code/work/cypress6/node_modules/eslint-plugin-react/index.js (loaded in ".eslintrc.js » plugin:@cypress/dev/tests#overrides[0]")

Please remove the "plugins" setting from either config or remove either plugin installation.
```

So I did what it said to fix it. It's not clear why this is occurring. It looks like it was introduced after https://github.com/cypress-io/cypress/pull/20332 was merged, but checking out the previous commit and running `yarn lint` locally still errors out. 🤷‍♂️ 