### PR TITLE
fix: Ensuring spec file presence prior to webpack-dev-server compilation

### DIFF
--- a/npm/webpack-dev-server/cypress/e2e/react.cy.ts
+++ b/npm/webpack-dev-server/cypress/e2e/react.cy.ts
@@ -56,5 +56,36 @@ for (const project of WEBPACK_REACT) {
 
       cy.get('.passed > .num').should('contain', 1)
     })
+
+    // https://cypress-io.atlassian.net/browse/UNIFY-1697
+    it('filters missing spec files from loader during pre-compilation', () => {
+      cy.visitApp()
+
+      // 1. assert spec executes successfully
+      cy.contains('App.cy.jsx').click()
+      cy.get('.passed > .num').should('contain', 1)
+
+      // 2. remove file from file system
+      cy.withCtx(async (ctx) => {
+        await ctx.actions.file.removeFileInProject(`src/App.cy.jsx`)
+      })
+
+      // 3. assert redirect back to #/specs with alert presented
+      cy.contains('[data-cy="alert"]', 'Spec not found')
+
+      // 4. recreate spec, with same name as removed spec
+      cy.findByTestId('new-spec-button').click()
+      cy.findByRole('dialog').within(() => {
+        cy.get('input').clear().type('src/App.cy.jsx')
+        cy.contains('button', 'Create Spec').click()
+      })
+
+      cy.findByRole('dialog').within(() => {
+        cy.contains('button', 'Okay, run the spec').click()
+      })
+
+      // 5. assert recreated spec executes successfully
+      cy.get('.passed > .num').should('contain', 1)
+    })
   })
 }

