### PR TITLE
Bugfix/fix electron slowness cy origin

### DIFF
--- a/packages/app/src/main.scss
+++ b/packages/app/src/main.scss
@@ -29,3 +29,14 @@ html {
     height: 0;
   }
 }
+
+// used to style the spec bridge needed for cy.origin.
+iframe.spec-bridge-iframe {
+  border: none;
+  height: 100%;
+  position: fixed;
+  visibility: hidden;
+  width: 100%;
+  top: 0;
+  left: 0;
+}

--- a/packages/driver/cypress/support/utils.js
+++ b/packages/driver/cypress/support/utils.js
@@ -107,10 +107,7 @@ const getAllFn = (...aliases) => {
   )
 }
 
-// FIXME: currently increasing the timeout here from 250ms to 3 second
-// due to some unknown performance issues with logs coming back in from the primary in the 10.0-release branch.
-// this timeout should be reduced in the future once these performance issues are addressed.
-const shouldWithTimeout = (cb, timeout = 3000) => {
+const shouldWithTimeout = (cb, timeout = 250) => {
   cy.wrap({}, { timeout }).should(cb)
 }
 

--- a/packages/driver/src/cy/commands/origin/index.ts
+++ b/packages/driver/src/cy/commands/origin/index.ts
@@ -48,7 +48,7 @@ export default (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, state: Cypre
     // not have a cy.origin for the intermediary origin.
     timeoutId = setTimeout(() => {
       Cypress.backend('cross:origin:release:html')
-    }, 1000)
+    }, 300)
   })
 
   Commands.addAll({

--- a/packages/runner/src/iframe/iframe.scss
+++ b/packages/runner/src/iframe/iframe.scss
@@ -95,11 +95,3 @@
     width: 100%;
   }
 }
-
-.spec-bridge-iframe {
-  border: none;
-  height: 100%;
-  position: fixed;
-  visibility: hidden;
-  width: 100%;
-}

