### PR TITLE
feat: support origin and domain name in switchToDomain

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1911,7 +1911,7 @@ declare namespace Cypress {
      *      cy.get('h1').should('equal', 'Example Domain')
      *    })
      */
-    switchToDomain(domain: string, fn: () => void): Chainable
+    switchToDomain(originOrDomain: string, fn: () => void): Chainable
     /**
      * Enables running Cypress commands in a secondary domain
      * @see https://on.cypress.io/switchToDomain
@@ -1921,7 +1921,7 @@ declare namespace Cypress {
      *      expect(foo).to.equal('foo')
      *    })
      */
-    switchToDomain<T>(domain: string, data: T[], fn: (data: T[]) => void): Chainable
+    switchToDomain<T>(originOrDomain: string, data: T[], fn: (data: T[]) => void): Chainable
 
     /**
      * Run a task in Node via the plugins file.

--- a/packages/driver/cypress/integration/e2e/multi-domain/basic_login_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/basic_login_spec.ts
@@ -5,7 +5,7 @@ describe('basic login', { experimentalSessionSupport: true }, () => {
     it('logs in with idp redirect', () => {
       cy.visit('/fixtures/auth/index.html') // Establishes Primary Domain
       cy.get('[data-cy="login-idp"]').click() // Takes you to idp.com
-      cy.switchToDomain('idp.com', () => {
+      cy.switchToDomain('http://idp.com:3500', () => {
         cy.get('[data-cy="username"]').type('BJohnson')
         cy.get('[data-cy="login"]').click()
       }) // Trailing edge wait, waiting to return to the primary domain
@@ -24,7 +24,7 @@ describe('basic login', { experimentalSessionSupport: true }, () => {
         win.location.href = 'http://www.idp.com:3500/fixtures/auth/idp.html'
       })
 
-      cy.switchToDomain('idp.com', () => {
+      cy.switchToDomain('http://idp.com:3500', () => {
         cy.get('[data-cy="username"]').type('FJohnson')
         cy.get('[data-cy="login"]').click()
       })
@@ -39,7 +39,7 @@ describe('basic login', { experimentalSessionSupport: true }, () => {
     it.skip('visits foobar first', () => {
       cy.visit('http://www.foobar.com:3500/fixtures/auth/index.html') // Establishes Primary Domain
       cy.get('[data-cy="login-idp"]').click() // Takes you to idp.com
-      cy.switchToDomain('idp.com', () => {
+      cy.switchToDomain('http://idp.com:3500', () => {
         cy.get('[data-cy="username"]').type('BJohnson')
         cy.get('[data-cy="login"]').click()
       }) // Trailing edge wait, waiting to return to the primary domain
@@ -182,9 +182,9 @@ describe('Multi-step Auth', { experimentalSessionSupport: true }, () => {
     cy.visit('/fixtures/auth/index.html')
     cy.get('[data-cy="login-with-approval"]').click() // takes you to foobar.com.../approval
     cy.url() //fail
-    cy.switchToDomain('foobar.com', () => { // Parent Domain is localhost
+    cy.switchToDomain('http://foobar.com:3500', () => { // Parent Domain is localhost
       cy.get('[data-cy="approve-orig"]').click() // takes you to idp.com
-      cy.switchToDomain('idp.com', () => { // Parent domain is foobar.com
+      cy.switchToDomain('http://idp.com:3500', () => { // Parent domain is foobar.com
         cy.get('[data-cy="username"]').type('MarkyMark')
         cy.get('[data-cy="login"]').click() // Takes you back to localhost
       }) // Does not wait on foobar.com because there are no subsequent commands (would wait forever)
@@ -220,7 +220,7 @@ describe('Multi-step Auth', { experimentalSessionSupport: true }, () => {
     cy.createDomain('foobar.com', { primaryDomain: 'localhost' }, () => { // Parent Domain is localhost
       cy.visit('http://www.foobar.com:3500/fixtures/auth/approval.html')
       cy.get('[data-cy="approve-orig"]').click() // takes you to idp.com
-      cy.switchToDomain('idp.com', () => { // Parent domain is foobar.com
+      cy.switchToDomain('http://idp.com:3500', () => { // Parent domain is foobar.com
         cy.get('[data-cy="username"]').type('MarkyMark')
         cy.get('[data-cy="login"]').click() // Takes you back to localhost
       }) // Does not wait on foobar.com because there are no subsequent commands (would wait forever)
@@ -236,9 +236,9 @@ describe('Multi-step Auth', { experimentalSessionSupport: true }, () => {
   it.skip('final auth redirects back to approval page - nested', () => {
     cy.visit('/fixtures/auth/index.html')
     cy.get('[data-cy="login-with-approval"]').click() // takes you to foobar.com.../approval
-    cy.switchToDomain('foobar.com', () => { // Parent Domain is localhost
+    cy.switchToDomain('http://foobar.com:3500', () => { // Parent Domain is localhost
       cy.get('[data-cy="approve-me"]').click() // takes you to idp.com
-      cy.switchToDomain('idp.com', () => { // Parent domain is foobar.com
+      cy.switchToDomain('http://idp.com:3500', () => { // Parent domain is foobar.com
         cy.get('[data-cy="username"]').type('MarkyMark')
         cy.get('[data-cy="login"]').click() // Takes you back to foobar.com.../approval
       }) // Waits on foobar because there are subsequent commands
@@ -256,16 +256,16 @@ describe('Multi-step Auth', { experimentalSessionSupport: true }, () => {
   it.skip('final auth redirects back to approval page - flat', () => {
     cy.visit('/fixtures/auth/index.html')
     cy.get('[data-cy="login-with-approval"]').click() // takes you to foobar.com.../approval
-    cy.switchToDomain('foobar.com', () => { // Parent Domain is localhost
+    cy.switchToDomain('http://foobar.com:3500', () => { // Parent Domain is localhost
       cy.get('[data-cy="approve-orig"]').click() // takes you to idp.com
     }) // waits on localhost forever, this breaks
 
-    cy.switchToDomain('idp.com', () => { // Parent Domain is localhost
+    cy.switchToDomain('http://idp.com:3500', () => { // Parent Domain is localhost
       cy.get('[data-cy="username"]').type('MarkyMark')
       cy.get('[data-cy="login"]').click() // Takes you back to foobar.com.../approval
     }) // waits on foobar forever, this breaks
 
-    cy.switchToDomain('foobar.com', () => { // Parent Domain is localhost
+    cy.switchToDomain('http://foobar.com:3500', () => { // Parent Domain is localhost
       cy.get('[data-cy="login-success"]').click() // Takes you back to localhost
     }) // Waits on localhost because there are subsequent commands
 

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_actions.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_actions.spec.ts
@@ -7,7 +7,7 @@ context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   it('.type()', () => {
     cy.get('a[data-cy="dom-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#input').type('foo')
       .should('have.value', 'foo')
     })
@@ -16,7 +16,7 @@ context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   it('.focus()', () => {
     cy.get('a[data-cy="dom-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#input').focus()
       .should('be.focused')
     })
@@ -25,7 +25,7 @@ context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   it('.blur()', () => {
     cy.get('a[data-cy="dom-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#input').type('foo').blur()
       .should('not.be.focused')
     })
@@ -34,7 +34,7 @@ context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   it('.clear()', () => {
     cy.get('a[data-cy="dom-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#input')
       .type('foo').should('have.value', 'foo')
       .clear().should('have.value', '')
@@ -44,7 +44,7 @@ context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   it('.submit()', () => {
     cy.get('a[data-cy="dom-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       const afterFormSubmitted = new Promise<void>((resolve) => {
         cy.once('form:submitted', resolve)
       })
@@ -57,7 +57,7 @@ context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   it('.click()', () => {
     cy.get('a[data-cy="dom-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#button').then(($btn) => {
         const onClick = new Promise<void>((resolve) => {
           $btn.on('click', () => resolve())
@@ -72,7 +72,7 @@ context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   it('.dblclick()', () => {
     cy.get('a[data-cy="dom-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#button').then(($btn) => {
         const afterDblClick = new Promise<void>((resolve) => {
           $btn.on('dblclick', () => resolve())
@@ -87,7 +87,7 @@ context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   it('.rightclick()', () => {
     cy.get('a[data-cy="dom-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#button').then(($btn) => {
         const afterContextmenu = new Promise<void>((resolve) => {
           $btn.on('contextmenu', () => resolve())
@@ -102,7 +102,7 @@ context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   it('.check()', () => {
     cy.get('a[data-cy="dom-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get(':checkbox[name="colors"][value="blue"]')
       .check().should('be.checked')
     })
@@ -111,7 +111,7 @@ context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   it('.uncheck()', () => {
     cy.get('a[data-cy="dom-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get(':checkbox[name="colors"][value="blue"]')
       .check().should('be.checked')
       .uncheck().should('not.be.checked')
@@ -121,7 +121,7 @@ context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   it('.select()', () => {
     cy.get('a[data-cy="dom-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('select[name="foods"]')
       .select('Japanese').should('have.value', 'Japanese')
     })
@@ -130,7 +130,7 @@ context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   it('.scrollIntoView()', () => {
     cy.get('a[data-cy="scrolling-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#scroll-into-view-vertical h5')
       .should('not.be.visible')
       .scrollIntoView().should('be.visible')
@@ -140,7 +140,7 @@ context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   it('.scrollTo()', () => {
     cy.get('a[data-cy="scrolling-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#scroll-into-view-vertical h5').should('not.be.visible')
       cy.get('#scroll-into-view-vertical').scrollTo(0, 300)
       cy.get('#scroll-into-view-vertical h5').should('be.visible')
@@ -150,7 +150,7 @@ context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   it('.trigger()', () => {
     cy.get('a[data-cy="dom-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#button').then(($btn) => {
         const afterClick = new Promise<void>((resolve) => {
           $btn.on('click', () => resolve())
@@ -165,7 +165,7 @@ context('multi-domain actions', { experimentalSessionSupport: true }, () => {
   it('.selectFile()', () => {
     cy.get('a[data-cy="files-form-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.wrap(Cypress.Buffer.from('foo')).as('foo')
 
       cy.get('#basic')

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_aliasing.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_aliasing.spec.ts
@@ -6,7 +6,7 @@ context('multi-domain aliasing', { experimentalSessionSupport: true }, () => {
   })
 
   it('.as()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get(':checkbox[name="colors"][value="blue"]').as('checkbox')
       cy.get('@checkbox').click().should('be.checked')
     })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_assertions.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_assertions.spec.ts
@@ -6,7 +6,7 @@ context('multi-domain assertions', { experimentalSessionSupport: true }, () => {
   })
 
   it('.should() and .and()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get(':checkbox[name="colors"][value="blue"]')
       .should('not.be.checked').and('not.be.disabled')
     })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_connectors.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_connectors.spec.ts
@@ -6,7 +6,7 @@ context('multi-domain connectors', { experimentalSessionSupport: true }, () => {
   })
 
   it('.each()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#by-name>[name="colors"]').each(($element, index) => {
         expect($element.prop('type')).to.equal('checkbox')
       })
@@ -14,19 +14,19 @@ context('multi-domain connectors', { experimentalSessionSupport: true }, () => {
   })
 
   it('.its()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#by-id>input').its('length').should('eq', 3)
     })
   })
 
   it('.invoke()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#button').invoke('text').should('eq', 'button')
     })
   })
 
   it('.spread()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       const arr = ['foo', 'bar', 'baz']
 
       cy.wrap(arr).spread((foo, bar, baz) => {
@@ -38,7 +38,7 @@ context('multi-domain connectors', { experimentalSessionSupport: true }, () => {
   })
 
   it('.then()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#by-id>input').then(($list) => {
         expect($list).to.have.length(3)
       })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_cookies.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_cookies.spec.ts
@@ -6,7 +6,7 @@ context('multi-domain cookies', { experimentalSessionSupport: true }, () => {
   })
 
   it('.getCookie(), .getCookies(), and .setCookie()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.getCookies().should('be.empty')
 
       cy.setCookie('foo', 'bar')
@@ -17,7 +17,7 @@ context('multi-domain cookies', { experimentalSessionSupport: true }, () => {
   })
 
   it('.clearCookie()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.setCookie('foo', 'bar')
       cy.getCookie('foo').should('not.be.null')
       cy.clearCookie('foo')
@@ -26,7 +26,7 @@ context('multi-domain cookies', { experimentalSessionSupport: true }, () => {
   })
 
   it('.clearCookies()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.setCookie('foo', 'bar')
       cy.setCookie('faz', 'baz')
 

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_files.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_files.spec.ts
@@ -6,7 +6,7 @@ context('multi-domain files', { experimentalSessionSupport: true }, () => {
   })
 
   it('.fixture()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.fixture('example.json').then((json) => {
         expect(json).to.be.an('object')
         expect(json.example).to.be.true
@@ -15,7 +15,7 @@ context('multi-domain files', { experimentalSessionSupport: true }, () => {
   })
 
   it('.readFile()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.readFile('cypress/fixtures/example.json').then((json) => {
         expect(json).to.be.an('object')
         expect(json.example).to.be.true
@@ -24,7 +24,7 @@ context('multi-domain files', { experimentalSessionSupport: true }, () => {
   })
 
   it('.writeFile()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       const contents = JSON.stringify({ foo: 'bar' })
 
       cy.stub(Cypress, 'backend').resolves({

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_local_storage.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_local_storage.spec.ts
@@ -6,7 +6,7 @@ context('multi-domain local storage', { experimentalSessionSupport: true }, () =
   })
 
   it('.clearLocalStorage()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.window().then((win) => {
         win.localStorage.setItem('foo', 'bar')
         expect(win.localStorage.getItem('foo')).to.equal('bar')

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_location.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_location.spec.ts
@@ -6,13 +6,13 @@ context('multi-domain location', { experimentalSessionSupport: true }, () => {
   })
 
   it('.hash()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.hash().should('be.empty')
     })
   })
 
   it('.location()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.location().should((location) => {
         expect(location.href).to.equal('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
         expect(location.origin).to.equal('http://www.foobar.com:3500')
@@ -21,8 +21,8 @@ context('multi-domain location', { experimentalSessionSupport: true }, () => {
   })
 
   it('.url()', () => {
-    cy.switchToDomain('foobar.com', () => {
-      cy.url().should('eq', 'http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
+    cy.switchToDomain('http://foobar.com:3500', () => {
+      cy.url().should('equal', 'http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
     })
   })
 })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
@@ -6,37 +6,37 @@ context('multi-domain misc', { experimentalSessionSupport: true }, () => {
   })
 
   it('.end()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#button').end().should('be.null')
     })
   })
 
   it('.exec()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.exec('echo foobar').its('stdout').should('contain', 'foobar')
     })
   })
 
   it('.focused()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#button').click().focused().should('have.id', 'button')
     })
   })
 
   it('.wrap()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.wrap({ foo: 'bar' }).should('deep.equal', { foo: 'bar' })
     })
   })
 
   it('.debug()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#button').debug().should('have.id', 'button')
     })
   })
 
   it('.log()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       const afterLogAdded = new Promise<void>((resolve) => {
         cy.once('log:added', () => {
           resolve()
@@ -49,7 +49,7 @@ context('multi-domain misc', { experimentalSessionSupport: true }, () => {
   })
 
   it('.pause()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       const afterPaused = new Promise<void>((resolve) => {
         cy.once('paused', () => {
           Cypress.emit('resume:all')
@@ -66,7 +66,7 @@ context('multi-domain misc', { experimentalSessionSupport: true }, () => {
   })
 
   it('.task()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.task('return:arg', 'works').should('eq', 'works')
     })
   })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_navigation.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_navigation.spec.ts
@@ -4,7 +4,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.visit('http://www.foobar.com:3500/fixtures/dom.html')
 
       cy.go('back')
@@ -19,7 +19,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="dom-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get(':checkbox[name="colors"][value="blue"]').check().should('be.checked')
       cy.reload()
       cy.get(':checkbox[name="colors"][value="blue"]').should('not.be.checked')
@@ -46,7 +46,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
         expect(primaryVisitLoadSpy).to.be.calledOnce
       })
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const secondaryCyBeforeLoadSpy = cy.spy()
         const secondaryCyLoadSpy = cy.spy()
         const secondaryVisitBeforeLoadSpy = cy.spy()
@@ -75,7 +75,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
     it('supports visiting primary first', () => {
       cy.visit('/fixtures/multi-domain.html')
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
 
         cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
@@ -83,7 +83,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
     })
 
     it('supports skipping visiting primary first', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
 
         cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
@@ -94,12 +94,12 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
     it.skip('supports nesting a third domain', () => {
       cy.visit('/fixtures/multi-domain.html')
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
 
         cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
 
-        cy.switchToDomain('idp.com', () => {
+        cy.switchToDomain('http://idp.com:3500', () => {
           cy.visit('http://www.idp.com:3500/fixtures/dom.html')
         })
       })
@@ -110,7 +110,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
 
       cy.get('a[data-cy="multi-domain-secondary-link"]').click()
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
 
         cy.visit('http://www.foobar.com:3500/fixtures/dom.html')
@@ -123,7 +123,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
 
       cy.get('a[data-cy="multi-domain-secondary-link"]').click()
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.visit('/fixtures/dom.html')
       })
     })
@@ -133,7 +133,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
 
       cy.get('a[data-cy="multi-domain-secondary-link"]').click()
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html#hashchange')
 
         cy.location('hash').should('equal', '#hashchange')
@@ -141,7 +141,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
     })
 
     it('navigates back to primary', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
         cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
       })
@@ -163,7 +163,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
       cy.visit('/fixtures/multi-domain.html')
       cy.get('a[data-cy="multi-domain-secondary-link"]').click()
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         // this call should error since we can't visit a cross-domain
         cy.visit('http://www.idp.com:3500/fixtures/dom.html')
       })
@@ -172,7 +172,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
     it('supports the query string option', () => {
       cy.visit('/fixtures/multi-domain.html')
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html', { qs: { foo: 'bar' } })
 
         cy.location('search').should('equal', '?foo=bar')
@@ -180,7 +180,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
     })
 
     it('can send a POST request', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.visit('http://www.foobar.com:3500/post-only', {
           method: 'POST',
           headers: {
@@ -201,7 +201,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
 
       cy.visit('/fixtures/multi-domain.html')
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
 
         cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
@@ -210,7 +210,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
 
     it('succeeds when the secondary is already defined but the AUT is still on the primary', () => {
       // setup the secondary to be on the secondary domain
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
 
         cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
@@ -220,7 +220,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
       cy.visit('/fixtures/multi-domain.html')
 
       // verify there aren't any issues when the AUT is on primary but the spec bridge is on secondary (cross-origin)
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.visit('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
 
         cy.get('[data-cy="dom-check"]').should('have.text', 'From a secondary domain')
@@ -230,7 +230,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
     it('does not navigate to about:blank in secondary if already visited in primary', () => {
       Cypress.state('hasVisitedAboutBlank', true)
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const urlChangedSpy = cy.spy(Cypress, 'emit').log(false).withArgs('url:changed')
         const aboutBlankSpy = cy.spy(Cypress.specBridgeCommunicator, 'toPrimary').log(false).withArgs('visit:about:blank')
 
@@ -249,7 +249,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
     it('navigates to about:blank in secondary if not already visited in primary', () => {
       Cypress.state('hasVisitedAboutBlank', false)
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const urlChangedSpy = cy.spy(Cypress, 'emit').log(false).withArgs('url:changed')
         const aboutBlankSpy = cy.spy(Cypress.specBridgeCommunicator, 'toPrimary').log(false).withArgs('visit:about:blank')
 
@@ -271,7 +271,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
 
     // TODO: un-skip once multiple remote states are supported
     it.skip('supports auth options and adding auth to subsequent requests', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.visit('http://www.foobar.com:3500/basic_auth', {
           auth: {
             username: 'cypress',
@@ -307,7 +307,7 @@ context('multi-domain navigation', { experimentalMultiDomain: true }, () => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.window().then((win) => {
         win.location.href = 'http://www.foobar.com:3500/fixtures/dom.html'
       })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_network_requests.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_network_requests.spec.ts
@@ -7,7 +7,7 @@ context.skip('multi-domain network requests', { experimentalSessionSupport: true
   })
 
   it('.request()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.request('/fixtures/example.json').should((response) => {
         expect(response.status).to.equal(200)
       })
@@ -15,7 +15,7 @@ context.skip('multi-domain network requests', { experimentalSessionSupport: true
   })
 
   it('.intercept()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.intercept('POST', '/post-only', {
         statusCode: 201,
         body: 'Added',

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_querying.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_querying.spec.ts
@@ -6,19 +6,19 @@ context('multi-domain querying', { experimentalSessionSupport: true }, () => {
   })
 
   it('.get()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#input')
     })
   })
 
   it('.contains()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.contains('Nested Find')
     })
   })
 
   it('.within()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#by-id').within(() => {
         cy.get('#input')
       })
@@ -26,7 +26,7 @@ context('multi-domain querying', { experimentalSessionSupport: true }, () => {
   })
 
   it('.root()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.root().should('match', 'html')
     })
   })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_querying_shadow.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_querying_shadow.spec.ts
@@ -6,7 +6,7 @@ context('multi-domain shadow dom', { experimentalSessionSupport: true }, () => {
   })
 
   it('.shadow()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#shadow-element-1').shadow().find('p.shadow-1')
       .should('have.text', 'Shadow Content 1')
     })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_screenshot.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_screenshot.spec.ts
@@ -21,7 +21,7 @@ context('multi-domain screenshot', { experimentalSessionSupport: true }, () => {
   it('captures the fullPage', () => {
     cy.viewport(600, 200)
 
-    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+    cy.switchToDomain('http://foobar.com:3500', [this.serverResult], ([serverResult]) => {
       const automationStub = cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
 
       cy.screenshot({ capture: 'fullPage' })
@@ -37,7 +37,7 @@ context('multi-domain screenshot', { experimentalSessionSupport: true }, () => {
   it('captures the runner', () => {
     cy.viewport(600, 200)
 
-    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+    cy.switchToDomain('http://foobar.com:3500', [this.serverResult], ([serverResult]) => {
       const automationStub = cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
 
       cy.screenshot({ capture: 'runner' })
@@ -51,7 +51,7 @@ context('multi-domain screenshot', { experimentalSessionSupport: true }, () => {
   it('captures the viewport', () => {
     cy.viewport(600, 200)
 
-    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+    cy.switchToDomain('http://foobar.com:3500', [this.serverResult], ([serverResult]) => {
       const automationStub = cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
 
       cy.screenshot({ capture: 'viewport' })
@@ -63,7 +63,7 @@ context('multi-domain screenshot', { experimentalSessionSupport: true }, () => {
   })
 
   it('supports multiple titles', () => {
-    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+    cy.switchToDomain('http://foobar.com:3500', [this.serverResult], ([serverResult]) => {
       const automationStub = cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
 
       cy.screenshot()
@@ -74,7 +74,7 @@ context('multi-domain screenshot', { experimentalSessionSupport: true }, () => {
   })
 
   it('supports the blackout option', () => {
-    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+    cy.switchToDomain('http://foobar.com:3500', [this.serverResult], ([serverResult]) => {
       cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
 
       cy.screenshot({
@@ -92,7 +92,7 @@ context('multi-domain screenshot', { experimentalSessionSupport: true }, () => {
   })
 
   it('supports element screenshots', () => {
-    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+    cy.switchToDomain('http://foobar.com:3500', [this.serverResult], ([serverResult]) => {
       const automationStub = cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
 
       cy.get('.tall-element').screenshot()
@@ -104,7 +104,7 @@ context('multi-domain screenshot', { experimentalSessionSupport: true }, () => {
   })
 
   it('supports screenshot retrying with appropriate naming', () => {
-    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+    cy.switchToDomain('http://foobar.com:3500', [this.serverResult], ([serverResult]) => {
       const automationStub = cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
 
       cy.state('runnable')._currentRetry = 2
@@ -117,7 +117,7 @@ context('multi-domain screenshot', { experimentalSessionSupport: true }, () => {
   })
 
   it('calls the onBeforeScreenshot callback', () => {
-    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+    cy.switchToDomain('http://foobar.com:3500', [this.serverResult], ([serverResult]) => {
       cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
       const onBeforeScreenshot = cy.stub()
 
@@ -127,7 +127,7 @@ context('multi-domain screenshot', { experimentalSessionSupport: true }, () => {
   })
 
   it('calls the onAfterScreenshot callback', () => {
-    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+    cy.switchToDomain('http://foobar.com:3500', [this.serverResult], ([serverResult]) => {
       cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
       const onAfterScreenshot = cy.stub()
 
@@ -137,7 +137,7 @@ context('multi-domain screenshot', { experimentalSessionSupport: true }, () => {
   })
 
   it('supports the Cypress.screenshot callbacks', () => {
-    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+    cy.switchToDomain('http://foobar.com:3500', [this.serverResult], ([serverResult]) => {
       cy.stub(Cypress, 'automation').withArgs('take:screenshot').resolves(serverResult)
       const onAfterScreenshot = cy.stub()
       const onBeforeScreenshot = cy.stub()
@@ -154,7 +154,7 @@ context('multi-domain screenshot', { experimentalSessionSupport: true }, () => {
   })
 
   it('supports pausing timers', () => {
-    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+    cy.switchToDomain('http://foobar.com:3500', [this.serverResult], ([serverResult]) => {
       cy.stub(Cypress, 'automation').withArgs('take:screenshot').returns(Cypress.Promise.delay(500, serverResult))
 
       cy.window().then((win) => {
@@ -187,7 +187,7 @@ context('multi-domain screenshot', { experimentalSessionSupport: true }, () => {
   })
 
   it('does not pause timers when disableTimersAndAnimations is false', () => {
-    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+    cy.switchToDomain('http://foobar.com:3500', [this.serverResult], ([serverResult]) => {
       cy.stub(Cypress, 'automation').withArgs('take:screenshot').returns(Cypress.Promise.delay(500, serverResult))
 
       cy.window().then((win) => {
@@ -217,7 +217,7 @@ context('multi-domain screenshot', { experimentalSessionSupport: true }, () => {
       expect(err.message).to.include('setTimeout error after screenshot')
     })
 
-    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+    cy.switchToDomain('http://foobar.com:3500', [this.serverResult], ([serverResult]) => {
       cy.stub(Cypress, 'automation').withArgs('take:screenshot').returns(Cypress.Promise.delay(100, serverResult))
 
       cy.window().then((win) => {
@@ -243,7 +243,7 @@ context('multi-domain screenshot', { experimentalSessionSupport: true }, () => {
       expect(err.docsUrl).to.deep.eq(['https://on.cypress.io/uncaught-exception-from-application'])
     })
 
-    cy.switchToDomain('foobar.com', [this.serverResult], ([serverResult]) => {
+    cy.switchToDomain('http://foobar.com:3500', [this.serverResult], ([serverResult]) => {
       cy.stub(Cypress, 'automation').withArgs('take:screenshot').returns(Cypress.Promise.delay(100, serverResult))
 
       cy.window().then((win) => {

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_session.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_session.spec.ts
@@ -10,7 +10,7 @@ context.skip('multi-domain session', { experimentalSessionSupport: true }, () =>
   })
 
   beforeEach(() => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.session('multi-domain', () => {
         localStorage.setItem('foo', 'bar')
       })
@@ -21,13 +21,13 @@ context.skip('multi-domain session', { experimentalSessionSupport: true }, () =>
   })
 
   it('verify new session', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       expect(localStorage.getItem('foo')).to.equal('bar')
     })
   })
 
   it('verify saved session', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       expect(localStorage.getItem('foo')).to.equal('bar')
     })
   })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_spies_stubs_clocks.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_spies_stubs_clocks.spec.ts
@@ -6,7 +6,7 @@ context('multi-domain spies, stubs, and clock', { experimentalSessionSupport: tr
   })
 
   it('spy()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       const foo = { bar () { } }
 
       cy.spy(foo, 'bar')
@@ -16,7 +16,7 @@ context('multi-domain spies, stubs, and clock', { experimentalSessionSupport: tr
   })
 
   it('stub()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       const foo = { bar () { } }
 
       cy.stub(foo, 'bar')
@@ -27,7 +27,7 @@ context('multi-domain spies, stubs, and clock', { experimentalSessionSupport: tr
 
   context('resets stubs', () => {
     it('creates the stub', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const stubEnv = cy.stub(Cypress, 'env').withArgs('foo').returns('bar')
 
         expect(Cypress.env('foo')).to.equal('bar')
@@ -38,7 +38,7 @@ context('multi-domain spies, stubs, and clock', { experimentalSessionSupport: tr
     })
 
     it('verifies the stub got restored', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         expect(Cypress.env('foo')).to.be.undefined
         // @ts-ignore
         expect(Cypress.env.isSinonProxy).to.be.undefined
@@ -48,7 +48,7 @@ context('multi-domain spies, stubs, and clock', { experimentalSessionSupport: tr
 
   context('resets spies', () => {
     it('creates the spy', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const stubEnv = cy.spy(Cypress, 'env')
 
         Cypress.env()
@@ -59,7 +59,7 @@ context('multi-domain spies, stubs, and clock', { experimentalSessionSupport: tr
     })
 
     it('verifies the spy got restored', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         // @ts-ignore
         expect(Cypress.env.isSinonProxy).to.be.undefined
       })
@@ -67,7 +67,7 @@ context('multi-domain spies, stubs, and clock', { experimentalSessionSupport: tr
   })
 
   it('clock() and tick()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       const now = Date.UTC(2022, 0, 12)
 
       cy.clock(now)

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_traversal.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_traversal.spec.ts
@@ -6,110 +6,110 @@ context('multi-domain traversal', { experimentalSessionSupport: true }, () => {
   })
 
   it('.children()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#by-id').children().should('have.length', 3)
     })
   })
 
   it('.closest()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#by-id').closest('form')
     })
   })
 
   it('.eq()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#by-id>input').eq(1).should('have.id', 'name')
     })
   })
 
   it('.filter()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#by-name>input')
       .filter('[name="dogs"]').should('have.length', 4)
     })
   })
 
   it('.find()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#by-id').find('input').should('have.length', 3)
     })
   })
 
   it('.first()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#by-id>input').first().should('have.id', 'input')
     })
   })
 
   it('.last()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#by-id>input').last().should('have.id', 'age')
     })
   })
 
   it('.next()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#input').next().should('have.id', 'name')
     })
   })
 
   it('.nextAll()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#input').nextAll().should('have.length', 2)
     })
   })
 
   it('.nextUntil()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#input').nextUntil('#age').should('have.length', 1)
     })
   })
 
   it('.not()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#by-id>input').not('#age').should('have.length', 2)
     })
   })
 
   it('.parent()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#by-id').parent().should('have.id', 'dom')
     })
   })
 
   it('.parents()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#by-id').parents().should('have.length', 3)
     })
   })
 
   it('.parentsUntil()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#by-id').parentsUntil('body').should('have.length', 1)
     })
   })
 
   it('.prev()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#age').prev().should('have.id', 'name')
     })
   })
 
   it('.prevAll()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#age').prevAll().should('have.length', 2)
     })
   })
 
   it('.prevUntil()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#age').prevUntil('#input').should('have.length', 1)
     })
   })
 
   it('.siblings()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('#input').siblings().should('have.length', 2)
     })
   })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_unsupported_commands.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_unsupported_commands.spec.ts
@@ -11,7 +11,7 @@ context('multi-domain unsupported commands', { experimentalSessionSupport: true 
       done()
     })
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.route('api')
     })
   })
@@ -22,7 +22,7 @@ context('multi-domain unsupported commands', { experimentalSessionSupport: true 
       done()
     })
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.server()
     })
   })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_viewport.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_viewport.spec.ts
@@ -7,7 +7,7 @@ context('multi-domain viewport', { experimentalSessionSupport: true }, () => {
 
   context('.viewport()', () => {
     it('changes the viewport', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.window().then((win) => {
           expect(win.innerHeight).to.equal(660)
           expect(win.innerWidth).to.equal(1000)
@@ -23,7 +23,7 @@ context('multi-domain viewport', { experimentalSessionSupport: true }, () => {
     })
 
     it('resets the viewport between tests', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.window().then((win) => {
           expect(win.innerHeight).to.equal(660)
           expect(win.innerWidth).to.equal(1000)
@@ -33,7 +33,7 @@ context('multi-domain viewport', { experimentalSessionSupport: true }, () => {
 
     context('cy.on(\'viewport:changed\')', () => {
       it('calls viewport:changed handler in switchToDomain', () => {
-        cy.switchToDomain('foobar.com', () => {
+        cy.switchToDomain('http://foobar.com:3500', () => {
           const viewportChangedSpy = cy.spy()
 
           cy.on('viewport:changed', viewportChangedSpy)
@@ -49,7 +49,7 @@ context('multi-domain viewport', { experimentalSessionSupport: true }, () => {
 
         cy.on('viewport:changed', viewportChangedSpy)
 
-        cy.switchToDomain('foobar.com', () => {
+        cy.switchToDomain('http://foobar.com:3500', () => {
           cy.viewport(320, 480)
         }).then(() => {
           expect(viewportChangedSpy).not.to.be.called
@@ -62,7 +62,7 @@ context('multi-domain viewport', { experimentalSessionSupport: true }, () => {
 
       before(() => {
         viewportChangedSpyPrimary = cy.spy()
-        cy.switchToDomain('foobar.com', () => {
+        cy.switchToDomain('http://foobar.com:3500', () => {
           // using global since a function can't be passed to switchToDomain
           // and we need to be able to remove the listener in the 'after' hook
           globalThis.viewportChangedSpySecondary = cy.spy()
@@ -71,7 +71,7 @@ context('multi-domain viewport', { experimentalSessionSupport: true }, () => {
 
       after(() => {
         Cypress.off('viewport:changed', viewportChangedSpyPrimary)
-        cy.switchToDomain('foobar.com', () => {
+        cy.switchToDomain('http://foobar.com:3500', () => {
           Cypress.off('viewport:changed', globalThis.viewportChangedSpySecondary)
         })
 
@@ -79,7 +79,7 @@ context('multi-domain viewport', { experimentalSessionSupport: true }, () => {
       })
 
       it('calls viewport:changed handler in switchToDomain', () => {
-        cy.switchToDomain('foobar.com', () => {
+        cy.switchToDomain('http://foobar.com:3500', () => {
           Cypress.on('viewport:changed', globalThis.viewportChangedSpySecondary)
 
           cy.viewport(320, 480).then(() => {
@@ -91,7 +91,7 @@ context('multi-domain viewport', { experimentalSessionSupport: true }, () => {
       it('does NOT call viewport:changed handler of primary', () => {
         Cypress.on('viewport:changed', viewportChangedSpyPrimary)
 
-        cy.switchToDomain('foobar.com', () => {
+        cy.switchToDomain('http://foobar.com:3500', () => {
           cy.viewport(320, 480)
         }).then(() => {
           expect(viewportChangedSpyPrimary).not.to.be.called
@@ -103,7 +103,7 @@ context('multi-domain viewport', { experimentalSessionSupport: true }, () => {
       // change the viewport in the primary first
       cy.viewport(320, 480)
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const viewportChangedSpy = cy.spy()
 
         cy.on('viewport:changed', viewportChangedSpy)
@@ -125,7 +125,7 @@ context('multi-domain viewport', { experimentalSessionSupport: true }, () => {
 
       cy.on('viewport:changed', viewportChangedSpy)
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         // change the viewport in the secondary first
         cy.viewport(320, 480)
 
@@ -146,11 +146,16 @@ context('multi-domain viewport', { experimentalSessionSupport: true }, () => {
     })
 
     it('syncs the viewport across multiple domains', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.viewport(320, 480)
         cy.window().then((win) => {
           expect(win.innerWidth).to.equal(320)
           expect(win.innerHeight).to.equal(480)
+        })
+
+        // navigate back to primary
+        cy.window().then((win) => {
+          win.location.href = 'http://localhost:3500/fixtures/multi-domain.html'
         })
       })
 
@@ -158,7 +163,7 @@ context('multi-domain viewport', { experimentalSessionSupport: true }, () => {
         win.location.href = 'http://www.idp.com:3500/fixtures/multi-domain.html'
       })
 
-      cy.switchToDomain('idp.com', () => {
+      cy.switchToDomain('http://idp.com:3500', () => {
         const viewportChangedSpy = cy.spy()
 
         cy.on('viewport:changed', viewportChangedSpy)

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_waiting.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_waiting.spec.ts
@@ -6,7 +6,7 @@ context('multi-domain waiting', { experimentalSessionSupport: true }, () => {
   })
 
   it('.wait()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.wait(500)
     })
   })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_window.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_window.spec.ts
@@ -6,19 +6,19 @@ context('multi-domain window', { experimentalSessionSupport: true }, () => {
   })
 
   it('.window()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.window().should('have.property', 'top')
     })
   })
 
   it('.document()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.document().should('have.property', 'charset').and('eq', 'UTF-8')
     })
   })
 
   it('.title()', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.title().should('include', 'DOM Fixture')
     })
   })

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_config_env_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_config_env_spec.ts
@@ -31,7 +31,7 @@
             resolve()
           })
 
-          cy.switchToDomain('foobar.com', () => {
+          cy.switchToDomain('http://foobar.com:3500', () => {
             // @ts-ignore
             Cypress.config('chromeWebSecurity', false)
           })
@@ -42,7 +42,7 @@
     context('serializable', () => {
       it(`syncs initial Cypress.${fnName}() from the primary domain to the secondary (synchronously)`, () => {
         Cypress[fnName](USED_KEYS.foo, 'bar')
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           // @ts-ignore
           const bar = Cypress[fnName](USED_KEYS.foo)
 
@@ -52,7 +52,7 @@
 
       it(`syncs serializable values in the Cypress.${fnName}() again to the secondary even after spec bridge is created`, () => {
         Cypress[fnName](USED_KEYS.foo, 'baz')
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           // @ts-ignore
           const baz = Cypress[fnName](USED_KEYS.foo)
 
@@ -61,7 +61,7 @@
       })
 
       it(`syncs serializable Cypress.${fnName}() values outwards from secondary (synchronously)`, () => {
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           // @ts-ignore
           Cypress[fnName](USED_KEYS.bar, 'baz')
         }).then(() => {
@@ -75,7 +75,7 @@
         // @ts-ignore
         Cypress[fnName](USED_KEYS.foo, 'bar')
 
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           // @ts-ignore
           Cypress[fnName](USED_KEYS.foo, undefined)
         }).then(() => {
@@ -84,7 +84,7 @@
       })
 
       it(`syncs serializable Cypress.${fnName}() values outwards from secondary (commands/async)`, () => {
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           cy.then(() => {
             // @ts-ignore
             Cypress[fnName](USED_KEYS.bar, 'quux')
@@ -97,7 +97,7 @@
       })
 
       it(`persists Cypress.${fnName}() changes made in the secondary, assuming primary has not overwritten with a serializable value`, () => {
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           // @ts-ignore
           const quux = Cypress[fnName](USED_KEYS.bar)
 
@@ -112,7 +112,7 @@
         },
       }, () => {
         return new Promise<void>((resolve) => {
-          cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+          cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
             setTimeout(() => {
               // this value STILL gets set, but will be blown away on the next switchToDomain with whatever exists in the primary
               // @ts-ignore
@@ -137,7 +137,7 @@
           [USED_KEYS.baz]: 'quux',
         },
       }, () => {
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           // in previous test, 'baz' was set to 'qux' after the callback window was closed.
           // this should be overwritten by 'quux' that exists in the primary
           // @ts-ignore
@@ -154,7 +154,7 @@
           [USED_KEYS.baz]: undefined,
         },
       }, () => {
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           // @ts-ignore
           const isNowUndefined = Cypress[fnName](USED_KEYS.baz)
 
@@ -168,7 +168,7 @@
 
       it('does not sync unserializable values from the primary to the secondary', () => {
         Cypress[fnName](USED_KEYS.unserializable, unserializableFunc)
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           // @ts-ignore
           const isUndefined = Cypress[fnName](USED_KEYS.unserializable)
 
@@ -178,7 +178,7 @@
 
       it('does not overwrite unserializable values in the primary when none exist in the secondary', () => {
         Cypress[fnName](USED_KEYS.unserializable, unserializableFunc)
-        cy.switchToDomain('foobar.com', () => undefined)
+        cy.switchToDomain('http://foobar.com:3500', () => undefined)
 
         const isFunc = Cypress[fnName](USED_KEYS.unserializable)
 
@@ -187,7 +187,7 @@
 
       it('overwrites unserializable values in the primary when serializable values of same key exist in secondary', () => {
         Cypress[fnName](USED_KEYS.unserializable, unserializableFunc)
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           // @ts-ignore
           Cypress[fnName](USED_KEYS.unserializable, undefined)
         }).then(() => {
@@ -198,7 +198,7 @@
       })
 
       it('overwrites unserializable values in the secondary when serializable values of same key exist in primary', () => {
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           const unserializableFuncSecondary = () => undefined
 
           // @ts-ignore
@@ -207,7 +207,7 @@
           Cypress[fnName](USED_KEYS.unserializable, undefined)
         })
 
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           // @ts-ignore
           const isUndefined = Cypress[fnName](USED_KEYS.unserializable)
 
@@ -221,7 +221,7 @@
 
       it('does not overwrite unserializable values in the primary when unserializable values of same key exist in secondary', () => {
         Cypress[fnName](USED_KEYS.unserializable, unserializableFunc)
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           const unserializableFuncSecondary = () => undefined
 
           // @ts-ignore
@@ -241,7 +241,7 @@
 
         Cypress[fnName](USED_KEYS.unserializable, partiallyUnserializableObject)
 
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           // @ts-ignore
           const doesNotContainPartialAProperty = Cypress[fnName](USED_KEYS.unserializable)
 
@@ -266,7 +266,7 @@
       }, function () {
         Cypress[fnName](USED_KEYS.error, new Error('error'))
 
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           // @ts-ignore
           const isUndefined = Cypress[fnName](USED_KEYS.error)
 
@@ -280,7 +280,7 @@
       }, () => {
         Cypress[fnName](USED_KEYS.error, new Error('error'))
 
-        cy.switchToDomain('foobar.com', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
+        cy.switchToDomain('http://foobar.com:3500', [fnName, USED_KEYS], ([fnName, USED_KEYS]) => {
           // @ts-ignore
           const isErrorObj = Cypress[fnName](USED_KEYS.error)
 

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_cypress_api.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_cypress_api.spec.ts
@@ -7,7 +7,7 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () =>
 
   context('Commands', () => {
     it('adds a custom command', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         // @ts-ignore
         Cypress.Commands.add('foo', () => 'bar')
 
@@ -16,14 +16,14 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () =>
       })
 
       // persists added command through spec bridge
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         // @ts-ignore
         cy.foo().should('equal', 'bar')
       })
     })
 
     it('overwrites an existing command in the spec bridge', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         // @ts-ignore
         Cypress.Commands.overwrite('foo', () => 'baz')
 
@@ -32,7 +32,7 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () =>
       })
 
       // persists overwritten command through spec bridge
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         // @ts-ignore
         cy.foo().should('equal', 'baz')
       })
@@ -45,7 +45,7 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () =>
         keystrokeDelay: 30,
       })
 
-      cy.switchToDomain('foobar.com', [defaults], ([primaryKeyboardDefaults]) => {
+      cy.switchToDomain('http://foobar.com:3500', [defaults], ([primaryKeyboardDefaults]) => {
         const multiDomainKeyboardDefaults = Cypress.Keyboard.defaults({})
 
         expect(multiDomainKeyboardDefaults).to.not.deep.equal(primaryKeyboardDefaults)
@@ -53,7 +53,7 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () =>
     })
 
     it('allows a user to configure defaults', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const multiDomainKeyboardDefaults = Cypress.Keyboard.defaults({
           keystrokeDelay: 60,
         })
@@ -64,7 +64,7 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () =>
       })
 
       // persists default configuration changes through spec bridge
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const multiDomainKeyboardDefaults = Cypress.Keyboard.defaults({})
 
         expect(multiDomainKeyboardDefaults).to.deep.include({
@@ -83,7 +83,7 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () =>
         onAfterScreenshot: () => undefined,
       })
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const multiDomainScreenshotDefaults = Cypress.Screenshot.defaults({})
 
         expect(multiDomainScreenshotDefaults).to.not.deep.include({
@@ -96,7 +96,7 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () =>
     })
 
     it('allows a user to configure defaults', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const multiDomainScreenshotDefaults = Cypress.Screenshot.defaults({
           blackout: ['foo'],
           overwrite: true,
@@ -109,7 +109,7 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () =>
       })
 
       // persists default configuration changes through spec bridge
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const multiDomainScreenshotDefaults = Cypress.Screenshot.defaults({})
 
         expect(multiDomainScreenshotDefaults).to.deep.include({
@@ -122,7 +122,7 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () =>
 
   context('dom', () => {
     it('provides a sanity check that the dom API exists on Cypress.*', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.get('[data-cy="dom-check"]').then(($el) => {
           expect(Cypress.dom.isAttached($el)).to.be.true
         })
@@ -133,7 +133,7 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () =>
   // TODO: Before implementing, understand how Cypress.session.* and cy.session() are supposed to function within the context of multi-domain
   context.skip('session', () => {
     it('clearAllSavedSessions() functions as expected', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         Cypress.session.clearAllSavedSessions()
       })
     })
@@ -141,37 +141,37 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () =>
 
   context('properties', () => {
     it('has arch property synced from primary', () => {
-      cy.switchToDomain('foobar.com', [Cypress.arch], ([theArch]) => {
+      cy.switchToDomain('http://foobar.com:3500', [Cypress.arch], ([theArch]) => {
         expect(Cypress.arch).to.equal(theArch)
       })
     })
 
     it('has browser property synced from primary', () => {
-      cy.switchToDomain('foobar.com', [Cypress.browser], ([theBrowser]) => {
+      cy.switchToDomain('http://foobar.com:3500', [Cypress.browser], ([theBrowser]) => {
         expect(Cypress.browser).to.deep.equal(theBrowser)
       })
     })
 
     it('has currentTest property synced from primary', () => {
-      cy.switchToDomain('foobar.com', [Cypress.currentTest], ([theCurrentTest]) => {
+      cy.switchToDomain('http://foobar.com:3500', [Cypress.currentTest], ([theCurrentTest]) => {
         expect(Cypress.currentTest).to.deep.equal(theCurrentTest)
       })
     })
 
     it('has platform property synced from primary', () => {
-      cy.switchToDomain('foobar.com', [Cypress.platform], ([thePlatform]) => {
+      cy.switchToDomain('http://foobar.com:3500', [Cypress.platform], ([thePlatform]) => {
         expect(Cypress.platform).to.equal(thePlatform)
       })
     })
 
     it('has testingType property synced from primary', () => {
-      cy.switchToDomain('foobar.com', [Cypress.testingType], ([theTestingType]) => {
+      cy.switchToDomain('http://foobar.com:3500', [Cypress.testingType], ([theTestingType]) => {
         expect(Cypress.testingType).to.deep.equal(theTestingType)
       })
     })
 
     it('has spec property synced from primary', () => {
-      cy.switchToDomain('foobar.com', [Cypress.spec], ([theSpec]) => {
+      cy.switchToDomain('http://foobar.com:3500', [Cypress.spec], ([theSpec]) => {
         expect(Cypress.spec).to.deep.equal(theSpec)
       })
     })
@@ -179,20 +179,20 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () =>
 
   context('methods', () => {
     it('isCy()', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         expect(Cypress.isCy(cy)).to.be.true
       })
     })
 
     it('isBrowser()', () => {
-      cy.switchToDomain('foobar.com', [Cypress.browser], ([theBrowser]) => {
+      cy.switchToDomain('http://foobar.com:3500', [Cypress.browser], ([theBrowser]) => {
         expect(Cypress.isBrowser(theBrowser.name)).to.equal(true)
       })
     })
 
     // FIXME: convert to cypress-in-cypress tests once possible
     it('log()', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         Cypress.log({
           message: 'test log',
         })
@@ -222,7 +222,7 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () =>
         done()
       })
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         Cypress.Server.defaults({})
       })
     })
@@ -233,7 +233,7 @@ describe('multi-domain Cypress API', { experimentalSessionSupport: true }, () =>
         done()
       })
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         // @ts-ignore
         Cypress.Cookies.preserveOnce({})
       })

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_events_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_events_spec.ts
@@ -8,7 +8,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
 
     cy.window().its('testPrimaryDomainBeforeLoad').should('be.true')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.on('window:before:load', (win: {testSecondaryWindowBeforeLoad: boolean}) => {
         win.testSecondaryWindowBeforeLoad = true
       })
@@ -34,7 +34,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
     })
 
     it('form:submitted', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const afterFormSubmitted = new Promise<void>((resolve) => {
           Cypress.once('form:submitted', (e) => {
             const $form = cy.$$('form')
@@ -50,7 +50,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
     })
 
     it('window:before:unload', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const afterWindowBeforeUnload = new Promise<void>((resolve) => {
           Cypress.once('window:before:unload', () => {
             expect(location.host).to.equal('foobar.com:3500')
@@ -66,7 +66,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
     })
 
     it('window:unload', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const afterWindowUnload = new Promise<void>((resolve) => {
           Cypress.once('window:unload', () => {
             expect(location.host).to.equal('foobar.com:3500')
@@ -82,7 +82,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
     })
 
     it('window:alert', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const afterWindowAlert = new Promise<void>((resolve) => {
           Cypress.once('window:alert', (text) => {
             expect(location.host).to.equal('foobar.com:3500')
@@ -97,7 +97,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
     })
 
     it('window:confirm', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const afterWindowConfirm = new Promise<void>((resolve) => {
           Cypress.once('window:confirm', (text) => {
             expect(location.host).to.equal('foobar.com:3500')
@@ -112,7 +112,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
     })
 
     it('window:confirmed - true when no window:confirm listeners return false', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const afterWindowConfirmed = new Promise<void>((resolve) => {
           Cypress.once('window:confirmed', (text, returnedFalse) => {
             expect(location.host).to.equal('foobar.com:3500')
@@ -132,7 +132,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
     })
 
     it('window:confirmed - false when any window:confirm listeners return false', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const afterWindowConfirmed = new Promise<void>((resolve) => {
           Cypress.once('window:confirmed', (text, returnedFalse) => {
             expect(location.host).to.equal('foobar.com:3500')

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_rerun_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_rerun_spec.ts
@@ -9,7 +9,7 @@ describe('multi-domain - rerun', { }, () => {
   // https://github.com/cypress-io/cypress/issues/18043
   it('successfully reruns tests', () => {
     // @ts-ignore
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('[data-cy="dom-check"]')
     })
     .then(() => {

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_spec.ts
@@ -6,7 +6,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
   })
 
   it('runs commands in secondary domain', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy
       .get('[data-cy="dom-check"]')
       .invoke('text')
@@ -51,7 +51,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
       ctx: {},
     }
 
-    cy.switchToDomain('foobar.com', [expectedRunnable], ([expectedRunnable]) => {
+    cy.switchToDomain('http://foobar.com:3500', [expectedRunnable], ([expectedRunnable]) => {
       const actualRunnable = cy.state('runnable')
 
       expect(actualRunnable.titlePath()).to.deep.equal(expectedRunnable.titlePath)
@@ -79,7 +79,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
       expect(primaryViewport).to.deep.equal(expectedViewport)
     })
 
-    cy.switchToDomain('foobar.com', [expectedViewport], ([expectedViewport]) => {
+    cy.switchToDomain('http://foobar.com:3500', [expectedViewport], ([expectedViewport]) => {
       const secondaryViewport = [cy.state('viewportWidth'), cy.state('viewportHeight')]
 
       expect(secondaryViewport).to.deep.equal(expectedViewport)
@@ -87,7 +87,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
   })
 
   it('handles querying nested elements', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy
       .get('form button')
       .invoke('text')
@@ -98,7 +98,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
   })
 
   it('sets up window.Cypress in secondary domain', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy
       .get('[data-cy="cypress-check"]')
       .invoke('text')
@@ -108,39 +108,39 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
 
   describe('data argument', () => {
     it('passes object to callback function', () => {
-      cy.switchToDomain('foobar.com', [{ foo: 'foo', bar: 'bar' }], ([{ foo, bar }]) => {
+      cy.switchToDomain('http://foobar.com:3500', [{ foo: 'foo', bar: 'bar' }], ([{ foo, bar }]) => {
         expect(foo).to.equal('foo')
         expect(bar).to.equal('bar')
       })
     })
 
     it('passes array to callback function', () => {
-      cy.switchToDomain('foobar.com', ['foo', 'bar'], ([foo, bar]) => {
+      cy.switchToDomain('http://foobar.com:3500', ['foo', 'bar'], ([foo, bar]) => {
         expect(foo).to.equal('foo')
         expect(bar).to.equal('bar')
       })
     })
 
     it('passes string to callback function', () => {
-      cy.switchToDomain('foobar.com', ['foo'], ([foo]) => {
+      cy.switchToDomain('http://foobar.com:3500', ['foo'], ([foo]) => {
         expect(foo).to.equal('foo')
       })
     })
 
     it('passes number to callback function', () => {
-      cy.switchToDomain('foobar.com', [1], ([num]) => {
+      cy.switchToDomain('http://foobar.com:3500', [1], ([num]) => {
         expect(num).to.equal(1)
       })
     })
 
     it('passes boolean to callback function', () => {
-      cy.switchToDomain('foobar.com', [true], ([bool]) => {
+      cy.switchToDomain('http://foobar.com:3500', [true], ([bool]) => {
         expect(bool).to.be.true
       })
     })
 
     it('passes mixed types to callback function', () => {
-      cy.switchToDomain('foobar.com', ['foo', 1, true], ([foo, num, bool]) => {
+      cy.switchToDomain('http://foobar.com:3500', ['foo', 1, true], ([foo, num, bool]) => {
         expect(foo).to.equal('foo')
         expect(num).to.equal(1)
         expect(bool).to.be.true
@@ -157,7 +157,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
           resolve(undefined)
         })
 
-        cy.switchToDomain('foobar.com', () => {
+        cy.switchToDomain('http://foobar.com:3500', () => {
           // done is not defined on purpose here as we want to test the error gets sent back to the primary domain correctly
           // @ts-ignore
           done()
@@ -171,7 +171,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
         done()
       })
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         throw 'oops'
       })
     })
@@ -183,7 +183,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
           resolve(undefined)
         })
 
-        cy.switchToDomain('foobar.com', () => {
+        cy.switchToDomain('http://foobar.com:3500', () => {
           throw 'oops'
         })
       })
@@ -200,7 +200,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
         done()
       })
 
-      cy.switchToDomain('foobar.com', [timeout], ([timeout]) => {
+      cy.switchToDomain('http://foobar.com:3500', [timeout], ([timeout]) => {
         cy.get('#doesnt-exist', {
           timeout,
         })
@@ -216,7 +216,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
         done()
       })
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.get('#doesnt-exist')
       })
     })
@@ -231,7 +231,7 @@ describe('domain validation', { experimentalSessionSupport: true }, () => {
       win.location.href = 'http://baz.foobar.com:3500/fixtures/auth/idp.html'
     })
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('[data-cy="username"]').type('TJohnson')
       cy.get('[data-cy="login"]').click()
     })
@@ -244,7 +244,7 @@ describe('domain validation', { experimentalSessionSupport: true }, () => {
   it('uses switchToDomain twice', () => {
     cy.visit('/fixtures/auth/index.html') // Establishes Primary Domain
     cy.get('[data-cy="login-idp"]').click() // Takes you to idp.com
-    cy.switchToDomain('idp.com', () => {
+    cy.switchToDomain('http://idp.com:3500', () => {
       cy.get('[data-cy="username"]').type('BJohnson')
       cy.get('[data-cy="login"]').click()
     }) // Trailing edge wait, waiting to return to the primary domain
@@ -260,7 +260,7 @@ describe('domain validation', { experimentalSessionSupport: true }, () => {
       win.location.href = 'http://baz.foobar.com:3500/fixtures/auth/idp.html'
     })
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('[data-cy="username"]').type('TJohnson')
       cy.get('[data-cy="login"]').click()
     }) // Trailing edge wait, waiting to return to the primary domain

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_uncaught_errors_spec.ts
@@ -29,7 +29,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true },
         done()
       })
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.get('.trigger-sync-error').click()
       })
     })
@@ -42,7 +42,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true },
 
       cy.on('fail', failureSpy)
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.on('uncaught:exception', () => false)
         cy.get('.trigger-sync-error').click()
       }).then(() => {
@@ -63,7 +63,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true },
         done()
       })
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.once('uncaught:exception', () => true)
         cy.get('.trigger-sync-error').click()
       })
@@ -72,7 +72,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true },
     // if we mutate the error, the app's listeners for 'error' or
     // 'unhandledrejection' will have our wrapped error instead of the original
     it('original error is not mutated for "error" in the switchToDomain', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.once('uncaught:exception', () => false)
 
         cy.get('.trigger-sync-error').click()
@@ -92,7 +92,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true },
         done()
       })
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         setTimeout(() => {
           throw new Error('setTimeout error')
         }, 50)
@@ -123,7 +123,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true },
         done()
       })
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.get('.trigger-async-error').click()
 
         // add the cy.wait here to keep commands streaming in,
@@ -140,7 +140,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true },
 
       cy.on('fail', failureSpy)
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         // the async error here should be thrown AFTER the current command and test has finished, resulting in a passed test with no fail being triggered in the primary
         cy.get('.trigger-async-error').click()
       }).then(() => {
@@ -158,7 +158,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true },
         done()
       })
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         setTimeout(() => {
           throw new Error('setTimeout error')
         }, 50)
@@ -170,7 +170,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true },
 
   describe('unhandled rejections', () => {
     it('unhandled rejection triggers uncaught:exception and has promise as third argument', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const r = cy.state('runnable')
 
         const afterUncaughtException = new Promise<void>((resolve) => {
@@ -194,7 +194,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true },
     })
 
     it('original error is not mutated for "unhandledrejection"', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.once('uncaught:exception', () => false)
 
         cy.get('.trigger-unhandled-rejection').click()
@@ -213,7 +213,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true },
         done()
       })
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         Promise.reject(new Error('rejected promise'))
 
         // add the cy.wait here to keep commands streaming in, forcing the
@@ -232,7 +232,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true },
         done()
       })
 
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         Promise.reject(new Error('rejected promise'))
       })
 
@@ -248,7 +248,7 @@ describe('multi-domain - uncaught errors', { experimentalSessionSupport: true },
       done()
     })
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.then(() => {
         throw new class CustomError extends Error {
           get name () {

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_validation_specs.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_validation_specs.ts
@@ -3,19 +3,123 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
   describe('successes', () => {
     it('succeeds on a localhost domain name', () => {
       cy.switchToDomain('localhost', () => undefined)
+      cy.then(() => {
+        const expectedSrc = `https://localhost/__cypress/multi-domain-iframes`
+        const iframe = window.top?.document.getElementById('Spec\ Bridge:\ localhost') as HTMLIFrameElement
+
+        expect(iframe.src).to.equal(expectedSrc)
+      })
     })
 
     it('succeeds on an ip address', () => {
       cy.switchToDomain('127.0.0.1', () => undefined)
+      cy.then(() => {
+        const expectedSrc = `https://127.0.0.1/__cypress/multi-domain-iframes`
+        const iframe = window.top?.document.getElementById('Spec\ Bridge:\ 127.0.0.1') as HTMLIFrameElement
+
+        expect(iframe.src).to.equal(expectedSrc)
+      })
     })
 
-    // TODO: an ipv6 address passes validation but hangs elsewhere in the code, Come back later and fix ipv6
+    // TODO: $Location does not support ipv6
     it.skip('succeeds on an ipv6 address', () => {
       cy.switchToDomain('0000:0000:0000:0000:0000:0000:0000:0001', () => undefined)
+      cy.then(() => {
+        const expectedSrc = `https://[::1]/__cypress/multi-domain-iframes`
+        const iframe = window.top?.document.getElementById('Spec\ Bridge:\ [::1]') as HTMLIFrameElement
+
+        expect(iframe.src).to.equal(expectedSrc)
+      })
     })
 
     it('succeeds on a unicode domain', () => {
       cy.switchToDomain('はじめよう.みんな', () => undefined)
+      cy.then(() => {
+        const expectedSrc = `https://xn--p8j9a0d9c9a.xn--q9jyb4c/__cypress/multi-domain-iframes`
+        const iframe = window.top?.document.getElementById('Spec\ Bridge:\ xn--p8j9a0d9c9a.xn--q9jyb4c') as HTMLIFrameElement
+
+        expect(iframe.src).to.equal(expectedSrc)
+      })
+    })
+
+    it('succeeds on a complete origin', () => {
+      cy.switchToDomain('http://foobar1.com:3500', () => {})
+      cy.then(() => {
+        const expectedSrc = `http://foobar1.com:3500/__cypress/multi-domain-iframes`
+        const iframe = window.top?.document.getElementById('Spec\ Bridge:\ foobar1.com') as HTMLIFrameElement
+
+        expect(iframe.src).to.equal(expectedSrc)
+      })
+    })
+
+    it('succeeds on a complete origin using https', () => {
+      cy.switchToDomain('https://foobar2.com:3500', () => {})
+      cy.then(() => {
+        const expectedSrc = `https://foobar2.com:3500/__cypress/multi-domain-iframes`
+        const iframe = window.top?.document.getElementById('Spec\ Bridge:\ foobar2.com') as HTMLIFrameElement
+
+        expect(iframe.src).to.equal(expectedSrc)
+      })
+    })
+
+    it('succeeds on a hostname and port', () => {
+      cy.switchToDomain('foobar3.com:3500', () => {})
+      cy.then(() => {
+        const expectedSrc = `https://foobar3.com:3500/__cypress/multi-domain-iframes`
+        const iframe = window.top?.document.getElementById('Spec\ Bridge:\ foobar3.com') as HTMLIFrameElement
+
+        expect(iframe.src).to.equal(expectedSrc)
+      })
+    })
+
+    it('succeeds on a protocol and hostname', () => {
+      cy.switchToDomain('http://foobar4.com', () => {})
+      cy.then(() => {
+        const expectedSrc = `http://foobar4.com/__cypress/multi-domain-iframes`
+        const iframe = window.top?.document.getElementById('Spec\ Bridge:\ foobar4.com') as HTMLIFrameElement
+
+        expect(iframe.src).to.equal(expectedSrc)
+      })
+    })
+
+    it('succeeds on a subdomain', () => {
+      cy.switchToDomain('app.foobar5.com', () => {})
+      cy.then(() => {
+        const expectedSrc = `https://foobar5.com/__cypress/multi-domain-iframes`
+        const iframe = window.top?.document.getElementById('Spec\ Bridge:\ app.foobar5.com') as HTMLIFrameElement
+
+        expect(iframe.src).to.equal(expectedSrc)
+      })
+    })
+
+    it('succeeds when only domain is passed', () => {
+      cy.switchToDomain('foobar6.com', () => undefined)
+      cy.then(() => {
+        const expectedSrc = `https://foobar6.com/__cypress/multi-domain-iframes`
+        const iframe = window.top?.document.getElementById('Spec\ Bridge:\ foobar6.com') as HTMLIFrameElement
+
+        expect(iframe.src).to.equal(expectedSrc)
+      })
+    })
+
+    it('succeeds on a public suffix with a subdomain', () => {
+      cy.switchToDomain('app.foobar.herokuapp.com', () => {})
+      cy.then(() => {
+        const expectedSrc = `https://foobar.herokuapp.com/__cypress/multi-domain-iframes`
+        const iframe = window.top?.document.getElementById('Spec\ Bridge:\ app.foobar.herokuapp.com') as HTMLIFrameElement
+
+        expect(iframe.src).to.equal(expectedSrc)
+      })
+    })
+
+    it('succeeds on a machine name', () => {
+      cy.switchToDomain('machine-name', () => undefined)
+      cy.then(() => {
+        const expectedSrc = `https://machine-name/__cypress/multi-domain-iframes`
+        const iframe = window.top?.document.getElementById('Spec\ Bridge:\ machine-name') as HTMLIFrameElement
+
+        expect(iframe.src).to.equal(expectedSrc)
+      })
     })
   })
 
@@ -34,7 +138,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
 
     it('errors if passed a non-string for the domain argument', (done) => {
       cy.on('fail', (err) => {
-        expect(err.message).to.equal('`cy.switchToDomain()` requires the first argument to be either \'localhost\', an ip address (\'127.0.0.1\') or a domain name (\'example.com\'). Domain names must not contain sub domains, ports or paths. You passed: ``')
+        expect(err.message).to.equal('`cy.switchToDomain()` requires the first argument to be either an origin (\'https://app.example.com\') or a domain name (\'example.com\'). The origin or domain name must not contain a path, hash, or query parameters. You passed: ``')
 
         done()
       })
@@ -43,44 +147,34 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
       cy.switchToDomain()
     })
 
-    it('errors if passed a top level domain name', (done) => {
+    it('errors if query params are provided', (done) => {
       cy.on('fail', (err) => {
-        expect(err.message).to.equal('`cy.switchToDomain()` requires the first argument to be either \'localhost\', an ip address (\'127.0.0.1\') or a domain name (\'example.com\'). Domain names must not contain sub domains, ports or paths. You passed: `foobar`')
+        expect(err.message).to.equal('`cy.switchToDomain()` requires the first argument to be either an origin (\'https://app.example.com\') or a domain name (\'example.com\'). The origin or domain name must not contain a path, hash, or query parameters. You passed: `foobar.com?foo=bar`')
 
         done()
       })
 
-      cy.switchToDomain('foobar', () => undefined)
-    })
-
-    it('errors if passed a domain name with a sub domain', (done) => {
-      cy.on('fail', (err) => {
-        expect(err.message).to.equal('`cy.switchToDomain()` requires the first argument to be either \'localhost\', an ip address (\'127.0.0.1\') or a domain name (\'example.com\'). Domain names must not contain sub domains, ports or paths. You passed: `eu.foobar.com`')
-
-        done()
-      })
-
-      cy.switchToDomain('eu.foobar.com', () => undefined)
-    })
-
-    it('errors if passed a domain name with a port', (done) => {
-      cy.on('fail', (err) => {
-        expect(err.message).to.equal('`cy.switchToDomain()` requires the first argument to be either \'localhost\', an ip address (\'127.0.0.1\') or a domain name (\'example.com\'). Domain names must not contain sub domains, ports or paths. You passed: `foobar.com:3000`')
-
-        done()
-      })
-
-      cy.switchToDomain('foobar.com:3000', () => undefined)
+      cy.switchToDomain('foobar.com?foo=bar', () => undefined)
     })
 
     it('errors if passed a domain name with a path', (done) => {
       cy.on('fail', (err) => {
-        expect(err.message).to.equal('`cy.switchToDomain()` requires the first argument to be either \'localhost\', an ip address (\'127.0.0.1\') or a domain name (\'example.com\'). Domain names must not contain sub domains, ports or paths. You passed: `foobar.com/login`')
+        expect(err.message).to.equal('`cy.switchToDomain()` requires the first argument to be either an origin (\'https://app.example.com\') or a domain name (\'example.com\'). The origin or domain name must not contain a path, hash, or query parameters. You passed: `foobar.com/login`')
 
         done()
       })
 
       cy.switchToDomain('foobar.com/login', () => undefined)
+    })
+
+    it('errors if passed a domain name with a hash', (done) => {
+      cy.on('fail', (err) => {
+        expect(err.message).to.equal('`cy.switchToDomain()` requires the first argument to be either an origin (\'https://app.example.com\') or a domain name (\'example.com\'). The origin or domain name must not contain a path, hash, or query parameters. You passed: `foobar.com/#hash`')
+
+        done()
+      })
+
+      cy.switchToDomain('foobar.com/#hash', () => undefined)
     })
 
     it('errors passing non-array to callback function', (done) => {

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_yield_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_yield_spec.ts
@@ -16,7 +16,7 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
   })
 
   it('yields a value', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy
       .get('[data-cy="dom-check"]')
       .invoke('text')
@@ -24,7 +24,7 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
   })
 
   it('yields the cy value even if a return is present', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy
       .get('[data-cy="dom-check"]')
       .invoke('text')
@@ -46,7 +46,7 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
       done()
     })
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy
       .get('[data-cy="dom-check"]')
       .invoke('text')
@@ -56,13 +56,13 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
   })
 
   it('yields synchronously', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       return 'From a secondary domain'
     }).should('equal', 'From a secondary domain')
   })
 
   it('yields asynchronously', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       return new Promise((resolve: (val: string) => any, reject) => {
         setTimeout(() => {
           resolve('From a secondary domain')
@@ -72,7 +72,7 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
   })
 
   it('succeeds if subject cannot be serialized and is not accessed synchronously', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       return {
         symbol: Symbol(''),
       }
@@ -90,7 +90,7 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
       done()
     })
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       return {
         symbol: Symbol(''),
       }
@@ -101,7 +101,7 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
   })
 
   it('succeeds if subject cannot be serialized and is not accessed', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('[data-cy="dom-check"]')
     })
     .then(() => {
@@ -119,7 +119,7 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
       done()
     })
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.get('[data-cy="dom-check"]')
     })
     .then((subject) => subject.text())
@@ -135,7 +135,7 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
       done()
     })
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.wrap({
         key: () => {
           return 'whoops'
@@ -155,7 +155,7 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
       done()
     })
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.wrap({
         key: Symbol('whoops'),
       })
@@ -172,7 +172,7 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
       done()
     })
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.wrap(() => {
         return 'text'
       })
@@ -192,7 +192,7 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
       done()
     })
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.wrap(Symbol('symbol'))
     })
     .should('equal', 'symbol')
@@ -212,7 +212,7 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
       done()
     })
 
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.wrap({
         key: new Error('Boom goes the dynamite'),
       })
@@ -224,7 +224,7 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
   })
 
   it('yields an object containing valid types', () => {
-    cy.switchToDomain('foobar.com', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
       cy.wrap({
         array: [
           1,

--- a/packages/driver/cypress/integration/e2e/multi-domain/navigation_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/navigation_spec.ts
@@ -28,7 +28,7 @@ describe('navigation events', { experimentalSessionSupport: true }, () => {
 
   describe('navigation:changed', () => {
     it('navigation:changed via hashChange', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const afterNavigationChanged = new Promise<void>((resolve) => {
           const listener = () => {
             cy.location().should((loc) => {
@@ -50,7 +50,7 @@ describe('navigation events', { experimentalSessionSupport: true }, () => {
 
     // TODO: this test should work but there seems to be a problem where the command queue ends prematurely
     it.skip('navigates forward and back using history', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.get('a[data-cy="multi-domain-page"]').click()
         .window().then((win) => {
           return new Promise((resolve) => {
@@ -71,7 +71,7 @@ describe('navigation events', { experimentalSessionSupport: true }, () => {
 
   describe('window:load', () => {
     it('reloads', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const logs: any[] = []
 
         cy.on('log:added', (attrs, log) => {
@@ -107,7 +107,7 @@ describe('navigation events', { experimentalSessionSupport: true }, () => {
     })
 
     it('navigates to a new page', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const logs: any[] = []
 
         cy.on('log:added', (attrs, log) => {
@@ -152,7 +152,7 @@ describe('navigation events', { experimentalSessionSupport: true }, () => {
 
   describe('url:changed', () => {
     it('reloads', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const afterUrlChanged = new Promise<void>((resolve) => {
           cy.once('url:changed', (url) => {
             expect(url).to.equal('http://www.foobar.com:3500/fixtures/multi-domain-secondary.html')
@@ -166,7 +166,7 @@ describe('navigation events', { experimentalSessionSupport: true }, () => {
     })
 
     it('navigates to a new page', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         const afterUrlChanged = new Promise<void>((resolve) => {
           let times = 0
           const listener = (url) => {
@@ -192,7 +192,7 @@ describe('navigation events', { experimentalSessionSupport: true }, () => {
 
     // TODO: this test should re revisited with the cypress in cypress tests available in 10.0
     it.skip('the runner url updates appropriately', () => {
-      cy.switchToDomain('foobar.com', () => {
+      cy.switchToDomain('http://foobar.com:3500', () => {
         cy.get('a[data-cy="multi-domain-page"]').click()
       })
     })

--- a/packages/driver/src/cy/multi-domain/index.ts
+++ b/packages/driver/src/cy/multi-domain/index.ts
@@ -4,6 +4,18 @@ import { Validator } from './validator'
 import { createUnserializableSubjectProxy } from './unserializable_subject_proxy'
 import { serializeRunnable } from './util'
 import { preprocessConfig, preprocessEnv, syncConfigToCurrentDomain, syncEnvToCurrentDomain } from '../../util/config'
+import { $Location } from '../../cypress/location'
+
+const reHttp = /^https?:\/\//
+
+const normalizeDomain = (domain) => {
+  // add the protocol if it's not present
+  if (!reHttp.test(domain)) {
+    domain = `https://${domain}`
+  }
+
+  return $Location.normalize(domain)
+}
 
 export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, state: Cypress.State, config: Cypress.InternalConfig) {
   let timeoutId
@@ -32,7 +44,7 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
   })
 
   Commands.addAll({
-    switchToDomain<T> (domain: string, dataOrFn: T[] | (() => {}), fn?: (data?: T[]) => {}) {
+    switchToDomain<T> (originOrDomain: string, dataOrFn: T[] | (() => {}), fn?: (data?: T[]) => {}) {
       clearTimeout(timeoutId)
       // this command runs for as long as the commands in the secondary
       // domain run, so it can't have its own timeout
@@ -56,7 +68,7 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
       const log = Cypress.log({
         name: 'switchToDomain',
         type: 'parent',
-        message: domain,
+        message: originOrDomain,
         end: true,
       })
 
@@ -68,8 +80,16 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
       validator.validate({
         callbackFn,
         data,
-        domain,
+        originOrDomain,
       })
+
+      // use URL to ensure unicode characters are correctly handled
+      const url = new URL(normalizeDomain(originOrDomain)).toString()
+      const location = $Location.create(url)
+
+      validator.validateLocation(location, originOrDomain)
+
+      const domain = location.superDomain
 
       return new Bluebird((resolve, reject) => {
         const cleanup = () => {
@@ -179,9 +199,8 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
           }
         })
 
-        // this signals to the runner to create the spec bridge for
-        // the specified domain
-        communicator.emit('expect:domain', domain)
+        // this signals to the runner to create the spec bridge for the specified origin policy
+        communicator.emit('expect:domain', location)
       })
     },
   })

--- a/packages/driver/src/cy/multi-domain/validator.ts
+++ b/packages/driver/src/cy/multi-domain/validator.ts
@@ -1,8 +1,6 @@
 import type $Log from '../../cypress/log'
 import $utils from '../../cypress/utils'
 import $errUtils from '../../cypress/error_utils'
-import isValidDomain from 'is-valid-domain'
-import { isIP } from 'is-ip'
 import { isString } from 'lodash'
 
 export class Validator {
@@ -14,13 +12,13 @@ export class Validator {
     this.onFailure = onFailure
   }
 
-  validate ({ callbackFn, data, domain }) {
-    if (!isString(domain) || domain !== 'localhost' && !isIP(domain) && !isValidDomain(domain, { allowUnicode: true, subdomain: false })) {
+  validate ({ callbackFn, data, originOrDomain }) {
+    if (!isString(originOrDomain)) {
       this.onFailure()
 
-      $errUtils.throwErrByPath('switchToDomain.invalid_domain_argument', {
+      $errUtils.throwErrByPath('switchToDomain.invalid_origin_argument', {
         onFail: this.log,
-        args: { arg: $utils.stringify(domain) },
+        args: { arg: $utils.stringify(originOrDomain) },
       })
     }
 
@@ -39,6 +37,18 @@ export class Validator {
       $errUtils.throwErrByPath('switchToDomain.invalid_fn_argument', {
         onFail: this.log,
         args: { arg: $utils.stringify(callbackFn) },
+      })
+    }
+  }
+
+  validateLocation (location, originOrDomain) {
+    // we don't support query params, hashes, or paths (except for '/')
+    if (location.search.length > 0 || location.pathname.length > 1 || location.hash.length > 0) {
+      this.onFailure()
+
+      $errUtils.throwErrByPath('switchToDomain.invalid_origin_argument', {
+        onFail: this.log,
+        args: { arg: $utils.stringify(originOrDomain) },
       })
     }
   }

--- a/packages/driver/src/cypress/error_messages.ts
+++ b/packages/driver/src/cypress/error_messages.ts
@@ -1693,8 +1693,8 @@ export default {
     experiment_not_enabled: {
       message: `${cmd('switchToDomain')} requires enabling the experimentalMultiDomain flag`,
     },
-    invalid_domain_argument: {
-      message: `${cmd('switchToDomain')} requires the first argument to be either 'localhost', an ip address ('127.0.0.1') or a domain name ('example.com'). Domain names must not contain sub domains, ports or paths. You passed: \`{{arg}}\``,
+    invalid_origin_argument: {
+      message: `${cmd('switchToDomain')} requires the first argument to be either an origin ('https://app.example.com') or a domain name ('example.com'). The origin or domain name must not contain a path, hash, or query parameters. You passed: \`{{arg}}\``,
     },
     invalid_data_argument: {
       message: `${cmd('switchToDomain')} requires the 'data' argument to be an array. You passed: \`{{arg}}\``,

--- a/packages/driver/src/multi-domain/communicator.ts
+++ b/packages/driver/src/multi-domain/communicator.ts
@@ -9,10 +9,6 @@ const debug = debugFn('cypress:driver:multi-domain')
 
 const CROSS_DOMAIN_PREFIX = 'cross:domain:'
 
-declare global {
-  interface Window { specBridgeDomain: string }
-}
-
 const preprocessErrorForPostMessage = (value) => {
   const { isDom } = $dom
 
@@ -199,14 +195,14 @@ export class SpecBridgeDomainCommunicator extends EventEmitter {
    * @param {any} data - any meta data to be sent with the event.
    */
   toPrimary (event: string, data?: any, options = { syncGlobals: false }) {
-    debug('<= to Primary ', event, data, window.specBridgeDomain)
+    debug('<= to Primary ', event, data, document.domain)
     if (options.syncGlobals) this.syncGlobalsToPrimary()
 
     this.handleSubjectAndErr(data, (data: any) => {
       this.windowReference.top.postMessage({
         event: `${CROSS_DOMAIN_PREFIX}${event}`,
         data,
-        domain: window.specBridgeDomain,
+        domain: document.domain,
       }, '*')
     })
   }

