### PR TITLE
fix: ensure multi domain passivity

### DIFF
--- a/packages/driver/cypress.json
+++ b/packages/driver/cypress.json
@@ -13,5 +13,6 @@
   "retries": {
     "runMode": 2,
     "openMode": 0
-  }
+  },
+  "experimentalMultiDomain": true
 }

--- a/packages/driver/cypress/integration/commands/navigation_spec.js
+++ b/packages/driver/cypress/integration/commands/navigation_spec.js
@@ -2134,34 +2134,6 @@ describe('src/cy/commands/navigation', () => {
         .get('#does-not-exist', { timeout: 200 }).should('have.class', 'foo')
       })
 
-      // TODO: This test is currently being skipped for multidomain and needs to be fixed. See issue #19632.
-      it.skip('captures cross origin failures', function (done) {
-        cy.once('fail', (err) => {
-          const { lastLog } = this
-
-          assertLogLength(this.logs, 2)
-          expect(err.message).to.include('Cypress detected a cross origin error happened on page load')
-          expect(err.docsUrl).to.eq('https://on.cypress.io/cross-origin-violation')
-          expect(lastLog.get('name')).to.eq('page load')
-          expect(lastLog.get('state')).to.eq('failed')
-          expect(lastLog.get('error')).to.eq(err)
-          expect(cy.state('onPageLoadErr')).to.be.null
-
-          done()
-        })
-
-        cy
-        .visit('/fixtures/jquery.html')
-        .window({ log: false }).then((win) => {
-          const url = 'http://localhost:3501/fixtures/generic.html'
-
-          const $a = win.$(`<a href='${url}'>jquery</a>`)
-          .appendTo(win.document.body)
-
-          causeSynchronousBeforeUnload($a)
-        })
-      })
-
       return null
     })
   })

