### PR TITLE
fix: moving away from runner and disconnecting websockets stops listening for changes to webpack build

### DIFF
--- a/packages/app/cypress/e2e/cypress-in-cypress-component.cy.ts
+++ b/packages/app/cypress/e2e/cypress-in-cypress-component.cy.ts
@@ -156,4 +156,59 @@ describe('Cypress In Cypress CT', { viewportWidth: 1500, defaultCommandTimeout: 
     cy.get('#unified-runner').should('have.css', 'width', '333px')
     cy.get('#unified-runner').should('have.css', 'height', '333px')
   })
+
+  it('moves away from runner and back, disconnects websocket and reconnects it correctly', () => {
+    cy.openProject('cypress-in-cypress')
+    cy.startAppServer('component')
+
+    cy.visitApp()
+    cy.contains('TestComponent.spec').click()
+    cy.get('[data-model-state="passed"]').should('contain', 'renders the test component')
+    cy.get('.passed > .num').should('contain', 1)
+    cy.get('.failed > .num').should('contain', '--')
+
+    cy.get('[href="#/runs"]').click()
+    cy.get('[data-cy="app-header-bar"]').findByText('Runs').should('be.visible')
+
+    cy.get('[href="#/specs"]').click()
+    cy.get('[data-cy="app-header-bar"]').findByText('Specs').should('be.visible')
+
+    cy.contains('TestComponent.spec').click()
+    cy.get('[data-model-state="passed"]').should('contain', 'renders the test component')
+
+    cy.window().then((win) => {
+      const connected = () => win.ws?.connected
+
+      win.ws?.close()
+
+      cy.wrap({
+        connected,
+      }).invoke('connected').should('be.false')
+
+      win.ws?.connect()
+
+      cy.wrap({
+        connected,
+      }).invoke('connected').should('be.true')
+    })
+
+    cy.withCtx((ctx, o) => {
+      ctx.actions.file.writeFileInProject(o.path, `
+import React from 'react'
+import { mount } from '@cypress/react'
+
+describe('TestComponent', () => {
+  it('renders the new test component', () => {
+    mount(<div>Component Test</div>)
+
+    cy.contains('Component Test').should('be.visible')
+  })
+})
+`)
+    }, { path: getPathForPlatform('src/TestComponent.spec.jsx') })
+
+    cy.get('[data-model-state="passed"]').should('contain', 'renders the new test component')
+    cy.get('.passed > .num').should('contain', 1)
+    cy.get('.failed > .num').should('contain', '--')
+  })
 })

