### PR TITLE
fix: add missing component-index.html

### DIFF
--- a/system-tests/projects/component-tests/cypress/support/component-index.html
+++ b/system-tests/projects/component-tests/cypress/support/component-index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>Components App</title>
+  </head>
+  <body>
+    <div id="__cy_root"></div>
+  </body>
+</html>


### PR DESCRIPTION
### User facing changelog
NA

### Additional details
Adding a missing file that was causing some the dev-server for certain tests to throw errors. No tests are failing, but good to cleanup the logs and have the system tests structured as they should be.

### How has the user experience changed?
No longer see 
```
ERROR in Entry module not found: Error: Can't resolve '/private/var/folders/8q/b_sy2fp93fs5k7mvkxn60g4r0000gn/T/cy-projects/component-tests/cypress/support/component-index.html' in '/private/var/folders/8q/b_sy2fp93fs5k7mvkxn60g4r0000gn/T/cy-projects/component-tests'
```
when running system tests that point to the `component-tests` project.

### PR Tasks

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
