### PR TITLE
fix: add safety check for command.clone when cmd does not have args

### DIFF
--- a/packages/driver/cypress/integration/cypress/command_spec.js
+++ b/packages/driver/cypress/integration/cypress/command_spec.js
@@ -1,0 +1,76 @@
+const { Command } = Cypress
+
+describe('driver/src/cypress/command', () => {
+  let command
+
+  context('$Command', () => {
+    context('._removeNonPrimitives', () => {
+      before(() => {
+        command = Command.create({ })
+      })
+
+      it('when args are undefined it does not remove non properties', () => {
+        const args = undefined
+
+        command._removeNonPrimitives(args)
+        expect(args).to.be.undefined
+      })
+
+      it('when args is an object it filters out non-primitive properties ', () => {
+        const args = ['.fake_get_selector', {
+          opt1: 'option',
+          opt2: {
+            nested: 'hello',
+          },
+        }]
+
+        command._removeNonPrimitives(args)
+        expect(args).to.be.eq(args)
+      })
+
+      it('sets log to true if previously options set it to false', () => {
+        const args = [{ log: false }]
+
+        command._removeNonPrimitives(args)
+        expect(args).to.have.length(1)
+        expect(args[0]).to.have.property('log')
+        expect(args[0].log).to.be.true
+      })
+    })
+
+    context('.clone', () => {
+      it('successfully clones command with arguments', () => {
+        const args = ['.selector']
+
+        command = Command.create({
+          type: 'parent',
+          name: 'command1',
+          chainerId: 'id1',
+          args,
+        })
+
+        const spy = cy.spy(command, '_removeNonPrimitives')
+        let clonedCommand = command.clone()
+
+        expect(clonedCommand).to.be.instanceOf(Command)
+        expect(spy).to.have.been.calledWith(args)
+        expect(clonedCommand.attributes).to.deep.eq(command.attributes)
+      })
+
+      it('successfully clones command with without arguments', () => {
+        command = Command.create({
+          type: 'parent',
+          name: 'command1',
+          chainerId: 'id1',
+        })
+
+        const spy = cy.spy(command, '_removeNonPrimitives')
+        let clonedCommand = command.clone()
+
+        expect(clonedCommand).to.be.instanceOf(Command)
+        expect(spy).to.have.been.calledWith(undefined)
+        expect(clonedCommand.attributes).to.deep.eq(command.attributes)
+      })
+    })
+  })
+})

--- a/packages/driver/src/cypress/command.ts
+++ b/packages/driver/src/cypress/command.ts
@@ -75,7 +75,7 @@ export class $Command {
     return this.attributes
   }
 
-  _removeNonPrimitives (args) {
+  _removeNonPrimitives (args: Array<any> = []) {
     // if the obj has options and
     // log is false, set it to true
     for (let i = args.length - 1; i >= 0; i--) {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

While pulling in the[ logGroup changes into within in the 10.x branch,](https://github.com/cypress-io/cypress/pull/20980) I noticed two consistent command failures with the following error:

<img width="562" alt="Screen Shot 2022-04-08 at 9 04 53 AM" src="https://user-images.githubusercontent.com/14099737/162453576-1bedcace-b388-4023-b4ba-8cdb82fe99bc.png">

The test flow could be summarized like:

```js
cy.get('modal').as('modalAlias').within(() => {}) // within using log group

// do something 

cy.get('@modalAlias') // command replay is triggered which includes replaying the end-logGroup command
```

When a command is replayed, it's cloned and injected into the command queue. 
When the command is cloned, it pull sanitize the commands args list to pull forward an create a new command. Generally commands have args, but because the injected end-logGroup command did not have args passed, it was undefined and caused this error.

This check just ensures commands lacking args can successfully be cloned.

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
