### PR TITLE
fix: silence dbus errors

### DIFF
--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -65,6 +65,9 @@ describe('lib/exec/spawn', function () {
         [46454:0702/140217.292555:ERROR:gles2_cmd_decoder.cc(4439)] [.RenderWorker-0x7f8bc5815a00.GpuRasterization]GL ERROR :GL_INVALID_FRAMEBUFFER_OPERATION : glDrawElements: framebuffer incomplete
         [46454:0702/140217.292584:ERROR:gles2_cmd_decoder.cc(4439)] [.RenderWorker-0x7f8bc5815a00.GpuRasterization]GL ERROR :GL_INVALID_FRAMEBUFFER_OPERATION : glClear: framebuffer incomplete
         [46454:0702/140217.292612:ERROR:gles2_cmd_decoder.cc(4439)] [.RenderWorker-0x7f8bc5815a00.GpuRasterization]GL ERROR :GL_INVALID_FRAMEBUFFER_OPERATION : glDrawElements: framebuffer incomplete'
+
+        [1957:0406/160550.146820:ERROR:bus.cc(392)] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
+        [1957:0406/160550.147994:ERROR:bus.cc(392)] Failed to connect to the bus: Address does not contain a colon
       `
 
       const lines = _


### PR DESCRIPTION
- Closes #19299

### User facing changelog
Silences electron warnings about being unable to connect to dbus. These errors are normal and expected, and do not result in test failures. They are present when running electron inside docker containers 100% of the time.

### Additional details
Chromium (which Electron uses) always makes several attempts to connect to the system dbus. This works fine in most desktop environments, but in a docker container, there is no dbus service and Chromium emits several error lines, similar to these:

```
[1957:0406/160550.146820:ERROR:bus.cc(392)] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
[1957:0406/160550.147994:ERROR:bus.cc(392)] Failed to connect to the bus: Address does not contain a colon
[1957:0406/160550.147994:ERROR:bus.cc(392)] Failed to connect to the bus: Address does not contain a colon
[1957:0406/160550.147994:ERROR:bus.cc(392)] Failed to connect to the bus: Address does not contain a colon
```

These warnings are absolutely harmless. Failure to connect to dbus means that electron won't be able to access the user's credential wallet (none exists in a docker container) and won't show up in the system tray (again, none exists). Failure to connect is expected and normal here, but users frequently misidentify these errors as the cause of their problems.

On a more technical level, chromium calls [dbus_bus_get()](https://dbus.freedesktop.org/doc/api/html/group__DBusBus.html#ga77ba5250adb84620f16007e1b023cf26), which is provided by libdbus. This call returns an error if dbus cannot be found or connected to for whatever reason. Chromium handles these errors correctly, internally ceasing to attempt to use the service, but it re-prints the errors to stderr while doing so.

Basically: It tries to connect, gets an error, and aborts. All very normal behavior, which is why no one has tried to 'fix' the problem. Because there is no problem.

### How has the user experience changed?
Users will no longer see errors in the log when running Cypress inside docker. Instead of:


![image](https://user-images.githubusercontent.com/3003404/162022906-d0a09ced-9616-4476-9d6d-1138b72a8ceb.png)


they'll get


![image](https://user-images.githubusercontent.com/3003404/162023044-e2659a22-52c9-467f-a7c4-35b603eeb32b.png)


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
