### PR TITLE
fix: Add hover states for test titles in reporter

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -494,7 +494,7 @@ commands:
       package:
         description: package to target
         type: enum
-        enum: ['frontend-shared', 'launchpad', 'app']
+        enum: ['frontend-shared', 'launchpad', 'app', 'reporter']
       browser:
         description: browser shortname to target
         type: string
@@ -1132,6 +1132,7 @@ jobs:
             run-frontend-shared-component-tests-chrome,
             run-launchpad-component-tests-chrome,
             run-launchpad-integration-tests-chrome,
+            run-reporter-component-tests-chrome,
             run-webpack-dev-server-integration-tests,
             run-vite-dev-server-integration-tests
       - run:
@@ -1474,6 +1475,21 @@ jobs:
       - run-driver-integration-tests:
           browser: electron
           experimentalSessionAndOrigin: true
+
+  run-reporter-component-tests-chrome:
+    <<: *defaults
+    parameters:
+      <<: *defaultsParameters
+      percy:
+        type: boolean
+        default: false
+    parallelism: 7
+    steps:
+      - run-new-ui-tests:
+          browser: chrome
+          percy: << parameters.percy >>
+          package: reporter
+          type: ct
 
   reporter-integration-tests:
     <<: *defaults
@@ -2324,6 +2340,11 @@ linux-workflow: &linux-workflow
         percy: true
         requires:
           - build
+    - run-reporter-component-tests-chrome:
+        context: [test-runner:cypress-record-key, test-runner:percy]
+        percy: true
+        requires:
+          - build
     - reporter-integration-tests:
         context: [test-runner:cypress-record-key, test-runner:percy]
         requires:
@@ -2413,6 +2434,7 @@ linux-workflow: &linux-workflow
           - run-frontend-shared-component-tests-chrome
           - run-launchpad-component-tests-chrome
           - run-launchpad-integration-tests-chrome
+          - run-reporter-component-tests-chrome
 
     # various testing scenarios, like building full binary
     # and testing it on a real project

--- a/circle.yml
+++ b/circle.yml
@@ -2341,7 +2341,7 @@ linux-workflow: &linux-workflow
         requires:
           - build
     - run-reporter-component-tests-chrome:
-        context: [test-runner:cypress-record-key, test-runner:percy]
+        context: [test-runner:launchpad-tests, test-runner:percy]
         percy: true
         requires:
           - build

--- a/circle.yml
+++ b/circle.yml
@@ -519,7 +519,7 @@ commands:
             cmd=$([[ <<parameters.percy>> == 'true' ]] && echo 'yarn percy exec --parallel -- --') || true
             DEBUG=<<parameters.debug>> \
             CYPRESS_KONFIG_ENV=production \
-            CYPRESS_RECORD_KEY=$TEST_LAUNCHPAD_RECORD_KEY \
+            CYPRESS_RECORD_KEY=${TEST_LAUNCHPAD_RECORD_KEY:-$MAIN_RECORD_KEY} \
             PERCY_PARALLEL_NONCE=$CIRCLE_SHA1 \
             PERCY_ENABLE=${PERCY_TOKEN:-0} \
             PERCY_PARALLEL_TOTAL=-1 \
@@ -2341,7 +2341,7 @@ linux-workflow: &linux-workflow
         requires:
           - build
     - run-reporter-component-tests-chrome:
-        context: [test-runner:launchpad-tests, test-runner:percy]
+        context: [test-runner:cypress-record-key, test-runner:percy]
         percy: true
         requires:
           - build

--- a/packages/reporter/cypress.config.ts
+++ b/packages/reporter/cypress.config.ts
@@ -1,15 +1,19 @@
 import { defineConfig } from 'cypress'
+import webpackConfig from './webpack.config.ts'
 
 export default defineConfig({
   projectId: 'ypt4pf',
   reporter: '../../node_modules/cypress-multi-reporters/index.js',
+
   reporterOptions: {
     configFile: '../../mocha-reporter-config.json',
   },
+
   retries: {
     runMode: 2,
     openMode: 0,
   },
+
   e2e: {
     baseUrl: 'http://localhost:5006',
     setupNodeEvents (_on, config) {
@@ -21,5 +25,13 @@ export default defineConfig({
     },
     viewportHeight: 660,
     viewportWidth: 400,
+  },
+
+  component: {
+    devServer: {
+      framework: 'react',
+      bundler: 'webpack',
+      webpackConfig,
+    },
   },
 })

--- a/packages/reporter/cypress/support/component-index.html
+++ b/packages/reporter/cypress/support/component-index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>Components App</title>
+  </head>
+  <body>
+    <div data-cy-root class="reporter" style="padding: 20px;"></div>
+  </body>
+</html>

--- a/packages/reporter/cypress/support/component.ts
+++ b/packages/reporter/cypress/support/component.ts
@@ -4,5 +4,13 @@ import { installCustomPercyCommand } from '@packages/ui-components/cypress/suppo
 
 import '../../src/main.scss'
 
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      mount: typeof mount
+    }
+  }
+}
+
 Cypress.Commands.add('mount', mount)
 installCustomPercyCommand()

