### PR TITLE
feat: show better error message if testing type is not configured

### DIFF
--- a/packages/data-context/src/data/ProjectLifecycleManager.ts
+++ b/packages/data-context/src/data/ProjectLifecycleManager.ts
@@ -542,6 +542,10 @@ export class ProjectLifecycleManager {
       return
     }
 
+    if (this.ctx.isRunMode && !this.isTestingTypeConfigured(testingType)) {
+      this.ctx.onError(getError('TESTING_TYPE_NOT_CONFIGURED', testingType))
+    }
+
     if (this.ctx.isRunMode || (this.isTestingTypeConfigured(testingType) && !(this.ctx.coreData.forceReconfigureProject && this.ctx.coreData.forceReconfigureProject[testingType]))) {
       this._configManager.loadTestingType()
     }

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -1547,6 +1547,14 @@ export const AllCypressErrors = {
       the devServer config as a ${fmt.highlight(devServerConfigFile)} option.
     `
   },
+
+  TESTING_TYPE_NOT_CONFIGURED: (testingType: TestingType) => {
+    return errTemplate`
+      The testing type selected (${fmt.highlight(testingType)}) is not configured in your config file.
+
+      Please update it, and try running it again.
+    `
+  },
 } as const
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
