### PR TITLE
chore: Re-organize tests in assertions_spec.js

### DIFF
--- a/packages/driver/cypress/integration/commands/assertions_spec.js
+++ b/packages/driver/cypress/integration/commands/assertions_spec.js
@@ -1151,7 +1151,7 @@ describe('src/cy/commands/assertions', () => {
     })
   })
 
-  context('format quotation marks', () => {
+  describe('message formatting', () => {
     const expectMarkdown = (test, message, done) => {
       cy.then(() => {
         test()
@@ -1168,70 +1168,83 @@ describe('src/cy/commands/assertions', () => {
       })
     }
 
-    it('preserves quotation marks in number strings', (done) => {
-      expectMarkdown(() => {
-        try {
-          expect(25).to.eq('25')
-        } catch (error) {} /* eslint-disable-line no-empty */
-      },
-      `expected **25** to equal **'25'**`,
-      done)
-    })
+    // https://github.com/cypress-io/cypress/issues/19116
+    it('text with backslashes', (done) => {
+      const text = '"<OE_D]dQ\\'
 
-    it('preserves quotation marks in empty string', (done) => {
-      expectMarkdown(() => {
-        try {
-          expect(42).to.eq('')
-        } catch (error) {} /* eslint-disable-line no-empty */
-      },
-      `expected **42** to equal **''**`,
-      done)
-    })
-
-    it('preserves quotation marks if escaped', (done) => {
       expectMarkdown(
-        () => expect(`\'cypress\'`).to.eq(`\'cypress\'`),
-        // ****'cypress'**** -> ** for emphasizing result string  + ** for emphasizing the entire result.
-        `expected **'cypress'** to equal ****'cypress'****`,
+        () => expect(text).to.equal(text),
+        `expected **"<OE_D]dQ\\\\** to equal **"<OE_D]dQ\\\\**`,
         done,
       )
     })
 
-    it('removes quotation marks in DOM elements', (done) => {
-      expectMarkdown(
-        () => {
-          cy.get('body').then(($body) => {
-            expect($body).to.contain('div')
-          })
+    describe('messages with quotation marks', () => {
+      it('preserves quotation marks in number strings', (done) => {
+        expectMarkdown(() => {
+          try {
+            expect(25).to.eq('25')
+          } catch (error) {} /* eslint-disable-line no-empty */
         },
-        `expected **<body>** to contain **div**`,
-        done,
-      )
-    })
+        `expected **25** to equal **'25'**`,
+        done)
+      })
 
-    it('removes quotation marks in strings', (done) => {
-      expectMarkdown(() => expect('cypress').to.eq('cypress'), `expected **cypress** to equal **cypress**`, done)
-    })
+      it('preserves quotation marks in empty string', (done) => {
+        expectMarkdown(() => {
+          try {
+            expect(42).to.eq('')
+          } catch (error) {} /* eslint-disable-line no-empty */
+        },
+        `expected **42** to equal **''**`,
+        done)
+      })
 
-    it('removes quotation marks in objects', (done) => {
-      expectMarkdown(
-        () => expect({ foo: 'bar' }).to.deep.eq({ foo: 'bar' }),
-        `expected **{ foo: bar }** to deeply equal **{ foo: bar }**`,
-        done,
-      )
-    })
+      it('preserves quotation marks if escaped', (done) => {
+        expectMarkdown(
+          () => expect(`\'cypress\'`).to.eq(`\'cypress\'`),
+          // ****'cypress'**** -> ** for emphasizing result string  + ** for emphasizing the entire result.
+          `expected **'cypress'** to equal ****'cypress'****`,
+          done,
+        )
+      })
 
-    it('formats keys properly for "have.all.keys"', (done) => {
-      const person = {
-        name: 'Joe',
-        age: 20,
-      }
+      it('removes quotation marks in DOM elements', (done) => {
+        expectMarkdown(
+          () => {
+            cy.get('body').then(($body) => {
+              expect($body).to.contain('div')
+            })
+          },
+          `expected **<body>** to contain **div**`,
+          done,
+        )
+      })
 
-      expectMarkdown(
-        () => expect(person).to.have.all.keys('name', 'age'),
-        `expected **{ name: Joe, age: 20 }** to have keys **name**, and **age**`,
-        done,
-      )
+      it('removes quotation marks in strings', (done) => {
+        expectMarkdown(() => expect('cypress').to.eq('cypress'), `expected **cypress** to equal **cypress**`, done)
+      })
+
+      it('removes quotation marks in objects', (done) => {
+        expectMarkdown(
+          () => expect({ foo: 'bar' }).to.deep.eq({ foo: 'bar' }),
+          `expected **{ foo: bar }** to deeply equal **{ foo: bar }**`,
+          done,
+        )
+      })
+
+      it('formats keys properly for "have.all.keys"', (done) => {
+        const person = {
+          name: 'Joe',
+          age: 20,
+        }
+
+        expectMarkdown(
+          () => expect(person).to.have.all.keys('name', 'age'),
+          `expected **{ name: Joe, age: 20 }** to have keys **name**, and **age**`,
+          done,
+        )
+      })
     })
 
     describe('formats strings with spaces', (done) => {
@@ -1266,36 +1279,6 @@ describe('src/cy/commands/assertions', () => {
           done,
         )
       })
-    })
-  })
-
-  // TODO: this suite should be merged with the suite above
-  describe('message formatting', () => {
-    const expectMarkdown = (test, message, done) => {
-      cy.then(() => {
-        test()
-      })
-
-      cy.on('log:added', (attrs, log) => {
-        if (attrs.name === 'assert') {
-          cy.removeAllListeners('log:added')
-
-          expect(log.get('message')).to.eq(message)
-
-          done()
-        }
-      })
-    }
-
-    // https://github.com/cypress-io/cypress/issues/19116
-    it('text with backslashes', (done) => {
-      const text = '"<OE_D]dQ\\'
-
-      expectMarkdown(
-        () => expect(text).to.equal(text),
-        `expected **"<OE_D]dQ\\\\** to equal **"<OE_D]dQ\\\\**`,
-        done,
-      )
     })
   })
 


### PR DESCRIPTION
- Related with [this comment](https://github.com/cypress-io/cypress/pull/20704#discussion_r830722608)

### User facing changelog

N/A. It's an internal house keeping. This PR re-organizes tests that are organized in the wrong way.

### Additional details
- Why was this change necessary? => Tests are organized in the wrong way.
- What is affected by this change? => N/A
- Any implementation details to explain? => N/A

### How has the user experience changed?

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
