### PR TITLE
test: add waits to visits directly to runner

### DIFF
--- a/packages/app/cypress/e2e/cypress-in-cypress-component.cy.ts
+++ b/packages/app/cypress/e2e/cypress-in-cypress-component.cy.ts
@@ -98,6 +98,9 @@ describe('Cypress In Cypress', { viewportWidth: 1500 }, () => {
 
     const goodFilePath = 'src/TestComponent.spec.jsx'
 
+    // TODO: Figure out why test is flaky without wait
+    // see: https://cypress-io.atlassian.net/browse/UNIFY-1294
+    cy.wait(1000)
     cy.visit(`http://localhost:4455/__/#/specs/runner?file=${goodFilePath}`)
 
     cy.contains('renders the test component').should('be.visible')

--- a/packages/app/cypress/e2e/cypress-in-cypress-component.cy.ts
+++ b/packages/app/cypress/e2e/cypress-in-cypress-component.cy.ts
@@ -100,7 +100,7 @@ describe('Cypress In Cypress', { viewportWidth: 1500 }, () => {
 
     // TODO: Figure out why test is flaky without wait
     // see: https://cypress-io.atlassian.net/browse/UNIFY-1294
-    cy.wait(1000)
+    cy.wait(2000)
     cy.visit(`http://localhost:4455/__/#/specs/runner?file=${goodFilePath}`)
 
     cy.contains('renders the test component').should('be.visible')

--- a/packages/app/cypress/e2e/cypress-in-cypress-e2e.cy.ts
+++ b/packages/app/cypress/e2e/cypress-in-cypress-e2e.cy.ts
@@ -110,7 +110,7 @@ describe('Cypress In Cypress', { viewportWidth: 1500 }, () => {
 
     // TODO: Figure out why test is flaky without wait
     // see: https://cypress-io.atlassian.net/browse/UNIFY-1294
-    cy.wait(1000)
+    cy.wait(2000)
     cy.visit(`http://localhost:4455/__/#/specs/runner?file=${goodFilePath}`)
 
     cy.contains('Dom Content').should('be.visible')

--- a/packages/app/cypress/e2e/cypress-in-cypress-e2e.cy.ts
+++ b/packages/app/cypress/e2e/cypress-in-cypress-e2e.cy.ts
@@ -108,6 +108,9 @@ describe('Cypress In Cypress', { viewportWidth: 1500 }, () => {
 
     const goodFilePath = 'cypress/e2e/dom-content.spec.js'
 
+    // TODO: Figure out why test is flaky without wait
+    // see: https://cypress-io.atlassian.net/browse/UNIFY-1294
+    cy.wait(1000)
     cy.visit(`http://localhost:4455/__/#/specs/runner?file=${goodFilePath}`)
 
     cy.contains('Dom Content').should('be.visible')


### PR DESCRIPTION
### User facing changelog
NA

### Additional details
Recently added tests that visit the runner page directly were experiencing flake without waits. This PR adds the waits and links to an issue for figuring out why they are flaky.

### How has the user experience changed?
NA
### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
