### PR TITLE
fix(driver): readFile - verify null contents to Buffer.from

### DIFF
--- a/packages/driver/src/cy/commands/files.ts
+++ b/packages/driver/src/cy/commands/files.ts
@@ -72,10 +72,11 @@ export default (Commands, Cypress, cy, state) => {
           }
         }).then(({ filePath, contents }) => {
           // https://github.com/cypress-io/cypress/issues/1558
+          // https://github.com/cypress-io/cypress/issues/20683
           // We invoke Buffer.from() in order to transform this from an ArrayBuffer -
-          // which socket.io uses to transfer the file over the websocket - into a
-          // `Buffer`, which webpack polyfills in the browser.
-          if (options.encoding === null) {
+          // which socket.io uses to transfer the file over the websocket - into a `Buffer`.
+          if (options.encoding === null && contents !== null) {
+          // if (options.encoding === null && contents !== null) {
             contents = Buffer.from(contents)
           }
 

--- a/packages/driver/src/cy/commands/files.ts
+++ b/packages/driver/src/cy/commands/files.ts
@@ -76,7 +76,6 @@ export default (Commands, Cypress, cy, state) => {
           // We invoke Buffer.from() in order to transform this from an ArrayBuffer -
           // which socket.io uses to transfer the file over the websocket - into a `Buffer`.
           if (options.encoding === null && contents !== null) {
-          // if (options.encoding === null && contents !== null) {
             contents = Buffer.from(contents)
           }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #20683
When `null` encoding is used, and a file cannot be found, we are passing `null` to Buffer.from which is throwing `TypeError: First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object`. This caused the command to bail instead of retrying and providing a meaningful error message to the users.

### User facing changelog
- Fixed an  issue in `cy.readFile()` where the command would not retry or provide a meaningful error message if `null` encoding was used and the file was not found. Fixed [#20683](https://github.com/cypress-io/cypress/issues/20683).

### How has the user experience changed?
| before | after|
| --- | ---|
| <img width="400" alt="Screen Shot 2022-03-18 at 9 34 39 AM" src="https://user-images.githubusercontent.com/14099737/159022710-f02a0de8-7fcb-469f-89b9-3c92f8c81793.png"> | <img width="400" alt="Screen Shot 2022-03-18 at 9 34 11 AM" src="https://user-images.githubusercontent.com/14099737/159022747-64ea6420-d206-425d-916d-ff4d692b14ef.png"> |
### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
