### PR TITLE
chore: clean up `debug` statements in preparation for 10.0 release, add `debug` docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -329,9 +329,7 @@ This will install all the dependencies for the repo and perform a preliminary bu
 yarn start
 ```
 
-If there are errors building the packages, prefix the commands with `DEBUG=cypress:*` to see more details.
-
-This outputs a lot of debugging lines. To focus on an individual module, run with `DEBUG=cypress:launcher` for instance.
+If there are errors building the packages, prefix the commands with `DEBUG=cypress:*` to see more details. This outputs a lot of debugging lines. To focus on an individual module, run with `DEBUG=cypress:launcher:*` for instance. See ["Debug logs"](./guides/debug-logs.md) for more info.
 
 When running `yarn start` this routes through the CLI and eventually calls `yarn dev` with the proper arguments. This enables Cypress day-to-day development to match the logic of the built binary + CLI integration.
 
@@ -411,30 +409,9 @@ Each package is responsible for building itself and testing itself and can do so
 | `test-integration` | Run all integration tests within the package; `exit 0` if N/A                                                                                            |
 | `test-watch`       | Run all unit tests in the package in watch mode                                                                                                          |
 
-#### Debugging
+#### Debug Logs
 
-Some packages use [debug](https://github.com/visionmedia/debug#readme) to
-log debug messages to the console. The naming scheme should be
-`cypress:<package name>`; where package name is without the `@packages` scope. For example to see launcher messages during unit
-tests start it using
-
-```bash
-$ DEBUG=cypress:launcher yarn test --scope @packages/launcher
-```
-
-If you want to see log messages from all Cypress projects use wild card
-
-```bash
-$ DEBUG=cypress:*
-```
-
-Or for an individual package:
-
-```bash
-DEBUG=cypress:cli
-DEBUG=cypress:server
-DEBUG=cypress:launcher
-```
+Many Cypress packages print out debugging information to console via the `debug` module. See ["Debug logs"](./guides/debug-logs.md) for more information.
 
 ### Coding Style
 

--- a/guides/README.md
+++ b/guides/README.md
@@ -10,11 +10,15 @@ For general contributor information, check out [`CONTRIBUTING.md`](../CONTRIBUTI
 
 ## Table of Contents
 
+* [App lifecycle](./building-release-artifacts.md)
 * [Building release artifacts](./building-release-artifacts.md)
 * [Code signing](./code-signing.md)
+* [Debug logs](./debug-logs.md)
 * [Determining the next version of Cypress to be released](./next-version.md)
-* [Remaining Platform Agnostic](./remaining-platform-agnostic.md)
+* [E2E Open Mode Testing](./e2e-open-testing.md)
 * [Error handling](./error-handling.md)
 * [Patching packages](./patch-package.md)
 * [Release process](./release-process.md)
 * [Testing other projects](./testing-other-projects.md)
+* [Testing strategy and style guide (draft)](./testing-strategy-and-styleguide.md)
+* [Writing cross-platform JavaScript](./writing-cross-platform-javascript.md)

--- a/guides/README.md
+++ b/guides/README.md
@@ -10,7 +10,7 @@ For general contributor information, check out [`CONTRIBUTING.md`](../CONTRIBUTI
 
 ## Table of Contents
 
-* [App lifecycle](./building-release-artifacts.md)
+* [App lifecycle](./app-lifecycle.md)
 * [Building release artifacts](./building-release-artifacts.md)
 * [Code signing](./code-signing.md)
 * [Debug logs](./debug-logs.md)

--- a/guides/debug-logs.md
+++ b/guides/debug-logs.md
@@ -19,7 +19,7 @@ cypress:{packageName}:{relative path to file from src root, using : to separate 
 Exceptions to these rules:
 * The `cli` uses `cypress:cli:*`.
 * NPM packages should use `{moduleName}` as a prefix instead of `cypress`, like `cypress-webpack-preprocessor` for `npm/webpack-preprocessor`.
-* In some places, like the proxy package, it's more useful to attach `debug` messages to something besides the module. In that case, it's okay to create namespaces as you see fit. But at least begin with `cypress:{packageName}` or `cypress-verbose:{packageName}`
+* In some places, like per-request in the `proxy` package, it's more useful to attach `debug` messages to something besides the module (like individual HTTP requests). In that case, it's okay to create namespaces as you see fit. But at least begin with `cypress:{packageName}` or `cypress-verbose:{packageName}`
 
 ## Using debug logs
 

--- a/guides/debug-logs.md
+++ b/guides/debug-logs.md
@@ -1,0 +1,42 @@
+# Debug Logs
+
+Many Cypress packages use the [`debug` module][debug] to log runtime info to the console.
+
+## Choosing a namespace
+
+The naming scheme for debug namespaces should generally follow this pattern:
+
+```
+cypress:{packageName}:{relative path to file from src root, using : to separate directories, minus index if applicable}
+
+# examples:
+# packages/server/lib/util/file.js -> cypress:server:util:file
+# packages/launcher/windows/index.ts -> cypress:launcher:windows
+```
+
+`cypress-verbose` can be used instead of `cypress` if the logs are overly verbose and would make the output of `DEBUG=cypress:*` unreadable.
+
+Exceptions to these rules:
+* The `cli` uses `cypress:cli:*`.
+* NPM packages should use `{moduleName}` as a prefix instead of `cypress`, like `cypress-webpack-preprocessor` for `npm/webpack-preprocessor`.
+* In some places, like the proxy package, it's more useful to attach `debug` messages to something besides the module. In that case, it's okay to create namespaces as you see fit. But at least begin with `cypress:{packageName}` or `cypress-verbose:{packageName}`
+
+## Using debug logs
+
+Pass the `DEBUG` environment variable to select a set of logs to print to `stderr`. Example selectors:
+
+```shell
+# frequently useful to get a sense of what is happening in the app at a high level
+DEBUG=cypress:*
+# print all info and verbose logs, but don't print verbose logs from `some-noisy-package`
+DEBUG=cypress:*,cypress-verbose:*,-cypress-verbose:some-noisy-package:*
+# print out verbose per-request data for proxied HTTP requests
+DEBUG=cypress-verbose:proxy:http
+
+# in the browser, set `localStorage.DEBUG`:
+localStorage.DEBUG = 'cypress:driver,cypress:driver:*'
+```
+
+For more info, see the [public documentation for printing debug logs](https://docs.cypress.io/guides/references/troubleshooting#Print-DEBUG-logs) and the [`debug` module docs][debug]
+
+[debug]: https://github.com/visionmedia/debug#readme

--- a/packages/config/src/browser.ts
+++ b/packages/config/src/browser.ts
@@ -16,7 +16,7 @@ export {
   BreakingOptionErrorKey,
 }
 
-const debug = Debug('cypress:config:validator')
+const debug = Debug('cypress:config:browser')
 
 const dashesOrUnderscoresRe = /^(_-)+/
 
@@ -134,7 +134,7 @@ export const matchesConfigKey = (key: string) => {
 }
 
 export const validate = (cfg: any, onErr: (property: string) => void) => {
-  debug('validating configuration', cfg)
+  debug('validating configuration')
 
   return _.each(cfg, (value, key) => {
     const validationFn = validationRules[key]

--- a/packages/data-context/src/data/ProjectConfigIpc.ts
+++ b/packages/data-context/src/data/ProjectConfigIpc.ts
@@ -235,7 +235,7 @@ export class ProjectConfigIpc extends EventEmitter {
       .value()
     }
 
-    debug('fork child process', CHILD_PROCESS_FILE_PATH, configProcessArgs, _.omit(childOptions, 'env'))
+    debug('fork child process %o', { CHILD_PROCESS_FILE_PATH, configProcessArgs, childOptions: _.omit(childOptions, 'env') })
 
     const proc = fork(CHILD_PROCESS_FILE_PATH, configProcessArgs, childOptions)
 

--- a/packages/data-context/src/sources/CloudDataSource.ts
+++ b/packages/data-context/src/sources/CloudDataSource.ts
@@ -27,7 +27,7 @@ import { pathToArray } from 'graphql/jsutils/Path'
 
 export type CloudDataResponse = ExecutionResult & Partial<OperationResult> & { executing?: Promise<ExecutionResult & Partial<OperationResult>> }
 
-const debug = debugLib('cypress:data-context:CloudDataSource')
+const debug = debugLib('cypress:data-context:sources:CloudDataSource')
 const cloudEnv = getenv('CYPRESS_INTERNAL_CLOUD_ENV', process.env.CYPRESS_INTERNAL_ENV || 'development') as keyof typeof REMOTE_SCHEMA_URLS
 
 const REMOTE_SCHEMA_URLS = {

--- a/packages/data-context/src/sources/GitDataSource.ts
+++ b/packages/data-context/src/sources/GitDataSource.ts
@@ -330,7 +330,7 @@ export class GitDataSource {
     }
 
     if (stdout.length !== absolutePaths.length) {
-      debug('error... %o', result)
+      debug('unexpected command execution result: %o', result)
       throw Error(`Expect result array to have same length as input. Input: ${absolutePaths.length} Output: ${stdout.length}`)
     }
 

--- a/packages/data-context/src/sources/GitDataSource.ts
+++ b/packages/data-context/src/sources/GitDataSource.ts
@@ -238,7 +238,7 @@ export class GitDataSource {
         this.#git.status(),
       ])
 
-      debug('stdout %s', stdout)
+      debugVerbose('stdout %s', stdout.toString())
 
       const changed: string[] = []
 
@@ -292,12 +292,12 @@ export class GitDataSource {
 
         this.#gitMeta.set(file, toSet)
         if (!_.isEqual(toSet, current)) {
-          debug(`updated %s %o`, file, toSet)
           changed.push(file)
         }
       }
 
       if (!this.#destroyed) {
+        debugVerbose(`updated %o`, changed)
         this.config.onGitInfoChange(changed)
       }
     } catch (e) {
@@ -326,15 +326,13 @@ export class GitDataSource {
     const stdout = result.stdout.split('\n')
 
     if (result.exitCode !== 0) {
-      debug(`error... stderr`, result.stderr)
+      debug(`error... %o`, result)
     }
 
     if (stdout.length !== absolutePaths.length) {
-      debug('error... stdout:', stdout)
+      debug('error... %o', result)
       throw Error(`Expect result array to have same length as input. Input: ${absolutePaths.length} Output: ${stdout.length}`)
     }
-
-    debug('stdout for git info', stdout)
 
     return stdout
   }

--- a/packages/data-context/src/sources/GitDataSource.ts
+++ b/packages/data-context/src/sources/GitDataSource.ts
@@ -326,7 +326,7 @@ export class GitDataSource {
     const stdout = result.stdout.split('\n')
 
     if (result.exitCode !== 0) {
-      debug(`error... %o`, result)
+      debug(`command execution error: %o`, result)
     }
 
     if (stdout.length !== absolutePaths.length) {

--- a/packages/data-context/src/sources/GitDataSource.ts
+++ b/packages/data-context/src/sources/GitDataSource.ts
@@ -10,8 +10,8 @@ import type { gitStatusType } from '@packages/types'
 import chokidar from 'chokidar'
 import _ from 'lodash'
 
-const debug = Debug('cypress:data-context:GitDataSource')
-const debugVerbose = Debug('cypress-verbose:data-context:GitDataSource')
+const debug = Debug('cypress:data-context:sources:GitDataSource')
+const debugVerbose = Debug('cypress-verbose:data-context:sources:GitDataSource')
 
 dayjs.extend(relativeTime)
 

--- a/packages/data-context/src/sources/GraphQLDataSource.ts
+++ b/packages/data-context/src/sources/GraphQLDataSource.ts
@@ -5,7 +5,7 @@ import type { core } from 'nexus'
 import type { DataContext } from '..'
 import { DocumentNodeBuilder } from '../util/DocumentNodeBuilder'
 
-const debug = debugLib('cypress:data-context:GraphQLDataSource')
+const debug = debugLib('cypress:data-context:sources:GraphQLDataSource')
 const RESOLVED_SOURCE = Symbol('RESOLVED_SOURCE')
 
 export interface PushResultParams {

--- a/packages/data-context/src/sources/ProjectDataSource.ts
+++ b/packages/data-context/src/sources/ProjectDataSource.ts
@@ -12,7 +12,7 @@ import parseGlob from 'parse-glob'
 import micromatch from 'micromatch'
 import RandExp from 'randexp'
 
-const debug = Debug('cypress:data-context')
+const debug = Debug('cypress:data-context:sources:ProjectDataSource')
 import assert from 'assert'
 
 import type { DataContext } from '..'

--- a/packages/data-context/src/sources/VersionsDataSource.ts
+++ b/packages/data-context/src/sources/VersionsDataSource.ts
@@ -124,7 +124,7 @@ export class VersionsDataSource {
 
     const responseJson = await response.json() as { time: Record<string, string>}
 
-    debug('NPM release dates %o', responseJson.time)
+    debug('NPM release dates received %o', { modified: responseJson.time.modified })
 
     return responseJson.time
   }

--- a/packages/data-context/src/sources/VersionsDataSource.ts
+++ b/packages/data-context/src/sources/VersionsDataSource.ts
@@ -3,7 +3,7 @@ import type { DataContext } from '..'
 import type { TestingType } from '@packages/types'
 import Debug from 'debug'
 
-const debug = Debug('cypress:data-context:versions-data-source')
+const debug = Debug('cypress:data-context:sources:VersionsDataSource')
 
 const pkg = require('@packages/root')
 const nmi = require('node-machine-id')

--- a/packages/launcher/README.md
+++ b/packages/launcher/README.md
@@ -30,6 +30,7 @@ Uses [debug](https://github.com/visionmedia/debug#readme)
 to output debug log messages. To turn on, use
 
 ```sh
