### PR TITLE
fix: Don't include defineConfig if cypress isn't available from project root

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -13,7 +13,7 @@
     "test": "yarn test-unit",
     "test:clean": "find ./test/__fixtures__ -depth -name 'output.*' -type f -exec rm {} \\;",
     "test-debug": "yarn test-unit --inspect-brk=5566",
-    "test-unit": "mocha --configFile=../../mocha-reporter-config.json -r @packages/ts/register 'test/**/*.spec.ts' --exit"
+    "test-unit": "mocha --configFile=../../mocha-reporter-config.json -r @packages/ts/register 'test/**/*.spec.ts' --exit --timeout 5000"
   },
   "dependencies": {
     "@babel/core": "^7",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -13,7 +13,7 @@
     "test": "yarn test-unit",
     "test:clean": "find ./test/__fixtures__ -depth -name 'output.*' -type f -exec rm {} \\;",
     "test-debug": "yarn test-unit --inspect-brk=5566",
-    "test-unit": "mocha --configFile=../../mocha-reporter-config.json -r @packages/ts/register 'test/**/*.spec.ts' --exit --timeout 5000"
+    "test-unit": "mocha --configFile=../../mocha-reporter-config.json -r @packages/ts/register 'test/**/*.spec.ts' --exit"
   },
   "dependencies": {
     "@babel/core": "^7",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -2,4 +2,4 @@
 // babel transforms, etc. into client-side usage of the config code
 export * from './browser'
 
-export { addProjectIdToCypressConfig, addToCypressConfig, addTestingTypeToCypressConfig, AddTestingTypeToCypressConfigOptions } from './ast-utils/addToCypressConfig'
+export { addProjectIdToCypressConfig, addToCypressConfig, addTestingTypeToCypressConfig, AddTestingTypeToCypressConfigOptions, defineConfigAvailable } from './ast-utils/addToCypressConfig'

--- a/packages/config/test/ast-utils/addToCypressConfig.spec.ts
+++ b/packages/config/test/ast-utils/addToCypressConfig.spec.ts
@@ -26,6 +26,7 @@ describe('addToCypressConfig', () => {
         testingType: 'e2e',
       },
       isProjectUsingESModules: false,
+      projectRoot: __dirname,
     })
 
     expect(stub.firstCall.args[1].trim()).to.eq(dedent`
@@ -50,6 +51,7 @@ describe('addToCypressConfig', () => {
         testingType: 'e2e',
       },
       isProjectUsingESModules: true,
+      projectRoot: __dirname,
     })
 
     expect(stub.firstCall.args[1].trim()).to.eq(dedent`
@@ -74,6 +76,7 @@ describe('addToCypressConfig', () => {
         testingType: 'e2e',
       },
       isProjectUsingESModules: false,
+      projectRoot: __dirname,
     })
 
     expect(stub.firstCall.args[1].trim()).to.eq(dedent`
@@ -91,6 +94,52 @@ describe('addToCypressConfig', () => {
     expect(result.result).to.eq('ADDED')
   })
 
+  it('will exclude defineConfig if cypress can\'t be imported from the projectRoot', async () => {
+    const result = await addTestingTypeToCypressConfig({
+      filePath: path.join(__dirname, '../__fixtures__/empty.config.js'),
+      info: {
+        testingType: 'e2e',
+      },
+      isProjectUsingESModules: false,
+      projectRoot: '/foo',
+    })
+
+    expect(stub.firstCall.args[1].trim()).to.eq(dedent`
+      module.exports = {
+        e2e: {
+          setupNodeEvents(on, config) {
+            // implement node event listeners here
+          },
+        },
+      };
+    `)
+
+    expect(result.result).to.eq('ADDED')
+  })
+
+  it('will exclude defineConfig if cypress can\'t be imported from the projectRoot for an ECMA Script project', async () => {
+    const result = await addTestingTypeToCypressConfig({
+      filePath: path.join(__dirname, '../__fixtures__/empty.config.js'),
+      info: {
+        testingType: 'e2e',
+      },
+      isProjectUsingESModules: true,
+      projectRoot: '/foo',
+    })
+
+    expect(stub.firstCall.args[1].trim()).to.eq(dedent`
+      export default {
+        e2e: {
+          setupNodeEvents(on, config) {
+            // implement node event listeners here
+          },
+        },
+      };
+    `)
+
+    expect(result.result).to.eq('ADDED')
+  })
+
   it('will error if we are unable to add to the config', async () => {
     const result = await addTestingTypeToCypressConfig({
       filePath: path.join(__dirname, '../__fixtures__/invalid.config.ts'),
@@ -98,6 +147,7 @@ describe('addToCypressConfig', () => {
         testingType: 'e2e',
       },
       isProjectUsingESModules: false,
+      projectRoot: __dirname,
     })
 
     expect(result.result).to.eq('NEEDS_MERGE')
@@ -111,6 +161,7 @@ describe('addToCypressConfig', () => {
         testingType: 'e2e',
       },
       isProjectUsingESModules: false,
+      projectRoot: __dirname,
     })
 
     expect(result.result).to.eq('NEEDS_MERGE')

--- a/packages/config/test/ast-utils/addToCypressConfig.spec.ts
+++ b/packages/config/test/ast-utils/addToCypressConfig.spec.ts
@@ -20,6 +20,9 @@ const { addTestingTypeToCypressConfig } = proxyquire('../../src/ast-utils/addToC
 
 describe('addToCypressConfig', () => {
   it('will create a ts file if the file is empty and the file path is ts', async () => {
+    // For some reason, the first test in this spec file is extremely slow, and times out in CI
+    // with the default of 2000ms.
+    this.timeout(5000)
     const result = await addTestingTypeToCypressConfig({
       filePath: path.join(__dirname, '../__fixtures__/empty.config.ts'),
       info: {

--- a/packages/config/test/ast-utils/addToCypressConfig.spec.ts
+++ b/packages/config/test/ast-utils/addToCypressConfig.spec.ts
@@ -20,9 +20,6 @@ const { addTestingTypeToCypressConfig } = proxyquire('../../src/ast-utils/addToC
 
 describe('addToCypressConfig', () => {
   it('will create a ts file if the file is empty and the file path is ts', async () => {
-    // For some reason, the first test in this spec file is extremely slow, and times out in CI
-    // with the default of 2000ms.
-    this.timeout(5000)
     const result = await addTestingTypeToCypressConfig({
       filePath: path.join(__dirname, '../__fixtures__/empty.config.ts'),
       info: {

--- a/packages/data-context/src/actions/WizardActions.ts
+++ b/packages/data-context/src/actions/WizardActions.ts
@@ -233,6 +233,7 @@ export class WizardActions {
       isProjectUsingESModules: this.ctx.lifecycleManager.metaState.isProjectUsingESModules,
       filePath: configFilePath,
       info: testingTypeInfo,
+      projectRoot: this.projectRoot,
     })
 
     const description = (testingType === 'e2e')

--- a/packages/data-context/src/sources/migration/codegen.ts
+++ b/packages/data-context/src/sources/migration/codegen.ts
@@ -15,7 +15,7 @@ import { LegacyCypressConfigJson, legacyIntegrationFolder } from '..'
 import { parse } from '@babel/parser'
 import generate from '@babel/generator'
 import _ from 'lodash'
-import { getBreakingKeys } from '@packages/config'
+import { defineConfigAvailable, getBreakingKeys } from '@packages/config'
 
 const debug = Debug('cypress:data-context:sources:migration:codegen')
 
@@ -145,24 +145,6 @@ export async function initComponentTestingMigration (
 
 async function getPluginRelativePath (cfg: LegacyCypressConfigJson, projectRoot: string): Promise<string | undefined> {
   return cfg.pluginsFile ? cfg.pluginsFile : await tryGetDefaultLegacyPluginsFile(projectRoot)
-}
-
-// If they are running an old version of Cypress
-// or running Cypress that isn't installed in their
-// project's node_modules, we don't want to include
-// defineConfig(/***/) in their cypress.config.js,
-// since it won't exist.
-export function defineConfigAvailable (projectRoot: string) {
-  try {
-    const cypress = require.resolve('cypress', {
-      paths: [projectRoot],
-    })
-    const api = require(cypress)
-
-    return 'defineConfig' in api
-  } catch (e) {
-    return false
-  }
 }
 
 function createCypressConfig (config: ConfigOptions, pluginPath: string | undefined, options: CreateConfigOptions): string {

--- a/packages/launchpad/cypress.config.ts
+++ b/packages/launchpad/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 import getenv from 'getenv'
 import { snapshotCypressDirectory } from './cypress/tasks/snapshotsScaffold'
+import { uninstallDependenciesInScaffoldedProject } from './cypress/tasks/uninstallDependenciesInScaffoldedProject'
 
 const CYPRESS_INTERNAL_CLOUD_ENV = getenv('CYPRESS_INTERNAL_CLOUD_ENV', process.env.CYPRESS_INTERNAL_ENV || 'development')
 
@@ -41,6 +42,7 @@ export default defineConfig({
 
       on('task', {
         snapshotCypressDirectory,
+        uninstallDependenciesInScaffoldedProject,
       })
 
       return await e2ePluginSetup(on, config)

--- a/packages/launchpad/cypress/e2e/scaffold-project.cy.ts
+++ b/packages/launchpad/cypress/e2e/scaffold-project.cy.ts
@@ -158,4 +158,17 @@ describe('scaffolding new projects', { defaultCommandTimeout: 7000 }, () => {
     scaffoldAndOpenCTProject({ name: 'pristine', framework: 'Create React App', removeFixturesFolder: false })
     assertScaffoldedFilesAreCorrect({ language, testingType: 'component', ctFramework: 'Create React App (v5)', customDirectory: 'without-fixtures' })
   })
+
+  it('generates valid config file for pristine project without cypress installed', () => {
+    cy.scaffoldProject('pristine')
+    cy.openProject('pristine')
+    cy.withCtx((ctx) => ctx.currentProject).then((currentProject) => {
+      cy.task('uninstallDependenciesInScaffoldedProject', { currentProject })
+    })
+
+    cy.visitLaunchpad()
+    cy.contains('button', cy.i18n.testingType.e2e.name).click()
+    cy.contains('button', cy.i18n.setupPage.step.continue).click()
+    cy.contains('h1', cy.i18n.setupPage.testingCard.chooseABrowser).should('be.visible')
+  })
 })

--- a/packages/launchpad/cypress/tasks/uninstallDependenciesInScaffoldedProject.ts
+++ b/packages/launchpad/cypress/tasks/uninstallDependenciesInScaffoldedProject.ts
@@ -1,0 +1,8 @@
+import fs from 'fs'
+import path from 'path'
+
+export async function uninstallDependenciesInScaffoldedProject ({ currentProject }) {
+  fs.rmdirSync(path.resolve(currentProject, '../node_modules'), { recursive: true, force: true })
+
+  return null
+}

--- a/packages/launchpad/cypress/tasks/uninstallDependenciesInScaffoldedProject.ts
+++ b/packages/launchpad/cypress/tasks/uninstallDependenciesInScaffoldedProject.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 
 export async function uninstallDependenciesInScaffoldedProject ({ currentProject }) {
+  // @ts-ignore
   fs.rmdirSync(path.resolve(currentProject, '../node_modules'), { recursive: true, force: true })
 
   return null


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/21999

### User facing changelog
Cypress will generate a correct config file when using the directly downloaded version on a fresh project.

### Additional details
Previously, the config file would contain `const { defineConfig } = require("cypress");` or similar, even though cypress was not available from the project root. This is no longer the case; if the user can't `require('cypress')`, then we omit `defineConfig`.

### Steps to test
1. Create an empty directory, `foobar`, or use an existing project without cypress configured.
2. `yarn cypress:open --project ../foobar`
3. Select e2e testing and continue through.

In 10.0.0, you get `Error: Cannot find module 'cypress'` after a few clicks. With this branch, you do not!

### How has the user experience changed?

### PR Tasks
- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
