### PR TITLE
fix: add support for Next.js v12.1.6

### DIFF
--- a/npm/react/plugins/next/findNextWebpackConfig.js
+++ b/npm/react/plugins/next/findNextWebpackConfig.js
@@ -29,11 +29,14 @@ async function getNextWebpackConfig (config) {
       buildId: `@cypress/react-${Math.random().toString()}`,
       config: nextConfig,
       dev: true,
-      isServer: false,
       pagesDir: findPagesDir(config.projectRoot),
       entrypoints: {},
       rewrites: { fallback: [], afterFiles: [], beforeFiles: [] },
       ...runWebpackSpan,
+      // Client webpack config for Next.js <= 12.1.5
+      isServer: false,
+      // Client webpack config for Next.js > 12.1.5
+      compilerType: 'client',
     },
   )
 


### PR DESCRIPTION
- Closes #19382

### User facing changelog
Add support for Next v12.1.6

### Additional details
The API for  [getNextJsBaseWebpackConfig](https://github.com/vercel/next.js/commit/0bf6655f1c9438591ca4cca8c34065ab164d9cc0) has changed in version 12.1.6 which was causing the resolved webpack config to not be the `client` webpack configuration. Small tweak passing in both options allows support for the new change and backwards compatibility.

### How has the user experience changed?
CT testing works with latest version on Next

### Testing
I have a clone of this PR targeting 10.0-release that has e2e tests covering this new version of Next.
https://github.com/cypress-io/cypress/pull/21515

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
