### PR TITLE
fix: standardize error and object serialization

### DIFF
--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
@@ -261,7 +261,7 @@ describe('multi-domain - uncaught errors', () => {
     it('handles users throwing dom elements', (done) => {
       cy.on('fail', (err) => {
         expect(err.name).to.equal('CypressError')
-        expect(err.message).to.equal('`cy.switchToDomain()` could not serialize or map the thrown value. Please make sure the value being thrown is supported by the structured clone algorithm.')
+        expect(err.message).to.equal('`cy.switchToDomain()` could not serialize the thrown value. Please make sure the value being thrown is supported by the structured clone algorithm.')
         done()
       })
 
@@ -274,7 +274,7 @@ describe('multi-domain - uncaught errors', () => {
     it('handles users throwing functions', (done) => {
       cy.on('fail', (err) => {
         expect(err.name).to.equal('CypressError')
-        expect(err.message).to.equal('`cy.switchToDomain()` could not serialize or map the thrown value. Please make sure the value being thrown is supported by the structured clone algorithm.')
+        expect(err.message).to.equal('`cy.switchToDomain()` could not serialize the thrown value. Please make sure the value being thrown is supported by the structured clone algorithm.')
         done()
       })
 
@@ -287,7 +287,7 @@ describe('multi-domain - uncaught errors', () => {
     it('handles users throwing symbols', (done) => {
       cy.on('fail', (err) => {
         expect(err.name).to.equal('CypressError')
-        expect(err.message).to.equal('`cy.switchToDomain()` could not serialize or map the thrown value. Please make sure the value being thrown is supported by the structured clone algorithm.')
+        expect(err.message).to.equal('`cy.switchToDomain()` could not serialize the thrown value. Please make sure the value being thrown is supported by the structured clone algorithm.')
         done()
       })
 
@@ -300,7 +300,7 @@ describe('multi-domain - uncaught errors', () => {
     it('handles users throwing promises', (done) => {
       cy.on('fail', (err) => {
         expect(err.name).to.equal('CypressError')
-        expect(err.message).to.equal('`cy.switchToDomain()` could not serialize or map the thrown value. Please make sure the value being thrown is supported by the structured clone algorithm.')
+        expect(err.message).to.equal('`cy.switchToDomain()` could not serialize the thrown value. Please make sure the value being thrown is supported by the structured clone algorithm.')
         done()
       })
 
@@ -464,7 +464,7 @@ describe('multi-domain - uncaught errors', () => {
     it('handles throwing of arbitrary data types that are serializable but cannot be mapped to an error', (done) => {
       cy.on('fail', (err) => {
         expect(err.name).to.equal('CypressError')
-        expect(err.message).to.equal('`cy.switchToDomain()` could not serialize or map the thrown value. Please make sure the value being thrown is supported by the structured clone algorithm.')
+        expect(err.message).to.equal('`cy.switchToDomain()` could not serialize the thrown value. Please make sure the value being thrown is supported by the structured clone algorithm.')
         done()
       })
 

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
@@ -10,13 +10,14 @@ describe('multi-domain - uncaught errors', () => {
   })
 
   describe('sync errors', () => {
-    it('appropriately reports negative assertions', () => {
+    it('appropriately reports negative assertions', (done) => {
       cy.on('fail', (err) => {
         expect(err.name).to.eq('AssertionError')
         expect(err.message).to.include('expected true to be false')
+        done()
       })
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.then(() => {
           expect(true).to.be.false
         })
@@ -266,7 +267,7 @@ describe('multi-domain - uncaught errors', () => {
       })
 
       // @ts-ignore
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         throw document.createElement('h1')
       })
     })
@@ -279,7 +280,7 @@ describe('multi-domain - uncaught errors', () => {
       })
 
       // @ts-ignore
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         throw () => undefined
       })
     })
@@ -292,7 +293,7 @@ describe('multi-domain - uncaught errors', () => {
       })
 
       // @ts-ignore
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         throw Symbol('foo')
       })
     })
@@ -305,7 +306,7 @@ describe('multi-domain - uncaught errors', () => {
       })
 
       // @ts-ignore
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         throw new Promise(() => {})
       })
     })
@@ -327,7 +328,7 @@ describe('multi-domain - uncaught errors', () => {
       })
 
       // @ts-ignore
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         class CustomError extends Error {
           private _name = 'CustomError'
           get name () {
@@ -364,7 +365,7 @@ describe('multi-domain - uncaught errors', () => {
       })
 
       // @ts-ignore
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         class FooBar {
           private _metasyntaticList = ['foo']
           get metasyntaticList (): string[] {
@@ -393,7 +394,7 @@ describe('multi-domain - uncaught errors', () => {
       })
 
       // @ts-ignore
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         throw 'oops'
       })
     })
@@ -406,7 +407,7 @@ describe('multi-domain - uncaught errors', () => {
       })
 
       // @ts-ignore
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         throw ['why would anyone do this?', 'this is odd']
       })
     })
@@ -419,7 +420,7 @@ describe('multi-domain - uncaught errors', () => {
       })
 
       // @ts-ignore
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         throw 2
       })
     })
@@ -432,7 +433,7 @@ describe('multi-domain - uncaught errors', () => {
       })
 
       // @ts-ignore
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         throw true
       })
     })
