### PR TITLE
chore: Only send honeycomb events for system tests run against binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ packages/proxy/lib/**/*.js
 # npm packages
 npm/**/cypress/screenshots
 
+# from app
+packages/app/cypress/videos
+
 # from example
 packages/example/app
 packages/example/build
@@ -92,8 +95,9 @@ system-tests/fixtures/large-img
 /packages/errors/__snapshot-html-local__
 
 # graphql, auto-generated
-/packages/launchpad/src/generated
 /packages/app/src/generated
+/packages/launchpad/src/generated
+/packages/frontend-shared/src/generated
 
 # from npm/create-cypress-tests
 /npm/create-cypress-tests/initial-template

--- a/circle.yml
+++ b/circle.yml
@@ -540,7 +540,7 @@ commands:
       - run:
           # Install deps + Cypress binary with yarn if yarn.lock present
           command: |
-            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip yarn add -DW ~/cypress/cypress.tgz
+            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip npm i --legacy-peer-deps ~/cypress/cypress.tgz
       - run:
           name: Run system tests
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -538,6 +538,10 @@ commands:
       - restore_cached_workspace
       - restore_cached_system_tests_deps
       - run:
+          # Install deps + Cypress binary with yarn if yarn.lock present
+          command: |
+            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip yarn add -D ~/cypress/cypress.tgz
+      - run:
           name: Run system tests
           command: |
             ALL_SPECS=`circleci tests glob "$HOME/cypress/system-tests/test-binary/*spec*"`

--- a/circle.yml
+++ b/circle.yml
@@ -540,7 +540,7 @@ commands:
       - run:
           # Install deps + Cypress binary with yarn if yarn.lock present
           command: |
-            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip yarn add -D ~/cypress/cypress.tgz
+            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip yarn add -DW ~/cypress/cypress.tgz
       - run:
           name: Run system tests
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -2084,19 +2084,15 @@ linux-workflow: &linux-workflow
         requires:
           - build
     - system-tests-chrome:
-        context: test-runner:performance-tracking
         requires:
           - system-tests-node-modules-install
     - system-tests-electron:
-        context: test-runner:performance-tracking
         requires:
           - system-tests-node-modules-install
     - system-tests-firefox:
-        context: test-runner:performance-tracking
         requires:
           - system-tests-node-modules-install
     - system-tests-non-root:
-        context: test-runner:performance-tracking
         executor: non-root-docker-user
         requires:
           - system-tests-node-modules-install
@@ -2294,6 +2290,7 @@ linux-workflow: &linux-workflow
         requires:
           - create-build-artifacts
     - binary-system-tests:
+        context: test-runner:performance-tracking
         requires:
           - create-build-artifacts
           - system-tests-node-modules-install

