### PR TITLE
chore: [Multi-domain] Fix uncaught error

### DIFF
--- a/packages/driver/src/cy/multi-domain/index.ts
+++ b/packages/driver/src/cy/multi-domain/index.ts
@@ -129,7 +129,7 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
           resolve(unserializableSubjectType ? createUnserializableSubjectProxy(unserializableSubjectType) : subject)
         }
 
-        const _reject = (err, cleanupOptions = {}) => {
+        const _reject = (err, cleanupOptions: {readyForOriginFailed?: boolean} = {}) => {
           cleanup(cleanupOptions)
           log?.error(err)
           reject(err)

--- a/packages/driver/src/cy/multi-domain/index.ts
+++ b/packages/driver/src/cy/multi-domain/index.ts
@@ -231,6 +231,9 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
                 logCounter: LogUtils.getCounter(),
               })
             } catch (err: any) {
+              // Release the request if 'run:origin:fn' fails
+              Cypress.backend('ready:for:origin', { originPolicy: location.originPolicy })
+
               const wrappedErr = $errUtils.errByPath('origin.run_origin_fn_errored', {
                 error: err.message,
               })

--- a/packages/driver/src/cy/multi-domain/index.ts
+++ b/packages/driver/src/cy/multi-domain/index.ts
@@ -110,9 +110,12 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
       cy.state('currentActiveOriginPolicy', originPolicy)
 
       return new Bluebird((resolve, reject, onCancel) => {
-        const cleanup = () => {
+        const cleanup = ({ readyForOriginFailed }: {readyForOriginFailed?: boolean} = {}): void => {
           cy.state('currentActiveOriginPolicy', undefined)
-          Cypress.backend('cross:origin:finished', location.originPolicy)
+          if (!readyForOriginFailed) {
+            Cypress.backend('cross:origin:finished', location.originPolicy)
+          }
+
           communicator.off('queue:finished', onQueueFinished)
           communicator.off('sync:globals', onSyncGlobals)
         }
@@ -126,8 +129,8 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
           resolve(unserializableSubjectType ? createUnserializableSubjectProxy(unserializableSubjectType) : subject)
         }
 
-        const _reject = (err) => {
-          cleanup()
+        const _reject = (err, cleanupOptions = {}) => {
+          cleanup(cleanupOptions)
           log?.error(err)
           reject(err)
         }
@@ -232,7 +235,7 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
               })
             } catch (err: any) {
               // Release the request if 'run:origin:fn' fails
-              Cypress.backend('ready:for:origin', { originPolicy: location.originPolicy })
+              Cypress.backend('ready:for:origin', { failed: true })
 
               const wrappedErr = $errUtils.errByPath('origin.run_origin_fn_errored', {
                 error: err.message,
@@ -244,7 +247,7 @@ export function addCommands (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy,
               // Prevent cypress from trying to add the function to the error log
               wrappedErr.onFail = () => {}
 
-              _reject(wrappedErr)
+              _reject(wrappedErr, { readyForOriginFailed: true })
             }
           }
         })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Quick fix for an uncaught error.

In the event that the `run:origin:fn` event fails a secondary error was thrown because we weren't releasing the request.

I didn't add a test because it's hard to test a negative, This wasn't caught in our existing tests because it's a second error and we already handled the first error.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
