### PR TITLE
fix: add possible frameworks to object API config

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2987,11 +2987,11 @@ declare namespace Cypress {
 
   type DevServerConfigObject = {
     bundler: 'webpack'
-    framework: 'react'
+    framework: 'react' | 'vue' | 'vue-cli' | 'nuxt' | 'create-react-app'
     webpackConfig?: PickConfigOpt<'webpackConfig'>
   } | {
     bundler: 'vite'
-    framework: 'react'
+    framework: 'react' | 'vue'
     viteConfig?: Omit<Exclude<PickConfigOpt<'viteConfig'>, undefined>, 'base' | 'root'>
   }
 

--- a/system-tests/project-fixtures/cra/cypress.config.ts
+++ b/system-tests/project-fixtures/cra/cypress.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'cypress'
 
-module.exports = defineConfig({
+export default defineConfig({
   component: {
     devServer: {
       framework: 'create-react-app',

--- a/system-tests/project-fixtures/nuxtjs2/cypress.config.ts
+++ b/system-tests/project-fixtures/nuxtjs2/cypress.config.ts
@@ -1,8 +1,10 @@
-module.exports = {
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
   component: {
     devServer: {
       framework: 'nuxt',
       bundler: 'webpack'
     }
   },
-}
+})

--- a/system-tests/project-fixtures/vue-cli/cypress.config.ts
+++ b/system-tests/project-fixtures/vue-cli/cypress.config.ts
@@ -1,8 +1,10 @@
-module.exports = {
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
   component: {
     devServer: {
       framework: 'vue-cli',
       bundler: 'webpack'
     }
   },
-}
+})


### PR DESCRIPTION
### Additional details
Fixes the types for the frameworks in the Cypress `d.ts`

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
