### PR TITLE
test: Updating readFile error test assertions that rely on consistent execution time

### DIFF
--- a/packages/driver/cypress/integration/commands/files_spec.js
+++ b/packages/driver/cypress/integration/commands/files_spec.js
@@ -293,10 +293,10 @@ describe('src/cy/commands/files', () => {
         err.filePath = '/path/to/foo.json'
 
         Cypress.backend.rejects(err)
-        let retries = 0
+        let hasRetried = false
 
         cy.on('command:retry', () => {
-          retries += 1
+          hasRetried = true
         })
 
         cy.on('fail', (err) => {
@@ -312,7 +312,8 @@ describe('src/cy/commands/files', () => {
             \`/path/to/foo.json\``)
 
           expect(err.docsUrl).to.eq('https://on.cypress.io/readfile')
-          expect(retries).to.eq(2)
+
+          expect(hasRetried).to.be.true
 
           done()
         })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This test was asserting on the exact number of command retries that were occurring prior to the command timeout being reached. This exact count has the potential to be non-deterministic based on the execution time of the command within our defined timeout (overridden here to 50ms).

I updated the test to validate that *at least one* retry has occurred, which validates that the retry logic is being executing as we expect without relying on a consistent execution time.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
