### PR TITLE
fix: increase timeouts for does not pause timers when disableTimersAn…

### DIFF
--- a/packages/driver/cypress/integration/e2e/origin/commands/screenshot.spec.ts
+++ b/packages/driver/cypress/integration/e2e/origin/commands/screenshot.spec.ts
@@ -210,7 +210,7 @@ context('cy.origin screenshot', () => {
         // Hide the element using setTimeout
           win.setTimeout(() => {
             (win.document.getElementsByClassName('tall-element')[0] as HTMLElement).style.display = 'none'
-          }, 50)
+          }, 100)
         })
 
         cy.screenshot({
@@ -219,11 +219,11 @@ context('cy.origin screenshot', () => {
           // Set the timeout to be longer than the element hiding timeout so it has time to run and hide the element
             setTimeout(() => {
               expect($el.find('.tall-element').css('display')).to.equal('none')
-            }, 100)
+            }, 200)
           },
         })
 
-        cy.wait(200)
+        cy.wait(400)
       })
     })
 


### PR DESCRIPTION
…dAnimations is false to prevent test race condition

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
Goal here is to try an reduce flake of the `does not pause timers when disableTimersAndAnimations is false` test inside the `cy.origin` suite. It was noticed that sometimes the `cy.screenshot` `onBeforeScreenshot` call & subsequent `setTimeout` were called before the `setTimeout` before the `window.then` in a few cases. Simply increasing the timeouts by a few milliseconds should resolve the issue (hopefully).

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
