### PR TITLE
fix: error regression - unexpected ANSI color chars shown on Firefox warning message about chromeWebSecurity

### DIFF
--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -30,6 +30,7 @@ import * as settings from './util/settings'
 import specsUtil from './util/specs'
 import system from './util/system'
 import Watchers from './watchers'
+import stripAnsi from 'strip-ansi'
 
 import type { LaunchArgs } from './open_project'
 
@@ -704,7 +705,7 @@ export class ProjectBase<TServer extends ServerE2E | ServerCt> extends EE {
 
         return {
           ...browser,
-          warning: browser.warning || errors.getMsgByType('CHROME_WEB_SECURITY_NOT_SUPPORTED', browser.name),
+          warning: browser.warning || stripAnsi(errors.getMsgByType('CHROME_WEB_SECURITY_NOT_SUPPORTED', browser.name)),
         }
       })
     }

--- a/packages/server/test/unit/project_spec.js
+++ b/packages/server/test/unit/project_spec.js
@@ -1,5 +1,3 @@
-const { theme } = require('@packages/errors/src/errTemplate')
-
 require('../spec_helper')
 
 const mockedEnv = require('mocked-env')
@@ -248,7 +246,7 @@ describe('lib/project-base', () => {
             family: 'some-other-family',
             name: 'some-other-name',
             warning: `\
-Your project has set the configuration option: ${theme.yellow('chromeWebSecurity')} to ${theme.blue('false')}
+Your project has set the configuration option: chromeWebSecurity to false
 
 This option will not have an effect in Some-other-name. Tests that rely on web security being disabled will not run as expected.\
 `,


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/20496

### User facing changelog
Fix regression that caused ANSI color chars to show up on Firefox warning message about `chromeWebSecurity`

### Additional details
This regression was introduced in Cypress version 9.5.0 as a result of this PR: https://github.com/cypress-io/cypress/pull/20072 where errors originating from the server (`@packages/errors`) were altered as part of a larger errors improvement.

To fix this regression, I simply stripped the ANSI chars from the warning message, since this config will display differently in 10.0 and will be deprecated with multi-domain anyway.

### How has the user experience changed?
Before:

<img width="799" alt="Screenshot 2022-03-07 at 11 38 28 AM" src="https://user-images.githubusercontent.com/27690333/157087624-3e4b1aa6-9f19-477f-a0e1-445cad8ca397.png">

After:

<img width="803" alt="Screenshot 2022-03-07 at 11 56 31 AM" src="https://user-images.githubusercontent.com/27690333/157087945-1c53480b-5ee7-4f0d-b3b9-1583395b8e08.png">

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
