### PR TITLE
feat: (multi-domain) adding support for cy.visit in multi-domain

### DIFF
--- a/packages/driver/cypress/integration/commands/navigation_spec.js
+++ b/packages/driver/cypress/integration/commands/navigation_spec.js
@@ -825,7 +825,7 @@ describe('src/cy/commands/navigation', () => {
         onLoad,
       })
       .then((win) => {
-        expect(win.bar).to.not.exist
+        expect(win.foo).to.equal('bar')
         expect(onLoad).not.to.have.been.called
       })
     })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
@@ -1,41 +1,10 @@
+import _ from 'lodash'
+
 // @ts-ignore / session support is needed for visiting about:blank between tests
 context('multi-domain misc', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
   beforeEach(() => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="dom-link"]').click()
-  })
-
-  it('verifies number of cy commands', () => {
-    // @ts-ignore
-    const actualCommands = Object.keys(cy.commandFns)
-    const expectedCommands = [
-      'check', 'uncheck', 'click', 'dblclick', 'rightclick', 'focus', 'blur', 'hover', 'scrollIntoView', 'scrollTo', 'select',
-      'selectFile', 'submit', 'type', 'clear', 'trigger', 'as', 'ng', 'should', 'and', 'clock', 'tick', 'spread', 'each', 'then',
-      'invoke', 'its', 'getCookie', 'getCookies', 'setCookie', 'clearCookie', 'clearCookies', 'pause', 'debug', 'exec', 'readFile',
-      'writeFile', 'fixture', 'clearLocalStorage', 'url', 'hash', 'location', 'end', 'noop', 'log', 'wrap', 'reload', 'go', 'visit',
-      'focused', 'get', 'contains', 'root', 'shadow', 'within', 'request', 'session', 'screenshot', 'task', 'find', 'filter', 'not',
-      'children', 'eq', 'closest', 'first', 'last', 'next', 'nextAll', 'nextUntil', 'parent', 'parents', 'parentsUntil', 'prev',
-      'prevAll', 'prevUntil', 'siblings', 'wait', 'title', 'window', 'document', 'viewport', 'server', 'route', 'intercept', 'switchToDomain',
-    ]
-    const addedCommands = Cypress._.difference(actualCommands, expectedCommands)
-    const removedCommands = Cypress._.difference(expectedCommands, actualCommands)
-
-    if (addedCommands.length && removedCommands.length) {
-      throw new Error(`Commands have been added to and removed from Cypress.
-
-        The following command(s) were added: ${addedCommands.join(', ')}
-        The following command(s) were removed: ${removedCommands.join(', ')}
-
-        Update this test accordingly.`)
-    }
-
-    if (addedCommands.length) {
-      throw new Error(`The following command(s) have been added to Cypress: ${addedCommands.join(', ')}. Please add the command(s) to this test.`)
-    }
-
-    if (removedCommands.length) {
-      throw new Error(`The following command(s) have been removed from Cypress: ${removedCommands.join(', ')}. Please remove the command(s) from this test.`)
-    }
   })
 
   it('.end()', () => {
@@ -103,4 +72,38 @@ context('multi-domain misc', { experimentalSessionSupport: true, experimentalMul
       cy.task('return:arg', 'works').should('eq', 'works')
     })
   })
+})
+
+it('verifies number of cy commands', () => {
+  // @ts-ignore
+  // remove 'getAll' command since it's a custom command we add for our own testing and not an actual cy command
+  const actualCommands = _.reject(Object.keys(cy.commandFns), (command) => command === 'getAll')
+  const expectedCommands = [
+    'check', 'uncheck', 'click', 'dblclick', 'rightclick', 'focus', 'blur', 'hover', 'scrollIntoView', 'scrollTo', 'select',
+    'selectFile', 'submit', 'type', 'clear', 'trigger', 'as', 'ng', 'should', 'and', 'clock', 'tick', 'spread', 'each', 'then',
+    'invoke', 'its', 'getCookie', 'getCookies', 'setCookie', 'clearCookie', 'clearCookies', 'pause', 'debug', 'exec', 'readFile',
+    'writeFile', 'fixture', 'clearLocalStorage', 'url', 'hash', 'location', 'end', 'noop', 'log', 'wrap', 'reload', 'go', 'visit',
+    'focused', 'get', 'contains', 'root', 'shadow', 'within', 'request', 'session', 'screenshot', 'task', 'find', 'filter', 'not',
+    'children', 'eq', 'closest', 'first', 'last', 'next', 'nextAll', 'nextUntil', 'parent', 'parents', 'parentsUntil', 'prev',
+    'prevAll', 'prevUntil', 'siblings', 'wait', 'title', 'window', 'document', 'viewport', 'server', 'route', 'intercept', 'switchToDomain',
+  ]
+  const addedCommands = Cypress._.difference(actualCommands, expectedCommands)
+  const removedCommands = Cypress._.difference(expectedCommands, actualCommands)
+
+  if (addedCommands.length && removedCommands.length) {
+    throw new Error(`Commands have been added to and removed from Cypress.
+
+      The following command(s) were added: ${addedCommands.join(', ')}
+      The following command(s) were removed: ${removedCommands.join(', ')}
+
+      Update this test accordingly.`)
+  }
+
+  if (addedCommands.length) {
+    throw new Error(`The following command(s) have been added to Cypress: ${addedCommands.join(', ')}. Please add tests for the command(s) in multi-domain and add the command(s) to this test.`)
+  }
+
+  if (removedCommands.length) {
+    throw new Error(`The following command(s) have been removed from Cypress: ${removedCommands.join(', ')}. Please remove the command(s) from this test.`)
+  }
 })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash'
