### PR TITLE
fix: ct project setup framework keys for next and nuxt

### DIFF
--- a/packages/scaffold-config/src/frameworks.ts
+++ b/packages/scaffold-config/src/frameworks.ts
@@ -166,7 +166,7 @@ export const WIZARD_FRAMEWORKS = [
   {
     type: 'nextjs',
     category: 'template',
-    configFramework: 'nextjs',
+    configFramework: 'next',
     name: 'Next.js',
     detectors: [dependencies.WIZARD_DEPENDENCY_NEXT],
     supportedBundlers: [dependencies.WIZARD_DEPENDENCY_WEBPACK],
@@ -184,7 +184,7 @@ export const WIZARD_FRAMEWORKS = [
   },
   {
     type: 'nuxtjs',
-    configFramework: 'nuxtjs',
+    configFramework: 'nuxt',
     category: 'template',
     name: 'Nuxt.js',
     detectors: [dependencies.WIZARD_DEPENDENCY_NUXT],


### PR DESCRIPTION
### User facing changelog
Use correct keys for ct frameworks based on [tech-brief](https://github.com/cypress-io/tech-briefs/tree/main/briefs/ct-architectural-improvements)

### Additional details
We have a mismatch of the keys the dev-servers expect vs what we scaffold.

We should be able to extract a type of webpack frameworks vs vite frameworks from the `WIZARD_FRAMEWORKS` but I'm no typescript wizard, so opted to fix it for now.

### How has the user experience changed?
CT project setup will now scaffold a config with the proper framework key.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
