### PR TITLE
chore: remove un-necessary conditional

### DIFF
--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -397,11 +397,7 @@ class $Cypress {
           return
         }
 
-        if (this.config('isTextTerminal')) {
-          return this.emit('mocha', 'start', args[0])
-        }
-
-        break
+        return this.emit('mocha', 'start', args[0])
 
       case 'runner:end':
         // mocha runner has finished running the tests
@@ -423,95 +419,54 @@ class $Cypress {
 
       case 'runner:suite:start':
         // mocha runner started processing a suite
-        if (this.config('isTextTerminal')) {
-          return this.emit('mocha', 'suite', ...args)
-        }
-
-        break
+        return this.emit('mocha', 'suite', ...args)
 
       case 'runner:suite:end':
         // mocha runner finished processing a suite
-        if (this.config('isTextTerminal')) {
-          return this.emit('mocha', 'suite end', ...args)
-        }
-
-        break
+        return this.emit('mocha', 'suite end', ...args)
 
       case 'runner:hook:start':
         // mocha runner started processing a hook
-        if (this.config('isTextTerminal')) {
-          return this.emit('mocha', 'hook', ...args)
-        }
-
-        break
+        return this.emit('mocha', 'hook', ...args)
 
       case 'runner:hook:end':
         // mocha runner finished processing a hook
-        if (this.config('isTextTerminal')) {
-          return this.emit('mocha', 'hook end', ...args)
-        }
-
-        break
+        return this.emit('mocha', 'hook end', ...args)
 
       case 'runner:test:start':
         // mocha runner started processing a hook
-        if (this.config('isTextTerminal')) {
-          return this.emit('mocha', 'test', ...args)
-        }
-
-        break
+        return this.emit('mocha', 'test', ...args)
 
       case 'runner:test:end':
-        if (this.config('isTextTerminal')) {
-          return this.emit('mocha', 'test end', ...args)
-        }
-
-        break
+        return this.emit('mocha', 'test end', ...args)
 
       case 'runner:pass':
         // mocha runner calculated a pass
         // this is delayed from when mocha would normally fire it
         // since we fire it after all afterEach hooks have ran
-        if (this.config('isTextTerminal')) {
-          return this.emit('mocha', 'pass', ...args)
-        }
-
-        break
+        return this.emit('mocha', 'pass', ...args)
 
       case 'runner:pending':
         // mocha runner calculated a pending test
-        if (this.config('isTextTerminal')) {
-          return this.emit('mocha', 'pending', ...args)
-        }
-
-        break
+        return this.emit('mocha', 'pending', ...args)
 
       case 'runner:fail': {
-        if (this.config('isTextTerminal')) {
-          return this.emit('mocha', 'fail', ...args)
-        }
-
-        break
+        return this.emit('mocha', 'fail', ...args)
       }
+
       // retry event only fired in mocha version 6+
       // https://github.com/mochajs/mocha/commit/2a76dd7589e4a1ed14dd2a33ab89f182e4c4a050
       case 'runner:retry': {
         // mocha runner calculated a pass
-        if (this.config('isTextTerminal')) {
-          this.emit('mocha', 'retry', ...args)
-        }
-
-        break
+        return this.emit('mocha', 'retry', ...args)
       }
 
       case 'mocha:runnable:run':
         return this.runner.onRunnableRun(...args)
 
       case 'runner:test:before:run':
-        if (this.config('isTextTerminal')) {
-          // needed for handling test retries
-          this.emit('mocha', 'test:before:run', args[0])
-        }
+        // needed for handling test retries
+        this.emit('mocha', 'test:before:run', args[0])
 
         this.emit('test:before:run', ...args)
         break
@@ -530,13 +485,10 @@ class $Cypress {
         // stats and runnable properties such as errors
         this.emit('test:after:run', ...args)
 
-        if (this.config('isTextTerminal')) {
-          // needed for calculating wallClockDuration
-          // and the timings of after + afterEach hooks
-          return this.emit('mocha', 'test:after:run', args[0])
-        }
+        // needed for calculating wallClockDuration
+        // and the timings of after + afterEach hooks
+        return this.emit('mocha', 'test:after:run', args[0])
 
-        break
       case 'cy:before:all:screenshots':
         return this.emit('before:all:screenshots', ...args)
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

I removed some conditionals that don't seem to be necessary in driver.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

When working on migration some specs from `runner` to `app`, eg [this PR](https://github.com/cypress-io/cypress/pull/20678), I dived into the driver to intercept the Mocha events. I noticed they all have an `if (config('isTextTerminal')) {` condition, that doesn't seem to do anything, so I removed them. I don't understand why we'd only emit these events in run mode, not open mode. If there's some specific reason, it'd be great to know so we can comment and document it.

**One** of the `if (config('isTextTerminal')) {` conditionals seems necessary. That's this one: https://github.com/cypress-io/cypress/blob/develop/packages/driver/src/cypress.ts#L418-L420. 

If I remove this conditional, one test fails - [this test](https://github.com/cypress-io/cypress/blob/develop/system-tests/test/session_spec.ts#L141) in `sessions_spec.ts`. [Failing on CI](https://app.circleci.com/pipelines/github/cypress-io/cypress/34501/workflows/4924d5c8-d306-4a39-b75c-4d1f544f5d70/jobs/1367930/tests#failed-test-0). 

That system test ultimately runs [this test](https://github.com/cypress-io/cypress/blob/develop/system-tests/projects/e2e/cypress/integration/session_persist_spec_1.js#L16) which does:

```js
// this simulates interactive/open mode
// so that the run does not complete until after reload
Cypress.config().isTextTerminal = false
```

I wonder if this is enough to truly simulate run mode. Interestingly enough, I removed that line from the 10.0-release branch and it's fine! I am not sure if this is a regression or the original code didn't make sense. I hope someone who has more context on driver can shed some light on this.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
