### PR TITLE
fix: cy.type('{enter}') on <input> elements submits the form correctly after Firefox 98.

### DIFF
--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -233,12 +233,11 @@ export default function (Commands, Cypress, cy, state, config) {
           return
         }
 
-        // In Firefox, submit event is automatically fired
+        // Before Firefox 98, submit event is automatically fired
         // when we send {Enter} KeyboardEvent to the input fields.
         // Because of that, we don't have to click the submit buttons.
         // Otherwise, we trigger submit events twice.
-        // But after Firefox 98, submit event isn't automatically fired.
-        if (!isFirefoxBefore98 || !Cypress.isBrowser('firefox')) {
+        if (!isFirefoxBefore98) {
           // issue the click event to the 'default button' of the form
           // we need this to be synchronous so not going through our
           // own click command

--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -174,6 +174,8 @@ export default function (Commands, Cypress, cy, state, config) {
     }
 
     const type = function () {
+      const isFirefoxBefore98 = Cypress.isBrowser('firefox') && Cypress.browserMajorVersion() < 98
+
       const simulateSubmitHandler = function () {
         const form = options.$el.parents('form')
 
@@ -235,7 +237,8 @@ export default function (Commands, Cypress, cy, state, config) {
         // when we send {Enter} KeyboardEvent to the input fields.
         // Because of that, we don't have to click the submit buttons.
         // Otherwise, we trigger submit events twice.
-        if (!Cypress.isBrowser('firefox')) {
+        // But after Firefox 98, submit event isn't automatically fired.
+        if (!isFirefoxBefore98 || !Cypress.isBrowser('firefox')) {
           // issue the click event to the 'default button' of the form
           // we need this to be synchronous so not going through our
           // own click command
@@ -274,7 +277,6 @@ export default function (Commands, Cypress, cy, state, config) {
 
       const isContentEditable = $elements.isContentEditable(options.$el.get(0))
       const isTextarea = $elements.isTextarea(options.$el.get(0))
-      const isFirefoxBefore98 = Cypress.isBrowser('firefox') && Cypress.browserMajorVersion() < 98
 
       const fireClickEvent = (el) => {
         const ctor = $dom.getDocumentFromElement(el).defaultView!.PointerEvent


### PR DESCRIPTION
- Closes #21033

### User facing changelog

cy.type('{enter}') submits the form correctly after Firefox 98.

### Additional details
- Why was this change necessary? => `Enter` event behavior change in Firefox 98 caused `cy.type('{enter}')` to not submit the `<form>`s.
- What is affected by this change? => N/A
- Any implementation details to explain? => N/A

### How has the user experience changed?

`<form>` is submitted correctly with `cy.type('{enter}')`.

### PR Tasks
- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
