### PR TITLE
chore: [Multi-domain] Update error messages based on feedback.

### DIFF
--- a/packages/driver/cypress/integration/e2e/multi-domain/navigation_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/navigation_spec.ts
@@ -208,7 +208,7 @@ describe('event timing', () => {
       cy.log('inside cy.origin foobar')
     })
 
-    // This command is run from localhost against the cross origin aut. Updating href is one of the few allowed commands. See https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#location
+    // This command is run from localhost against the cross-origin aut. Updating href is one of the few allowed commands. See https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#location
     cy.window().then((win) => {
       win.location.href = 'http://www.idp.com:3500/fixtures/multi-domain.html'
     })
@@ -264,10 +264,10 @@ describe('errors', () => {
     cy.on('fail', (err) => {
       expect(err.message).to.include(`Timed out after waiting \`5000ms\` for your remote page to load on origin(s):`)
       expect(err.message).to.include(`\n- \`http://localhost:3500\`\n`)
-      expect(err.message).to.include(`A cross origin request for \`http://www.foobar.com:3500/fixtures/auth/idp.html?redirect=http%3A%2F%2Flocalhost%3A3500%2Ffixtures%2Fauth%2Findex.html\` was detected.`)
-      expect(err.message).to.include(`A command that triggers cross origin navigation must be immediately followed by a \`cy.origin()\` command:`)
+      expect(err.message).to.include(`A cross-origin request for \`http://www.foobar.com:3500/fixtures/auth/idp.html?redirect=http%3A%2F%2Flocalhost%3A3500%2Ffixtures%2Fauth%2Findex.html\` was detected.`)
+      expect(err.message).to.include(`A command that triggers cross-origin navigation must be immediately followed by a \`cy.origin()\` command:`)
       expect(err.message).to.include(`\`\ncy.origin(\'http://foobar.com:3500\', () => {\n  <commands targeting http://www.foobar.com:3500 go here>\n})\n\``)
-      expect(err.message).to.include(`If the cross origin request was an intermediary state, you can try increasing the \`pageLoadTimeout\` value in \`cypress.json\` to wait longer`)
+      expect(err.message).to.include(`If the cross-origin request was an intermediary state, you can try increasing the \`pageLoadTimeout\` value in \`cypress.json\` to wait longer`)
 
       expect(err.message).not.to.include(`The following error originated from your test code, not from Cypress`)
       expect(err.message).not.to.include(`The following error originated from your application code, not from Cypress`)
@@ -279,11 +279,11 @@ describe('errors', () => {
     cy.get('[data-cy="login-foobar"]')
   })
 
-  it('never redirects to the cross origin', { defaultCommandTimeout: 50 }, (done) => {
+  it('never redirects to the cross-origin', { defaultCommandTimeout: 50 }, (done) => {
     cy.on('fail', (err) => {
       expect(err.message).to.include(`Timed out retrying after 50ms: Expected to find element: \`[data-cy="username"]\`, but never found it`)
       expect(err.message).to.include(`The command was expected to run against origin \`http://idp.com:3500\` but the application is at origin \`http://localhost:3500\`.`)
-      expect(err.message).to.include(`This commonly happens when you have either not navigated to the expected origin or have navigated away unexpected.`)
+      expect(err.message).to.include(`This commonly happens when you have either not navigated to the expected origin or have navigated away unexpectedly.`)
       //  make sure that the secondary origin failures do NOT show up as spec failures or AUT failures
       expect(err.message).not.to.include(`The following error originated from your test code, not from Cypress`)
       expect(err.message).not.to.include(`The following error originated from your application code, not from Cypress`)
@@ -302,11 +302,11 @@ describe('errors', () => {
     .should('equal', 'Welcome BJohnson')
   })
 
-  it('redirects to the wrong cross origin', { pageLoadTimeout: 5000 }, (done) => {
+  it('redirects to the wrong cross-origin', { pageLoadTimeout: 5000 }, (done) => {
     cy.on('fail', (err) => {
       expect(err.message).to.include(`Timed out after waiting \`5000ms\` for your remote page to load on origin(s):`)
       expect(err.message).to.include(`\n- \`http://idp.com:3500\`\n`)
-      expect(err.message).to.include(`A cross origin request for \`http://www.foobar.com:3500/fixtures/auth/idp.html?redirect=http%3A%2F%2Flocalhost%3A3500%2Ffixtures%2Fauth%2Findex.html\` was detected.`)
+      expect(err.message).to.include(`A cross-origin request for \`http://www.foobar.com:3500/fixtures/auth/idp.html?redirect=http%3A%2F%2Flocalhost%3A3500%2Ffixtures%2Fauth%2Findex.html\` was detected.`)
       expect(err.message).to.include(`\`\ncy.origin(\'http://foobar.com:3500\', () => {\n  <commands targeting http://www.foobar.com:3500 go here>\n})\n\``)
 
       expect(err.message).not.to.include(`The following error originated from your test code, not from Cypress`)
@@ -349,11 +349,11 @@ describe('errors', () => {
     .should('equal', 'Welcome BJohnson')
   })
 
-  it('redirects to an unexpected cross origin', { pageLoadTimeout: 5000 }, (done) => {
+  it('redirects to an unexpected cross-origin', { pageLoadTimeout: 5000 }, (done) => {
     cy.on('fail', (err) => {
       expect(err.message).to.include(`Timed out after waiting \`5000ms\` for your remote page to load on origin(s):`)
       expect(err.message).to.include(`\n- \`http://localhost:3500\`\n`)
-      expect(err.message).to.include(`A cross origin request for \`http://www.foobar.com:3500/fixtures/auth/index.html\` was detected.`)
+      expect(err.message).to.include(`A cross-origin request for \`http://www.foobar.com:3500/fixtures/auth/index.html\` was detected.`)
       expect(err.message).to.include(`\`\ncy.origin(\'http://foobar.com:3500\', () => {\n  <commands targeting http://www.foobar.com:3500 go here>\n})\n\``)
 
       expect(err.message).not.to.include(`The following error originated from your test code, not from Cypress`)
@@ -376,11 +376,11 @@ describe('errors', () => {
     .should('equal', 'Welcome BJohnson')
   })
 
-  it('redirects to an unexpected cross origin and calls another command in the cy.origin command', { pageLoadTimeout: 5000 }, (done) => {
+  it('redirects to an unexpected cross-origin and calls another command in the cy.origin command', { pageLoadTimeout: 5000 }, (done) => {
     cy.on('fail', (err) => {
       expect(err.message).to.include(`Timed out after waiting \`5000ms\` for your remote page to load on origin(s):`)
       expect(err.message).to.include(`\n- \`http://idp.com:3500\`\n`)
-      expect(err.message).to.include(`A cross origin request for \`http://www.foobar.com:3500/fixtures/auth/index.html\` was detected.`)
+      expect(err.message).to.include(`A cross-origin request for \`http://www.foobar.com:3500/fixtures/auth/index.html\` was detected.`)
       expect(err.message).to.include(`\`\ncy.origin(\'http://foobar.com:3500\', () => {\n  <commands targeting http://www.foobar.com:3500 go here>\n})\n\``)
 
       expect(err.message).not.to.include(`The following error originated from your test code, not from Cypress`)
@@ -453,7 +453,7 @@ describe('errors', () => {
       cy.on('fail', (err) => {
         expect(err.message).to.include(`Timed out after waiting \`5000ms\` for your remote page to load on origin(s):`)
         expect(err.message).to.include(`\n- \`http://localhost:3500\`\n`)
-        expect(err.message).to.include(`A cross origin request for \`http://www.foobar.com:3500/fixtures/auth/index.html\` was detected.`)
+        expect(err.message).to.include(`A cross-origin request for \`http://www.foobar.com:3500/fixtures/auth/index.html\` was detected.`)
         expect(err.message).to.include(`\`\ncy.origin(\'http://foobar.com:3500\', () => {\n  <commands targeting http://www.foobar.com:3500 go here>\n})\n\``)
 
         expect(err.message).not.to.include(`The following error originated from your test code, not from Cypress`)
@@ -502,7 +502,7 @@ describe('errors', () => {
       cy.on('fail', (err) => {
         expect(err.message).to.include(`Timed out after waiting \`5000ms\` for your remote page to load on origin(s):`)
         expect(err.message).to.include(`\n- \`http://localhost:3500\`\n`)
-        expect(err.message).to.include(`A cross origin request for \`http://www.foobar.com:3500/fixtures/auth/index.html\` was detected.`)
+        expect(err.message).to.include(`A cross-origin request for \`http://www.foobar.com:3500/fixtures/auth/index.html\` was detected.`)
         expect(err.message).to.include(`\`\ncy.origin(\'http://foobar.com:3500\', () => {\n  <commands targeting http://www.foobar.com:3500 go here>\n})\n\``)
 
         expect(err.message).not.to.include(`The following error originated from your test code, not from Cypress`)

--- a/packages/driver/cypress/integration/e2e/multi-domain/navigation_spec.ts
+++ b/packages/driver/cypress/integration/e2e/multi-domain/navigation_spec.ts
@@ -264,7 +264,6 @@ describe('errors', () => {
     cy.on('fail', (err) => {
       expect(err.message).to.include(`Timed out after waiting \`5000ms\` for your remote page to load on origin(s):`)
       expect(err.message).to.include(`\n- \`http://localhost:3500\`\n`)
-      expect(err.message).to.include(`Your page did not fire its \`load\` event within \`5000ms\`.`)
       expect(err.message).to.include(`A cross origin request for \`http://www.foobar.com:3500/fixtures/auth/idp.html?redirect=http%3A%2F%2Flocalhost%3A3500%2Ffixtures%2Fauth%2Findex.html\` was detected.`)
       expect(err.message).to.include(`A command that triggers cross origin navigation must be immediately followed by a \`cy.origin()\` command:`)
       expect(err.message).to.include(`\`\ncy.origin(\'http://foobar.com:3500\', () => {\n  <commands targeting http://www.foobar.com:3500 go here>\n})\n\``)
@@ -283,7 +282,8 @@ describe('errors', () => {
   it('never redirects to the cross origin', { defaultCommandTimeout: 50 }, (done) => {
     cy.on('fail', (err) => {
       expect(err.message).to.include(`Timed out retrying after 50ms: Expected to find element: \`[data-cy="username"]\`, but never found it`)
-      expect(err.message).to.include(`The command was expected to run against origin: \`http://idp.com:3500\` but the application is at origin: \`http://localhost:3500\`.`)
+      expect(err.message).to.include(`The command was expected to run against origin \`http://idp.com:3500\` but the application is at origin \`http://localhost:3500\`.`)
+      expect(err.message).to.include(`This commonly happens when you have either not navigated to the expected origin or have navigated away unexpected.`)
       //  make sure that the secondary origin failures do NOT show up as spec failures or AUT failures
       expect(err.message).not.to.include(`The following error originated from your test code, not from Cypress`)
       expect(err.message).not.to.include(`The following error originated from your application code, not from Cypress`)
@@ -330,7 +330,7 @@ describe('errors', () => {
   it('never returns to the primary origin', { defaultCommandTimeout: 50 }, (done) => {
     cy.on('fail', (err) => {
       expect(err.message).to.include(`Timed out retrying after 50ms: Expected to find element: \`[data-cy="welcome"]\`, but never found it`)
-      expect(err.message).to.include(`The command was expected to run against origin: \`http://localhost:3500\` but the application is at origin: \`http://idp.com:3500\`.`)
+      expect(err.message).to.include(`The command was expected to run against origin \`http://localhost:3500\` but the application is at origin \`http://idp.com:3500\`.`)
       //  make sure that the secondary origin failures do NOT show up as spec failures or AUT failures
       expect(err.message).not.to.include(`The following error originated from your test code, not from Cypress`)
       expect(err.message).not.to.include(`The following error originated from your application code, not from Cypress`)
@@ -408,7 +408,7 @@ describe('errors', () => {
   it('fails in cy.origin when a command is run after we return to localhost', { defaultCommandTimeout: 50 }, (done) => {
     cy.on('fail', (err) => {
       expect(err.message).to.include(`Timed out retrying after 50ms: Expected to find element: \`[data-cy="cannot_find"]\`, but never found it`)
-      expect(err.message).to.include(`The command was expected to run against origin: \`http://idp.com:3500\` but the application is at origin: \`http://localhost:3500\`.`)
+      expect(err.message).to.include(`The command was expected to run against origin \`http://idp.com:3500\` but the application is at origin \`http://localhost:3500\`.`)
       //  make sure that the secondary origin failures do NOT show up as spec failures or AUT failures
       expect(err.message).not.to.include(`The following error originated from your test code, not from Cypress`)
       expect(err.message).not.to.include(`The following error originated from your application code, not from Cypress`)

--- a/packages/driver/src/cypress/error_messages.ts
+++ b/packages/driver/src/cypress/error_messages.ts
@@ -898,7 +898,7 @@ export default {
       return stripIndent`\
         The command was expected to run against origin \`${commandOrigin }\` but the application is at origin \`${autOrigin}\`.
 
-        This commonly happens when you have either not navigated to the expected origin or have navigated away unexpected.`
+        This commonly happens when you have either not navigated to the expected origin or have navigated away unexpectedly.`
     },
   },
 
@@ -998,9 +998,9 @@ export default {
 
           - ${originPolicies.map((originPolicy) => `\`${originPolicy}\``).join('\n       -')}
 
-          A cross origin request for \`${crossOriginUrl.href}\` was detected.
+          A cross-origin request for \`${crossOriginUrl.href}\` was detected.
 
-          A command that triggers cross origin navigation must be immediately followed by a ${cmd('origin')} command:
+          A command that triggers cross-origin navigation must be immediately followed by a ${cmd('origin')} command:
 
           \`\`\`
           cy.origin('${crossOriginUrl.originPolicy}', () => {
@@ -1008,7 +1008,7 @@ export default {
           })
           \`\`\`
 
-          If the cross origin request was an intermediary state, you can try increasing the \`pageLoadTimeout\` value in ${formatConfigFile(configFile)} to wait longer.
+          If the cross-origin request was an intermediary state, you can try increasing the \`pageLoadTimeout\` value in ${formatConfigFile(configFile)} to wait longer.
 
           Browsers will not fire the \`load\` event until all stylesheets and scripts are done downloading.
 

--- a/packages/driver/src/cypress/error_messages.ts
+++ b/packages/driver/src/cypress/error_messages.ts
@@ -895,7 +895,10 @@ export default {
       return `Timed out retrying after ${ms}ms: `
     },
     cross_origin_command ({ commandOrigin, autOrigin }) {
-      return `The command was expected to run against origin: \`${commandOrigin }\` but the application is at origin: \`${autOrigin}\`.`
+      return stripIndent`\
+        The command was expected to run against origin \`${commandOrigin }\` but the application is at origin \`${autOrigin}\`.
+
+        This commonly happens when you have either not navigated to the expected origin or have navigated away unexpected.`
     },
   },
 
@@ -989,29 +992,29 @@ export default {
         If so, increase \`redirectionLimit\` value in configuration.`
     },
     cross_origin_load_timed_out ({ ms, configFile, crossOriginUrl, originPolicies }) {
-      return stripIndent`\
+      return {
+        message: stripIndent`\
+          Timed out after waiting \`${ms}ms\` for your remote page to load on origin(s):
 
-        Timed out after waiting \`${ms}ms\` for your remote page to load on origin(s):
+          - ${originPolicies.map((originPolicy) => `\`${originPolicy}\``).join('\n       -')}
 
-        - ${originPolicies.map((originPolicy) => `\`${originPolicy}\``).join('\n       -')}
+          A cross origin request for \`${crossOriginUrl.href}\` was detected.
 
-        Your page did not fire its \`load\` event within \`${ms}ms\`.
+          A command that triggers cross origin navigation must be immediately followed by a ${cmd('origin')} command:
 
-        A cross origin request for \`${crossOriginUrl.href}\` was detected.
+          \`\`\`
+          cy.origin('${crossOriginUrl.originPolicy}', () => {
+            <commands targeting ${crossOriginUrl.origin} go here>
+          })
+          \`\`\`
 
-        A command that triggers cross origin navigation must be immediately followed by a ${cmd('origin')} command:
+          If the cross origin request was an intermediary state, you can try increasing the \`pageLoadTimeout\` value in ${formatConfigFile(configFile)} to wait longer.
 
-        \`\`\`
-        cy.origin('${crossOriginUrl.originPolicy}', () => {
-          <commands targeting ${crossOriginUrl.origin} go here>
-        })
-        \`\`\`
+          Browsers will not fire the \`load\` event until all stylesheets and scripts are done downloading.
 
-        If the cross origin request was an intermediary state, you can try increasing the \`pageLoadTimeout\` value in ${formatConfigFile(configFile)} to wait longer.
-
-        Browsers will not fire the \`load\` event until all stylesheets and scripts are done downloading.
-
-        When this \`load\` event occurs, Cypress will continue running commands.`
+          When this \`load\` event occurs, Cypress will continue running commands.`,
+        docsUrl: 'https://on.cypress.io/origin',
+      }
     },
   },
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Added some updates to the error messages based on feedback

cross_origin_load_timed_out:
* added cy.origin docs url
* removed redundant page did not load message

cross_origin_command:
* removed colons
* added further explanation of likely causes.


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

When a page load times out when a cross origin request exists
<img width="1790" alt="Screen Shot 2022-04-08 at 8 34 59 AM" src="https://user-images.githubusercontent.com/1588747/162446576-3ed55bc4-8107-438d-9d9d-6b0334cc8729.png">

When a command times out and the aut origin does not match the command origin
<img width="1790" alt="Screen Shot 2022-04-08 at 8 36 45 AM" src="https://user-images.githubusercontent.com/1588747/162447008-28626c2c-625f-4b86-91ad-2d2b12ba0df0.png">


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
