### PR TITLE
fix: use multiple icons on Linux

### DIFF
--- a/packages/icons/__snapshots__/icons_spec.ts.js
+++ b/packages/icons/__snapshots__/icons_spec.ts.js
@@ -1,0 +1,88 @@
+exports['Cypress Icons has expected icon set data URLs 1'] = [
+  {
+    "width": 128,
+    "height": 128,
+    "dataURL": "replaced for snapshot"
+  },
+  {
+    "width": 128,
+    "height": 128,
+    "scaleFactor": 2,
+    "dataURL": "replaced for snapshot"
+  },
+  {
+    "width": 16,
+    "height": 16,
+    "dataURL": "replaced for snapshot"
+  },
+  {
+    "width": 16,
+    "height": 16,
+    "scaleFactor": 2,
+    "dataURL": "replaced for snapshot"
+  },
+  {
+    "width": 19,
+    "height": 19,
+    "dataURL": "replaced for snapshot"
+  },
+  {
+    "width": 24,
+    "height": 24,
+    "dataURL": "replaced for snapshot"
+  },
+  {
+    "width": 256,
+    "height": 256,
+    "dataURL": "replaced for snapshot"
+  },
+  {
+    "width": 256,
+    "height": 256,
+    "scaleFactor": 2,
+    "dataURL": "replaced for snapshot"
+  },
+  {
+    "width": 32,
+    "height": 32,
+    "dataURL": "replaced for snapshot"
+  },
+  {
+    "width": 32,
+    "height": 32,
+    "scaleFactor": 2,
+    "dataURL": "replaced for snapshot"
+  },
+  {
+    "width": 38,
+    "height": 38,
+    "dataURL": "replaced for snapshot"
+  },
+  {
+    "width": 48,
+    "height": 48,
+    "dataURL": "replaced for snapshot"
+  },
+  {
+    "width": 48,
+    "height": 48,
+    "scaleFactor": 2,
+    "dataURL": "replaced for snapshot"
+  },
+  {
+    "width": 512,
+    "height": 512,
+    "dataURL": "replaced for snapshot"
+  },
+  {
+    "width": 512,
+    "height": 512,
+    "scaleFactor": 2,
+    "dataURL": "replaced for snapshot"
+  },
+  {
+    "width": 64,
+    "height": 64,
+    "dataURL": "replaced for snapshot"
+  }
+]

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -7,15 +7,15 @@
   "scripts": {
     "build-prod": "yarn build",
     "build": "scripts/build.sh && ts-node ./src/ico.ts",
-    "test": "NODE_ENV=test mocha",
-    "test-watch": "NODE_ENV=test mocha --watch",
-    "release": "releaser"
+    "test-unit": "NODE_ENV=test mocha -r @packages/ts/register test/*.ts",
+    "test": "yarn test-unit"
   },
   "devDependencies": {
     "@types/mocha": "^8.0.3",
     "@types/to-ico": "^1.1.1",
     "chai": "^4.2.0",
     "mocha": "^8.1.3",
+    "snap-shot-it": "7.9.6",
     "to-ico": "^1.1.5"
   },
   "files": [

--- a/packages/icons/src/icons.ts
+++ b/packages/icons/src/icons.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import { promises as fs } from 'fs'
 
 const dist = [__dirname, '..', 'dist']
 
@@ -16,4 +17,27 @@ export const getPathToIcon = (filename: string) => {
 
 export const getPathToLogo = (filename: string) => {
   return distPath('logo', filename)
+}
+
+export async function getIconsAsDataURLs () {
+  const iconFilenames = await fs.readdir(getPathToIcon('.'))
+
+  const resultWithNulls = await Promise.all(iconFilenames.map(async iconFilename => {
+    const matches = /^icon_(?<width>[0-9]+)x(?<height>[0-9]+)(?<scaleFactorSlug>@[0-9]+x)?\.png$/.exec(iconFilename)
+
+    if (!matches) return null
+
+    const base64 = await fs.readFile(getPathToIcon(iconFilename), { encoding: 'base64' })
+    const { width, height, scaleFactorSlug } = matches.groups!
+
+    return {
+      width: Number(width),
+      height: Number(height),
+      scaleFactor: scaleFactorSlug ? Number(scaleFactorSlug.slice(1, -1)) : undefined,
+      dataURL: `data:image/png;base64,${base64}`
+    }
+  }))
+
+  return resultWithNulls
+  .filter(x => x) as Array<{ scaleFactor: number, width: number, height: number, dataURL: string }>
 }

--- a/packages/icons/test/icons_spec.ts
+++ b/packages/icons/test/icons_spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 import * as icons from '../src/icons'
+import snapshot from 'snap-shot-it'
 
 const cwd = process.cwd()
 
@@ -14,5 +15,14 @@ describe('Cypress Icons', function () {
 
   it('returns path to logo', function () {
     expect(icons.getPathToLogo('cypress-bw.png')).to.eq(`${cwd }/dist/logo/cypress-bw.png`)
+  })
+
+  it('has expected icon set data URLs', async () => {
+    const ret = await icons.getIconsAsDataURLs()
+    ret.forEach(val => {
+      expect(val.dataURL).to.match(/^data:image\/png;/).and.have.length.greaterThan(100)
+      val.dataURL = 'replaced for snapshot'
+    })
+    snapshot(ret)
   })
 })

--- a/packages/server/test/unit/modes/interactive_spec.js
+++ b/packages/server/test/unit/modes/interactive_spec.js
@@ -25,15 +25,15 @@ describe('gui/interactive', () => {
   })
 
   context('.getWindowArgs', () => {
-    it('quits app when onClose is called', () => {
+    it('quits app when onClose is called', async () => {
       electron.app.quit = sinon.stub()
-      interactiveMode.getWindowArgs({}).onClose()
+      (await interactiveMode.getWindowArgs({})).onClose()
 
       expect(electron.app.quit).to.be.called
     })
 
-    it('tracks state properties', () => {
-      const { trackState } = interactiveMode.getWindowArgs({})
+    it('tracks state properties', async () => {
+      const { trackState } = await interactiveMode.getWindowArgs({})
 
       const args = _.pick(trackState, 'width', 'height', 'x', 'y', 'devTools')
 
@@ -50,50 +50,50 @@ describe('gui/interactive', () => {
       // Choose preferred if you have no valid choice
       // Use the saved value if it's valid
       describe('when no dimension', () => {
-        it('renders with preferred width if no width saved', () => {
-          expect(interactiveMode.getWindowArgs({}).width).to.equal(1200)
+        it('renders with preferred width if no width saved', async () => {
+          expect(await interactiveMode.getWindowArgs({}).width).to.equal(1200)
         })
 
-        it('renders with preferred height if no height saved', () => {
-          expect(interactiveMode.getWindowArgs({}).height).to.equal(800)
+        it('renders with preferred height if no height saved', async () => {
+          expect(await interactiveMode.getWindowArgs({}).height).to.equal(800)
         })
       })
 
       describe('when saved dimension is too small', () => {
-        it('uses the preferred width', () => {
-          expect(interactiveMode.getWindowArgs({ appWidth: 1 }).width).to.equal(1200)
+        it('uses the preferred width', async () => {
+          expect((await interactiveMode.getWindowArgs({ appWidth: 1 })).width).to.equal(1200)
         })
 
         it('uses the preferred height', () => {
-          expect(interactiveMode.getWindowArgs({ appHeight: 1 }).height).to.equal(800)
+          expect((await interactiveMode.getWindowArgs({ appHeight: 1 })).height).to.equal(800)
         })
       })
 
       describe('when saved dimension is within min/max dimension', () => {
-        it('uses the saved width', () => {
-          expect(interactiveMode.getWindowArgs({ appWidth: 1500 }).width).to.equal(1500)
+        it('uses the saved width', async () => {
+          expect((await interactiveMode.getWindowArgs({ appWidth: 1500 })).width).to.equal(1500)
         })
 
-        it('uses the saved height', () => {
-          expect(interactiveMode.getWindowArgs({ appHeight: 1500 }).height).to.equal(1500)
+        it('uses the saved height', async () => {
+          expect((await interactiveMode.getWindowArgs({ appHeight: 1500 })).height).to.equal(1500)
         })
       })
     })
 
-    it('renders with saved x if it exists', () => {
-      expect(interactiveMode.getWindowArgs({ appX: 3 }).x).to.equal(3)
+    it('renders with saved x if it exists', async () => {
+      expect(await (interactiveMode.getWindowArgs({ appX: 3 })).x).to.equal(3)
     })
 
-    it('renders with no x if no x saved', () => {
-      expect(interactiveMode.getWindowArgs({}).x).to.be.undefined
+    it('renders with no x if no x saved', async () => {
+      expect(await (interactiveMode.getWindowArgs({})).x).to.be.undefined
     })
 
-    it('renders with saved y if it exists', () => {
-      expect(interactiveMode.getWindowArgs({ appY: 4 }).y).to.equal(4)
+    it('renders with saved y if it exists', async () => {
+      expect(await (interactiveMode.getWindowArgs({ appY: 4 })).y).to.equal(4)
     })
 
-    it('renders with no y if no y saved', () => {
-      expect(interactiveMode.getWindowArgs({}).y).to.be.undefined
+    it('renders with no y if no y saved', async () => {
+      expect(await (interactiveMode.getWindowArgs({})).y).to.be.undefined
     })
 
     describe('on window focus', () => {
@@ -101,20 +101,20 @@ describe('gui/interactive', () => {
         sinon.stub(menu, 'set')
       })
 
-      it('calls menu.set withInternalDevTools: true when in dev env', () => {
+      it('calls menu.set withInternalDevTools: true when in dev env', async () => {
         const env = process.env['CYPRESS_INTERNAL_ENV']
 
         process.env['CYPRESS_INTERNAL_ENV'] = 'development'
-        interactiveMode.getWindowArgs({}).onFocus()
+        await (interactiveMode.getWindowArgs({})).onFocus()
         expect(menu.set.lastCall.args[0].withInternalDevTools).to.be.true
         process.env['CYPRESS_INTERNAL_ENV'] = env
       })
 
-      it('calls menu.set withInternalDevTools: false when not in dev env', () => {
+      it('calls menu.set withInternalDevTools: false when not in dev env', async () => {
         const env = process.env['CYPRESS_INTERNAL_ENV']
 
         process.env['CYPRESS_INTERNAL_ENV'] = 'production'
-        interactiveMode.getWindowArgs({}).onFocus()
+        await (interactiveMode.getWindowArgs({})).onFocus()
         expect(menu.set.lastCall.args[0].withInternalDevTools).to.be.false
         process.env['CYPRESS_INTERNAL_ENV'] = env
       })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details

On Windows and Mac we already provide a multi-res icon set. On Linux we are just using the 128px one, which causes pixelization.

This is an attempt to use a multi-res nativeImage to get the same effect on Linux. 

But right now it seems that Electron is not choosing the most appropriate icon size.

We may be encountering this:

* https://github.com/electron/electron/issues/33044
* https://github.com/electron/electron/issues/468#issuecomment-48555401

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
