### PR TITLE
fix(bug): indeterminate checkbox state doesn't get changed

### DIFF
--- a/packages/driver/cypress/integration/commands/actions/check_spec.js
+++ b/packages/driver/cypress/integration/commands/actions/check_spec.js
@@ -71,6 +71,21 @@ describe('src/cy/commands/actions/check', () => {
       })
     })
 
+    // https://github.com/cypress-io/cypress/issues/19098
+    it('removes indeterminate prop when checkbox is checked', () => {
+      const intermediateCheckbox = $(`<input type='checkbox' name="indeterminate">`)
+
+      intermediateCheckbox.prop('indeterminate', true)
+
+      $('body').append(intermediateCheckbox)
+
+      cy.get(':checkbox[name=\'indeterminate\']').check().then(($checkbox) => {
+        const hasIndeterminate = $checkbox.prop('indeterminate')
+
+        expect(hasIndeterminate).to.be.false
+      })
+    })
+
     it('is a noop if already checked', () => {
       const checkbox = ':checkbox[name=\'colors\'][value=\'blue\']'
 
@@ -836,6 +851,21 @@ describe('src/cy/commands/actions/check', () => {
 
         expect($chk.get(0)).to.eq(cockatoo.get(0))
         expect($chk.get(1)).to.eq(cockatoo.get(1))
+      })
+    })
+
+    // https://github.com/cypress-io/cypress/issues/19098
+    it('removes indeterminate prop when checkbox is unchecked', () => {
+      const indeterminateCheckbox = $(`<input type='checkbox' name="indeterminate">`)
+
+      indeterminateCheckbox.prop('indeterminate', true)
+
+      $('body').append(indeterminateCheckbox)
+
+      cy.get(':checkbox[name=\'indeterminate\']').uncheck().then(($checkbox) => {
+        const hasIndeterminate = $checkbox.prop('indeterminate')
+
+        expect(hasIndeterminate).to.be.false
       })
     })
 

--- a/packages/driver/src/cy/commands/actions/check.ts
+++ b/packages/driver/src/cy/commands/actions/check.ts
@@ -113,6 +113,13 @@ const checkOrUncheck = (Cypress, cy, type, subject, values: any[] = [], userOpti
           cy.ensureVisibility($el, options._log)
         }
 
+        // if the checkbox is in an indeterminate state, checking or unchecking should set the
+        // prop to false to move it into a "determinate" state
+        // https://github.com/cypress-io/cypress/issues/19098
+        if ($el.prop('indeterminate')) {
+          $el.prop('indeterminate', false)
+        }
+
         if (options._log) {
           const inputType = $el.is(':radio') ? 'radio' : 'checkbox'
 


### PR DESCRIPTION
- Closes #19098

### User facing changelog
Now the checkbox will show an appropriate checked or unchecked state and will not remain in indeterminate state on the browser UI. 

### Additional details
using .prop(indeterminate, false) here because as per the removeProp documentation it can lead to unexpected results and it was indeed not working as expected while I tried to use it. 

### Steps to test
2 tests have been added in check_spec.js 

1.  removes indeterminate prop when checkbox is checked
2. removes indeterminate prop when checkbox is unchecked

### How has the user experience changed?
**Before**
<img width="1216" alt="image" src="https://user-images.githubusercontent.com/2032911/170767909-458fb28e-e349-4ac4-b94f-99ae7c5c107b.png">

**After**
<img width="1216" alt="image" src="https://user-images.githubusercontent.com/2032911/170768007-efe1e7ab-0e65-4ee6-ace0-831393fff6c8.png">


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
