### PR TITLE
fix: (multi-domain) fix injection issue

### DIFF
--- a/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_events_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/multi_domain_events_spec.ts
@@ -50,7 +50,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
     })
 
     it('window:before:unload', () => {
-      cy.switchToDomain('http://foobar.com:3500', () => {
+      cy.switchToDomain('http://www.foobar.com:3500', () => {
         const afterWindowBeforeUnload = new Promise<void>((resolve) => {
           Cypress.once('window:before:unload', () => {
             expect(location.host).to.equal('foobar.com:3500')
@@ -58,15 +58,14 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
           })
         })
 
-        // TODO: update to use relative path once available
-        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain.html')
+        cy.visit('/fixtures/multi-domain.html')
 
         cy.wrap(afterWindowBeforeUnload)
       })
     })
 
     it('window:unload', () => {
-      cy.switchToDomain('http://foobar.com:3500', () => {
+      cy.switchToDomain('http://www.foobar.com:3500', () => {
         const afterWindowUnload = new Promise<void>((resolve) => {
           Cypress.once('window:unload', () => {
             expect(location.host).to.equal('foobar.com:3500')
@@ -74,8 +73,7 @@ describe('multi-domain', { experimentalSessionSupport: true }, () => {
           })
         })
 
-        // TODO: update to use relative path once available
-        cy.visit('http://www.foobar.com:3500/fixtures/multi-domain.html')
+        cy.visit('/fixtures/multi-domain.html')
 
         cy.wrap(afterWindowUnload)
       })

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -241,11 +241,7 @@ const MaybeDelayForMultiDomain: ResponseMiddleware = function () {
     this.debug('is cross-domain, delay until ready:for:domain event')
 
     this.serverBus.once('ready:for:domain', ({ failed }) => {
-      this.debug(`ready for domain${failed ? ' failed' : ''}, let it go`)
-
-      if (!failed) {
-        this.res.wantsInjection = 'fullMultiDomain'
-      }
+      this.debug(`received ready:for:domain${failed ? ' failed' : ''}, let the response proceed`)
 
       this.next()
     })

--- a/packages/proxy/test/unit/http/response-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/response-middleware.spec.ts
@@ -272,8 +272,6 @@ describe('http/response-middleware', function () {
 
       ctx.serverBus.once.withArgs('ready:for:domain').args[0][1]({ originPolicy: 'http://foobar.com' })
 
-      expect(ctx.res.wantsInjection).to.equal('fullMultiDomain')
-
       return promise
     })
 
@@ -299,8 +297,6 @@ describe('http/response-middleware', function () {
       expect(ctx.serverBus.emit).to.be.calledWith('cross:domain:delaying:html', { href: 'http://www.idp.com/test' })
 
       ctx.serverBus.once.withArgs('ready:for:domain').args[0][1]({ failed: true })
-
-      expect(ctx.res.wantsInjection).to.be.undefined
 
       return promise
     })

--- a/packages/runner/injection/multi-domain.js
+++ b/packages/runner/injection/multi-domain.js
@@ -29,13 +29,6 @@ const findCypress = () => {
 
 const Cypress = findCypress()
 
-// TODO: If the spec bridge is not found we should throw some kind of error to main cypress, this should account for redirects so maybe wait a bit before throwing?
-// This may not be needed if we defer to the first command
-if (!Cypress) {
-  throw new Error('Something went terribly wrong and we cannot proceed. We expected to find the global \
-Cypress in the spec bridge window but it is missing.')
-}
-
 // the timers are wrapped in the injection code similar to the primary domain
 const timers = createTimers()
 

--- a/packages/server/lib/remote_states.ts
+++ b/packages/server/lib/remote_states.ts
@@ -55,7 +55,7 @@ export class RemoteStates {
   get (url: string) {
     const state = this.remoteStates.get(cors.getOriginPolicy(url))
 
-    debug('Getting remote state: %o for: %s', state, url)
+    debug('getting remote state: %o for: %s', state, url)
 
     return _.cloneDeep(state)
   }
@@ -74,7 +74,7 @@ export class RemoteStates {
   }
 
   reset () {
-    debug('Resetting remote state')
+    debug('resetting remote state')
 
     const stateArray = Array.from(this.remoteStates.entries())
 
@@ -133,14 +133,20 @@ export class RemoteStates {
       this.originStack[0] = remoteOriginPolicy
     }
 
-    debug('Setting remote state %o for %s', state, remoteOriginPolicy)
+    debug('setting remote state %o for %s', state, remoteOriginPolicy)
 
     return this.get(remoteOriginPolicy) as Cypress.RemoteState
   }
 
   addEventListeners (eventEmitter: EventEmitter) {
     eventEmitter.on('ready:for:domain', ({ originPolicy, failed }) => {
-      if (failed) return
+      if (failed) {
+        debug('received ready:for:domain failed, don\'t add origin to remote states')
+
+        return
+      }
+
+      debug(`received ready:for:domain, add origin ${originPolicy} to remote states`)
 
       const existingOrigin = this.remoteStates.get(originPolicy)
 
@@ -154,6 +160,8 @@ export class RemoteStates {
     })
 
     eventEmitter.on('cross:origin:finished', (originPolicy) => {
+      debug(`received cross:origin:finished, remove ${originPolicy} from origin stack`)
+
       this.removeCurrentOrigin(originPolicy)
     })
   }
@@ -169,7 +177,7 @@ export class RemoteStates {
   private addOrigin (originPolicy) {
     this.originStack.push(originPolicy)
 
-    debug('Added origin: ', originPolicy)
+    debug('added origin: ', originPolicy)
   }
 
   private removeCurrentOrigin (originPolicy) {
@@ -181,6 +189,6 @@ export class RemoteStates {
 
     this.originStack.pop()
 
-    debug('Removed current origin: ', originPolicy)
+    debug('removed current origin: ', originPolicy)
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes n/a

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
When the `ready:for:domain` event is received in the `response-middleware`, we assume that the request is `multi-domain` and set `wantsInjection` to `fullMultiDomain`. However, this is not the case when the user navigates to a cross-origin and then sets up a `switchToDomain` for a different origin. In order to fix the issue, I am removing setting `wantsInjection` on the `ready:for:domain` event and instead allowing the request to flow through the normal `setInjection` middleware that will correctly determine the injection level. I am also removing the `Cypress` check in `injections/multi-domain.js` since this scenario should not be possible.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
