### PR TITLE
fix: Command Log performance v2

### DIFF
--- a/packages/reporter/src/hooks/hooks.scss
+++ b/packages/reporter/src/hooks/hooks.scss
@@ -21,6 +21,7 @@
           color: #6a6b6c;
         }
 
+        .hook-show-all-commands,
         .hook-open-in-ide {
           display: block;
         }
@@ -49,7 +50,9 @@
         display: none;
       }
 
+      .hook-show-all-commands,
       .hook-open-in-ide {
+        cursor: pointer;
         align-items: center;
         color: #6a6b6c;
         display: none;


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This is a followup to https://github.com/cypress-io/cypress/pull/21007.  In this iteration, we limit the amount of commands that show up by default, but we also expose a toggle which when clicked, shows all of the commands.

This is not the ideal solution of "virtualizing" the list to show only what is necessary as the user scrolls, but it is sort of a half way between providing some control over what commands show vs providing no control in the sense that no data is loss, and the user can control whether or not to show all or some of the commands.

Some notes to point out:
* By default, we only show 50 commands, so that local testing and CI runs can benefit from the performance improvements of a short command list
    * If we reversed this and started off showing the full list, and made the truncated list opt-in, than runs in CI would not be able to reap the performance benefits of the feature showcased in this PR
* When the test is running, I think a user is typically not clicking through snapshots as this could interfere with the test itself, so it seems ok to default to showing a small amount of commands, and that showing all commands requires an interaction
* If the user needs to see the rest of the commands and click through the snapshots, they can opt in by clicking "Show all commands"
    * In the use-cases I'm familiar with, it's only when I stop the test, or the test fails, that I might want to do this to further my investigation of a test run

Some gifs to illustrate this behavior, as well as illustrate the performance difference between showing all the commands vs a truncated list:

#### Toggling Between "show 50" and "show all commands"

The gif reveals that as soon as Show All is clicked (to show all the commands), there are immediate performance implications.

Once they click "Show last 50 commands" to re-hide the commands, the performance becomes smooth again

![cypress-fast](https://user-images.githubusercontent.com/3589158/162865691-00de6764-307e-402e-b034-4f723893b09b.gif)

#### llustrating that a user can go back and "show all" to interact with snapshots of any command they want

Even though we show only 50 by default, the user can reveal all the commands, and click on any of them to view the snapshot at that moment in time, so no data loss occurs

![cypress-debug](https://user-images.githubusercontent.com/3589158/162865728-81a3c300-8a1c-439a-9c0a-146960cf056a.gif)




### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
