### PR TITLE
chore: fix windows node_modules install step

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -31,6 +31,12 @@ mainBuildFilters: &mainBuildFilters
         - 10.0-release
         - unify-1449-check-path-length-in-build
 
+# allows us to disable the main flow if we don't want to test it for a certain branch
+linuxWorkflowFilters: &linux-workflow-filters
+  unless:
+    or:
+    - equal: [ 'tgriesser/chore/fix-windows-build', << pipeline.git.branch >> ]
+
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
 # so just add your branch to the list here to build and test on Mac
@@ -49,7 +55,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
     - equal: [ '10.0-release', << pipeline.git.branch >> ]
-    - equal: [ unify-1449-check-path-length-in-build, << pipeline.git.branch >> ]
+    - equal: [ 'tgriesser/chore/fix-windows-build', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -2535,6 +2541,7 @@ windows-workflow: &windows-workflow
 workflows:
   linux:
     <<: *linux-workflow
+    <<: *linux-workflow-filters
   mac:
     <<: *mac-workflow
     <<: *mac-workflow-filters

--- a/circle.yml
+++ b/circle.yml
@@ -281,14 +281,14 @@ commands:
               circleci-agent step halt
             fi
       - run: date +%Y-%U > cache_date
-      - restore_cache:
-          name: Restore weekly yarn cache
-          keys:
-            - v{{ .Environment.CACHE_VERSION }}-{{ checksum "platform_key" }}-deps-root-weekly-{{ checksum "cache_date" }}
+      # - restore_cache:
+      #     name: Restore weekly yarn cache
+      #     keys:
+      #       - v{{ .Environment.CACHE_VERSION }}-{{ checksum "platform_key" }}-deps-root-weekly-{{ checksum "cache_date" }}
       - run:
           name: Install Node Modules
           command: |
-            yarn --prefer-offline --frozen-lockfile
+            yarn --frozen-lockfile
           no_output_timeout: 20m
       - prepare-modules-cache:
           dont-move: <<parameters.only-cache-for-root-user>> # we don't move, so we don't hit any issues unpacking symlinks

--- a/circle.yml
+++ b/circle.yml
@@ -31,11 +31,13 @@ mainBuildFilters: &mainBuildFilters
         - 10.0-release
         - unify-1449-check-path-length-in-build
 
-# allows us to disable the main flow if we don't want to test it for a certain branch
-linuxWorkflowFilters: &linux-workflow-filters
+# uncomment & add to the branch conditions below to disable the main linux
+# flow if we don't want to test it for a certain branch
+linuxWorkflowExcludeFilters: &linux-workflow-exclude-filters
   unless:
     or:
-    - equal: [ 'tgriesser/chore/fix-windows-build', << pipeline.git.branch >> ]
+    - false
+    # - equal: [ 'tgriesser/chore/fix-windows-build', << pipeline.git.branch >> ]
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -2541,7 +2543,7 @@ windows-workflow: &windows-workflow
 workflows:
   linux:
     <<: *linux-workflow
-    <<: *linux-workflow-filters
+    <<: *linux-workflow-exclude-filters
   mac:
     <<: *mac-workflow
     <<: *mac-workflow-filters

--- a/circle.yml
+++ b/circle.yml
@@ -288,7 +288,7 @@ commands:
       - run:
           name: Install Node Modules
           command: |
-            yarn --prefer-offline --frozen-lockfile --cache-folder ~/.yarn
+            yarn --prefer-offline --frozen-lockfile
           no_output_timeout: 20m
       - prepare-modules-cache:
           dont-move: <<parameters.only-cache-for-root-user>> # we don't move, so we don't hit any issues unpacking symlinks

--- a/circle.yml
+++ b/circle.yml
@@ -281,14 +281,14 @@ commands:
               circleci-agent step halt
             fi
       - run: date +%Y-%U > cache_date
-      # - restore_cache:
-      #     name: Restore weekly yarn cache
-      #     keys:
-      #       - v{{ .Environment.CACHE_VERSION }}-{{ checksum "platform_key" }}-deps-root-weekly-{{ checksum "cache_date" }}
+      - restore_cache:
+          name: Restore weekly yarn cache
+          keys:
+            - v{{ .Environment.CACHE_VERSION }}-{{ checksum "platform_key" }}-deps-root-weekly-{{ checksum "cache_date" }}
       - run:
           name: Install Node Modules
           command: |
-            yarn --frozen-lockfile
+            yarn --prefer-offline --frozen-lockfile --cache-folder ~/.yarn
           no_output_timeout: 20m
       - prepare-modules-cache:
           dont-move: <<parameters.only-cache-for-root-user>> # we don't move, so we don't hit any issues unpacking symlinks

--- a/cli/scripts/post-install.js
+++ b/cli/scripts/post-install.js
@@ -25,6 +25,8 @@ fs.ensureDirSync(join(__dirname, '..', 'types'))
 includeTypes.forEach((folder) => {
   const source = resolvePkg(`@types/${folder}`, { cwd: __dirname })
 
+  console.log(`copying ${folder} from ${source}`)
+
   fs.copySync(source, join(__dirname, '..', 'types', folder))
 })
 

--- a/npm/webpack-dev-server-fresh/package.json
+++ b/npm/webpack-dev-server-fresh/package.json
@@ -21,7 +21,7 @@
     "html-webpack-plugin-4": "npm:html-webpack-plugin@^4",
     "html-webpack-plugin-5": "npm:html-webpack-plugin@^5",
     "speed-measure-webpack-plugin": "1.4.2",
-    "tsutils": "^3.21.0",
+    "tslib": "^2.3.1",
     "webpack-dev-server": "^4.7.4",
     "webpack-merge": "^5.4.0"
   },
