### PR TITLE
test: remove flaky click from navigation spec

### DIFF
--- a/packages/app/cypress/e2e/sidebar_navigation.cy.ts
+++ b/packages/app/cypress/e2e/sidebar_navigation.cy.ts
@@ -251,8 +251,6 @@ describe('Sidebar Navigation', () => {
     it('resize nav sends the correct value on the mutation', () => {
       cy.contains('fixture.js').click()
 
-      cy.get('.toggle-specs-text').click()
-
       cy.withCtx((ctx, o) => {
         o.sinon.stub(ctx.actions.localSettings, 'setPreferences').resolves()
       })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://cypress-io.atlassian.net/browse/UNIFY-1718

### User facing changelog

No changes.

### Additional details

The flaky test is checking that the mutation to store the width of the InlineSpecsList is called with a specific width value. 

To check the value, the test expects at a certain position of the right hand edge of the reporter, the reporter takes up the full space between the nav and the AUT. 

Previously, it used to click the "toggle specs list" button to close the specs list, before doing the test. Now that the specs list is closed by default, this test is in the weird situation of only passing when that click flakes, which is a known issue (see comment [here](https://github.com/cypress-io/cypress/blob/c110aa19412ca42c6f83fd87acca81729f955af9/packages/reporter/cypress/e2e/header.cy.ts#L44)), we often use `{ force: true }` elsewhere when clicking that button in an e2e test.

This PR removes the click since it is no longer needed.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
