### PR TITLE
fix: [Multi-domain] Preserve switchToDomain command logs between top domain changes.

### DIFF
--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_log.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_log.spec.ts
@@ -3,6 +3,7 @@ import { assertLogLength } from '../../../../support/utils'
 // @ts-ignore / session support is needed for visiting about:blank between tests
 context('log', { experimentalSessionSupport: true }, () => {
   let logs: any = []
+  let lastTestLogId = ''
 
   beforeEach(() => {
     logs = []
@@ -21,9 +22,8 @@ context('log', { experimentalSessionSupport: true }, () => {
         const listener = (attrs) => {
           if (attrs.message === 'test log in multi-domain') {
             expect(attrs.message).to.eq('test log in multi-domain')
-            expect(attrs.id).to.equal('log-http://foobar.com:3500-7')
             cy.removeListener('log:added', listener)
-            resolve()
+            resolve(attrs.id)
           }
         }
 
@@ -32,12 +32,13 @@ context('log', { experimentalSessionSupport: true }, () => {
 
       cy.log('test log in multi-domain')
       cy.wrap(afterLogAdded)
-    }).then(() => {
+    }).then((id) => {
+      lastTestLogId = id
       // Verify the log is also fired in the primary domain.
       expect(logs[6].get('message')).to.eq('test log in multi-domain')
       // Verify the log has the same ID as was generated in the cross-origin
-      expect(logs[6].get('id')).to.equal('log-http://foobar.com:3500-7')
-      assertLogLength(logs, 12)
+      expect(logs[6].get('id')).to.equal(id)
+      assertLogLength(logs, 11)
     })
   })
 
@@ -47,9 +48,8 @@ context('log', { experimentalSessionSupport: true }, () => {
         const listener = (attrs) => {
           if (attrs.message === 'test log in multi-domain') {
             expect(attrs.message).to.eq('test log in multi-domain')
-            expect(attrs.id).to.equal('log-http://foobar.com:3500-21')
             cy.removeListener('log:added', listener)
-            resolve()
+            resolve(attrs.id)
           }
         }
 
@@ -58,11 +58,12 @@ context('log', { experimentalSessionSupport: true }, () => {
 
       cy.log('test log in multi-domain')
       cy.wrap(afterLogAdded)
-    }).then(() => {
+    }).then((id) => {
       // Verify the log is also fired in the primary domain.
       expect(logs[6].get('message')).to.eq('test log in multi-domain')
       // Verify the log has the same ID as was generated in the cross-origin
-      expect(logs[6].get('id')).to.equal('log-http://foobar.com:3500-21')
+      expect(logs[6].get('id')).to.equal(id)
+      expect(logs[6].get('id')).to.not.equal(lastTestLogId)
       assertLogLength(logs, 12)
     })
   })

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_log.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_log.spec.ts
@@ -1,0 +1,69 @@
+import { assertLogLength } from '../../../../support/utils'
+
+// @ts-ignore / session support is needed for visiting about:blank between tests
+context('log', { experimentalSessionSupport: true }, () => {
+  let logs: any = []
+
+  beforeEach(() => {
+    logs = []
+
+    cy.on('log:added', (attrs, log) => {
+      logs.push(log)
+    })
+
+    cy.visit('/fixtures/multi-domain.html')
+    cy.get('a[data-cy="dom-link"]').click()
+  })
+
+  it('it logs in primary and secondary domains', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
+      const afterLogAdded = new Promise<void>((resolve) => {
+        const listener = (attrs) => {
+          if (attrs.message === 'test log in multi-domain') {
+            expect(attrs.message).to.eq('test log in multi-domain')
+            expect(attrs.id).to.equal('log-http://foobar.com:3500-7')
+            cy.removeListener('log:added', listener)
+            resolve()
+          }
+        }
+
+        cy.on('log:added', listener)
+      })
+
+      cy.log('test log in multi-domain')
+      cy.wrap(afterLogAdded)
+    }).then(() => {
+      // Verify the log is also fired in the primary domain.
+      expect(logs[6].get('message')).to.eq('test log in multi-domain')
+      // Verify the log has the same ID as was generated in the cross-origin
+      expect(logs[6].get('id')).to.equal('log-http://foobar.com:3500-7')
+      assertLogLength(logs, 12)
+    })
+  })
+
+  it('has a different id in a second test', () => {
+    cy.switchToDomain('http://foobar.com:3500', () => {
+      const afterLogAdded = new Promise<void>((resolve) => {
+        const listener = (attrs) => {
+          if (attrs.message === 'test log in multi-domain') {
+            expect(attrs.message).to.eq('test log in multi-domain')
+            expect(attrs.id).to.equal('log-http://foobar.com:3500-21')
+            cy.removeListener('log:added', listener)
+            resolve()
+          }
+        }
+
+        cy.on('log:added', listener)
+      })
+
+      cy.log('test log in multi-domain')
+      cy.wrap(afterLogAdded)
+    }).then(() => {
+      // Verify the log is also fired in the primary domain.
+      expect(logs[6].get('message')).to.eq('test log in multi-domain')
+      // Verify the log has the same ID as was generated in the cross-origin
+      expect(logs[6].get('id')).to.equal('log-http://foobar.com:3500-21')
+      assertLogLength(logs, 12)
+    })
+  })
+})

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_log.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_log.spec.ts
@@ -16,7 +16,7 @@ context('log', { experimentalSessionSupport: true }, () => {
     cy.get('a[data-cy="dom-link"]').click()
   })
 
-  it('it logs in primary and secondary domains', () => {
+  it('logs in primary and secondary domains', () => {
     cy.switchToDomain('http://foobar.com:3500', () => {
       const afterLogAdded = new Promise<void>((resolve) => {
         const listener = (attrs) => {

--- a/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/commands/multi_domain_misc.spec.ts
@@ -35,19 +35,6 @@ context('multi-domain misc', { experimentalSessionSupport: true }, () => {
     })
   })
 
-  it('.log()', () => {
-    cy.switchToDomain('http://foobar.com:3500', () => {
-      const afterLogAdded = new Promise<void>((resolve) => {
-        cy.once('log:added', () => {
-          resolve()
-        })
-      })
-
-      cy.log('test log in multi-domain')
-      cy.wrap(afterLogAdded)
-    })
-  })
-
   it('.pause()', () => {
     cy.switchToDomain('http://foobar.com:3500', () => {
       const afterPaused = new Promise<void>((resolve) => {

--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_yield_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_yield_spec.ts
@@ -83,8 +83,8 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
 
   it('throws if subject cannot be serialized and is accessed synchronously', (done) => {
     cy.on('fail', (err) => {
-      assertLogLength(logs, 6)
-      expect(logs[5].get('error')).to.eq(err)
+      assertLogLength(logs, 7)
+      expect(logs[6].get('error')).to.eq(err)
       expect(err.message).to.include('`cy.switchToDomain()` could not serialize the subject due to one of its properties not being supported by the structured clone algorithm.')
 
       done()
@@ -112,8 +112,8 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
 
   it('throws if subject cannot be serialized and is accessed', (done) => {
     cy.on('fail', (err) => {
-      assertLogLength(logs, 6)
-      expect(logs[5].get('error')).to.eq(err)
+      assertLogLength(logs, 8)
+      expect(logs[7].get('error')).to.eq(err)
       expect(err.message).to.include('`cy.switchToDomain()` could not serialize the subject due to one of its properties not being supported by the structured clone algorithm.')
 
       done()
@@ -128,8 +128,8 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
 
   it('throws if an object contains a function', (done) => {
     cy.on('fail', (err) => {
-      assertLogLength(logs, 6)
-      expect(logs[5].get('error')).to.eq(err)
+      assertLogLength(logs, 8)
+      expect(logs[7].get('error')).to.eq(err)
       expect(err.message).to.include('`cy.switchToDomain()` could not serialize the subject due to one of its properties not being supported by the structured clone algorithm.')
 
       done()
@@ -148,8 +148,8 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
 
   it('throws if an object contains a symbol', (done) => {
     cy.on('fail', (err) => {
-      assertLogLength(logs, 6)
-      expect(logs[5].get('error')).to.eq(err)
+      assertLogLength(logs, 8)
+      expect(logs[7].get('error')).to.eq(err)
       expect(err.message).to.include('`cy.switchToDomain()` could not serialize the subject due to one of its properties not being supported by the structured clone algorithm.')
 
       done()
@@ -165,8 +165,8 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
 
   it('throws if an object is a function', (done) => {
     cy.on('fail', (err) => {
-      assertLogLength(logs, 6)
-      expect(logs[5].get('error')).to.eq(err)
+      assertLogLength(logs, 8)
+      expect(logs[7].get('error')).to.eq(err)
       expect(err.message).to.include('`cy.switchToDomain()` could not serialize the subject due to functions not being supported by the structured clone algorithm.')
 
       done()
@@ -185,8 +185,8 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
 
   it('throws if an object is a symbol', (done) => {
     cy.on('fail', (err) => {
-      assertLogLength(logs, 6)
-      expect(logs[5].get('error')).to.eq(err)
+      assertLogLength(logs, 8)
+      expect(logs[7].get('error')).to.eq(err)
       expect(err.message).to.include('`cy.switchToDomain()` could not serialize the subject due to symbols not being supported by the structured clone algorithm.')
 
       done()
@@ -204,8 +204,8 @@ describe('multi-domain yields', { experimentalSessionSupport: true }, () => {
 
     cy.on('fail', (err) => {
       if (!isChromium) {
-        assertLogLength(logs, 6)
-        expect(logs[5].get('error')).to.eq(err)
+        assertLogLength(logs, 8)
+        expect(logs[7].get('error')).to.eq(err)
         expect(err.message).to.include('`cy.switchToDomain()` could not serialize the subject due to one of its properties not being supported by the structured clone algorithm.')
       }
 

--- a/packages/driver/src/cy/multi-domain/index.ts
+++ b/packages/driver/src/cy/multi-domain/index.ts
@@ -5,6 +5,7 @@ import { createUnserializableSubjectProxy } from './unserializable_subject_proxy
 import { serializeRunnable } from './util'
 import { preprocessConfig, preprocessEnv, syncConfigToCurrentDomain, syncEnvToCurrentDomain } from '../../util/config'
 import { $Location } from '../../cypress/location'
+import { LogUtils } from '../../cypress/log'
 
 const reHttp = /^https?:\/\//
 
@@ -191,6 +192,7 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
                 },
                 config: preprocessConfig(Cypress.config()),
                 env: preprocessEnv(Cypress.env()),
+                logCounter: LogUtils.getCounter(),
               })
             } catch (err: any) {
               const wrappedErr = $errUtils.errByPath('switchToDomain.run_domain_fn_errored', {

--- a/packages/driver/src/cypress/log.ts
+++ b/packages/driver/src/cypress/log.ts
@@ -106,6 +106,10 @@ export const LogUtils = {
   setCounter: (num) => {
     return counter = num
   },
+
+  getCounter: () => {
+    return counter
+  },
 }
 
 const defaults = function (state, config, obj) {

--- a/packages/driver/src/multi-domain/domain_fn.ts
+++ b/packages/driver/src/multi-domain/domain_fn.ts
@@ -3,6 +3,7 @@ import $errUtils from '../cypress/error_utils'
 import $utils from '../cypress/utils'
 import { syncConfigToCurrentDomain, syncEnvToCurrentDomain } from '../util/config'
 import type { Runnable, Test } from 'mocha'
+import { LogUtils } from '../cypress/log'
 
 interface RunDomainFnOptions {
   config: Cypress.Config
@@ -11,7 +12,7 @@ interface RunDomainFnOptions {
   fn: string
   skipConfigValidation: boolean
   state: {}
-  isStable: boolean
+  logCounter: number
 }
 
 interface serializedRunnable {
@@ -82,11 +83,14 @@ export const handleDomainFn = (Cypress: Cypress.Cypress, cy: $Cy) => {
   }
 
   Cypress.specBridgeCommunicator.on('run:domain:fn', async (options: RunDomainFnOptions) => {
-    const { config, data, env, fn, state, skipConfigValidation } = options
+    const { config, data, env, fn, state, skipConfigValidation, logCounter } = options
 
     let queueFinished = false
 
     reset(state)
+
+    // Set the counter for log ids
+    LogUtils.setCounter(logCounter)
 
     // @ts-ignore
     window.__cySkipValidateConfig = skipConfigValidation || false

--- a/packages/runner-shared/src/event-manager.js
+++ b/packages/runner-shared/src/event-manager.js
@@ -582,12 +582,21 @@ export const eventManager = {
 
     Cypress.multiDomainCommunicator.on('after:screenshot', handleAfterScreenshot)
 
+    const crossOriginLogs = {}
+
     Cypress.multiDomainCommunicator.on('log:added', (attrs) => {
-      reporterBus.emit('reporter:log:add', attrs)
+      // Create a new local log representation of the cross origin log.
+      // It will be attached to the current command.
+      // We also keep a reference to it to update it in the future.
+      crossOriginLogs[attrs.id] = Cypress.log(attrs)
     })
 
     Cypress.multiDomainCommunicator.on('log:changed', (attrs) => {
-      reporterBus.emit('reporter:log:state:changed', attrs)
+      // Retrieve the referenced log and update it.
+      const log = crossOriginLogs[attrs.id]
+
+      // this will trigger a log changed event for the log itself.
+      log?.set(attrs)
     })
   },
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #20621

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

There were two things wrong that caused the disappearing logs when switching the top domain. 

1. The logs in the spec bridges always started at zero so we were getting duplicate log ids.
2. The logs in the switchToDomain were not getting attached to any commands in the primary domain. This lead to the commands getting lost when state was preserved and then rehydrated during a top domain switch event.

To resolve these problem, this PR passes the current log count into the secondary domain to reset its count on each `run:domain:fn` event. This may result in skipped number sequences per domain, but it will ensure unique id's across all domains, regardless of the situation. (Having a spec bridge that turns into top and back again comes to mind)

Secondly we attach the command logs to the current command by injecting the command log earier in the flow. Where previously we were calling directly to the runner, we now create a full fledge command log and attach it to the current command. For updates, we keep a reference of cross origin logs and update them as updates roll in, subsequently triggering the command updated action in the primary domain as well.

This has the side effect of firing the log:added event in the primary domain when the even was logged in a cross-origin frame. I think this is ok because the log truly is being added and updated in the primary domain, as that is where it is displayed from.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Before:
<img width="1661" alt="Screen Shot 2022-03-22 at 3 45 29 PM" src="https://user-images.githubusercontent.com/1588747/159572799-ac88ac17-a452-4ca9-a30c-8dc4331d9145.png">

After:
<img width="1661" alt="Screen Shot 2022-03-22 at 3 44 42 PM" src="https://user-images.githubusercontent.com/1588747/159572792-d69f1238-d418-4371-80d2-37448c6f2ec7.png">


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
