### PR TITLE
fix:cy.wait using array with one alias returns a single interception,…

### DIFF
--- a/packages/driver/src/cy/commands/waiting.ts
+++ b/packages/driver/src/cy/commands/waiting.ts
@@ -251,9 +251,8 @@ export default (Commands, Cypress, cy, state) => {
       return waitForXhr(str, _.omit(options, 'error'))
     })
     .then((responses) => {
-      // if we only asked to wait for one alias
-      // then return that, else return the array of xhr responses
-      const ret = responses.length === 1 ? responses[0] : responses
+      // return the array of xhr responses
+      const ret = responses
 
       if (log) {
         log.set('consoleProps', () => {


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/19317 <!-- link to the issue here, if there is one -->

### User facing changelog
n/a
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
cy.wait([@myIterception]).then((res) => ...) should yield res as a an array of Interception objects, granted it would be an array of one Interception.
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
