### PR TITLE
docs: recommend watch / cypress:open processes in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "test-watch": "lerna exec yarn test-watch --ignore \"'@packages/{driver,root,static,web-config}'\"",
     "type-check": "yarn lerna exec yarn type-check --scope @tooling/system-tests && node scripts/type_check",
     "verify:mocha:results": "node ./scripts/verify_mocha_results",
-    "watch": "yarn gulp dev:watch",
+    "watch": "yarn gulp watch",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -4,11 +4,12 @@ This is the front-end for the Cypress App.
 
 ## Development
 
-1. `yarn dev` (inside of `packages/app`)
-2. It will open launchpad
-3. Select Component or E2E Testing
-3. Open chrome (or another browser)
-4. It will show the new Vite powered app 
+1. `yarn watch` (inside of root)
+1. `yarn cypress:open` (inside of `packages/app`)
+1. It will open launchpad
+1. Select Component or E2E Testing
+1. Open chrome (or another browser)
+1. It will show the new Vite powered app
 
 ## How the App works
 

--- a/packages/launchpad/README.md
+++ b/packages/launchpad/README.md
@@ -41,14 +41,25 @@ For the best development experience, you will want to use VS Code with the [Vola
 
 ```bash
 ## from repo root
-yarn dev
+yarn watch
 ```
 
-This starts Vite in watch mode. It also starts the GraphQL Server. You can access it on `http://localhost:52200/graphql`.
+This starts Vite in watch mode, and any code-generation scripts that need to be running in the background to support our environment. 
+
+In a seprate terminal, run:
+
+```bash
+## from repo root
+yarn cypress:open
+```
+
+This starts the GraphQL Server, and opens Cypress. By running this separate from the `yarn watch`, you can kill & respawn the Cypress binary without the overhead of the watch processes you'd see by running `yarn dev`. 
+
+You can access the GraphQL inspector on `http://localhost:52200/graphql`.
 
 ![graphql](../graphql/gql.png)
 
-If you notice your IDE has not updated and is showing errors, even after `yarn watch` has run`, you might need to reopen your IDE. With the amount of code generation running, sometimes the IDE does not recognize that the code has changed.
+If you notice your IDE has not updated and is showing errors, even after `yarn watch` has run, you might need to reload your IDE. With the amount of code generation running, sometimes the IDE does not recognize that the code has changed.
 
 ## Testing
 

--- a/scripts/gulp/gulpfile.ts
+++ b/scripts/gulp/gulpfile.ts
@@ -19,6 +19,7 @@ import { exitAfterAll } from './tasks/gulpRegistry'
 import { execSync } from 'child_process'
 import { webpackRunner } from './tasks/gulpWebpack'
 import { e2eTestScaffold, e2eTestScaffoldWatch } from './tasks/gulpE2ETestScaffold'
+import dedent from 'dedent'
 
 if (process.env.CYPRESS_INTERNAL_VITE_DEV) {
   process.env.CYPRESS_INTERNAL_VITE_APP_PORT ??= '3333'
@@ -60,6 +61,8 @@ gulp.task(
     webpackRunner,
     gulp.series(
       makePathMap,
+      // Before dev, fetch the latest "remote" schema from the Cypress dashboard
+      syncRemoteGraphQL,
       gulp.parallel(
         viteClean,
         e2eTestScaffoldWatch,
@@ -73,10 +76,23 @@ gulp.task(
         viteApp,
         viteLaunchpad,
       ),
-
-      // And we're finally ready for electron, watching for changes in
-      // /graphql to auto-restart the server
     ),
+  ),
+)
+
+gulp.task(
+  'watch',
+  gulp.series(
+    'dev:watch',
+    // And we're finally ready for electron, watching for changes in
+    // /graphql to auto-restart the server
+    async function logInfo () {
+      console.log(dedent`
+        "yarn watch" is complete, and is now watching your files for code-generation updates.
+
+        In a separate terminal, run "yarn cypress:open" to start Cypress
+      `)
+    },
   ),
 )
 
@@ -88,9 +104,6 @@ gulp.task(
     // And we're finally ready for electron, watching for changes in
     // /graphql to auto-restart the server
     startCypressWatch,
-
-    // Before dev, fetch the latest "remote" schema from the Cypress dashboard
-    syncRemoteGraphQL,
   ),
 )
 


### PR DESCRIPTION
Recommends using two separate commands `watch` / `cypress:open` rather than `dev` when running Cypress for local development. This allows for a faster feedback loops when you need to kill & re-spawn the Cypress binary.

### User facing changelog

N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
