### PR TITLE
fix(cypress/schematic): run configuration does not work anymore without baseUrl 

### DIFF
--- a/npm/cypress-schematic/README.md
+++ b/npm/cypress-schematic/README.md
@@ -178,7 +178,9 @@ Read our docs to learn more about working with [reporters](https://on.cypress.io
 
 ### Running the builder with a different baseUrl
 
-You can specify a `baseUrl` that is different than the one in `cypress.json`. To do this, add `baseUrl` to `configurations` like the following: 
+You can specify a `baseUrl` that is different than the one in `cypress.json`. There are two ways to do this.
+
+1. Add `baseUrl` to `configurations` like the following: 
 
 ```json
 "cypress-open": {
@@ -202,6 +204,15 @@ You can specify a `baseUrl` that is different than the one in `cypress.json`. To
     }
   }
 }
+```
+
+2. Add custom options to `devServerTarget` in `angular.json`:
+
+```json
+"options": {
+  "host": "localhost",
+  "port": 4200
+},
 ```
 
 In order to prevent the application from building, add the following to the end of your command:

--- a/npm/cypress-schematic/package.json
+++ b/npm/cypress-schematic/package.json
@@ -10,7 +10,7 @@
     "build:watch": "tsc -p tsconfig.json --watch",
     "clean12": "git checkout HEAD -- sandbox12 && git clean -f -d sandbox12",
     "launch12": "yarn link:sandbox12 && cd sandbox12 && ng add @cypress/schematic && cd ..",
-    "launch:test12": "yarn link:sandbox12 && cd sandbox12 && ng add @cypress/schematic --e2eUpdate=true && cd ..",
+    "launch:test12": "yarn link:sandbox12 && cd sandbox12 && ng add @cypress/schematic --e2eUpdate && cd ..",
     "link:sandbox12": "yarn link && cd sandbox12 && yarn link @cypress/schematic",
     "test": "mocha -r @packages/ts/register --reporter mocha-multi-reporters --reporter-options configFile=../../mocha-reporter-config.json src/**/*.spec.ts",
     "test:e2e:sandbox12": "cd sandbox12 && ng run sandbox:cypress-run",

--- a/npm/cypress-schematic/src/builders/cypress/cypressBuilderOptions.ts
+++ b/npm/cypress-schematic/src/builders/cypress/cypressBuilderOptions.ts
@@ -4,8 +4,6 @@ export interface CypressBuilderOptions extends JsonObject {
   baseUrl: string
   configFile: string
   browser: 'electron' | 'chrome' | 'chromium' | 'canary' | 'firefox' | 'edge' | string
-  devServerTarget: string
-  devServerBaseUrl: string
   env: Record<string, string>
   quiet: boolean
   exit: boolean

--- a/npm/cypress-schematic/src/builders/cypress/cypressBuilderOptions.ts
+++ b/npm/cypress-schematic/src/builders/cypress/cypressBuilderOptions.ts
@@ -4,6 +4,7 @@ export interface CypressBuilderOptions extends JsonObject {
   baseUrl: string
   configFile: string
   browser: 'electron' | 'chrome' | 'chromium' | 'canary' | 'firefox' | 'edge' | string
+  devServerTarget: string
   env: Record<string, string>
   quiet: boolean
   exit: boolean

--- a/npm/cypress-schematic/src/builders/cypress/cypressBuilderOptions.ts
+++ b/npm/cypress-schematic/src/builders/cypress/cypressBuilderOptions.ts
@@ -5,6 +5,7 @@ export interface CypressBuilderOptions extends JsonObject {
   configFile: string
   browser: 'electron' | 'chrome' | 'chromium' | 'canary' | 'firefox' | 'edge' | string
   devServerTarget: string
+  devServerBaseUrl: string
   env: Record<string, string>
   quiet: boolean
   exit: boolean

--- a/npm/cypress-schematic/src/builders/cypress/index.ts
+++ b/npm/cypress-schematic/src/builders/cypress/index.ts
@@ -83,10 +83,10 @@ function initCypress (userOptions: CypressBuilderOptions): Observable<BuilderOut
   }
 
   if (userOptions.configFile === undefined) {
-    options.config = {}
+    options.config = { e2e: { baseUrl: userOptions.devServerBaseUrl as string } }
   }
 
-  options.config = { ...options.config, baseUrl: userOptions.devServerBaseUrl }
+  options.config = { ...options.config }
 
   const { watch, headless } = userOptions
 

--- a/npm/cypress-schematic/src/builders/cypress/index.ts
+++ b/npm/cypress-schematic/src/builders/cypress/index.ts
@@ -46,7 +46,7 @@ function runCypress (
     }),
     switchMap((options: CypressBuilderOptions) => {
       return (options.devServerTarget
-        ? startDevServer({ devServerTarget: options.devServerTarget as string, watch: options.watch, context }).pipe(
+        ? startDevServer({ devServerTarget: options.devServerTarget, watch: options.watch, context }).pipe(
           map((devServerBaseUrl: string) => options.baseUrl || devServerBaseUrl),
         )
         : of(options.baseUrl)
@@ -86,7 +86,7 @@ function initCypress (userOptions: CypressBuilderOptions): Observable<BuilderOut
     options.config = {}
   }
 
-  options.config = { ...options.config, baseUrl: userOptions.devServerBaseUrl as string }
+  options.config = { ...options.config, baseUrl: userOptions.devServerBaseUrl }
 
   const { watch, headless } = userOptions
 

--- a/npm/cypress-schematic/src/builders/cypress/index.ts
+++ b/npm/cypress-schematic/src/builders/cypress/index.ts
@@ -46,7 +46,7 @@ function runCypress (
     }),
     switchMap((options: CypressBuilderOptions) => {
       return (options.devServerTarget
-        ? startDevServer({ devServerTarget: options.devServerTarget, watch: options.watch, context }).pipe(
+        ? startDevServer({ devServerTarget: options.devServerTarget as string, watch: options.watch, context }).pipe(
           map((devServerBaseUrl: string) => options.baseUrl || devServerBaseUrl),
         )
         : of(options.baseUrl)
@@ -86,7 +86,7 @@ function initCypress (userOptions: CypressBuilderOptions): Observable<BuilderOut
     options.config = {}
   }
 
-  options.config = { ...options.config, baseUrl: userOptions.devServerBaseUrl }
+  options.config = { ...options.config, baseUrl: userOptions.devServerBaseUrl as string }
 
   const { watch, headless } = userOptions
 

--- a/npm/cypress-schematic/src/builders/cypress/index.ts
+++ b/npm/cypress-schematic/src/builders/cypress/index.ts
@@ -86,9 +86,7 @@ function initCypress (userOptions: CypressBuilderOptions): Observable<BuilderOut
     options.config = {}
   }
 
-  if (userOptions.baseUrl) {
-    options.config = { ...options.config, e2e: { ...options.config?.e2e, baseUrl: userOptions.baseUrl } }
-  }
+  options.config = { ...options.config, baseUrl: userOptions.devServerBaseUrl }
 
   const { watch, headless } = userOptions
 


### PR DESCRIPTION
Fixes #21555.

Users can now add custom options to `devServerTarget` in `angular.json` to specify `baseUrl`:

```json
"options": {
  "host": "localhost",
  "port": 4200
},
```