### PR TITLE
fix: clear remote data by marking all query data as stale on logout

### DIFF
--- a/packages/app/cypress/e2e/settings.cy.ts
+++ b/packages/app/cypress/e2e/settings.cy.ts
@@ -103,6 +103,30 @@ describe('App: Settings', () => {
       cy.contains('Record Key').should('not.exist')
       cy.contains('Record Key')
     })
+
+    it('clears nested cloud data (record key) upon logging out', () => {
+      cy.startAppServer('e2e')
+      cy.loginUser()
+      cy.visitApp()
+      cy.withCtx((ctx, o) => {
+        o.sinon.spy(ctx.actions.auth, 'logout')
+      })
+
+      cy.get(`[href='#/settings']`).click()
+      cy.contains('Dashboard Settings').click()
+      cy.contains('Record Key').should('exist')
+      cy.get(`[href='#/runs']`).click()
+      cy.get('[data-cy="user-avatar-title"]').click()
+      cy.findByRole('button', { name: 'Log Out' }).click()
+
+      cy.withRetryableCtx((ctx, o) => {
+        expect(ctx.actions.auth.logout).to.have.been.calledOnce
+      })
+
+      cy.get(`[href='#/settings']`).click()
+      cy.contains('Dashboard Settings').click()
+      cy.contains('Record Key').should('not.exist')
+    })
   })
 
   describe('Project Settings', () => {

--- a/packages/frontend-shared/src/graphql/urqlClient.ts
+++ b/packages/frontend-shared/src/graphql/urqlClient.ts
@@ -25,7 +25,19 @@ import { urqlFetchSocketAdapter } from './urqlFetchSocketAdapter'
 const toast = useToast()
 
 export function makeCacheExchange (schema: any = urqlSchema) {
-  return graphcacheExchange({ ...urqlCacheKeys, schema })
+  return graphcacheExchange({
+    ...urqlCacheKeys,
+    schema,
+    updates: {
+      Mutation: {
+        logout (parent, args, cache, info) {
+          // Invalidate all queries locally upon logging out, to ensure there's no stale cloud data
+          // https://formidable.com/open-source/urql/docs/graphcache/cache-updates/#invalidating-entities
+          cache.invalidate({ __typename: 'Query' })
+        },
+      },
+    },
+  })
 }
 
 declare global {


### PR DESCRIPTION
- Closes UNIFY-1652

### User facing changelog

When logging out, the "Record Key" section, and any other stale cloud data will no longer be visible.

### Additional details

When logging out, we want to clear out any remote data that might have been cached on the client. We can do this by invalidating the `Query` field for the cache using [`cache.invalidate`](https://formidable.com/open-source/urql/docs/api/graphcache/#invalidate), on logout which will result in refetching all data with the latest info from the electron server.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
