### PR TITLE
test: update screenshot system-tests flake so that it no longer compares images for uniqueness that represent the same state

### DIFF
--- a/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
+++ b/packages/driver/cypress/integration/commands/net_stubbing_spec.ts
@@ -11,6 +11,8 @@ const testFail = (cb, expectedDocsUrl = 'https://on.cypress.io/intercept') => {
   })
 }
 
+// Due to an issue with requests leaking between tests, we need to ensure that routes are unique from test to test
+// See https://github.com/cypress-io/cypress/issues/20397
 let routeCount = 0
 const uniqueRoute = (route) => {
   routeCount += 1

--- a/system-tests/test/screenshots_spec.js
+++ b/system-tests/test/screenshots_spec.js
@@ -95,8 +95,11 @@ describe('e2e screenshots', () => {
           fs.statAsync(screenshot9).get('size'),
         ])
         .then((sizes) => {
-          // make sure all of the values are unique
-          expect(sizes).to.deep.eq(_.uniq(sizes))
+          // make sure all of the values are unique. Ignore comparing 6 and 7 since they can sometimes be the same since the
+          // visual state of the reporter is the same in both cases
+          const sizesToCompare = [...sizes.slice(0, 5), ...sizes.slice(7, -1)]
+
+          expect(sizesToCompare).to.deep.eq(_.uniq(sizesToCompare))
         }).then(() => {
           return Promise.all([
             sizeOf(screenshot1),
@@ -106,6 +109,8 @@ describe('e2e screenshots', () => {
             sizeOf(screenshot5),
             sizeOf(screenshot6),
             sizeOf(screenshot7),
+            sizeOf(screenshot8),
+            sizeOf(screenshot9),
           ])
         }).then((dimensions = []) => {
           if (browser === 'electron') {

--- a/system-tests/test/screenshots_spec.js
+++ b/system-tests/test/screenshots_spec.js
@@ -90,16 +90,15 @@ describe('e2e screenshots', () => {
           fs.statAsync(screenshot4).get('size'),
           fs.statAsync(screenshot5).get('size'),
           fs.statAsync(screenshot6).get('size'),
-          fs.statAsync(screenshot7).get('size'),
+          // Ignore comparing 6 and 7 since they can sometimes be the same since we take the screenshot as close to the failure as possible and
+          // the test run error may not have displayed yet. Leaving this commented in case we want to change this behavior in the future
+          // fs.statAsync(screenshot7).get('size'),
           fs.statAsync(screenshot8).get('size'),
           fs.statAsync(screenshot9).get('size'),
         ])
         .then((sizes) => {
-          // make sure all of the values are unique. Ignore comparing 6 and 7 since they can sometimes be the same since the
-          // visual state of the reporter is the same in both cases
-          const sizesToCompare = [...sizes.slice(0, 5), ...sizes.slice(7, -1)]
-
-          expect(sizesToCompare).to.deep.eq(_.uniq(sizesToCompare))
+          // make sure all of the values are unique
+          expect(sizes).to.deep.eq(_.uniq(sizes))
         }).then(() => {
           return Promise.all([
             sizeOf(screenshot1),

--- a/system-tests/test/screenshots_spec.js
+++ b/system-tests/test/screenshots_spec.js
@@ -108,8 +108,6 @@ describe('e2e screenshots', () => {
             sizeOf(screenshot5),
             sizeOf(screenshot6),
             sizeOf(screenshot7),
-            sizeOf(screenshot8),
-            sizeOf(screenshot9),
           ])
         }).then((dimensions = []) => {
           if (browser === 'electron') {


### PR DESCRIPTION
### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This fixes a flake with screenshot system tests. Specifically, we are checking that image sizes are unique that are taken during the test (if the size is different, the image is likely different). Two images specifically will sporadically be identical images and this causes a flake. The two images in question are created by simulating an exception in both the beforeEach and afterEach hooks. Both exceptions will create an image and both will display the same state of the reporter since the images capture the state at the time of the exception and not when the exception itself is displayed. Before 10.0 we were still saved by the running timer for the overall test since it would keep track of the times out to the 100th of a second. In 10.0 that was switched to be to the nearest second so this happens much more frequently.

The fix for this is to ignore one of the potentially duplicated images when doing the uniqueness check.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
