### PR TITLE
fix: ensure that proxy logs are updated after the xhr has actually completed

### DIFF
--- a/packages/driver/cypress/integration/cypress/proxy-logging_spec.ts
+++ b/packages/driver/cypress/integration/cypress/proxy-logging_spec.ts
@@ -181,15 +181,22 @@ describe('Proxy Logging', () => {
           }
         })
 
-        const oldOnload = cy.state('server').options.onLoad
+        const xhr = new win.XMLHttpRequest()
 
-        cy.stub(cy.state('server').options, 'onLoad').log(false).callsFake(function (...args) {
-          setTimeout(() => {
-            oldOnload.call(this, ...args)
-          }, 500)
+        const logIncomingRequest = Cypress.ProxyLogging.logIncomingRequest
+        const updateRequestWithResponse = Cypress.ProxyLogging.updateRequestWithResponse
+
+        // To simulate the xhr call landing second, we send updateRequestWithResponse immediately after
+        // the call is intercepted
+        cy.stub(Cypress.ProxyLogging, 'logIncomingRequest').log(false).callsFake(function (...args) {
+          logIncomingRequest.call(this, ...args)
+          updateRequestWithResponse.call(this, {
+            requestId: args[0].requestId,
+            status: 404,
+          })
         })
 
-        const xhr = new win.XMLHttpRequest()
+        cy.stub(Cypress.ProxyLogging, 'updateRequestWithResponse').log(false).callsFake(function () {})
 
         xhr.open('GET', '/some-url')
         xhr.send()

--- a/packages/driver/src/cypress/proxy-logging.ts
+++ b/packages/driver/src/cypress/proxy-logging.ts
@@ -344,20 +344,13 @@ export default class ProxyLogging {
       return debug('unmatched responseReceived event %o', responseReceived)
     }
 
-    if (proxyRequest.xhr && proxyRequest.xhr.xhr.readyState !== 4) {
-      const oldOnload = proxyRequest.xhr.xhr.onload
-      const proxyLogging = this
-
-      proxyRequest.xhr.xhr.onload = function (...args) {
-        if (oldOnload) {
-          oldOnload.call(this, ...args)
-        }
-
-        proxyLogging.updateProxyRequestWithResponse(proxyRequest, responseReceived)
-      }
+    if (proxyRequest.xhr && proxyRequest.xhr.xhr.readyState !== XMLHttpRequest.DONE) {
+      proxyRequest.xhr.xhr.addEventListener('load', () => {
+        this.updateProxyRequestWithResponse(proxyRequest, responseReceived)
+      })
+    } else {
+      this.updateProxyRequestWithResponse(proxyRequest, responseReceived)
     }
-
-    this.updateProxyRequestWithResponse(proxyRequest, responseReceived)
   }
 
   private updateRequestWithError (error: RequestError): void {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #21361 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

XHR calls will now properly display the response body in the command log

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

When the proxy gets the close event for the response, we send the `response:received` event to the client. There is a race condition where this might reach the client before the XHR readystate has been updated on the client. If this happens, the xhr that gets attached to the log will not have a response body yet. To fix this, we will listen to the `onload` event of the xhr call if the xhr call hasn't completed and delay updating the proxy logging response until then.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [X] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
