### PR TITLE
fix: Allow submit button to be outside of the form for implicit submission

### DIFF
--- a/packages/driver/cypress/fixtures/dom.html
+++ b/packages/driver/cypress/fixtures/dom.html
@@ -323,6 +323,12 @@
           <button type="submit">submit me</button>
         </form>
 
+        <form id="multiple-inputs-and-button-submit-outside-form">
+          <input name="fname" />
+          <input name="lname" />
+        </form>
+        <button form="multiple-inputs-and-button-submit-outside-form" type="submit">submit me</button>
+
         <form id="multiple-inputs-and-reset-and-submit-buttons">
           <input name="fname" />
           <input name="lname" />

--- a/packages/driver/cypress/fixtures/dom.html
+++ b/packages/driver/cypress/fixtures/dom.html
@@ -323,11 +323,11 @@
           <button type="submit">submit me</button>
         </form>
 
-        <form id="multiple-inputs-and-button-submit-outside-form">
+        <form id="multiple-inputs-and-button-submit.outside-form">
           <input name="fname" />
           <input name="lname" />
         </form>
-        <button form="multiple-inputs-and-button-submit-outside-form" type="submit">submit me</button>
+        <button form="multiple-inputs-and-button-submit.outside-form" type="submit">submit me</button>
 
         <form id="multiple-inputs-and-reset-and-submit-buttons">
           <input name="fname" />

--- a/packages/driver/cypress/fixtures/form.html
+++ b/packages/driver/cypress/fixtures/form.html
@@ -86,12 +86,6 @@
         <button type="submit">submit me</button>
       </form>
 
-      <form id="multiple-inputs-and-button-submit-outside-form">
-        <input name="fname" />
-        <input name="lname" />
-      </form>
-      <button form="multiple-inputs-and-button-submit-outside-form" type="submit">submit me</button>
-
       <form id="multiple-inputs-and-button-with-no-type">
         <input name="fname" />
         <input name="lname" />

--- a/packages/driver/cypress/fixtures/form.html
+++ b/packages/driver/cypress/fixtures/form.html
@@ -86,6 +86,12 @@
         <button type="submit">submit me</button>
       </form>
 
+      <form id="multiple-inputs-and-button-submit-outside-form">
+        <input name="fname" />
+        <input name="lname" />
+      </form>
+      <button form="multiple-inputs-and-button-submit-outside-form" type="submit">submit me</button>
+
       <form id="multiple-inputs-and-button-with-no-type">
         <input name="fname" />
         <input name="lname" />

--- a/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
@@ -1511,6 +1511,18 @@ describe('src/cy/commands/actions/type - #type special chars', () => {
       })
     })
 