--- a/packages/driver/cypress/integration/e2e/multi-domain/basic_login_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/basic_login_spec.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck / session support is needed for visiting about:blank between tests
-describe('basic login', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+describe('basic login', { experimentalSessionSupport: true }, () => {
   // Scenario, Token based auth. Visit site, redirect to IDP hosted on secondary domain, login and redirect back to site.
   describe('visit primary first', () => {
     it('logs in with idp redirect', () => {
@@ -176,7 +176,7 @@ describe('basic login', { experimentalSessionSupport: true, experimentalMultiDom
 })
 
 // session support is needed for visiting about:blank between tests
-describe('Multi-step Auth', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+describe('Multi-step Auth', { experimentalSessionSupport: true }, () => {
   // TODO: Switch to domain does not work in switch to domain yet.
   it.skip('final auth redirects back to localhost - nested', () => {
     cy.visit('/fixtures/auth/index.html')

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_actions.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_actions.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain actions', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
   })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_aliasing.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_aliasing.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain aliasing', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain aliasing', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="dom-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_assertions.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_assertions.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain assertions', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain assertions', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="dom-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_connectors.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_connectors.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain connectors', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain connectors', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="dom-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_cookies.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_cookies.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain cookies', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain cookies', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_files.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_files.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain files', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain files', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_local_storage.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_local_storage.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain local storage', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain local storage', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_location.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_location.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain location', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain location', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain misc', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain misc', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="dom-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_navigation.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_navigation.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain navigation', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain navigation', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="dom-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_network_requests.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_network_requests.spec.ts
@@ -1,6 +1,6 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
 // FIXME: received cross-origin errors
-context.skip('multi-domain network requests', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context.skip('multi-domain network requests', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="request-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_querying.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_querying.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain querying', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain querying', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="dom-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_querying_shadow.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_querying_shadow.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain shadow dom', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain shadow dom', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="shadow-dom-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_screenshot.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_screenshot.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain screenshot', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain screenshot', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     this.serverResult = {
       path: '/path/to/screenshot',

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_session.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_session.spec.ts
@@ -3,7 +3,7 @@
 // You must enable the experimentalSessionSupport flag in order to use Cypress session commands
 // at throwIfNoSessionSupport(webpack:///../driver/src/cy/commands/sessions.ts?:287:76)
 // at session(webpack:///../driver/src/cy/commands/sessions.ts?:516:7)
-context.skip('multi-domain session', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context.skip('multi-domain session', { experimentalSessionSupport: true }, () => {
   before(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="dom-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_spies_stubs_clocks.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_spies_stubs_clocks.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain spies, stubs, and clock', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain spies, stubs, and clock', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_traversal.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_traversal.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain traversal', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain traversal', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="dom-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_unsupported_commands.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_unsupported_commands.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain unsupported commands', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain unsupported commands', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_viewport.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_viewport.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain viewport', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain viewport', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_waiting.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_waiting.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain waiting', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain waiting', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_window.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_window.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain window', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+context('multi-domain window', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="dom-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_config_env_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_config_env_spec.ts
@@ -1,6 +1,6 @@
 ['config', 'env'].forEach((fnName) => {
   // @ts-ignore
-  describe(`multi-domain - Cypress.${fnName}()`, { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+  describe(`multi-domain - Cypress.${fnName}()`, { experimentalSessionSupport: true }, () => {
     const USED_KEYS = {
       foo: 'multi-domain-foo',
       bar: 'multi-domain-bar',

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_cypress_api.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_cypress_api.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests+
-describe('multi-domain Cypress API', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_events_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_events_spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-describe('multi-domain', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+describe('multi-domain', { experimentalSessionSupport: true }, () => {
   it('window:before:load event', () => {
     cy.visit('/fixtures/multi-domain.html')
     cy.on('window:before:load', (win: {testPrimaryDomainBeforeLoad: boolean}) => {

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_rerun_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_rerun_spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-describe('multi-domain - rerun', { experimentalMultiDomain: true }, () => {
+describe('multi-domain - rerun', { }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-describe('multi-domain', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+describe('multi-domain', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()
@@ -206,7 +206,7 @@ describe('multi-domain', { experimentalSessionSupport: true, experimentalMultiDo
 })
 
 // @ts-ignore
-describe('domain validation', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+describe('domain validation', { experimentalSessionSupport: true }, () => {
   it('finds the right spec bridge with a subdomain', () => {
     cy.visit('/fixtures/auth/index.html') // Establishes Primary Domain
     cy.window().then((win) => {

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+describe('multi-domain - uncaught errors', { experimentalSessionSupport: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="errors-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_validation_specs.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_validation_specs.ts
@@ -1,5 +1,5 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
-describe('multi-domain', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+describe('multi-domain', { experimentalSessionSupport: true }, () => {
   describe('successes', () => {
     it('succeeds on a localhost domain name', () => {
       cy.switchToDomain('localhost', () => undefined)

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_yield_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_yield_spec.ts
@@ -1,7 +1,7 @@
 import { assertLogLength } from '../../../support/utils'
 
 // @ts-ignore / session support is needed for visiting about:blank between tests
-describe('multi-domain yields', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
   let logs: any = []
 
   beforeEach(() => {

--- a/packages/driver/cypress/integration/e2e/multi-domain/navigation_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/navigation_spec.ts
@@ -12,7 +12,7 @@ const reifyLogs = (logs) => {
 }
 
 // @ts-ignore / session support is needed for visiting about:blank between tests
-describe('navigation events', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+describe('navigation events', { experimentalSessionSupport: true }, () => {
   let logs: any = []
 
   beforeEach(() => {

--- a/packages/proxy/lib/http/index.ts
+++ b/packages/proxy/lib/http/index.ts
@@ -53,7 +53,7 @@ export const defaultMiddleware = {
 }
 
 export type ServerCtx = Readonly<{
-  config: CyServer.Config
+  config: CyServer.Config & Cypress.Config
   shouldCorrelatePreRequests?: () => boolean
   getFileServerToken: () => string
   getRemoteState: CyServer.getRemoteState

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -231,7 +231,7 @@ const MaybeDelayForMultiDomain: ResponseMiddleware = function () {
   const isRenderedHTML = reqWillRenderHtml(this.req)
   const isAUTFrame = this.req.isAUTFrame
 
-  if (isCrossDomain && isAUTFrame && (isHTML || isRenderedHTML)) {
+  if (this.config.experimentalMultiDomain && isCrossDomain && isAUTFrame && (isHTML || isRenderedHTML)) {
     this.debug('is cross-domain, delay until domain:ready event')
 
     this.serverBus.once('ready:for:domain', () => {
@@ -272,7 +272,7 @@ const SetInjectionLevel: ResponseMiddleware = function () {
     const isHTML = resContentTypeIs(this.incomingRes, 'text/html')
     const isAUTFrame = this.req.isAUTFrame
 
-    if (!isReqMatchOriginPolicy && isAUTFrame && (isHTML || isRenderedHTML)) {
+    if (this.config.experimentalMultiDomain && !isReqMatchOriginPolicy && isAUTFrame && (isHTML || isRenderedHTML)) {
       this.debug('- multi-domain injection')
 
       return 'fullMultiDomain'

--- a/system-tests/__snapshots__/navigation_spec.ts.js
+++ b/system-tests/__snapshots__/navigation_spec.ts.js
@@ -1,0 +1,94 @@
+exports['e2e cross origin navigation / captures cross origin failures when "experimentalMultiDomain" config value is falsy'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      1 found (navigation_cross_origin_errors.ts)                                        │
+  │ Searched:   cypress/integration/navigation_cross_origin_errors.ts                              │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  navigation_cross_origin_errors.ts                                               (1 of 1)
+
+
+  navigation cross origin errors
+    1) displays cross origin failures when "experimentalMultiDomain" is turned off
+
+
+  0 passing
+  1 failing
+
+  1) navigation cross origin errors
+       displays cross origin failures when "experimentalMultiDomain" is turned off:
+     CypressError: Cypress detected a cross origin error happened on page load:
+
+  > [Cross origin error message]
+
+Before the page load, you were bound to the origin policy:
+
+  > http://localhost:13370
+
+A cross origin error happens when your application navigates to a new URL which does not match the origin policy above.
+
+A new URL does not match the origin policy if the 'protocol', 'port' (if specified), and/or 'host' (unless of the same superdomain) are different.
+
+Cypress does not allow you to navigate to a different origin URL within a single test.
+
+You may need to restructure some of your test code to avoid this problem.
+
+Alternatively you can also disable Chrome Web Security in Chromium-based browsers which will turn off this restriction by setting { chromeWebSecurity: false } in \`cypress.json\`.
+
+https://on.cypress.io/cross-origin-violation
+      [stack trace lines]
+
+
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        1                                                                                │
+  │ Passing:      0                                                                                │
+  │ Failing:      1                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  1                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     navigation_cross_origin_errors.ts                                                │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Screenshots)
+
+  -  /XXX/XXX/XXX/cypress/screenshots/navigation_cross_origin_errors.ts/navigation cr     (1280x720)
+     oss origin errors -- displays cross origin failures when experimentalMultiDomain               
+      is turned off (failed).png                                                                    
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/navigation_cross_origin_errors.     (X second)
+                          ts.mp4                                                                    
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✖  navigation_cross_origin_errors.ts        XX:XX        1        -        1        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✖  1 of 1 failed (100%)                     XX:XX        1        -        1        -        -  
+
+
+`

--- a/system-tests/projects/e2e/cypress/integration/navigation_cross_origin_errors.ts
+++ b/system-tests/projects/e2e/cypress/integration/navigation_cross_origin_errors.ts
@@ -1,0 +1,10 @@
+describe('navigation cross origin errors', () => {
+  it('displays cross origin failures when "experimentalMultiDomain" is turned off', function () {
+    // @ts-ignore
+    cy.visit('/jquery.html').window().then((win) => {
+      const constructedCrossOriginAnchor = win.$(`<a href='http://www.foobar.com:4466/cross_origin.html'>cross origin</a>`).appendTo(win.document.body)
+
+      constructedCrossOriginAnchor.get(0).click()
+    })
+  })
+})

--- a/system-tests/test/navigation_spec.ts
+++ b/system-tests/test/navigation_spec.ts
@@ -1,0 +1,51 @@
+import systemTests, { expect } from '../lib/system-tests'
+
+const PORT = 13370
+const onServer = function (app) {
+  app.get('/cross_origin.html', (req, res) => {
+    res.send('<html><h1>cross origin</h1></html>')
+  })
+}
+
+// FIXME: This partially solves https://github.com/cypress-io/cypress/issues/19632 but only when "experimentalMultiDomain" is false.
+// TODO: This will be further solved by https://github.com/cypress-io/cypress/issues/20428
+describe('e2e cross origin navigation', () => {
+  systemTests.setup({
+    servers: [{
+      port: 4466,
+      onServer,
+    }],
+    settings: {
+      hosts: {
+        '*.foobar.com': '127.0.0.1',
+      },
+    },
+  })
+
+  // FIXME: add test that supports this for firefox
+  systemTests.it('captures cross origin failures when "experimentalMultiDomain" config value is falsy', {
+    // keep the port the same to prevent issues with the snapshot
+    port: PORT,
+    spec: 'navigation_cross_origin_errors.ts',
+    browser: ['chrome', 'electron'],
+    snapshot: true,
+    expectedExitCode: 1,
+    config: {
+      experimentalMultiDomain: false,
+    },
+    async onRun (exec) {
+      const res = await exec()
+
+      expect(res.stdout).to.contain('Cypress detected a cross origin error happened on page load')
+      expect(res.stdout).to.contain('Before the page load, you were bound to the origin policy:')
+      expect(res.stdout).to.contain('A cross origin error happens when your application navigates to a new URL which does not match the origin policy above.')
+      expect(res.stdout).to.contain('A new URL does not match the origin policy if the \'protocol\', \'port\' (if specified), and/or \'host\' (unless of the same superdomain) are different.')
+      expect(res.stdout).to.contain('Cypress does not allow you to navigate to a different origin URL within a single test.')
+      expect(res.stdout).to.contain('You may need to restructure some of your test code to avoid this problem.')
+      expect(res.stdout).to.contain('Alternatively you can also disable Chrome Web Security in Chromium-based browsers which will turn off this restriction by setting { chromeWebSecurity: false } in `cypress.json`.')
+      expect(res.stdout).to.contain('https://on.cypress.io/cross-origin-violation')
+
+      expect(res.code).to.eq(1)
+    },
+  })
+})

--- a/system-tests/test/navigation_spec.ts
+++ b/system-tests/test/navigation_spec.ts
@@ -44,8 +44,6 @@ describe('e2e cross origin navigation', () => {
       expect(res.stdout).to.contain('You may need to restructure some of your test code to avoid this problem.')
       expect(res.stdout).to.contain('Alternatively you can also disable Chrome Web Security in Chromium-based browsers which will turn off this restriction by setting { chromeWebSecurity: false } in `cypress.json`.')
       expect(res.stdout).to.contain('https://on.cypress.io/cross-origin-violation')
-
-      expect(res.code).to.eq(1)
     },
   })
 })

--- a/system-tests/test/web_security_spec.js
+++ b/system-tests/test/web_security_spec.js
@@ -40,7 +40,7 @@ const onServer = function (app) {
 
   app.get('/cors', (req, res) => {
     res.send(`<script>
-      fetch('https://127.0.0.2:44665/cross_origin')
+      fetch('https://www.foo.com:44665/cross_origin')
       .then((res) => res.text())
       .then(text => {
         if (text.includes('cross origin')) document.write('success!')
@@ -83,6 +83,7 @@ describe('e2e web security', () => {
       },
       snapshot: true,
       browser: ['chrome', 'electron'],
+      expectedExitCode: 0,
     })
   })
 

--- a/system-tests/test/web_security_spec.js
+++ b/system-tests/test/web_security_spec.js
@@ -83,7 +83,6 @@ describe('e2e web security', () => {
       },
       snapshot: true,
       browser: ['chrome', 'electron'],
-      expectedExitCode: 0,
     })
   })
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #19882

### User facing changelog
n/a

### Additional details
To prevent current users from being impacted by the multi-domain work, `experimentalMultiDomain` config checks have been added in the proxy to prevent any injection/delaying issues for users when they upgrade cypress when multi-domain is released, but aren't actively using it. The goal here is to make sure cross origin behavior with cypress remains the same when multi-domain is not in use.

Most of the code changes are minimal, but tests needed to be updated/added. I added tests for the `SetInjectionLevel` middleware to help better understand what injections are needed in what cases, as well as to test current injection behavior with/without the presence of configuration options. 

While working on multi-domain, we skipped the `captures cross origin failures` test in `navigation_spec` as `fullMultiDomain` was being injected regardless of flag. Since the `experimentalMultiDomain` config option is now set to true for all driver tests, this test was migrated to a system test to test when this option is `false`. There are currently some issues replicating this behavior in firefox under system-test, and the test needs to be updated in the future once a suitable testing method is found.

#####  `navigation_spec` `captures cross origin failures` results on `develop`
![](https://user-images.githubusercontent.com/3980464/156433624-4d5c54db-a250-4bcd-91d7-9dba60257bbb.png)

#####  `navigation_spec` `captures cross origin failures`converted to system-test running headfully example (slightly different)
![](https://user-images.githubusercontent.com/3980464/156431858-b8bcc747-b276-48c3-91e9-0f72283af183.png)

While doing work on this issue, I noticed that there was a test in the `web_security_spec` system test that was passing but should be failing. I adjusted the code to yield the following and hopefully gives us something to fall back on for multi-domain.

![](https://user-images.githubusercontent.com/3980464/156420423-e8b70cfd-e559-4553-b014-12112076051a.png)

![](https://user-images.githubusercontent.com/3980464/156420437-0746d664-6960-4108-8a28-51c3cfc438df.png)

### How has the user experience changed?
N/A
### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