-DEBUG=cypress:launcher yarn workspace @packages/launcher test
+DEBUG=cypress:launcher:* yarn workspace @packages/launcher test
 ```
 
+Verbose messages, including detailed stdout, are available under `cypress-verbose:launcher:*`.

--- a/packages/launcher/lib/browsers.ts
+++ b/packages/launcher/lib/browsers.ts
@@ -3,7 +3,7 @@ import * as cp from 'child_process'
 import { browsers, FoundBrowser } from '@packages/types'
 import type { Readable } from 'stream'
 
-const debug = Debug('cypress:launcher:browsers')
+export const debug = Debug('cypress:launcher:browsers')
 
 export { browsers }
 

--- a/packages/launcher/lib/browsers.ts
+++ b/packages/launcher/lib/browsers.ts
@@ -1,7 +1,9 @@
-import { log } from './log'
+import Debug from 'debug'
 import * as cp from 'child_process'
 import { browsers, FoundBrowser } from '@packages/types'
 import type { Readable } from 'stream'
+
+const debug = Debug('cypress:launcher:browsers')
 
 export { browsers }
 
@@ -18,7 +20,7 @@ export function launch (
   args: string[] = [],
   defaultBrowserEnv = {},
 ): LaunchedBrowser {
-  log('launching browser %o', { browser, url })
+  debug('launching browser %o', { browser, url })
 
   if (!browser.path) {
     throw new Error(`Browser ${browser.name} is missing path`)
@@ -28,7 +30,7 @@ export function launch (
     args = [url].concat(args)
   }
 
-  log('spawning browser with args %o', { args })
+  debug('spawning browser with args %o', { args })
 
   // allow setting default env vars such as MOZ_HEADLESS_WIDTH
   // but only if it's not already set by the environment
@@ -37,15 +39,15 @@ export function launch (
   const proc = cp.spawn(browser.path, args, { stdio: ['ignore', 'pipe', 'pipe'], env })
 
   proc.stdout.on('data', (buf) => {
-    log('%s stdout: %s', browser.name, String(buf).trim())
+    debug('%s stdout: %s', browser.name, String(buf).trim())
   })
 
   proc.stderr.on('data', (buf) => {
-    log('%s stderr: %s', browser.name, String(buf).trim())
+    debug('%s stderr: %s', browser.name, String(buf).trim())
   })
 
   proc.on('exit', (code, signal) => {
-    log('%s exited: %o', browser.name, { code, signal })
+    debug('%s exited: %o', browser.name, { code, signal })
   })
 
   return proc

--- a/packages/launcher/lib/darwin/index.ts
+++ b/packages/launcher/lib/darwin/index.ts
@@ -1,8 +1,10 @@
 import { findApp, FindAppParams } from './util'
 import type { Browser, DetectedBrowser } from '@packages/types'
 import * as linuxHelper from '../linux'
-import { log } from '../log'
+import Debug from 'debug'
 import { get } from 'lodash'
+
+const debugVerbose = Debug('cypress-verbose:launcher:darwin')
 
 type Detectors = {
   [name: string]: {
@@ -98,16 +100,15 @@ export function detect (browser: Browser): Promise<DetectedBrowser> {
 
   if (!findAppParams) {
     // ok, maybe it is custom alias?
-    log('detecting custom browser %s on darwin', browser.name)
+    debugVerbose('could not find %s in findApp map, falling back to linux detection method', browser.name)
 
     return linuxHelper.detect(browser)
   }
 
   return findApp(findAppParams)
   .then((val) => ({ name: browser.name, ...val }))
-  .catch(() => {
-    log('could not detect %s using traditional Mac methods', browser.name)
-    log('trying linux search')
+  .catch((err) => {
+    debugVerbose('could not detect %s using findApp %o, falling back to linux detection method', browser.name, err)
 
     return linuxHelper.detect(browser)
   })

--- a/packages/launcher/lib/darwin/util.ts
+++ b/packages/launcher/lib/darwin/util.ts
@@ -1,21 +1,23 @@
-import { log } from '../log'
+import Debug from 'debug'
 import { notInstalledErr } from '../errors'
 import { utils } from '../utils'
 import * as fs from 'fs-extra'
 import * as path from 'path'
 import * as plist from 'plist'
 
+const debugVerbose = Debug('cypress-verbose:launcher:darwin:util')
+
 /** parses Info.plist file from given application and returns a property */
 export function parsePlist (p: string, property: string): Promise<string> {
   const pl = path.join(p, 'Contents', 'Info.plist')
 
-  log('reading property file "%s"', pl)
+  debugVerbose('reading property file "%s"', pl)
 
   const failed = (e: Error) => {
     const msg = `Info.plist not found: ${pl}
     ${e.message}`
 
-    log('could not read Info.plist %o', { pl, e })
+    debugVerbose('could not read Info.plist %o', { pl, e })
     throw notInstalledErr('', msg)
   }
 
@@ -31,16 +33,16 @@ export function parsePlist (p: string, property: string): Promise<string> {
 export function mdfind (id: string): Promise<string> {
   const cmd = `mdfind 'kMDItemCFBundleIdentifier=="${id}"' | head -1`
 
-  log('looking for bundle id %s using command: %s', id, cmd)
+  debugVerbose('looking for bundle id %s using command: %s', id, cmd)
 
   const logFound = (str: string) => {
-    log('found %s at %s', id, str)
+    debugVerbose('found %s at %s', id, str)
 
     return str
   }
 
   const failedToFind = () => {
-    log('could not find %s', id)
+    debugVerbose('could not find %s', id)
     throw notInstalledErr(id)
   }
 
@@ -74,11 +76,11 @@ function formApplicationPath (appName: string) {
 
 /** finds an application and its version */
 export function findApp ({ appName, executable, appId, versionProperty }: FindAppParams): Promise<AppInfo> {
-  log('looking for app %s id %s', executable, appId)
+  debugVerbose('looking for app %s id %s', executable, appId)
 
   const findVersion = (foundPath: string) => {
     return parsePlist(foundPath, versionProperty).then((version) => {
-      log('got plist: %o', { foundPath, version })
+      debugVerbose('got plist: %o', { foundPath, version })
 
       return {
         path: path.join(foundPath, executable),
@@ -94,7 +96,7 @@ export function findApp ({ appName, executable, appId, versionProperty }: FindAp
   const tryFullApplicationFind = () => {
     const applicationPath = formApplicationPath(appName)
 
-    log('looking for application %s', applicationPath)
+    debugVerbose('looking for application %s', applicationPath)
 
     return findVersion(applicationPath)
   }

--- a/packages/launcher/lib/linux/index.ts
+++ b/packages/launcher/lib/linux/index.ts
@@ -1,4 +1,4 @@
-import { log } from '../log'
+import Debug from 'debug'
 import type { FoundBrowser, Browser } from '@packages/types'
 import type { PathData } from '../types'
 import { notInstalledErr } from '../errors'
@@ -8,6 +8,9 @@ import { promises as fs } from 'fs'
 import path from 'path'
 import Bluebird from 'bluebird'
 import which from 'which'
+
+const debug = Debug('cypress:launcher:linux')
+const debugVerbose = Debug('cypress-verbose:launcher:linux')
 
 async function isFirefoxSnap (binary: string): Promise<boolean> {
   try {
@@ -29,7 +32,7 @@ async function isFirefoxSnap (binary: string): Promise<boolean> {
     })())
     .timeout(30000)
   } catch (err) {
-    log('failed to check if Firefox is a snap, assuming it isn\'t %o', { err, binary })
+    debug('failed to check if Firefox is a snap, assuming it isn\'t %o', { err, binary })
 
     return false
   }
@@ -52,7 +55,7 @@ function getLinuxBrowser (
       return m[1]
     }
 
-    log(
+    debug(
       'Could not extract version from stdout using regex: %o', {
         stdout,
         versionRegex,
@@ -63,7 +66,7 @@ function getLinuxBrowser (
   }
 
   const logAndThrowError = (err: Error) => {
-    log(
+    debug(
       'Received error detecting browser binary: "%s" with error:',
       binary,
       err.message,
@@ -78,7 +81,7 @@ function getLinuxBrowser (
     if (name === 'chromium' && versionString.endsWith('snap')) {
       // when running as a snap, chromium can only write to certain directories
       // @see https://github.com/cypress-io/cypress/issues/7020
-      log('chromium is running as a snap, changing profile path')
+      debug('chromium is running as a snap, changing profile path')
       foundBrowser.profilePath = path.join(os.homedir(), 'snap', 'chromium', 'current')
 
       return
@@ -87,7 +90,7 @@ function getLinuxBrowser (
     if (name === 'firefox' && (await isFirefoxSnap(binary))) {
       // if the binary in the path points to a script that calls the snap, set a snap-specific profile path
       // @see https://github.com/cypress-io/cypress/issues/19793
-      log('firefox is running as a snap, changing profile path')
+      debug('firefox is running as a snap, changing profile path')
       foundBrowser.profilePath = path.join(os.homedir(), 'snap', 'firefox', 'current')
 
       return
@@ -106,14 +109,14 @@ function getLinuxBrowser (
 }
 
 export function getVersionString (path: string) {
-  log('finding version string using command "%s --version"', path)
+  debugVerbose('finding version string using command "%s --version"', path)
 
   return Bluebird.resolve(utils.getOutput(path, ['--version']))
   .timeout(30000, `Timed out after 30 seconds getting browser version for ${path}`)
   .then((val) => val.stdout)
   .then((val) => val.trim())
   .then((val) => {
-    log('stdout: %s', val)
+    debugVerbose('stdout for "%s --version": %s', path, val)
 
     return val
   })

--- a/packages/launcher/lib/linux/index.ts
+++ b/packages/launcher/lib/linux/index.ts
@@ -66,7 +66,7 @@ function getLinuxBrowser (
   }
 
   const logAndThrowError = (err: Error) => {
-    debug(
+    debugVerbose(
       'Received error detecting browser binary: "%s" with error:',
       binary,
       err.message,

--- a/packages/launcher/lib/log.ts
+++ b/packages/launcher/lib/log.ts
@@ -1,3 +1,0 @@
-import debug from 'debug'
-
-export const log = debug('cypress:launcher')

--- a/packages/launcher/lib/windows/index.ts
+++ b/packages/launcher/lib/windows/index.ts
@@ -4,9 +4,12 @@ import os from 'os'
 import { join, normalize, win32 } from 'path'
 import { get } from 'lodash'
 import { notInstalledErr } from '../errors'
-import { log } from '../log'
+import Debug from 'debug'
 import type { PathData } from '../types'
 import type { Browser, FoundBrowser } from '@packages/types'
+
+const debug = Debug('cypress:launcher:windows')
+const debugVerbose = Debug('cypress-verbose:launcher:windows')
 
 function formFullAppPath (name: string) {
   return [
@@ -115,7 +118,7 @@ function getWindowsBrowser (browser: Browser): Promise<FoundBrowser> {
 
   const exePaths = formFullAppPathFn(browser.name)
 
-  log('looking at possible paths... %o', { browser, exePaths })
+  debugVerbose('looking at possible paths... %o', { browser, exePaths })
 
   // shift and try paths 1-by-1 until we find one that works
   const tryNextExePath = async () => {
@@ -130,7 +133,7 @@ function getWindowsBrowser (browser: Browser): Promise<FoundBrowser> {
 
     return fse.pathExists(path)
     .then((exists) => {
-      log('found %s ?', path, exists)
+      debugVerbose('found %s ? %o', path, { exists })
 
       if (!exists) {
         return tryNextExePath()
@@ -139,7 +142,7 @@ function getWindowsBrowser (browser: Browser): Promise<FoundBrowser> {
       // Use exports.getVersionString here, rather than our local reference
       // to that variable so that the tests can easily mock it
       return exports.getVersionString(path).then((version) => {
-        log('browser %s at \'%s\' version %s', browser.name, exePath, version)
+        debug('got version string for %s: %o', browser.name, { exePath, version })
 
         return {
           name: browser.name,
@@ -149,7 +152,7 @@ function getWindowsBrowser (browser: Browser): Promise<FoundBrowser> {
       })
     })
     .catch((err) => {
-      log('error while looking up exe, trying next exePath %o', { exePath, exePaths, err })
+      debug('error while looking up exe, trying next exePath %o', { exePath, exePaths, err })
 
       return tryNextExePath()
     })

--- a/packages/server/lib/browsers/firefox.ts
+++ b/packages/server/lib/browsers/firefox.ts
@@ -5,12 +5,11 @@ import Debug from 'debug'
 import getPort from 'get-port'
 import path from 'path'
 import urlUtil from 'url'
-import { launch, LaunchedBrowser } from '@packages/launcher/lib/browsers'
+import { debug as launcherDebug, launch, LaunchedBrowser } from '@packages/launcher/lib/browsers'
 import FirefoxProfile from 'firefox-profile'
 import * as errors from '../errors'
 import firefoxUtil from './firefox-util'
 import utils from './utils'
-import * as launcherDebug from '@packages/launcher/lib/log'
 import type { Browser, BrowserInstance } from './types'
 import { EventEmitter } from 'events'
 import os from 'os'
@@ -303,7 +302,7 @@ const defaultPreferences = {
   'media.devices.insecure.enabled':	true,
   'media.getusermedia.insecure.enabled': true,
 
-  'marionette.log.level': launcherDebug.log.enabled ? 'Debug' : undefined,
+  'marionette.log.level': launcherDebug.enabled ? 'Debug' : undefined,
 
   // where to download files
   // 0: desktop

--- a/packages/server/lib/util/editors.ts
+++ b/packages/server/lib/util/editors.ts
@@ -13,7 +13,7 @@ export const osFileSystemExplorer = {
   linux: 'File System',
 } as const
 
-const debug = debugModule('cypress:server:editors')
+const debug = debugModule('cypress:server:util:editors')
 
 const createEditor = (editor: Editor): Editor => {
   return {
@@ -43,8 +43,6 @@ const computerOpener = (): Editor => {
 
 const getUserEditors = async (): Promise<Editor[]> => {
   return Bluebird.filter(getEnvEditors(), (editor) => {
-    debug('check if user has editor %s with binary %s', editor.name, editor.binary)
-
     return shell.commandExists(editor.binary)
   })
   .then((editors: Editor[] = []) => {

--- a/packages/server/lib/util/file.js
+++ b/packages/server/lib/util/file.js
@@ -2,7 +2,7 @@ const _ = require('lodash')
 const os = require('os')
 const md5 = require('md5')
 const path = require('path')
-const debug = require('debug')('cypress:server:file')
+const debugVerbose = require('debug')('cypress-verbose:server:util:file')
 const Promise = require('bluebird')
 const lockFile = Promise.promisifyAll(require('lockfile'))
 const { fs } = require('./fs')
@@ -57,7 +57,7 @@ class File {
   }
 
   transaction (fn) {
-    debug('transaction for %s', this.path)
+    debugVerbose('transaction for %s', this.path)
 
     return this._addToQueue(() => {
       return fn({
@@ -68,19 +68,19 @@ class File {
   }
 
   get (...args) {
-    debug('get values from %s', this.path)
+    debugVerbose('get values from %s', this.path)
 
     return this._get(false, ...args)
   }
 
   set (...args) {
-    debug('set values in %s', this.path)
+    debugVerbose('set values in %s', this.path)
 
     return this._set(false, ...args)
   }
 
   remove () {
-    debug('remove %s', this.path)
+    debugVerbose('remove %s', this.path)
     this._cache = {}
 
     return this._lock()
@@ -88,7 +88,7 @@ class File {
       return fs.removeAsync(this.path)
     })
     .finally(() => {
-      debug('remove succeeded or failed for %s', this.path)
+      debugVerbose('remove succeeded or failed for %s', this.path)
 
       return this._unlock()
     })
@@ -134,7 +134,7 @@ class File {
   _read () {
     return this._lock()
     .then(() => {
-      debug('read %s', this.path)
+      debugVerbose('read %s', this.path)
 
       return fs.readJsonAsync(this.path, 'utf8')
     })
@@ -151,7 +151,7 @@ class File {
       throw err
     })
     .finally(() => {
-      debug('read succeeded or failed for %s', this.path)
+      debugVerbose('read succeeded or failed for %s', this.path)
 
       return this._unlock()
     })
@@ -206,19 +206,19 @@ class File {
   _write () {
     return this._lock()
     .then(() => {
-      debug('write %s', this.path)
+      debugVerbose('write %s', this.path)
 
       return fs.outputJsonAsync(this.path, this._cache, { spaces: 2 })
     })
     .finally(() => {
-      debug('write succeeded or failed for %s', this.path)
+      debugVerbose('write succeeded or failed for %s', this.path)
 
       return this._unlock()
     })
   }
 
   _lock () {
-    debug('attempt to get lock on %s', this.path)
+    debugVerbose('attempt to get lock on %s', this.path)
 
     return fs
     .ensureDirAsync(this._lockFileDir)
@@ -227,21 +227,21 @@ class File {
       return lockFile.lockAsync(this._lockFilePath, { wait: LOCK_TIMEOUT })
     })
     .finally(() => {
-      return debug('getting lock succeeded or failed for %s', this.path)
+      return debugVerbose('getting lock succeeded or failed for %s', this.path)
     })
   }
 
   _unlock () {
-    debug('attempt to unlock %s', this.path)
+    debugVerbose('attempt to unlock %s', this.path)
 
     return lockFile
     .unlockAsync(this._lockFilePath)
     .timeout(env.get('FILE_UNLOCK_TIMEOUT') || LOCK_TIMEOUT)
     .catch(Promise.TimeoutError, () => { // ignore timeouts
-      debug(`unlock timeout error for %s`, this._lockFilePath)
+      debugVerbose(`unlock timeout error for %s`, this._lockFilePath)
     })
     .finally(() => {
-      return debug('unlock succeeded or failed for %s', this.path)
+      return debugVerbose('unlock succeeded or failed for %s', this.path)
     })
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog

If we want to consider this user-facing:

* Removed some verbose `DEBUG=cypress:*` lines and moved others to the `DEBUG=cypress-verbose:*` namespace.

### Additional details

- I noticed that we have added a lot of debug lines to our already-bloated `DEBUG` namespaces.
- With 10.0, there are going to be a lot of changes and potentially a lot of bug reports, so it's important that we take the opportunity to clean up `DEBUG` and make it easier to read and more useful before we start getting reports with `DEBUG` logs in them.
- This PR:
  - Documents the way that `debug` namespaces are handled in `cypress`. Previously, the way we named debug namespaces was not documented.
  - Removes or moves to `cypress-verbose` a lot of `debug` statements, some added in 10.0, some existing in 9.x
    - Of note, `packages/launcher` is now using namespaces instead of just `cypress:launcher`
  - Updates some namespaces to follow the written standard

### How has the user experience changed?

`debug` output is easier to parse and make sense of.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
