### PR TITLE
fix: scroll of inline specs list

### DIFF
--- a/packages/app/src/specs/InlineSpecList.cy.tsx
+++ b/packages/app/src/specs/InlineSpecList.cy.tsx
@@ -34,6 +34,12 @@ describe('InlineSpecList', () => {
     .should('exist')
     .and('have.length', 7)
 
+    // overflow is required for the virtual list to work
+    // this test will fail if the overflow set by `useVirtualList`
+    // is overridden
+    cy.get('[data-cy="specs-list-container"]')
+    .should('have.css', 'overflow-y', 'auto')
+
     cy.percySnapshot()
   })
 

--- a/packages/app/src/specs/InlineSpecListTree.vue
+++ b/packages/app/src/specs/InlineSpecListTree.vue
@@ -2,6 +2,7 @@
   <div
     v-bind="containerProps"
     class="pt-8px specs-list-container"
+    data-cy="specs-list-container"
   >
     <ul
       v-bind="wrapperProps"

--- a/packages/app/src/specs/InlineSpecListTree.vue
+++ b/packages/app/src/specs/InlineSpecListTree.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-bind="containerProps"
-    class="pt-8px specs-list-container overflow-hidden"
+    class="pt-8px specs-list-container"
   >
     <ul
       v-bind="wrapperProps"


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog

In the Runner page, the inline specs list will now scroll as expected.

### Additional details

The overflow styles were changed incorrectly in [this PR](https://github.com/cypress-io/cypress/pull/21598) last week. Removing the `overflow-hidden` class restores the correct behavior of the specs list. The `!important` of the tailwind class clobbered the overflow that the `useVirtualList` sets on the wrapper of the virtual list.

### Steps to test

Visit a spec and confirm that the inline specs list is scrollable vertically.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?