### PR TITLE
fix: avoid nextjs unsafeCache and watchOptions

### DIFF
--- a/npm/react/plugins/next/findNextWebpackConfig.js
+++ b/npm/react/plugins/next/findNextWebpackConfig.js
@@ -41,6 +41,15 @@ async function getNextWebpackConfig (config) {
 
   checkSWC(nextWebpackConfig, config)
 
+  if (nextWebpackConfig.watchOptions && Array.isArray(nextWebpackConfig.watchOptions?.ignored)) {
+    nextWebpackConfig.watchOptions = {
+      ...nextWebpackConfig.watchOptions,
+      ignored: [...nextWebpackConfig.watchOptions.ignored.map((pattern) => !/node_modules/.test(pattern)), '**/node_modules/!(@cypress/webpack-dev-server/dist/browser.js)**'],
+    }
+
+    debug('found options next.js watchOptions.ignored %O', nextWebpackConfig.watchOptions.ignored)
+  }
+
   return nextWebpackConfig
 }
 

--- a/npm/react/plugins/next/findNextWebpackConfig.js
+++ b/npm/react/plugins/next/findNextWebpackConfig.js
@@ -44,7 +44,7 @@ async function getNextWebpackConfig (config) {
   if (nextWebpackConfig.watchOptions && Array.isArray(nextWebpackConfig.watchOptions?.ignored)) {
     nextWebpackConfig.watchOptions = {
       ...nextWebpackConfig.watchOptions,
-      ignored: [...nextWebpackConfig.watchOptions.ignored.map((pattern) => !/node_modules/.test(pattern)), '**/node_modules/!(@cypress/webpack-dev-server/dist/browser.js)**'],
+      ignored: [...nextWebpackConfig.watchOptions.ignored.filter((pattern) => !/node_modules/.test(pattern)), '**/node_modules/!(@cypress/webpack-dev-server/dist/browser.js)**'],
     }
 
     debug('found options next.js watchOptions.ignored %O', nextWebpackConfig.watchOptions.ignored)

--- a/npm/react/plugins/next/findNextWebpackConfig.js
+++ b/npm/react/plugins/next/findNextWebpackConfig.js
@@ -41,7 +41,7 @@ async function getNextWebpackConfig (config) {
 
   checkSWC(nextWebpackConfig, config)
 
-  if (nextWebpackConfig.watchOptions && Array.isArray(nextWebpackConfig.watchOptions?.ignored)) {
+  if (nextWebpackConfig.watchOptions && Array.isArray(nextWebpackConfig.watchOptions.ignored)) {
     nextWebpackConfig.watchOptions = {
       ...nextWebpackConfig.watchOptions,
       ignored: [...nextWebpackConfig.watchOptions.ignored.filter((pattern) => !/node_modules/.test(pattern)), '**/node_modules/!(@cypress/webpack-dev-server/dist/browser.js)**'],

--- a/npm/webpack-dev-server/src/browser.ts
+++ b/npm/webpack-dev-server/src/browser.ts
@@ -1,5 +1,8 @@
-function render () {
-  require(`!!./loader.js!./browser.js?${(new Date()).getTime()}`)
+// In the last version of nextjs, the caching mechanism is hard to remove.
+// The cacheBust here allows us to disable it in open mode while keeping it in run mode.
+// When user will add a new spec in edit mode, there won't be any cache.
+function render (cacheBust: boolean) {
+  require(`!!./loader.js!./browser.js${cacheBust ? `?${(new Date()).getTime()}` : ''}`)
 }
 
-render()
+render(!parent.Cypress.config('isTextTerminal'))

--- a/npm/webpack-dev-server/src/browser.ts
+++ b/npm/webpack-dev-server/src/browser.ts
@@ -1,8 +1,5 @@
-// In the last version of nextjs, the caching mechanism is hard to remove.
-// The cacheBust here allows us to disable it in open mode while keeping it in run mode.
-// When user will add a new spec in edit mode, there won't be any cache.
-function render (cacheBust: boolean) {
-  require(`!!./loader.js!./browser.js${cacheBust ? `?${(new Date()).getTime()}` : ''}`)
+function render () {
+  require('!!./loader.js!./browser.js')
 }
 
-render(!parent.Cypress.config('isTextTerminal'))
+render()

--- a/npm/webpack-dev-server/src/browser.ts
+++ b/npm/webpack-dev-server/src/browser.ts
@@ -1,5 +1,5 @@
 function render () {
-  require('!!./loader.js!./browser.js')
+  require(`!!./loader.js!./browser.js?${(new Date()).getTime()}`)
 }
 
 render()

--- a/npm/webpack-dev-server/src/makeWebpackConfig.ts
+++ b/npm/webpack-dev-server/src/makeWebpackConfig.ts
@@ -78,6 +78,14 @@ export async function makeWebpackConfig (userWebpackConfig: webpack.Configuratio
     })
   }
 
+  if (typeof userWebpackConfig?.module?.unsafeCache === 'function') {
+    const originalCachePredicate = userWebpackConfig.module.unsafeCache
+
+    userWebpackConfig.module.unsafeCache = (module: any) => {
+      return originalCachePredicate(module) && !/[\\/]webpack-dev-server[\\/]dist[\\/]browser\.js/.test(module.resource)
+    }
+  }
+
   const mergedConfig = merge<webpack.Configuration>(
     userWebpackConfig,
     makeDefaultWebpackConfig(template),

--- a/npm/webpack-dev-server/src/makeWebpackConfig.ts
+++ b/npm/webpack-dev-server/src/makeWebpackConfig.ts
@@ -86,19 +86,6 @@ export async function makeWebpackConfig (userWebpackConfig: webpack.Configuratio
     }
   }
 
-  if (userWebpackConfig.watchOptions) {
-    userWebpackConfig.watchOptions = {
-      ...userWebpackConfig.watchOptions,
-      ignored: Array.isArray(userWebpackConfig.watchOptions.ignored)
-        ? [...userWebpackConfig.watchOptions.ignored, '!(**/@cypress/webpack-dev-server/dist/browser.js)']
-        : typeof userWebpackConfig.watchOptions.ignored === 'string'
-          ? [userWebpackConfig.watchOptions.ignored, '!(**/node_modules/@cypress/webpack-dev-server/dist/browser.js)']
-          : userWebpackConfig.watchOptions.ignored,
-    }
-
-    debug('watchOptions.ignored %O', userWebpackConfig.watchOptions.ignored)
-  }
-
   const mergedConfig = merge<webpack.Configuration>(
     userWebpackConfig,
     makeDefaultWebpackConfig(template),

--- a/npm/webpack-dev-server/src/makeWebpackConfig.ts
+++ b/npm/webpack-dev-server/src/makeWebpackConfig.ts
@@ -86,6 +86,19 @@ export async function makeWebpackConfig (userWebpackConfig: webpack.Configuratio
     }
   }
 
+  if (userWebpackConfig.watchOptions) {
+    userWebpackConfig.watchOptions = {
+      ...userWebpackConfig.watchOptions,
+      ignored: Array.isArray(userWebpackConfig.watchOptions.ignored)
+        ? [...userWebpackConfig.watchOptions.ignored, '!(**/@cypress/webpack-dev-server/dist/browser.js)']
+        : typeof userWebpackConfig.watchOptions.ignored === 'string'
+          ? [userWebpackConfig.watchOptions.ignored, '!(**/node_modules/@cypress/webpack-dev-server/dist/browser.js)']
+          : userWebpackConfig.watchOptions.ignored,
+    }
+
+    debug('watchOptions.ignored %O', userWebpackConfig.watchOptions.ignored)
+  }
+
   const mergedConfig = merge<webpack.Configuration>(
     userWebpackConfig,
     makeDefaultWebpackConfig(template),


### PR DESCRIPTION
- Closes UNIFY-1133

In webpack 5 it seems that loaders called with the exact same query are not re-run. 
This creates a situation where the Cypress file watcher is updating the files but the new files are never pushed in the loader. It results in Cypress throwing a (No tests found) error since the spec exists but not in the AUT.

In this PR I disable caching and unsafe caching for the browser.js file.
