### PR TITLE
chore: rename DEBUG cypress-trace -> trace-cypress

### DIFF
--- a/packages/data-context/src/util/autoBindDebug.ts
+++ b/packages/data-context/src/util/autoBindDebug.ts
@@ -12,7 +12,7 @@ const debugLibCache: Record<string, debugLib.Debugger> = {}
  * set DEBUG=cypress-trace:<ClassName> to utilize the logging
  */
 export function autoBindDebug <T extends object> (obj: T): T {
-  const ns = `cypress-trace:${obj.constructor.name}`
+  const ns = `trace-cypress:${obj.constructor.name}`
   const debug = debugLibCache[ns] = debugLibCache[ns] || debugLib(ns)
 
   if (!debug.enabled) {


### PR DESCRIPTION
- Closes N/A

### User facing changelog

N/A

### Additional details

Follow re: #21621, makes `cypress*` a bit more tolerable, by moving the `autoBindDebug` helper which is only meant for advanced race-condition debugging to `trace-cypress` debug namespace

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
