### PR TITLE
fix: use decodeURI in loader and add tests

### DIFF
--- a/npm/webpack-dev-server/src/loader.ts
+++ b/npm/webpack-dev-server/src/loader.ts
@@ -18,7 +18,7 @@ const makeImport = (file: Cypress.Cypress['spec'], filename: string, chunkName: 
   const magicComments = chunkName ? `/* webpackChunkName: "${chunkName}" */` : ''
 
   return `"${filename}": {
-    shouldLoad: () => document.location.pathname.includes("${file.absolute}"),
+    shouldLoad: () => decodeURI(document.location.pathname).includes("${file.absolute}"),
     load: () => import("${file.absolute}" ${magicComments}),
     chunkName: "${chunkName}",
   }`

--- a/npm/webpack-dev-server/test/e2e.spec.ts
+++ b/npm/webpack-dev-server/test/e2e.spec.ts
@@ -97,6 +97,25 @@ describe('#startDevServer', () => {
     })
   })
 
+  it('serves a file with spaces via a webpack dev server', async () => {
+    const { port, close } = await startDevServer({
+      webpackConfig,
+      options: {
+        config,
+        specs: createSpecs('foo bar.spec.js'),
+        devServerEvents: new EventEmitter(),
+      },
+    })
+
+    const response = await requestSpecFile(encodeURI('/test/fixtures/foo bar.spec.js'), port as number)
+
+    expect(response).to.eq(`it('this is a spec with a path containing a space', () => {})\n`)
+
+    return new Promise((res) => {
+      close(() => res())
+    })
+  })
+
   it('emits dev-server:compile:success event on successful compilation', async () => {
     const devServerEvents = new EventEmitter()
     const { close } = await startDevServer({

--- a/npm/webpack-dev-server/test/fixtures/foo bar.spec.js
+++ b/npm/webpack-dev-server/test/fixtures/foo bar.spec.js
@@ -1,0 +1,1 @@
+it('this is a spec with a path containing a space', () => {})

--- a/system-tests/projects/webpack-dev-server/cypress/component/foo bar.spec.js
+++ b/system-tests/projects/webpack-dev-server/cypress/component/foo bar.spec.js
@@ -1,0 +1,5 @@
+describe('this test is in a file with space in the path', () => {
+  it('works great!', () => {
+    expect(1).to.eq(1)
+  })
+})


### PR DESCRIPTION
Use `decodeURI` so as to allow specs with `[]` and spaces to be loaded and executed.