--- a/system-tests/__snapshots__/spec_bridge_in_viewport_spec.ts.js
+++ b/system-tests/__snapshots__/spec_bridge_in_viewport_spec.ts.js
@@ -1,0 +1,59 @@
+exports['e2e spec bridge in viewport / Overlays the reporter/AUT and is not positioned off screen, leading to potential performance impacts with cy.origin'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:      1.2.3                                                                            │
+  │ Browser:      FooBrowser 88                                                                    │
+  │ Specs:        1 found (spec_bridge.cy.ts)                                                      │
+  │ Searched:     cypress/e2e/spec_bridge.cy.ts                                                    │
+  │ Experiments:  experimentalSessionAndOrigin=true                                                │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  spec_bridge.cy.ts                                                               (1 of 1)
+
+
+  ✓ visits foobar.com and types foobar inside an input
+
+  1 passing
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        1                                                                                │
+  │ Passing:      1                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     spec_bridge.cy.ts                                                                │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/spec_bridge.cy.ts.mp4               (X second)
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✔  spec_bridge.cy.ts                        XX:XX        1        1        -        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✔  All specs passed!                        XX:XX        1        1        -        -        -  
+
+
+`

--- a/system-tests/projects/e2e/cypress/e2e/spec_bridge.cy.ts
+++ b/system-tests/projects/e2e/cypress/e2e/spec_bridge.cy.ts
@@ -1,0 +1,20 @@
+it('visits foobar.com and types foobar inside an input', () => {
+  cy.visit('primary_origin.html')
+  cy.get('[data-cy="cross_origin_secondary_link"]').click()
+
+  cy.origin('http://foobar.com:4466', () => {
+    cy.get('[data-cy="text-input"]').type('foobar')
+  })
+
+  // ensure stability
+  cy.then(() => {
+    const specBridgeIframe: HTMLIFrameElement = window.top.document.querySelector('.spec-bridge-iframe')
+    const currentBody = window.top.document.querySelector('body')
+
+    // make sure the spec bridge overlays the reporter/AUT and is not off the screen
+    expect(specBridgeIframe.offsetTop).to.equal(currentBody.offsetTop)
+    expect(specBridgeIframe.offsetLeft).to.equal(currentBody.offsetLeft)
+    expect(specBridgeIframe.clientWidth).to.equal(currentBody.clientWidth)
+    expect(specBridgeIframe.clientHeight).to.equal(currentBody.clientHeight)
+  })
+})

--- a/system-tests/projects/e2e/secondary_origin.html
+++ b/system-tests/projects/e2e/secondary_origin.html
@@ -6,6 +6,7 @@
   <p data-cy="dom-check">From a secondary origin</p>
   <p data-cy="cypress-check"></p>
   <p data-cy="window-before-load"></p>
+  <input data-cy="text-input" type="text"/>
   <form>
     <button type="submit">Submit</button>
   </form>

--- a/system-tests/test/spec_bridge_in_viewport_spec.ts
+++ b/system-tests/test/spec_bridge_in_viewport_spec.ts
@@ -1,0 +1,38 @@
+import path from 'path'
+import systemTests from '../lib/system-tests'
+import Fixtures from '../lib/fixtures'
+
+const e2ePath = Fixtures.projectPath('e2e')
+
+const PORT = 3500
+const onServer = function (app) {
+  app.get('/secondary_origin.html', (_, res) => {
+    res.sendFile(path.join(e2ePath, `secondary_origin.html`))
+  })
+}
+
+describe('e2e spec bridge in viewport', () => {
+  systemTests.setup({
+    servers: [{
+      port: 4466,
+      onServer,
+    }],
+    settings: {
+      hosts: {
+        '*.foobar.com': '127.0.0.1',
+      },
+    },
+  })
+
+  systemTests.it('Overlays the reporter/AUT and is not positioned off screen, leading to potential performance impacts with cy.origin', {
+    // keep the port the same to prevent issues with the snapshot
+    port: PORT,
+    spec: 'spec_bridge.cy.ts',
+    snapshot: true,
+    browser: 'electron',
+    expectedExitCode: 0,
+    config: {
+      experimentalSessionAndOrigin: true,
+    },
+  })
+})


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #21375

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
After merging `cy.origin` into the `10.0-release` branch, it was noticed that certain `cy.origin` tests were performing incredibly slow in electron. It turns out the root cause of this was the spec bridge iframe being beneath the Spec Runner / Reporter / AUT, which for some reason was causing electron to slow down drastically. In `9.x`, the spec bridge overlays the Reporter / AUT due to how the UI layout is structured. That structured changed in `10.x`, which made this problem visible. We were able to reproduce this issue in `9.x` by attaching the spec bridge after the `body` element, instead of within it. To fix this in `10.x`, we need to set the spec bridge to be within the viewport by set `top` and `left` to `0`. This is verified by a new system test added to make sure the spec bridge isn't shifted south of the AUT.

#### _CURRENT_ in `9.x` Spec Bridge overlaying AUT (no performance issue visible)
![9 x-spec-bridge-in-frame](https://user-images.githubusercontent.com/3980464/167963515-a0a6c61c-f167-4426-a2ef-17419159dff0.gif)

#### `9.x` Spec Bridge beneath AUT (performance issues present)
![9 x-spec-bridge-out-of-frame](https://user-images.githubusercontent.com/3980464/167963546-7f632336-67ec-4e9f-b249-770a4f707b0c.gif)

#### _CURRENT_ `9.x` Spec Bridge beneath AUT (performance issues present)

#### `10.x` Spec Bridge overlaying AUT (no performance issue visible)
![10 x-spec-bridge-in-frame](https://user-images.githubusercontent.com/3980464/167964229-e36b05af-907b-41d1-ab4b-617b9e7f0f60.gif)

#### _CURRENT_ `10.x` Spec Bridge beneath AUT (performance issues present)
![10 x-spec-bridge-out-of-frame](https://user-images.githubusercontent.com/3980464/167964392-8c97d418-efc5-4f50-a63e-6277cf6bf5be.gif)


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