--- a/packages/runner/src/iframe/iframes.jsx
+++ b/packages/runner/src/iframe/iframes.jsx
@@ -170,12 +170,12 @@ export default class Iframes extends Component {
     return $autIframe
   }
 
-  _addCrossDomainIframe = (domain) => {
-    const id = `Spec Bridge: ${domain}`
+  _addCrossDomainIframe = (location) => {
+    const id = `Spec Bridge: ${location.hostname}`
 
     // if it already exists, don't add another one
     if (document.getElementById(id)) {
-      this.props.eventManager.notifyCrossDomainBridgeReady(domain)
+      this.props.eventManager.notifyCrossDomainBridgeReady(location.hostname)
 
       return
     }
@@ -186,8 +186,7 @@ export default class Iframes extends Component {
       // container since it needs to match the size of the top window for screenshots
       $container: $(document.body),
       className: 'spec-bridge-iframe',
-      // TODO: Update this to the correct origin once we decide on string vs object
-      src: `//${domain}:3500/${this.props.config.namespace}/multi-domain-iframes/${encodeURIComponent(domain)}`,
+      src: `${location.originPolicy}/${this.props.config.namespace}/multi-domain-iframes`,
     })
   }
 

--- a/packages/server/lib/controllers/files.js
+++ b/packages/server/lib/controllers/files.js
@@ -52,7 +52,7 @@ module.exports = {
 
   handleMultiDomainIframe (req, res) {
     const iframePath = cwd('lib', 'html', 'multi-domain-iframe.html')
-    const domain = decodeURI(req.params.domain)
+    const domain = req.hostname
 
     const iframeOptions = {
       domain,

--- a/packages/server/lib/html/multi-domain-iframe.html
+++ b/packages/server/lib/html/multi-domain-iframe.html
@@ -7,7 +7,6 @@
   <body>
     <script type="text/javascript">
       document.domain = '{{domain}}';
-      window.specBridgeDomain = '{{domain}}';
     </script>
     <script src="/__cypress/runner/cypress_multi_domain_runner.js"></script>
   </body>

--- a/packages/server/lib/routes-e2e.ts
+++ b/packages/server/lib/routes-e2e.ts
@@ -129,8 +129,8 @@ export const createRoutesE2E = ({
     res.sendFile(file, { etag: false })
   })
 
-  routesE2E.get('/__cypress/multi-domain-iframes/:domain', (req, res) => {
-    debug('handling multi-domain iframe for domain: %s', decodeURI(req.params.domain))
+  routesE2E.get('/__cypress/multi-domain-iframes', (req, res) => {
+    debug('handling multi-domain iframe for domain: %s', req.hostname)
 
     files.handleMultiDomainIframe(req, res)
   })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #19901 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Users are currently only able to setup the spec bridge using the domain name. The prevents them from specifying a protocol (http vs https) and from specifying a specific port. This change allows users to provide an origin or a domain name.

Note: the messaging is still assuming a single domain so while this change allows an origin to be passed, only one spec bridge for a particular domain will be created.

* updated `switchToDomain` command to accept an origin or domain
  * if no protocol is provided, `https` is assumed
    * i.e. `foobar.com` -> `https://foobar.com`
  * errors is given a path, hash, or query params
* created spec bridge using the origin policy (protocol, super domain, and port)
* removed `window.specBridgeDomain` as unicode domains no longer need it
* updated all of the `switchToDomain` calls to use origin `https://foobar.com:3500` instead of just `foobar.com`

Supported:

```
http://example.com
https://example.com
http://example.com:3500
example.com
example.com:3500
app.example.com
sub.app.herokuapp.com
localhost
127.1.1.1
はじめよう.みんな
machine-name
```

Not currently supported:

```
http://[0000:0000:0000:0000:0000:0000:0000:0001]
```

Not supported:

```
example.com/path
example.com?foo=bar
example.com/#path
```

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Users are now able to pass an origin or domain into `switchToDomain`.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
