### PR TITLE
chore: percy flake around version upgrade modal

### DIFF
--- a/packages/frontend-shared/src/gql-components/HeaderBarContent.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/HeaderBarContent.cy.tsx
@@ -125,6 +125,14 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
   })
 
   it('shows hint and modal to upgrade to latest version of cypress', () => {
+    // Set the clock to ensure that our percy snapshots always have the same relative time frame
+    //
+    // With this value they are:
+    //
+    // 8.7.0 - Released 7 months ago
+    // 8.6.0 - Released last year
+    cy.clock(Date.UTC(2022, 4, 26), ['Date'])
+
     cy.mountFragment(HeaderBar_HeaderBarContentFragmentDoc, {
       onResult: (result) => {
         if (result.currentProject) {


### PR DESCRIPTION
- Closes UNIFY-1545

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

The version upgrade modal displays a time frame relative to the current date (e.g. 10 months ago). In order to ensure there is no percy flake, we will use `cy.clock()` to set now to a given date. I picked the date to ensure we would have a couple of different types of days specifically:

* 8.7.0 - Released 7 months ago
* 8.6.0 - Released last year

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
