### PR TITLE
fix(cli): decrease the length of pre-release cache path

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ mainBuildFilters: &mainBuildFilters
       only:
         - develop
         - 10.0-release
-        - use-contexts
+        - unify-1449-beta-slug-length
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -38,8 +38,7 @@ macWorkflowFilters: &mac-workflow-filters
   when:
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
-    
-    - equal: [ new-cmd-group-9.x, << pipeline.git.branch >> ]
+    - equal: [ unify-1449-beta-slug-length, << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -49,7 +48,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     or:
     - equal: [ master, << pipeline.git.branch >> ]
     - equal: [ develop, << pipeline.git.branch >> ]
-    - equal: [ use-contexts, << pipeline.git.branch >> ]
+    - equal: [ unify-1449-beta-slug-length, << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -1635,7 +1634,7 @@ jobs:
       - run:
           name: Check current branch to persist artifacts
           command: |
-            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "use-contexts" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "unify-1449-beta-slug-length" ]]; then
               echo "Not uploading artifacts or posting install comment for this branch."
               circleci-agent step halt
             fi

--- a/cli/__snapshots__/install_spec.js
+++ b/cli/__snapshots__/install_spec.js
@@ -264,11 +264,11 @@ exports['/lib/tasks/install .start non-stable builds logs a warning about instal
 Bugs may be present which do not exist in production builds.
 
 This build was created from:
-  * Commit SHA: abc123
+  * Commit SHA: 3b7f0b5c59def1e9b5f385bd585c9b2836706c29
   * Commit Branch: aBranchName
   * Commit Timestamp: 1996-11-27Txx:xx:xx.000Z
 
-Installing Cypress (version: https://cdn.cypress.io/beta/binary/0.0.0-development/darwin-x64/aBranchName-abc123/cypress.zip)
+Installing Cypress (version: https://cdn.cypress.io/beta/binary/0.0.0-development/darwin-x64/aBranchName-3b7f0b5c59def1e9b5f385bd585c9b2836706c29/cypress.zip)
 
 
 ⠋  Downloaded Cypress

--- a/cli/lib/tasks/state.js
+++ b/cli/lib/tasks/state.js
@@ -52,7 +52,7 @@ const getBinaryDir = (version = util.pkgVersion()) => {
 
 const getVersionDir = (version = util.pkgVersion(), buildInfo = util.pkgBuildInfo()) => {
   if (buildInfo && !buildInfo.stable) {
-    version = ['beta', buildInfo.commitBranch, buildInfo.commitSha.slice(0, 8)].join('-')
+    version = ['beta', version, buildInfo.commitBranch, buildInfo.commitSha.slice(0, 8)].join('-')
   }
 
   return path.join(getCacheDir(), version)

--- a/cli/lib/tasks/state.js
+++ b/cli/lib/tasks/state.js
@@ -52,7 +52,7 @@ const getBinaryDir = (version = util.pkgVersion()) => {
 
 const getVersionDir = (version = util.pkgVersion(), buildInfo = util.pkgBuildInfo()) => {
   if (buildInfo && !buildInfo.stable) {
-    version = ['beta', version, buildInfo.commitBranch, buildInfo.commitSha].join('-')
+    version = ['beta', buildInfo.commitBranch, buildInfo.commitSha.slice(0, 8)].join('-')
   }
 
   return path.join(getCacheDir(), version)

--- a/cli/test/lib/tasks/install_spec.js
+++ b/cli/test/lib/tasks/install_spec.js
@@ -101,7 +101,7 @@ describe('/lib/tasks/install', function () {
       it('installs to the expected pre-release cache dir', async function () {
         state.getVersionDir.restore()
         await runInstall()
-        expect(unzip.start).to.be.calledWithMatch({ installDir: sinon.match(/\/Cypress\/beta\-aBranchName\-3b7f0b5c$/) })
+        expect(unzip.start).to.be.calledWithMatch({ installDir: sinon.match(/\/Cypress\/beta\-1\.2\.3\-aBranchName\-3b7f0b5c$/) })
       })
     })
 

--- a/cli/test/lib/tasks/install_spec.js
+++ b/cli/test/lib/tasks/install_spec.js
@@ -74,28 +74,34 @@ describe('/lib/tasks/install', function () {
     })
 
     describe('non-stable builds', () => {
+      const buildInfo = {
+        stable: false,
+        commitSha: '3b7f0b5c59def1e9b5f385bd585c9b2836706c29',
+        commitBranch: 'aBranchName',
+        commitDate: new Date('11-27-1996').toISOString(),
+      }
+
       function runInstall () {
-        return install.start({
-          buildInfo: {
-            stable: false,
-            commitSha: 'abc123',
-            commitBranch: 'aBranchName',
-            commitDate: new Date('11-27-1996').toISOString(),
-          },
-        })
+        return install.start({ buildInfo })
       }
 
       it('install from a constructed CDN URL', async function () {
         await runInstall()
 
         expect(download.start).to.be.calledWithMatch({
-          version: 'https://cdn.cypress.io/beta/binary/0.0.0-development/darwin-x64/aBranchName-abc123/cypress.zip',
+          version: 'https://cdn.cypress.io/beta/binary/0.0.0-development/darwin-x64/aBranchName-3b7f0b5c59def1e9b5f385bd585c9b2836706c29/cypress.zip',
         })
       })
 
       it('logs a warning about installing a pre-release', async function () {
         await runInstall()
         snapshot(normalize(this.stdout.toString()))
+      })
+
+      it('installs to the expected pre-release cache dir', async function () {
+        state.getVersionDir.restore()
+        await runInstall()
+        expect(unzip.start).to.be.calledWithMatch({ installDir: sinon.match(/\/Cypress\/beta\-aBranchName\-3b7f0b5c$/) })
       })
     })
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Partially addresses UNIFY-1449

### User facing changelog

- Decreased the length of the Cypress cache path when installing pre-releases. This should improve the experience for Windows users, where the max path length is 260 characters by default.

### Additional details

- Pre-release paths are getting ridiculously long since #20296 leading to issues like trying to unpack `C:\Users\Administrator\AppData\Local\Cypress\Cache\beta-10.0.0-10.0-release-404447e397190ebb0f8ce0bb270ea9a806ca78c6\Cypress\resources\app\node_modules\remark-mdx\node_modules\@babel\plugin-proposal-object-rest-spread\node_modules\@babel\helper-plugin-utils\lib` and failing on Windows because the path is too long (261 characters)
- ~~Removed `version` from the path altogether since it's not relevant in development.~~ Keeping `version` as a rough indicator of when the pre-release was installed.
- Trimmed 40-character Git SHA to 8 characters. Combined with the branch name this is still highly unlikely to collide.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