--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -65,6 +65,14 @@ export class EventManager {
   }
 
   addGlobalListeners (state: MobxRunnerStore, options: AddGlobalListenerOptions) {
+    // Moving away from the runner turns off all websocket listeners. addGlobalListeners adds them back
+    // but connect is added when the websocket is created elsewhere so we need to add it back.
+    if (!this.ws.hasListeners('connect')) {
+      this.ws.on('connect', () => {
+        this.ws.emit('runner:connected')
+      })
+    }
+
     const rerun = () => {
       if (!this) {
         // if the tests have been reloaded

--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -140,10 +140,6 @@ export class EventManager {
       rerun()
     })
 
-    this.ws.on('specs:changed', ({ specs, testingType }) => {
-      state.setSpecs(specs)
-    })
-
     this.ws.on('dev-server:hmr:error', (error) => {
       Cypress.stop()
       this.localBus.emit('script:error', error)

--- a/packages/app/src/settings/project/RecordKey.vue
+++ b/packages/app/src/settings/project/RecordKey.vue
@@ -23,7 +23,7 @@
     >
       <CodeBox
         :code="recordKey"
-        :prefix-icon="IconTerminal"
+        :prefix-icon="IconKey"
         confidential
       />
       <CopyButton
@@ -49,7 +49,7 @@ import Button from '@cy/components/Button.vue'
 import CopyButton from '@cy/gql-components/CopyButton.vue'
 import ExternalLink from '@cy/gql-components/ExternalLink.vue'
 import { useExternalLink } from '@cy/gql-components/useExternalLink'
-import IconTerminal from '~icons/cy/terminal_x16.svg'
+import IconKey from '~icons/cy/placeholder_x16.svg'
 import IconExport from '~icons/cy/export_x16.svg'
 import type { RecordKeyFragment } from '../../generated/graphql'
 import SettingsSection from '../SettingsSection.vue'

--- a/packages/app/src/settings/project/RecordKey.vue
+++ b/packages/app/src/settings/project/RecordKey.vue
@@ -23,7 +23,7 @@
     >
       <CodeBox
         :code="recordKey"
-        :prefix-icon="IconKey"
+        :prefix-icon="IconTerminal"
         confidential
       />
       <CopyButton
@@ -49,7 +49,7 @@ import Button from '@cy/components/Button.vue'
 import CopyButton from '@cy/gql-components/CopyButton.vue'
 import ExternalLink from '@cy/gql-components/ExternalLink.vue'
 import { useExternalLink } from '@cy/gql-components/useExternalLink'
-import IconKey from '~icons/cy/placeholder_x16.svg'
+import IconTerminal from '~icons/cy/terminal_x16.svg'
 import IconExport from '~icons/cy/export_x16.svg'
 import type { RecordKeyFragment } from '../../generated/graphql'
 import SettingsSection from '../SettingsSection.vue'

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -453,10 +453,6 @@ export class ProjectBase<TServer extends Server> extends EE {
     this.ctx.setAppSocketServer(io)
   }
 
-  changeToUrl (url) {
-    this.server.changeToUrl(url)
-  }
-
   async closeBrowserTabs () {
     return this.server.socket.closeBrowserTabs()
   }

--- a/packages/server/lib/server-base.ts
+++ b/packages/server/lib/server-base.ts
@@ -576,10 +576,6 @@ export abstract class ServerBase<TSocket extends SocketE2E | SocketCt> {
     return this._socket && this._socket.end()
   }
 
-  changeToUrl (url) {
-    return this._socket && this._socket.changeToUrl(url)
-  }
-
   async sendFocusBrowserMessage () {
     this._socket && await this._socket.sendFocusBrowserMessage()
   }
@@ -622,9 +618,5 @@ export abstract class ServerBase<TSocket extends SocketE2E | SocketCt> {
     socket.once('upstream-connected', this.socketAllowed.add)
 
     return this.httpsProxy.connect(req, socket, head)
-  }
-
-  sendSpecList (specs: Cypress.Cypress['spec'][], testingType: Cypress.TestingType) {
-    return this.socket.sendSpecList(specs, testingType)
   }
 }

--- a/packages/server/lib/socket-base.ts
+++ b/packages/server/lib/socket-base.ts
@@ -567,10 +567,6 @@ export class SocketBase {
     return this._io?.emit('tests:finished')
   }
 
-  changeToUrl (url) {
-    return this.toRunner('change:to:url', url)
-  }
-
   async closeBrowserTabs () {
     if (this._sendCloseBrowserTabsMessage) {
       await this._sendCloseBrowserTabsMessage()
@@ -595,9 +591,5 @@ export class SocketBase {
 
   close () {
     return this._io?.close()
-  }
-
-  sendSpecList (specs, testingType: Cypress.TestingType) {
-    this.toRunner('specs:changed', { specs, testingType })
   }
 }


### PR DESCRIPTION
- Closes UNIFY-1651

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

In component testing, when the user moves away from the spec runner (for example to the Runs page) and then goes back to the spec runner, reruns due to webpack dev server recompilations will now properly reset the state of the reporter.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

The steps to recreate this issue were:

1. Launch the app and run a component test
2. Click the runs tab
3. Go back to the spec list tab
4. Run the component test from step 1 again
5. Put your computer to sleep
6. Wake the computer
7. Modify the test in step 1
8. The test re-runs but the spec totals don't reset

What ends up happening in this flow is we [set up the websocket](https://github.com/cypress-io/cypress/blob/10.0-release/packages/app/src/runner/index.ts#L38-L44) and [on connection](https://github.com/cypress-io/cypress/blob/10.0-release/packages/server/lib/socket-base.ts#L315-L325) we set up the server to join the `runner` room. When we [move away](https://github.com/cypress-io/cypress/blob/10.0-release/packages/app/src/runner/unifiedRunner.ts#L18) from the spec list tab, we [teardown](https://github.com/cypress-io/cypress/blob/10.0-release/packages/app/src/runner/index.ts#L182) the event manager and [turn off](https://github.com/cypress-io/cypress/blob/10.0-release/packages/app/src/runner/event-manager.ts#L590) all websocket events. When we return to the spec list tab, we [turn on](https://github.com/cypress-io/cypress/blob/10.0-release/packages/app/src/runner/event-manager.ts#L67) all websocket events again except for the initial connection event. When the computer goes to sleep, the websocket connection is killed, and when it is reestablished, the connection event doesn't fire again and thus we never join the `runner` room again. Thus, when we modify a test file and recompile the webpack bundle, the `runner` channel is [notified](https://github.com/cypress-io/cypress/blob/10.0-release/packages/server/lib/socket-ct.ts#L19-L21), but nothing is listening on the client. Thus, the [event manager](https://github.com/cypress-io/cypress/blob/10.0-release/packages/app/src/runner/event-manager.ts#L146) is not notified and the reporter is not [reset](https://github.com/cypress-io/cypress/blob/10.0-release/packages/app/src/runner/event-manager.ts#L615).

To fix this, we should ensure that we are setting up the `connect` listener along with the other listeners in `addGlobalListeners`. We only do this if that event is not already set up. This flow is broken only in component testing, but I added a corresponding test in e2e as well to ensure that flow stays stable as well.

In addition on this PR, we clean up some dead code that was discovered.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Before:

https://user-images.githubusercontent.com/4873279/166166747-61b349d7-637d-44e8-81ec-88849b36a01a.mov

After:

https://user-images.githubusercontent.com/4873279/166166828-6e0c7373-cec3-4ab5-828f-7691a18fbe37.mov

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
