### PR TITLE
fix: use prettier to format migrated config

### DIFF
--- a/packages/config/src/ast-utils/addToCypressConfig.ts
+++ b/packages/config/src/ast-utils/addToCypressConfig.ts
@@ -5,6 +5,7 @@ import dedent from 'dedent'
 import path from 'path'
 import debugLib from 'debug'
 import { parse, print } from 'recast'
+import prettier from 'prettier'
 
 import { addToCypressConfigPlugin } from './addToCypressConfigPlugin'
 import { addComponentDefinition, addE2EDefinition, ASTComponentDefinitionConfig } from './astConfigHelpers'
@@ -158,9 +159,6 @@ function getEmptyCodeBlock (outputType: OutputExtension) {
 
 function maybeFormatWithPrettier (code: string, filePath: string) {
   try {
-    const prettierImportPath = require.resolve('prettier', { paths: [path.dirname(filePath)] })
-    const prettier = require(prettierImportPath) as typeof import('prettier')
-
     return prettier.format(code, {
       filepath: filePath,
     })

--- a/packages/data-context/src/actions/MigrationActions.ts
+++ b/packages/data-context/src/actions/MigrationActions.ts
@@ -324,10 +324,10 @@ export class MigrationActions {
   }
 
   async assertSuccessfulConfigMigration (migratedConfigFile: string = 'cypress.config.js') {
-    const actual = formatConfig(await this.ctx.file.readFileInProject(migratedConfigFile), migratedConfigFile)
+    const actual = formatConfig(await this.ctx.file.readFileInProject(migratedConfigFile))
 
     const configExtension = path.extname(migratedConfigFile)
-    const expected = formatConfig(await this.ctx.file.readFileInProject(`expected-cypress.config${configExtension}`), migratedConfigFile)
+    const expected = formatConfig(await this.ctx.file.readFileInProject(`expected-cypress.config${configExtension}`))
 
     if (actual !== expected) {
       throw Error(`Expected ${actual} to equal ${expected}`)

--- a/packages/data-context/src/sources/migration/codegen.ts
+++ b/packages/data-context/src/sources/migration/codegen.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import globby from 'globby'
 import type { TestingType } from '@packages/types'
+import prettier from 'prettier'
 import { formatMigrationFile } from './format'
 import { substitute } from './autoRename'
 import { supportFileRegexps } from './regexps'
@@ -172,7 +173,6 @@ function createCypressConfig (config: ConfigOptions, pluginPath: string | undefi
         `import { defineConfig } from 'cypress'
   
         export default defineConfig({${globalString}${e2eString}${componentString}})`,
-        options.projectRoot,
       )
     }
 
@@ -180,15 +180,14 @@ function createCypressConfig (config: ConfigOptions, pluginPath: string | undefi
       `const { defineConfig } = require('cypress')
 
       module.exports = defineConfig({${globalString}${e2eString}${componentString}})`,
-      options.projectRoot,
     )
   }
 
   if (options.hasTypescript) {
-    return formatConfig(`export default {${globalString}${e2eString}${componentString}}`, options.projectRoot)
+    return formatConfig(`export default {${globalString}${e2eString}${componentString}}`)
   }
 
-  return formatConfig(`module.exports = {${globalString}${e2eString}${componentString}}`, options.projectRoot)
+  return formatConfig(`module.exports = {${globalString}${e2eString}${componentString}}`)
 }
 
 function formatObjectForConfig (obj: Record<string, unknown>) {
@@ -449,11 +448,8 @@ export function getSpecPattern (cfg: LegacyCypressConfigJson, testType: TestingT
   return specPattern
 }
 
-export function formatConfig (config: string, projectRoot: string): string {
+export function formatConfig (config: string): string {
   try {
-    const prettierPath = require.resolve('prettier', { paths: [projectRoot] })
-    const prettier = require(prettierPath)
-
     return prettier.format(config, {
       semi: false,
       singleQuote: true,


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Do not use users prettier, because is possible that it has not been installed and the result of the config may be like this one:
![image](https://user-images.githubusercontent.com/15656860/165554825-23679d70-d7b3-4e7d-bf04-0f2ab0dcf912.png)

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
