### PR TITLE
fix: `cy.type()` + `{enter}` or ` ` should work with Firefox 98+

### DIFF
--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -334,9 +334,16 @@ export default function (Commands, Cypress, cy, state, config) {
           }
 
           if (
-            // Firefox sends a click event when the Space key is pressed.
-            // We don't want to send it twice.
-            !Cypress.isBrowser('firefox') &&
+            (
+              // Before Firefox 98,
+              // Firefox sends a click event when the Space key is pressed.
+              // We don't want to send it twice.
+              !Cypress.isBrowser('firefox') ||
+              // After Firefox 98,
+              // it sends a click event automatically if the element is a <button>
+              // it does not if the element is an <input>
+              (Cypress.isBrowser('firefox') && Cypress.browserMajorVersion() >= 98 && $elements.isInput(event.target))
+            ) &&
             // Click event is sent after keyup event with space key.
             event.type === 'keyup' && event.code === 'Space' &&
             // When event is prevented, the click event should not be emitted
@@ -352,6 +359,16 @@ export default function (Commands, Cypress, cy, state, config) {
             fireClickEvent(event.target)
 
             keydownEvents = []
+
+            // After Firefox 98,
+            // Firefox doesn't update checkbox automatically even if the click event is sent.
+            if (Cypress.isBrowser('firefox')) {
+              if (event.target.type === 'checkbox') {
+                event.target.checked = !event.target.checked
+              } else if (event.target.type === 'radio') { // when checked is false, here cannot be reached because of the above condition
+                event.target.checked = true
+              }
+            }
           }
         },
 
@@ -404,8 +421,13 @@ export default function (Commands, Cypress, cy, state, config) {
           // https://github.com/cypress-io/cypress/issues/19541
           // Send click event on type('{enter}')
           if (sendClickEvent) {
-            // Firefox sends a click event automatically.
-            if (!Cypress.isBrowser('firefox')) {
+            if (
+              // Before Firefox 98, it sends a click event automatically.
+              !Cypress.isBrowser('firefox') ||
+              // After Firefox 98,
+              // it sends a click event automatically if the element is a <button>
+              // it does not if the element is an <input>
+              (Cypress.isBrowser('firefox') && Cypress.browserMajorVersion() >= 98 && $elements.isInput(el))) {
               fireClickEvent(el)
             }
           }

--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -274,6 +274,7 @@ export default function (Commands, Cypress, cy, state, config) {
 
       const isContentEditable = $elements.isContentEditable(options.$el.get(0))
       const isTextarea = $elements.isTextarea(options.$el.get(0))
+      const isFirefoxBefore98 = Cypress.isBrowser('firefox') && Cypress.browserMajorVersion() < 98
 
       const fireClickEvent = (el) => {
         const ctor = $dom.getDocumentFromElement(el).defaultView!.PointerEvent
@@ -342,7 +343,7 @@ export default function (Commands, Cypress, cy, state, config) {
               // After Firefox 98,
               // it sends a click event automatically if the element is a <button>
               // it does not if the element is an <input>
-              (Cypress.isBrowser('firefox') && Cypress.browserMajorVersion() >= 98 && $elements.isInput(event.target))
+              (!isFirefoxBefore98 && $elements.isInput(event.target))
             ) &&
             // Click event is sent after keyup event with space key.
             event.type === 'keyup' && event.code === 'Space' &&
@@ -427,7 +428,7 @@ export default function (Commands, Cypress, cy, state, config) {
               // After Firefox 98,
               // it sends a click event automatically if the element is a <button>
               // it does not if the element is an <input>
-              (Cypress.isBrowser('firefox') && Cypress.browserMajorVersion() >= 98 && $elements.isInput(el))) {
+              (!isFirefoxBefore98 && $elements.isInput(el))) {
               fireClickEvent(el)
             }
           }

--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -100,6 +100,7 @@ class $Cypress {
   isCy: any
   log: any
   isBrowser: any
+  browserMajorVersion: any
   emit: any
   emitThen: any
   emitMap: any

--- a/packages/driver/src/cypress/browser.ts
+++ b/packages/driver/src/cypress/browser.ts
@@ -69,5 +69,6 @@ export default (config) => {
   return {
     browser: config.browser,
     isBrowser: _.partial(isBrowser, config),
+    browserMajorVersion: () => config.browser.majorVersion,
   }
 }


### PR DESCRIPTION
- Closes #20562

### User facing changelog

`cy.type()` + `{enter}` or ` ` should work with Firefox 98+

### Additional details
- Why was this change necessary? => Some `click` event related behaviors of Firefox has been changed with 98. This breaks `cy.type()`.
- What is affected by this change? => N/A


### Any implementation details to explain?

Before Firefox 98, it automatically sent `click` event to all button-like elements. But after 98, it only does that with `<button>` element and does nothing with other button-like `<input>` elements. 

In addition, it does not change the state of `<input type="checkbox">` `<input type="radio">`. I fixed that, too. 

### How has the user experience changed?

`cy.type()` works well with Firefox 98+

### IMPORTANT NOTE

Currently Cypress CI uses Firefox 93. We couldn't detect this problem because of that. And the current CI cannot test this scenario. This should be tested manually.

### PR Tasks
- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
