### PR TITLE
refactor: remove for-of loop with await, replace with Promise.all + map

### DIFF
--- a/packages/data-context/src/codegen/code-generator.ts
+++ b/packages/data-context/src/codegen/code-generator.ts
@@ -3,6 +3,7 @@ import { isBinaryFile } from 'isbinaryfile'
 import * as path from 'path'
 import * as ejs from 'ejs'
 import fm from 'front-matter'
+import _ from 'lodash'
 
 export interface Action {
   templateDir: string
@@ -133,7 +134,7 @@ async function allFilesInDir (parent: string): Promise<string[]> {
     return isDir ? await allFilesInDir(child) : child
   }))
 
-  return result.flat()
+  return _.flatten(result)
 }
 
 function frontMatter (content: string, args: { [key: string]: any }) {

--- a/packages/data-context/src/codegen/code-generator.ts
+++ b/packages/data-context/src/codegen/code-generator.ts
@@ -93,7 +93,7 @@ export async function codeGenerator (
         content: content.toString(),
       } as const
     } catch (e) {
-      return e instanceof Error ? e : new Error(e)
+      return e instanceof Error ? e : new Error(String(e))
     }
   }))
 


### PR DESCRIPTION
Perf improvement/generally the pattern we should be following for loop iteration & promises, the `for / of` with an `await` in the body will execute in series, while the `Promise.all` loop executes in parallel.

Minor thing, but just a good idea to an eye out for these & replace anytime it won't affect the outcome.