### PR TITLE
test: fix flaky launchpad test

### DIFF
--- a/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
+++ b/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
@@ -186,7 +186,7 @@ describe('Choose a Browser Page', () => {
       cy.get('h1').should('contain', 'Choose a Browser')
 
       cy.withCtx((ctx, o) => {
-        ctx.actions.project.launchProject = o.sinon.spy()
+        o.sinon.spy(ctx.actions.project, 'launchProject')
       })
 
       cy.intercept('mutation-OpenBrowser_LaunchProject', cy.stub().as('launchProject'))
@@ -251,7 +251,7 @@ describe('Choose a Browser Page', () => {
       cy.openProject('launchpad', ['--e2e'])
       cy.withCtx((ctx, o) => {
         ctx.project.setRelaunchBrowser(true)
-        ctx.actions.project.launchProject = o.sinon.stub()
+        o.sinon.stub(ctx.actions.project, 'launchProject')
       })
 
       cy.visitLaunchpad()


### PR DESCRIPTION
### User facing changelog
na

### Additional details
Some improper stubbing in `choose-a-browser.cy.ts` was causing `open-mode.cy.ts` to fail if it happened to run first in CI.

https://app.circleci.com/pipelines/github/cypress-io/cypress/38605/workflows/16edf69c-4b38-4c59-977c-348ef7501456/jobs/1566814/parallel-runs/1

### Steps to test
I tested this by lifting all the code from `choose-a-browser.cy.ts` and pasting it at the top of `open-mode.cy.ts`. The test was failing every time I did this.


https://user-images.githubusercontent.com/25158820/170370246-6a9f42a5-3efe-462a-b255-2987cbdb7c98.mov



### How has the user experience changed?
na

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