@@ -445,7 +446,7 @@ describe('multi-domain - uncaught errors', () => {
       })
 
       // @ts-ignore
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         throw null
       })
     })
@@ -458,7 +459,7 @@ describe('multi-domain - uncaught errors', () => {
       })
 
       // @ts-ignore
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         throw undefined
       })
     })
@@ -471,7 +472,7 @@ describe('multi-domain - uncaught errors', () => {
       })
 
       // @ts-ignore
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         throw new Date()
       })
     })

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
@@ -319,7 +319,7 @@ describe('multi-domain - uncaught errors', () => {
         expect(err._name).to.equal('CustomError')
         expect(err.foo).to.equal('bar')
 
-        const { writable } = Object.getOwnPropertyDescriptor(err, 'name') || {}
+        const { writable } = Object.getOwnPropertyDescriptor(err, 'name') as PropertyDescriptor
 
         // After serialization, read-only properties are now writable
         expect(writable).to.be.true
@@ -343,7 +343,7 @@ describe('multi-domain - uncaught errors', () => {
         // @ts-ignore
         customErrorInstance.foo = 'bar'
 
-        const { writable } = Object.getOwnPropertyDescriptor(CustomError, 'name') || {}
+        const { writable } = Object.getOwnPropertyDescriptor(CustomError, 'name') as PropertyDescriptor
 
         // make sure the name property is read-only before serializing it through postMessage
         expect(writable).to.be.false

--- a/packages/driver/src/cy/multi-domain/index.ts
+++ b/packages/driver/src/cy/multi-domain/index.ts
@@ -2,7 +2,7 @@ import Bluebird from 'bluebird'
 import $errUtils from '../../cypress/error_utils'
 import { Validator } from './validator'
 import { createUnserializableSubjectProxy } from './unserializable_subject_proxy'
-import { reifyCrossDomainError, serializeRunnable } from './util'
+import { serializeRunnable } from './util'
 import { preprocessConfig, preprocessEnv, syncConfigToCurrentDomain, syncEnvToCurrentDomain } from '../../util/config'
 
 export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, state: Cypress.State, config: Cypress.InternalConfig) {
@@ -92,7 +92,7 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
 
         const onQueueFinished = ({ err, subject, unserializableSubjectType }) => {
           if (err) {
-            return _reject(reifyCrossDomainError(err, userInvocationStack))
+            return _reject(err)
           }
 
           _resolve({ subject, unserializableSubjectType })
@@ -110,7 +110,7 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
           sendReadyForDomain()
 
           if (err) {
-            return _reject(reifyCrossDomainError(err, userInvocationStack))
+            return _reject(err)
           }
 
           // if there are not commands and a synchronous return from the callback,
@@ -164,6 +164,7 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
                 config: preprocessConfig(Cypress.config()),
                 env: preprocessEnv(Cypress.env()),
                 isStable: state('isStable'),
+                userInvocationStack,
               })
             } catch (err: any) {
               const wrappedErr = $errUtils.errByPath('switchToDomain.run_domain_fn_errored', {

--- a/packages/driver/src/cy/multi-domain/index.ts
+++ b/packages/driver/src/cy/multi-domain/index.ts
@@ -46,7 +46,7 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
   Commands.addAll({
     switchToDomain<T> (originOrDomain: string, dataOrFn: T[] | (() => {}), fn?: (data?: T[]) => {}) {
       // store the invocation stack in the case that `switchToDomain` errors
-      const userInvocationStack = state('current').get('userInvocationStack')
+      communicator.userInvocationStack = state('current').get('userInvocationStack')
 
       clearTimeout(timeoutId)
       // this command runs for as long as the commands in the secondary
@@ -183,7 +183,6 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
                 config: preprocessConfig(Cypress.config()),
                 env: preprocessEnv(Cypress.env()),
                 isStable: state('isStable'),
-                userInvocationStack,
               })
             } catch (err: any) {
               const wrappedErr = $errUtils.errByPath('switchToDomain.run_domain_fn_errored', {

--- a/packages/driver/src/cy/multi-domain/index.ts
+++ b/packages/driver/src/cy/multi-domain/index.ts
@@ -90,8 +90,8 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
           reject(err)
         }
 
-        const onQueueFinished = ({ err, subject, unserializableSubjectType, hasMultiDomainError }) => {
-          if (hasMultiDomainError) {
+        const onQueueFinished = ({ err, subject, unserializableSubjectType }) => {
+          if (err) {
             return _reject(reifyCrossDomainError(err, userInvocationStack))
           }
 
@@ -105,11 +105,11 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
         })
 
         communicator.once('ran:domain:fn', (details) => {
-          const { subject, unserializableSubjectType, err, finished, hasMultiDomainError } = details
+          const { subject, unserializableSubjectType, err, finished } = details
 
           sendReadyForDomain()
 
-          if (hasMultiDomainError) {
+          if (err) {
             return _reject(reifyCrossDomainError(err, userInvocationStack))
           }
 

--- a/packages/driver/src/cy/multi-domain/util.ts
+++ b/packages/driver/src/cy/multi-domain/util.ts
@@ -1,32 +1,4 @@
 import _ from 'lodash'
-import $stackUtils from '../../cypress/stack_utils'
-import $errUtils from '../../cypress/error_utils'
-import { UNSERIALIZABLE } from '../../util/serialization'
-
-export const reifyCrossDomainError = (serializedError: any, userInvocationStack: string) => {
-  // we have no idea what type the error this is... could be 'undefined', a plain old object, or something else entirely
-
-  let reifiedError = $errUtils.errByPath('switchToDomain.failed_to_serialize_or_map_thrown_value')
-
-  if (_.isArray(serializedError)) {
-    // if the error is an array of anything, create a normal error with the stringified values of the passed in array
-    reifiedError = new Error(serializedError.toString())
-  } else if (_.isObject(serializedError as any)) {
-    // otherwise, try to determine if there are any error details in the object and merge the error objects together
-    let errorToMerge = serializedError?.message ? new Error(serializedError?.message || '') : reifiedError
-
-    reifiedError = _.assignWith(errorToMerge, serializedError)
-  } else if (serializedError !== UNSERIALIZABLE) {
-    reifiedError = new Error(`${serializedError}`)
-  }
-
-  // @ts-ignore
-  reifiedError.onFail = () => {}
-
-  reifiedError.stack = $stackUtils.replacedStack(reifiedError, userInvocationStack)
-
-  return reifiedError
-}
 
 export const serializeRunnable = (runnable) => {
   if (!runnable) return undefined

--- a/packages/driver/src/cypress/error_messages.ts
+++ b/packages/driver/src/cypress/error_messages.ts
@@ -1738,7 +1738,7 @@ export default {
     },
     failed_to_serialize_or_map_thrown_value: {
       message: stripIndent`\
-      ${cmd('switchToDomain')} could not serialize or map the thrown value. Please make sure the value being thrown is supported by the structured clone algorithm.`,
+      ${cmd('switchToDomain')} could not serialize the thrown value. Please make sure the value being thrown is supported by the structured clone algorithm.`,
     },
     // TODO: These deprecation warnings and forbidden use errors need to be audited before releasing multi-domain
     route: {

--- a/packages/driver/src/cypress/error_messages.ts
+++ b/packages/driver/src/cypress/error_messages.ts
@@ -1736,6 +1736,10 @@ export default {
       message: stripIndent`\
       ${cmd('switchToDomain')} could not serialize the subject due to symbols not being supported by the structured clone algorithm.`,
     },
+    failed_to_serialize_or_map_thrown_value: {
+      message: stripIndent`\
+      ${cmd('switchToDomain')} could not serialize or map the thrown value. Please make sure the value being thrown is supported by the structured clone algorithm.`,
+    },
     // TODO: These deprecation warnings and forbidden use errors need to be audited before releasing multi-domain
     route: {
       unsupported: {

--- a/packages/driver/src/multi-domain/communicator.ts
+++ b/packages/driver/src/multi-domain/communicator.ts
@@ -117,10 +117,15 @@ export class SpecBridgeDomainCommunicator extends EventEmitter {
         } catch (e) {
           err = e
         }
+
+        // give the `err` truthiness if it's a falsey value like undefined/null/false
+        if (hasMultiDomainError && !err) {
+          err = new Error(`${err}`)
+        }
       }
 
       // We always want to make sure errors are posted, so clean it up to send.
-      send({ ...rest, subject, err, hasMultiDomainError })
+      send({ ...rest, subject, err })
     } catch (err: any) {
       if (subject && err.name === 'DataCloneError') {
         // Send the type of object that failed to serialize.

--- a/packages/driver/src/multi-domain/communicator.ts
+++ b/packages/driver/src/multi-domain/communicator.ts
@@ -21,7 +21,7 @@ const CROSS_DOMAIN_PREFIX = 'cross:domain:'
 export class PrimaryDomainCommunicator extends EventEmitter {
   private windowReference: Window | undefined
   private crossDomainDriverWindows: {[key: string]: Window} = {}
-  private userInvocationStack?: string
+  userInvocationStack?: string
 
   /**
    * Initializes the event handler to receive messages from the spec bridge.
@@ -79,11 +79,6 @@ export class PrimaryDomainCommunicator extends EventEmitter {
   }
 
   toSpecBridge (domain: string, event: string, data?: any) {
-    if (data?.userInvocationStack) {
-      this.userInvocationStack = data.userInvocationStack
-      delete data.userInvocationStack
-    }
-
     debug('=> to spec bridge', domain, event, data)
     // If there is no crossDomainDriverWindow, there is no need to send the message.
     this.crossDomainDriverWindows[domain]?.postMessage({

--- a/packages/driver/src/multi-domain/communicator.ts
+++ b/packages/driver/src/multi-domain/communicator.ts
@@ -1,7 +1,7 @@
 import debugFn from 'debug'
 import { EventEmitter } from 'events'
 import { preprocessConfig, preprocessEnv } from '../util/config'
-import { preprocessErrorsForSerialization } from '../util/serialization'
+import { preprocessForSerialization } from '../util/serialization'
 
 const debug = debugFn('cypress:driver:multi-domain')
 
@@ -113,7 +113,7 @@ export class SpecBridgeDomainCommunicator extends EventEmitter {
     try {
       if (hasMultiDomainError) {
         try {
-          err = preprocessErrorsForSerialization(err)
+          err = preprocessForSerialization(err)
         } catch (e) {
           err = e
         }

--- a/packages/driver/src/multi-domain/communicator.ts
+++ b/packages/driver/src/multi-domain/communicator.ts
@@ -1,9 +1,7 @@
-import clone from 'clone'
 import debugFn from 'debug'
 import { EventEmitter } from 'events'
-import _ from 'lodash'
-import $dom from '../dom'
 import { preprocessConfig, preprocessEnv } from '../util/config'
+import { preprocessErrorsForSerialization } from '../util/serialization'
 
 const debug = debugFn('cypress:driver:multi-domain')
 
@@ -11,47 +9,6 @@ const CROSS_DOMAIN_PREFIX = 'cross:domain:'
 
 declare global {
   interface Window { specBridgeDomain: string }
-}
-
-const preprocessErrorForPostMessage = (value) => {
-  const { isDom } = $dom
-
-  if (_.isError(value)) {
-    const serializableError = _.mapValues(clone(value), preprocessErrorForPostMessage)
-
-    return {
-      ... serializableError,
-      // Native Error types currently cannot be cloned in Firefox when using 'postMessage'.
-      // Please see https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm for more details
-      name: value.name,
-      message: value.message,
-      stack: value.stack,
-    }
-  }
-
-  if (_.isArray(value)) {
-    return _.map(value, preprocessErrorForPostMessage)
-  }
-
-  if (isDom(value)) {
-    return $dom.stringify(value, 'short')
-  }
-
-  if (_.isFunction(value)) {
-    return value.toString()
-  }
-
-  if (_.isObject(value)) {
-    // clone to nuke circular references
-    // and blow away anything that throws
-    try {
-      return _.mapValues(clone(value), preprocessErrorForPostMessage)
-    } catch (err) {
-      return null
-    }
-  }
-
-  return value
 }
 
 /**
@@ -144,15 +101,26 @@ export class SpecBridgeDomainCommunicator extends EventEmitter {
   private windowReference
 
   private handleSubjectAndErr = (data: any = {}, send: (data: any) => void) => {
-    const { subject, err, ...rest } = data
+    let { subject, err, ...rest } = data
 
-    if (!subject && !err) {
+    // check to see if the 'err' key is defined, and if it is, we have an error of any type
+    const hasMultiDomainError = !!Object.getOwnPropertyDescriptor(data, 'err')
+
+    if (!subject && !hasMultiDomainError) {
       return send(rest)
     }
 
     try {
+      if (hasMultiDomainError) {
+        try {
+          err = preprocessErrorsForSerialization(err)
+        } catch (e) {
+          err = e
+        }
+      }
+
       // We always want to make sure errors are posted, so clean it up to send.
-      send({ ...rest, subject, err: preprocessErrorForPostMessage(err) })
+      send({ ...rest, subject, err, hasMultiDomainError })
     } catch (err: any) {
       if (subject && err.name === 'DataCloneError') {
         // Send the type of object that failed to serialize.

--- a/packages/driver/src/multi-domain/communicator.ts
+++ b/packages/driver/src/multi-domain/communicator.ts
@@ -113,14 +113,14 @@ export class SpecBridgeDomainCommunicator extends EventEmitter {
     try {
       if (hasMultiDomainError) {
         try {
+          // give the `err` truthiness if it's a falsey value like undefined/null/false
+          if (!err) {
+            err = new Error(`${err}`)
+          }
+
           err = preprocessForSerialization(err)
         } catch (e) {
           err = e
-        }
-
-        // give the `err` truthiness if it's a falsey value like undefined/null/false
-        if (hasMultiDomainError && !err) {
-          err = new Error(`${err}`)
         }
       }
 

--- a/packages/driver/src/util/config.ts
+++ b/packages/driver/src/util/config.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import { options } from '@packages/config'
-import { omitUnserializablePropertiesFromObj } from './serialization'
+import { preprocessForSerialization } from './serialization'
 
 /**
  * Mutates the config/env object serialized from the other domain to omit read-only values
@@ -54,9 +54,9 @@ export const syncEnvToCurrentDomain = (env: Cypress.ObjectLike) => {
 }
 
 export const preprocessConfig = (config: Cypress.Config) => {
-  return omitUnserializablePropertiesFromObj(config) as Cypress.Config
+  return preprocessForSerialization(config) as Cypress.Config
 }
 
 export const preprocessEnv = (env: Cypress.ObjectLike) => {
-  return omitUnserializablePropertiesFromObj(env) as Cypress.Config
+  return preprocessForSerialization(env) as Cypress.Config
 }

--- a/packages/driver/src/util/config.ts
+++ b/packages/driver/src/util/config.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import { options } from '@packages/config'
-import { preprocessObjForSerialization } from './serialization'
+import { omitUnserializablePropertiesFromObj } from './serialization'
 
 /**
  * Mutates the config/env object serialized from the other domain to omit read-only values
@@ -54,9 +54,9 @@ export const syncEnvToCurrentDomain = (env: Cypress.ObjectLike) => {
 }
 
 export const preprocessConfig = (config: Cypress.Config) => {
-  return preprocessObjForSerialization(config) as Cypress.Config
+  return omitUnserializablePropertiesFromObj(config) as Cypress.Config
 }
 
 export const preprocessEnv = (env: Cypress.ObjectLike) => {
-  return preprocessObjForSerialization(env) as Cypress.Config
+  return omitUnserializablePropertiesFromObj(env) as Cypress.Config
 }

--- a/packages/driver/src/util/serialization.ts
+++ b/packages/driver/src/util/serialization.ts
@@ -79,7 +79,7 @@ const convertObjectToSerializableLiteral = (obj): typeof obj => {
  * firefox
  * structuredClone(new Error('myError')) -> throws error as native error cannot be serialized
  *
- * This method takes a similar the 'chromium' approach to structuredClone, except that the prototype chain is walked and ANY serializable value, including getters, is serialized.
+ * This method takes a similar approach as the 'chromium' structuredClone algorithm, except that the prototype chain is walked and ANY serializable value, including getters, is serialized.
  * Please see https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#things_that_dont_work_with_structured_clone.
  *
  *  NOTE: If an object nested inside valueToSanitize contains an unserializable property, the whole object is deemed as unserializable

--- a/packages/driver/src/util/serialization.ts
+++ b/packages/driver/src/util/serialization.ts
@@ -1,6 +1,8 @@
 import _ from 'lodash'
 import structuredClonePonyfill from 'core-js-pure/actual/structured-clone'
 
+export const UNSERIALIZABLE = '__cypress_unserializable_value'
+
 // If a native structuredClone exists, use that to determine if a value can be serialized or not. Otherwise, use the ponyfill.
 // we need this because some implementations of SCA treat certain values as unserializable (ex: Error is serializable in ponyfill but NOT in firefox implementations)
 // @ts-ignore
@@ -27,12 +29,95 @@ const isSerializableInCurrentBrowser = (value: any) => {
 }
 
 /**
+ * Walks the prototype chain and finds any serializable properties that exist on the object or its prototypes.
+ * If the property can be serialized, the property is added to the literal.
+ * This means read-only properties are now read/write on the literal.
+ *
+ * Please see https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#things_that_dont_work_with_structured_clone for more details.
+ * @param obj Object that is being converted
+ * @returns a new object void of prototype chain (object literal) with all serializable properties
+ */
+const convertObjectToSerializableLiteral = (obj): typeof obj => {
+  const allProps: string[] = []
+  let currentObjectRef = obj
+
+  do {
+    const props = Object.getOwnPropertyNames(currentObjectRef)
+
+    props.forEach((prop: string) => {
+      if (!allProps.includes(prop) && isSerializableInCurrentBrowser(currentObjectRef[prop])) {
+        allProps.push(prop)
+      }
+    })
+
+    currentObjectRef = Object.getPrototypeOf(currentObjectRef)
+  } while (currentObjectRef)
+
+  const objectAsLiteral = {}
+
+  allProps.forEach((key) => {
+    objectAsLiteral[key] = obj[key]
+  })
+
+  return objectAsLiteral
+}
+
+/**
  * Sanitizes any unserializable values from a object to prep for postMessage serialization
  * @param objectToSanitize Object that might have unserializable properties
  * @returns a copy of this object with all unserializable keys omitted from the object.
  *
  * NOTE: If an object nested inside objectToSanitize contains an unserializable property, the whole object is deemed as unserializable
  */
-export const preprocessObjForSerialization = <T>(objectToSanitize: { [key: string]: any }): T => {
+export const omitUnserializablePropertiesFromObj = <T>(objectToSanitize: { [key: string]: any }): T => {
   return _.pickBy(objectToSanitize, isSerializableInCurrentBrowser) as T
+}
+
+/**
+ * Sanitizes any unserializable values to prep for postMessage serialization. All Objects, including Errors, are mapped to an Object literal with
+ * whatever serialization properties they have, including their prototype hierarchy.
+ * This keeps behavior consistent between browsers without having to worry about the inner workings of structuredClone(). For example:
+ *
+ * chromium
+ * new Error('myError') -> Object literal with message key having value 'myError'. Also, other custom properties on the object are omitted and only name, message, and stack are preserved
+ *
+ * For instance:
+ * var a = new Error('myError')
+ * a.foo = 'bar'
+ * var b = structuredClone(a)
+ * b.foo // is undefined
+ *
+ * firefox
+ * structuredClone(new Error('myError')) -> throws error as native error cannot be serialized
+ *
+ * This method takes a similar the 'chromium' approach to structuredClone, except that hte prototype chain is walked and ANY serializable value, including getters, are serialized.
+ * Please see https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#things_that_dont_work_with_structured_clone.
+ * @param valueToSanitize subject of sanitization that might be unserializable or have unserializable properties
+ * @returns a serializable form of the Error/Object. If the value passed in cannot be serialized, an error is thrown
+ * @throws 'unserializable'
+ */
+export const preprocessErrorsForSerialization = <T>(valueToSanitize: { [key: string]: any }): T | undefined => {
+// Even if native errors can be serialized through postMessage, many properties are omitted on structuredClone(), including prototypical hierarchy
+// because of this, we preprocess native errors to objects and postprocess them once they come back to the primary domain
+
+  if (_.isArray(valueToSanitize)) {
+    return _.filter(valueToSanitize, preprocessErrorsForSerialization) as unknown as T
+  }
+
+  if (_.isObject(valueToSanitize)) {
+    try {
+      const sanitizedValue = convertObjectToSerializableLiteral(valueToSanitize) as T
+
+      return sanitizedValue
+    } catch (err) {
+      // if its not serializable, tell the primary to inform the user that the value thrown could not be serialized
+      throw UNSERIALIZABLE
+    }
+  }
+
+  if (!isSerializableInCurrentBrowser(valueToSanitize)) {
+    throw UNSERIALIZABLE
+  }
+
+  return valueToSanitize
 }

--- a/system-tests/__snapshots__/multi_domain_error_spec.ts.js
+++ b/system-tests/__snapshots__/multi_domain_error_spec.ts.js
@@ -1,0 +1,74 @@
+exports['e2e multi domain errors / captures the stack trace correctly for multi-domain errors to point users to their "switchToDomain" callback'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      1 found (multi_domain_error_spec.ts)                                               │
+  │ Searched:   cypress/integration/multi_domain_error_spec.ts                                     │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  multi_domain_error_spec.ts                                                      (1 of 1)
+
+
+  multi-domain
+    1) tries to find an element that doesn't exist and fails
+
+
+  0 passing
+  1 failing
+
+  1) multi-domain
+       tries to find an element that doesn't exist and fails:
+     AssertionError: Timed out retrying after 1000ms: Expected to find element: \`#doesnotexist\`, but never found it.
+      [stack trace lines]
+
+
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        1                                                                                │
+  │ Passing:      0                                                                                │
+  │ Failing:      1                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  1                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     multi_domain_error_spec.ts                                                       │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Screenshots)
+
+  -  /XXX/XXX/XXX/cypress/screenshots/multi_domain_error_spec.ts/multi-domain -- trie     (1280x720)
+     s to find an element that doesn't exist and fails (failed).png                                 
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/multi_domain_error_spec.ts.mp4      (X second)
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✖  multi_domain_error_spec.ts               XX:XX        1        -        1        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✖  1 of 1 failed (100%)                     XX:XX        1        -        1        -        -  
+
+
+`

--- a/system-tests/projects/e2e/cypress/integration/multi_domain_error_spec.ts
+++ b/system-tests/projects/e2e/cypress/integration/multi_domain_error_spec.ts
@@ -6,7 +6,7 @@ describe('multi-domain', () => {
   })
 
   it('tries to find an element that doesn\'t exist and fails', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:4466', () => {
       cy.get('#doesnotexist', {
         timeout: 1000,
       })

--- a/system-tests/projects/e2e/cypress/integration/multi_domain_error_spec.ts
+++ b/system-tests/projects/e2e/cypress/integration/multi_domain_error_spec.ts
@@ -1,0 +1,15 @@
+// @ts-ignore / session support is needed for visiting about:blank between tests
+describe('multi-domain', () => {
+  beforeEach(() => {
+    cy.visit('/multi_domain.html')
+    cy.get('a[data-cy="multi_domain_secondary_link"]').click()
+  })
+
+  it('tries to find an element that doesn\'t exist and fails', () => {
+    cy.switchToDomain('foobar.com', () => {
+      cy.get('#doesnotexist', {
+        timeout: 1000,
+      })
+    })
+  })
+})

--- a/system-tests/projects/e2e/multi_domain.html
+++ b/system-tests/projects/e2e/multi_domain.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+  <style>
+    a {
+      display: block;
+    }
+  </style>
+  <div>
+    Go to different domain:
+    <a data-cy="multi_domain_secondary_link"
+        href="http://www.foobar.com:4466/multi_domain_secondary.html">http://www.foobar.com:4466/multi_domain_secondary.html</a>
+  </div>
+</body>
+</html>

--- a/system-tests/projects/e2e/multi_domain_secondary.html
+++ b/system-tests/projects/e2e/multi_domain_secondary.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+  <p data-cy="dom-check">From a secondary domain</p>
+  <p data-cy="cypress-check"></p>
+  <p data-cy="window-before-load"></p>
+  <form>
+    <button type="submit">Submit</button>
+  </form>
+  <button data-cy="alert">Alert</button>
+  <button data-cy="confirm">Confirm</button>
+  <button data-cy="reload">reload</button>
+  <a data-cy="hashChange" href='#hashChange'>hashChange</a>
+  <a data-cy="multi-domain-page"
+        href="/fixtures/multi_domain.html">/fixtures/multi_domain.html</a>
+
+  <script>
+    if (window.Cypress) {
+      document.querySelector('[data-cy="cypress-check"]').innerText = 'Has window.Cypress'
+    }
+
+    if (window.testSecondaryWindowBeforeLoad){
+      document.querySelector('[data-cy="window-before-load"]').innerText = 'Window Before Load Called'
+    }
+
+    document.querySelector('[data-cy="alert"]').addEventListener('click', () => {
+      window.alert('the alert text')
+    })
+
+    document.querySelector('[data-cy="confirm"]').addEventListener('click', () => {
+      window.confirm('the confirm text')
+    })
+
+    document.querySelector('[data-cy="reload"]').addEventListener('click', () => {
+      window.location.reload()
+    })
+  </script>
+</body>
+</html>

--- a/system-tests/test/multi_domain_error_spec.ts
+++ b/system-tests/test/multi_domain_error_spec.ts
@@ -1,0 +1,47 @@
+import path from 'path'
+import systemTests, { expect } from '../lib/system-tests'
+import Fixtures from '../lib/fixtures'
+
+const e2ePath = Fixtures.projectPath('e2e')
+
+const PORT = 3500
+const onServer = function (app) {
+  app.get('/multi_domain_secondary.html', (_, res) => {
+    res.sendFile(path.join(e2ePath, `multi_domain_secondary.html`))
+  })
+}
+
+describe('e2e multi domain errors', () => {
+  systemTests.setup({
+    servers: [{
+      port: 4466,
+      onServer,
+    }],
+    settings: {
+      hosts: {
+        '*.foobar.com': '127.0.0.1',
+      },
+    },
+  })
+
+  systemTests.it('captures the stack trace correctly for multi-domain errors to point users to their "switchToDomain" callback', {
+    // keep the port the same to prevent issues with the snapshot
+    port: PORT,
+    spec: 'multi_domain_error_spec.ts',
+    snapshot: true,
+    expectedExitCode: 1,
+    config: {
+      experimentalMultiDomain: true,
+      experimentalSessionSupport: true,
+    },
+    async onRun (exec) {
+      const res = await exec()
+
+      expect(res.stdout).to.contain('AssertionError')
+      expect(res.stdout).to.contain('Timed out retrying after 1000ms: Expected to find element: `#doesnotexist`, but never found it.')
+
+      // check to make sure the snapshot contains the 'switchToDomain' sourcemap. TODO: This is probably more appropriate for a cy-in-cy test
+      expect(res.stdout).to.contain('http://localhost:3500/__cypress/tests?p=cypress/integration/multi_domain_error_spec.ts:103:12')
+    },
+  })
+})


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### User facing changelog
n/a

### Additional details
After the large refactor changes incorporated in #20247, `switchToDomain` error stack invocations were temporarily removed until we could safely reincorporate them. This PR addresses re adding those stack invocations, as well as condolidating the error/thrown preprocessing logic with the config preprocessing logic.

 In `structuredClone`, Objects are serialized to literals while omitting prototype hierarchy values as well as omitting `get`, `set`, and other properties when cloning (see [here](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#things_that_dont_work_with_structured_clone)). 

`Error`s, even though they are objects, are handled differently depending on the implementation of `structuredClone`. Firefox cannot serialize `Error`s through `structuredClone` and chrome/polyfill implementations can clone `Error`s, but only keep `name`, `message`, and `stack`. These Error objects are also casted to object literals.

The changes here propose that we preprocess `Error`s and `Object`s the same before sending them off to `postMessage`. Regardless of the context, `Error`s and `Object`s now walk to prototype tree and add any serializable value to an object literal. This way, most serializable properties are preserved without having to deal with the caveats of `structuredClone`. Now that these are processed the same, a single method can be used to preprocess thrown errors as well as sync config/env.

Whenever a value is thrown from the secondary domain, we try to map it to an error. If this value cannot be mapped to an error to present to the user (serializable or otherwise), a `CypressError` is thrown with the message `'cy.switchToDomain()' could not serialize or map the thrown value. Please make sure the value being thrown is supported by the structured clone algorithm.`

![](https://user-images.githubusercontent.com/3980464/157332841-b0c46bb0-71b1-400d-9a85-f0f0bb6acbc5.png)


A small system test was added to verify the stack trace behavior. This is likely a bit more appropriate for a `cy-in-cy` test, which we should convert once unification is merged. 
![](https://user-images.githubusercontent.com/3980464/157323957-8ccf8e30-5524-4fc6-ad4b-8a7694a5209a.png)


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
