### PR TITLE
backmerge develop into 10.0-release

### DIFF
--- a/browser-versions.json
+++ b/browser-versions.json
@@ -1,4 +1,4 @@
 {
-  "chrome:beta": "100.0.4896.60",
-  "chrome:stable": "100.0.4896.60"
+  "chrome:beta": "101.0.4951.15",
+  "chrome:stable": "100.0.4896.75"
 }

--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ mainBuildFilters: &mainBuildFilters
       only:
         - develop
         - 10.0-release
-        - 10.0-use-contexts
+        - marktnoonan/merg-develop-2022-4-5
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -39,7 +39,7 @@ macWorkflowFilters: &mac-workflow-filters
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
     - equal: [ '10.0-release', << pipeline.git.branch >> ]
-    - equal: [ 10.0-use-contexts, << pipeline.git.branch >> ]
+    - equal: [ marktnoonan/merg-develop-2022-4-5, << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -49,7 +49,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
     - equal: [ '10.0-release', << pipeline.git.branch >> ]
-    - equal: [ 10.0-use-contexts, << pipeline.git.branch >> ]
+    - equal: [ marktnoonan/merg-develop-2022-4-5, << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -1704,7 +1704,7 @@ jobs:
       - run:
           name: Check current branch to persist artifacts
           command: |
-            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "10.0-use-contexts" && "$CIRCLE_BRANCH" != "10.0-release" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "marktnoonan/merg-develop-2022-4-5" && "$CIRCLE_BRANCH" != "10.0-release" ]]; then
               echo "Not uploading artifacts or posting install comment for this branch."
               circleci-agent step halt
             fi

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2341,7 +2341,7 @@ declare namespace Cypress {
   type Agent<T extends sinon.SinonSpy> = SinonSpyAgent<T> & T
 
   interface CookieDefaults {
-    preserve: string | string[] | RegExp | ((cookie: any) => boolean)
+    preserve: string | string[] | RegExp | ((cookie: Cookie) => boolean)
   }
 
   interface Failable {

--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -103,6 +103,7 @@ class $Cypress {
   isCy: any
   log: any
   isBrowser: any
+  browserMajorVersion: any
   emit: any
   emitThen: any
   emitMap: any

--- a/packages/driver/src/cypress/browser.ts
+++ b/packages/driver/src/cypress/browser.ts
@@ -69,5 +69,6 @@ export default (config) => {
   return {
     browser: config.browser,
     isBrowser: _.partial(isBrowser, config),
+    browserMajorVersion: () => config.browser.majorVersion,
   }
 }

--- a/packages/driver/src/cypress/log.ts
+++ b/packages/driver/src/cypress/log.ts
@@ -232,7 +232,8 @@ class Log {
     this.cy = cy
     this.state = state
     this.config = config
-    this.fireChangeEvent = fireChangeEvent
+    // only fire the log:state:changed event as fast as every 4ms
+    this.fireChangeEvent = _.debounce(fireChangeEvent, 4)
     this.obj = defaults(state, config, obj)
 
     extendEvents(this)
@@ -557,16 +558,8 @@ class LogManager {
     this.logs[id] = true
   }
 
-  // only fire the log:state:changed event
-  // as fast as every 4ms
   fireChangeEvent (log) {
-    const triggerStateChanged = () => {
-      return this.trigger(log, 'command:log:changed')
-    }
-
-    const debounceFn = _.debounce(triggerStateChanged, 4)
-
-    return debounceFn()
+    return this.trigger(log, 'command:log:changed')
   }
 
   createLogFn (cy, state, config) {

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -17,6 +17,9 @@ const WEBSOCKET_NOT_OPEN_RE = /^WebSocket is (?:not open|already in CLOSING or C
  */
 export namespace CRIWrapper {
   export type Command =
+    'Page.enable' |
+    'Network.enable' |
+    'Console.enable' |
     'Browser.getVersion' |
     'Page.bringToFront' |
     'Page.captureScreenshot' |
@@ -103,6 +106,7 @@ type DeferredPromise = { resolve: Function, reject: Function }
 
 export const create = async (target: string, onAsynchronousError: Function, host?: string, port?: number): Promise<CRIWrapper.Client> => {
   const subscriptions: {eventName: CRIWrapper.EventName, cb: Function}[] = []
+  const enableCommands: CRIWrapper.Command[] = []
   let enqueuedCommands: {command: CRIWrapper.Command, params: any, p: DeferredPromise }[] = []
 
   let closed = false // has the user called .close on this?
@@ -125,7 +129,14 @@ export const create = async (target: string, onAsynchronousError: Function, host
     try {
       await connect()
 
-      debug('restoring subscriptions + running queued commands... %o', { subscriptions, enqueuedCommands })
+      debug('restoring subscriptions + running *.enable and queued commands... %o', { subscriptions, enableCommands, enqueuedCommands })
+
+      // '*.enable' commands need to be resent on reconnect or any events in
+      // that namespace will no longer be received
+      await Promise.all(enableCommands.map((cmdName) => {
+        return cri.send(cmdName)
+      }))
+
       subscriptions.forEach((sub) => {
         cri.on(sub.eventName, sub.cb)
       })
@@ -146,7 +157,7 @@ export const create = async (target: string, onAsynchronousError: Function, host
   }
 
   const connect = async () => {
-    cri?.close()
+    await cri?.close()
 
     debug('connecting %o', { target })
 
@@ -155,6 +166,13 @@ export const create = async (target: string, onAsynchronousError: Function, host
       port,
       target,
       local: true,
+      // Minor optimization. chrome-remote-interface creates a DSL based on
+      // this so you can call methods instead of using the event emitter
+      // (e.g. cri.Network.enable() instead of cri.send('Network.enable'))
+      // We only use the event emitter, so if we pass in an empty protcol,
+      // it will keep c-r-i from looping through it and needlessly creating
+      // the DSL
+      protocol: { domains: [] },
     })
 
     connected = true
@@ -176,10 +194,20 @@ export const create = async (target: string, onAsynchronousError: Function, host
         })
       }
 
+      // Keep track of '*.enable' commands so they can be resent when
+      // reconnecting
+      if (command.endsWith('.enable')) {
+        enableCommands.push(command)
+      }
+
       if (connected) {
         try {
           return await cri.send(command, params)
         } catch (err) {
+          // This error occurs when the browser has been left open for a long
+          // time and/or the user's computer has been put to sleep. The
+          // socket disconnects and we need to recreate the socket and
+          // connection
           if (!WEBSOCKET_NOT_OPEN_RE.test(err.message)) {
             throw err
           }
@@ -207,6 +235,9 @@ export const create = async (target: string, onAsynchronousError: Function, host
 
       return cri.close()
     },
+
+    // @ts-ignore
+    reconnect,
   }
 
   return client

--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -266,6 +266,7 @@ const parseSpecArgv = (pattern) => {
 
     if (token === ',') {
       const isBreakable =
+          (!opens.length && !closes.length) ||
           index > opens[opens.length - 1] &&
           index > closes[closes.length - 1] &&
           opens.length === closes.length
@@ -301,7 +302,7 @@ const parseSpecArgv = (pattern) => {
       rule.comma - offset,
     )
 
-    offset = offsettedBy
+    offset += offsettedBy
     carry = mutated
 
     return res

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -12,8 +12,11 @@ describe('lib/browsers/cri-client', function () {
     create: typeof create
   }
   let send: sinon.SinonStub
-  let criImport: sinon.SinonStub & {
-    New: sinon.SinonStub
+  let criImport: sinon.SinonStub
+  let criStub: {
+    send: typeof send
+    close: sinon.SinonStub
+    _notifier: EventEmitter
   }
   let onError: sinon.SinonStub
   let getClient: () => ReturnType<typeof create>
@@ -21,17 +24,18 @@ describe('lib/browsers/cri-client', function () {
   beforeEach(function () {
     send = sinon.stub()
     onError = sinon.stub()
+    criStub = {
+      send,
+      close: sinon.stub(),
+      _notifier: new EventEmitter(),
+    }
 
     criImport = sinon.stub()
     .withArgs({
       target: DEBUGGER_URL,
       local: true,
     })
-    .resolves({
-      send,
-      close: sinon.stub(),
-      _notifier: new EventEmitter(),
-    })
+    .resolves(criStub)
 
     criImport.New = sinon.stub().withArgs({ host: HOST, port: PORT, url: 'about:blank' }).resolves({ webSocketDebuggerUrl: 'http://web/socket/url' })
 
@@ -88,6 +92,30 @@ describe('lib/browsers/cri-client', function () {
           })
         })
       })
+    })
+  })
+
+  describe('on reconnect', () => {
+    it('resends *.enable commands', async () => {
+      criStub._notifier.on = sinon.stub()
+
+      const client = await getClient()
+
+      client.send('Page.enable')
+      client.send('Page.foo')
+      client.send('Page.bar')
+      client.send('Network.enable')
+      client.send('Network.baz')
+
+      // clear out previous calls before reconnect
+      criStub.send.reset()
+
+      // @ts-ignore
+      await criStub._notifier.on.withArgs('disconnect').args[0][1]()
+
+      expect(criStub.send).to.be.calledTwice
+      expect(criStub.send).to.be.calledWith('Page.enable')
+      expect(criStub.send).to.be.calledWith('Network.enable')
     })
   })
 })

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -12,7 +12,9 @@ describe('lib/browsers/cri-client', function () {
     create: typeof create
   }
   let send: sinon.SinonStub
-  let criImport: sinon.SinonStub
+  let criImport: sinon.SinonStub & {
+    New: sinon.SinonStub
+  }
   let criStub: {
     send: typeof send
     close: sinon.SinonStub

--- a/packages/server/test/unit/util/args_spec.js
+++ b/packages/server/test/unit/util/args_spec.js
@@ -186,6 +186,36 @@ describe('lib/util/args', () => {
 
       expect(options.spec[0]).to.eq(`${cwd}/cypress/integration/{a,b,c}/*.js`)
     })
+
+    // https://github.com/cypress-io/cypress/issues/20794
+    it('does not split at filename with glob pattern', function () {
+      const options = this.setup('--spec', 'cypress/integration/foo/bar/[baz]/test.ts,cypress/integration/foo1/bar/[baz]/test.ts,cypress/integration/foo2/bar/baz/test.ts,cypress/integration/foo3/bar/baz/foo4.ts')
+
+      expect(options.spec[0]).to.eq(`${cwd}/cypress/integration/foo/bar/[baz]/test.ts`)
+      expect(options.spec[1]).to.eq(`${cwd}/cypress/integration/foo1/bar/[baz]/test.ts`)
+      expect(options.spec[2]).to.eq(`${cwd}/cypress/integration/foo2/bar/baz/test.ts`)
+      expect(options.spec[3]).to.eq(`${cwd}/cypress/integration/foo3/bar/baz/foo4.ts`)
+    })
+
+    // https://github.com/cypress-io/cypress/issues/20794
+    it('correctly splits at comma with glob pattern', function () {
+      const options = this.setup('--spec', 'cypress/integration/foo/bar/baz/test.ts,cypress/integration/foo1/bar/[baz]/test.ts,cypress/integration/foo2/bar/baz/test.ts,cypress/integration/foo3/bar/baz/foo4.ts')
+
+      expect(options.spec[0]).to.eq(`${cwd}/cypress/integration/foo/bar/baz/test.ts`)
+      expect(options.spec[1]).to.eq(`${cwd}/cypress/integration/foo1/bar/[baz]/test.ts`)
+      expect(options.spec[2]).to.eq(`${cwd}/cypress/integration/foo2/bar/baz/test.ts`)
+      expect(options.spec[3]).to.eq(`${cwd}/cypress/integration/foo3/bar/baz/foo4.ts`)
+    })
+
+    // https://github.com/cypress-io/cypress/issues/20794
+    it('correctly splits at comma with escaped glob pattern', function () {
+      const options = this.setup('--spec', 'cypress/integration/foo/bar/\[baz\]/test.ts,cypress/integration/foo1/bar/\[baz1\]/test.ts,cypress/integration/foo2/bar/baz/test.ts,cypress/integration/foo3/bar/baz/foo4.ts')
+
+      expect(options.spec[0]).to.eq(`${cwd}/cypress/integration/foo/bar/\[baz\]/test.ts`)
+      expect(options.spec[1]).to.eq(`${cwd}/cypress/integration/foo1/bar/\[baz1\]/test.ts`)
+      expect(options.spec[2]).to.eq(`${cwd}/cypress/integration/foo2/bar/baz/test.ts`)
+      expect(options.spec[3]).to.eq(`${cwd}/cypress/integration/foo3/bar/baz/foo4.ts`)
+    })
   })
 
   context('--tag', () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

Straigthforward merge, two conflicts:

- `CRIWrapper` vs `CRI` in `packages/server/lib/browsers/cri-client.ts` - adjusted to keep `CRIWrapper` in 10.0-release
- small conflict around `criStub` in `packages/server/test/unit/browsers/cri-client_spec.ts` 