### PR TITLE
chore: deprecate chromeWebSecurity

### DIFF
--- a/cli/schema/cypress.schema.json
+++ b/cli/schema/cypress.schema.json
@@ -181,7 +181,7 @@
         "chromeWebSecurity": {
           "type": "boolean",
           "default": true,
-          "description": "Whether Chrome Web Security for same-origin policy and insecure mixed content is enabled. Read more about this at https://on.cypress.io/web-security"
+          "description": "DEPRECATED: Please use cy.origin() instead. Whether Chrome Web Security for same-origin policy and insecure mixed content is enabled. Read more about this at https://on.cypress.io/web-security"
         },
         "userAgent": {
           "type": "string",

--- a/cli/types/cypress-npm-api.d.ts
+++ b/cli/types/cypress-npm-api.d.ts
@@ -25,7 +25,6 @@ declare namespace CypressCommandLine {
       browser: 'chrome',
       config: {
         baseUrl: 'http://localhost:8080',
-        chromeWebSecurity: false,
       },
       env: {
         foo: 'bar',

--- a/packages/config/__snapshots__/index_spec.js
+++ b/packages/config/__snapshots__/index_spec.js
@@ -1,5 +1,6 @@
 exports['config/lib/index .getBreakingKeys returns list of breaking config keys 1'] = [
   "blacklistHosts",
+  "chromeWebSecurity",
   "experimentalComponentTesting",
   "experimentalGetCookiesSameSite",
   "experimentalNetworkStubbing",

--- a/packages/config/lib/index.js
+++ b/packages/config/lib/index.js
@@ -79,7 +79,7 @@ module.exports = {
   validateNoBreakingConfig: (cfg, onWarning, onErr) => {
     breakingOptions.forEach(({ name, errorKey, newName, isWarning, value }) => {
       if (cfg.hasOwnProperty(name)) {
-        if (value && cfg[name] !== value) {
+        if (value !== undefined && cfg[name] !== value) {
           // Bail if a value is specified but the config does not have that value.
           return
         }

--- a/packages/config/lib/options.ts
+++ b/packages/config/lib/options.ts
@@ -35,7 +35,7 @@ interface BreakingOption {
   /**
    * Configuration value of the configuration option to check against.
    */
-  value?: string
+  value?: string | boolean
   /**
    * The new configuration key that is replacing the existing configuration key.
    */
@@ -486,6 +486,11 @@ export const breakingOptions: Array<BreakingOption> = [
     name: 'blacklistHosts',
     errorKey: 'RENAMED_CONFIG_OPTION',
     newName: 'blockHosts',
+  }, {
+    name: 'chromeWebSecurity',
+    errorKey: 'CHROME_WEB_SECURITY_DEPRECATED',
+    value: false,
+    isWarning: true,
   }, {
     name: 'experimentalComponentTesting',
     errorKey: 'EXPERIMENTAL_COMPONENT_TESTING_REMOVED',

--- a/packages/driver/cypress/integration/commands/navigation_spec.js
+++ b/packages/driver/cypress/integration/commands/navigation_spec.js
@@ -2177,11 +2177,14 @@ describe('src/cy/commands/navigation', () => {
               > ${error}\n
             Before the page load, you were bound to the origin policy:\n
               > http://localhost:3500\n
+            In order to navigate to a different origin, you can enable the \`experimentalSessionAndOrigin\` flag and use \`cy.origin()\`:\n
+            \`cy.get('.goToAnotherOrigin').click()\`
+            \`cy.origin('http://localhost:3500', () => {\`
+            \`  <commands targeting http://localhost:3500 go here>\`
+            \`})\`\n
             A cross origin error happens when your application navigates to a new URL which does not match the origin policy above.\n
             A new URL does not match the origin policy if the 'protocol', 'port' (if specified), and/or 'host' (unless of the same superdomain) are different.\n
-            Cypress does not allow you to navigate to a different origin URL within a single test.\n
-            You may need to restructure some of your test code to avoid this problem.\n
-            Alternatively you can also disable Chrome Web Security in Chromium-based browsers which will turn off this restriction by setting { chromeWebSecurity: false } in \`cypress.json\`.`)
+            Cypress does not allow you to navigate to a different origin URL within a single test without using \`cy.origin()\`.`)
 
             expect(err.docsUrl).to.eq('https://on.cypress.io/cross-origin-violation')
           }

--- a/packages/driver/src/cy/commands/navigation.ts
+++ b/packages/driver/src/cy/commands/navigation.ts
@@ -346,7 +346,6 @@ const stabilityChanged = (Cypress, state, config, stable) => {
       $errUtils.throwErrByPath('navigation.cross_origin', {
         onFail: options._log,
         args: {
-          configFile: Cypress.config('configFile'),
           message: err.message,
           originPolicy,
         },

--- a/packages/driver/src/cypress/error_messages.ts
+++ b/packages/driver/src/cypress/error_messages.ts
@@ -950,7 +950,7 @@ export default {
   },
 
   navigation: {
-    cross_origin ({ message, originPolicy, configFile }) {
+    cross_origin ({ message, originPolicy }) {
       return {
         message: stripIndent`\
           Cypress detected a cross origin error happened on page load:
@@ -961,15 +961,18 @@ export default {
 
             > ${originPolicy}
 
+          In order to navigate to a different origin, you can enable the \`experimentalSessionAndOrigin\` flag and use ${cmd('origin')}:
+
+          \`cy.get('.goToAnotherOrigin').click()\`
+          \`cy.origin('${originPolicy}', () => {\`
+          \`  <commands targeting ${originPolicy} go here>\`
+          \`})\`
+
           A cross origin error happens when your application navigates to a new URL which does not match the origin policy above.
 
           A new URL does not match the origin policy if the 'protocol', 'port' (if specified), and/or 'host' (unless of the same superdomain) are different.
 
-          Cypress does not allow you to navigate to a different origin URL within a single test.
-
-          You may need to restructure some of your test code to avoid this problem.
-
-          Alternatively you can also disable Chrome Web Security in Chromium-based browsers which will turn off this restriction by setting { chromeWebSecurity: false } in ${formatConfigFile(configFile)}.`,
+          Cypress does not allow you to navigate to a different origin URL within a single test without using ${cmd('origin')}.`,
         docsUrl: 'https://on.cypress.io/cross-origin-violation',
       }
     },

--- a/packages/errors/__snapshot-html__/CHROME_WEB_SECURITY_DEPRECATED.html
+++ b/packages/errors/__snapshot-html__/CHROME_WEB_SECURITY_DEPRECATED.html
@@ -34,9 +34,7 @@
     </style>
   
     </head>
-    <body><pre><span style="color:#e05561">The <span style="color:#e5e510">firefoxGcInterval<span style="color:#e05561"> configuration option was removed in Cypress version 8.0.0. It was introduced to work around a bug in Firefox 79 and below.<span style="color:#e6e6e6">
+    <body><pre><span style="color:#e05561">Deprecation Warning: <span style="color:#e5e510">chromeWebSecurity<span style="color:#e05561"> configuration option will be removed in a future release.<span style="color:#e6e6e6">
 <span style="color:#e05561"><span style="color:#e6e6e6">
-<span style="color:#e05561">Since Cypress no longer supports Firefox 85 and below in Cypress version 8.0.0, this option was removed.<span style="color:#e6e6e6">
-<span style="color:#e05561"><span style="color:#e6e6e6">
-<span style="color:#e05561">You can safely remove this option from your config.<span style="color:#e6e6e6"></span></span></span></span></span></span></span></span></span></span></span></span>
+<span style="color:#e05561">As of Cypress version 9.6.0, <span style="color:#4ec4ff">cy.origin()<span style="color:#e05561"> is available to replace <span style="color:#e5e510">chromeWebSecurity<span style="color:#e05561">. It is recommended to implement <span style="color:#4ec4ff">cy.origin()<span style="color:#e05561"> and remove the <span style="color:#e5e510">chromeWebSecurity<span style="color:#e05561"> configuration option from <span style="color:#4ec4ff">/path/to/configFile.json<span style="color:#e05561">.<span style="color:#e6e6e6"></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span>
 </pre></body></html>

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -88,6 +88,12 @@ export const AllCypressErrors = {
 
         This option will not have an effect in ${fmt.off(_.capitalize(browser))}. Tests that rely on web security being disabled will not run as expected.`
   },
+  CHROME_WEB_SECURITY_DEPRECATED: ({ name, configFile }: { name: string, configFile: string }) => {
+    return errTemplate`\
+      Deprecation Warning: ${fmt.highlight(name)} configuration option will be removed in a future release.
+
+      As of ${fmt.cypressVersion(`9.6.0`)}, ${fmt.code('cy.origin()')} is available to replace ${fmt.highlight(name)}. It is recommended to implement ${fmt.code('cy.origin()')} and remove the ${fmt.highlight(name)} configuration option from ${fmt.highlightTertiary(configFile)}.`
+  },
   BROWSER_NOT_FOUND_BY_NAME: (browser: string, foundBrowsersStr: string[]) => {
     let canarySuffix: PartialErr | null = null
 
@@ -1078,7 +1084,7 @@ export const AllCypressErrors = {
     return errTemplate`\
         The ${fmt.highlight(`firefoxGcInterval`)} configuration option was removed in ${fmt.cypressVersion(`8.0.0`)}. It was introduced to work around a bug in Firefox 79 and below.
 
-        Since Cypress no longer supports Firefox 85 and below in Cypress ${fmt.cypressVersion(`8.0.0`)}, this option was removed.
+        Since Cypress no longer supports Firefox 85 and below in ${fmt.cypressVersion(`8.0.0`)}, this option was removed.
 
         You can safely remove this option from your config.`
   },

--- a/packages/errors/test/unit/visualSnapshotErrors_spec.ts
+++ b/packages/errors/test/unit/visualSnapshotErrors_spec.ts
@@ -996,6 +996,11 @@ describe('visual error templates', () => {
         default: [],
       }
     },
+    CHROME_WEB_SECURITY_DEPRECATED: () => {
+      return {
+        default: [{ name: 'chromeWebSecurity', configFile: '/path/to/configFile.json' }],
+      }
+    },
     EXPERIMENTAL_COMPONENT_TESTING_REMOVED: () => {
       return {
         default: [{ configFile: '/path/to/configFile.json' }],

--- a/packages/server/test/unit/config_spec.js
+++ b/packages/server/test/unit/config_spec.js
@@ -1403,6 +1403,16 @@ describe('lib/config', () => {
       })
     })
 
+    it('warns if chromeWebSecurity is passed', async function () {
+      const warning = sinon.spy(errors, 'warning')
+
+      await this.defaults('chromeWebSecurity', false, {
+        chromeWebSecurity: false,
+      })
+
+      expect(warning).to.be.calledWith('CHROME_WEB_SECURITY_DEPRECATED')
+    })
+
     // @see https://github.com/cypress-io/cypress/issues/6892
     it('warns if experimentalGetCookiesSameSite is passed', async function () {
       const warning = sinon.spy(errors, 'warning')

--- a/system-tests/__snapshots__/web_security_spec.js
+++ b/system-tests/__snapshots__/web_security_spec.js
@@ -154,6 +154,9 @@ https://on.cypress.io/origin
 `
 
 exports['e2e web security / when disabled / passes'] = `
+Deprecation Warning: chromeWebSecurity configuration option will be removed in a future release.
+
+As of Cypress version 9.6.0, cy.origin() is available to replace chromeWebSecurity. It is recommended to implement cy.origin() and remove the chromeWebSecurity configuration option from cypress.json.
 
 ====================================================================================================
 
@@ -220,6 +223,9 @@ exports['e2e web security / when disabled / passes'] = `
 `
 
 exports['e2e web security / firefox / displays warning when firefox and chromeWebSecurity:false'] = `
+Deprecation Warning: chromeWebSecurity configuration option will be removed in a future release.
+
+As of Cypress version 9.6.0, cy.origin() is available to replace chromeWebSecurity. It is recommended to implement cy.origin() and remove the chromeWebSecurity configuration option from cypress.json.
 
 ====================================================================================================
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #19892

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
The `chromeWebSecurity` configuration option has been deprecated and will be removed in a future release. We encourage you to use `cy.origin` instead.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
With the addition of `cy.origin`, the `chromeWebSecurity` configuration option is no longer needed to allow users to navigate cross-origin. As such, this change deprecates the `chromeWebSecurity` option and notifies the user via a terminal warning that the option has been deprecated.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
<img width="1046" alt="Screen Shot 2022-05-11 at 10 47 29 AM" src="https://user-images.githubusercontent.com/2002044/167903867-840aca38-8f41-41b5-b40d-fa3d98520fc7.png">

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [x] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
