### PR TITLE
chore: add missing dep to server/package.json

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -59,6 +59,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ '10.0-release', << pipeline.git.branch >> ]
     - equal: [ chore/cutover-to-bundled-react-mount, << pipeline.git.branch >> ]
     - equal: [ 'unify-1036-windows-test-projects', << pipeline.git.branch >> ]
+    - equal: [ 'lmiller1990/fixing-windows-build-artifacts', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -133,6 +133,7 @@
     "@cypress/debugging-proxy": "2.0.1",
     "@cypress/json-schemas": "5.39.0",
     "@cypress/sinon-chai": "2.9.1",
+    "@cypress/vite-dev-server": "0.0.0-development",
     "@cypress/webpack-dev-server": "0.0.0-development",
     "@ffprobe-installer/ffprobe": "1.1.0",
     "@packages/config": "0.0.0-development",


### PR DESCRIPTION
Added missing dependency to `server/package.json` -  we've got `@cypress/webpack-dev-server` as a devDep, we should also have `@cypress/vite-dev-server`, since we are using it during development. 

Edit: potentially we don't need *either* of these as devDeps. In that case, we might just remove them both. I'll come back to this.

I initially thought this was causing some build artefact steps to fail on CI, but now I think those were just flaky. Either way, good to include this dependency.
