### PR TITLE
fix(session): error thrown by unset cookies when printing session details to dev tools console

### DIFF
--- a/packages/driver/src/cy/commands/sessions.ts
+++ b/packages/driver/src/cy/commands/sessions.ts
@@ -9,9 +9,9 @@ const currentTestRegisteredSessions = new Map()
 
 /**
  * rules for clearing session data:
- * if page reloads due to top navigation OR user hard reload, session data should NOT be cleared
- * if user relaunches the browser or launches a new spec, session data SHOULD be cleared
- * session data SHOULD be cleared between specs in run mode
+ *  - if page reloads due to top navigation OR user hard reload, session data should NOT be cleared
+ *  - if user relaunches the browser or launches a new spec, session data SHOULD be cleared
+ *  - session data SHOULD be cleared between specs in run mode
  *
  * therefore session data should be cleared with spec browser launch
  */
@@ -35,8 +35,8 @@ const getSessionDetailsForTable = (sessState) => {
 const isSecureContext = (url) => url.startsWith('https:')
 
 const getCurrentOriginStorage = () => {
-  // localStorage.length propery is not always accurate, we must stringify to check for entries
-  // for ex) try setting localStorge.key = 'val' and reading localStorage.length, may be 0.
+  // localStorage.length property is not always accurate, we must stringify to check for entries
+  // for ex) try setting localStorage.key = 'val' and reading localStorage.length, may be 0.
   const _localStorageStr = JSON.stringify(window.localStorage)
   const _localStorage = _localStorageStr.length > 2 && JSON.parse(_localStorageStr)
   const _sessionStorageStr = JSON.stringify(window.sessionStorage)
@@ -109,7 +109,7 @@ const setPostMessageLocalStorage = async (specWindow, originOptions) => {
     specWindow.removeEventListener('message', onPostMessage)
     $iframeContainer.remove()
   })
-  .catch((err) => {
+  .catch(() => {
     Cypress.log({
       name: 'warning',
       message: `failed to access session localStorage data on origin(s): ${_.xor(origins, successOrigins).join(', ')}`,
@@ -118,30 +118,38 @@ const setPostMessageLocalStorage = async (specWindow, originOptions) => {
 }
 
 const getConsoleProps = (sessState) => {
-  const ret = {
-    id: sessState.id,
-    table: _.compact(_.flatMap(getSessionDetailsForTable(sessState), (val, domain) => {
-      return [() => {
-        return {
-          name: `🍪 Cookies - ${domain} (${val.cookies.length})`,
-          data: val.cookies,
-        }
-      },
-      val.localStorage && (() => {
-        return {
-          name: `📁 Storage - ${domain} (${_.keys(val.localStorage.value).length})`,
-          data: _.map(val.localStorage.value, (value, key) => {
-            return {
-              key, value,
-            }
-          }),
-        }
-      })]
-    }))
-    ,
-  }
+  const sessionDetails = getSessionDetailsForTable(sessState)
 
-  return ret
+  const tables = _.flatMap(sessionDetails, (val, domain) => {
+    const cookiesTable = () => {
+      return {
+        name: `🍪 Cookies - ${domain} (${val.cookies.length})`,
+        data: val.cookies,
+      }
+    }
+
+    const localStorageTable = () => {
+      return {
+        name: `📁 Storage - ${domain} (${_.keys(val.localStorage.value).length})`,
+        data: _.map(val.localStorage.value, (value, key) => {
+          return {
+            key,
+            value,
+          }
+        }),
+      }
+    }
+
+    return [
+      val.cookies && cookiesTable,
+      val.localStorage && localStorageTable,
+    ]
+  })
+
+  return {
+    id: sessState.id,
+    table: _.compact(tables),
+  }
 }
 
 const getPostMessageLocalStorage = (specWindow, origins): Promise<any[]> => {
@@ -211,6 +219,7 @@ export default function (Commands, Cypress, cy) {
 
     return currentSessions[id]
   }
+
   const clearActiveSessions = () => {
     const curSessions = cy.state('activeSessions') || {}
 
@@ -284,7 +293,6 @@ export default function (Commands, Cypress, cy) {
   }
 
   const sessions = {
-
     defineSession (options = {} as any) {
       const sess_state = {
         id: options.id,
@@ -495,7 +503,6 @@ export default function (Commands, Cypress, cy) {
         return
       })
     },
-
   }
 
   Cypress.on('run:start', () => {
@@ -515,7 +522,7 @@ export default function (Commands, Cypress, cy) {
       // backup session command so we can set it as codeFrame location for errors later on
       const sessionCommand = cy.state('current')
 
-      // stringfy deterministically if we were given an object
+      // stringify deterministically if we were given an object
       id = typeof id === 'string' ? id : stringifyStable(id)
 
       if (options) {
@@ -523,12 +530,12 @@ export default function (Commands, Cypress, cy) {
           $errUtils.throwErrByPath('sessions.session.wrongArgOptions')
         }
 
-        const validopts = {
+        const validOpts = {
           'validate': 'function',
         }
 
         Object.keys(options).forEach((key) => {
-          const expectedType = validopts[key]
+          const expectedType = validOpts[key]
 
           if (!expectedType) {
             $errUtils.throwErrByPath('sessions.session.wrongArgOptionUnexpected', { args: { key } })

--- a/packages/runner/cypress/integration/sessions.ui.spec.js
+++ b/packages/runner/cypress/integration/sessions.ui.spec.js
@@ -11,8 +11,21 @@ describe('runner/cypress sessions.ui.spec', { viewportWidth: 1000, viewportHeigh
       })
     })
 
-    cy.get('.sessions-container').click()
+    cy.get('.sessions-container')
+    .should('contain', 'Sessions (1)')
+    .click()
     .should('contain', 'blank_session')
+
+    cy.get('.command-name-session')
+    .first()
+    .find('i.successful')
+    .siblings()
+    .should('contain', '(new) blank_session')
+
+    cy.get('.command-name-session')
+    .last()
+    .contains('blank_session')
+    .click()
 
     cy.percySnapshot()
   })
@@ -34,40 +47,77 @@ describe('runner/cypress sessions.ui.spec', { viewportWidth: 1000, viewportHeigh
       })
 
       it('t1', () => {
-        assert(true)
+        expect(window.localStorage.foo).to.eq('val')
       })
 
       it('t2', () => {
-        assert(true)
+        expect(window.localStorage.foo).to.eq('val')
       })
 
       it('t3', () => {
-        assert(true)
+        expect(window.localStorage.foo).to.eq('val')
       })
     })
 
     cy.get('.test').each(($el) => cy.wrap($el).click())
 
-    cy.get('.sessions-container').eq(0).click()
-    .should('contain', '1')
+    cy.log('validating new session was created')
+    cy.get('.test').eq(0).within(() => {
+      cy.get('.sessions-container')
+      .should('contain', 'Sessions (1)')
+      .click()
+      .should('contain', 'user1')
 
-    cy.get('.sessions-container').eq(1).click()
-    .should('contain', '1')
+      cy.get('.command-name-session')
+      .first()
+      .find('i.successful')
+      .siblings()
+      .should('contain', '(new) user1')
 
-    cy.get('.test').eq(0)
-    .should('contain', 'Sessions (1)')
-    .should('contain', 'user1')
-    .should('contain', '(new)')
+      cy.get('.command-name-session')
+      .last()
+      .contains('user1')
+      .click()
 
-    cy.get('.test').eq(1)
-    .should('contain', 'Sessions (1)')
-    .should('contain', 'user1')
-    .should('contain', '(saved)')
+      cy.get('.command-name-assert')
+      .should('have.class', 'command-state-passed')
+    })
 
-    cy.get('.test').eq(2)
-    .should('contain', 'Sessions (1)')
-    .should('contain', 'user1')
-    .should('contain', '(recreated)')
+    cy.log('validating previous session was used')
+    cy.get('.test').eq(1).within(() => {
+      cy.get('.sessions-container')
+      .should('contain', 'Sessions (1)')
+      .click()
+      .should('contain', 'user1')
+
+      cy.get('.command-name-session')
+      .first()
+      .find('i.pending')
+      .siblings()
+      .should('contain', '(saved) user1')
+
+      cy.get('.command-name-session')
+      .last()
+      .contains('user1')
+    })
+
+    cy.log('validating session was recreated after it failed to verify')
+    cy.get('.test').eq(2).within(() => {
+      cy.get('.sessions-container')
+      .should('contain', 'Sessions (1)')
+      .click()
+      .should('contain', 'user1')
+
+      cy.get('.command-name-session')
+      .first()
+      .find('i.bad')
+      .siblings()
+      .should('contain', '(recreated) user1')
+
+      cy.get('.command-name-session')
+      .last()
+      .contains('user1')
+    })
 
     cy.percySnapshot()
   })


### PR DESCRIPTION
Fixes issue observed when cookies have not be set within a session and the user clicks the command log to view additional details. Discovered this issue when following along with the cy.session documentation examples in the docs pages.

**Error details**
<img width="495" alt="Screen Shot 2022-04-05 at 5 46 56 PM" src="https://user-images.githubusercontent.com/14099737/162061057-aff90e70-a5da-4cbe-a16f-9006af8f85e4.png">
<img width="641" alt="Screen Shot 2022-04-05 at 5 47 07 PM" src="https://user-images.githubusercontent.com/14099737/162061058-15490a4a-da2d-4d96-9d8b-5bcf4d01df80.png">

**Observe issue & fix from updated tests:**

https://user-images.githubusercontent.com/14099737/162060904-5c153199-7ba1-40c6-afa0-c982ad454a7c.mov

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
Fixed an edge-case error observed in `cy.session` where an error is thrown when no cookies have been set for the session and the user clicks the session command log to view additional details in the dev tools console.

### How has the user experience changed?
No error when clicking the session log.

### PR Tas
- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?