### PR TITLE
fix: can't switch from electron browser to another

### DIFF
--- a/packages/data-context/src/actions/ProjectActions.ts
+++ b/packages/data-context/src/actions/ProjectActions.ts
@@ -64,6 +64,7 @@ export class ProjectActions {
       d.scaffoldedFiles = null
       d.baseError = null
       d.warnings = []
+      d.app.browserStatus = 'closed'
     })
 
     this.ctx.lifecycleManager.clearCurrentProject()

--- a/packages/server/lib/browsers/index.js
+++ b/packages/server/lib/browsers/index.js
@@ -12,7 +12,7 @@ const isBrowserFamily = check.oneOf(['chromium', 'firefox'])
 
 let instance = null
 
-const kill = function (unbind, isProcessExit) {
+const kill = function (unbind = true, isProcessExit = false) {
   // Clean up the instance when the browser is closed
   if (!instance) {
     debug('browsers.kill called with no active instance')
@@ -24,12 +24,12 @@ const kill = function (unbind, isProcessExit) {
 
   instance = null
 
-  if (unbind) {
-    _instance.removeAllListeners()
-  }
-
   return new Promise((resolve) => {
     _instance.once('exit', () => {
+      if (unbind) {
+        _instance.removeAllListeners()
+      }
+
       debug('browser process killed')
 
       resolve()
@@ -149,6 +149,8 @@ module.exports = {
         onBrowserClose () {},
       })
 
+      ctx.browser.setBrowserStatus('opening')
+
       const browserLauncher = getBrowserLauncher(browser)
 
       if (!browserLauncher) {
@@ -195,7 +197,12 @@ module.exports = {
         // the browser opening
         return Promise.delay(1000)
         .then(() => {
+          if (instance === null) {
+            return null
+          }
+
           options.onBrowserOpen()
+          ctx.browser.setBrowserStatus('open')
 
           return instance
         })

--- a/packages/server/lib/open_project.ts
+++ b/packages/server/lib/open_project.ts
@@ -180,13 +180,7 @@ export class OpenProject {
           return browsers.connectToNewSpec(browser, { onInitializeNewBrowserTab, ...options }, automation)
         }
 
-        this._ctx?.browser.setBrowserStatus('opening')
-
         return browsers.open(browser, options, automation, this._ctx)
-      }).then((browserInstance) => {
-        this._ctx?.browser.setBrowserStatus('open')
-
-        return browserInstance
       })
     }
 


### PR DESCRIPTION
- Closes [UNIFY-1249](https://cypress-io.atlassian.net/browse/UNIFY-1249)

### User facing changelog
Fix bug that prevented users from switching from Electron to another browser.

### Additional details
When switching from Electron to another browser, the `kill` function was never resolving, causing the process to hang and never open the browser the user switched to. This was due to the `kill` function removing all the listeners from the Electron window before it received the `exit` event which included the "closed" event that was triggering the "exit" event.

This also fixes a regression where "onBrowserClosed" was never being called. This function was cleaning up the preprocessor and firing the `after:spec` event.

I also moved the calling of `setBrowserStatus` to fix some race conditions that were occurring if you opened a browser and switched to another browser before everything settled. This was necessary since now that the exit listeners are actually firing before kill, the state of the Launchpad Browser Select was falling out of sync.

### How has the user experience changed?

https://user-images.githubusercontent.com/25158820/157724236-a757e876-026b-47ec-ba9c-d90486b191cb.mov

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
