### PR TITLE
fix(types): add correct type for preserve cookie callback

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2341,7 +2341,7 @@ declare namespace Cypress {
   type Agent<T extends sinon.SinonSpy> = SinonSpyAgent<T> & T
 
   interface CookieDefaults {
-    preserve: string | string[] | RegExp | ((cookie: any) => boolean)
+    preserve: string | string[] | RegExp | ((cookie: Cookie) => boolean)
   }
 
   interface Failable {


### PR DESCRIPTION
### User facing changelog
Added the correct type for a cookie for the callback to preserve cookies. 

### Additional details
This type was set to `any`, but a correct type `Cookie` already exists.
