### PR TITLE
fix: cy.request follows RFC7230 5.4

### DIFF
--- a/packages/driver/cypress/integration/commands/request_spec.js
+++ b/packages/driver/cypress/integration/commands/request_spec.js
@@ -1387,4 +1387,16 @@ describe('src/cy/commands/request', () => {
       })
     })
   })
+
+  context('#request tests without Cypress.backend() stub', () => {
+    it('host field is added to the headers', (done) => {
+      cy.on('fail', (err) => {
+        expect(err.message).to.include('"host": "localhost:3500"')
+
+        done()
+      })
+
+      cy.request('/')
+    })
+  })
 })

--- a/packages/server/lib/server-base.ts
+++ b/packages/server/lib/server-base.ts
@@ -374,6 +374,21 @@ export abstract class ServerBase<TSocket extends SocketE2E | SocketCt> {
   }
 
   _onRequest (headers, automationRequest, options) {
+    // RFC7230 5.4 specifies that:
+    // A client MUST send a Host header field in all HTTP/1.1 request messages.
+    // @see https://datatracker.ietf.org/doc/html/rfc7230#section-5.4
+    //
+    // If Host header field is not defined in options.headers object,
+    // we define it here.
+
+    if (!options.headers) {
+      options.headers = {}
+    }
+
+    let url = new URL(options.url)
+
+    options.headers['host'] = url.host
+
     // @ts-ignore
     return this.request.sendPromise(headers, automationRequest, options)
   }

--- a/system-tests/__snapshots__/request_spec.ts.js
+++ b/system-tests/__snapshots__/request_spec.ts.js
@@ -227,6 +227,7 @@ Method: GET
 URL: http://localhost:2294/statusCode?code=503
 Headers: {
   "Connection": "keep-alive",
+  "host": "localhost:2294",
   "user-agent": "foo",
   "accept": "*/*",
   "accept-encoding": "gzip, deflate"
@@ -345,6 +346,7 @@ Method: GET
 URL: http://localhost:2294/myreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallylong
 Headers: {
   "Connection": "keep-alive",
+  "host": "localhost:2294",
   "user-agent": "foo",
   "accept": "*/*",
   "accept-encoding": "gzip, deflate"


### PR DESCRIPTION
- Closes #20289

### User facing changelog

`cy.request()` now always sends `host` header field.

### Additional details
- Why was this change necessary? => [RFC7230 5.4](https://datatracker.ietf.org/doc/html/rfc7230#section-5.4) states that all requests must send "Host" header field, but `cy.request` doesn't if it is not specified by the user. 
- What is affected by this change? => N/A
- Any implementation details to explain? => I decided to add this on the server side, because it would break all `request_spec.js` tests.

### How has the user experience changed?

**Before:** Some strict servers don't allow empty "host" field and `cy.request` fails.
**After:** It passes for those servers.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
