### PR TITLE
chore: (multi-domain) url:changed fix, revert about:blank, use Cypress.specBridgeCommunicator, Cypress.isMultiDomain

### DIFF
--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_navigation.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_navigation.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-context('multi-domain navigation', { experimentalMultiDomain: true, experimentalSessionSupport: true }, () => {
+context('multi-domain navigation', { experimentalSessionSupport: true }, () => {
   it('.go()', () => {
     cy.visit('/fixtures/multi-domain.html')
     cy.get('a[data-cy="multi-domain-secondary-link"]').click()

--- a/packages/driver/src/cy/commands/navigation.ts
+++ b/packages/driver/src/cy/commands/navigation.ts
@@ -95,7 +95,7 @@ const specifyFileByRelativePath = (url, log) => {
 }
 
 const aboutBlank = (cy, win) => {
-  if (Cypress.state('isMultiDomain')) {
+  if (Cypress.isMultiDomain) {
     return new Promise((resolve) => {
       Cypress.specBridgeCommunicator.once('visit:about:blank:end', resolve)
 
@@ -454,7 +454,7 @@ const normalizeOptions = (options) => {
   .pick(REQUEST_URL_OPTS)
   .extend({
     timeout: options.responseTimeout,
-    isMultiDomain: !!Cypress.state('isMultiDomain'),
+    isMultiDomain: Cypress.isMultiDomain,
   })
   .value()
 }
@@ -921,7 +921,7 @@ export default (Commands, Cypress, cy, state, config) => {
 
           // if this is multi-domain, we need to tell the primary to change
           // the AUT iframe since we don't have access to it
-          if (Cypress.state('isMultiDomain')) {
+          if (Cypress.isMultiDomain) {
             return Cypress.specBridgeCommunicator.toPrimary('visit:url', { url })
           }
 
@@ -1092,7 +1092,7 @@ export default (Commands, Cypress, cy, state, config) => {
           // if we are in multi-domain and the origin policies weren't the same,
           // we need to throw an error since the user tried to visit a new
           // domain which isn't allowed within a multi-domain block
-          if (Cypress.state('isMultiDomain') && win) {
+          if (Cypress.isMultiDomain && win) {
             // TODO: need a better error message
             return cannotVisitDifferentOrigin(remote.origin, previousDomainVisited, remote, existing, options._log)
           }

--- a/packages/driver/src/cy/multi-domain/index.ts
+++ b/packages/driver/src/cy/multi-domain/index.ts
@@ -99,10 +99,9 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
           _resolve({ subject, unserializableSubjectType })
         }
 
-        communicator.once('sync:globals', ({ config, env, state }) => {
+        communicator.once('sync:globals', ({ config, env }) => {
           syncConfigToCurrentDomain(config)
           syncEnvToCurrentDomain(env)
-          Cypress.state(state)
         })
 
         communicator.once('ran:domain:fn', (details) => {

--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -58,7 +58,7 @@ const throwPrivateCommandInterface = (method) => {
 }
 
 class $Cypress {
-  constructor (config = {}) {
+  constructor () {
     this.cy = null
     this.chai = null
     this.mocha = null
@@ -74,11 +74,9 @@ class $Cypress {
     this.$ = jqueryProxyFn.bind(this)
 
     _.extend(this.$, $)
-
-    this.setConfig(config)
   }
 
-  setConfig (config = {}) {
+  setConfig (config: Cypress.ObjectLike = {}) {
     // config.remote
     // {
     //   origin: "http://localhost:2020"
@@ -126,6 +124,9 @@ class $Cypress {
     // slice up the behavior
     config.isInteractive = !config.isTextTerminal
 
+    // true if this Cypress belongs to multi-domain
+    this.isMultiDomain = config.isMultiDomain || false
+
     // enable long stack traces when
     // we not are running headlessly
     // for debuggability but disable
@@ -138,18 +139,16 @@ class $Cypress {
 
     // TODO: env is unintentionally preserved between soft reruns unlike config.
     // change this in the NEXT_BREAKING
-    const { env, __isMultiDomain } = config
+    const { env } = config
 
-    const isMultiDomainCypress: boolean = __isMultiDomain || false
-
-    config = _.omit(config, 'env', 'remote', 'resolved', 'scaffoldedFiles', 'state', 'testingType', '__isMultiDomain')
+    config = _.omit(config, 'env', 'remote', 'resolved', 'scaffoldedFiles', 'state', 'testingType', 'isMultiDomain')
 
     _.extend(this, browserInfo(config))
 
     this.state = $SetterGetter.create({})
     this.originalConfig = _.cloneDeep(config)
     this.config = $SetterGetter.create(config, (config) => {
-      if (isMultiDomainCypress ? !window.__cySkipValidateConfig : !window.top.__cySkipValidateConfig) {
+      if (this.isMultiDomain ? !window.__cySkipValidateConfig : !window.top.__cySkipValidateConfig) {
         validateNoReadOnlyConfig(config, (errProperty) => {
           const errPath = this.state('runnable')
             ? 'config.invalid_cypress_config_override'
@@ -682,7 +681,11 @@ class $Cypress {
   }
 
   static create (config) {
-    return new $Cypress(config)
+    const cypress = new $Cypress()
+
+    cypress.setConfig(config)
+
+    return cypress
   }
 }
 

--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -76,7 +76,7 @@ class $Cypress {
     _.extend(this.$, $)
   }
 
-  setConfig (config: Cypress.ObjectLike = {}) {
+  configure (config: Cypress.ObjectLike = {}) {
     // config.remote
     // {
     //   origin: "http://localhost:2020"
@@ -683,7 +683,7 @@ class $Cypress {
   static create (config) {
     const cypress = new $Cypress()
 
-    cypress.setConfig(config)
+    cypress.configure(config)
 
     return cypress
   }

--- a/packages/driver/src/multi-domain/communicator.ts
+++ b/packages/driver/src/multi-domain/communicator.ts
@@ -143,7 +143,7 @@ export class PrimaryDomainCommunicator extends EventEmitter {
 export class SpecBridgeDomainCommunicator extends EventEmitter {
   private windowReference
 
-  private handleSubjectAndErr = (data: any = {}, send: (data: any) => void) => {
+  private handleSubjectAndErr = (data: Cypress.ObjectLike = {}, send: (data: Cypress.ObjectLike) => void) => {
     const { subject, err, ...rest } = data
 
     if (!subject && !err) {
@@ -196,13 +196,13 @@ export class SpecBridgeDomainCommunicator extends EventEmitter {
   /**
    * Events to be sent to the primary communicator instance.
    * @param {string} event - the name of the event to be sent.
-   * @param {any} data - any meta data to be sent with the event.
+   * @param {Cypress.ObjectLike} data - any meta data to be sent with the event.
    */
-  toPrimary (event: string, data?: any, options = { syncGlobals: false }) {
+  toPrimary (event: string, data?: Cypress.ObjectLike, options: { syncGlobals: boolean } = { syncGlobals: false }) {
     debug('<= to Primary ', event, data, window.specBridgeDomain)
     if (options.syncGlobals) this.syncGlobalsToPrimary()
 
-    this.handleSubjectAndErr(data, (data: any) => {
+    this.handleSubjectAndErr(data, (data: Cypress.ObjectLike) => {
       this.windowReference.top.postMessage({
         event: `${CROSS_DOMAIN_PREFIX}${event}`,
         data,

--- a/packages/driver/src/multi-domain/communicator.ts
+++ b/packages/driver/src/multi-domain/communicator.ts
@@ -170,9 +170,6 @@ export class SpecBridgeDomainCommunicator extends EventEmitter {
     this.toPrimary('sync:globals', {
       config: preprocessConfig(Cypress.config()),
       env: preprocessEnv(Cypress.env()),
-      state: {
-        hasVisitedAboutBlank: Cypress.state('hasVisitedAboutBlank'),
-      },
     })
   }
 

--- a/packages/driver/src/multi-domain/cypress.ts
+++ b/packages/driver/src/multi-domain/cypress.ts
@@ -37,7 +37,7 @@ const createCypress = () => {
 const setup = (cypressConfig: Cypress.Config, env: Cypress.ObjectLike) => {
   const Cypress = window.Cypress
 
-  Cypress.setConfig({
+  Cypress.configure({
     ...cypressConfig,
     env,
     // never turn on video for multi-domain when syncing the config. This is handled in the primary.

--- a/packages/driver/src/multi-domain/cypress.ts
+++ b/packages/driver/src/multi-domain/cypress.ts
@@ -9,7 +9,6 @@ import { $Cy } from '../cypress/cy'
 import $Commands from '../cypress/commands'
 import $Log from '../cypress/log'
 import { bindToListeners } from '../cy/listeners'
-import { SpecBridgeDomainCommunicator } from './communicator'
 import { handleDomainFn } from './domain_fn'
 import { handleLogs } from './events/logs'
 import { handleSocketEvents } from './events/socket'
@@ -21,30 +20,33 @@ import { handleMiscEvents } from './events/misc'
 import { handleUnsupportedAPIs } from './unsupported_apis'
 import $Mocha from '../cypress/mocha'
 
-const specBridgeCommunicator = new SpecBridgeDomainCommunicator()
+const createCypress = () => {
+  // @ts-ignore
+  const Cypress = window.Cypress = new $Cypress() as Cypress.Cypress
 
-specBridgeCommunicator.initialize(window)
+  Cypress.specBridgeCommunicator.initialize(window)
 
-specBridgeCommunicator.once('initialize:cypress', ({ config, env }) => {
-  // eventually, setup will get called again on rerun and cy will
-  // get re-created
-  setup(config, env)
-})
+  Cypress.specBridgeCommunicator.once('initialize:cypress', ({ config, env }) => {
+    // eventually, setup will get called again on rerun and cy will get re-created
+    setup(config, env)
+  })
+
+  Cypress.specBridgeCommunicator.toPrimary('bridge:ready')
+}
 
 const setup = (cypressConfig: Cypress.Config, env: Cypress.ObjectLike) => {
-  // @ts-ignore
-  const Cypress = window.Cypress = $Cypress.create({
+  const Cypress = window.Cypress
+
+  Cypress.setConfig({
     ...cypressConfig,
     env,
-    __isMultiDomain: true,
     // never turn on video for multi-domain when syncing the config. This is handled in the primary.
     video: false,
+    isMultiDomain: true,
     // multi-domain cannot be used in component testing and is only valid for e2e.
     // This value is not synced with the config because it is omitted on big Cypress creation, as well as a few other key properties
     testingType: 'e2e',
-  }) as Cypress.Cypress
-
-  Cypress.specBridgeCommunicator.initialize(window)
+  })
 
   // @ts-ignore
   const cy = window.cy = new $Cy(window, Cypress, Cypress.Cookies, Cypress.state, Cypress.config, false)
@@ -71,13 +73,13 @@ const setup = (cypressConfig: Cypress.Config, env: Cypress.ObjectLike) => {
   // @ts-ignore
   Cypress.isCy = cy.isCy
 
-  handleDomainFn(Cypress, cy, specBridgeCommunicator)
-  handleLogs(Cypress, specBridgeCommunicator)
+  handleDomainFn(Cypress, cy)
+  handleLogs(Cypress)
   handleSocketEvents(Cypress)
   handleSpecWindowEvents(cy)
-  handleMiscEvents(Cypress, cy, specBridgeCommunicator)
-  handleScreenshots(Cypress, specBridgeCommunicator)
-  handleTestEvents(Cypress, specBridgeCommunicator)
+  handleMiscEvents(Cypress, cy)
+  handleScreenshots(Cypress)
+  handleTestEvents(Cypress)
   handleUnsupportedAPIs(Cypress, cy)
 
   cy.onBeforeAppWindowLoad = onBeforeAppWindowLoad(Cypress, cy)
@@ -123,7 +125,7 @@ const onBeforeAppWindowLoad = (Cypress: Cypress.Cypress, cy: $Cy) => (autWindow:
       // This is also call on the on 'load' event in cy
       Cypress.action('app:window:load', autWindow)
 
-      specBridgeCommunicator.toPrimary('window:load', { url: cy.getRemoteLocation('href') })
+      Cypress.specBridgeCommunicator.toPrimary('window:load', { url: cy.getRemoteLocation('href') })
       cy.isStable(true, 'load')
     },
     onUnload (e) {
@@ -150,4 +152,4 @@ const onBeforeAppWindowLoad = (Cypress: Cypress.Cypress, cy: $Cy) => (autWindow:
   })
 }
 
-specBridgeCommunicator.toPrimary('bridge:ready')
+createCypress()

--- a/packages/driver/src/multi-domain/domain_fn.ts
+++ b/packages/driver/src/multi-domain/domain_fn.ts
@@ -1,5 +1,4 @@
 import type { $Cy } from '../cypress/cy'
-import type { SpecBridgeDomainCommunicator } from './communicator'
 import $errUtils from '../cypress/error_utils'
 import $utils from '../cypress/utils'
 import { syncConfigToCurrentDomain, syncEnvToCurrentDomain } from '../util/config'
@@ -54,7 +53,7 @@ const rehydrateRunnable = (data: serializedRunnable): Runnable|Test => {
   return runnable
 }
 
-export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeCommunicator: SpecBridgeDomainCommunicator) => {
+export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy) => {
   const reset = (state) => {
     cy.reset({})
 
@@ -84,7 +83,7 @@ export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeComm
     cy.state('runnable').state = 'passed'
   }
 
-  specBridgeCommunicator.on('run:domain:fn', async (options: RunDomainFnOptions) => {
+  Cypress.specBridgeCommunicator.on('run:domain:fn', async (options: RunDomainFnOptions) => {
     const { config, data, env, fn, state, skipConfigValidation, isStable } = options
 
     let queueFinished = false
@@ -106,13 +105,13 @@ export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeComm
       if (queueFinished) {
         // If the queue is already finished, send this event instead because
         // the primary won't be listening for 'queue:finished' anymore
-        specBridgeCommunicator.toPrimary('uncaught:error', { err })
+        Cypress.specBridgeCommunicator.toPrimary('uncaught:error', { err })
 
         return
       }
 
       cy.stop()
-      specBridgeCommunicator.toPrimary('queue:finished', { err }, { syncGlobals: true })
+      Cypress.specBridgeCommunicator.toPrimary('queue:finished', { err }, { syncGlobals: true })
     })
 
     try {
@@ -132,7 +131,7 @@ export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeComm
         // value
         const subject = hasCommands ? undefined : await value
 
-        specBridgeCommunicator.toPrimary('ran:domain:fn', {
+        Cypress.specBridgeCommunicator.toPrimary('ran:domain:fn', {
           subject,
           finished: !hasCommands,
         }, {
@@ -151,7 +150,7 @@ export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeComm
       }
     } catch (err) {
       setRunnableStateToPassed()
-      specBridgeCommunicator.toPrimary('ran:domain:fn', { err }, { syncGlobals: true })
+      Cypress.specBridgeCommunicator.toPrimary('ran:domain:fn', { err }, { syncGlobals: true })
 
       return
     }
@@ -160,7 +159,7 @@ export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeComm
     .then(() => {
       queueFinished = true
       setRunnableStateToPassed()
-      specBridgeCommunicator.toPrimary('queue:finished', {
+      Cypress.specBridgeCommunicator.toPrimary('queue:finished', {
         subject: cy.state('subject'),
       }, {
         syncGlobals: true,

--- a/packages/driver/src/multi-domain/domain_fn.ts
+++ b/packages/driver/src/multi-domain/domain_fn.ts
@@ -73,8 +73,6 @@ export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy) => {
 
     // Set the state ctx to the runnable ctx to ensure they remain in sync
     cy.state('ctx', cy.state('runnable').ctx)
-
-    cy.state('isMultiDomain', true)
   }
 
   const setRunnableStateToPassed = () => {

--- a/packages/driver/src/multi-domain/events/logs.ts
+++ b/packages/driver/src/multi-domain/events/logs.ts
@@ -1,14 +1,12 @@
-import type { SpecBridgeDomainCommunicator } from '../communicator'
-
 import $Log from '../../cypress/log'
 
-export const handleLogs = (Cypress: Cypress.Cypress, specBridgeCommunicator: SpecBridgeDomainCommunicator) => {
+export const handleLogs = (Cypress: Cypress.Cypress) => {
   const onLogAdded = (attrs) => {
     // TODO:
     // - handle printing console props (need to add to runner)
     //     this.runner.addLog(args[0], this.config('isInteractive'))
 
-    specBridgeCommunicator.toPrimary('log:added', $Log.getDisplayProps(attrs))
+    Cypress.specBridgeCommunicator.toPrimary('log:added', $Log.getDisplayProps(attrs))
   }
 
   const onLogChanged = (attrs) => {
@@ -18,7 +16,7 @@ export const handleLogs = (Cypress: Cypress.Cypress, specBridgeCommunicator: Spe
     // - notify runner? maybe not
     //     this.runner.addLog(args[0], this.config('isInteractive'))
 
-    specBridgeCommunicator.toPrimary('log:changed', $Log.getDisplayProps(attrs))
+    Cypress.specBridgeCommunicator.toPrimary('log:changed', $Log.getDisplayProps(attrs))
   }
 
   Cypress.on('log:added', onLogAdded)

--- a/packages/driver/src/multi-domain/events/misc.ts
+++ b/packages/driver/src/multi-domain/events/misc.ts
@@ -1,22 +1,21 @@
 import type { $Cy } from '../../cypress/cy'
-import type { SpecBridgeDomainCommunicator } from '../communicator'
 
-export const handleMiscEvents = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeCommunicator: SpecBridgeDomainCommunicator) => {
+export const handleMiscEvents = (Cypress: Cypress.Cypress, cy: $Cy) => {
   Cypress.on('viewport:changed', (viewport, callbackFn) => {
-    specBridgeCommunicator.once('viewport:changed:end', () => {
+    Cypress.specBridgeCommunicator.once('viewport:changed:end', () => {
       callbackFn()
     })
 
-    specBridgeCommunicator.toPrimary('viewport:changed', viewport)
+    Cypress.specBridgeCommunicator.toPrimary('viewport:changed', viewport)
   })
 
   // TODO: Should state syncing be built into cy.state instead of being explicitly called?
-  specBridgeCommunicator.on('sync:state', (state) => {
+  Cypress.specBridgeCommunicator.on('sync:state', (state) => {
     cy.state(state)
   })
 
   // Listen for window load events from the primary window to resolve page loads
-  specBridgeCommunicator.on('window:load', ({ url }) => {
+  Cypress.specBridgeCommunicator.on('window:load', ({ url }) => {
     cy.isStable(true, 'load')
     Cypress.emit('internal:window:load', { type: 'cross:domain', url })
   })
@@ -24,6 +23,6 @@ export const handleMiscEvents = (Cypress: Cypress.Cypress, cy: $Cy, specBridgeCo
   // Forward url:changed Message to the primary domain to enable changing the url displayed in the AUT
   // @ts-ignore
   Cypress.on('url:changed', (url) => {
-    specBridgeCommunicator.toPrimary('url:changed', url)
+    Cypress.specBridgeCommunicator.toPrimary('url:changed', { url })
   })
 }

--- a/packages/driver/src/multi-domain/events/screenshots.ts
+++ b/packages/driver/src/multi-domain/events/screenshots.ts
@@ -1,15 +1,13 @@
-import type { SpecBridgeDomainCommunicator } from '../communicator'
-
-export const handleScreenshots = (Cypress: Cypress.Cypress, specBridgeCommunicator: SpecBridgeDomainCommunicator) => {
+export const handleScreenshots = (Cypress: Cypress.Cypress) => {
   Cypress.on('before:screenshot', (config, callbackFn) => {
-    specBridgeCommunicator.once('before:screenshot:end', () => {
+    Cypress.specBridgeCommunicator.once('before:screenshot:end', () => {
       callbackFn()
     })
 
-    specBridgeCommunicator.toPrimary('before:screenshot', config)
+    Cypress.specBridgeCommunicator.toPrimary('before:screenshot', config)
   })
 
   Cypress.on('after:screenshot', (config) => {
-    specBridgeCommunicator.toPrimary('after:screenshot', config)
+    Cypress.specBridgeCommunicator.toPrimary('after:screenshot', config)
   })
 }

--- a/packages/driver/src/multi-domain/events/test.ts
+++ b/packages/driver/src/multi-domain/events/test.ts
@@ -1,11 +1,9 @@
-import type { SpecBridgeDomainCommunicator } from '../communicator'
-
-export const handleTestEvents = (Cypress: Cypress.Cypress, specBridgeCommunicator: SpecBridgeDomainCommunicator) => {
-  specBridgeCommunicator.on('test:before:run', (...args) => {
+export const handleTestEvents = (Cypress: Cypress.Cypress) => {
+  Cypress.specBridgeCommunicator.on('test:before:run', (...args) => {
     Cypress.emit('test:before:run', ...args)
   })
 
-  specBridgeCommunicator.on('test:before:run:async', (...args) => {
+  Cypress.specBridgeCommunicator.on('test:before:run:async', (...args) => {
     Cypress.emit('test:before:run:async', ...args)
   })
 }

--- a/packages/driver/types/internal-types.d.ts
+++ b/packages/driver/types/internal-types.d.ts
@@ -53,7 +53,7 @@ declare namespace Cypress {
     multiDomainCommunicator: import('../src/multi-domain/communicator').PrimaryDomainCommunicator
     specBridgeCommunicator: import('../src/multi-domain/communicator').SpecBridgeDomainCommunicator
     mocha: $Mocha
-    setConfig: (config: Cypress.ObjectLike) => void
+    configure: (config: Cypress.ObjectLike) => void
     isMultiDomain: boolean
   }
 

--- a/packages/driver/types/internal-types.d.ts
+++ b/packages/driver/types/internal-types.d.ts
@@ -49,10 +49,12 @@ declare namespace Cypress {
     utils: CypressUtils
     state: State
     events: Events
-    emit: ((event: string, payload?: any) => void)
+    emit: (event: string, payload?: any) => void
     multiDomainCommunicator: import('../src/multi-domain/communicator').PrimaryDomainCommunicator
     specBridgeCommunicator: import('../src/multi-domain/communicator').SpecBridgeDomainCommunicator
     mocha: $Mocha
+    setConfig: (config: Cypress.ObjectLike) => void
+    isMultiDomain: boolean
   }
 
   interface CypressUtils {

--- a/packages/runner-shared/src/event-manager.js
+++ b/packages/runner-shared/src/event-manager.js
@@ -548,7 +548,7 @@ export const eventManager = {
       handleBeforeScreenshot(config, callback)
     })
 
-    Cypress.multiDomainCommunicator.on('url:changed', (url) => {
+    Cypress.multiDomainCommunicator.on('url:changed', ({ url }) => {
       localBus.emit('url:changed', url)
     })
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
* Updated the `url:changed` event in the secondary to correctly serialize the url so it displays correctly in the AUT header (instead of `[object Object]`).
  * When sending to the primary, we assume the `data` param is a key-value object but in this case, we were passing the url as a string. I updated the url to be passed as an object and updated the type of the `data` param to be `Cypres.ObjectLike` to prevent the issue in the future.
* Added `Cypress.isMultiDomain` and removed `Cypress.state('isMultiDomain')` and `__isMultiDomainCypress` so there is only one boolean to determine if `Cypress` is in multi-domain.
* Reverted the `about:blank` changes made in #20467 since we are requiring `experimentalSessionSupport` which visits `about:blank` between tests.
* Updated `multi-domain/cypress.ts` to use `Cypress.specBridgeCommunicator` instead of it's own `specBridgeCommunicator`.
  * When `cypress.ts` is loaded, `Cypress` is created but not configured until the `initialize:cypress` event is received. This allows the `specBridgeCommunicator` to be used prior to `Cypress` being fully configured. 

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
AUT URL Before:
<img width="711" alt="Screen Shot 2022-03-10 at 5 15 49 PM" src="https://user-images.githubusercontent.com/2002044/157777152-4316f8b8-8233-4311-9018-795fa74a6e7d.png">

AUT URL After:
<img width="710" alt="Screen Shot 2022-03-10 at 5 15 01 PM" src="https://user-images.githubusercontent.com/2002044/157777206-5eff2808-db64-4b92-9fe5-734c0216340f.png">

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
