### PR TITLE
fix: Successfully create new specs files that do not have a known extension

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -46,7 +46,6 @@ macWorkflowFilters: &mac-workflow-filters
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
     - equal: [ '10.0-release', << pipeline.git.branch >> ]
-    - equal: [ 'tbiethman/issue-21236', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -56,6 +55,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
     - equal: [ '10.0-release', << pipeline.git.branch >> ]
+    - equal: [ 'tbiethman/UNIFY-1787-spec-names-with-ext', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>

--- a/packages/app/cypress/e2e/specs.cy.ts
+++ b/packages/app/cypress/e2e/specs.cy.ts
@@ -448,7 +448,7 @@ describe('App: Specs', () => {
           cy.contains('button', defaultMessages.createSpec.createSpec).should('not.be.disabled').click()
           cy.contains('h2', defaultMessages.createSpec.successPage.header)
 
-          cy.get('[data-cy="file-row"]').contains(getPathForPlatform('src/e2e/spec.js')).should('be.exist')
+          cy.get('[data-cy="file-row"]').contains(getPathForPlatform('src/e2e/spec.js')).should('be.visible')
         })
       })
 

--- a/packages/app/cypress/e2e/specs.cy.ts
+++ b/packages/app/cypress/e2e/specs.cy.ts
@@ -433,7 +433,9 @@ describe('App: Specs', () => {
             await ctx.actions.file.writeFileInProject('cypress.config.js', config)
           })
 
-          cy.contains('No Specs Found').should('be.visible')
+          // Timeout is increased here to allow ample time for the config change to be processed
+          cy.contains('No Specs Found', { timeout: 10000 }).should('be.visible')
+
           cy.findByRole('button', { name: 'New Spec' }).click()
           cy.contains('Create new empty spec').click()
 
@@ -708,7 +710,8 @@ describe('App: Specs', () => {
           await ctx.actions.file.writeFileInProject('cypress.config.js', config)
         })
 
-        cy.contains('No Specs Found').should('be.visible')
+        // Timeout is increased here to allow ample time for the config change to be processed
+        cy.contains('No Specs Found', { timeout: 10000 }).should('be.visible')
         cy.findByRole('button', { name: 'New Spec' }).click()
 
         cy.findByRole('dialog', {

--- a/packages/app/cypress/e2e/specs.cy.ts
+++ b/packages/app/cypress/e2e/specs.cy.ts
@@ -420,6 +420,34 @@ describe('App: Specs', () => {
 
           cy.visitApp().get('[data-cy-row]').contains('MyTest.cy.js')
         })
+
+        it('generates spec with file name that does not contain a known spec extension', () => {
+          cy.withCtx(async (ctx) => {
+            let config = ctx.actions.file.readFileInProject('cypress.config.js')
+
+            config = config.replace(
+                `specPattern: 'src/**/*.{cy,spec}.{js,jsx}'`,
+                `specPattern: 'src/e2e/**/*.{js,jsx}'`,
+            )
+
+            await ctx.actions.file.writeFileInProject('cypress.config.js', config)
+          })
+
+          cy.contains('No Specs Found').should('be.visible')
+          cy.findByRole('button', { name: 'New Spec' }).click()
+          cy.contains('Create new empty spec').click()
+
+          cy.findAllByLabelText(defaultMessages.createSpec.e2e.importEmptySpec.inputPlaceholder)
+          .as('enterSpecInput')
+
+          cy.get('@enterSpecInput').invoke('val').should('eq', getPathForPlatform('src/e2e/spec.js'))
+          cy.contains(defaultMessages.createSpec.e2e.importEmptySpec.invalidSpecWarning).should('not.exist')
+
+          cy.contains('button', defaultMessages.createSpec.createSpec).should('not.be.disabled').click()
+          cy.contains('h2', defaultMessages.createSpec.successPage.header)
+
+          cy.get('[data-cy="file-row"]').contains(getPathForPlatform('src/e2e/spec.js')).should('be.exist')
+        })
       })
 
       it('shows extension warning', () => {
@@ -666,6 +694,36 @@ describe('App: Specs', () => {
         cy.contains('Cancel').click()
 
         cy.findByRole('dialog', { name: 'Enter the path for your new spec' }).should('not.exist')
+      })
+
+      it('generates spec with file name that does not contain a known spec extension', () => {
+        cy.withCtx(async (ctx) => {
+          let config = ctx.actions.file.readFileInProject('cypress.config.js')
+
+          config = config.replace(
+              `specPattern: 'src/specs-folder/*.cy.{js,jsx}'`,
+              `specPattern: 'src/specs-folder/*.{js,jsx}'`,
+          )
+
+          await ctx.actions.file.writeFileInProject('cypress.config.js', config)
+        })
+
+        cy.contains('No Specs Found').should('be.visible')
+        cy.findByRole('button', { name: 'New Spec' }).click()
+
+        cy.findByRole('dialog', {
+          name: 'Enter the path for your new spec',
+        }).within(() => {
+          cy.findByLabelText('Enter a relative path...').invoke('val').should('eq', getPathForPlatform('src/specs-folder/ComponentName.js'))
+
+          cy.findByRole('button', { name: 'Create Spec' }).click()
+        })
+
+        cy.findByRole('dialog', {
+          name: defaultMessages.createSpec.successPage.header,
+        }).as('SuccessDialog').within(() => {
+          cy.contains(getPathForPlatform('src/specs-folder/ComponentName.js')).should('be.visible')
+        })
       })
     })
   })

