### PR TITLE
feat: scaffold and register cy.mount command for CT

### DIFF
--- a/packages/data-context/src/actions/WizardActions.ts
+++ b/packages/data-context/src/actions/WizardActions.ts
@@ -1,6 +1,6 @@
 import type { CodeLanguageEnum, NexusGenEnums, NexusGenObjects } from '@packages/graphql/src/gen/nxs.gen'
 import { CODE_LANGUAGES } from '@packages/types'
-import { detect, WIZARD_FRAMEWORKS, WIZARD_BUNDLERS, supportFileBody, commandsFileBody } from '@packages/scaffold-config'
+import { detect, WIZARD_FRAMEWORKS, WIZARD_BUNDLERS, commandsFileBody, supportFileComponent, supportFileE2E } from '@packages/scaffold-config'
 import assert from 'assert'
 import dedent from 'dedent'
 import path from 'path'
@@ -210,7 +210,18 @@ export class WizardActions {
     // @ts-ignore
     await this.ctx.fs.mkdir(supportDir, { recursive: true })
 
-    const fileContent = fileName === 'commands' ? commandsFileBody(language) : supportFileBody(fileName, language)
+    let fileContent: string | undefined
+
+    if (fileName === 'commands') {
+      fileContent = commandsFileBody(language)
+    } else if (fileName === 'e2e') {
+      fileContent = supportFileE2E(language)
+    } else if (fileName === 'component') {
+      assert(this.ctx.coreData.wizard.chosenFramework)
+      fileContent = supportFileComponent(language, this.ctx.coreData.wizard.chosenFramework)
+    }
+
+    assert(fileContent)
 
     await this.scaffoldFile(supportFile, fileContent, 'Scaffold default support file')
 

--- a/packages/data-context/src/actions/WizardActions.ts
+++ b/packages/data-context/src/actions/WizardActions.ts
@@ -1,6 +1,6 @@
 import type { CodeLanguageEnum, NexusGenEnums, NexusGenObjects } from '@packages/graphql/src/gen/nxs.gen'
 import { CODE_LANGUAGES } from '@packages/types'
-import { detect, WIZARD_FRAMEWORKS, WIZARD_BUNDLERS } from '@packages/scaffold-config'
+import { detect, WIZARD_FRAMEWORKS, WIZARD_BUNDLERS, supportFileBody, commandsFileBody } from '@packages/scaffold-config'
 import assert from 'assert'
 import dedent from 'dedent'
 import path from 'path'
@@ -210,7 +210,7 @@ export class WizardActions {
     // @ts-ignore
     await this.ctx.fs.mkdir(supportDir, { recursive: true })
 
-    const fileContent = fileName === 'commands' ? this.commandsFileBody(language) : this.supportFileBody(fileName, language)
+    const fileContent = fileName === 'commands' ? commandsFileBody(language) : supportFileBody(fileName, language)
 
     await this.scaffoldFile(supportFile, fileContent, 'Scaffold default support file')
 
@@ -392,78 +392,7 @@ export class WizardActions {
   private ensureDir (type: 'component' | 'e2e' | 'fixtures') {
     return this.ctx.fs.ensureDir(path.join(this.projectRoot, 'cypress', type))
   }
-
-  private supportFileBody (fileName: 'e2e' | 'component', language: CodeLanguageEnum) {
-    return dedent`
-      // ***********************************************************
-      // This example support/${fileName}.${language} is processed and
-      // loaded automatically before your test files.
-      //
-      // This is a great place to put global configuration and
-      // behavior that modifies Cypress.
-      //
-      // You can change the location of this file or turn off
-      // automatically serving support files with the
-      // 'supportFile' configuration option.
-      //
-      // You can read more here:
-      // https://on.cypress.io/configuration
-      // ***********************************************************
-  
-      // Import commands.js using ES2015 syntax:
-      import './commands'
-  
-      // Alternatively you can use CommonJS syntax:
-      // require('./commands')
-    `
-  }
-
-  private commandsFileBody (language: CodeLanguageEnum) {
-    return dedent`
-      ${language === 'ts' ? '/// <reference types="cypress" />' : ''}
-      // ***********************************************
-      // This example commands.${language} shows you how to
-      // create various custom commands and overwrite
-      // existing commands.
-      //
-      // For more comprehensive examples of custom
-      // commands please read more here:
-      // https://on.cypress.io/custom-commands
-      // ***********************************************
-      //
-      //
-      // -- This is a parent command --
-      // Cypress.Commands.add('login', (email, password) => { ... })
-      //
-      //
-      // -- This is a child command --
-      // Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-      //
-      //
-      // -- This is a dual command --
-      // Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-      //
-      //
-      // -- This will overwrite an existing command --
-      // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-      ${language === 'ts' ? COMMAND_TYPES : ''}
-    `
-  }
 }
-
-const COMMAND_TYPES = dedent`
-//
-// declare global {
-//   namespace Cypress {
-//     interface Chainable {
-//       login(email: string, password: string): Chainable<void>
-//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
-//     }
-//   }
-// }
-`
 
 const E2E_SCAFFOLD_BODY = dedent`
   e2e: {

--- a/packages/launchpad/src/setup/OpenBrowserList.vue
+++ b/packages/launchpad/src/setup/OpenBrowserList.vue
@@ -140,7 +140,7 @@
         size="sm"
         variant="text"
         :prefix-icon="ArrowRightIcon"
-        prefix-icon-class="icon-dark-gray-500 transform transition-transform ease-in -translate-y-1px duration-200 inline-block group-hocus:icon-dark-indigo-500 rotate-180 group-hocus:translate-x-2px"
+        prefix-icon-class="icon-dark-gray-500 transform transition-transform ease-in duration-200 inline-block group-hocus:icon-dark-indigo-500 rotate-180 group-hocus:-translate-x-2px"
         class="font-medium mx-auto text-gray-600 hocus-link-default group hocus:text-indigo-500"
         @click="emit('navigatedBack')"
       >

--- a/packages/scaffold-config/src/commandFile.ts
+++ b/packages/scaffold-config/src/commandFile.ts
@@ -1,0 +1,48 @@
+import type { CodeLanguage } from '@packages/types'
+import dedent from 'dedent'
+
+const COMMAND_TYPES = dedent`
+//
+// declare global {
+//   namespace Cypress {
+//     interface Chainable {
+//       login(email: string, password: string): Chainable<void>
+//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
+//     }
+//   }
+// }
+`
+
+export function commandsFileBody (language: CodeLanguage['type']) {
+  return dedent`
+    ${language === 'ts' ? '/// <reference types="cypress" />' : ''}
+    // ***********************************************
+    // This example commands.${language} shows you how to
+    // create various custom commands and overwrite
+    // existing commands.
+    //
+    // For more comprehensive examples of custom
+    // commands please read more here:
+    // https://on.cypress.io/custom-commands
+    // ***********************************************
+    //
+    //
+    // -- This is a parent command --
+    // Cypress.Commands.add('login', (email, password) => { ... })
+    //
+    //
+    // -- This is a child command --
+    // Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+    //
+    //
+    // -- This is a dual command --
+    // Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+    //
+    //
+    // -- This will overwrite an existing command --
+    // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+    ${language === 'ts' ? COMMAND_TYPES : ''}
+  `
+}

--- a/packages/scaffold-config/src/frameworks.ts
+++ b/packages/scaffold-config/src/frameworks.ts
@@ -121,6 +121,7 @@ export const WIZARD_FRAMEWORKS = [
     createCypressConfig,
     codeGenFramework: 'react',
     glob: '*.{js,jsx,tsx}',
+    mountModule: 'cypress/react',
   },
   {
     type: 'vueclivue2',
@@ -140,6 +141,7 @@ export const WIZARD_FRAMEWORKS = [
     createCypressConfig,
     codeGenFramework: 'vue',
     glob: '*.vue',
+    mountModule: 'cypress/vue2',
   },
   {
     type: 'vueclivue3',
@@ -159,6 +161,7 @@ export const WIZARD_FRAMEWORKS = [
     createCypressConfig,
     codeGenFramework: 'vue',
     glob: '*.vue',
+    mountModule: 'cypress/vue',
   },
   {
     type: 'nextjs',
@@ -177,6 +180,7 @@ export const WIZARD_FRAMEWORKS = [
     createCypressConfig,
     codeGenFramework: 'react',
     glob: '*.{js,jsx,tsx}',
+    mountModule: 'cypress/react',
   },
   {
     type: 'nuxtjs',
@@ -195,6 +199,7 @@ export const WIZARD_FRAMEWORKS = [
     createCypressConfig,
     codeGenFramework: 'vue',
     glob: '*.vue',
+    mountModule: 'cypress/vue2',
   },
   {
     type: 'vue2',
@@ -213,6 +218,7 @@ export const WIZARD_FRAMEWORKS = [
     createCypressConfig,
     codeGenFramework: 'vue',
     glob: '*.vue',
+    mountModule: 'cypress/vue2',
   },
   {
     type: 'vue3',
@@ -231,6 +237,7 @@ export const WIZARD_FRAMEWORKS = [
     createCypressConfig,
     codeGenFramework: 'vue',
     glob: '*.vue',
+    mountModule: 'cypress/vue',
   },
   {
     type: 'react',
@@ -249,5 +256,6 @@ export const WIZARD_FRAMEWORKS = [
     createCypressConfig,
     codeGenFramework: 'react',
     glob: '*.{js,jsx,tsx}',
+    mountModule: 'cypress/react',
   },
 ] as const

--- a/packages/scaffold-config/src/index.ts
+++ b/packages/scaffold-config/src/index.ts
@@ -1,6 +1,8 @@
 /* eslint-disable padding-line-between-statements */
 // created by autobarrel, do not modify directly
 
+export * from './commandFile'
 export * from './dependencies'
 export * from './detect'
 export * from './frameworks'
+export * from './supportFile'

--- a/packages/scaffold-config/src/supportFile.ts
+++ b/packages/scaffold-config/src/supportFile.ts
@@ -70,7 +70,7 @@ export function supportFileComponent (language: CodeLanguage['type'], framework:
       declare global {
         namespace Cypress {
           interface Chainable {
-            mount(...): Cypress.Chainable<MountReturn>
+            mount: typeof mount
           }
         }
       }

--- a/packages/scaffold-config/src/supportFile.ts
+++ b/packages/scaffold-config/src/supportFile.ts
@@ -2,10 +2,10 @@ import type { CodeLanguage } from '@packages/types'
 import dedent from 'dedent'
 import type { WizardFrontendFramework } from '.'
 
-export function supportFileBody (fileName: 'e2e' | 'component', language: CodeLanguage['type']) {
+export function supportFileE2E (language: CodeLanguage['type']) {
   return dedent`
     // ***********************************************************
-    // This example support/${fileName}.${language} is processed and
+    // This example support/e2e.${language} is processed and
     // loaded automatically before your test files.
     //
     // This is a great place to put global configuration and

--- a/packages/scaffold-config/src/supportFile.ts
+++ b/packages/scaffold-config/src/supportFile.ts
@@ -1,5 +1,6 @@
 import type { CodeLanguage } from '@packages/types'
 import dedent from 'dedent'
+import type { WizardFrontendFramework } from '.'
 
 export function supportFileBody (fileName: 'e2e' | 'component', language: CodeLanguage['type']) {
   return dedent`
@@ -24,4 +25,67 @@ export function supportFileBody (fileName: 'e2e' | 'component', language: CodeLa
     // Alternatively you can use CommonJS syntax:
     // require('./commands')
   `
+}
+
+export function supportFileComponent (language: CodeLanguage['type'], framework: WizardFrontendFramework) {
+  const supportFileTemplate = dedent`
+    // ***********************************************************
+    // This example support/component.${language} is processed and
+    // loaded automatically before your test files.
+    //
+    // This is a great place to put global configuration and
+    // behavior that modifies Cypress.
+    //
+    // You can change the location of this file or turn off
+    // automatically serving support files with the
+    // 'supportFile' configuration option.
+    //
+    // You can read more here:
+    // https://on.cypress.io/configuration
+    // ***********************************************************
+
+    // Import commands.js using ES2015 syntax:
+    import './commands'
+
+    // Alternatively you can use CommonJS syntax:
+    // require('./commands')
+  `
+
+  const exampleUse = dedent`
+    // Example use:
+    // cy.mount(${framework.mountModule === 'cypress/react' ? '<MyComponent />' : 'MyComponent'})
+  `
+
+  const NEWLINE = '\n\n'
+
+  if (language === 'ts') {
+    const registerMount = dedent`
+      import { mount } from '${framework.mountModule}'
+      import type { MountReturn } from '${framework.mountModule}'
+
+      // Augment the Cypress namespace to include type definitions for
+      // your custom command.
+      // Alternatively, can be defined in cypress/support/component.d.ts
+      // with a <reference path="./component" /> at the top of your spec.
+      declare global {
+        namespace Cypress {
+          interface Chainable {
+            mount(...): Cypress.Chainable<MountReturn>
+          }
+        }
+      }
+
+      Cypress.Commands.add('mount', mount)
+    `
+
+    return [supportFileTemplate, registerMount, exampleUse].join(NEWLINE)
+  }
+
+  const registerMount = dedent`
+    import { mount } from '${framework.mountModule}'
+
+    Cypress.Commands.add('mount', mount)
+  `
+
+  return [supportFileTemplate, registerMount, exampleUse].join(NEWLINE)
 }

--- a/packages/scaffold-config/src/supportFile.ts
+++ b/packages/scaffold-config/src/supportFile.ts
@@ -1,0 +1,27 @@
+import type { CodeLanguage } from '@packages/types'
+import dedent from 'dedent'
+
+export function supportFileBody (fileName: 'e2e' | 'component', language: CodeLanguage['type']) {
+  return dedent`
+    // ***********************************************************
+    // This example support/${fileName}.${language} is processed and
+    // loaded automatically before your test files.
+    //
+    // This is a great place to put global configuration and
+    // behavior that modifies Cypress.
+    //
+    // You can change the location of this file or turn off
+    // automatically serving support files with the
+    // 'supportFile' configuration option.
+    //
+    // You can read more here:
+    // https://on.cypress.io/configuration
+    // ***********************************************************
+
+    // Import commands.js using ES2015 syntax:
+    import './commands'
+
+    // Alternatively you can use CommonJS syntax:
+    // require('./commands')
+  `
+}

--- a/packages/scaffold-config/test/unit/supportFile.spec.ts
+++ b/packages/scaffold-config/test/unit/supportFile.spec.ts
@@ -77,7 +77,7 @@ describe('supportFileComponent', () => {
     declare global {
       namespace Cypress {
         interface Chainable {
-          mount(...): Cypress.Chainable<MountReturn>
+          mount: typeof mount
         }
       }
     }
@@ -158,7 +158,7 @@ describe('supportFileComponent', () => {
     declare global {
       namespace Cypress {
         interface Chainable {
-          mount(...): Cypress.Chainable<MountReturn>
+          mount: typeof mount
         }
       }
     }

--- a/packages/scaffold-config/test/unit/supportFile.spec.ts
+++ b/packages/scaffold-config/test/unit/supportFile.spec.ts
@@ -1,0 +1,172 @@
+import { supportFileComponent } from '../../src/supportFile'
+import { WIZARD_FRAMEWORKS, WizardFrontendFramework } from '../../src/frameworks'
+import dedent from 'dedent'
+import { expect } from 'chai'
+
+function findByMountingModule (mountModule: WizardFrontendFramework['mountModule']) {
+  return WIZARD_FRAMEWORKS.find((x) => x.mountModule === mountModule)!
+}
+
+describe('supportFileComponent', () => {
+  it('handles cypress/react and JS (example with JSX)', () => {
+    const actual = supportFileComponent('js', findByMountingModule('cypress/react'))
+
+    expect(actual).to.eq(dedent`
+    // ***********************************************************
+    // This example support/component.js is processed and
+    // loaded automatically before your test files.
+    //
+    // This is a great place to put global configuration and
+    // behavior that modifies Cypress.
+    //
+    // You can change the location of this file or turn off
+    // automatically serving support files with the
+    // 'supportFile' configuration option.
+    //
+    // You can read more here:
+    // https://on.cypress.io/configuration
+    // ***********************************************************
+
+    // Import commands.js using ES2015 syntax:
+    import './commands'
+
+    // Alternatively you can use CommonJS syntax:
+    // require('./commands')
+
+    import { mount } from 'cypress/react'
+
+    Cypress.Commands.add('mount', mount)
+
+    // Example use:
+    // cy.mount(<MyComponent />)
+    `)
+  })
+
+  it('handles cypress/react and TS (example with JSX)', () => {
+    const actual = supportFileComponent('ts', findByMountingModule('cypress/react'))
+
+    expect(actual).to.eq(dedent`
+    // ***********************************************************
+    // This example support/component.ts is processed and
+    // loaded automatically before your test files.
+    //
+    // This is a great place to put global configuration and
+    // behavior that modifies Cypress.
+    //
+    // You can change the location of this file or turn off
+    // automatically serving support files with the
+    // 'supportFile' configuration option.
+    //
+    // You can read more here:
+    // https://on.cypress.io/configuration
+    // ***********************************************************
+
+    // Import commands.js using ES2015 syntax:
+    import './commands'
+
+    // Alternatively you can use CommonJS syntax:
+    // require('./commands')
+
+    import { mount } from 'cypress/react'
+    import type { MountReturn } from 'cypress/react'
+
+    // Augment the Cypress namespace to include type definitions for
+    // your custom command.
+    // Alternatively, can be defined in cypress/support/component.d.ts
+    // with a <reference path="./component" /> at the top of your spec.
+    declare global {
+      namespace Cypress {
+        interface Chainable {
+          mount(...): Cypress.Chainable<MountReturn>
+        }
+      }
+    }
+
+    Cypress.Commands.add('mount', mount)
+
+    // Example use:
+    // cy.mount(<MyComponent />)
+    `)
+  })
+
+  it('handles cypress/vue and JS (example no JSX)', () => {
+    const actual = supportFileComponent('js', findByMountingModule('cypress/vue'))
+
+    expect(actual).to.eq(dedent`
+    // ***********************************************************
+    // This example support/component.js is processed and
+    // loaded automatically before your test files.
+    //
+    // This is a great place to put global configuration and
+    // behavior that modifies Cypress.
+    //
+    // You can change the location of this file or turn off
+    // automatically serving support files with the
+    // 'supportFile' configuration option.
+    //
+    // You can read more here:
+    // https://on.cypress.io/configuration
+    // ***********************************************************
+
+    // Import commands.js using ES2015 syntax:
+    import './commands'
+
+    // Alternatively you can use CommonJS syntax:
+    // require('./commands')
+
+    import { mount } from 'cypress/vue'
+
+    Cypress.Commands.add('mount', mount)
+
+    // Example use:
+    // cy.mount(MyComponent)
+    `)
+  })
+
+  it('handles cypress/vue and TS (example no JSX)', () => {
+    const actual = supportFileComponent('ts', findByMountingModule('cypress/vue'))
+
+    expect(actual).to.eq(dedent`
+    // ***********************************************************
+    // This example support/component.ts is processed and
+    // loaded automatically before your test files.
+    //
+    // This is a great place to put global configuration and
+    // behavior that modifies Cypress.
+    //
+    // You can change the location of this file or turn off
+    // automatically serving support files with the
+    // 'supportFile' configuration option.
+    //
+    // You can read more here:
+    // https://on.cypress.io/configuration
+    // ***********************************************************
+
+    // Import commands.js using ES2015 syntax:
+    import './commands'
+
+    // Alternatively you can use CommonJS syntax:
+    // require('./commands')
+
+    import { mount } from 'cypress/vue'
+    import type { MountReturn } from 'cypress/vue'
+
+    // Augment the Cypress namespace to include type definitions for
+    // your custom command.
+    // Alternatively, can be defined in cypress/support/component.d.ts
+    // with a <reference path="./component" /> at the top of your spec.
+    declare global {
+      namespace Cypress {
+        interface Chainable {
+          mount(...): Cypress.Chainable<MountReturn>
+        }
+      }
+    }
+
+    Cypress.Commands.add('mount', mount)
+
+    // Example use:
+    // cy.mount(MyComponent)
+    `)
+  })
+})

--- a/system-tests/projects/component-tests/cypress/support/component-index.html
+++ b/system-tests/projects/component-tests/cypress/support/component-index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>Components App</title>
+  </head>
+  <body>
+    <div id="__cy_root"></div>
+  </body>
+</html>

--- a/system-tests/projects/pristine/expected-cypress-js-component-create-react-app-v5/cypress/support/component.js
+++ b/system-tests/projects/pristine/expected-cypress-js-component-create-react-app-v5/cypress/support/component.js
@@ -18,3 +18,10 @@ import './commands'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+import { mount } from 'cypress/react'
+
+Cypress.Commands.add('mount', mount)
+
+// Example use:
+// cy.mount(<MyComponent />)

--- a/system-tests/projects/pristine/expected-cypress-ts-component-create-react-app-v5/cypress/support/component.ts
+++ b/system-tests/projects/pristine/expected-cypress-ts-component-create-react-app-v5/cypress/support/component.ts
@@ -18,3 +18,23 @@ import './commands'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+import { mount } from 'cypress/react'
+import type { MountReturn } from 'cypress/react'
+
+// Augment the Cypress namespace to include type definitions for
+// your custom command.
+// Alternatively, can be defined in cypress/support/component.d.ts
+// with a <reference path="./component" /> at the top of your spec.
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      mount(...): Cypress.Chainable<MountReturn>
+    }
+  }
+}
+
+Cypress.Commands.add('mount', mount)
+
+// Example use:
+// cy.mount(<MyComponent />)

--- a/system-tests/projects/pristine/expected-cypress-ts-component-create-react-app-v5/cypress/support/component.ts
+++ b/system-tests/projects/pristine/expected-cypress-ts-component-create-react-app-v5/cypress/support/component.ts
@@ -29,7 +29,7 @@ import type { MountReturn } from 'cypress/react'
 declare global {
   namespace Cypress {
     interface Chainable {
-      mount(...): Cypress.Chainable<MountReturn>
+      mount: typeof mount
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://cypress-io.atlassian.net/browse/UNIFY-1387

**note**: forked from https://github.com/cypress-io/cypress/pull/20893
**note**: the generated file will be invalid until https://cypress-io.atlassian.net/browse/UNIFY-1386 lands, which bundles the mount commands in the binary.

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Scaffold correct supportFile for component testing, including adding custom `mount` command and type definitions, if using TypeScript.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We register a convinient `cy.mount` command for CT when scaffolding a new project, or migrating an existing one.

Example for a project using React and TypeScript:

```ts
// ***********************************************************
// This example support/component.ts is processed and
// loaded automatically before your test files.
//
// This is a great place to put global configuration and
// behavior that modifies Cypress.
//
// You can change the location of this file or turn off
// automatically serving support files with the
// 'supportFile' configuration option.
//
// You can read more here:
// https://on.cypress.io/configuration
// ***********************************************************
// Import commands.js using ES2015 syntax:
import './commands'

// Alternatively you can use CommonJS syntax:
// require('./commands')
import { mount } from 'cypress/react'
import type { MountReturn } from 'cypress/react'

// Augment the Cypress namespace to include type definitions for
// your custom command.
// Alternatively, can be defined in cypress/support/component.d.ts
// with a <reference path="./component" /> at the top of your spec.
declare global {
  namespace Cypress {
    interface Chainable {
      mount(...): Cypress.Chainable<MountReturn>
    }
  }
}

Cypress.Commands.add('mount', mount)

// Example use:
// cy.mount(<MyComponent />)
```

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Better scaffolding for CT based on your framework.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