--- a/npm/webpack-dev-server/cypress/e2e/webpack-dev-server.cy.ts
+++ b/npm/webpack-dev-server/cypress/e2e/webpack-dev-server.cy.ts
@@ -1,3 +1,4 @@
+/// <reference path="../support/e2e.ts" />
 describe('Config options', () => {
   it('supports supportFile = false', () => {
     cy.scaffoldProject('webpack5_wds4-react')
@@ -6,6 +7,41 @@ describe('Config options', () => {
 
     cy.visitApp()
     cy.contains('App.cy.jsx').click()
+    cy.get('.passed > .num').should('contain', 1)
+  })
+
+  // https://cypress-io.atlassian.net/browse/UNIFY-1697
+  it('filters missing spec files from loader during pre-compilation', () => {
+    cy.scaffoldProject('webpack5_wds4-react')
+    cy.openProject('webpack5_wds4-react', ['--config-file', 'cypress-webpack.config.ts'])
+    cy.startAppServer('component')
+
+    cy.visitApp()
+
+    // 1. assert test executes successfully
+    cy.contains('App.cy.jsx').click()
+    cy.get('.passed > .num').should('contain', 1)
+
+    // 2. remove file from file system
+    cy.withCtx(async (ctx) => {
+      await ctx.actions.file.removeFileInProject(`src/App.cy.jsx`)
+    })
+
+    // 3. assert redirect back to #/specs with alert presented
+    cy.contains('[data-cy="alert"]', 'Spec not found')
+
+    // 4. recreate spec with same name as removed spec
+    cy.findByTestId('new-spec-button').click()
+    cy.findByRole('dialog').within(() => {
+      cy.get('input').clear().type('src/App.cy.jsx')
+      cy.contains('button', 'Create Spec').click()
+    })
+
+    cy.findByRole('dialog').within(() => {
+      cy.contains('button', 'Okay, run the spec').click()
+    })
+
+    // 5. assert recreated spec runs successfully
     cy.get('.passed > .num').should('contain', 1)
   })
 })

--- a/npm/webpack-dev-server/cypress/e2e/webpack-dev-server.cy.ts
+++ b/npm/webpack-dev-server/cypress/e2e/webpack-dev-server.cy.ts
@@ -1,4 +1,3 @@
-/// <reference path="../support/e2e.ts" />
 describe('Config options', () => {
   it('supports supportFile = false', () => {
     cy.scaffoldProject('webpack5_wds4-react')
@@ -18,7 +17,7 @@ describe('Config options', () => {
 
     cy.visitApp()
 
-    // 1. assert test executes successfully
+    // 1. assert spec executes successfully
     cy.contains('App.cy.jsx').click()
     cy.get('.passed > .num').should('contain', 1)
 
@@ -30,7 +29,7 @@ describe('Config options', () => {
     // 3. assert redirect back to #/specs with alert presented
     cy.contains('[data-cy="alert"]', 'Spec not found')
 
-    // 4. recreate spec with same name as removed spec
+    // 4. recreate spec, with same name as removed spec
     cy.findByTestId('new-spec-button').click()
     cy.findByRole('dialog').within(() => {
       cy.get('input').clear().type('src/App.cy.jsx')
@@ -41,7 +40,7 @@ describe('Config options', () => {
       cy.contains('button', 'Okay, run the spec').click()
     })
 
-    // 5. assert recreated spec runs successfully
+    // 5. assert recreated spec executes successfully
     cy.get('.passed > .num').should('contain', 1)
   })
 })

--- a/npm/webpack-dev-server/cypress/e2e/webpack-dev-server.cy.ts
+++ b/npm/webpack-dev-server/cypress/e2e/webpack-dev-server.cy.ts
@@ -8,39 +8,4 @@ describe('Config options', () => {
     cy.contains('App.cy.jsx').click()
     cy.get('.passed > .num').should('contain', 1)
   })
-
-  // https://cypress-io.atlassian.net/browse/UNIFY-1697
-  it('filters missing spec files from loader during pre-compilation', () => {
-    cy.scaffoldProject('webpack5_wds4-react')
-    cy.openProject('webpack5_wds4-react', ['--config-file', 'cypress-webpack.config.ts'])
-    cy.startAppServer('component')
-
-    cy.visitApp()
-
-    // 1. assert spec executes successfully
-    cy.contains('App.cy.jsx').click()
-    cy.get('.passed > .num').should('contain', 1)
-
-    // 2. remove file from file system
-    cy.withCtx(async (ctx) => {
-      await ctx.actions.file.removeFileInProject(`src/App.cy.jsx`)
-    })
-
-    // 3. assert redirect back to #/specs with alert presented
-    cy.contains('[data-cy="alert"]', 'Spec not found')
-
-    // 4. recreate spec, with same name as removed spec
-    cy.findByTestId('new-spec-button').click()
-    cy.findByRole('dialog').within(() => {
-      cy.get('input').clear().type('src/App.cy.jsx')
-      cy.contains('button', 'Create Spec').click()
-    })
-
-    cy.findByRole('dialog').within(() => {
-      cy.contains('button', 'Okay, run the spec').click()
-    })
-
-    // 5. assert recreated spec executes successfully
-    cy.get('.passed > .num').should('contain', 1)
-  })
 })

--- a/npm/webpack-dev-server/package.json
+++ b/npm/webpack-dev-server/package.json
@@ -18,6 +18,7 @@
     "test-unit": "mocha -r ts-node/register/transpile-only --config ./test/.mocharc.js"
   },
   "dependencies": {
+    "fs-extra": "9.1.0",
     "html-webpack-plugin-4": "npm:html-webpack-plugin@^4",
     "html-webpack-plugin-5": "npm:html-webpack-plugin@^5",
     "speed-measure-webpack-plugin": "1.4.2",

--- a/npm/webpack-dev-server/src/devServer.ts
+++ b/npm/webpack-dev-server/src/devServer.ts
@@ -66,6 +66,8 @@ export function devServer (devServerConfig: WebpackDevServerConfig): Promise<Cyp
           process.exit(1)
         }
       }
+
+      devServerConfig.devServerEvents.emit('dev-server:compile:done')
     })
 
     if (result.version === 3) {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes UNIFY-1697

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

There is a race condition between our webpack compilation and our emission of the `dev-server:specs:changed` event. When a spec file is removed from the file system, we attempt to compile prior to updating our internal `files` property within the plugin, causing the loader to reference files that no longer exist.

I updated the `CypressCTWebpackPlugin` to filter out files in state that no longer exist on the file system during the beforeCompile phase. This prevents both the initial error from being presented at file removal time and allows the file to be immediately executed when re-created.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->


https://user-images.githubusercontent.com/1711637/169138230-2e4a3493-0726-4a1c-9eb1-2074fadc9aef.mov


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [n/a] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
