### PR TITLE
chore: fix ExpectType assertions

### DIFF
--- a/cli/types/tests/plugins-config.ts
+++ b/cli/types/tests/plugins-config.ts
@@ -6,15 +6,15 @@ const pluginConfig: Cypress.PluginConfig = (on, config) => {}
 // allows synchronous returns
 const pluginConfig2: Cypress.PluginConfig = (on, config) => {
   config // $ExpectType PluginConfigOptions
-  config.baseUrl // $ExpectType: string
-  config.configFile // $ExpectType: string | false
-  config.fixturesFolder // $ExpectType: string | false
-  config.pluginsFile // $ExpectType: string | false
-  config.screenshotsFolder // $ExpectType: string | false
-  config.videoCompression // $ExpectType: number | false
-  config.projectRoot // $ExpectType: string
-  config.version // $ExpectType: string
-  config.testingType // $ExpectType: TestingType
+  config.baseUrl // $ExpectType string
+  config.configFile // $ExpectType string | false
+  config.fixturesFolder // $ExpectType string | false
+  config.pluginsFile // $ExpectType string | false
+  config.screenshotsFolder // $ExpectType string | false
+  config.videoCompression // $ExpectType number | false
+  config.projectRoot // $ExpectType string
+  config.version // $ExpectType string
+  config.testingType // $ExpectType TestingType
 
   on('before:browser:launch', (browser, options) => {
     browser.displayName // $ExpectType string


### PR DESCRIPTION
### Additional details

Several `$ExpectType` assertions contained a colon `$ExpectType:` which was silently failing the type assertion.
