### PR TITLE
chore: Distribute tests to desktop-gui containers. Make `desktop-gui` tests faster!

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -468,28 +468,13 @@ commands:
       - restore_cached_workspace
       - run:
           command: |
-            if [[ -v MAIN_RECORD_KEY ]]; then
-              # internal PR
-
-              cmd=$([[ <<parameters.percy>> == 'true' ]] && echo 'yarn percy exec --parallel -- --') || true
-              CYPRESS_KONFIG_ENV=production \
-              CYPRESS_RECORD_KEY=$MAIN_RECORD_KEY \
-              PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
-              PERCY_ENABLE=${PERCY_TOKEN:-0} \
-              PERCY_PARALLEL_TOTAL=-1 \
-              $cmd yarn workspace @packages/runner cypress:run --record --parallel --group runner-integration-<<parameters.browser>> --browser <<parameters.browser>>
-            else
-              # external PR
-              TESTFILES=$(circleci tests glob "cypress/integration/**/*spec.*" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
-              echo "Test files for this machine are $TESTFILES"
-
-              cmd=$([[ <<parameters.percy>> == 'true' ]] && echo 'yarn percy exec --parallel -- --') || true
-              CYPRESS_KONFIG_ENV=production \
-              PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
-              PERCY_ENABLE=${PERCY_TOKEN:-0} \
-              PERCY_PARALLEL_TOTAL=-1 \
-              $cmd yarn workspace @packages/runner cypress:run --browser <<parameters.browser>> --spec $TESTFILES
-            fi
+            cmd=$([[ <<parameters.percy>> == 'true' ]] && echo 'yarn percy exec --parallel -- --') || true
+            CYPRESS_KONFIG_ENV=production \
+            CYPRESS_RECORD_KEY=$MAIN_RECORD_KEY \
+            PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
+            PERCY_ENABLE=${PERCY_TOKEN:-0} \
+            PERCY_PARALLEL_TOTAL=-1 \
+            $cmd yarn workspace @packages/runner cypress:run --record --parallel --group runner-integration-<<parameters.browser>> --browser <<parameters.browser>>
       - verify-mocha-results
       - store_test_results:
           path: /tmp/cypress

--- a/circle.yml
+++ b/circle.yml
@@ -1351,16 +1351,27 @@ jobs:
           working_directory: packages/desktop-gui
       - run:
           command: |
-            TESTFILES=$(circleci tests glob "cypress/integration/**/*spec.*" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
-            echo "Test files for this machine are $TESTFILES"
+            if [[ -v MAIN_RECORD_KEY ]]; then
+              # internal PR
+              CYPRESS_KONFIG_ENV=production \
+              CYPRESS_RECORD_KEY=$MAIN_RECORD_KEY \
+              PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
+              PERCY_ENABLE=${PERCY_TOKEN:-0} \
+              PERCY_PARALLEL_TOTAL=-1 \
+              yarn percy exec --parallel -- -- \
+              yarn cypress:run --record --parallel --group 2x-desktop-gui
+            else
+              # external PR
+              TESTFILES=$(circleci tests glob "cypress/integration/**/*spec.*" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
+              echo "Test files for this machine are $TESTFILES"
 
-            CYPRESS_KONFIG_ENV=production \
-            CYPRESS_RECORD_KEY=$MAIN_RECORD_KEY \
-            PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
-            PERCY_ENABLE=${PERCY_TOKEN:-0} \
-            PERCY_PARALLEL_TOTAL=-1 \
-            yarn percy exec --parallel -- -- \
-            yarn cypress:run --record --parallel --group 2x-desktop-gui --spec $TESTFILES
+              CYPRESS_KONFIG_ENV=production \
+              PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
+              PERCY_ENABLE=${PERCY_TOKEN:-0} \
+              PERCY_PARALLEL_TOTAL=-1 \
+              yarn percy exec --parallel -- -- \
+              yarn cypress:run --spec $TESTFILES
+            fi
           working_directory: packages/desktop-gui
       - verify-mocha-results
       - store_test_results:

--- a/circle.yml
+++ b/circle.yml
@@ -1351,13 +1351,16 @@ jobs:
           working_directory: packages/desktop-gui
       - run:
           command: |
+            TESTFILES=$(circleci tests glob "cypress/integration/**/*spec.*" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
+            echo "Test files for this machine are $TESTFILES"
+
             CYPRESS_KONFIG_ENV=production \
             CYPRESS_RECORD_KEY=$MAIN_RECORD_KEY \
             PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
             PERCY_ENABLE=${PERCY_TOKEN:-0} \
             PERCY_PARALLEL_TOTAL=-1 \
             yarn percy exec --parallel -- -- \
-            yarn cypress:run --record --parallel --group 2x-desktop-gui
+            yarn cypress:run --record --parallel --group 2x-desktop-gui --spec $TESTFILES
           working_directory: packages/desktop-gui
       - verify-mocha-results
       - store_test_results:

--- a/circle.yml
+++ b/circle.yml
@@ -468,13 +468,28 @@ commands:
       - restore_cached_workspace
       - run:
           command: |
-            cmd=$([[ <<parameters.percy>> == 'true' ]] && echo 'yarn percy exec --parallel -- --') || true
-            CYPRESS_KONFIG_ENV=production \
-            CYPRESS_RECORD_KEY=$MAIN_RECORD_KEY \
-            PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
-            PERCY_ENABLE=${PERCY_TOKEN:-0} \
-            PERCY_PARALLEL_TOTAL=-1 \
-            $cmd yarn workspace @packages/runner cypress:run --record --parallel --group runner-integration-<<parameters.browser>> --browser <<parameters.browser>>
+            if [[ -v MAIN_RECORD_KEY ]]; then
+              # internal PR
+
+              cmd=$([[ <<parameters.percy>> == 'true' ]] && echo 'yarn percy exec --parallel -- --') || true
+              CYPRESS_KONFIG_ENV=production \
+              CYPRESS_RECORD_KEY=$MAIN_RECORD_KEY \
+              PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
+              PERCY_ENABLE=${PERCY_TOKEN:-0} \
+              PERCY_PARALLEL_TOTAL=-1 \
+              $cmd yarn workspace @packages/runner cypress:run --record --parallel --group runner-integration-<<parameters.browser>> --browser <<parameters.browser>>
+            else
+              # external PR
+              TESTFILES=$(circleci tests glob "cypress/integration/**/*spec.*" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
+              echo "Test files for this machine are $TESTFILES"
+
+              cmd=$([[ <<parameters.percy>> == 'true' ]] && echo 'yarn percy exec --parallel -- --') || true
+              CYPRESS_KONFIG_ENV=production \
+              PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
+              PERCY_ENABLE=${PERCY_TOKEN:-0} \
+              PERCY_PARALLEL_TOTAL=-1 \
+              $cmd yarn workspace @packages/runner cypress:run --browser <<parameters.browser>> --spec $TESTFILES
+            fi
       - verify-mocha-results
       - store_test_results:
           path: /tmp/cypress


### PR DESCRIPTION
- Related with #21304
- Closes #21318

### User facing changelog

N/A. It's an internal CI change. 

### Additional details

#### Why was this change necessary? 

For some reason, a test in `settings_spec.js` of `desktop-gui` CI failed on all recent PRs of mine (#21286, #21285, #21197, #21283). So, I tested it with #21304 that it happens with an empty commit. 

I investigated this failure and learned that it's a flaky test and run 7 times ([5 passed, 2 failed](https://app.circleci.com/pipelines/github/cypress-io/cypress/37258/workflows/fa6c4589-3ccc-4dc6-9761-56419cd602a5/jobs/1498481/parallel-runs/0?filterBy=FAILED)). Because each container of desktop-gui is running all of the desktop-gui tests. 

It was the reason why `desktop-gui` is always super late to finish.

And it can cause unwanted flakiness.

#### What is affected by this change?

N/A

#### Any implementation details to explain?

* I distributed tests to the containers. Currently, each container runs 3 test suites. 
* I used the code at driver tests.
* It's much faster to run CI. `desktop-gui` finishes before others. 

### How has the user experience changed?

N/A.

### PR Tasks
- [na] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
