### PR TITLE
fix: empty state urls in navigation

### DIFF
--- a/packages/driver/cypress/integration/cy/navigation_spec.js
+++ b/packages/driver/cypress/integration/cy/navigation_spec.js
@@ -146,6 +146,28 @@ describe('cy/navigation', () => {
       expect(triggeredHashChange).to.be.false
     })
 
+    it('when no urls or urlPosition in state', () => {
+      const state = $SetterGetter.create({
+        navHistoryDelta: 1,
+      })
+
+      const triggeredHashChange = historyNavigationTriggeredHashChange(state)
+
+      expect(triggeredHashChange).to.be.false
+    })
+
+    it('when no urlPosition in state', () => {
+      const state = $SetterGetter.create({
+        navHistoryDelta: 1,
+        url: 'https://my_url.com/',
+        urls: ['https://my_url.com/', 'https://my_url.com/home'],
+      })
+
+      const triggeredHashChange = historyNavigationTriggeredHashChange(state)
+
+      expect(triggeredHashChange).to.be.false
+    })
+
     it('when neither url has a hash', () => {
       const state = $SetterGetter.create({
         navHistoryDelta: 1,

--- a/packages/driver/src/cy/navigation.ts
+++ b/packages/driver/src/cy/navigation.ts
@@ -26,12 +26,12 @@ export const historyNavigationTriggeredHashChange = (state): boolean => {
   }
 
   const urls = state('urls')
+  const urlPosition = state('urlPosition')
 
-  if (_.isEmpty(urls)) {
+  if (_.isEmpty(urls) || urlPosition === undefined) {
     return false
   }
 
-  const urlPosition = state('urlPosition')
   const currentUrl = $Location.create(urls[urlPosition])
 
   const nextPosition = urlPosition + delta

--- a/packages/driver/src/cy/navigation.ts
+++ b/packages/driver/src/cy/navigation.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { $Location } from '../cypress/location'
 
 export const bothUrlsMatchAndOneHasHash = (current, remote, eitherShouldHaveHash: boolean = false): boolean => {
@@ -25,6 +26,11 @@ export const historyNavigationTriggeredHashChange = (state): boolean => {
   }
 
   const urls = state('urls')
+
+  if (_.isEmpty(urls)) {
+    return false
+  }
+
   const urlPosition = state('urlPosition')
   const currentUrl = $Location.create(urls[urlPosition])
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #19749
- Closes #20539 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
This issue occurs during url state changes and Cypress attempts to test the current url, but the state is empty.

### How has the user experience changed?
<!-- Provide before and after examples of the change. Screenshots or GIFs are preferred. -->
Cypress stops randomly throwing this error and failing tests:
`TypeError: Cannot read properties of undefined (reading 'undefined')`

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
