### PR TITLE
chore: fix data-context clean script, scaffoldProjectNodeModule in open mode

### DIFF
--- a/packages/data-context/package.json
+++ b/packages/data-context/package.json
@@ -9,7 +9,7 @@
     "check-ts": "tsc --noEmit && yarn -s tslint",
     "clean-deps": "rimraf node_modules",
     "tslint": "tslint --config ../ts/tslint.json --project .",
-    "clean": "rimraf './{src,test}/**/*(!.stories).js'",
+    "clean": "rimraf './{src,test}/**/*!(.stories).js'",
     "test": "yarn test-unit",
     "test-unit": "mocha -r @packages/ts/register --config ./test/.mocharc.js"
   },

--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -66,6 +66,7 @@ interface FixturesShape {
   scaffold (): void
   scaffoldProject (project: string): void
   scaffoldCommonNodeModules(): Promise<void>
+  scaffoldProjectNodeModules(project: string): Promise<void>
   scaffoldWatch (): void
   remove (): void
   removeProject (name): void
@@ -116,6 +117,8 @@ async function makeE2ETasks () {
     await Fixtures.scaffoldProject(projectName)
 
     await Fixtures.scaffoldCommonNodeModules()
+
+    await Fixtures.scaffoldProjectNodeModules(projectName)
 
     scaffoldedProjects.add(projectName)
 


### PR DESCRIPTION
- Fix "clean" script, noticed this was broken while pairing w/ @emilyrohrbough last week
- Scaffold `package.json` deps if they exist in a system-test directory in open-mode, as we do in regular system tests