### PR TITLE
feat: allow passing --inspect / --inspect-brk in disted binary

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ mainBuildFilters: &mainBuildFilters
       only:
         - develop
         - 10.0-release
-        - marktnoonan/merg-develop-2022-4-5
+        - tgriesser/feat/always-add-inspect-flag
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -39,7 +39,7 @@ macWorkflowFilters: &mac-workflow-filters
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
     - equal: [ '10.0-release', << pipeline.git.branch >> ]
-    - equal: [ marktnoonan/merg-develop-2022-4-5, << pipeline.git.branch >> ]
+    - equal: [ tgriesser/feat/always-add-inspect-flag, << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -49,7 +49,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
     - equal: [ '10.0-release', << pipeline.git.branch >> ]
-    - equal: [ marktnoonan/merg-develop-2022-4-5, << pipeline.git.branch >> ]
+    - equal: [ tgriesser/feat/always-add-inspect-flag, << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -1704,7 +1704,7 @@ jobs:
       - run:
           name: Check current branch to persist artifacts
           command: |
-            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "marktnoonan/merg-develop-2022-4-5" && "$CIRCLE_BRANCH" != "10.0-release" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "tgriesser/feat/always-add-inspect-flag" && "$CIRCLE_BRANCH" != "10.0-release" ]]; then
               echo "Not uploading artifacts or posting install comment for this branch."
               circleci-agent step halt
             fi

--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -285,7 +285,7 @@ const addCypressOpenCommand = (program) => {
 }
 
 const maybeAddInspectFlags = (program) => {
-  if (process.argv.includes('--dev')) {
+  if (process.argv.includes('--inspect') || process.argv.includes('--inspect-brk')) {
     return program
     .option('--inspect', 'Node option')
     .option('--inspect-brk', 'Node option')

--- a/cli/test/lib/cli_spec.js
+++ b/cli/test/lib/cli_spec.js
@@ -21,8 +21,11 @@ const { expect } = require('chai')
 describe('cli', () => {
   require('mocha-banner').register()
 
+  const processArgv = process.argv
+
   beforeEach(() => {
     logger.reset()
+    process.argv = []
     sinon.stub(process, 'exit')
 
     os.platform.returns('darwin')
@@ -36,6 +39,10 @@ describe('cli', () => {
 
       return cli.init(cliArgs)
     }
+  })
+
+  afterEach(() => {
+    process.argv = processArgv
   })
 
   context('unknown option', () => {
@@ -520,6 +527,18 @@ describe('cli', () => {
       // sinon.stub(open, 'start').resolves()
       this.exec('open --port 7878 --global')
       expect(open.start).to.be.calledWith({ port: '7878', global: true })
+    })
+
+    it('calls open.start with inspect', () => {
+      process.argv = ['--inspect']
+      this.exec('open --port 7878 --inspect')
+      expect(open.start).to.be.calledWith({ inspect: true, port: '7878' })
+    })
+
+    it('calls open.start with inspect-brk', () => {
+      process.argv = ['--inspect-brk']
+      this.exec('open --port 7878 --inspect-brk')
+      expect(open.start).to.be.calledWith({ inspectBrk: true, port: '7878' })
     })
 
     it('calls open.start + catches errors', (done) => {


### PR DESCRIPTION
### User facing changelog

N/A

### Additional details

Rather than keying off the `--dev` flag to determine whether we can `--inspect` / `--inspect-brk`, which makes it only possible in local development, this instead checks for `--inspect` / `--inspect-brk` in the `process.argv` to add them to the available flags to trigger debugging. This way, the commands don't show up in `--help` / aren't advertised as a public contract, but they're available if you really need them.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] N/A Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [x] N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [x] N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
