### PR TITLE
fix: click event is fired correctly when focus has changed

### DIFF
--- a/packages/driver/cypress/fixtures/click-event-by-type.html
+++ b/packages/driver/cypress/fixtures/click-event-by-type.html
@@ -6,14 +6,33 @@
   </head>
 
   <body>
-    <button id="reset">clear log</button>
-    <button id="target-button-tag">button tag</button>
-    <input id="target-input-button" type="button" value="input button" />
-    <input id="target-input-image" type="image" value="input image" />
-    <input id="target-input-reset" type="reset" value="input reset" />
-    <input id="target-input-submit" type="submit" value="input submit" />
-    <input id="target-input-checkbox" type="checkbox" value="input checkbox" />
-    <input id="target-input-radio" type="radio" value="input radio" />
+    <div>
+      <button id="reset">clear log</button>
+    </div>
+    
+    <div>
+      <input id="input-text" type="text" />
+      <select id="focus-options">
+        <option value="clear">clear</option>
+        <option value="button-tag">button tag</option>
+        <option value="input-button">input button</option>
+        <option value="input-image">input image</option>
+        <option value="input-reset">input reset</option>
+        <option value="input-submit">input submit</option>
+        <option value="input-checkbox">input checkbox</option>
+        <option value="input-radio">input radio</option>
+      </select>
+    </div>
+
+    <div>
+      <button id="target-button-tag">button tag</button>
+      <input id="target-input-button" type="button" value="input button" />
+      <input id="target-input-image" type="image" value="input image" />
+      <input id="target-input-reset" type="reset" value="input reset" />
+      <input id="target-input-submit" type="submit" value="input submit" />
+      <input id="target-input-checkbox" type="checkbox" value="input checkbox" />
+      <input id="target-input-radio" type="radio" value="input radio" />
+    </div>
 
     <div id="log"></div>
 
@@ -70,6 +89,32 @@
           updateLog("keyup");
         });
       });
+
+      let handler = null
+      const focusOptions = document.getElementById("focus-options");
+
+      focusOptions.addEventListener('change', (event) => {
+        const val = event.target.value;
+        const target = document.getElementById('input-text');
+
+        if (handler) {
+          target.removeEventListener('keydown', handler);
+        }
+
+        if (val === 'clear') {
+          handler = null
+
+          return
+        }
+
+        handler = (e) => {
+          const focusEl = document.getElementById(`target-${val}`);
+
+          focusEl.focus()
+        }
+
+        target.addEventListener('keydown', handler);
+      })
     </script>
   </body>
 </html>

--- a/packages/driver/cypress/integration/commands/actions/type_events_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_events_spec.js
@@ -585,16 +585,16 @@ describe('src/cy/commands/actions/type - #type events', () => {
 
     describe('triggers', () => {
       const targets = [
-        '#target-button-tag',
-        '#target-input-button',
-        '#target-input-image',
-        '#target-input-reset',
-        '#target-input-submit',
+        'button-tag',
+        'input-button',
+        'input-image',
+        'input-reset',
+        'input-submit',
       ]
 
       targets.forEach((target) => {
         it(target, () => {
-          cy.get(target).focus().type('{enter}')
+          cy.get(`#target-${target}`).focus().type('{enter}')
 
           cy.get('li').should('have.length', 4)
           cy.get('li').eq(0).should('have.text', 'keydown')
@@ -603,22 +603,49 @@ describe('src/cy/commands/actions/type - #type events', () => {
           cy.get('li').eq(3).should('have.text', 'keyup')
         })
       })
+
+      describe('keydown triggered on another element', () => {
+        targets.forEach((target) => {
+          it(target, () => {
+            cy.get('#focus-options').select(target)
+            cy.get('#input-text').focus().type('{enter}')
+
+            cy.get('li').should('have.length', 3)
+            cy.get('li').eq(0).should('have.text', 'keypress')
+            cy.get('li').eq(1).should('have.text', 'click')
+            cy.get('li').eq(2).should('have.text', 'keyup')
+          })
+        })
+      })
     })
 
     describe('does not trigger', () => {
       const targets = [
-        '#target-input-checkbox',
-        '#target-input-radio',
+        'input-checkbox',
+        'input-radio',
       ]
 
       targets.forEach((target) => {
         it(target, () => {
-          cy.get(target).focus().type('{enter}')
+          cy.get(`#target-${target}`).focus().type('{enter}')
 
           cy.get('li').should('have.length', 3)
           cy.get('li').eq(0).should('have.text', 'keydown')
           cy.get('li').eq(1).should('have.text', 'keypress')
           cy.get('li').eq(2).should('have.text', 'keyup')
+        })
+      })
+
+      describe('keydown triggered on another element', () => {
+        targets.forEach((target) => {
+          it(target, () => {
+            cy.get('#focus-options').select(target)
+            cy.get('#input-text').focus().type('{enter}')
+
+            cy.get('li').should('have.length', 2)
+            cy.get('li').eq(0).should('have.text', 'keypress')
+            cy.get('li').eq(1).should('have.text', 'keyup')
+          })
         })
       })
     })
@@ -768,6 +795,29 @@ describe('src/cy/commands/actions/type - #type events', () => {
         cy.get('li').eq(3).should('have.text', 'keyup')
 
         cy.get('#target-input-radio').should('be.checked')
+      })
+    })
+
+    describe('keydown on another element does not trigger click', () => {
+      const targets = [
+        'button-tag',
+        'input-button',
+        'input-image',
+        'input-reset',
+        'input-submit',
+        'input-checkbox',
+        'input-radio',
+      ]
+
+      targets.forEach((target) => {
+        it(target, () => {
+          cy.get('#focus-options').select('button-tag')
+          cy.get('#input-text').focus().type(' ')
+
+          cy.get('li').should('have.length', 2)
+          cy.get('li').eq(0).should('have.text', 'keypress')
+          cy.get('li').eq(1).should('have.text', 'keyup')
+        })
       })
     })
   })

