### PR TITLE
fix: git data source unit test failure

### DIFF
--- a/packages/data-context/test/unit/sources/GitDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/GitDataSource.spec.ts
@@ -46,19 +46,19 @@ describe('GitDataSource', () => {
       ctx.git.gitInfo(xhrSpec),
     ])
 
-    expect(created.lastModifiedHumanReadable).to.match(/(a few|[0-9]) second?s ago/)
+    expect(created.lastModifiedHumanReadable).to.match(/(a few|[0-9]) seconds? ago/)
     expect(created.statusType).to.eql('created')
     // do not want to set this explicitly in the test, since it can mess up your local git instance
     expect(created.author).not.to.be.undefined
     expect(created.lastModifiedTimestamp).not.to.be.undefined
 
-    expect(unmodified.lastModifiedHumanReadable).to.match(/(a few|[0-9]) second?s ago/)
+    expect(unmodified.lastModifiedHumanReadable).to.match(/(a few|[0-9]) seconds? ago/)
     expect(unmodified.statusType).to.eql('unmodified')
     // do not want to set this explicitly in the test, since it can mess up your local git instance
     expect(unmodified.author).not.to.be.undefined
     expect(unmodified.lastModifiedTimestamp).not.to.be.undefined
 
-    expect(modified.lastModifiedHumanReadable).to.match(/(a few|[0-9]) second?s ago/)
+    expect(modified.lastModifiedHumanReadable).to.match(/(a few|[0-9]) seconds? ago/)
     expect(modified.statusType).to.eql('modified')
     // do not want to set this explicitly in the test, since it can mess up your local git instance
     expect(modified.author).not.to.be.undefined


### PR DESCRIPTION
### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Currently, the regular expressions in the GitDataSource unit tests test for 

```
/(a few|[0-9]) second?s ago/
```

which will not catch `1 second`

Updating the regular expression to be

```
/(a few|[0-9]) seconds? ago/
```

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
