### PR TITLE
fix: revert "fix: types for Cypress.Commands.add (#20376)"

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -10,12 +10,10 @@ declare namespace Cypress {
   type PrevSubject = keyof PrevSubjectMap
   type TestingType = 'e2e' | 'component'
   type PluginConfig = (on: PluginEvents, config: PluginConfigOptions) => void | ConfigOptions | Promise<ConfigOptions>
-  interface JQueryWithSelector<TElement = HTMLElement> extends JQuery<TElement> {
-    selector?: string | null
-  }
+
   interface PrevSubjectMap<O = unknown> {
     optional: O
-    element: JQueryWithSelector
+    element: JQuery
     document: Document
     window: Window
   }
@@ -469,9 +467,8 @@ declare namespace Cypress {
     Commands: {
       add<T extends keyof Chainable>(name: T, fn: CommandFn<T>): void
       add<T extends keyof Chainable>(name: T, options: CommandOptions & {prevSubject: false}, fn: CommandFn<T>): void
-      add<T extends keyof Chainable, S = any>(name: T, options: CommandOptions & {prevSubject: true}, fn: CommandFnWithSubject<T, S>): void
       add<T extends keyof Chainable, S extends PrevSubject>(
-          name: T, options: CommandOptions & { prevSubject: S | ['optional'] }, fn: CommandFnWithSubject<T, PrevSubjectMap[S]>,
+          name: T, options: CommandOptions & { prevSubject: true | S | ['optional'] }, fn: CommandFnWithSubject<T, PrevSubjectMap[S]>,
       ): void
       add<T extends keyof Chainable, S extends PrevSubject>(
           name: T, options: CommandOptions & { prevSubject: S[] }, fn: CommandFnWithSubject<T, PrevSubjectMap<void>[S]>,

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -83,7 +83,7 @@ namespace CypressCommandsTests {
     arg // $ExpectType string
   })
   Cypress.Commands.add('newCommand', { prevSubject: true }, (subject, arg) => {
-    subject // $ExpectType any
+    subject // $ExpectType unknown
     arg // $ExpectType string
     return
   })
@@ -113,13 +113,11 @@ namespace CypressCommandsTests {
     arg // $ExpectType string
   })
   Cypress.Commands.add('newCommand', { prevSubject: 'element' }, (subject, arg) => {
-    subject // $ExpectType JQueryWithSelector<HTMLElement>
-    subject.selector // $ExpectType string | null | undefined
+    subject // $ExpectType JQuery<HTMLElement>
     arg // $ExpectType string
   })
   Cypress.Commands.add('newCommand', { prevSubject: ['element'] }, (subject, arg) => {
-    subject // $ExpectType JQueryWithSelector<HTMLElement>
-    subject.selector // $ExpectType string | null | undefined
+    subject // $ExpectType JQuery<HTMLElement>
     arg // $ExpectType string
   })
   Cypress.Commands.add('newCommand', { prevSubject: ['element', 'document', 'window'] }, (subject, arg) => {
@@ -128,8 +126,7 @@ namespace CypressCommandsTests {
     } else if (subject instanceof Document) {
       subject // $ExpectType Document
     } else {
-      subject // $ExpectType JQueryWithSelector<HTMLElement>
-      subject.selector // $ExpectType string | null | undefined
+      subject // $ExpectType JQuery<HTMLElement>
     }
     arg // $ExpectType string
   })
@@ -139,7 +136,7 @@ namespace CypressCommandsTests {
     } else if (subject instanceof Document) {
       subject // $ExpectType Document
     } else if (subject) {
-      subject // $ExpectType JQueryWithSelector<HTMLElement>
+      subject // $ExpectType JQuery<HTMLElement>
     } else {
       subject // $ExpectType void
     }
@@ -274,7 +271,7 @@ namespace CypressCommandsTests {
     originalFn.apply(this, [arg]) // $ExpectType Chainable<number>
   })
   Cypress.Commands.overwrite<'type', 'element'>('type', (originalFn, element, text, options?: Partial<Cypress.TypeOptions & {sensitive: boolean}>) => {
-    element // $ExpectType JQueryWithSelector<HTMLElement>
+    element // $ExpectType JQuery<HTMLElement>
     text // $ExpectType string
 
     if (options && options.sensitive) {


### PR DESCRIPTION
Reverts cypress-io/cypress#20377

This merge caused unintentional type check failures ( 92d94252ca90c10d65b4d8ce4a5b6bbebed87b18 ) because I didn't update the PR with `develop` before merging :grimacing: 

Failure: https://app.circleci.com/pipelines/github/cypress-io/cypress/36421/workflows/c59bf671-cfde-4305-83b3-d46fbc95c0fc/jobs/1458838

Once this merges I'll ask the original contributor to re-open a PR against develop.