### PR TITLE
fix: partial fix for #21997 & #22004, throw the originalError

### DIFF
--- a/npm/webpack-dev-server/package.json
+++ b/npm/webpack-dev-server/package.json
@@ -18,7 +18,7 @@
     "test-unit": "mocha -r ts-node/register/transpile-only --config ./test/.mocharc.js"
   },
   "dependencies": {
-    "find-up": "6.3.0",
+    "find-up": "5.0.0",
     "fs-extra": "9.1.0",
     "html-webpack-plugin-4": "npm:html-webpack-plugin@^4",
     "html-webpack-plugin-5": "npm:html-webpack-plugin@^5",

--- a/packages/server/lib/plugins/child/run_require_async_child.js
+++ b/packages/server/lib/plugins/child/run_require_async_child.js
@@ -97,10 +97,12 @@ function run (ipc, file, projectRoot) {
     //   3a. Yes: Use bundleRequire
     //   3b. No: Continue through to `await import(configFile)`
     // 4. Use node's dynamic import to import the configFile
+    let originalError
 
     try {
       return require(file)
     } catch (err) {
+      originalError = err
       if (!err.stack.includes('[ERR_REQUIRE_ESM]') && !err.stack.includes('SyntaxError: Cannot use import statement outside a module')) {
         throw err
       }
@@ -122,8 +124,15 @@ function run (ipc, file, projectRoot) {
         debug(`User doesn't have esbuild. Going to use native node imports.`)
 
         // We cannot replace the initial `require` with `await import` because
-        // Certain modules cannot be dynamically imported
-        return await import(file)
+        // Certain modules cannot be dynamically imported. If this throws, however, we want
+        // to show the original error that was thrown, because that's ultimately the source of the problem
+        try {
+          return await import(file)
+        } catch (e) {
+          // If we aren't able to import the file at all, throw the original error, since that has more accurate information
+          // of what failed to begin with
+          throw originalError
+        }
       }
 
       throw err

--- a/system-tests/test/config_modules_spec.ts
+++ b/system-tests/test/config_modules_spec.ts
@@ -32,6 +32,13 @@ describe('cypress config with esm and cjs', function () {
       spec: 'app.cy.js',
       browser: 'chrome',
       expectedExitCode: 1,
+      snapshot: true,
+      onStdout (stdout) {
+        expect(stdout).to.include('nearest parent package.json contains "type": "module" which defines all .ts files in that package scope as ES modules')
+
+        // Need to make this stable b/c of filepaths, and snapshot: true is needed to invoke onStdout
+        return 'STDOUT_ERROR_VALIDATED'
+      },
     })
   })
 


### PR DESCRIPTION
- Related to #21997, #22004

### User facing changelog

Throws the first error encountered when failing due to an esm import, when Node's ESM loading cannot not handle it. This will provide better information about the actual error encountered, such as when processed via `ts-node` for TypeScript files.

### Additional details
Not the full fix for the issues, but will surface better warnings around the issue


### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
