### PR TITLE
fix: remove relative vite import

### DIFF
--- a/packages/server/lib/plugins/child/run_require_async_child.js
+++ b/packages/server/lib/plugins/child/run_require_async_child.js
@@ -77,7 +77,7 @@ function run (ipc, file, projectRoot) {
       }
 
       if (devServer.bundler === 'vite') {
-        return { devServer: require('../../../../../npm/vite-dev-server').devServer, objApi: true }
+        return { devServer: require('@cypress/vite-dev-server').devServer, objApi: true }
       }
     }
 


### PR DESCRIPTION
Remove relative import of vite from run `packages/server/lib/plugins/child/run_require_async_child.js`
