### PR TITLE
chore: update kitchensink pr to point to 10.0.0 pr

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1689,7 +1689,6 @@ jobs:
     steps:
       - clone-repo-and-checkout-branch:
           repo: cypress-example-kitchensink
-          pull_request_id: 528
       - install-required-node
       - run:
           name: Remove cypress.json
@@ -2005,7 +2004,6 @@ jobs:
       - test-binary-against-repo:
           repo: cypress-example-kitchensink
           browser: "electron"
-          pull_request_id: 528
 
   test-binary-against-kitchensink-firefox:
     <<: *defaults
@@ -2013,7 +2011,6 @@ jobs:
       - test-binary-against-repo:
           repo: cypress-example-kitchensink
           browser: firefox
-          pull_request_id: 528
 
   test-binary-against-kitchensink-chrome:
     <<: *defaults
@@ -2021,7 +2018,6 @@ jobs:
       - test-binary-against-repo:
           repo: cypress-example-kitchensink
           browser: chrome
-          pull_request_id: 528
 
   test-binary-against-todomvc-firefox:
     <<: *defaults

--- a/circle.yml
+++ b/circle.yml
@@ -1689,7 +1689,7 @@ jobs:
     steps:
       - clone-repo-and-checkout-branch:
           repo: cypress-example-kitchensink
-          pull_request_id: 524
+          pull_request_id: 528
       - install-required-node
       - run:
           name: Remove cypress.json
@@ -2005,7 +2005,7 @@ jobs:
       - test-binary-against-repo:
           repo: cypress-example-kitchensink
           browser: "electron"
-          pull_request_id: 524
+          pull_request_id: 528
 
   test-binary-against-kitchensink-firefox:
     <<: *defaults
@@ -2013,7 +2013,7 @@ jobs:
       - test-binary-against-repo:
           repo: cypress-example-kitchensink
           browser: firefox
-          pull_request_id: 524
+          pull_request_id: 528
 
   test-binary-against-kitchensink-chrome:
     <<: *defaults
@@ -2021,7 +2021,7 @@ jobs:
       - test-binary-against-repo:
           repo: cypress-example-kitchensink
           browser: chrome
-          pull_request_id: 524
+          pull_request_id: 528
 
   test-binary-against-todomvc-firefox:
     <<: *defaults


### PR DESCRIPTION
### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

In order to get the latest 10.0 changes on kitchen sink, we need to be pointing to the 10.0 pr.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
