### PR TITLE
fix: make the primary domain communicator a singleton per cypress instance

### DIFF
--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -37,7 +37,7 @@ import ProxyLogging from './cypress/proxy-logging'
 import * as $Events from './cypress/events'
 import $Keyboard from './cy/keyboard'
 import * as resolvers from './cypress/resolvers'
-import { PrimaryDomainCommunicator, PrimaryDomainCommunicatorFactory, SpecBridgeDomainCommunicator } from './multi-domain/communicator'
+import { PrimaryDomainCommunicator, SpecBridgeDomainCommunicator } from './multi-domain/communicator'
 
 const debug = debugFn('cypress:driver:cypress')
 
@@ -153,7 +153,7 @@ class $Cypress {
     this.Commands = null
     this.$autIframe = null
     this.onSpecReady = null
-    this.multiDomainCommunicator = PrimaryDomainCommunicatorFactory.create()
+    this.multiDomainCommunicator = new PrimaryDomainCommunicator()
     this.specBridgeCommunicator = new SpecBridgeDomainCommunicator()
     this.isMultiDomain = false
 

--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -37,7 +37,7 @@ import ProxyLogging from './cypress/proxy-logging'
 import * as $Events from './cypress/events'
 import $Keyboard from './cy/keyboard'
 import * as resolvers from './cypress/resolvers'
-import { PrimaryDomainCommunicator, SpecBridgeDomainCommunicator } from './multi-domain/communicator'
+import { PrimaryDomainCommunicator, PrimaryDomainCommunicatorFactory, SpecBridgeDomainCommunicator } from './multi-domain/communicator'
 
 const debug = debugFn('cypress:driver:cypress')
 
@@ -153,7 +153,7 @@ class $Cypress {
     this.Commands = null
     this.$autIframe = null
     this.onSpecReady = null
-    this.multiDomainCommunicator = new PrimaryDomainCommunicator()
+    this.multiDomainCommunicator = PrimaryDomainCommunicatorFactory.create()
     this.specBridgeCommunicator = new SpecBridgeDomainCommunicator()
     this.isMultiDomain = false
 

--- a/packages/driver/src/multi-domain/communicator.ts
+++ b/packages/driver/src/multi-domain/communicator.ts
@@ -29,9 +29,6 @@ export class PrimaryDomainCommunicator extends EventEmitter {
    * @returns {Void}
    */
   onMessage ({ data, source }) {
-    // currently used for tests, can be removed later
-    if (data?.actual) return
-
     // check if message is cross domain and if so, feed the message into
     // the cross domain bus with args and strip prefix
     if (data?.event?.includes(CROSS_DOMAIN_PREFIX)) {

--- a/packages/driver/src/multi-domain/communicator.ts
+++ b/packages/driver/src/multi-domain/communicator.ts
@@ -6,6 +6,7 @@ import { preprocessForSerialization, reifyCrossDomainError } from '../util/seria
 const debug = debugFn('cypress:driver:multi-domain')
 
 const CROSS_DOMAIN_PREFIX = 'cross:domain:'
+let primaryDomainCommunicatorSingleton: PrimaryDomainCommunicator | null = null
 
 /**
  * Primary domain communicator. Responsible for sending/receiving events throughout
@@ -22,6 +23,24 @@ export class PrimaryDomainCommunicator extends EventEmitter {
   private windowReference: Window | undefined
   private crossDomainDriverWindows: {[key: string]: Window} = {}
   userInvocationStack?: string
+
+  constructor () {
+    // There should only be one PrimaryDomainCommunicator per Cypress instance (Ex: primary domain, specbridge1, specbridge2, ...).
+    // Spec Bridges will create a PrimaryDomainCommunicator instance, but will never initialize the window.top message listener
+    // this means that methods that communicate through postMessage can send, but spec bridge PrimaryDomainCommunicator
+    // will never receive any events.
+    if (!primaryDomainCommunicatorSingleton) {
+      // @ts-ignore
+      super()
+      primaryDomainCommunicatorSingleton = this
+    }
+
+    // for the primary domain, the PrimaryDomainCommunicator needs to be a singleton.
+    // multiple PrimaryDomainCommunicator instances recreated on test refreshes/reloads cause dangling instances
+    // of the window.top message listener, stacking message events multiple times.
+    // The window.top instance does not change between test reloads, and we only need to bind it once
+    return primaryDomainCommunicatorSingleton
+  }
 
   /**
    * Initializes the event handler to receive messages from the spec bridge.

--- a/packages/driver/src/multi-domain/cypress.ts
+++ b/packages/driver/src/multi-domain/cypress.ts
@@ -24,8 +24,6 @@ const createCypress = () => {
   // @ts-ignore
   const Cypress = window.Cypress = new $Cypress() as Cypress.Cypress
 
-  Cypress.specBridgeCommunicator.initialize(window)
-
   Cypress.specBridgeCommunicator.once('initialize:cypress', ({ config, env }) => {
     // eventually, setup will get called again on rerun and cy will get re-created
     setup(config, env)
@@ -165,5 +163,10 @@ const onBeforeAppWindowLoad = (Cypress: Cypress.Cypress, cy: $Cy) => (autWindow:
     },
   })
 }
+
+// only bind the message handler one time when the spec bridge is created
+window.addEventListener('message', ({ data }) => {
+  Cypress?.specBridgeCommunicator.onMessage({ data })
+}, false)
 
 createCypress()

--- a/packages/runner-shared/src/event-manager.js
+++ b/packages/runner-shared/src/event-manager.js
@@ -320,6 +320,12 @@ export const eventManager = {
       this._clearAllCookies()
       this._setUnload()
     })
+
+    // The window.top should not change between test reloads, and we only need to bind the message event once
+    // Forward all message events to the current instance of the multi-domain communicator
+    window.top?.addEventListener('message', ({ data, source }) => {
+      Cypress?.multiDomainCommunicator.onMessage({ data, source })
+    }, false)
   },
 
   start (config) {
@@ -511,8 +517,6 @@ export const eventManager = {
         studioRecorder.testFailed()
       }
     })
-
-    Cypress.multiDomainCommunicator.initialize(window)
 
     Cypress.on('test:before:run', (...args) => {
       Cypress.multiDomainCommunicator.toAllSpecBridges('test:before:run', ...args)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### User facing changelog
N/A

### Additional details
When we reload tests, this errors tends to pop up anytime we edit tests that are dealing with errors in multi-domain. This is caused by multiple instances of the `primaryDomainCommunicator` being created, but rebinding the same `window.top.addEventListener('message')` on recreation. This leads to duplicate `message` events. This was introduced in #20520 when the `userInvocationStack` was added to the `primaryDomainCommunicator` instance [here](https://github.com/cypress-io/cypress/pull/20520/commits/525d3d043c2573b6a03c97074c0cc3efc1986588#diff-020c1583f496d3e76864f6520d8ac704ed5f608af74ded72518fa30c193107e9L49). The dangling `primaryDomainCommunicator` instance would NOT have the `userInvocationStack` set, which would fail to reify errors coming back from the other domain.

~The proposed fix here is to make the `primaryDomainCommunicator` a singleton, so the `window.top.addEventListener('message')` is only bound once. Since the top reference should not change through `open` mode, this should work correctly.~

##### Update 3/17/22
Instead of creating a singleton, we will only bind the message handler once in the primary when global listeners are added, and once in the spec bridge on creation. This refactors the initialize methods to be onMessage handlers where message events get forwarded to whatever the current instance of the communicator exists

Currently not sure of a good way to test this yet. I was thinking of maybe adding an assertion to the rerun test, but that doesn't exactly work since the file is loaded back in.

##### the error before fix
![](https://user-images.githubusercontent.com/3980464/158684552-b9f0b066-2201-4390-97f3-3e4268a236ae.png)


#### after fix (rerunning consistently)
![](https://user-images.githubusercontent.com/3980464/158686457-31ef3f59-6b5e-4525-ada9-6f92fd5e198e.png)


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
