### PR TITLE
test: fix system-tests-firefox downloads flake

### DIFF
--- a/system-tests/projects/downloads/cypress/integration/downloads_spec.ts
+++ b/system-tests/projects/downloads/cypress/integration/downloads_spec.ts
@@ -6,27 +6,7 @@ describe('downloads', () => {
   })
 
   it('handles csv file download', () => {
-    // HACK: monkey-patching Cypress.downloads.end to ensure the download has
-    // finished before asserting on its contents. this test was flakey b/c
-    // sometimes file was read before the browser had written its contents.
-    // consider creating events for downloads or some API, so that this can
-    // be done without hacks
-    const awaitDownload = new Promise<void>((resolve) => {
-      // @ts-ignore
-      const end = Cypress.downloads.end
-
-      // @ts-ignore
-      Cypress.downloads.end = (arg) => {
-        resolve()
-
-        return end(arg)
-      }
-    })
-
-    cy.get('[data-cy=download-csv]').click().then(() => {
-      return awaitDownload
-    })
-
+    cy.get('[data-cy=download-csv]').click()
     cy
     .readFile(`${Cypress.config('downloadsFolder')}/records.csv`)
     .should('contain', '"Joe","Smith"')

--- a/system-tests/test/downloads_spec.ts
+++ b/system-tests/test/downloads_spec.ts
@@ -23,7 +23,7 @@ describe('e2e downloads', () => {
 
   systemTests.it('allows changing the downloads folder', {
     project: 'downloads',
-    spec: '*',
+    spec: 'downloads_spec.ts',
     config: {
       downloadsFolder: 'cypress/dls',
       video: false,


### PR DESCRIPTION
### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

There was a [change](https://github.com/cypress-io/cypress/commit/2ee98938cd7b1c7b6cf368681c6f827682dabec2#diff-c1ed819829a1be91181002a07a7e3399f0c435939b724e49e4fd5d2d6f23befeR9-R29) made on the multi domain branch to fix a flake. The purpose of this change was to ensure that we are waiting for the download of the csv file before we check its contents.

Unfortunately, this left an additional flake. That flake was caused because we were downloading the same file multiple times in different tests and thus the second one actually gets placed at records(1).csv. In addition, the first file download doesn't have the fix that the second file download has so the file is not guaranteed to be downloaded. Therefore when the second test executes it's actually reading the location of the first test's download which may or may not be there.

To fix the second flake, we will limit the test that are run to just `download_spec` since that is the only test necessary to test switching download locations. Also, since readFile actually will retry until all chained assertions pass, the first fix is no longer necessary and that both flakes will be resolved if we just limit the tests being run to `download_spec` in this scenario.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
