### PR TITLE
chore: speed up mac build times in CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,7 @@ macWorkflowFilters: &mac-workflow-filters
   when:
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
-    - equal: [ fix-next-version-in-test-repos, << pipeline.git.branch >> ]
+    - equal: [ faster-mac-builds, << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -81,6 +81,7 @@ executors:
     macos:
       # Executor should have Node >= required version
       xcode: "13.0.0"
+    resource_class: macos.x86.medium.gen2
     environment:
       PLATFORM: mac
 
@@ -2301,12 +2302,13 @@ mac-workflow: &mac-workflow
     - node_modules_install:
         name: darwin-node-modules-install
         executor: mac
+        resource_class: macos.x86.medium.gen2
         only-cache-for-root-user: true
 
     - build:
         name: darwin-build
         executor: mac
-        resource_class: medium
+        resource_class: macos.x86.medium.gen2
         requires:
           - darwin-node-modules-install
 
@@ -2325,7 +2327,7 @@ mac-workflow: &mac-workflow
           - test-runner:upload
           - test-runner:commit-status-checks
         executor: mac
-        resource_class: medium
+        resource_class: macos.x86.medium.gen2
         requires:
           - darwin-build
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->
<img width="489" alt="Screen Shot 2022-03-03 at 4 00 01 PM" src="https://user-images.githubusercontent.com/14099737/156660066-aa64073c-63f8-4341-adef-d953bd084788.png">

- https://discuss.circleci.com/t/coming-soon-gen2-macos-resources/41886/16

Updated and pushed to see build times were faster. Seems like they might just be!

[Reference Build Times](https://app.circleci.com/pipelines/github/cypress-io/cypress?branch=develop&filter=all) - Looked at jobs without installing node_modules
<img width="1340" alt="Screen Shot 2022-03-03 at 4 02 30 PM" src="https://user-images.githubusercontent.com/14099737/156660342-a8c03819-6f8a-447e-a68d-799aad922be9.png">


[Updated Build Times](https://app.circleci.com/pipelines/github/cypress-io/cypress?branch=faster-mac-builds&filter=all) - Neither build installed node_modules

<img width="1352" alt="Screen Shot 2022-03-03 at 4 01 47 PM" src="https://user-images.githubusercontent.com/14099737/156660359-57c1fc8f-920d-4174-a3e6-648f96f3a088.png">