@@ -32,7 +32,6 @@
     "chai": "^4.3.6",
     "mocha": "^9.2.2",
     "proxyquire": "2.1.3",
-    "rimraf": "3.0.2",
     "sinon": "^13.0.1",
     "snap-shot-it": "^7.9.6",
     "ts-node": "^10.2.1",

--- a/npm/webpack-dev-server-fresh/package.json
+++ b/npm/webpack-dev-server-fresh/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "html-webpack-plugin-4": "npm:html-webpack-plugin@^4",
     "html-webpack-plugin-5": "npm:html-webpack-plugin@^5",
-    "rimraf": "3.0.2",
     "speed-measure-webpack-plugin": "1.4.2",
     "tsutils": "^3.21.0",
     "webpack-dev-server": "^4.7.4",
@@ -33,6 +32,7 @@
     "chai": "^4.3.6",
     "mocha": "^9.2.2",
     "proxyquire": "2.1.3",
+    "rimraf": "3.0.2",
     "sinon": "^13.0.1",
     "snap-shot-it": "^7.9.6",
     "ts-node": "^10.2.1",

--- a/system-tests/package.json
+++ b/system-tests/package.json
@@ -75,6 +75,7 @@
     "multer": "1.4.2",
     "nock": "12.0.2",
     "proxyquire": "2.1.3",
+    "rimraf": "3.0.2",
     "semver": "7.3.2",
     "sinon": "5.1.1",
     "snap-shot-it": "7.9.3",

--- a/system-tests/package.json
+++ b/system-tests/package.json
@@ -75,7 +75,6 @@
     "multer": "1.4.2",
     "nock": "12.0.2",
     "proxyquire": "2.1.3",
-    "rimraf": "3.0.2",
     "semver": "7.3.2",
     "sinon": "5.1.1",
     "snap-shot-it": "7.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -42009,7 +42009,7 @@ tslib@2.1.0, tslib@~2.1.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
-tslib@2.3.1, tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0, tslib@~2.3.0:
+tslib@2.3.1, tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.3.1, tslib@~2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -42098,7 +42098,7 @@ tsutils@^2.29.0:
   dependencies:
     tslib "^1.8.1"
 
-tsutils@^3.17.1, tsutils@^3.21.0:
+tsutils@^3.17.1:
   version "3.21.0"
   resolved "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==


### PR DESCRIPTION
### User facing changelog

N/A

### Additional details

Fixes the windows CI failing at the `node_modules` step after #20951 - seemingly just because we added `rimraf` to dependencies. Don't have time to do a full diagnosis, but it seems the symlinking + hoisting + rimraf 

Adds a `linux-workflow-filters` if we want to skip the linux workflow on WIP branches

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