+    context('2 inputs, 1 \'submit\' element button[type=submit]', () => {
+      it('triggers form submit', function (done) {
+        this.$forms.find('#multiple-inputs-and-button-submit-outside-form').submit((e) => {
+          e.preventDefault()
+
+          done()
+        })
+
+        cy.get('#multiple-inputs-and-button-submit-outside-form input:first').type('foo{enter}')
+      })
+    })
+
     context(`2 inputs, 1 'submit' button[type=submit], 1 'reset' button[type=reset]`, () => {
       it('triggers form submit', function () {
         const submit = cy.stub()

--- a/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
@@ -1511,7 +1511,7 @@ describe('src/cy/commands/actions/type - #type special chars', () => {
       })
     })
 
-    context('2 inputs, 1 \'submit\' element button[type=submit]', () => {
+    context('2 inputs, 1 \'submit\' element button[type=submit] outside of the form', () => {
       it('triggers form submit', function (done) {
         this.$forms.find('#multiple-inputs-and-button-submit-outside-form').submit((e) => {
           e.preventDefault()

--- a/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
@@ -1487,13 +1487,13 @@ describe('src/cy/commands/actions/type - #type special chars', () => {
       })
 
       it('triggers form submit when the submit button is outside of the form', function (done) {
-        this.$forms.find('#multiple-inputs-and-button-submit-outside-form').submit((e) => {
+        this.$forms.find('[id="multiple-inputs-and-button-submit.outside-form"]').submit((e) => {
           e.preventDefault()
 
           done()
         })
 
-        cy.get('#multiple-inputs-and-button-submit-outside-form input:first').type('foo{enter}')
+        cy.get('[id="multiple-inputs-and-button-submit.outside-form"] input:first').type('foo{enter}')
       })
 
       it('causes click event on the button[type=submit]', function (done) {

--- a/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/type_special_chars_spec.js
@@ -1486,6 +1486,16 @@ describe('src/cy/commands/actions/type - #type special chars', () => {
         cy.get('#multiple-inputs-and-button-submit input:first').type('foo{enter}')
       })
 
+      it('triggers form submit when the submit button is outside of the form', function (done) {
+        this.$forms.find('#multiple-inputs-and-button-submit-outside-form').submit((e) => {
+          e.preventDefault()
+
+          done()
+        })
+
+        cy.get('#multiple-inputs-and-button-submit-outside-form input:first').type('foo{enter}')
+      })
+
       it('causes click event on the button[type=submit]', function (done) {
         this.$forms.find('#multiple-inputs-and-button-submit button[type=submit]').click((e) => {
           e.preventDefault()
@@ -1508,18 +1518,6 @@ describe('src/cy/commands/actions/type - #type special chars', () => {
         cy.get('#multiple-inputs-and-button-submit input:first').type('f{enter}').then(() => {
           done()
         })
-      })
-    })
-
-    context('2 inputs, 1 \'submit\' element button[type=submit] outside of the form', () => {
-      it('triggers form submit', function (done) {
-        this.$forms.find('#multiple-inputs-and-button-submit-outside-form').submit((e) => {
-          e.preventDefault()
-
-          done()
-        })
-
-        cy.get('#multiple-inputs-and-button-submit-outside-form input:first').type('foo{enter}')
       })
     })
 

--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -173,7 +173,7 @@ export default function (Commands, Cypress, cy, state, config) {
     const win = state('window')
 
     const getDefaultButtons = (form) => {
-      const formId = form.attr('id')
+      const formId = CSS.escape(form.attr('id'))
       const nestedButtons = form.find('input, button')
 
       const possibleDefaultButtons: JQuery<any> = formId ? $dom.wrap(_.uniq([

--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -176,12 +176,12 @@ export default function (Commands, Cypress, cy, state, config) {
       const formId = form.attr('id')
       const nestedButtons = form.find('input, button')
 
-      const possibleDefaultButtons = formId ? $dom.wrap(_.uniq([
+      const possibleDefaultButtons: JQuery<any> = formId ? $dom.wrap(_.uniq([
         ...nestedButtons,
         ...cy.$$('body').find(`input[form='${formId}'], button[form='${formId}']`),
       ])) : nestedButtons
 
-      return $dom.wrap(possibleDefaultButtons).filter((__, el) => {
+      return possibleDefaultButtons.filter((__, el) => {
         const $el = $dom.wrap(el)
 
         return (

--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -173,7 +173,15 @@ export default function (Commands, Cypress, cy, state, config) {
     const win = state('window')
 
     const getDefaultButtons = (form) => {
-      return form.find('input, button').filter((__, el) => {
+      const formId = form.attr('id')
+      const nestedButtons = form.find('input, button')
+
+      const possibleDefaultButtons = formId ? $dom.wrap(_.uniq([
+        ...nestedButtons,
+        ...cy.$$('body').find(`input[form='${formId}'], button[form='${formId}']`),
+      ])) : nestedButtons
+
+      return $dom.wrap(possibleDefaultButtons).filter((__, el) => {
         const $el = $dom.wrap(el)
 
         return (

--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -178,7 +178,7 @@ export default function (Commands, Cypress, cy, state, config) {
 
       const possibleDefaultButtons: JQuery<any> = formId ? $dom.wrap(_.uniq([
         ...nestedButtons,
-        ...cy.$$('body').find(`input[form='${formId}'], button[form='${formId}']`),
+        ...$dom.query('body', form.attr('ownerDocument')).find(`input[form='${formId}'], button[form='${formId}']`),
       ])) : nestedButtons
 
       return possibleDefaultButtons.filter((__, el) => {

--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -178,7 +178,7 @@ export default function (Commands, Cypress, cy, state, config) {
 
       const possibleDefaultButtons: JQuery<any> = formId ? $dom.wrap(_.uniq([
         ...nestedButtons,
-        ...$dom.query('body', form.attr('ownerDocument')).find(`input[form='${formId}'], button[form='${formId}']`),
+        ...$dom.query('body', form.prop('ownerDocument')).find(`input[form="${formId}"], button[form="${formId}"]`),
       ])) : nestedButtons
 
       return possibleDefaultButtons.filter((__, el) => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #21163 

### User facing changelog
Submit buttons can be outside of the form for implicit submission

### Additional details
Implicit submit wasn't working when the submit button wasn't nested within the form

### How has the user experience changed?
Implicit submit with the enter key works when the submit button is outside of the form, but associated with a form attribute

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