--- a/packages/data-context/src/actions/ProjectActions.ts
+++ b/packages/data-context/src/actions/ProjectActions.ts
@@ -346,22 +346,6 @@ export class ProjectActions {
       throw Error(`Cannot create spec without currentProject.`)
     }
 
-    const parsed = path.parse(codeGenCandidate)
-
-    const possibleExtensions = ['.cy', '.spec', '.test', '-spec', '-test', '_spec']
-
-    const getFileExtension = () => {
-      if (erroredCodegenCandidate) {
-        return ''
-      }
-
-      return (
-        possibleExtensions.find((ext) => {
-          return codeGenCandidate.endsWith(ext + parsed.ext)
-        }) || parsed.ext
-      )
-    }
-
     const getCodeGenPath = () => {
       return codeGenType === 'e2e' || erroredCodegenCandidate
         ? this.ctx.path.join(
@@ -371,13 +355,11 @@ export class ProjectActions {
         : codeGenCandidate
     }
 
-    const specFileExtension = getFileExtension()
     const codeGenPath = getCodeGenPath()
 
     const newSpecCodeGenOptions = new SpecOptions(this.ctx, {
       codeGenPath,
       codeGenType,
-      specFileExtension,
       erroredCodegenCandidate,
     })
 

--- a/packages/data-context/src/codegen/spec-options.ts
+++ b/packages/data-context/src/codegen/spec-options.ts
@@ -10,7 +10,8 @@ interface CodeGenOptions {
 }
 
 // Spec file extensions that we will preserve when updating the file name
-// due to a file with that name already existing on the file system.
+// due the existence of duplicate files.
+//
 // Example:
 //   Button.cy.ts   -> Button-copy-1.cy.ts
 //   Button_spec.js -> Button-copy-1_spec.js
@@ -37,11 +38,11 @@ export class SpecOptions {
       return ''
     }
 
-    const candidateSpecExtension = expectedSpecExtensions.find((specExtension) => {
+    const foundSpecExtension = expectedSpecExtensions.find((specExtension) => {
       return this.parsedPath.base.endsWith(specExtension + this.parsedPath.ext)
     })
 
-    return candidateSpecExtension || ''
+    return foundSpecExtension || ''
   }
 
   private async getFilename () {

--- a/packages/data-context/test/unit/codegen/spec-options.spec.ts
+++ b/packages/data-context/test/unit/codegen/spec-options.spec.ts
@@ -21,6 +21,10 @@ describe('spec-options', () => {
   })
 
   describe('getCodeGenOptions', () => {
+    it('uses expected set of spec extensions', () => {
+      expect(expectedSpecExtensions).to.deep.eq(['.cy', '.spec', '.test', '-spec', '-test', '_spec'])
+    })
+
     context('unique file names', () => {
       for (const specExtension of expectedSpecExtensions) {
         it(`generates options for name names with extension ${specExtension}`, async () => {

--- a/packages/data-context/test/unit/codegen/spec-options.spec.ts
+++ b/packages/data-context/test/unit/codegen/spec-options.spec.ts
@@ -1,0 +1,145 @@
+import { expect } from 'chai'
+import fs from 'fs-extra'
+import path from 'path'
+import { DataContext } from '../../../src'
+import { SpecOptions, expectedSpecExtensions } from '../../../src/codegen/spec-options'
+import { createTestDataContext } from '../helper'
+
+const tmpPath = path.join(__dirname, 'tmp/test-code-gen')
+
+describe('spec-options', () => {
+  let ctx: DataContext
+
+  beforeEach(async () => {
+    await fs.remove(tmpPath)
+
+    ctx = createTestDataContext()
+
+    ctx.update((s) => {
+      s.currentProject = tmpPath
+    })
+  })
+
+  describe('getCodeGenOptions', () => {
+    context('unique file names', () => {
+      for (const specExtension of expectedSpecExtensions) {
+        it(`generates options for name names with extension ${specExtension}`, async () => {
+          const testSpecOptions = new SpecOptions(ctx, {
+            codeGenPath: `${tmpPath}/TestName${specExtension}.js`,
+            codeGenType: 'e2e',
+          })
+
+          const result = await testSpecOptions.getCodeGenOptions()
+
+          expect(result.codeGenType).to.eq('e2e')
+          expect(result.fileName).to.eq(`TestName${specExtension}.js`)
+        })
+      }
+
+      it('generates options for file name without spec extension', async () => {
+        const testSpecOptions = new SpecOptions(ctx, {
+          codeGenPath: `${tmpPath}/TestName.js`,
+          codeGenType: 'e2e',
+        })
+
+        const result = await testSpecOptions.getCodeGenOptions()
+
+        expect(result.codeGenType).to.eq('e2e')
+        expect(result.fileName).to.eq(`TestName.js`)
+      })
+
+      it('generates options for file name with multiple extensions', async () => {
+        const testSpecOptions = new SpecOptions(ctx, {
+          codeGenPath: `${tmpPath}/TestName.foo.bar.js`,
+          codeGenType: 'e2e',
+        })
+
+        const result = await testSpecOptions.getCodeGenOptions()
+
+        expect(result.codeGenType).to.eq('e2e')
+        expect(result.fileName).to.eq(`TestName.foo.bar.js`)
+      })
+
+      it('generates options with given codeGenType', async () => {
+        const testSpecOptions = new SpecOptions(ctx, {
+          codeGenPath: `${tmpPath}/TestName.js`,
+          codeGenType: 'component',
+        })
+
+        const result = await testSpecOptions.getCodeGenOptions()
+
+        expect(result.codeGenType).to.eq('component')
+      })
+    })
+
+    context('duplicate files names', () => {
+      for (const specExtension of expectedSpecExtensions) {
+        it(`generates options for file name with extension ${specExtension}`, async () => {
+          const testSpecOptions = new SpecOptions(ctx, {
+            codeGenPath: `${tmpPath}/TestName${specExtension}.js`,
+            codeGenType: 'e2e',
+          })
+
+          await fs.outputFile(`${tmpPath}/TestName${specExtension}.js`, '// foo')
+
+          let result = await testSpecOptions.getCodeGenOptions()
+
+          expect(result.codeGenType).to.eq('e2e')
+          expect(result.fileName).to.eq(`TestName-copy-1${specExtension}.js`)
+
+          // Add copy to file system and generate options again, index should increment
+          await fs.outputFile(`${tmpPath}/TestName-copy-1${specExtension}.js`, '// foo')
+
+          result = await testSpecOptions.getCodeGenOptions()
+
+          expect(result.codeGenType).to.eq('e2e')
+          expect(result.fileName).to.eq(`TestName-copy-2${specExtension}.js`)
+        })
+      }
+
+      it('generates options for file name without spec extension', async () => {
+        const testSpecOptions = new SpecOptions(ctx, {
+          codeGenPath: `${tmpPath}/TestName.js`,
+          codeGenType: 'e2e',
+        })
+
+        await fs.outputFile(`${tmpPath}/TestName.js`, '// foo')
+
+        let result = await testSpecOptions.getCodeGenOptions()
+
+        expect(result.codeGenType).to.eq('e2e')
+        expect(result.fileName).to.eq(`TestName-copy-1.js`)
+
+        // Add copy to file system and generate options again, index should increment
+        await fs.outputFile(`${tmpPath}/TestName-copy-1.js`, '// foo')
+
+        result = await testSpecOptions.getCodeGenOptions()
+
+        expect(result.codeGenType).to.eq('e2e')
+        expect(result.fileName).to.eq(`TestName-copy-2.js`)
+      })
+
+      it('generates options for file name with multiple extensions', async () => {
+        const testSpecOptions = new SpecOptions(ctx, {
+          codeGenPath: `${tmpPath}/TestName.foo.bar.js`,
+          codeGenType: 'e2e',
+        })
+
+        await fs.outputFile(`${tmpPath}/TestName.foo.bar.js`, '// foo')
+
+        let result = await testSpecOptions.getCodeGenOptions()
+
+        expect(result.codeGenType).to.eq('e2e')
+        expect(result.fileName).to.eq(`TestName.foo.bar-copy-1.js`)
+
+        // Add copy to file system and generate options again, index should increment
+        await fs.outputFile(`${tmpPath}/TestName.foo.bar-copy-1.js`, '// foo')
+
+        result = await testSpecOptions.getCodeGenOptions()
+
+        expect(result.codeGenType).to.eq('e2e')
+        expect(result.fileName).to.eq(`TestName.foo.bar-copy-2.js`)
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes UNIFY-1787

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

When we process the proposed file name for a new spec created in the app, we try to find a known spec file extension (`.cy`, `.spec`, `_spec`, etc.) within in. We do this so that if the file name as provided is found to be a duplicate, we can update the name without mangling this extension, which would in all likelihood result in the file not matching the spec pattern. 

As reported in the JIRA issue, the file name would be generated incorrectly if it didn't end with one of our expected spec extensions. This was due to our falling back to the _file_ extension in the absence of an expected spec extension, inadvertently doubling the file extension in the resulting file name. I corrected this by instead falling back to nothing and letting the file parsing continue like normal.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [N/A] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [N/A] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
