### PR TITLE
fix: remove fs sync warning

### DIFF
--- a/packages/scaffold-config/src/detect.ts
+++ b/packages/scaffold-config/src/detect.ts
@@ -1,7 +1,7 @@
 import { WIZARD_FRAMEWORKS, inPkgJson } from './frameworks'
 import { WIZARD_BUNDLERS } from './dependencies'
 import path from 'path'
-import fs from 'fs-extra'
+import fs from 'fs'
 import globby from 'globby'
 import type { PkgJson } from '.'
 import Debug from 'debug'


### PR DESCRIPTION
- Closes N/A

### User facing changelog
N/A

### Additional details

There's an incorrect check around `fs.existsSync` patched on `fs-extra` that tells us we can't use it. This is incorrect, we actually shouldn't be using `readFileSync`, as this is what opens a file descriptor. We can address that change in a separate PR.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
