### PR TITLE
chore: enable @cypress/schematic for npm publishing

### DIFF
--- a/npm/cypress-schematic/package.json
+++ b/npm/cypress-schematic/package.json
@@ -2,7 +2,6 @@
   "name": "@cypress/schematic",
   "version": "0.0.0-development",
   "description": "Official Cypress schematic for the Angular CLI",
-  "private": true,
   "main": "./src",
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
### User facing changelog
Breaking change for `@cypress/schematic` to support scaffolding and building Cypress 10.x projects

### Additional details
na

### Steps to test
I tested this by making the commits on master and running `node ./scripts/npm-release.js`. The output shows a breaking change for `@cypress/schematic`.

![Screen Shot 2022-06-01 at 12 07 17 PM](https://user-images.githubusercontent.com/25158820/171463923-8efe51bc-d6c8-4d54-862d-753489b5eabb.png)


### How has the user experience changed?
na

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
