### PR TITLE
fix(server): fallback to filesystem polling on network drives

### DIFF
--- a/packages/server/lib/watchers.js
+++ b/packages/server/lib/watchers.js
@@ -32,7 +32,13 @@ class Watchers {
       onError: null,
     })
 
-    const w = chokidar.watch(filePath, options)
+    let w
+
+    try {
+      w = chokidar.watch(filePath, options)
+    } catch (e) {
+      w = chokidar.watch(filePath, { ...options, usePolling: true })
+    }
 
     this._add(filePath, w)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22555,14 +22555,7 @@ is-color-stop@^1.0.0, is-color-stop@^1.1.0:
     rgb-regex "^1.0.1"
     rgba-regex "^1.0.0"
 
-is-core-module@^2.1.0, is-core-module@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
-  integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
-  dependencies:
-    has "^1.0.3"
-
-is-core-module@^2.2.0:
+is-core-module@^2.1.0, is-core-module@^2.2.0, is-core-module@^2.8.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
   integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==


### PR DESCRIPTION
chokidar provides an option which supports using fs.watchFile where fs.watch does not work, this will fallback in the case of errors using chokidar.watch

#21530

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #21530

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
Provided file system watching fallback to let Cypress watch networked file systems.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Running Cypress on Windows and trying to load a project via a networked WSL drive causes an EISDIR error on `cypress.json` and the directory itself. This is due to a [documented limitation](https://nodejs.org/docs/latest/api/fs.html#availability) of `fs.watch()` which usually throws errors when trying to watch networked file systems.

The library which provides watching functionality has a [configuration option `usePolling: true`](https://github.com/paulmillr/chokidar#performance) to fallback to `fs.watchFile()` instead of `fs.watch()` to allow networked file systems to be watched as opposed to throwing a fatal error. This can be forced manually with an environment variable `CHOKIDAR_USEPOLLING=1`. 

This PR wraps `chokidar.watch()` in a try-catch to catch any errors if `fs.watch()` does not work and tries again with `usePolling: true` to allow for minimal configuration in the command line and seamless execution. A unit test is provided which throws an error on the first call to test the try-catch and calling parameters.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

1. Clone test repo into WSL
2. Download Cypress for Windows
3. When prompted, navigate to the project folder via the network mounted Linux drive

Cypress should list your tests - previously it would crash unless `CHOKIDAR_USEPOLLING=1` was set.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
- [na] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)?
