### PR TITLE
fix: Updating link detection in markdown content

### DIFF
--- a/packages/app/cypress/e2e/settings.cy.ts
+++ b/packages/app/cypress/e2e/settings.cy.ts
@@ -104,6 +104,13 @@ describe('App: Settings', () => {
       cy.findByText('Project Settings').click()
       cy.get('[data-cy="file-match-indicator"]').contains('2 Matches')
       cy.get('[data-cy="spec-pattern"]').contains('**/*.cy.{js,jsx,ts,tsx}')
+
+      cy.get('[data-cy="settings-specPatterns"').within(() => {
+        cy.validateExternalLink({
+          name: 'Learn more.',
+          href: 'https://on.cypress.io/test-type-options',
+        })
+      })
     })
 
     it('shows the Spec Patterns section (edited specPattern value)', () => {
@@ -125,10 +132,53 @@ describe('App: Settings', () => {
       cy.findByText('Settings').click()
       cy.findByText('Project Settings').click()
       cy.get('[data-cy="settings-experiments"]').within(() => {
-        cy.get('[data-cy="experiment-experimentalFetchPolyfill"]')
-        cy.get('[data-cy="experiment-experimentalInteractiveRunEvents"]')
-        cy.get('[data-cy="experiment-experimentalSessionSupport"]')
-        cy.get('[data-cy="experiment-experimentalSourceRewriting"]')
+        cy.validateExternalLink({
+          name: 'Learn more.',
+          href: 'https://on.cypress.io/experiments',
+        })
+
+        cy.get('[data-cy="experiment-experimentalFetchPolyfill"]').within(() => {
+          cy.validateExternalLink({
+            name: 'cy.intercept()',
+            href: 'https://on.cypress.io/intercept',
+          })
+        })
+
+        cy.get('[data-cy="experiment-experimentalInteractiveRunEvents"]').within(() => {
+          cy.validateExternalLink({
+            name: 'before:run',
+            href: 'https://on.cypress.io/before-run',
+          })
+
+          cy.validateExternalLink({
+            name: 'after:run',
+            href: 'https://on.cypress.io/after-run',
+          })
+
+          cy.validateExternalLink({
+            name: 'before:spec',
+            href: 'https://on.cypress.io/before-spec',
+          })
+
+          cy.validateExternalLink({
+            name: 'after:spec',
+            href: 'https://on.cypress.io/after-spec',
+          })
+        })
+
+        cy.get('[data-cy="experiment-experimentalSessionSupport"]').within(() => {
+          cy.validateExternalLink({
+            name: 'cy.session()',
+            href: 'https://on.cypress.io/session',
+          })
+        })
+
+        cy.get('[data-cy="experiment-experimentalSourceRewriting"]').within(() => {
+          cy.validateExternalLink({
+            name: '#5273',
+            href: 'https://github.com/cypress-io/cypress/issues/5273',
+          })
+        })
       })
     })
 

--- a/packages/frontend-shared/src/composables/examples/UseMarkdownExample.cy.tsx
+++ b/packages/frontend-shared/src/composables/examples/UseMarkdownExample.cy.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink_OpenExternalDocument } from '../../generated/graphql'
 import UseMarkdownExample from './UseMarkdownExample.vue'
 
 describe('useMarkdown', () => {
@@ -30,6 +31,10 @@ const heres = {
 }
 \`\`\`
 
+[Simple Link](www.test.com)
+[\`Code Link\`](www.code.com)
+
+
     `
 
     cy.mount(<UseMarkdownExample
@@ -39,5 +44,24 @@ const heres = {
 
     cy.get('ul').should('have.class', 'list-disc')
     cy.get('code').first().should('have.class', 'bg-pink-200').and('have.class', 'text-pink-600')
+
+    const openExternalStub = cy.stub()
+
+    cy.stubMutationResolver(ExternalLink_OpenExternalDocument, (defineResult, { url }) => {
+      openExternalStub(url)
+
+      return defineResult({
+        openExternal: true,
+      })
+    })
+
+    cy.contains('a', 'Simple Link').click()
+    cy.wrap(openExternalStub).should('have.been.calledWith', 'www.test.com')
+
+    cy.contains('a', 'Code Link').within(() => {
+      cy.get('code').click()
+    })
+
+    cy.wrap(openExternalStub).should('have.been.calledWith', 'www.code.com')
   })
 })

--- a/packages/frontend-shared/src/composables/useMarkdown.ts
+++ b/packages/frontend-shared/src/composables/useMarkdown.ts
@@ -102,8 +102,15 @@ export const useMarkdown = (target: Ref<HTMLElement>, text: MaybeRef<string>, op
 
     whenever(target, () => {
       useEventListener(target, 'click', (e: MouseEvent) => {
+        const link = (e.target as HTMLElement).closest('a[href]')
+
+        if (!link) {
+          return
+        }
+
         e.preventDefault()
-        const url = (e.target as HTMLElement).getAttribute('href')
+
+        const url = link.getAttribute('href')
 
         if (url) {
           open(url)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes UNIFY-1063

Some of the links in our markdown content are styled with inner `<code>` elements, which causes our link detection logic to fail. In these instances, the click target is the `<code>` element, not the link itself.

I updated the logic to search for parent links to prevent this. I also added component test coverage for the `useMarkdown` composable and e2e coverage for the links in Settings.

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
