### PR TITLE
fix: do not allow experimentalSessionAndOrigin to be available in CT …

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3043,7 +3043,7 @@ declare namespace Cypress {
     viteConfig?: Omit<Exclude<PickConfigOpt<'viteConfig'>, undefined>, 'base' | 'root'>
   }
 
-  interface ComponentConfigOptions<ComponentDevServerOpts = any> extends Omit<CoreConfigOptions, 'baseUrl'> {
+  interface ComponentConfigOptions<ComponentDevServerOpts = any> extends Omit<CoreConfigOptions, 'baseUrl' | 'experimentalSessionAndOrigin'> {
     devServer: DevServerFn<ComponentDevServerOpts> | DevServerConfigOptions
     devServerConfig?: ComponentDevServerOpts
   }

--- a/packages/config/src/options.ts
+++ b/packages/config/src/options.ts
@@ -209,7 +209,7 @@ const resolvedOptions: Array<ResolvedConfigOption> = [
     defaultValue: false,
     validation: validate.isBoolean,
     isExperimental: true,
-    canUpdateDuringTestTime: true,
+    canUpdateDuringTestTime: false,
   }, {
     name: 'experimentalSourceRewriting',
     defaultValue: false,
@@ -638,6 +638,11 @@ export const breakingRootOptions: Array<BreakingOption> = [
     isWarning: false,
     testingTypes: ['e2e'],
   }, {
+    name: 'experimentalSessionAndOrigin',
+    errorKey: 'CONFIG_FILE_INVALID_ROOT_CONFIG_E2E',
+    isWarning: false,
+    testingTypes: ['e2e'],
+  }, {
     name: 'excludeSpecPattern',
     errorKey: 'CONFIG_FILE_INVALID_ROOT_CONFIG',
     isWarning: false,
@@ -681,6 +686,11 @@ export const testingTypeBreakingOptions: { e2e: Array<BreakingOption>, component
   component: [
     {
       name: 'baseUrl',
+      errorKey: 'CONFIG_FILE_INVALID_TESTING_TYPE_CONFIG_COMPONENT',
+      isWarning: false,
+    },
+    {
+      name: 'experimentalSessionAndOrigin',
       errorKey: 'CONFIG_FILE_INVALID_TESTING_TYPE_CONFIG_COMPONENT',
       isWarning: false,
     },

--- a/packages/data-context/__snapshots__/codegen.spec.ts.js
+++ b/packages/data-context/__snapshots__/codegen.spec.ts.js
@@ -28,6 +28,7 @@ module.exports = defineConfig({
       return require('./cypress/plugins/index.js')(on, config)
     },
     baseUrl: 'localhost:3000',
+    experimentalSessionAndOrigin: true,
   },
   component: {
     setupNodeEvents(on, config) {},
@@ -68,6 +69,7 @@ module.exports = defineConfig({
     },
     retries: 2,
     baseUrl: 'localhost:300',
+    experimentalSessionAndOrigin: true,
     slowTestThreshold: 500,
   },
   component: {

--- a/packages/data-context/src/sources/migration/codegen.ts
+++ b/packages/data-context/src/sources/migration/codegen.ts
@@ -434,6 +434,7 @@ export function reduceConfig (cfg: LegacyCypressConfigJson, options: CreateConfi
           e2e: { ...acc.e2e, supportFile: val },
         }
       case 'baseUrl':
+      case 'experimentalSessionAndOrigin':
         return {
           ...acc,
           e2e: { ...acc.e2e, [key]: val },

--- a/packages/data-context/test/unit/sources/migration/codegen.spec.ts
+++ b/packages/data-context/test/unit/sources/migration/codegen.spec.ts
@@ -60,6 +60,7 @@ describe('cypress.config.js generation', () => {
     const config: Partial<Cypress.Config> = {
       e2e: {
         baseUrl: 'localhost:3000',
+        experimentalSessionAndOrigin: true,
       },
     }
 
@@ -126,6 +127,7 @@ describe('cypress.config.js generation', () => {
     const config = {
       viewportWidth: 300,
       baseUrl: 'localhost:300',
+      experimentalSessionAndOrigin: true,
       slowTestThreshold: 500,
       e2e: {
         retries: 2,

--- a/system-tests/__snapshots__/config_spec.js
+++ b/system-tests/__snapshots__/config_spec.js
@@ -408,3 +408,18 @@ Please remove this option or add this as a component testing type property: comp
 https://on.cypress.io/migration-guide
 
 `
+
+exports['e2e config throws an error if experimentalSessionAndOrigin is set on the component level 1'] = `
+The component.experimentalSessionAndOrigin configuration option is not valid for component testing.
+
+Please remove this option or add this as an e2e testing type property: e2e.experimentalSessionAndOrigin
+
+{
+  e2e: {
+    experimentalSessionAndOrigin: '...',
+  }
+}
+
+https://on.cypress.io/migration-guide
+
+`

--- a/system-tests/projects/invalid-root-level-config/invalid-component-experimentalSessionAndOrigin-config.js
+++ b/system-tests/projects/invalid-root-level-config/invalid-component-experimentalSessionAndOrigin-config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  component: {
+    experimentalSessionAndOrigin: true,
+  },
+}

--- a/system-tests/projects/migration/cypress.json
+++ b/system-tests/projects/migration/cypress.json
@@ -6,6 +6,7 @@
   "componentFolder": "src",
   "testFiles": "**/*.spec.{tsx,js}",
   "pluginsFile": "cypress/plugins/index.js",
+  "experimentalSessionAndOrigin": true,
   "e2e": {
     "defaultCommandTimeout": 10000,
     "slowTestThreshold": 5000

--- a/system-tests/projects/migration/expected-cypress.config.js
+++ b/system-tests/projects/migration/expected-cypress.config.js
@@ -15,6 +15,7 @@ module.exports = defineConfig({
     slowTestThreshold: 5000,
     baseUrl: 'http://localhost:3000',
     specPattern: 'cypress/e2e/**/*.spec.{tsx,js}',
+    experimentalSessionAndOrigin: true,
   },
   component: {
     setupNodeEvents (on, config) {},

--- a/system-tests/test/config_spec.js
+++ b/system-tests/test/config_spec.js
@@ -170,6 +170,18 @@ describe('e2e config', () => {
     })
   })
 
+  it('throws an error if experimentalSessionAndOrigin is set on the component level', async function () {
+    await Fixtures.scaffoldProject('invalid-root-level-config')
+
+    return systemTests.exec(this, {
+      project: 'invalid-root-level-config',
+      configFile: 'invalid-component-experimentalSessionAndOrigin-config.js',
+      testingType: 'component',
+      expectedExitCode: 1,
+      snapshot: true,
+    })
+  })
+
   it('throws an error if indexHtml is set on the root level', async function () {
     await Fixtures.scaffoldProject('invalid-root-level-config')
 


### PR DESCRIPTION
…per https://github.com/cypress-io/cypress/issues/21573

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #21573

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
The goal of this PR is to make `experimentalSessionAndOrigin` scoped to `e2e` testing only until we evaluate how session would be used, as well as test isolation, in the CT environment.

Updates to the `config` have been added to forbid use of the `experimentalSessionAndOrigin` flag, as well as added tests to make sure `experimentalSessionAndOrigin` is migrated to the `e2e` config options and not kept at the root level. There is also an added system test to verify error messaging if a user tries to add the `experimentalSessionAndOrigin` flag under the `component` config.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