-
 // @ts-ignore / session support is needed for visiting about:blank between tests
 context('multi-domain misc', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
   beforeEach(() => {
@@ -77,7 +75,7 @@ context('multi-domain misc', { experimentalSessionSupport: true, experimentalMul
 it('verifies number of cy commands', () => {
   // @ts-ignore
   // remove 'getAll' command since it's a custom command we add for our own testing and not an actual cy command
-  const actualCommands = _.reject(Object.keys(cy.commandFns), (command) => command === 'getAll')
+  const actualCommands = Cypress._.reject(Object.keys(cy.commandFns), (command) => command === 'getAll')
   const expectedCommands = [
     'check', 'uncheck', 'click', 'dblclick', 'rightclick', 'focus', 'blur', 'hover', 'scrollIntoView', 'scrollTo', 'select',
     'selectFile', 'submit', 'type', 'clear', 'trigger', 'as', 'ng', 'should', 'and', 'clock', 'tick', 'spread', 'each', 'then',

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_navigation.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_navigation.spec.ts
@@ -1,5 +1,5 @@
-// @ts-ignore / session support is needed for visiting about:blank between tests
-context('multi-domain navigation', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
+// @ts-ignore
+context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
   it('.go()', () => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_navigation.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_navigation.spec.ts
@@ -226,6 +226,39 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
         cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
       })
     })
+
+    // TODO: un-skip once multiple remote states are supported
+    it.skip('supports auth options and adding auth to subsequent requests', () => {
+      cy.switchToDomain('foobar.com', () => {
+        cy.visit('http://www.foobar.com:3500/basic_auth', {
+          auth: {
+            username: 'cypress',
+            password: 'password123',
+          },
+        })
+
+        cy.get('body').should('have.text', 'basic auth worked')
+
+        cy.window().then({ timeout: 60000 }, (win) => {
+          return new Cypress.Promise(((resolve, reject) => {
+            const xhr = new win.XMLHttpRequest()
+
+            xhr.open('GET', '/basic_auth')
+            xhr.onload = function () {
+              try {
+                expect(this.responseText).to.include('basic auth worked')
+
+                return resolve(win)
+              } catch (err) {
+                return reject(err)
+              }
+            }
+
+            return xhr.send()
+          }))
+        })
+      })
+    })
   })
 
   it('supports navigating through changing the window.location.href', () => {

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_navigation.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_navigation.spec.ts
@@ -227,6 +227,48 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
       })
     })
 
+    it('does not navigate to about:blank in secondary if already visited in primary', () => {
+      Cypress.state('hasVisitedAboutBlank', true)
+
+      cy.switchToDomain('foobar.com', () => {
+        const urlChangedSpy = cy.spy(Cypress, 'emit').log(false).withArgs('url:changed')
+        const aboutBlankSpy = cy.spy(Cypress.specBridgeCommunicator, 'toPrimary').log(false).withArgs('visit:about:blank')
+
+        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html').then(() => {
+          expect(urlChangedSpy).to.have.been.calledOnce
+          expect(urlChangedSpy.firstCall).to.be.calledWith(
+            'url:changed',
+            'http://www.foobar.com:3500/fixtures/multi-domain-secondary.html',
+          )
+
+          expect(aboutBlankSpy).to.not.have.been.called
+        })
+      })
+    })
+
+    it('navigates to about:blank in secondary if not already visited in primary', () => {
+      Cypress.state('hasVisitedAboutBlank', false)
+
+      cy.switchToDomain('foobar.com', () => {
+        const urlChangedSpy = cy.spy(Cypress, 'emit').log(false).withArgs('url:changed')
+        const aboutBlankSpy = cy.spy(Cypress.specBridgeCommunicator, 'toPrimary').log(false).withArgs('visit:about:blank')
+
+        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html').then(() => {
+          expect(urlChangedSpy).to.have.been.calledOnce
+          expect(urlChangedSpy.firstCall).to.be.calledWith(
+            'url:changed',
+            'http://www.foobar.com:3500/fixtures/multi-domain-secondary.html',
+          )
+
+          expect(aboutBlankSpy).to.have.been.calledOnce
+        })
+      })
+
+      cy.then(() => {
+        expect(Cypress.state('hasVisitedAboutBlank')).to.equal(true)
+      })
+    })
+
     // TODO: un-skip once multiple remote states are supported
     it.skip('supports auth options and adding auth to subsequent requests', () => {
       cy.switchToDomain('foobar.com', () => {

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_navigation.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_navigation.spec.ts
@@ -1,26 +1,24 @@
 // @ts-ignore / session support is needed for visiting about:blank between tests
 context('multi-domain navigation', { experimentalSessionSupport: true, experimentalMultiDomain: true }, () => {
-  beforeEach(() => {
+  it('.go()', () => {
     cy.visit('/fixtures/multi-domain.html')
-    cy.get('a[data-cy="dom-link"]').click()
-  })
+    cy.get('a[data-cy="multi-domain-secondary-link"]').click()
 
-  // FIXME: CypressError: Timed out after waiting `undefinedms` for your remote page to load.
-  // Your page did not fire its `load` event within`undefinedms`.
-  // You can try increasing the `pageLoadTimeout` value in `undefined` to wait longer.
-  // Browsers will not fire the `load` event until all stylesheets and scripts are done downloading.
-  // When this `load` event occurs, Cypress will continue running commands.
-  // at timedOutWaitingForPageLoad(webpack:///../driver/src/cy/commands/navigation.ts?:59:72)
-  // at eval (webpack:///../driver/src/cy/commands/navigation.ts?:1143:16)
-  it.skip('.go()', () => {
     cy.switchToDomain('foobar.com', () => {
-      cy.visit('/fixtures/generic.html')
+      cy.visit('http://www.foobar.com:3500/fixtures/dom.html')
+
       cy.go('back')
+      cy.location('pathname').should('include', 'multi-domain-secondary.html')
+
+      cy.go('forward')
       cy.location('pathname').should('include', 'dom.html')
     })
   })
 
   it('.reload()', () => {
+    cy.visit('/fixtures/multi-domain.html')
+    cy.get('a[data-cy="dom-link"]').click()
+
     cy.switchToDomain('foobar.com', () => {
       cy.get(':checkbox[name="colors"][value="blue"]').check().should('be.checked')
       cy.reload()
@@ -28,16 +26,218 @@ context('multi-domain navigation', { experimentalSessionSupport: true, experimen
     })
   })
 
-  // FIXME: CypressError: Timed out after waiting `undefinedms` for your remote page to load.
-  // Your page did not fire its `load` event within `undefinedms`.
-  // You can try increasing the `pageLoadTimeout` value in `undefined` to wait longer.
-  // Browsers will not fire the `load` event until all stylesheets and scripts are done downloading.
-  // When this `load` event occurs, Cypress will continue running commands.
-  // at timedOutWaitingForPageLoad (webpack:///../driver/src/cy/commands/navigation.ts?:59:72)
-  // at eval (webpack:///../driver/src/cy/commands/navigation.ts?:1143:16)
-  it.skip('.visit()', () => {
+  context('.visit()', () => {
+    it('calls the correct load handlers', () => {
+      const primaryCyBeforeLoadSpy = cy.spy()
+      const primaryCyLoadSpy = cy.spy()
+      const primaryVisitBeforeLoadSpy = cy.spy()
+      const primaryVisitLoadSpy = cy.spy()
+
+      cy.on('window:before:load', primaryCyBeforeLoadSpy)
+      cy.on('window:load', primaryCyLoadSpy)
+
+      cy.visit('/fixtures/multi-domain.html', {
+        onBeforeLoad: primaryVisitBeforeLoadSpy,
+        onLoad: primaryVisitLoadSpy,
+      }).then(() => {
+        expect(primaryCyBeforeLoadSpy).to.be.calledOnce
+        expect(primaryCyLoadSpy).to.be.calledTwice // twice because it's also called for 'about:blank'
+        expect(primaryVisitBeforeLoadSpy).to.be.calledOnce
+        expect(primaryVisitLoadSpy).to.be.calledOnce
+      })
+
+      cy.switchToDomain('foobar.com', () => {
+        const secondaryCyBeforeLoadSpy = cy.spy()
+        const secondaryCyLoadSpy = cy.spy()
+        const secondaryVisitBeforeLoadSpy = cy.spy()
+        const secondaryVisitLoadSpy = cy.spy()
+
+        cy.on('window:before:load', secondaryCyBeforeLoadSpy)
+        cy.on('window:load', secondaryCyLoadSpy)
+
+        cy.visit('http://www.foobar.com:3500/fixtures/dom.html', {
+          onBeforeLoad: secondaryVisitBeforeLoadSpy,
+          onLoad: secondaryVisitLoadSpy,
+        }).then(() => {
+          expect(secondaryCyBeforeLoadSpy).to.be.calledOnce
+          expect(secondaryCyLoadSpy).to.be.calledOnce
+          expect(secondaryVisitBeforeLoadSpy).to.be.calledOnce
+          expect(secondaryVisitLoadSpy).to.be.calledOnce
+        })
+      }).then(() => {
+        expect(primaryCyBeforeLoadSpy).to.be.calledOnce
+        expect(primaryCyLoadSpy).to.be.calledTwice
+        expect(primaryVisitBeforeLoadSpy).to.be.calledOnce
+        expect(primaryVisitLoadSpy).to.be.calledOnce
+      })
+    })
+
+    it('supports visiting primary first', () => {
+      cy.visit('/fixtures/multi-domain.html')
+
+      cy.switchToDomain('foobar.com', () => {
+        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
+
+        cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
+      })
+    })
+
+    it('supports skipping visiting primary first', () => {
+      cy.switchToDomain('foobar.com', () => {
+        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
+
+        cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
+      })
+    })
+
+    // TODO: we don't support nested domains yet...
+    it.skip('supports nesting a third domain', () => {
+      cy.visit('/fixtures/multi-domain.html')
+
+      cy.switchToDomain('foobar.com', () => {
+        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
+
+        cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
+
+        cy.switchToDomain('idp.com', () => {
+          cy.visit('http://www.idp.com:3500/fixtures/dom.html')
+        })
+      })
+    })
+
+    it('supports navigating to secondary through button and then visiting', () => {
+      cy.visit('/fixtures/multi-domain.html')
+
+      cy.get('a[data-cy="multi-domain-secondary-link"]').click()
+
+      cy.switchToDomain('foobar.com', () => {
+        cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
+
+        cy.visit('http://www.foobar.com:3500/fixtures/dom.html')
+      })
+    })
+
+    // TODO: add support for relative links within secondary
+    it.skip('supports relative urls within secondary', () => {
+      cy.visit('/fixtures/multi-domain.html')
+
+      cy.get('a[data-cy="multi-domain-secondary-link"]').click()
+
+      cy.switchToDomain('foobar.com', () => {
+        cy.visit('/fixtures/dom.html')
+      })
+    })
+
+    it('supports hash change within secondary', () => {
+      cy.visit('/fixtures/multi-domain.html')
+
+      cy.get('a[data-cy="multi-domain-secondary-link"]').click()
+
+      cy.switchToDomain('foobar.com', () => {
+        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html#hashchange')
+
+        cy.location('hash').should('equal', '#hashchange')
+      })
+    })
+
+    it('navigates back to primary', () => {
+      cy.switchToDomain('foobar.com', () => {
+        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
+        cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
+      })
+
+      cy.visit('/fixtures/multi-domain.html')
+
+      cy.get('a[data-cy="multi-domain-secondary-link"]').should('have.text', 'http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
+      cy.location('href').should('equal', 'http://localhost:3500/fixtures/multi-domain.html')
+    })
+
+    it('errors when visiting a new domain within switchToDomain', (done) => {
+      cy.on('fail', (e) => {
+        expect(e.message).to.include('failed trying to load:\n\nhttp://www.idp.com:3500/fixtures/dom.html')
+        expect(e.message).to.include('failed because you are attempting to visit a URL that is of a different origin')
+
+        done()
+      })
+
+      cy.visit('/fixtures/multi-domain.html')
+      cy.get('a[data-cy="multi-domain-secondary-link"]').click()
+
+      cy.switchToDomain('foobar.com', () => {
+        // this call should error since we can't visit a cross-domain
+        cy.visit('http://www.idp.com:3500/fixtures/dom.html')
+      })
+    })
+
+    it('supports the query string option', () => {
+      cy.visit('/fixtures/multi-domain.html')
+
+      cy.switchToDomain('foobar.com', () => {
+        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html', { qs: { foo: 'bar' } })
+
+        cy.location('search').should('equal', '?foo=bar')
+      })
+    })
+
+    it('can send a POST request', () => {
+      cy.switchToDomain('foobar.com', () => {
+        cy.visit('http://www.foobar.com:3500/post-only', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
+            bar: 'baz',
+          }),
+        })
+
+        cy.contains('it worked!').contains('{"bar":"baz"}')
+      })
+    })
+
+    it('succeeds when the AUT window in the secondary is undefined', () => {
+      // manually remove the spec bridge iframe to ensure Cypress.state('window') is not already set
+      window.top?.document.getElementById('Spec\ Bridge:\ foobar.com')?.remove()
+
+      cy.visit('/fixtures/multi-domain.html')
+
+      cy.switchToDomain('foobar.com', () => {
+        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
+
+        cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
+      })
+    })
+
+    it('succeeds when the secondary is already defined but the AUT is still on the primary', () => {
+      // setup the secondary to be on the secondary domain
+      cy.switchToDomain('foobar.com', () => {
+        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
+
+        cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
+      })
+
+      // update the AUT to be on the primary domain
+      cy.visit('/fixtures/multi-domain.html')
+
+      // verify there aren't any issues when the AUT is on primary but the spec bridge is on secondary (cross-origin)
+      cy.switchToDomain('foobar.com', () => {
+        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
+
+        cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
+      })
+    })
+  })
+
+  it('supports navigating through changing the window.location.href', () => {
+    cy.visit('/fixtures/multi-domain.html')
+    cy.get('a[data-cy="multi-domain-secondary-link"]').click()
+
     cy.switchToDomain('foobar.com', () => {
-      cy.visit('/fixtures/generic.html')
+      cy.window().then((win) => {
+        win.location.href = 'http://www.foobar.com:3500/fixtures/dom.html'
+      })
+
+      cy.location('pathname').should('equal', '/fixtures/dom.html')
     })
   })
 })

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_cypress_api.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_cypress_api.spec.ts
@@ -5,44 +5,36 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true, experim
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()
   })
 
-  // FIXME: Commands adding/overwriting should be condensed into one test with two switchToDomain tests
-  // once multiple switchToDomain calls are supported
   context('Commands', () => {
-    context('add', () => {
-      it('adds a custom command', () => {
-        cy.switchToDomain('foobar.com', () => {
-          // @ts-ignore
-          Cypress.Commands.add('foo', () => 'bar')
+    it('adds a custom command', () => {
+      cy.switchToDomain('foobar.com', () => {
+        // @ts-ignore
+        Cypress.Commands.add('foo', () => 'bar')
 
-          // @ts-ignore
-          cy.foo().should('equal', 'bar')
-        })
+        // @ts-ignore
+        cy.foo().should('equal', 'bar')
       })
 
-      it('persists defined commands through spec bridge', () => {
-        cy.switchToDomain('foobar.com', () => {
-          // @ts-ignore
-          cy.foo().should('equal', 'bar')
-        })
+      // persists added command through spec bridge
+      cy.switchToDomain('foobar.com', () => {
+        // @ts-ignore
+        cy.foo().should('equal', 'bar')
       })
     })
 
-    context('overwrite', () => {
-      it('overwrites an existing command in the spec bridge', () => {
-        cy.switchToDomain('foobar.com', () => {
-          // @ts-ignore
-          Cypress.Commands.overwrite('foo', () => 'baz')
+    it('overwrites an existing command in the spec bridge', () => {
+      cy.switchToDomain('foobar.com', () => {
+        // @ts-ignore
+        Cypress.Commands.overwrite('foo', () => 'baz')
 
-          // @ts-ignore
-          cy.foo().should('equal', 'baz')
-        })
+        // @ts-ignore
+        cy.foo().should('equal', 'baz')
       })
 
-      it('persists overwritten command through spec bridge', () => {
-        cy.switchToDomain('foobar.com', () => {
-          // @ts-ignore
-          cy.foo().should('equal', 'baz')
-        })
+      // persists overwritten command through spec bridge
+      cy.switchToDomain('foobar.com', () => {
+        // @ts-ignore
+        cy.foo().should('equal', 'baz')
       })
     })
   })
@@ -60,8 +52,6 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true, experim
       })
     })
 
-    // FIXME: Commands adding/overwriting should be condensed into one test with two switchToDomain tests
-    // once multiple switchToDomain calls are supported
     it('allows a user to configure defaults', () => {
       cy.switchToDomain('foobar.com', () => {
         const multiDomainKeyboardDefaults = Cypress.Keyboard.defaults({
@@ -72,9 +62,8 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true, experim
           keystrokeDelay: 60,
         })
       })
-    })
 
-    it('persists default configuration changes through spec bridge', () => {
+      // persists default configuration changes through spec bridge
       cy.switchToDomain('foobar.com', () => {
         const multiDomainKeyboardDefaults = Cypress.Keyboard.defaults({})
 
@@ -106,8 +95,6 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true, experim
       })
     })
 
-    // FIXME: Commands adding/overwriting should be condensed into one test with two switchToDomain tests
-    // once multiple switchToDomain calls are supported
     it('allows a user to configure defaults', () => {
       cy.switchToDomain('foobar.com', () => {
         const multiDomainScreenshotDefaults = Cypress.Screenshot.defaults({
@@ -120,9 +107,8 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true, experim
           overwrite: true,
         })
       })
-    })
 
-    it('persists default configuration changes through spec bridge', () => {
+      // persists default configuration changes through spec bridge
       cy.switchToDomain('foobar.com', () => {
         const multiDomainScreenshotDefaults = Cypress.Screenshot.defaults({})
 

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_events_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_events_spec.ts
@@ -21,11 +21,10 @@ describe('multi-domain', { experimentalSessionSupport: true, experimentalMultiDo
       .should('equal', 'Window Before Load Called')
     })
 
-    // TODO enable once we can re-visit the primary domain.
-    // cy.visit('/fixtures/multi-domain.html')
+    cy.visit('/fixtures/multi-domain.html')
 
-    // cy.window().its('testPrimaryDomainBeforeLoad').should('be.true')
-    // cy.window().its('testSecondaryWindowBeforeLoad').should('be.undefined')
+    cy.window().its('testPrimaryDomainBeforeLoad').should('be.true')
+    cy.window().its('testSecondaryWindowBeforeLoad').should('be.undefined')
   })
 
   describe('post window load events', () => {
@@ -54,14 +53,13 @@ describe('multi-domain', { experimentalSessionSupport: true, experimentalMultiDo
       cy.switchToDomain('foobar.com', () => {
         const afterWindowBeforeUnload = new Promise<void>((resolve) => {
           Cypress.once('window:before:unload', () => {
-            expect(location.host).to.equal('foobar.com')
+            expect(location.host).to.equal('foobar.com:3500')
             resolve()
           })
         })
 
-        cy.window().then((window) => {
-          window.location.href = '/fixtures/multi-domain.html'
-        })
+        // TODO: update to use relative path once available
+        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain.html')
 
         cy.wrap(afterWindowBeforeUnload)
       })
@@ -71,14 +69,13 @@ describe('multi-domain', { experimentalSessionSupport: true, experimentalMultiDo
       cy.switchToDomain('foobar.com', () => {
         const afterWindowUnload = new Promise<void>((resolve) => {
           Cypress.once('window:unload', () => {
-            expect(location.host).to.equal('foobar.com')
+            expect(location.host).to.equal('foobar.com:3500')
             resolve()
           })
         })
 
-        cy.window().then((window) => {
-          window.location.href = '/fixtures/multi-domain.html'
-        })
+        // TODO: update to use relative path once available
+        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain.html')
 
         cy.wrap(afterWindowUnload)
       })
@@ -88,7 +85,7 @@ describe('multi-domain', { experimentalSessionSupport: true, experimentalMultiDo
       cy.switchToDomain('foobar.com', () => {
         const afterWindowAlert = new Promise<void>((resolve) => {
           Cypress.once('window:alert', (text) => {
-            expect(location.host).to.equal('foobar.com')
+            expect(location.host).to.equal('foobar.com:3500')
             expect(`window:alert ${text}`).to.equal('window:alert the alert text')
             resolve()
           })
@@ -103,7 +100,7 @@ describe('multi-domain', { experimentalSessionSupport: true, experimentalMultiDo
       cy.switchToDomain('foobar.com', () => {
         const afterWindowConfirm = new Promise<void>((resolve) => {
           Cypress.once('window:confirm', (text) => {
-            expect(location.host).to.equal('foobar.com')
+            expect(location.host).to.equal('foobar.com:3500')
             expect(`window:confirm ${text}`).to.equal('window:confirm the confirm text')
             resolve()
           })
@@ -118,7 +115,7 @@ describe('multi-domain', { experimentalSessionSupport: true, experimentalMultiDo
       cy.switchToDomain('foobar.com', () => {
         const afterWindowConfirmed = new Promise<void>((resolve) => {
           Cypress.once('window:confirmed', (text, returnedFalse) => {
-            expect(location.host).to.equal('foobar.com')
+            expect(location.host).to.equal('foobar.com:3500')
             expect(`window:confirmed ${text} - ${returnedFalse}`).to.equal('window:confirmed the confirm text - true')
             resolve()
           })
@@ -138,7 +135,7 @@ describe('multi-domain', { experimentalSessionSupport: true, experimentalMultiDo
       cy.switchToDomain('foobar.com', () => {
         const afterWindowConfirmed = new Promise<void>((resolve) => {
           Cypress.once('window:confirmed', (text, returnedFalse) => {
-            expect(location.host).to.equal('foobar.com')
+            expect(location.host).to.equal('foobar.com:3500')
             expect(`window:confirmed ${text} - ${returnedFalse}`).to.equal('window:confirmed the confirm text - false')
             resolve()
           })

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
@@ -6,7 +6,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
   })
 
   describe('sync errors', () => {
-    it('fails the current test/command if sync errors are thrown from the switchToDomain callback', () => {
+    it('fails the current test/command if sync errors are thrown from the switchToDomain callback', (done) => {
       const uncaughtExceptionSpy = cy.spy()
       const r = cy.state('runnable')
 
@@ -25,6 +25,8 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
         // lastly, make sure the `uncaught:exception' handler is NOT called in the primary
         expect(uncaughtExceptionSpy).not.to.be.called
         expect(runnable).to.be.equal(r)
+
+        done()
       })
 
       cy.switchToDomain('foobar.com', () => {
@@ -49,7 +51,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
       })
     })
 
-    it('returns true from cy.on(uncaught:exception), resulting in cy:fail to be called in the primary', () => {
+    it('returns true from cy.on(uncaught:exception), resulting in cy:fail to be called in the primary', (done) => {
       cy.on('fail', (err) => {
         expect(err.name).to.eq('Error')
         expect(err.message).to.include('sync error')
@@ -57,6 +59,8 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
         expect(err.message).to.not.include('https://on.cypress.io/uncaught-exception-from-application')
         // @ts-ignore
         expect(err.docsUrl).to.deep.eq(['https://on.cypress.io/uncaught-exception-from-application'])
+
+        done()
       })
 
       cy.switchToDomain('foobar.com', () => {
@@ -99,7 +103,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
       })
     })
 
-    it('fails the current test/command if async errors are thrown from the secondary domain AUT', () => {
+    it('fails the current test/command if async errors are thrown from the secondary domain AUT', (done) => {
       const uncaughtExceptionSpy = cy.spy()
       const r = cy.state('runnable')
 
@@ -115,6 +119,8 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true, e
 
         expect(uncaughtExceptionSpy).not.to.be.called
         expect(runnable).to.be.equal(r)
+
+        done()
       })
 
       cy.switchToDomain('foobar.com', () => {

--- a/packages/driver/src/cy/commands/navigation.ts
+++ b/packages/driver/src/cy/commands/navigation.ts
@@ -445,7 +445,10 @@ const normalizeOptions = (options) => {
   return _
   .chain(options)
   .pick(REQUEST_URL_OPTS)
-  .extend({ timeout: options.responseTimeout, isMultiDomain: !!Cypress.state('isMultiDomain') })
+  .extend({
+    timeout: options.responseTimeout,
+    isMultiDomain: !!Cypress.state('isMultiDomain'),
+  })
   .value()
 }
 
@@ -543,7 +546,7 @@ export default (Commands, Cypress, cy, state, config) => {
     } catch (e) {} // eslint-disable-line no-empty
   })
 
-  Cypress.multiDomainCommunicator.on('visit:url', ({ url }, _domain) => {
+  Cypress.multiDomainCommunicator.on('visit:url', ({ url }) => {
     $utils.iframeSrc(Cypress.$autIframe, url)
   })
 

--- a/packages/driver/src/cy/multi-domain/index.ts
+++ b/packages/driver/src/cy/multi-domain/index.ts
@@ -162,6 +162,7 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
                 },
                 config: preprocessConfig(Cypress.config()),
                 env: preprocessEnv(Cypress.env()),
+                isStable: state('isStable'),
               })
             } catch (err: any) {
               const wrappedErr = $errUtils.errByPath('switchToDomain.run_domain_fn_errored', {

--- a/packages/driver/src/cy/multi-domain/index.ts
+++ b/packages/driver/src/cy/multi-domain/index.ts
@@ -99,9 +99,10 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
           _resolve({ subject, unserializableSubjectType })
         }
 
-        communicator.once('sync:config', ({ config, env }) => {
+        communicator.once('sync:globals', ({ config, env, state }) => {
           syncConfigToCurrentDomain(config)
           syncEnvToCurrentDomain(env)
+          Cypress.state(state)
         })
 
         communicator.once('ran:domain:fn', (details) => {
@@ -159,6 +160,7 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
                   runnable: serializeRunnable(Cypress.state('runnable')),
                   duringUserTestExecution: Cypress.state('duringUserTestExecution'),
                   hookId: state('hookId'),
+                  hasVisitedAboutBlank: state('hasVisitedAboutBlank'),
                 },
                 config: preprocessConfig(Cypress.config()),
                 env: preprocessEnv(Cypress.env()),

--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -39,7 +39,7 @@ import ProxyLogging from './cypress/proxy-logging'
 import * as $Events from './cypress/events'
 import $Keyboard from './cy/keyboard'
 import * as resolvers from './cypress/resolvers'
-import { PrimaryDomainCommunicator } from './multi-domain/communicator'
+import { PrimaryDomainCommunicator, SpecBridgeDomainCommunicator } from './multi-domain/communicator'
 
 const debug = debugFn('cypress:driver:cypress')
 
@@ -68,6 +68,7 @@ class $Cypress {
     this.$autIframe = null
     this.onSpecReady = null
     this.multiDomainCommunicator = new PrimaryDomainCommunicator()
+    this.specBridgeCommunicator = new SpecBridgeDomainCommunicator()
 
     this.events = $Events.extend(this)
     this.$ = jqueryProxyFn.bind(this)

--- a/packages/driver/src/multi-domain/communicator.ts
+++ b/packages/driver/src/multi-domain/communicator.ts
@@ -166,10 +166,13 @@ export class SpecBridgeDomainCommunicator extends EventEmitter {
     }
   }
 
-  private syncConfigEnvToPrimary = () => {
-    this.toPrimary('sync:config', {
+  private syncGlobalsToPrimary = () => {
+    this.toPrimary('sync:globals', {
       config: preprocessConfig(Cypress.config()),
       env: preprocessEnv(Cypress.env()),
+      state: {
+        hasVisitedAboutBlank: Cypress.state('hasVisitedAboutBlank'),
+      },
     })
   }
 
@@ -195,9 +198,9 @@ export class SpecBridgeDomainCommunicator extends EventEmitter {
    * @param {string} event - the name of the event to be sent.
    * @param {any} data - any meta data to be sent with the event.
    */
-  toPrimary (event: string, data?: any, options = { syncConfig: false }) {
+  toPrimary (event: string, data?: any, options = { syncGlobals: false }) {
     debug('<= to Primary ', event, data, window.specBridgeDomain)
-    if (options.syncConfig) this.syncConfigEnvToPrimary()
+    if (options.syncGlobals) this.syncGlobalsToPrimary()
 
     this.handleSubjectAndErr(data, (data: any) => {
       this.windowReference.top.postMessage({

--- a/packages/driver/src/multi-domain/cypress.ts
+++ b/packages/driver/src/multi-domain/cypress.ts
@@ -43,6 +43,8 @@ const setup = (cypressConfig: Cypress.Config, env: Cypress.ObjectLike) => {
     testingType: 'e2e',
   }) as Cypress.Cypress
 
+  Cypress.specBridgeCommunicator.initialize(window)
+
   // @ts-ignore
   const cy = window.cy = new $Cy(window, Cypress, Cypress.Cookies, Cypress.state, Cypress.config, false)
 

--- a/packages/driver/src/multi-domain/domain_fn.ts
+++ b/packages/driver/src/multi-domain/domain_fn.ts
@@ -151,7 +151,7 @@ export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeComm
       }
     } catch (err) {
       setRunnableStateToPassed()
-      specBridgeCommunicator.toPrimary('ran:domain:fn', { err }, { syncConfig: true })
+      specBridgeCommunicator.toPrimary('ran:domain:fn', { err }, { syncGlobals: true })
 
       return
     }

--- a/packages/driver/src/multi-domain/domain_fn.ts
+++ b/packages/driver/src/multi-domain/domain_fn.ts
@@ -11,6 +11,7 @@ interface RunDomainFnOptions {
   fn: string
   skipConfigValidation: boolean
   state: {}
+  isStable: boolean
 }
 
 export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeCommunicator: SpecBridgeDomainCommunicator) => {
@@ -39,17 +40,18 @@ export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeComm
     // Set the state ctx to the runnable ctx to ensure they remain in sync
     cy.state('ctx', cy.state('runnable').ctx)
 
-    // Stability is always false when we start as the page will always be
-    // loading at this point
-    cy.isStable(false, 'multi-domain-start')
+    cy.state('isMultiDomain', true)
   }
 
   specBridgeCommunicator.on('run:domain:fn', async (options: RunDomainFnOptions) => {
-    const { config, data, env, fn, state, skipConfigValidation } = options
+    const { config, data, env, fn, state, skipConfigValidation, isStable } = options
 
     let queueFinished = false
 
     reset(state)
+
+    // Stability is sync'd with the primary stability
+    cy.isStable(isStable, 'multi:domain:fn')
 
     // @ts-ignore
     window.__cySkipValidateConfig = skipConfigValidation || false

--- a/packages/driver/src/multi-domain/domain_fn.ts
+++ b/packages/driver/src/multi-domain/domain_fn.ts
@@ -70,7 +70,7 @@ export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeComm
       }
 
       cy.stop()
-      specBridgeCommunicator.toPrimary('queue:finished', { err }, { syncConfig: true })
+      specBridgeCommunicator.toPrimary('queue:finished', { err }, { syncGlobals: true })
     })
 
     try {
@@ -94,10 +94,10 @@ export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeComm
           subject,
           finished: !hasCommands,
         }, {
-          // Only sync the config if there are no commands in queue
+          // Only sync the globals if there are no commands in queue
           // (for instance, only assertions exist in the callback)
           // since it means the callback is finished at this point
-          syncConfig: !hasCommands,
+          syncGlobals: !hasCommands,
         })
 
         if (!hasCommands) {
@@ -107,7 +107,7 @@ export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeComm
         }
       }
     } catch (err) {
-      specBridgeCommunicator.toPrimary('ran:domain:fn', { err }, { syncConfig: true })
+      specBridgeCommunicator.toPrimary('ran:domain:fn', { err }, { syncGlobals: true })
 
       return
     }
@@ -118,7 +118,7 @@ export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeComm
       specBridgeCommunicator.toPrimary('queue:finished', {
         subject: cy.state('subject'),
       }, {
-        syncConfig: true,
+        syncGlobals: true,
       })
     })
   })

--- a/packages/driver/src/multi-domain/events/misc.ts
+++ b/packages/driver/src/multi-domain/events/misc.ts
@@ -11,7 +11,10 @@ export const handleMiscEvents = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeCo
   })
 
   specBridgeCommunicator.on('viewport:changed:end', () => {
-    if (viewportChangedCallbackFn) viewportChangedCallbackFn()
+    if (viewportChangedCallbackFn) {
+      viewportChangedCallbackFn()
+      viewportChangedCallbackFn = null
+    }
   })
 
   // TODO: Should state syncing be built into cy.state instead of being explicitly called?
@@ -29,5 +32,9 @@ export const handleMiscEvents = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeCo
   // @ts-ignore
   Cypress.on('url:changed', (url) => {
     specBridgeCommunicator.toPrimary('url:changed', url)
+  })
+
+  Cypress.on('multi:domain:visit:url', (args) => {
+    specBridgeCommunicator.toPrimary('visit:url', args)
   })
 }

--- a/packages/driver/src/multi-domain/events/misc.ts
+++ b/packages/driver/src/multi-domain/events/misc.ts
@@ -1,20 +1,13 @@
 import type { $Cy } from '../../cypress/cy'
 import type { SpecBridgeDomainCommunicator } from '../communicator'
 
-let viewportChangedCallbackFn
-
 export const handleMiscEvents = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeCommunicator: SpecBridgeDomainCommunicator) => {
-  Cypress.on('viewport:changed', (viewport, fn) => {
-    viewportChangedCallbackFn = fn
+  Cypress.on('viewport:changed', (viewport, callbackFn) => {
+    specBridgeCommunicator.once('viewport:changed:end', () => {
+      callbackFn()
+    })
 
     specBridgeCommunicator.toPrimary('viewport:changed', viewport)
-  })
-
-  specBridgeCommunicator.on('viewport:changed:end', () => {
-    if (viewportChangedCallbackFn) {
-      viewportChangedCallbackFn()
-      viewportChangedCallbackFn = null
-    }
   })
 
   // TODO: Should state syncing be built into cy.state instead of being explicitly called?
@@ -32,9 +25,5 @@ export const handleMiscEvents = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeCo
   // @ts-ignore
   Cypress.on('url:changed', (url) => {
     specBridgeCommunicator.toPrimary('url:changed', url)
-  })
-
-  Cypress.on('multi:domain:visit:url', (args) => {
-    specBridgeCommunicator.toPrimary('visit:url', args)
   })
 }

--- a/packages/driver/src/multi-domain/events/screenshots.ts
+++ b/packages/driver/src/multi-domain/events/screenshots.ts
@@ -10,7 +10,10 @@ export const handleScreenshots = (Cypress: Cypress.Cypress, specBridgeCommunicat
   })
 
   specBridgeCommunicator.on('before:screenshot:end', () => {
-    if (beforeScreenshotCallback) beforeScreenshotCallback()
+    if (beforeScreenshotCallback) {
+      beforeScreenshotCallback()
+      beforeScreenshotCallback = null
+    }
   })
 
   Cypress.on('after:screenshot', (config) => {

--- a/packages/driver/src/multi-domain/events/screenshots.ts
+++ b/packages/driver/src/multi-domain/events/screenshots.ts
@@ -1,19 +1,12 @@
 import type { SpecBridgeDomainCommunicator } from '../communicator'
 
 export const handleScreenshots = (Cypress: Cypress.Cypress, specBridgeCommunicator: SpecBridgeDomainCommunicator) => {
-  let beforeScreenshotCallback
-
-  Cypress.on('before:screenshot', (config, cb) => {
-    beforeScreenshotCallback = cb
+  Cypress.on('before:screenshot', (config, callbackFn) => {
+    specBridgeCommunicator.once('before:screenshot:end', () => {
+      callbackFn()
+    })
 
     specBridgeCommunicator.toPrimary('before:screenshot', config)
-  })
-
-  specBridgeCommunicator.on('before:screenshot:end', () => {
-    if (beforeScreenshotCallback) {
-      beforeScreenshotCallback()
-      beforeScreenshotCallback = null
-    }
   })
 
   Cypress.on('after:screenshot', (config) => {

--- a/packages/driver/types/internal-types.d.ts
+++ b/packages/driver/types/internal-types.d.ts
@@ -17,7 +17,6 @@ declare namespace Cypress {
     (action: 'viewport:changed', fn?: (viewport: { viewportWidth: string, viewportHeight: string }, callback: () => void) => void)
     (action: 'before:screenshot', fn: (config: {}, fn: () => void) => void)
     (action: 'after:screenshot', config: {})
-    (action: 'multi:domain:visit:url', fn: ({ url: string }) => void)
   }
 
   interface cy {
@@ -52,6 +51,7 @@ declare namespace Cypress {
     events: Events
     emit: ((event: string, payload?: any) => void)
     multiDomainCommunicator: import('../src/multi-domain/communicator').PrimaryDomainCommunicator
+    specBridgeCommunicator: import('../src/multi-domain/communicator').SpecBridgeDomainCommunicator
   }
 
   interface CypressUtils {

--- a/packages/driver/types/internal-types.d.ts
+++ b/packages/driver/types/internal-types.d.ts
@@ -17,6 +17,7 @@ declare namespace Cypress {
     (action: 'viewport:changed', fn?: (viewport: { viewportWidth: string, viewportHeight: string }, callback: () => void) => void)
     (action: 'before:screenshot', fn: (config: {}, fn: () => void) => void)
     (action: 'after:screenshot', config: {})
+    (action: 'multi:domain:visit:url', fn: ({ url: string }) => void)
   }
 
   interface cy {

--- a/packages/proxy/lib/http/request-middleware.ts
+++ b/packages/proxy/lib/http/request-middleware.ts
@@ -81,7 +81,7 @@ const MaybeEndRequestWithBufferedResponse: RequestMiddleware = function () {
 
   if (buffer) {
     this.debug('ending request with buffered response')
-    this.res.wantsInjection = 'full'
+    this.res.wantsInjection = buffer.isMultiDomain ? 'fullMultiDomain' : 'full'
 
     return this.onResponse(buffer.response, buffer.stream)
   }

--- a/packages/proxy/lib/http/util/buffers.ts
+++ b/packages/proxy/lib/http/util/buffers.ts
@@ -12,6 +12,7 @@ export type HttpBuffer = {
   response: IncomingMessage
   stream: Readable
   url: string
+  isMultiDomain: boolean
 }
 
 const stripPort = (url) => {

--- a/packages/proxy/test/unit/http/helpers.ts
+++ b/packages/proxy/test/unit/http/helpers.ts
@@ -2,6 +2,7 @@ import { HttpMiddleware, _runStage } from '../../../lib/http'
 
 export function testMiddleware (middleware: HttpMiddleware<any>[], ctx = {}) {
   const fullCtx = {
+    debug: () => {},
     req: {},
     res: {},
     config: {},

--- a/packages/runner/src/iframe/iframes.jsx
+++ b/packages/runner/src/iframe/iframes.jsx
@@ -186,7 +186,8 @@ export default class Iframes extends Component {
       // container since it needs to match the size of the top window for screenshots
       $container: $(document.body),
       className: 'spec-bridge-iframe',
-      src: `//${domain}/${this.props.config.namespace}/multi-domain-iframes/${encodeURIComponent(domain)}`,
+      // TODO: Update this to the correct origin once we decide on string vs object
+      src: `//${domain}:3500/${this.props.config.namespace}/multi-domain-iframes/${encodeURIComponent(domain)}`,
     })
   }
 

--- a/packages/server/lib/server-e2e.ts
+++ b/packages/server/lib/server-e2e.ts
@@ -307,8 +307,6 @@ export class ServerE2E extends ServerBase<SocketE2E> {
                   // handling a local file and we aren't in multi-domain
                   if (!handlingLocalFile && !options.isMultiDomain) {
                     this._onDomainSet(newUrl, options)
-                  } else {
-                    restorePreviousState()
                   }
 
                   const responseBufferStream = new stream.PassThrough({

--- a/packages/server/lib/server-e2e.ts
+++ b/packages/server/lib/server-e2e.ts
@@ -304,9 +304,11 @@ export class ServerE2E extends ServerBase<SocketE2E> {
                 // and set the domain vs not
                 if (isOk && details.isHtml) {
                   // reset the domain to the new url if we're not
-                  // handling a local file
-                  if (!handlingLocalFile) {
+                  // handling a local file and we aren't in multi-domain
+                  if (!handlingLocalFile && !options.isMultiDomain) {
                     this._onDomainSet(newUrl, options)
+                  } else {
+                    restorePreviousState()
                   }
 
                   const responseBufferStream = new stream.PassThrough({
@@ -321,6 +323,7 @@ export class ServerE2E extends ServerBase<SocketE2E> {
                     details,
                     originalUrl,
                     response: incomingRes,
+                    isMultiDomain: options.isMultiDomain,
                   })
                 } else {
                   // TODO: move this logic to the driver too for


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #19857
- Closes #20431
- Closes #19876

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
This change supports the following:
* Using `cy.visit()` within `switchToDomain` both as the first navigation to a new domain or navigating within the domain
  * Note: relative urls are NOT currently supported
* Using `cy.go()` within `switchToDomain`

Details:
* Stability is sync'd in from primary domain to allow the command queue to proceed
* When requesting a change to the iframe src prop in the secondary, a message is sent to the primary to perform that actual change since the secondary does not have access to the `$autIframe`
* When resolving the url on the backend, the `isMultiDomain` value is passed along to:
  * prevent the server from updating the remote state with the new origin
  * inject `fullMultiDomain` for buffered multi-domain responses
* `hasVisitedAboutBlank` is sync'd between primary and secondary to ensure `about:blank` is only visited once for the spec

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Users are now able to use `cy.visit()` within `switchToDomain`

```
    it('supports visiting primary first', () => {
      // visit primary that doesn't redirect to secondary
      cy.visit('/fixtures/multi-domain.html')

      cy.switchToDomain('foobar.com', () => {
        // visit secondary
        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')

        cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
      })
    })
```
<img width="1802" alt="Screen Shot 2022-03-03 at 10 33 54 AM" src="https://user-images.githubusercontent.com/2002044/156619840-1574413d-4b2b-4261-a331-f4fd1f631574.png">

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
