### PR TITLE
refactor: reduce flake in launchpad tests, return null for videoEmbedHtml if not needed

### DIFF
--- a/packages/data-context/src/sources/MigrationDataSource.ts
+++ b/packages/data-context/src/sources/MigrationDataSource.ts
@@ -97,12 +97,20 @@ export class MigrationDataSource {
   }
 
   async getVideoEmbedHtml () {
+    if (this.ctx.coreData.migration.videoEmbedHtml) {
+      return this.ctx.coreData.migration.videoEmbedHtml
+    }
+
     const versionData = await this.ctx.versions.versionData()
     const embedOnLink = `https://on.cypress.io/v10-video-embed/${versionData.current.version}`
 
     try {
       const response = await this.ctx.util.fetch(embedOnLink, { method: 'GET' })
       const { videoHtml } = await response.json()
+
+      this.ctx.update((d) => {
+        d.migration.videoEmbedHtml = videoHtml
+      })
 
       return videoHtml
     } catch {

--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -252,6 +252,18 @@ async function makeE2ETasks () {
           }), { status: 200 })
         }
 
+        if (String(url).startsWith('https://on.cypress.io/v10-video-embed/')) {
+          return new Response(JSON.stringify({
+            videoHtml: `<iframe
+              src="https://player.vimeo.com/video/668764401?h=0cbc785eef"
+              class="rounded h-full bg-gray-1000 w-full"
+              frameborder="0"
+              allow="autoplay; fullscreen; picture-in-picture"
+              allowfullscreen
+            />`,
+          }), { status: 200 })
+        }
+
         return fetchApi(url, init)
       })
 

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Migration.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Migration.ts
@@ -230,6 +230,10 @@ export const Migration = objectType({
     t.string('videoEmbedHtml', {
       description: 'Markup for the migration landing page video embed',
       resolve: (source, args, ctx) => {
+        if (!ctx.lifecycleManager.metaState.needsCypressJsonMigration) {
+          return null
+        }
+
         return ctx.migration.getVideoEmbedHtml()
       },
     })

--- a/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
+++ b/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
@@ -30,7 +30,7 @@ describe('Choose a Browser Page', () => {
 
       cy.percySnapshot()
 
-      cy.withCtx((ctx, o) => {
+      cy.withRetryableCtx((ctx, o) => {
         expect(ctx._apis.projectApi.launchProject).to.be.calledOnce
       })
     })

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -1,4 +1,5 @@
 import type { ProjectFixtureDir } from '@tooling/system-tests'
+import type { SinonStub } from 'sinon'
 import { getPathForPlatform } from './support/getPathForPlatform'
 
 // @ts-ignore
@@ -178,6 +179,20 @@ describe('Opening unmigrated project', () => {
     cy.visitLaunchpad()
     cy.contains(cy.i18n.welcomePage.title).should('be.visible')
     cy.contains(cy.i18n.migration.landingPage.title).should('not.exist')
+  })
+
+  it('should only hit the video on link once & cache it', () => {
+    cy.scaffoldProject('migration')
+    cy.openProject('migration')
+
+    cy.visitLaunchpad()
+    cy.contains(cy.i18n.migration.landingPage.title).should('be.visible')
+
+    cy.visitLaunchpad()
+    cy.contains(cy.i18n.migration.landingPage.title).should('be.visible')
+    cy.withCtx((ctx, o) => {
+      expect((ctx.util.fetch as SinonStub).args.filter((a) => String(a[0]).includes('v10-video-embed')).length).to.eq(1)
+    })
   })
 })
 

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -41,7 +41,7 @@ function skipCTMigration () {
 function migrateAndVerifyConfig (migratedConfigFile: string = 'cypress.config.js') {
   cy.contains('Migrate the configuration for me').click()
 
-  cy.withCtx(async (ctx, o) => {
+  cy.withRetryableCtx(async (ctx, o) => {
     const configStats = await ctx.file.checkIfFileExists(o.migratedConfigFile)
 
     expect(configStats).to.not.be.null.and.not.be.undefined

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -218,8 +218,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
     runAutoRename()
 
-    cy.wait(100)
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = [
         'cypress/component/button.cy.js',
         'cypress/component/input.cy.tsx',
@@ -261,9 +260,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
       runAutoRename()
 
-      cy.wait(100)
-
-      cy.withCtx(async (ctx) => {
+      cy.withRetryableCtx(async (ctx) => {
         const specs = [
           'cypress/e2e/foo.cy.ts',
           'cypress/component/button.cy.js',
@@ -281,7 +278,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
       migrateAndVerifyConfig()
       finishMigrationAndContinue()
 
-      cy.withCtx(async (ctx) => {
+      cy.withRetryableCtx(async (ctx) => {
         const integrationFolderStats = await ctx.file.checkIfFileExists(ctx.path.join('cypress', 'integration'))
 
         expect(integrationFolderStats).to.be.null
@@ -336,9 +333,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
       cy.findByText('Rename the folder for me').click()
 
-      cy.wait(100)
-
-      cy.withCtx(async (ctx) => {
+      cy.withRetryableCtx(async (ctx) => {
         const specs = [
           'cypress/e2e/foo.spec.js',
         ]
@@ -378,9 +373,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
     runAutoRename()
 
-    cy.wait(100)
-
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = [
         'cypress/e2e/foo.cy.ts',
         'cypress/component/button.cy.js',
@@ -429,9 +422,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
     runAutoRename()
 
-    cy.wait(100)
-
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = [
         'cypress/e2e/foo.cy.ts',
         'cypress/component/button.cy.js',
@@ -449,7 +440,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
     migrateAndVerifyConfig()
     finishMigrationAndContinue()
 
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const integrationFolderStats = await ctx.file.checkIfFileExists(ctx.path.join('cypress', 'integration'))
 
       expect(integrationFolderStats).to.be.null
@@ -478,9 +469,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
     runAutoRename()
 
-    cy.wait(100)
-
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = ['src/basic.cy.js']
 
       for (const spec of specs) {
@@ -542,9 +531,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
     runAutoRename()
 
-    cy.wait(100)
-
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = ['cypress/e2e/basic.test.js']
 
       for (const spec of specs) {
@@ -589,9 +576,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
     runAutoRename()
 
-    cy.wait(100)
-
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = ['cypress/e2e/foo.cy.js']
 
       for (const spec of specs) {
@@ -636,9 +621,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
     runAutoRename()
 
-    cy.wait(100)
-
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = ['cypress/e2e/foo.spec.js']
 
       for (const spec of specs) {
@@ -683,9 +666,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
     runAutoRename()
 
-    cy.wait(100)
-
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = ['cypress/e2e/foo.spec.js']
 
       for (const spec of specs) {
@@ -729,9 +710,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
     runAutoRename()
 
-    cy.wait(100)
-
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = ['cypress/e2e/foo.cy.js']
 
       for (const spec of specs) {
@@ -767,9 +746,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
     runAutoRename()
 
-    cy.wait(100)
-
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = ['cypress/e2e/foo.cy.coffee']
 
       for (const spec of specs) {
@@ -805,9 +782,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
     runAutoRename()
 
-    cy.wait(100)
-
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = ['cypress/e2e/foo.cy.cjsx']
 
       for (const spec of specs) {
@@ -1004,8 +979,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
     runAutoRename()
 
-    cy.wait(100)
-    cy.withCtx((ctx) => {
+    cy.withRetryableCtx((ctx) => {
       ['cypress/e2e/foo.cy.js'].forEach(async (spec) => {
         const stats = await ctx.file.checkIfFileExists(ctx.path.join(spec))
 
@@ -1022,7 +996,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
     startMigrationFor('migration-specs-already-migrated')
     cy.get(renameAutoStep).should('not.exist')
 
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = [
         'cypress/tests/foo.cy.js',
       ]
@@ -1064,9 +1038,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
     runAutoRename()
 
-    cy.wait(100)
-
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = [
         'cypress/e2e/app-spec2.cy.js',
         'cypress/e2e/app_spec2.cy.js',
@@ -1116,9 +1088,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
       runAutoRename()
 
-      cy.wait(100)
-
-      cy.withCtx(async (ctx) => {
+      cy.withRetryableCtx(async (ctx) => {
         const specs = [
           'cypress/custom-integration/foo.cy.ts',
           'cypress/custom-component/button.cy.js',
@@ -1166,7 +1136,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
       cy.findByText('Skip renaming specs').click()
 
-      cy.withCtx(async (ctx) => {
+      cy.withRetryableCtx(async (ctx) => {
         const specs = [
           'cypress/custom-integration/foo.spec.ts',
           'cypress/custom-component/button.spec.js',
@@ -1241,9 +1211,7 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
 
     runAutoRename()
 
-    cy.wait(100)
-
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const files = ['cypress/e2e/foo.cy.js', 'cypress/e2e/example.json']
 
       for (const file of files) {
@@ -1328,7 +1296,7 @@ describe('Migration', { viewportWidth: 1200, retries: { openMode: 0, runMode: 2 
     cy.findByText('Rename the support file for me').click()
     cy.findByText('Migrate the configuration for me').click()
 
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const configStats = await ctx.file.checkIfFileExists('cypress.config.js')
 
       expect(configStats).to.not.be.null.and.not.be.undefined
@@ -1415,9 +1383,7 @@ describe('Migrate custom config files', () => {
 
     runAutoRename()
 
-    cy.wait(100)
-
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = ['cypress/e2e/foo.cy.js']
 
       for (const spec of specs) {
@@ -1467,9 +1433,7 @@ describe('Migrate custom config files', () => {
 
     runAutoRename()
 
-    cy.wait(100)
-
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = ['cypress/e2e/foo.cy.js']
 
       for (const spec of specs) {
@@ -1519,9 +1483,7 @@ describe('Migrate custom config files', () => {
 
     runAutoRename()
 
-    cy.wait(100)
-
-    cy.withCtx(async (ctx) => {
+    cy.withRetryableCtx(async (ctx) => {
       const specs = ['cypress/e2e/foo.cy.js']
 
       for (const spec of specs) {

--- a/packages/launchpad/cypress/e2e/open-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/open-mode.cy.ts
@@ -55,6 +55,8 @@ describe('Launchpad: Open Mode', () => {
       cy.get('h1').should('contain', 'Choose a Browser')
       cy.get('[data-cy-browser=firefox]').should('have.attr', 'aria-checked', 'true')
       cy.get('button[data-cy=launch-button]').invoke('text').should('include', 'Start E2E Testing in Firefox')
+
+      cy.wait(100)
     })
 
     it('auto-launches the browser when launched with --browser --testingType --project', () => {
@@ -70,6 +72,8 @@ describe('Launchpad: Open Mode', () => {
       cy.get('h1').should('contain', 'Choose a Browser')
       cy.get('[data-cy-browser=firefox]').should('have.attr', 'aria-checked', 'true')
       cy.get('button[data-cy=launch-button]').invoke('text').should('include', 'Start E2E Testing in Firefox')
+
+      cy.wait(100)
 
       cy.withRetryableCtx((ctx) => {
         expect(ctx._apis.projectApi.launchProject).to.be.calledOnce

--- a/packages/launchpad/cypress/e2e/open-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/open-mode.cy.ts
@@ -71,7 +71,7 @@ describe('Launchpad: Open Mode', () => {
       cy.get('[data-cy-browser=firefox]').should('have.attr', 'aria-checked', 'true')
       cy.get('button[data-cy=launch-button]').invoke('text').should('include', 'Start E2E Testing in Firefox')
 
-      cy.withCtx((ctx) => {
+      cy.withRetryableCtx((ctx) => {
         expect(ctx._apis.projectApi.launchProject).to.be.calledOnce
       })
     })

--- a/packages/launchpad/cypress/e2e/open-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/open-mode.cy.ts
@@ -58,11 +58,11 @@ describe('Launchpad: Open Mode', () => {
     })
 
     it('auto-launches the browser when launched with --browser --testingType --project', () => {
+      cy.scaffoldProject('launchpad')
       cy.withCtx((ctx, o) => {
         o.sinon.stub(ctx._apis.projectApi, 'launchProject').resolves()
       })
 
-      cy.scaffoldProject('launchpad')
       cy.openProject('launchpad', ['--browser', 'firefox', '--e2e'])
 
       // Need to visit after args have been configured, todo: fix in #18776

--- a/packages/launchpad/src/setup/TestingTypeCards.vue
+++ b/packages/launchpad/src/setup/TestingTypeCards.vue
@@ -42,7 +42,9 @@ const props = defineProps<{
 }>()
 
 function selectTestingType (testingType: 'e2e' | 'component') {
-  mutation.executeMutation({ testingType })
+  if (!mutation.fetching.value) {
+    mutation.executeMutation({ testingType })
+  }
 }
 
 </script>


### PR DESCRIPTION
- Closes UNIFY-1740

### User facing changelog

A bit of cleanup from flake seen in tests for #21560, in `migration.cy.ts` & `project-setup.cy.ts` also we don't want to be hitting the on link and returning for `videoEmbedHtml` unless we are currently migrating.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
