### PR TITLE
chore: [Multi-domain] Reset timeout after transition from `before` to `it` while unstable.

### DIFF
--- a/packages/driver/cypress/integration/cypress/command_queue_spec.ts
+++ b/packages/driver/cypress/integration/cypress/command_queue_spec.ts
@@ -193,3 +193,34 @@ describe('src/cypress/command_queue', () => {
     })
   })
 })
+
+describe('stability', () => {
+  beforeEach(() => {
+    cy.visit('/fixtures/auth/index.html')
+    cy.window().then((win) => {
+      win.location.href = 'http://localhost:3500/timeout?ms=1000'
+    })
+  })
+
+  it('fails if the page does not load within the page load timeout', { defaultCommandTimeout: 50, pageLoadTimeout: 500 }, (done) => {
+    cy.on('fail', (err) => {
+      expect(err.message).to.include(`Timed out after waiting \`500ms\` for your remote page to load.`)
+      done()
+    })
+
+    cy.get('[data-cy="login-idp"]').click() // Takes you to idp.com
+  })
+
+  it('waits for the page to load before running the command', { defaultCommandTimeout: 50 }, () => {
+    cy.get('body').invoke('text').should('equal', 'timeout')
+  })
+
+  it('will retry and fail the command after the page loads', { defaultCommandTimeout: 50 }, (done) => {
+    cy.on('fail', (err) => {
+      expect(err.message).to.include(`Timed out retrying after 50ms: expected 'timeout' to equal 'not timeout'`)
+      done()
+    })
+
+    cy.get('body').invoke('text').should('equal', 'not timeout')
+  })
+})

--- a/packages/driver/src/cypress/command_queue.ts
+++ b/packages/driver/src/cypress/command_queue.ts
@@ -316,10 +316,10 @@ export class CommandQueue extends Queue<Command> {
       // store the previous timeout
       const prevTimeout = this.timeout()
 
-      // if (!cy.state('isStable')) {
-      //   // console.log('tried to clear timeout in command queue')
-      //   cy.clearTimeout()
-      // }
+      if (!cy.state('isStable')) {
+        // console.log('tried to clear timeout in command queue')
+        cy.clearTimeout()
+      }
 
       // store the current runnable
       const runnable = this.state('runnable')

--- a/packages/driver/src/cypress/command_queue.ts
+++ b/packages/driver/src/cypress/command_queue.ts
@@ -316,6 +316,11 @@ export class CommandQueue extends Queue<Command> {
       // store the previous timeout
       const prevTimeout = this.timeout()
 
+      // if (!cy.state('isStable')) {
+      //   // console.log('tried to clear timeout in command queue')
+      //   cy.clearTimeout()
+      // }
+
       // store the current runnable
       const runnable = this.state('runnable')
 

--- a/packages/driver/src/cypress/command_queue.ts
+++ b/packages/driver/src/cypress/command_queue.ts
@@ -316,8 +316,8 @@ export class CommandQueue extends Queue<Command> {
       // store the previous timeout
       const prevTimeout = this.timeout()
 
+      // If we have created a timeout but are in an unstable state, clear the timeout in favor of the on load timeout already running.
       if (!cy.state('isStable')) {
-        // console.log('tried to clear timeout in command queue')
         cy.clearTimeout()
       }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We discovered a flaky test were with experimentalLoginFlows enabled, on a transition from a before block to an it block while unstable, the command queue would use the command timeout instead of relying on the page load timeout.

This pr corrects it by disabling the timeout during the command queue if the state is unstable.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
