### PR TITLE
fix: automation disconnected error appearing when switching browsers

### DIFF
--- a/packages/server/lib/socket-base.ts
+++ b/packages/server/lib/socket-base.ts
@@ -213,6 +213,8 @@ export class SocketBase {
       const headers = socket.request?.headers ?? {}
 
       socket.on('automation:client:connected', () => {
+        const connectedBrowser = getCtx().coreData.activeBrowser
+
         if (automationClient === socket) {
           return
         }
@@ -224,8 +226,10 @@ export class SocketBase {
         // if our automation disconnects then we're
         // in trouble and should probably bomb everything
         automationClient.on('disconnect', () => {
-          // if we've stopped then don't do anything
-          if (this.ended) {
+          const activeBrowser = getCtx().coreData.activeBrowser
+
+          // if we've stopped or if we've switched to another browser then don't do anything
+          if (this.ended || (connectedBrowser?.path !== activeBrowser?.path)) {
             return
           }
 

--- a/packages/server/test/unit/socket_spec.js
+++ b/packages/server/test/unit/socket_spec.js
@@ -25,6 +25,9 @@ let ctx
 describe('lib/socket', () => {
   beforeEach(function () {
     ctx = getCtx()
+    ctx.coreData.activeBrowser = {
+      path: 'path-to-browser-one',
+    }
 
     // Don't bother initializing the child process, etc for this
     sinon.stub(ctx.actions.project, 'initializeActiveProject')
@@ -237,6 +240,19 @@ describe('lib/socket', () => {
 
             return done()
           })
+        })
+
+        it('returns early if disconnect event is from another browser', function (done) {
+          const delaySpy = sinon.spy(Promise, 'delay')
+
+          this.extClient.on('disconnect', () => {
+            expect(delaySpy).to.not.have.been.calledWith(2000)
+
+            return done()
+          })
+
+          ctx.coreData.activeBrowser = { path: 'path-to-browser-two' }
+          this.extClient.disconnect()
         })
 
         it('returns true when tab matches magic string', function (done) {


### PR DESCRIPTION
- Closes [UNIFY-1638](https://cypress-io.atlassian.net/browse/UNIFY-1638)

### User facing changelog
Fixes a bug where switching to another browser that opens quickly can catch the `automation:disconnected` event from the previously closed browser

### Additional details
There was a race condition where switching from one browser to another would surface the `automation:disconnected` event if the new browser can open quickly. I was only able to reproduce this when switching to Electron since Electron can open so quickly, but it could likely happen to any browser if your machine is fast enough.

This PR compares the last browser that was opened to the currently active browser. If we have a new browser, we can safely ignore the disconnect event. What was happening was that the user could switch to Electron and be running a test before the disconnect event from the other browser was fired. It would then emit a message to the frontend that the automation disconnected, and the event manager for the new browser would intercept this message and cause the app to think it's in a broken state.

We reuse the same socket connection when switching browsers, so I couldn't remove the listeners or restart the socket.

### How has the user experience changed?
Before

https://user-images.githubusercontent.com/25158820/165829155-f9fb0a7a-c4fa-4884-9505-649e4f0f8a8c.mov

After:


https://user-images.githubusercontent.com/25158820/165829184-1d0babd4-0092-4e2b-a7e1-024b524fb586.mov



### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
