### PR TITLE
fix(deps): add 'lodash' to webpack-dev-server plugin dependencies

### DIFF
--- a/npm/webpack-dev-server/package.json
+++ b/npm/webpack-dev-server/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "debug": "^4.3.2",
+    "lodash": "^4.17.21",
     "semver": "^7.3.4",
     "webpack-merge": "^5.4.0"
   },


### PR DESCRIPTION
Fixes [Issue # 18070](https://github.com/cypress-io/cypress/issues/18070)

> > ### Current behavior
> Use cypress component testing with cypress-react-selector with yarn 2 (PnP)
> 
> > yarn cypress open-ct
> 
> The function exported by the plugins file threw an error.
> 
> We invoked the function exported by `/Users/francis/temp/test-material-ui/cypress/plugins/index.js`, but it threw an error.
> 
> Error: @cypress/webpack-dev-server tried to access lodash, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
> 
> Required package: lodash Required by: @cypress/webpack-dev-server@virtual:75543d871e7c13242968c702e15bd65752052208169d6a9c713f2479a33c6be9684ca5208d64d7483a58061fe11b15c623f68d66865cff731493cbf160b2633a#npm:1.6.0 (via /Users/francis/temp/test-material-ui/.yarn/**virtual**/@cypress-webpack-dev-server-virtual-64fa467786/0/cache/@cypress-webpack-dev-server-npm-1.6.0-8a7c245dc5-39df29ddd3.zip/node_modules/@cypress/webpack-dev-server/dist/)
> 
> Require stack:
> 
> * /Users/francis/temp/test-material-ui/.yarn/**virtual**/@cypress-webpack-dev-server-virtual-64fa467786/0/cache/@cypress-webpack-dev-server-npm-1.6.0-8a7c245dc5-39df29ddd3.zip/node_modules/@cypress/webpack-dev-server/dist/plugin.js
> * /Users/francis/temp/test-material-ui/.yarn/**virtual**/@cypress-webpack-dev-server-virtual-64fa467786/0/cache/@cypress-webpack-dev-server-npm-1.6.0-8a7c245dc5-39df29ddd3.zip/node_modules/@cypress/webpack-dev-server/dist/makeWebpackConfig.js
> * /Users/francis/temp/test-material-ui/.yarn/**virtual**/@cypress-webpack-dev-server-virtual-64fa467786/0/cache/@cypress-webpack-dev-server-npm-1.6.0-8a7c245dc5-39df29ddd3.zip/node_modules/@cypress/webpack-dev-server/dist/startServer.js
> * /Users/francis/temp/test-material-ui/.yarn/**virtual**/@cypress-webpack-dev-server-virtual-64fa467786/0/cache/@cypress-webpack-dev-server-npm-1.6.0-8a7c245dc5-39df29ddd3.zip/node_modules/@cypress/webpack-dev-server/dist/index.js
> * /Users/francis/temp/test-material-ui/.yarn/**virtual**/@cypress-react-virtual-cf8e38ac08/0/cache/@cypress-react-npm-5.10.0-0880f09a0c-eaa959ffaa.zip/node_modules/@cypress/react/plugins/react-scripts/index.js
> * /Users/francis/temp/test-material-ui/cypress/plugins/index.js
> * /Users/francis/Library/Caches/Cypress/8.3.1/Cypress.app/Contents/Resources/app/packages/server/lib/plugins/child/run_plugins.js
> * /Users/francis/Library/Caches/Cypress/8.3.1/Cypress.app/Contents/Resources/app/packages/server/lib/plugins/child/index.js
>   at Function.external_module_.Module._resolveFilename (/Users/francis/temp/test-material-ui/.pnp.cjs:31396:55)
>   at external_module_.Module._load (/Users/francis/temp/test-material-ui/.pnp.cjs:31195:48)
>   at Function.f._load (electron/js2c/asar_bundle.js:5:12913)
>   at Module.require (internal/modules/cjs/loader.js:959:19)
>   at require (internal/modules/cjs/helpers.js:88:18)
>   at Object. (/Users/francis/temp/test-material-ui/.yarn/**virtual**/@cypress-webpack-dev-server-virtual-64fa467786/0/cache/@cypress-webpack-dev-server-npm-1.6.0-8a7c245dc5-39df29ddd3.zip/node_modules/@cypress/webpack-dev-server/dist/plugin.js:8:34)
>   at Module._compile (internal/modules/cjs/loader.js:1078:30)
>   at Object.Module._extensions..js (internal/modules/cjs/loader.js:1108:10)
>   at Module.load (internal/modules/cjs/loader.js:935:32)
>   at external_module_.Module._load (/Users/francis/temp/test-material-ui/.pnp.cjs:31245:14)
>   at Function.f._load (electron/js2c/asar_bundle.js:5:12913)
>   at Module.require (internal/modules/cjs/loader.js:959:19)
>   at require (internal/modules/cjs/helpers.js:88:18)
>   at Object. (/Users/francis/temp/test-material-ui/.yarn/**virtual**/@cypress-webpack-dev-server-virtual-64fa467786/0/cache/@cypress-webpack-dev-server-npm-1.6.0-8a7c245dc5-39df29ddd3.zip/node_modules/@cypress/webpack-dev-server/dist/makeWebpackConfig.js:39:34)
>   at Module._compile (internal/modules/cjs/loader.js:1078:30)
>   at Object.Module._extensions..js (internal/modules/cjs/loader.js:1108:10)
> 
> ### Desired behavior
> > yarn cypress open-ct
> 
> (it works)
> 
> ### Test code to reproduce
> https://github.com/francisu/test-material-ui
> 
> > git clone https://github.com/francisu/test-material-ui
> > cd test-material-ui
> > git checkout yarn2-lodash
> > yarn install
> > yarn cypress open-ct
> 
> ### Cypress Version
> 8.3.1
> 
> ### Other
> Fix is simple, just add lodash as a dependency in npm/webpack-dev-server
> 
> _No response_