--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -275,16 +275,23 @@ export default function (Commands, Cypress, cy, state, config) {
       const isContentEditable = $elements.isContentEditable(options.$el.get(0))
       const isTextarea = $elements.isTextarea(options.$el.get(0))
 
-      // click event is only fired on button, image, submit, reset elements.
-      // That's why we cannot use $elements.isButtonLike() here.
-      const type = (type) => $elements.isInputType(options.$el.get(0), type)
-      const sendClickEvent = type('button') || type('image') || type('submit') || type('reset')
-
       const fireClickEvent = (el) => {
         const ctor = $dom.getDocumentFromElement(el).defaultView!.PointerEvent
         const event = new ctor('click')
 
         el.dispatchEvent(event)
+      }
+
+      let keydownEvents: any[] = []
+
+      const keydownFiredOnThisElement = (el) => {
+        for (let i = 0; i < keydownEvents.length; i++) {
+          if (keydownEvents[i].type === 'keydown' && keydownEvents[i].el === el) {
+            return true
+          }
+        }
+
+        return false
       }
 
       return keyboard.type({
@@ -332,21 +339,32 @@ export default function (Commands, Cypress, cy, state, config) {
             updateTable(id, key, event, value)
           }
 
+          if (event.type === 'keydown') {
+            keydownEvents.push({
+              el: event.target,
+              type: event.type,
+            })
+          }
+
           if (
             // Firefox sends a click event when the Space key is pressed.
-            // We don't want send it twice.
+            // We don't want to send it twice.
             !Cypress.isBrowser('firefox') &&
             // Click event is sent after keyup event with space key.
             event.type === 'keyup' && event.code === 'Space' &&
+            // When event is prevented, the click event should not be emitted
+            !event.defaultPrevented &&
             // Click events should be only sent to button-like elements.
             // event.target is null when used with shadow DOM.
             (event.target && $elements.isButtonLike(event.target)) &&
             // When a space key is pressed for input radio elements, the click event is only fired when it's not checked.
             !(event.target.tagName === 'INPUT' && event.target.type === 'radio' && event.target.checked === true) &&
-            // When event is prevented, the click event should not be emitted
-            !event.defaultPrevented
+            // When a space key is pressed on another element, the click event should not be fired.
+            keydownFiredOnThisElement(event.target)
           ) {
             fireClickEvent(event.target)
+
+            keydownEvents = []
           }
         },
 
@@ -390,6 +408,11 @@ export default function (Commands, Cypress, cy, state, config) {
           if (isTextarea || isContentEditable) {
             return
           }
+
+          // click event is only fired on button, image, submit, reset elements.
+          // That's why we cannot use $elements.isButtonLike() here.
+          const type = (type) => $elements.isInputType(el, type)
+          const sendClickEvent = type('button') || type('image') || type('submit') || type('reset')
 
           // https://github.com/cypress-io/cypress/issues/19541
           // Send click event on type('{enter}')

--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -284,16 +284,6 @@ export default function (Commands, Cypress, cy, state, config) {
 
       let keydownEvents: any[] = []
 
-      const keydownFiredOnThisElement = (el) => {
-        for (let i = 0; i < keydownEvents.length; i++) {
-          if (keydownEvents[i].type === 'keydown' && keydownEvents[i].el === el) {
-            return true
-          }
-        }
-
-        return false
-      }
-
       return keyboard.type({
         $el: options.$el,
         chars,
@@ -340,10 +330,7 @@ export default function (Commands, Cypress, cy, state, config) {
           }
 
           if (event.type === 'keydown') {
-            keydownEvents.push({
-              el: event.target,
-              type: event.type,
-            })
+            keydownEvents.push(event.target)
           }
 
           if (
@@ -360,7 +347,7 @@ export default function (Commands, Cypress, cy, state, config) {
             // When a space key is pressed for input radio elements, the click event is only fired when it's not checked.
             !(event.target.tagName === 'INPUT' && event.target.type === 'radio' && event.target.checked === true) &&
             // When a space key is pressed on another element, the click event should not be fired.
-            keydownFiredOnThisElement(event.target)
+            keydownEvents.includes(event.target)
           ) {
             fireClickEvent(event.target)
 


### PR DESCRIPTION
- Next step of #20191
- Final step of #19541
- Related with [this comment](https://github.com/cypress-io/cypress/pull/19726#issuecomment-1021238555)

### User facing changelog

Click events are fired correctly when focus is changed on event handlers. 

### Additional details
- Why was this change necessary? => When the focus is changed on event handlers, the newly focused object got the click event. This PR simulates this behavior. 
- What is affected by this change? => N/A


### Any implementation details to explain?

Click event emitting is a bit different between enter and space. 

* Click event is fired on the newly-focused element when enter is pressed. 
* Click event is not fired on any element when space is pressed.

Before this PR, Cypress behavior is the opposite (not firing on enter and firing on space). This PR fixes this issue. 

### How has the user experience changed?

**Before:** Click event is not sent on enter and sent on space. => Buggy behavior.
**After:** Click event is sent on enter and not sent on space. => Correct behavior.

### PR Tasks
- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
