### PR TITLE
chore: add regression test for ts detection

### DIFF
--- a/packages/scaffold-config/test/unit/detect.spec.ts
+++ b/packages/scaffold-config/test/unit/detect.spec.ts
@@ -304,4 +304,16 @@ describe('detectLanguage', () => {
 
     expect(actual).to.eq('ts')
   })
+
+  it('ignores node_modules when checking for tsconfig.json', async () => {
+    const projectRoot = await scaffoldMigrationProject('pristine-cjs-project')
+
+    await fs.mkdirp(path.join(projectRoot, 'node_modules', 'some-node-module'))
+    await fs.writeFile(path.join(projectRoot, 'node_modules', 'some-node-module', 'tsconfig.json'), '')
+    const pkgJson = fs.readJsonSync(path.join(projectRoot, 'package.json'))
+
+    const actual = detectLanguage(projectRoot, pkgJson)
+
+    expect(actual).to.eq('js')
+  })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://cypress-io.atlassian.net/browse/UNIFY-1765 (already closed, adding regression test)

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Fix a bug where `tsconfig.json` in `node_modules` incorrectly flags that the user's project is using TypeScript.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

As per [this tech brief](https://github.com/cypress-io/tech-briefs/pull/22) we changed how we detect TS for the user project. We are using `globby` to detect `tsconfig.json` in the project root, and using the `gitignore: true` flag to ignore files in common places like `node_modules`.

This does not work for one use case - where the user is not using `git`, which means `node_modules` is incorrectly included when globbing for `tsconfig.json`. This was fixed as side effect of another, unrelated PR: https://github.com/cypress-io/cypress/commit/aa4c0b5e09ac4a7049a332556b8c0182dbb0d669#diff-ce8622dde6ed83c3ceb55b5766f02a3dd06e26b84a51e0de44083e9246a768bfR138 but a regression test was not added at that point, so I'm adding one now.



### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

The language is correctly inferred for projects that do not use `git`.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
