### PR TITLE
fix(unify): Sort all resolved config values alphabetically

### DIFF
--- a/packages/app/src/settings/project/ConfigCode.vue
+++ b/packages/app/src/settings/project/ConfigCode.vue
@@ -20,7 +20,7 @@
       {<br>
       <div class="pl-24px">
         <span
-          v-for="{ field, value, from } in props.gql.config"
+          v-for="{ field, value, from } in sortAlphabetical(props.gql.config)"
           :key="field"
         >
           {{ field }}:
@@ -73,6 +73,12 @@ fragment ConfigCode on CurrentProject {
 const props = defineProps<{
   gql: ConfigCodeFragment
 }>()
+
+const sortAlphabetical = (config) => {
+  return config.sort((a, b) => {
+    return a.field.localeCompare(b.field)
+  })
+}
 
 // a bug in vite demands that we do this passthrough
 const colorMap = CONFIG_LEGEND_COLOR_MAP

--- a/packages/config/src/options.ts
+++ b/packages/config/src/options.ts
@@ -407,6 +407,16 @@ const resolvedOptions: Array<ResolvedConfigOption> = [
 
 const runtimeOptions: Array<RuntimeConfigOption> = [
   {
+    // Internal config field, useful to ignore the e2e specPattern set by the user
+    // or the default one when looking fot CT, it needs to be a config property because after
+    // having the final config that has the e2e property flattened/compacted
+    // we may not be able to get the value to ignore.
+    name: 'additionalIgnorePattern',
+    defaultValue: (options: Record<string, any> = {}) => options.testingType === 'component' ? defaultSpecPattern.e2e : undefined,
+    validation: validate.isString,
+    isInternal: true,
+    canUpdateDuringTestTime: false,
+  }, {
     name: 'autoOpen',
     defaultValue: false,
     validation: validate.isBoolean,
@@ -511,16 +521,6 @@ const runtimeOptions: Array<RuntimeConfigOption> = [
     validation: validate.isString,
     isInternal: true,
     canUpdateDuringTestTime: false,
-  }, {
-    // Internal config field, useful to ignore the e2e specPattern set by the user
-    // or the default one when looking fot CT, it needs to be a config property because after
-    // having the final config that has the e2e property flattened/compacted
-    // we may not be able to get the value to ignore.
-    name: 'additionalIgnorePattern',
-    defaultValue: (options: Record<string, any> = {}) => options.testingType === 'component' ? defaultSpecPattern.e2e : undefined,
-    validation: validate.isString,
-    isInternal: true,
-    canUpdateDuringTestTime: false,
   },
 ]
 
@@ -543,35 +543,17 @@ export const additionalOptionsToResolveConfig = [
  */
 export const breakingOptions: Array<BreakingOption> = [
   {
+    name: 'blacklistHosts',
+    errorKey: 'RENAMED_CONFIG_OPTION',
+    newName: 'blockHosts',
+    isWarning: false,
+  }, {
     name: 'componentFolder',
     errorKey: 'COMPONENT_FOLDER_REMOVED',
     isWarning: false,
   }, {
-    name: 'integrationFolder',
-    errorKey: 'INTEGRATION_FOLDER_REMOVED',
-    isWarning: false,
-  }, {
-    name: 'testFiles',
-    errorKey: 'TEST_FILES_RENAMED',
-    newName: 'specPattern',
-    isWarning: false,
-  }, {
-    name: 'ignoreTestFiles',
-    errorKey: 'TEST_FILES_RENAMED',
-    newName: 'excludeSpecPattern',
-    isWarning: false,
-  }, {
-    name: 'pluginsFile',
-    errorKey: 'PLUGINS_FILE_CONFIG_OPTION_REMOVED',
-    isWarning: false,
-  }, {
     name: 'experimentalComponentTesting',
     errorKey: 'EXPERIMENTAL_COMPONENT_TESTING_REMOVED',
-    isWarning: false,
-  }, {
-    name: 'blacklistHosts',
-    errorKey: 'RENAMED_CONFIG_OPTION',
-    newName: 'blockHosts',
     isWarning: false,
   }, {
     name: 'experimentalGetCookiesSameSite',
@@ -599,6 +581,15 @@ export const breakingOptions: Array<BreakingOption> = [
     errorKey: 'FIREFOX_GC_INTERVAL_REMOVED',
     isWarning: true,
   }, {
+    name: 'ignoreTestFiles',
+    errorKey: 'TEST_FILES_RENAMED',
+    newName: 'excludeSpecPattern',
+    isWarning: false,
+  }, {
+    name: 'integrationFolder',
+    errorKey: 'INTEGRATION_FOLDER_REMOVED',
+    isWarning: false,
+  }, {
     name: 'nodeVersion',
     value: 'system',
     errorKey: 'NODE_VERSION_DEPRECATION_SYSTEM',
@@ -608,51 +599,54 @@ export const breakingOptions: Array<BreakingOption> = [
     value: 'bundled',
     errorKey: 'NODE_VERSION_DEPRECATION_BUNDLED',
     isWarning: true,
+  }, {
+    name: 'pluginsFile',
+    errorKey: 'PLUGINS_FILE_CONFIG_OPTION_REMOVED',
+    isWarning: false,
+  }, {
+    name: 'testFiles',
+    errorKey: 'TEST_FILES_RENAMED',
+    newName: 'specPattern',
+    isWarning: false,
   },
 ]
 
 export const breakingRootOptions: Array<BreakingOption> = [
   {
-    name: 'supportFile',
-    errorKey: 'CONFIG_FILE_INVALID_ROOT_CONFIG',
-    isWarning: false,
-    testingTypes: ['component', 'e2e'],
-  },
-  {
-    name: 'specPattern',
-    errorKey: 'CONFIG_FILE_INVALID_ROOT_CONFIG',
-    isWarning: false,
-    testingTypes: ['component', 'e2e'],
-  },
-  {
-    name: 'excludeSpecPattern',
-    errorKey: 'CONFIG_FILE_INVALID_ROOT_CONFIG',
-    isWarning: false,
-    testingTypes: ['component', 'e2e'],
-  },
-  {
-    name: 'experimentalStudio',
-    errorKey: 'EXPERIMENTAL_STUDIO_REMOVED',
-    isWarning: true,
-    testingTypes: ['component', 'e2e'],
-  },
-  {
     name: 'baseUrl',
     errorKey: 'CONFIG_FILE_INVALID_ROOT_CONFIG_E2E',
     isWarning: false,
     testingTypes: ['e2e'],
-  },
-  {
-    name: 'slowTestThreshold',
+  }, {
+    name: 'excludeSpecPattern',
     errorKey: 'CONFIG_FILE_INVALID_ROOT_CONFIG',
     isWarning: false,
     testingTypes: ['component', 'e2e'],
-  },
-  {
+  }, {
+    name: 'experimentalStudio',
+    errorKey: 'EXPERIMENTAL_STUDIO_REMOVED',
+    isWarning: true,
+    testingTypes: ['component', 'e2e'],
+  }, {
     name: 'indexHtmlFile',
     errorKey: 'CONFIG_FILE_INVALID_ROOT_CONFIG_COMPONENT',
     isWarning: false,
     testingTypes: ['component'],
+  }, {
+    name: 'slowTestThreshold',
+    errorKey: 'CONFIG_FILE_INVALID_ROOT_CONFIG',
+    isWarning: false,
+    testingTypes: ['component', 'e2e'],
+  }, {
+    name: 'specPattern',
+    errorKey: 'CONFIG_FILE_INVALID_ROOT_CONFIG',
+    isWarning: false,
+    testingTypes: ['component', 'e2e'],
+  }, {
+    name: 'supportFile',
+    errorKey: 'CONFIG_FILE_INVALID_ROOT_CONFIG',
+    isWarning: false,
+    testingTypes: ['component', 'e2e'],
   },
 ]
 


### PR DESCRIPTION
- Closes [UNIFY-1475](https://cypress-io.atlassian.net/browse/UNIFY-1475?atlOrigin=eyJpIjoiNDdkNjc1YTRiNmQ4NGE0ZjhhNmFjN2I3NWM3NDgzNmUiLCJwIjoiaiJ9)

### User facing changelog
All of the keys from the config (Project Settings) are sorted except a few at the bottom.

### Additional details
Before:
![image](https://user-images.githubusercontent.com/27690333/165130598-fb6b84b4-0124-47bd-971d-5dcf5a341c09.png)

After:
<img width="1381" alt="Screenshot 2022-04-25 at 12 16 57 PM" src="https://user-images.githubusercontent.com/27690333/165130645-79440c36-b1c3-485b-bd1d-b32bbae80c20.png">

I also sorted the resolved config options list alphabetically within the file to make it more organized code, even though this has no effect on what is displayed to the user (since we sort at the end after we merge all of the config anyway).

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
