### PR TITLE
Feat/brotli deflate support

### DIFF
--- a/packages/proxy/lib/http/index.ts
+++ b/packages/proxy/lib/http/index.ts
@@ -20,6 +20,12 @@ import { DeferredSourceMapCache } from '@packages/rewriter'
 
 const debugRequests = Debug('cypress-verbose:proxy:http')
 
+export const AllowedContentEncodings = [
+  'gzip',
+  'deflate',
+  'br',
+]
+
 export enum HttpStages {
   IncomingRequest,
   IncomingResponse,

--- a/packages/proxy/lib/http/request-middleware.ts
+++ b/packages/proxy/lib/http/request-middleware.ts
@@ -3,6 +3,7 @@ import { blocked, cors } from '@packages/network'
 import { InterceptRequest } from '@packages/net-stubbing'
 import debugModule from 'debug'
 import type { HttpMiddleware } from './'
+// eslint-disable-next-line no-duplicate-imports
 import { AllowedContentEncodings } from './'
 
 export type RequestMiddleware = HttpMiddleware<{

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -5,6 +5,7 @@ import { cors, concatStream, httpUtils } from '@packages/network'
 import type { CypressIncomingRequest, CypressOutgoingResponse } from '@packages/proxy'
 import debugModule from 'debug'
 import type { HttpMiddleware } from '.'
+// eslint-disable-next-line no-duplicate-imports
 import { AllowedContentEncodings } from '.'
 import iconv from 'iconv-lite'
 import type { IncomingMessage, IncomingHttpHeaders } from 'http'
@@ -157,6 +158,7 @@ const AttachPlainTextStreamFn: ResponseMiddleware = function () {
         if (!AllowedContentEncodings.includes(encoding)) {
           debug('received unsupported content encoding: %s, not uncompressing body', encoding)
           this.next()
+
           return
         }
       }

--- a/packages/proxy/test/unit/http/response-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/response-middleware.spec.ts
@@ -24,7 +24,7 @@ describe('http/response-middleware', function () {
       'MaybeEndWithEmptyBody',
       'MaybeInjectHtml',
       'MaybeRemoveSecurity',
-      'GzipBody',
+      'ReCompressBody',
       'SendResponseBodyToClient',
     ])
   })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes the following issues:
  - https://github.com/cypress-io/cypress/issues/6197
  - https://github.com/cypress-io/cypress/issues/9029
 - and implements `Brotli` as suggested in https://github.com/cypress-io/cypress/issues/535

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
Does this count as user facing? If so...

Support `Brotli` and `deflate` as content-encoding methods for increased compatibility and performance.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

<https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding>
<https://en.wikipedia.org/wiki/Brotli>

- Why was this change necessary?
  - The `cypress` interception proxy currently only supports `gzip` and plaintext content encoding. This change adds `Brotli` and `deflate` support
  - Faced issues end to end testing a website with compressed `Brotli` assets
  - Brotli support has been added over the years to web browsers, with 94% of worldwide users using a browser that supports the format
- What is affected by this change?
  - Cypress `proxy` module
- Any implementation details to explain?
  - The change is implemented a similar way to the `gzip` support, but as it now supports multiple content-encodings there's a need to loop through the `content-encoding` header to decompress and compress in the order they were applied instead of explicitly checking for the encoding method
  - There are no tests for `gzip` encoding so I did not add any tests for the new encodings

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

`Brotli` and `deflate` requests will no longer return no content and instead return desired content.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
