### PR TITLE
fix: show correct error message when a regex starting with `=` is passed to `cy.contains`.

### DIFF
--- a/packages/driver/cypress/integration/commands/querying/querying_spec.js
+++ b/packages/driver/cypress/integration/commands/querying/querying_spec.js
@@ -1230,6 +1230,16 @@ describe('src/cy/commands/querying', () => {
       cy.get('#backslashes').contains('"<OE_D]dQ\\')
     })
 
+    // https://github.com/cypress-io/cypress/issues/21108
+    it('shows correct error message when regex starts with =(equals sign)', () => {
+      cy.on('fail', (err) => {
+        expect(err.message).to.include('Expected to find content')
+      })
+
+      cy.visit('fixtures/dom.html')
+      cy.contains(/=[0-6]/, { timeout: 100 }).should('have.text', 'a=2')
+    })
+
     describe('should(\'not.exist\')', () => {
       it('returns null when no content exists', () => {
         cy.contains('alksjdflkasjdflkajsdf').should('not.exist').then(($el) => {

--- a/packages/driver/src/config/jquery.ts
+++ b/packages/driver/src/config/jquery.ts
@@ -51,6 +51,14 @@ $.find.matchesSelector = function (elem, expr) {
       return matchesSelector.apply(_this, args)
     },
     catchFn (e) {
+      // https://github.com/cypress-io/cypress/issues/21108
+      // When regex starts with =, it is a syntax error when nothing found.
+      // Because Sizzle internally escapes = to handle attribute selectors.
+      // @see https://github.com/jquery/sizzle/blob/20390f05731af380833b5aa805db97de0b91268a/external/jquery/jquery.js#L4363-L4370
+      if (e.message.includes(`Syntax error, unrecognized expression: :cy-contains('`)) {
+        return false
+      }
+
       throw e
     },
     finallyFn () {


### PR DESCRIPTION
- Closes #21108

### User facing changelog

Correct error message is shown and Cypress is properly retried when a regex starting with `=` is passed to `cy.contains`.

### Additional details
- Why was this change necessary? => Cypress doesn't work correctly when a regex starting with `=` is passed to `cy.contains`.
- What is affected by this change? => N/A
- Any implementation details to explain? => It was happening because Sizzle, jQuery selector engine escapes `=` to handle attribute selectors. I changed our jquery config code to handle this exceptional case. 

### How has the user experience changed?

```js
// Before: Fail with Syntax Error message + doesn't retry.
// After: Timed out error message + retry.
cy.contains(/=[0-6]/) 
```

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
