### PR TITLE
fix: prevent showing project cache if user is not member

### DIFF
--- a/packages/app/cypress/e2e/runs.cy.ts
+++ b/packages/app/cypress/e2e/runs.cy.ts
@@ -520,6 +520,51 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
         expect((ctx.actions.electron.openExternal as SinonStub).lastCall.lastArg).to.eq('http://dummy.cypress.io/runs/0')
       })
     })
+
+    it('displays a list of recorded runs if a run has been recorded and remove them if user has been removed of project', () => {
+      cy.remoteGraphQLIntercept(async (obj) => {
+        if (obj.result.data?.cloudProjectsBySlugs && obj.callCount > 1) {
+          for (let proj of obj.result.data.cloudProjectsBySlugs) {
+            proj.__typename = 'CloudProjectUnauthorized'
+            proj.message = 'Cloud Project Unauthorized'
+            proj.hasRequestedAccess = false
+
+            delete proj.recordKeys
+            delete proj.runs
+          }
+        }
+
+        return obj.result
+      })
+
+      cy.loginUser()
+      cy.visitApp()
+      cy.get('[href="#/runs"]').click()
+      cy.get('[href="http://dummy.cypress.io/runs/0"]').first().within(() => {
+        cy.findByText('fix: make gql work CANCELLED')
+        cy.get('[data-cy="run-card-icon"]')
+      })
+
+      cy.get('[href="http://dummy.cypress.io/runs/1"]').first().within(() => {
+        cy.findByText('fix: make gql work ERRORED')
+        cy.get('[data-cy="run-card-icon"]')
+      })
+
+      cy.get('[href="http://dummy.cypress.io/runs/2"]').first().within(() => {
+        cy.findByText('fix: make gql work FAILED')
+        cy.get('[data-cy="run-card-icon"]')
+      })
+
+      // For some reason this has to happen twice, or the mocked cache is not gonna
+      // be updated, in prod it should work fine
+      cy.get('[href="#/settings"]').click()
+      cy.get('[href="#/runs"]').click()
+
+      cy.get('[href="#/settings"]').click()
+      cy.get('[href="#/runs"]').click()
+
+      cy.findByText(defaultMessages.runs.errors.unauthorized.button).should('be.visible')
+    })
   })
 
   describe('no internet connection', () => {

--- a/packages/graphql/src/stitching/remoteGraphQLCalls.ts
+++ b/packages/graphql/src/stitching/remoteGraphQLCalls.ts
@@ -35,6 +35,9 @@ export function cloudProjectBySlug (slug: string, context: DataContext, info: Gr
     key: slug,
     fieldName: 'cloudProjectsBySlugs',
     context,
+    rootValue: {
+      // requestPolicy: 'cache-and-network',
+    },
   })
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one --> [UNIFY-1568](https://cypress-io.atlassian.net/browse/UNIFY-1568)

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
