### PR TITLE
fix: remove asset size warnings and enable nuxt e2e tests

### DIFF
--- a/npm/webpack-dev-server-fresh/cypress.config.ts
+++ b/npm/webpack-dev-server-fresh/cypress.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'cypress'
 export default defineConfig({
   projectId: 'ypt4pf',
   e2e: {
-    defaultCommandTimeout: 10000, // these take a bit longer b/c they're e2e open mode test
+    defaultCommandTimeout: 20000, // these take a bit longer b/c they're e2e open mode test
     async setupNodeEvents (on, config) {
       if (!process.env.HTTP_PROXY_TARGET_FOR_ORIGIN_REQUESTS) {
         throw new Error('HTTP_PROXY_TARGET_FOR_ORIGIN_REQUESTS is missing. Close Cypress and run tests using the `yarn cypress:*` commands from the `packages/app` directory')

--- a/npm/webpack-dev-server-fresh/cypress/e2e/create-react-app.cy.ts
+++ b/npm/webpack-dev-server-fresh/cypress/e2e/create-react-app.cy.ts
@@ -38,7 +38,7 @@ for (const project of WEBPACK_REACT) {
         )
       })
 
-      cy.get('.failed > .num', { timeout: 10000 }).should('contain', 1)
+      cy.get('.failed > .num').should('contain', 1)
 
       cy.withCtx(async (ctx) => {
         await ctx.actions.file.writeFileInProject(

--- a/npm/webpack-dev-server-fresh/cypress/e2e/nuxt.cy.ts
+++ b/npm/webpack-dev-server-fresh/cypress/e2e/nuxt.cy.ts
@@ -2,7 +2,7 @@
 /// <reference path="../support/e2e.ts" />
 import type { ProjectFixtureDir } from '@tooling/system-tests/lib/fixtureDirs'
 
-const PROJECTS: ProjectFixtureDir[] = ['nuxtjs2', 'vuecli4-vue2']
+const PROJECTS: ProjectFixtureDir[] = ['nuxtjs2']
 
 // Add to this list to focus on a particular permutation
 const ONLY_PROJECTS: ProjectFixtureDir[] = []
@@ -14,16 +14,55 @@ for (const project of PROJECTS) {
 
   // TODO: This will work once `cypress/vue2` is bundled in the binary
   // Since Nuxt.js 2 is based on `vue@2`.
-  describe.skip(`Working with ${project}`, () => {
+  describe(`Working with ${project}`, () => {
     beforeEach(() => {
       cy.scaffoldProject(project)
       cy.openProject(project)
       cy.startAppServer('component')
     })
 
-    it('should mount a passing test', () => {
+    it('should mount a passing test and live-reload', () => {
       cy.visitApp()
       cy.contains('Tutorial.cy.js').click()
+      cy.get('.passed > .num').should('contain', 1)
+
+      cy.withCtx(async (ctx) => {
+        const tutorialVuePath = ctx.path.join('components', 'Tutorial.vue')
+
+        await ctx.actions.file.writeFileInProject(
+          tutorialVuePath,
+          (await ctx.file.readFileInProject(tutorialVuePath)).replace('Nuxt', 'Tutorial'),
+        )
+      })
+
+      cy.get('.failed > .num', { timeout: 10000 }).should('contain', 1)
+
+      cy.withCtx(async (ctx) => {
+        const tutorialCyPath = ctx.path.join('components', 'Tutorial.cy.js')
+
+        await ctx.actions.file.writeFileInProject(
+          tutorialCyPath,
+          (await ctx.file.readFileInProject(tutorialCyPath)).replace('Nuxt', 'Tutorial'),
+        )
+      })
+
+      cy.get('.passed > .num').should('contain', 1)
+    })
+
+    it('should detect new spec', () => {
+      cy.visitApp()
+
+      cy.withCtx(async (ctx) => {
+        const newSpecPath = ctx.path.join('components', 'New.cy.js')
+        const tutorialCyPath = ctx.path.join('components', 'Tutorial.cy.js')
+
+        await ctx.actions.file.writeFileInProject(
+          newSpecPath,
+          await ctx.file.readFileInProject(tutorialCyPath),
+        )
+      })
+
+      cy.contains('New.cy.js').click()
       cy.get('.passed > .num').should('contain', 1)
     })
   })

--- a/npm/webpack-dev-server-fresh/cypress/e2e/nuxt.cy.ts
+++ b/npm/webpack-dev-server-fresh/cypress/e2e/nuxt.cy.ts
@@ -35,7 +35,7 @@ for (const project of PROJECTS) {
         )
       })
 
-      cy.get('.failed > .num', { timeout: 10000 }).should('contain', 1)
+      cy.get('.failed > .num').should('contain', 1)
 
       cy.withCtx(async (ctx) => {
         const tutorialCyPath = ctx.path.join('components', 'Tutorial.cy.js')

--- a/npm/webpack-dev-server-fresh/src/helpers/nuxtHandler.ts
+++ b/npm/webpack-dev-server-fresh/src/helpers/nuxtHandler.ts
@@ -16,6 +16,10 @@ export async function nuxtHandler ({ devServerConfig }: PresetHandler): Promise<
 
     const webpackConfig = await getWebpackConfig()
 
+    // Nuxt has asset size warnings configured by default which will cause webpack overlays to appear
+    // in the browser which we don't want.
+    delete webpackConfig.performance
+
     debug('webpack config %o', webpackConfig)
 
     return webpackConfig

--- a/npm/webpack-dev-server-fresh/test/handlers/nuxtHandler.spec.ts
+++ b/npm/webpack-dev-server-fresh/test/handlers/nuxtHandler.spec.ts
@@ -19,5 +19,6 @@ describe('nuxtHandler', function () {
 
     // Verify it's a Vue-specific webpack config by seeing if VueLoader is present.
     expect(config.plugins.find((plug) => plug.constructor.name === 'VueLoader'))
+    expect(config.performance).to.be.undefined
   })
 })

--- a/system-tests/project-fixtures/nuxtjs2/cypress.config.ts
+++ b/system-tests/project-fixtures/nuxtjs2/cypress.config.ts
@@ -4,7 +4,15 @@ export default defineConfig({
   component: {
     devServer: {
       framework: 'nuxt',
-      bundler: 'webpack'
-    }
+      bundler: 'webpack',
+      // Necessary due to cypress/vue resolving from cypress/node_modules rather than the project root
+      webpackConfig: {
+        resolve: {
+          alias: {
+            'vue': require.resolve('vue'),
+          }
+        }
+      }
+    },
   },
 })


### PR DESCRIPTION
- Closes [UNIFY-1210](https://cypress-io.atlassian.net/browse/UNIFY-1210)

### User facing changelog
Remove asset size warnings from nuxt webpack-dev-server

### Additional details
The default nuxt webpack config has `webpack.performance` configured which causes an overlay in the browser if a bundle is too large. This is unnecessary for development/testing purposes so the `performance` object is now removed from the webpack configuration.

I enabled the tests for nuxt now that `cypress/vue2` has been merged. Had to add a webpack alias to the system test to get around a module resolution issue that is specific to system-tests. The system-tests for nuxt are slower than the rest as it takes longer for webpack to recompile the files so I bumped the `defaultCommandTimeout`.

### How has the user experience changed?
Two tests, first showing the unwanted overlay and second after the removal.

https://user-images.githubusercontent.com/25158820/163271295-bd1eb136-63f9-4c54-959c-fc8cc64e6a66.mov

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