--- a/system-tests/__snapshots__/screenshots_spec.js
+++ b/system-tests/__snapshots__/screenshots_spec.js
@@ -1,14 +1,23 @@
 exports['e2e screenshots / passes'] = `
+⚠ Warning: It looks like you're passing CYPRESS_INTERNAL_ENV=test
+
+The environment variable "CYPRESS_INTERNAL_ENV" is reserved and should only be used internally.
+
+Unset the "CYPRESS_INTERNAL_ENV" environment variable and run Cypress again.
+⚠ Warning: Binary version 9.5.3 does not match the expected package version 0.0.0-development
+
+  These versions may not work properly together.
 
 ====================================================================================================
 
   (Run Starting)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Cypress:    1.2.3                                                                              │
-  │ Browser:    FooBrowser 88                                                                      │
-  │ Specs:      1 found (screenshots_spec.js)                                                      │
-  │ Searched:   cypress/integration/screenshots_spec.js                                            │
+  │ Cypress:        1.2.3                                                                          │
+  │ Browser:        FooBrowser 88                                                                  │
+  │ Node Version:   vX (/foo/bar/node)                                                             │
+  │ Specs:          1 found (screenshots_spec.js)                                                  │
+  │ Searched:       cypress/integration/screenshots_spec.js                                        │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
 
 

--- a/system-tests/lib/system-tests.ts
+++ b/system-tests/lib/system-tests.ts
@@ -1,7 +1,6 @@
 const snapshot = require('snap-shot-it')
 
 import type { SpawnOptions } from 'child_process'
-import os from 'os'
 import stream from 'stream'
 import { expect } from './spec_helper'
 import { dockerSpawner } from './docker'
@@ -790,7 +789,6 @@ const systemTests = {
   },
 
   args (options: ExecOptions) {
-    console.log(options)
     debug('converting options to args %o', { options })
 
     const projectPath = Fixtures.projectPath(options.project)
@@ -800,7 +798,7 @@ const systemTests = {
     if (options.withBinary && options.dockerImage) {
       args.push(`run`, `--project=${projectPath}`)
     } else if (options.withBinary) {
-      args.push('../cli/bin/cypress', `run`, `--project=${projectPath}`)
+      args.push('node_modules/.bin/cypress', `run`, `--project=${projectPath}`)
     } else {
       args.push(
         require.resolve('@packages/server'),
@@ -1049,8 +1047,6 @@ const systemTests = {
 
       // disable frame skipping to make quick Chromium tests have matching snapshots/working video
       CYPRESS_EVERY_NTH_FRAME: 1,
-
-      ...(options.withBinary && !options.dockerImage ? { CYPRESS_RUN_BINARY: `../build/build/${os.platform()}-unpacked/Cypress` } : {}),
 
       // force file watching for use with --no-exit
       ...(options.noExit ? { CYPRESS_INTERNAL_FORCE_FILEWATCH: '1' } : {}),

--- a/system-tests/lib/system-tests.ts
+++ b/system-tests/lib/system-tests.ts
@@ -798,7 +798,7 @@ const systemTests = {
     if (options.withBinary && options.dockerImage) {
       args.push(`run`, `--project=${projectPath}`)
     } else if (options.withBinary) {
-      args.push('node_modules/.bin/cypress', `run`, `--project=${projectPath}`)
+      args.push('../node_modules/.bin/cypress', `run`, `--project=${projectPath}`)
     } else {
       args.push(
         require.resolve('@packages/server'),

--- a/system-tests/test-binary/screenshots_spec.js
+++ b/system-tests/test-binary/screenshots_spec.js
@@ -61,6 +61,7 @@ describe('e2e screenshots', () => {
   // and are also generated automatically on failure with
   // the test title as the file name
   systemTests.it('passes', {
+    withBinary: true,
     spec: 'screenshots_spec.js',
     expectedExitCode: 5,
     snapshot: true,

--- a/system-tests/test-binary/screenshots_spec.js
+++ b/system-tests/test-binary/screenshots_spec.js
@@ -62,6 +62,7 @@ describe('e2e screenshots', () => {
   // the test title as the file name
   systemTests.it('passes', {
     withBinary: true,
+    dockerImage: 'cypress/base:16',
     spec: 'screenshots_spec.js',
     expectedExitCode: 5,
     snapshot: true,

--- a/system-tests/test-binary/screenshots_spec.js
+++ b/system-tests/test-binary/screenshots_spec.js
@@ -62,7 +62,6 @@ describe('e2e screenshots', () => {
   // the test title as the file name
   systemTests.it('passes', {
     withBinary: true,
-    dockerImage: 'cypress/base:16.5.0',
     spec: 'screenshots_spec.js',
     expectedExitCode: 5,
     snapshot: true,

--- a/system-tests/test-binary/screenshots_spec.js
+++ b/system-tests/test-binary/screenshots_spec.js
@@ -62,7 +62,7 @@ describe('e2e screenshots', () => {
   // the test title as the file name
   systemTests.it('passes', {
     withBinary: true,
-    dockerImage: 'cypress/base:16',
+    dockerImage: 'cypress/base:16.5.0',
     spec: 'screenshots_spec.js',
     expectedExitCode: 5,
     snapshot: true,

--- a/system-tests/test-binary/video_compression_spec.js
+++ b/system-tests/test-binary/video_compression_spec.js
@@ -38,6 +38,7 @@ describe('e2e video compression', () => {
     false,
   ].forEach((headed) => {
     systemTests.it(`passes (head${headed ? 'ed' : 'less'})`, {
+      withBinary: true,
       // videos are corrupted in firefox due to known issues
       browser: '!firefox',
       spec: 'video_compression_spec.js',

--- a/system-tests/test-binary/video_compression_spec.js
+++ b/system-tests/test-binary/video_compression_spec.js
@@ -39,7 +39,7 @@ describe('e2e video compression', () => {
   ].forEach((headed) => {
     systemTests.it(`passes (head${headed ? 'ed' : 'less'})`, {
       withBinary: true,
-      dockerImage: 'cypress/base:16',
+      dockerImage: 'cypress/base:16.5.0',
       // videos are corrupted in firefox due to known issues
       browser: '!firefox',
       spec: 'video_compression_spec.js',

--- a/system-tests/test-binary/video_compression_spec.js
+++ b/system-tests/test-binary/video_compression_spec.js
@@ -39,6 +39,7 @@ describe('e2e video compression', () => {
   ].forEach((headed) => {
     systemTests.it(`passes (head${headed ? 'ed' : 'less'})`, {
       withBinary: true,
+      dockerImage: 'cypress/base:16',
       // videos are corrupted in firefox due to known issues
       browser: '!firefox',
       spec: 'video_compression_spec.js',

--- a/system-tests/test-binary/video_compression_spec.js
+++ b/system-tests/test-binary/video_compression_spec.js
@@ -39,7 +39,6 @@ describe('e2e video compression', () => {
   ].forEach((headed) => {
     systemTests.it(`passes (head${headed ? 'ed' : 'less'})`, {
       withBinary: true,
-      dockerImage: 'cypress/base:16.5.0',
       // videos are corrupted in firefox due to known issues
       browser: '!firefox',
       spec: 'video_compression_spec.js',


### PR DESCRIPTION
## Draft only, not ready for review.

- Closes https://cypress-io.atlassian.net/browse/UNIFY-1126

### User facing changelog
No user-facing changes.

### Additional details
This PR modifies our circle build to only report honeycomb events for system tests run against the final binary, which is more reflective of release performance.

### How has the user experience changed?

### PR Tasks


- [N/A] Have tests been added/updated?
- [N/A] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
