### PR TITLE
fix: webpack-dev-server performance

### DIFF
--- a/npm/webpack-dev-server/src/plugin.ts
+++ b/npm/webpack-dev-server/src/plugin.ts
@@ -41,6 +41,7 @@ export default class CypressCTOptionsPlugin {
   private files: Cypress.Cypress['spec'][] = []
   private supportFile: string
   private errorEmitted = false
+  private compilation: Webpack45Compilation | null = null
 
   private readonly projectRoot: string
   private readonly devServerEvents: EventEmitter
@@ -52,47 +53,55 @@ export default class CypressCTOptionsPlugin {
     this.devServerEvents = options.devServerEvents
   }
 
-  private pluginFunc = (context: CypressCTWebpackContext) => {
-    context._cypress = {
+  private addLoaderContext = (loaderContext: object, module: any) => {
+    (loaderContext as CypressCTWebpackContext)._cypress = {
       files: this.files,
       projectRoot: this.projectRoot,
       supportFile: this.supportFile,
     }
   };
 
-  private setupCustomHMR = (compiler: webpack.Compiler) => {
-    compiler.hooks.afterCompile.tap(
-      'CypressCTOptionsPlugin',
-      (compilation) => {
-        const stats = compilation.getStats()
+  private afterCompile = () => {
+    if (!this.compilation) {
+      return
+    }
 
-        if (stats.hasErrors()) {
-          this.errorEmitted = true
+    const stats = this.compilation.getStats()
 
-          // webpack 4: string[]
-          // webpack 5: Error[]
-          const errors = stats.toJson().errors as Array<Error | string> | undefined
+    if (stats.hasErrors()) {
+      this.errorEmitted = true
 
-          if (!errors || !errors.length) {
-            return
-          }
+      // webpack 4: string[]
+      // webpack 5: Error[]
+      const errors = stats.toJson().errors as Array<Error | string> | undefined
 
-          this.devServerEvents.emit('dev-server:compile:error', normalizeError(errors[0]))
-        } else if (this.errorEmitted) {
-          // compilation succeed but assets haven't emitted to the output yet
-          this.devServerEvents.emit('dev-server:compile:error', null)
-        }
-      },
-    )
+      if (!errors || !errors.length) {
+        return
+      }
 
-    compiler.hooks.afterEmit.tap(
-      'CypressCTOptionsPlugin',
-      (compilation) => {
-        if (!compilation.getStats().hasErrors()) {
-          this.devServerEvents.emit('dev-server:compile:success')
-        }
-      },
-    )
+      this.devServerEvents.emit('dev-server:compile:error', normalizeError(errors[0]))
+    } else if (this.errorEmitted) {
+      // compilation succeed but assets haven't emitted to the output yet
+      this.devServerEvents.emit('dev-server:compile:error', null)
+    }
+  }
+
+  private afterEmit = () => {
+    if (!this.compilation?.getStats().hasErrors()) {
+      this.devServerEvents.emit('dev-server:compile:success')
+    }
+  }
+
+  private onSpecsChange = (specs: Cypress.Cypress['spec'][]) => {
+    if (!this.compilation || _.isEqual(specs, this.files)) {
+      return
+    }
+
+    this.files = specs
+    const inputFileSystem = this.compilation.inputFileSystem
+    const utimesSync: UtimesSync = semver.gt('4.0.0', webpack.version) ? inputFileSystem.fileSystem.utimesSync : fs.utimesSync
+
+    utimesSync(path.resolve(__dirname, 'browser.js'), new Date(), new Date())
   }
 
   /**
@@ -100,37 +109,25 @@ export default class CypressCTOptionsPlugin {
    * @param compilation webpack 4 `compilation.Compilation`, webpack 5
    *   `Compilation`
    */
-  private plugin = (compilation: Webpack45Compilation) => {
-    this.devServerEvents.on('dev-server:specs:changed', (specs) => {
-      if (_.isEqual(specs, this.files)) return
+  private addCompilationHooks = (compilation: Webpack45Compilation) => {
+    this.compilation = compilation
 
-      this.files = specs
-      const inputFileSystem = compilation.inputFileSystem
-      const utimesSync: UtimesSync = semver.gt('4.0.0', webpack.version) ? inputFileSystem.fileSystem.utimesSync : fs.utimesSync
-
-      utimesSync(path.resolve(__dirname, 'browser.js'), new Date(), new Date())
-    })
-
-    // Webpack 5
     /* istanbul ignore next */
     if ('NormalModule' in webpack) {
-      webpack.NormalModule.getCompilationHooks(compilation).loader.tap(
-        'CypressCTOptionsPlugin',
-        (context) => this.pluginFunc(context as CypressCTWebpackContext),
-      )
+      // Webpack 5
+      const loader = webpack.NormalModule.getCompilationHooks(compilation).loader
 
-      return
+      loader.tap('CypressCTOptionsPlugin', this.addLoaderContext)
+    } else {
+      // Webpack 4
+      compilation.hooks.normalModuleLoader.tap('CypressCTOptionsPlugin', this.addLoaderContext)
     }
-
-    // Webpack 4
-    compilation.hooks.normalModuleLoader.tap(
-      'CypressCTOptionsPlugin',
-      (context) => this.pluginFunc(context as CypressCTWebpackContext),
-    )
   };
 
   apply (compiler: Compiler): void {
-    this.setupCustomHMR(compiler)
-    compiler.hooks.compilation.tap('CypressCTOptionsPlugin', (compilation) => this.plugin(compilation as Webpack45Compilation))
+    this.devServerEvents.on('dev-server:specs:changed', this.onSpecsChange)
+    compiler.hooks.afterCompile.tap('CypressCTOptionsPlugin', this.afterCompile)
+    compiler.hooks.afterEmit.tap('CypressCTOptionsPlugin', this.afterEmit)
+    compiler.hooks.compilation.tap('CypressCTOptionsPlugin', (compilation) => this.addCompilationHooks(compilation as Webpack45Compilation))
   }
 }

--- a/npm/webpack-dev-server/src/startServer.ts
+++ b/npm/webpack-dev-server/src/startServer.ts
@@ -4,6 +4,7 @@ import WebpackDevServer from 'webpack-dev-server'
 import { makeWebpackConfig, UserWebpackDevServerOptions } from './makeWebpackConfig'
 import { webpackDevServerFacts } from './webpackDevServerFacts'
 import type { CypressWebpackDevServerConfig } from '.'
+import { normalizeError } from './plugin'
 
 export interface StartDevServer extends UserWebpackDevServerOptions, CypressWebpackDevServerConfig {
   /* this is the Cypress dev server configuration object */
@@ -43,6 +44,9 @@ export async function start ({ webpackConfig: userWebpackConfig, indexHtmlFile, 
   if (isTextTerminal) {
     compiler.hooks.done.tap('cyCustomErrorBuild', function (stats) {
       if (stats.hasErrors()) {
+        const errors = stats.compilation.errors
+
+        options.devServerEvents.emit('dev-server:compile:error', normalizeError(errors[0]))
         exitProcess(1)
       }
     })

--- a/npm/webpack-dev-server/test/e2e.spec.ts
+++ b/npm/webpack-dev-server/test/e2e.spec.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import sinon from 'sinon'
 import { expect } from 'chai'
-import { EventEmitter } from 'events'
+import { once, EventEmitter } from 'events'
 import http from 'http'
 import fs from 'fs'
 import { webpackDevServerFacts } from '../src/webpackDevServerFacts'
@@ -71,9 +71,7 @@ describe('#startDevServer', () => {
 
     expect(response).to.eq('const foo = () => {}\n')
 
-    return new Promise((res) => {
-      close(() => res())
-    })
+    await close()
   })
 
   it('emits dev-server:compile:success event on successful compilation', async () => {
@@ -87,48 +85,38 @@ describe('#startDevServer', () => {
       },
     })
 
-    return new Promise((res) => {
-      devServerEvents.on('dev-server:compile:success', () => {
-        close(() => res())
-      })
-    })
+    await once(devServerEvents, 'dev-server:compile:success')
+    await close()
   })
 
   it('emits dev-server:compile:error event on error compilation', async () => {
     const devServerEvents = new EventEmitter()
-
     const exitSpy = sinon.stub()
 
+    const badSpec = `${root}/test/fixtures/compilation-fails.spec.js`
     const { close } = await startDevServer({
       webpackConfig,
       options: {
         config,
         specs: [
           {
-            name: `${root}/test/fixtures/compilation-fails.spec.js`,
-            relative: `${root}/test/fixtures/compilation-fails.spec.js`,
-            absolute: `${root}/test/fixtures/compilation-fails.spec.js`,
+            name: badSpec,
+            relative: badSpec,
+            absolute: badSpec,
           },
         ],
         devServerEvents,
       },
     }, exitSpy as any)
 
-    exitSpy()
+    const [err] = await once(devServerEvents, 'dev-server:compile:error')
 
-    return new Promise((res) => {
-      devServerEvents.on('dev-server:compile:error', (err: string) => {
-        if (webpackDevServerFacts.isV3()) {
-          expect(err).to.contain('./test/fixtures/compilation-fails.spec.js 1:5')
-        }
+    expect(err).to.contain('Module parse failed: Unexpected token (1:5)')
+    expect(err).to.contain('You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders')
+    expect(err).to.contain('> this is an invalid spec file')
+    expect(exitSpy.calledOnce).to.be.true
 
-        expect(err).to.contain('Module parse failed: Unexpected token (1:5)')
-        expect(err).to.contain('You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders')
-        expect(err).to.contain('> this is an invalid spec file')
-        expect(exitSpy.calledOnce).to.be.true
-        close(() => res())
-      })
-    })
+    await close()
   })
 
   it('touches browser.js when a spec file is added and recompile', async function () {
@@ -150,21 +138,15 @@ describe('#startDevServer', () => {
 
     const oldmtime = fs.statSync('./dist/browser.js').mtimeMs
 
-    let firstCompile = true
+    await once(devServerEvents, 'dev-server:compile:success')
+    devServerEvents.emit('dev-server:specs:changed', [newSpec])
 
-    return new Promise((res) => {
-      devServerEvents.on('dev-server:compile:success', () => {
-        if (firstCompile) {
-          firstCompile = false
-          devServerEvents.emit('dev-server:specs:changed', [newSpec])
-          const updatedmtime = fs.statSync('./dist/browser.js').mtimeMs
+    await once(devServerEvents, 'dev-server:compile:success')
+    const updatedmtime = fs.statSync('./dist/browser.js').mtimeMs
 
-          expect(oldmtime).to.not.equal(updatedmtime)
-        } else {
-          close(() => res())
-        }
-      })
-    })
+    expect(oldmtime).to.not.equal(updatedmtime)
+
+    await close()
   })
 
   it('accepts the devServer signature', async function () {
@@ -182,9 +164,7 @@ describe('#startDevServer', () => {
 
     expect(response).to.eq('const foo = () => {}\n')
 
-    return new Promise((res) => {
-      close(() => res())
-    })
+    await close()
   })
 })
 .timeout(5000)


### PR DESCRIPTION
- Closes #20359 

### User facing changelog
Fixes a minor memory leak in webpack-dev-server, and removes additional user webpack plugins to improve performance.

### Additional details

### How has the user experience changed?
On linux systems, projects using component testing built with Create React App will compile slightly faster (5-15%). Removes console warnings when webpack recompiles many times (eg, cypress is left open while the user works on their project).

### PR Tasks
- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
