### PR TITLE
chore: remove parallelism from test-binary-against-repo jobs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1911,7 +1911,6 @@ jobs:
 
   test-binary-against-recipes-chrome:
     <<: *defaults
-    parallelism: 3
     steps:
       - test-binary-against-repo:
           repo: cypress-example-recipes
@@ -1919,7 +1918,6 @@ jobs:
 
   test-binary-against-recipes:
     <<: *defaults
-    parallelism: 3
     steps:
       - test-binary-against-repo:
           repo: cypress-example-recipes


### PR DESCRIPTION
### User facing changelog
N/A

### Additional details

Removes parallelism from a few jobs against remote repose that aren't benefitting from it

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- N/A Have tests been added/updated?
- N/A Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- N/A Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
