### PR TITLE
chore: fix build due to mis merge

### DIFF
--- a/packages/app/cypress/e2e/cypress-in-cypress-component.cy.ts
+++ b/packages/app/cypress/e2e/cypress-in-cypress-component.cy.ts
@@ -173,6 +173,61 @@ describe('Cypress In Cypress CT', { viewportWidth: 1500, defaultCommandTimeout: 
 
       cy.get('.passed > .num').should('contain', 1)
     })
+
+    it('moves away from runner and back, disconnects websocket and reconnects it correctly', () => {
+      cy.openProject('cypress-in-cypress')
+      cy.startAppServer('component')
+
+      cy.visitApp()
+      cy.contains('TestComponent.spec').click()
+      cy.get('[data-model-state="passed"]').should('contain', 'renders the test component')
+      cy.get('.passed > .num').should('contain', 1)
+      cy.get('.failed > .num').should('contain', '--')
+
+      cy.get('[href="#/runs"]').click()
+      cy.get('[data-cy="app-header-bar"]').findByText('Runs').should('be.visible')
+
+      cy.get('[href="#/specs"]').click()
+      cy.get('[data-cy="app-header-bar"]').findByText('Specs').should('be.visible')
+
+      cy.contains('TestComponent.spec').click()
+      cy.get('[data-model-state="passed"]').should('contain', 'renders the test component')
+
+      cy.window().then((win) => {
+        const connected = () => win.ws?.connected
+
+        win.ws?.close()
+
+        cy.wrap({
+          connected,
+        }).invoke('connected').should('be.false')
+
+        win.ws?.connect()
+
+        cy.wrap({
+          connected,
+        }).invoke('connected').should('be.true')
+      })
+
+      cy.withCtx((ctx, o) => {
+        ctx.actions.file.writeFileInProject(o.path, `
+  import React from 'react'
+  import { mount } from '@cypress/react'
+
+  describe('TestComponent', () => {
+    it('renders the new test component', () => {
+      mount(<div>Component Test</div>)
+
+      cy.contains('Component Test').should('be.visible')
+    })
+  })
+  `)
+      }, { path: getPathForPlatform('src/TestComponent.spec.jsx') })
+
+      cy.get('[data-model-state="passed"]').should('contain', 'renders the new test component')
+      cy.get('.passed > .num').should('contain', 1)
+      cy.get('.failed > .num').should('contain', '--')
+    })
   })
 
   context('custom config', () => {
@@ -191,60 +246,5 @@ describe('Cypress In Cypress CT', { viewportWidth: 1500, defaultCommandTimeout: 
       cy.get('#unified-runner').should('have.css', 'width', '333px')
       cy.get('#unified-runner').should('have.css', 'height', '333px')
     })
-  })
-
-  it('moves away from runner and back, disconnects websocket and reconnects it correctly', () => {
-    cy.openProject('cypress-in-cypress')
-    cy.startAppServer('component')
-
-    cy.visitApp()
-    cy.contains('TestComponent.spec').click()
-    cy.get('[data-model-state="passed"]').should('contain', 'renders the test component')
-    cy.get('.passed > .num').should('contain', 1)
-    cy.get('.failed > .num').should('contain', '--')
-
-    cy.get('[href="#/runs"]').click()
-    cy.get('[data-cy="app-header-bar"]').findByText('Runs').should('be.visible')
-
-    cy.get('[href="#/specs"]').click()
-    cy.get('[data-cy="app-header-bar"]').findByText('Specs').should('be.visible')
-
-    cy.contains('TestComponent.spec').click()
-    cy.get('[data-model-state="passed"]').should('contain', 'renders the test component')
-
-    cy.window().then((win) => {
-      const connected = () => win.ws?.connected
-
-      win.ws?.close()
-
-      cy.wrap({
-        connected,
-      }).invoke('connected').should('be.false')
-
-      win.ws?.connect()
-
-      cy.wrap({
-        connected,
-      }).invoke('connected').should('be.true')
-    })
-
-    cy.withCtx((ctx, o) => {
-      ctx.actions.file.writeFileInProject(o.path, `
-import React from 'react'
-import { mount } from '@cypress/react'
-
-describe('TestComponent', () => {
-  it('renders the new test component', () => {
-    mount(<div>Component Test</div>)
-
-    cy.contains('Component Test').should('be.visible')
-  })
-})
-`)
-    }, { path: getPathForPlatform('src/TestComponent.spec.jsx') })
-
-    cy.get('[data-model-state="passed"]').should('contain', 'renders the new test component')
-    cy.get('.passed > .num').should('contain', 1)
-    cy.get('.failed > .num').should('contain', '--')
   })
 })


### PR DESCRIPTION
### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

There was a mismerge in 10.0 that caused beforeEach's to not be run in cypress-in-cypress-component. This fixes that issue

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
