### PR TITLE
fix: guard against infinite loop in unhandled exception handling

### DIFF
--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -13,15 +13,7 @@ if (process.env.CY_NET_PROFILE && isRunningElectron) {
   process.stdout.write(`Network profiler writing to ${netProfiler.logPath}\n`)
 }
 
-const globalExceptionHandler = async (err) => {
-  await require('./lib/errors').logException(err)
-  process.exit(1)
-}
-
-process.removeAllListeners('unhandledRejection')
-process.on('unhandledRejection', globalExceptionHandler)
-process.removeAllListeners('uncaughtException')
-process.on('uncaughtException', globalExceptionHandler)
+require('./lib/unhandled_exceptions')
 
 process.env.UV_THREADPOOL_SIZE = 128
 

--- a/packages/server/lib/unhandled_exceptions.js
+++ b/packages/server/lib/unhandled_exceptions.js
@@ -1,0 +1,9 @@
+const globalExceptionHandler = async (err) => {
+  await require('./errors').logException(err)
+  process.exit(1)
+}
+
+process.removeAllListeners('unhandledRejection')
+process.once('unhandledRejection', globalExceptionHandler)
+process.removeAllListeners('uncaughtException')
+process.once('uncaughtException', globalExceptionHandler)

--- a/packages/server/test/unit/unhandled_exceptions_spec.js
+++ b/packages/server/test/unit/unhandled_exceptions_spec.js
@@ -1,0 +1,54 @@
+const path = require('path')
+const proxyquire = require('proxyquire').preserveCache()
+const sinon = require('sinon')
+
+describe('unhandled_exceptions: infinite loop guard', () => {
+  const INFINITE_LOOP_GUARD = 5
+  let errCount = 0
+
+  function noop () {}
+
+  beforeEach(() => {
+    errCount = 0
+    proxyquire(path.join(__dirname, '../../lib/unhandled_exceptions'), {
+      './errors': {
+        get logException () {
+          errCount++
+          if (errCount < INFINITE_LOOP_GUARD) {
+            throw new SyntaxError('Invalid file')
+          }
+
+          return () => {}
+        },
+      },
+    })
+
+    sinon.stub(process, 'exit').callsFake(() => {
+      // Should only be hit if we hit the infinite loop
+    })
+
+    // Add additional listeners to prevent the test from exiting
+    process.on('uncaughtException', noop)
+    process.on('unhandledRejection', noop)
+  })
+
+  afterEach(() => {
+    process.off('uncaughtException', noop)
+    process.off('unhandledRejection', noop)
+  })
+
+  it('only binds once to the unhandledRejection / uncaughtException to prevent infinite loop in startup', (done) => {
+    process.emit('uncaughtException', new Error('Some Error'))
+
+    // Run for a few ms and check the number of loops through the unhandled exception path.
+    // If it's more than a few, it means we are infinite looping because we didn't bind a .once
+    // to the default uncaughtException / unhandledRejection handler
+    setTimeout(() => {
+      if (errCount < INFINITE_LOOP_GUARD) {
+        done()
+      } else {
+        done(new Error('Infinite Loop Hit'))
+      }
+    }, 10)
+  })
+})


### PR DESCRIPTION
- Closes UNIFY-1191

### User facing changelog

N/A

### Additional details

@emilyrohrbough ran into an issue where a syntax error in `data-context` was causing an infinite loop. This was due to how we bind the `unhandledRejection` / `uncaughtException`, and the fact that we `await` a dynamic import within there. If the `require` hooks fails, it will hit the exception handler and loop.

It's an edge case, but one we should be accounting for by only adding a `.once` handler for the uncaught handlers. This way, it'll bubble up to being a top-level error. Tested by ensuring that throwing an error within the `require` codepath will not infinite loop.
### How has the user experience changed?
The app will not hang if you do something like add an `await` outside of an `async` block in the `VersionsDataSource` constructor.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] N/A Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [x] N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [x] N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
