### PR TITLE
fix: cy.contains handles input[type=submit] correctly.

### DIFF
--- a/packages/driver/cypress/integration/commands/querying/querying_spec.js
+++ b/packages/driver/cypress/integration/commands/querying/querying_spec.js
@@ -1040,6 +1040,15 @@ describe('src/cy/commands/querying', () => {
       })
     })
 
+    // https://github.com/cypress-io/cypress/issues/21166
+    it('can find input type=submits by Regex', () => {
+      cy.contains(/input contains submit/).then(($el) => {
+        expect($el.length).to.eq(1)
+
+        expect($el).to.match('input[type=submit]')
+      })
+    })
+
     it('has an optional filter argument', () => {
       cy.contains('ul', 'li 0').then(($el) => {
         expect($el.length).to.eq(1)

--- a/packages/driver/src/dom/elements/find.ts
+++ b/packages/driver/src/dom/elements/find.ts
@@ -247,6 +247,10 @@ export const getContainsSelector = (text, filter = '', options: {
 
     // taken from jquery's normal contains method
     cyContainsSelector = function (elem) {
+      if (elem.type === 'submit' && elem.tagName === 'INPUT') {
+        return text.test(elem.value)
+      }
+
       const testText = normalizeWhitespaces(elem)
 
       return text.test(testText)


### PR DESCRIPTION
- Closes #21166

### User facing changelog

`cy.contains` handles `input[type=submit]` correctly.

### Additional details
- Why was this change necessary? => `cy.contains` cannot find the text of `input[type=submit]` elements. 
- What is affected by this change? => N/A
- Any implementation details to explain? => N/A

### How has the user experience changed?

```html
<input type="submit" value="Text" />
```

```js
cy.contains(/Text/) // Before: fails. After: works.
```

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
