### PR TITLE
fix: remove MountReturn from scaffolded ct support file

### DIFF
--- a/packages/scaffold-config/src/supportFile.ts
+++ b/packages/scaffold-config/src/supportFile.ts
@@ -61,7 +61,6 @@ export function supportFileComponent (language: CodeLanguage['type'], framework:
   if (language === 'ts') {
     const registerMount = dedent`
       import { mount } from '${framework.mountModule}'
-      import type { MountReturn } from '${framework.mountModule}'
 
       // Augment the Cypress namespace to include type definitions for
       // your custom command.

--- a/packages/scaffold-config/test/unit/supportFile.spec.ts
+++ b/packages/scaffold-config/test/unit/supportFile.spec.ts
@@ -68,7 +68,6 @@ describe('supportFileComponent', () => {
     // require('./commands')
 
     import { mount } from 'cypress/react'
-    import type { MountReturn } from 'cypress/react'
 
     // Augment the Cypress namespace to include type definitions for
     // your custom command.
@@ -149,7 +148,6 @@ describe('supportFileComponent', () => {
     // require('./commands')
 
     import { mount } from 'cypress/vue'
-    import type { MountReturn } from 'cypress/vue'
 
     // Augment the Cypress namespace to include type definitions for
     // your custom command.

--- a/system-tests/projects/pristine/expected-cypress-ts-component-create-react-app-v5/cypress/support/component.ts
+++ b/system-tests/projects/pristine/expected-cypress-ts-component-create-react-app-v5/cypress/support/component.ts
@@ -20,7 +20,6 @@ import './commands'
 // require('./commands')
 
 import { mount } from 'cypress/react'
-import type { MountReturn } from 'cypress/react'
 
 // Augment the Cypress namespace to include type definitions for
 // your custom command.


### PR DESCRIPTION
### User facing changelog
Remove unused `MountReturn` import from scaffolded support file

### Additional details
`MountReturn` isn't an exported or defined type for `@cypress/vue` so it was throwing an error on project setup. We never used it anyway since we were scaffolding:
```
declare global {
  namespace Cypress {
    interface Chainable {
      mount: typeof mount
    }
  }
}
```

Since we do `typeof mount`, the return type is derived from `mount`.

### How has the user experience changed?
The `component.ts` file no longer has an invalid import.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