--- a/packages/reporter/cypress/support/component.ts
+++ b/packages/reporter/cypress/support/component.ts
@@ -1,0 +1,8 @@
+import { mount } from 'cypress/react'
+import 'cypress-real-events/support'
+import { installCustomPercyCommand } from '@packages/ui-components/cypress/support/customPercyCommand'
+
+import '../../src/main.scss'
+
+Cypress.Commands.add('mount', mount)
+installCustomPercyCommand()

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -8,6 +8,7 @@
     "clean-deps": "rimraf node_modules",
     "cypress:open": "node ../../scripts/cypress open --project .",
     "cypress:run": "node ../../scripts/cypress run --project .",
+    "cypress:run:ct": "cross-env TZ=America/New_York node ../../scripts/cypress run --component --project .",
     "watch": "yarn build-for-tests --watch --progress"
   },
   "devDependencies": {

--- a/packages/reporter/src/hooks/hooks.cy.tsx
+++ b/packages/reporter/src/hooks/hooks.cy.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { Hook } from './hooks'
+
+import '../main.scss'
+
+describe('hooks/hooks.tsx', () => {
+  it('should mount', () => {
+    const model = {
+      failed: false,
+      hookName: 'TEST BODY',
+    }
+
+    cy.mount(<div className="runnable suite">
+      <div className="hooks-container">
+        <Hook model={model} showNumber={false} />
+      </div>
+    </div>)
+
+    cy.percySnapshot()
+
+    cy.contains('TEST BODY').click().realHover()
+    cy.percySnapshot()
+  })
+})

--- a/packages/reporter/src/hooks/hooks.scss
+++ b/packages/reporter/src/hooks/hooks.scss
@@ -14,9 +14,7 @@
       width: 100%;
 
       &:hover {
-        .collapsible-header {
-          color: $gray-300;
-        }
+        background-color: $gray-900;
 
         .hook-open-in-ide {
           cursor: pointer;

--- a/packages/reporter/src/runnables/runnables.scss
+++ b/packages/reporter/src/runnables/runnables.scss
@@ -110,7 +110,7 @@
 
         .collapsible-header-inner {
           &:hover {
-            background-color: $gray-1000;
+            background-color: $gray-900;
             cursor: pointer;
           }
 

--- a/packages/reporter/src/test/test.cy.tsx
+++ b/packages/reporter/src/test/test.cy.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import Test from './test'
+
+describe('test/test.tsx', () => {
+  it('should mount', () => {
+    const model = {
+      isOpen: false,
+      level: 0,
+      state: 'passed',
+      title: 'foobar',
+      attempts: [],
+    }
+
+    const appState = {
+      studioActive: false,
+    }
+
+    cy.mount(<div className="runnable suite">
+      <Test model={model} appState={appState} />
+    </div>)
+
+    cy.percySnapshot()
+
+    cy.contains('foobar').click().realHover()
+    cy.percySnapshot()
+  })
+})

--- a/packages/ui-components/cypress/support/customPercyCommand.ts
+++ b/packages/ui-components/cypress/support/customPercyCommand.ts
@@ -72,7 +72,7 @@ class ElementOverrideManager {
    */
   performOverrides (cy: Cypress.cy, overrides: NonNullable<CustomSnapshotOptions['elementOverrides']>) {
     const observer = new MutationObserver((mutations) => {
-      this.mutationStack ??= []
+      this.mutationStack = this.mutationStack || []
       this.mutationStack.push(...mutations)
     })
 


### PR DESCRIPTION
- Closes https://cypress-io.atlassian.net/browse/UNIFY-1737

### User facing changelog
Hovering over test names now highlights the row to indicate clickability. Unifies styles for hovering over test name / hook name / command name.

### Additional details
Adds first component tests (primarily percy snapshots) to `packages/reporter`.

### Steps to test
1. After checking out branch, use `yarn dev` to recompile reporter css, otherwise you won't see the updates.
2. `cypress open` any project.
3. Select any configured testing type, launch any browser, run any spec.
4. Mouse over the command list - notice rows highlight under the mouse.

### How has the user experience changed?
Old behavior:

![Old Behavior](https://user-images.githubusercontent.com/3003404/170352145-654272df-c20d-49c2-928f-f68d676f5897.gif)

New behavior:

![New Behavior](https://user-images.githubusercontent.com/3003404/170352161-5caf050d-1054-4285-bf95-0442730bd9fd.gif)

### PR Tasks
- [x] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
