### PR TITLE
fix: `cy.contains` and `should('contain')` handle backslash correctly.

### DIFF
--- a/packages/driver/cypress/fixtures/dom.html
+++ b/packages/driver/cypress/fixtures/dom.html
@@ -160,8 +160,6 @@
 
       </div>
 
-      <div id="backslashes">"&lt;OE_D]dQ\</div>
-
       <div id="wrapper">
         <div id="upper">
           <div class="item"><em>New</em> York</div>

--- a/packages/driver/cypress/fixtures/dom.html
+++ b/packages/driver/cypress/fixtures/dom.html
@@ -160,6 +160,8 @@
 
       </div>
 
+      <div id="backslashes">"&lt;OE_D]dQ\</div>
+
       <div id="wrapper">
         <div id="upper">
           <div class="item"><em>New</em> York</div>

--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -1277,6 +1277,36 @@ describe('src/cy/commands/assertions', () => {
     })
   })
 
+  // TODO: this suite should be merged with the suite above
+  describe('message formatting', () => {
+    const expectMarkdown = (test, message, done) => {
+      cy.then(() => {
+        test()
+      })
+
+      cy.on('log:added', (attrs, log) => {
+        if (attrs.name === 'assert') {
+          cy.removeAllListeners('log:added')
+
+          expect(log.get('message')).to.eq(message)
+
+          done()
+        }
+      })
+    }
+
+    // https://github.com/cypress-io/cypress/issues/19116
+    it('text with backslashes', (done) => {
+      const text = '"<OE_D]dQ\\'
+
+      expectMarkdown(
+        () => expect(text).to.equal(text),
+        `expected **"<OE_D]dQ\\\\** to equal **"<OE_D]dQ\\\\**`,
+        done,
+      )
+    })
+  })
+
   context('chai overrides', () => {
     beforeEach(function () {
       this.$body = cy.$$('body')
@@ -1326,6 +1356,15 @@ describe('src/cy/commands/assertions', () => {
         cy.$$($span).appendTo(cy.$$('body'))
 
         cy.get('#escape-quotes').should('contain', 'shouldn\'t')
+      })
+
+      // https://github.com/cypress-io/cypress/issues/19116
+      it('escapes backslashes', () => {
+        const $span = '<span id="escape-backslashes">"&lt;OE_D]dQ\\</span>'
+
+        cy.$$($span).appendTo(cy.$$('body'))
+
+        cy.get('#escape-backslashes').should('contain', '"<OE_D]dQ\\')
       })
     })
 

--- a/packages/driver/cypress/integration/commands/querying/querying_spec.js
+++ b/packages/driver/cypress/integration/commands/querying/querying_spec.js
@@ -1226,6 +1226,7 @@ describe('src/cy/commands/querying', () => {
 
     // https://github.com/cypress-io/cypress/issues/19116
     it('handles backslashes', () => {
+      $('<div id="backslashes">"&lt;OE_D]dQ\\</div>').appendTo(cy.$$('body'))
       cy.get('#backslashes').contains('"<OE_D]dQ\\')
     })
 

--- a/packages/driver/cypress/integration/commands/querying/querying_spec.js
+++ b/packages/driver/cypress/integration/commands/querying/querying_spec.js
@@ -1224,6 +1224,11 @@ describe('src/cy/commands/querying', () => {
       cy.contains(/\'/)
     })
 
+    // https://github.com/cypress-io/cypress/issues/19116
+    it('handles backslashes', () => {
+      cy.get('#backslashes').contains('"<OE_D]dQ\\')
+    })
+
     describe('should(\'not.exist\')', () => {
       it('returns null when no content exists', () => {
         cy.contains('alksjdflkasjdflkajsdf').should('not.exist').then(($el) => {

--- a/packages/driver/src/cy/chai.ts
+++ b/packages/driver/src/cy/chai.ts
@@ -29,6 +29,8 @@ const trailingWhitespaces = /\s*'\*\*/g
 const whitespace = /\s/g
 const valueHasLeadingOrTrailingWhitespaces = /\*\*'\s+|\s+'\*\*/g
 const imageMarkdown = /!\[.*?\]\(.*?\)/g
+const doubleslashRe = /\\\\/g
+const escapedDoubleslashRe = /__doulbe_slash__/g
 
 type CreateFunc = ((specWindow, state, assertFn) => ({
   chai: Chai.ChaiStatic
@@ -102,6 +104,9 @@ chai.use((chai, u) => {
 
     return
   })
+
+  const escapeDoubleSlash = (str: string) => str.replace(doubleslashRe, '__doulbe_slash__')
+  const restoreDoubleSlash = (str: string) => str.replace(escapedDoubleslashRe, '\\\\')
 
   // remove any single quotes between our **,
   // except escaped quotes, empty strings and number strings.
@@ -277,7 +282,9 @@ chai.use((chai, u) => {
           return _super.apply(this, arguments)
         }
 
-        const escText = $utils.escapeQuotes(text)
+        const escText = $utils.escapeQuotes(
+          $utils.escapeBackslashes(text),
+        )
 
         const selector = `:contains('${escText}'), [type='submit'][value~='${escText}']`
 
@@ -457,7 +464,9 @@ chai.use((chai, u) => {
       let message = chaiUtils.getMessage(this, customArgs as Chai.AssertionArgs)
       const actual = chaiUtils.getActual(this, customArgs as Chai.AssertionArgs)
 
+      message = escapeDoubleSlash(message)
       message = removeOrKeepSingleQuotesBetweenStars(message)
+      message = restoreDoubleSlash(message)
       message = escapeMarkdown(message)
 
       try {

--- a/packages/driver/src/cy/chai.ts
+++ b/packages/driver/src/cy/chai.ts
@@ -31,7 +31,7 @@ const whitespace = /\s/g
 const valueHasLeadingOrTrailingWhitespaces = /\*\*'\s+|\s+'\*\*/g
 const imageMarkdown = /!\[.*?\]\(.*?\)/g
 const doubleslashRe = /\\\\/g
-const escapedDoubleslashRe = /__doulbe_slash__/g
+const escapedDoubleslashRe = /__double_slash__/g
 
 type CreateFunc = ((specWindow, state, assertFn) => ({
   chai: Chai.ChaiStatic
@@ -106,7 +106,7 @@ chai.use((chai, u) => {
     return
   })
 
-  const escapeDoubleSlash = (str: string) => str.replace(doubleslashRe, '__doulbe_slash__')
+  const escapeDoubleSlash = (str: string) => str.replace(doubleslashRe, '__double_slash__')
   const restoreDoubleSlash = (str: string) => str.replace(escapedDoubleslashRe, '\\\\')
 
   // remove any single quotes between our **,

--- a/packages/driver/src/cy/chai.ts
+++ b/packages/driver/src/cy/chai.ts
@@ -8,6 +8,7 @@ import sinonChai from '@cypress/sinon-chai'
 
 import $dom from '../dom'
 import $utils from '../cypress/utils'
+import { escapeBackslashes, escapeQuotes } from '../util/escape'
 import $errUtils from '../cypress/error_utils'
 import $stackUtils from '../cypress/stack_utils'
 import $chaiJquery from '../cypress/chai_jquery'
@@ -282,8 +283,8 @@ chai.use((chai, u) => {
           return _super.apply(this, arguments)
         }
 
-        const escText = $utils.escapeQuotes(
-          $utils.escapeBackslashes(text),
+        const escText = escapeQuotes(
+          escapeBackslashes(text),
         )
 
         const selector = `:contains('${escText}'), [type='submit'][value~='${escText}']`

--- a/packages/driver/src/cypress/utils.ts
+++ b/packages/driver/src/cypress/utils.ts
@@ -11,6 +11,7 @@ import { $Location } from './location'
 const tagOpen = /\[([a-z\s='"-]+)\]/g
 const tagClosed = /\[\/([a-z]+)\]/g
 const quotesRe = /('|")/g
+const backslashRe = /\\/g
 
 const defaultOptions = {
   delay: 10,
@@ -271,6 +272,11 @@ export default {
     // convert to str and escape any single
     // or double quotes
     return (`${text}`).replace(quotesRe, '\\$1')
+  },
+
+  escapeBackslashes (text) {
+    // convert to str and escape any backslashes
+    return (`${text}`).replace(backslashRe, '\\\\')
   },
 
   normalizeNumber (num) {

--- a/packages/driver/src/cypress/utils.ts
+++ b/packages/driver/src/cypress/utils.ts
@@ -10,8 +10,6 @@ import { $Location } from './location'
 
 const tagOpen = /\[([a-z\s='"-]+)\]/g
 const tagClosed = /\[\/([a-z]+)\]/g
-const quotesRe = /('|")/g
-const backslashRe = /\\/g
 
 const defaultOptions = {
   delay: 10,
@@ -266,17 +264,6 @@ export default {
     } catch (e) {
       return false
     }
-  },
-
-  escapeQuotes (text) {
-    // convert to str and escape any single
-    // or double quotes
-    return (`${text}`).replace(quotesRe, '\\$1')
-  },
-
-  escapeBackslashes (text) {
-    // convert to str and escape any backslashes
-    return (`${text}`).replace(backslashRe, '\\\\')
   },
 
   normalizeNumber (num) {

--- a/packages/driver/src/dom/elements/find.ts
+++ b/packages/driver/src/dom/elements/find.ts
@@ -4,7 +4,8 @@ import $document from '../document'
 import $jquery from '../jquery'
 import { getTagName } from './elementHelpers'
 import { isWithinShadowRoot, getShadowElementFromPoint } from './shadow'
-import { normalizeWhitespaces, escapeQuotes } from './utils'
+import { normalizeWhitespaces } from './utils'
+import { escapeQuotes } from '../../util/escape'
 
 /**
  * Find Parents relative to an initial element

--- a/packages/driver/src/dom/elements/find.ts
+++ b/packages/driver/src/dom/elements/find.ts
@@ -5,7 +5,7 @@ import $jquery from '../jquery'
 import { getTagName } from './elementHelpers'
 import { isWithinShadowRoot, getShadowElementFromPoint } from './shadow'
 import { normalizeWhitespaces } from './utils'
-import { escapeQuotes } from '../../util/escape'
+import { escapeQuotes, escapeBackslashes } from '../../util/escape'
 
 /**
  * Find Parents relative to an initial element
@@ -229,7 +229,9 @@ export const getContainsSelector = (text, filter = '', options: {
 } = {}) => {
   const $expr = $.expr[':']
 
-  const escapedText = escapeQuotes(text)
+  const escapedText = escapeQuotes(
+    escapeBackslashes(text),
+  )
 
   // they may have written the filter as
   // comma separated dom els, so we want to search all

--- a/packages/driver/src/dom/elements/utils.ts
+++ b/packages/driver/src/dom/elements/utils.ts
@@ -5,7 +5,6 @@ import $window from '../window'
 import $document from '../document'
 
 const whitespaces = /\s+/g
-const quotesRe = /('|")/g
 
 // When multiple space characters are considered as a single whitespace in all tags except <pre>.
 export const normalizeWhitespaces = (elem) => {
@@ -27,12 +26,6 @@ export const isSame = function ($el1, $el2) {
 
 export const isSelector = ($el: JQuery<HTMLElement>, selector) => {
   return $el.is(selector)
-}
-
-export function escapeQuotes (text) {
-  // convert to str and escape any single
-  // or double quotes
-  return (`${text}`).replace(quotesRe, '\\$1')
 }
 
 export function switchCase (value, casesObj, defaultKey = 'default') {

--- a/packages/driver/src/util/escape.ts
+++ b/packages/driver/src/util/escape.ts
@@ -1,0 +1,13 @@
+const quotesRe = /('|")/g
+const backslashRe = /\\/g
+
+export function escapeQuotes (text) {
+  // convert to str and escape any single
+  // or double quotes
+  return (`${text}`).replace(quotesRe, '\\$1')
+}
+
+export function escapeBackslashes (text) {
+  // convert to str and escape any backslashes
+  return (`${text}`).replace(backslashRe, '\\\\')
+}


### PR DESCRIPTION
- Closes #19116

### User facing changelog

`cy.contains` and `should('contain')` handle backslash correctly.

### Additional details
- Why was this change necessary? => Using backslash in `cy.contains` and `should('contain')` doesn't work.
- What is affected by this change? => N/A

### Any implementation details to explain? 

Using backslash breaks the Sizzle selectors below:

https://github.com/cypress-io/cypress/blob/b0fe8bf0dd90d302e51b8d75782edb3b19d5af3e/packages/driver/src/cy/chai.ts#L282

https://github.com/cypress-io/cypress/blob/b0fe8bf0dd90d302e51b8d75782edb3b19d5af3e/packages/driver/src/dom/elements/find.ts#L277

For example, strings like `<asdf\` escape the quotation marks and breaks the query.

So, I escaped the quotation marks. 

But I had to solve a few more problems like:

* redundant `escapeQuotes` functions. => create `utils/escape.ts` file and move them there.
* `should('contain')` message are not shown correctly. => I had to escape the double quotes first. 

### How has the user experience changed?

```js
cy.get('#backslashes').contains('"<OE_D]dQ\\')
cy.get('#escape-backslashes').should('contain', '"<OE_D]dQ\\')
```

**Before:** Fails.
**After:** Passes.

### PR Tasks
- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
