### PR TITLE
fix(cli): show additional mitigation steps for max path length error

### DIFF
--- a/cli/__snapshots__/errors_spec.js
+++ b/cli/__snapshots__/errors_spec.js
@@ -32,6 +32,7 @@ exports['errors individual has the following errors 1'] = [
   "childProcessKilled",
   "failedDownload",
   "failedUnzip",
+  "failedUnzipWindowsMaxPathLength",
   "incompatibleHeadlessFlags",
   "invalidCacheDirectory",
   "invalidCypressEnv",

--- a/cli/__snapshots__/unzip_spec.js
+++ b/cli/__snapshots__/unzip_spec.js
@@ -1,4 +1,4 @@
-exports['unzip error 1'] = `
+exports['lib/tasks/unzip throws when cannot unzip 1'] = `
 Error: The Cypress App could not be unzipped.
 
 Search for an existing issue or open a GitHub issue at
@@ -12,6 +12,24 @@ Error: end of central directory record signature not found
 ----------
 
 Platform: darwin-x64 (Foo-OsVersion)
+Cypress Version: 1.2.3
+
+`
+
+exports['lib/tasks/unzip throws max path length error when cannot unzip due to realpath ENOENT on windows 1'] = `
+Error: The Cypress App could not be unzipped.
+
+This is most likely because the maximum path length is being exceeded on your system.
+
+Read here for solutions to this problem: https://on.cypress.io/error-messages#win-max-path-length
+
+----------
+
+Error: failed
+
+----------
+
+Platform: win32-x64 (Foo-OsVersion)
 Cypress Version: 1.2.3
 
 `

--- a/cli/__snapshots__/unzip_spec.js
+++ b/cli/__snapshots__/unzip_spec.js
@@ -21,7 +21,7 @@ Error: The Cypress App could not be unzipped.
 
 This is most likely because the maximum path length is being exceeded on your system.
 
-Read here for solutions to this problem: https://on.cypress.io/error-messages#win-max-path-length
+Read here for solutions to this problem: https://on.cypress.io/win-max-path-length-error
 
 ----------
 

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -58,6 +58,13 @@ const failedUnzip = {
   solution: genericErrorSolution,
 }
 
+const failedUnzipWindowsMaxPathLength = {
+  description: 'The Cypress App could not be unzipped.',
+  solution: `This is most likely because the maximum path length is being exceeded on your system.
+
+  Read here for solutions to this problem: https://on.cypress.io/error-messages#win-max-path-length`,
+}
+
 const missingApp = (binaryDir) => {
   return {
     description: `No version of Cypress is installed in: ${chalk.cyan(
@@ -404,6 +411,7 @@ module.exports = {
     unexpected,
     failedDownload,
     failedUnzip,
+    failedUnzipWindowsMaxPathLength,
     invalidCypressEnv,
     invalidCacheDirectory,
     CYPRESS_RUN_BINARY,

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -62,7 +62,7 @@ const failedUnzipWindowsMaxPathLength = {
   description: 'The Cypress App could not be unzipped.',
   solution: `This is most likely because the maximum path length is being exceeded on your system.
 
-  Read here for solutions to this problem: https://on.cypress.io/error-messages#win-max-path-length`,
+  Read here for solutions to this problem: https://on.cypress.io/win-max-path-length-error`,
 }
 
 const missingApp = (binaryDir) => {

--- a/cli/lib/tasks/unzip.js
+++ b/cli/lib/tasks/unzip.js
@@ -3,7 +3,6 @@ const la = require('lazy-ass')
 const is = require('check-more-types')
 const cp = require('child_process')
 const os = require('os')
-const path = require('path')
 const yauzl = require('yauzl')
 const debug = require('debug')('cypress:cli:unzip')
 const extract = require('extract-zip')
@@ -196,24 +195,8 @@ const unzip = ({ zipFilePath, installDir, progress }) => {
   })
 }
 
-async function isWindowsMaxFilePathError (err) {
-  if (!(os.platform === 'win32' && err.code === 'ENOENT' && err.syscall === 'realpath')) return false
-
-  // an ENOENT on realpath on Windows is usually due to the max path length restriction.
-  // do a test write to confirm if they have this restriction.
-  const tmp = os.tmpdir()
-  let longPath = path.join(tmp, `cy-long-filename-test-`)
-
-  longPath += 'a'.repeat(Math.max(270 - longPath.length, 0))
-
-  try {
-    await fs.writeFile(longPath, 'this is a test to see if this system supports extra-long filenames')
-  } catch (err) {
-    // if an ENOENT error occurred, we are hitting the max path length
-    return err.code === 'ENOENT'
-  }
-
-  return false
+function isMaybeWindowsMaxPathLengthError (err) {
+  return os.platform() === 'win32' && err.code === 'ENOENT' && err.syscall === 'realpath'
 }
 
 const start = async ({ zipFilePath, installDir, progress }) => {
@@ -235,8 +218,8 @@ const start = async ({ zipFilePath, installDir, progress }) => {
 
     await unzip({ zipFilePath, installDir, progress })
   } catch (err) {
-    const errorTemplate = (await isWindowsMaxFilePathError(err)) ?
-      errors.failedUnzipWindowsMaxFilePath
+    const errorTemplate = isMaybeWindowsMaxPathLengthError(err) ?
+      errors.failedUnzipWindowsMaxPathLength
       : errors.failedUnzip
 
     await throwFormErrorText(errorTemplate)(err)

--- a/cli/lib/tasks/unzip.js
+++ b/cli/lib/tasks/unzip.js
@@ -195,7 +195,7 @@ const unzip = ({ zipFilePath, installDir, progress }) => {
   })
 }
 
-const start = ({ zipFilePath, installDir, progress }) => {
+const start = async ({ zipFilePath, installDir, progress }) => {
   la(is.unemptyString(installDir), 'missing installDir')
   if (!progress) {
     progress = { onProgress: () => {
@@ -203,18 +203,19 @@ const start = ({ zipFilePath, installDir, progress }) => {
     } }
   }
 
-  return fs.pathExists(installDir)
-  .then((exists) => {
-    if (exists) {
+  try {
+    const installDirExists = await fs.pathExists(installDir)
+
+    if (installDirExists) {
       debug('removing existing unzipped binary', installDir)
 
-      return fs.removeAsync(installDir)
+      await fs.removeAsync(installDir)
     }
-  })
-  .then(() => {
-    return unzip({ zipFilePath, installDir, progress })
-  })
-  .catch(throwFormErrorText(errors.failedUnzip))
+
+    await unzip({ zipFilePath, installDir, progress })
+  } catch (err) {
+    await throwFormErrorText(errors.failedUnzip)(err)
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes UNIFY-1449

### User facing changelog

- Improved the error message Cypress throws when max file length is exceeded on Windows platforms and added mitigation steps.
- This is pretty easy to check - the syscall is always `realpath` and the code is always `ENOENT` when this throws.
- Could have done an even more excessive check like in [155742b](https://github.com/cypress-io/cypress/pull/21047/commits/155742b0131fd5166d61820ef87c57a3fce3f650) but I think this is not necessary.
- Also opened a docs PR for the mitigation steps: https://github.com/cypress-io/cypress-documentation/pull/4437
- And an onlink PR: https://github.com/cypress-io/cypress-services/pull/4441

### Additional details

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->https://github.com/cypress-io/cypress-documentation/pull/4437
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
