### PR TITLE
chore: Refactor cri-client to use async/await

### DIFF
--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -161,7 +161,7 @@ const normalizeResourceType = (resourceType: string | undefined): ResourceType =
   return ffToStandardResourceTypeMap[resourceType] || 'other'
 }
 
-type SendDebuggerCommand = (message: string, data?: any) => Bluebird<any>
+type SendDebuggerCommand = (message: string, data?: any) => Promise<any>
 type OnFn = (eventName: string, cb: Function) => void
 
 // the intersection of what's valid in CDP and what's valid in FFCDP
@@ -230,7 +230,7 @@ export class CdpAutomation {
     })
   }
 
-  private getCookiesByUrl = (url): Bluebird<CyCookie[]> => {
+  private getCookiesByUrl = (url): Promise<CyCookie[]> => {
     return this.sendDebuggerCommandFn('Network.getCookies', {
       urls: [url],
     })
@@ -242,7 +242,7 @@ export class CdpAutomation {
     })
   }
 
-  private getCookie = (filter: CyCookieFilter): Bluebird<CyCookie | null> => {
+  private getCookie = (filter: CyCookieFilter): Promise<CyCookie | null> => {
     return this.getAllCookies(filter)
     .then((cookies) => {
       return _.get(cookies, 0, null)
@@ -285,15 +285,18 @@ export class CdpAutomation {
 
       case 'clear:cookie':
         return this.getCookie(data)
-        // tap, so we can resolve with the value of the removed cookie
-        // also, getting the cookie via CDP first will ensure that we send a cookie `domain` to CDP
-        // that matches the cookie domain that is really stored
-        .tap((cookieToBeCleared) => {
+        // always resolve with the value of the removed cookie. also, getting
+        // the cookie via CDP first will ensure that we send a cookie `domain`
+        // to CDP that matches the cookie domain that is really stored
+        .then((cookieToBeCleared) => {
           if (!cookieToBeCleared) {
-            return
+            return cookieToBeCleared
           }
 
           return this.sendDebuggerCommandFn('Network.deleteCookies', _.pick(cookieToBeCleared, 'name', 'domain'))
+          .then(() => {
+            return cookieToBeCleared
+          })
         })
 
       case 'clear:cookies':

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -179,12 +179,11 @@ export const create = async (target: websocketUrl, onAsynchronousError: Function
 
     debug('connecting %o', { target })
 
-    const newCri = await chromeRemoteInterface({
+    cri = await chromeRemoteInterface({
       target,
       local: true,
     })
 
-    cri = newCri
     connected = true
 
     maybeDebugCdpMessages(cri)

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -1,4 +1,3 @@
-import Bluebird from 'bluebird'
 import debugModule from 'debug'
 import _ from 'lodash'
 
@@ -48,17 +47,17 @@ interface CRIWrapper {
   /**
    * Get the `protocolVersion` supported by the browser.
    */
-  getProtocolVersion (): Bluebird<Version>
+  getProtocolVersion (): Promise<Version>
   /**
    * Rejects if `protocolVersion` is less than the current version.
    * @param protocolVersion CDP version string (ex: 1.3)
    */
-  ensureMinimumProtocolVersion(protocolVersion: string): Bluebird<void>
+  ensureMinimumProtocolVersion(protocolVersion: string): Promise<void>
   /**
    * Sends a command to the Chrome remote interface.
    * @example client.send('Page.navigate', { url })
   */
-  send (command: CRI.Command, params?: object): Bluebird<any>
+  send (command: CRI.Command, params?: object): Promise<any>
   /**
    * Registers callback for particular event.
    * @see https://github.com/cyrus-and/chrome-remote-interface#class-cdp
@@ -67,7 +66,7 @@ interface CRIWrapper {
   /**
    * Calls underlying remote interface client close
   */
-  close (): Bluebird<void>
+  close (): Promise<void>
 }
 
 interface Version {
@@ -137,7 +136,7 @@ export { chromeRemoteInterface }
 
 type DeferredPromise = { resolve: Function, reject: Function }
 
-export const create = Bluebird.method((target: websocketUrl, onAsynchronousError: Function): Bluebird<CRIWrapper> => {
+export const create = async (target: websocketUrl, onAsynchronousError: Function): Promise<CRIWrapper> => {
   const subscriptions: {eventName: CRI.EventName, cb: Function}[] = []
   let enqueuedCommands: {command: CRI.Command, params: any, p: DeferredPromise }[] = []
 
@@ -147,7 +146,7 @@ export const create = Bluebird.method((target: websocketUrl, onAsynchronousError
   let cri
   let client: CRIWrapper
 
-  const reconnect = () => {
+  const reconnect = async () => {
     debug('disconnected, attempting to reconnect... %o', { closed })
 
     connected = false
@@ -156,8 +155,9 @@ export const create = Bluebird.method((target: websocketUrl, onAsynchronousError
       return
     }
 
-    return connect()
-    .then(() => {
+    try {
+      await connect()
+
       debug('restoring subscriptions + running queued commands... %o', { subscriptions, enqueuedCommands })
       subscriptions.forEach((sub) => {
         cri.on(sub.eventName, sub.cb)
@@ -169,98 +169,96 @@ export const create = Bluebird.method((target: websocketUrl, onAsynchronousError
       })
 
       enqueuedCommands = []
-    })
-    .catch((err) => {
+    } catch (err) {
       onAsynchronousError(errors.get('CDP_COULD_NOT_RECONNECT', err))
-    })
+    }
   }
 
-  const connect = () => {
+  const connect = async () => {
     cri?.close()
 
     debug('connecting %o', { target })
 
-    return chromeRemoteInterface({
+    const newCri = await chromeRemoteInterface({
       target,
       local: true,
     })
-    .then((newCri) => {
-      cri = newCri
-      connected = true
 
-      maybeDebugCdpMessages(cri)
+    cri = newCri
+    connected = true
 
-      cri.send = Bluebird.promisify(cri.send, { context: cri })
+    maybeDebugCdpMessages(cri)
 
-      // @see https://github.com/cyrus-and/chrome-remote-interface/issues/72
-      cri._notifier.on('disconnect', reconnect)
-    })
+    // @see https://github.com/cyrus-and/chrome-remote-interface/issues/72
+    cri._notifier.on('disconnect', reconnect)
   }
 
-  return connect()
-  .then(() => {
-    const ensureMinimumProtocolVersion = (protocolVersion: string) => {
-      return getProtocolVersion()
-      .then((actual) => {
-        const minimum = getMajorMinorVersion(protocolVersion)
+  await connect()
 
-        if (!isVersionGte(actual, minimum)) {
-          errors.throw('CDP_VERSION_TOO_OLD', protocolVersion, actual)
-        }
-      })
+  const ensureMinimumProtocolVersion = async (protocolVersion: string) => {
+    const actual = await getProtocolVersion()
+    const minimum = getMajorMinorVersion(protocolVersion)
+
+    if (!isVersionGte(actual, minimum)) {
+      errors.throw('CDP_VERSION_TOO_OLD', protocolVersion, actual)
     }
+  }
 
-    const getProtocolVersion = _.memoize(() => {
-      return client.send('Browser.getVersion')
+  const getProtocolVersion = _.memoize(async () => {
+    let version
+
+    try {
+      version = await client.send('Browser.getVersion')
+    } catch (_) {
       // could be any version <= 1.2
-      .catchReturn({ protocolVersion: '0.0' })
-      .then(({ protocolVersion }) => {
-        return getMajorMinorVersion(protocolVersion)
-      })
-    })
-
-    client = {
-      ensureMinimumProtocolVersion,
-      getProtocolVersion,
-      send: Bluebird.method((command: CRI.Command, params?: object) => {
-        const enqueue = () => {
-          return new Bluebird((resolve, reject) => {
-            enqueuedCommands.push({ command, params, p: { resolve, reject } })
-          })
-        }
-
-        if (connected) {
-          return cri.send(command, params)
-          .catch((err) => {
-            if (!WEBSOCKET_NOT_OPEN_RE.test(err.message)) {
-              throw err
-            }
-
-            debug('encountered closed websocket on send %o', { command, params, err })
-
-            const p = enqueue()
-
-            reconnect()
-
-            return p
-          })
-        }
-
-        return enqueue()
-      }),
-      on (eventName: CRI.EventName, cb: Function) {
-        subscriptions.push({ eventName, cb })
-        debug('registering CDP on event %o', { eventName })
-
-        return cri.on(eventName, cb)
-      },
-      close () {
-        closed = true
-
-        return cri.close()
-      },
+      version = { protocolVersion: '0.0' }
     }
 
-    return client
+    return getMajorMinorVersion(version.protocolVersion)
   })
-})
+
+  client = {
+    ensureMinimumProtocolVersion,
+    getProtocolVersion,
+    async send (command: CRI.Command, params?: object) {
+      const enqueue = () => {
+        return new Promise((resolve, reject) => {
+          enqueuedCommands.push({ command, params, p: { resolve, reject } })
+        })
+      }
+
+      if (connected) {
+        try {
+          return cri.send(command, params)
+        } catch (err) {
+          if (!WEBSOCKET_NOT_OPEN_RE.test(err.message)) {
+            throw err
+          }
+
+          debug('encountered closed websocket on send %o', { command, params, err })
+
+          const p = enqueue()
+
+          reconnect()
+
+          return p
+        }
+      }
+
+      return enqueue()
+    },
+    on (eventName: CRI.EventName, cb: Function) {
+      subscriptions.push({ eventName, cb })
+      debug('registering CDP on event %o', { eventName })
+
+      return cri.on(eventName, cb)
+    },
+    close () {
+      closed = true
+
+      return cri.close()
+    },
+  }
+
+  return client
+}

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -229,7 +229,7 @@ export const create = async (target: websocketUrl, onAsynchronousError: Function
 
       if (connected) {
         try {
-          return cri.send(command, params)
+          return await cri.send(command, params)
         } catch (err) {
           if (!WEBSOCKET_NOT_OPEN_RE.test(err.message)) {
             throw err

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -1,4 +1,3 @@
-import Bluebird from 'bluebird'
 import chalk from 'chalk'
 import EventEmitter from 'events'
 import { create } from '../../../lib/browsers/cri-client'
@@ -17,8 +16,6 @@ describe('lib/browsers/cri-client', function () {
   let getClient: () => ReturnType<typeof create>
 
   beforeEach(function () {
-    sinon.stub(Bluebird, 'promisify').returnsArg(0)
-
     send = sinon.stub()
     onError = sinon.stub()
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog

N/A

### Additional details

This refactors `packages/server/lib/browsers/cri-client.ts` to use async/await instead of Bluebird promises. It's a precursor to work being done in this file related to reconnecting to the CDP. There are no functional changes in this PR.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- N/A Have tests been added/updated?
- N/A Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
