### PR TITLE
fix: prevent RunCard styles from leaking outside of component

### DIFF
--- a/packages/app/src/runs/RunCard.vue
+++ b/packages/app/src/runs/RunCard.vue
@@ -130,7 +130,7 @@ const tags = computed(() => {
 
 </script>
 
-<style>
+<style scoped>
 li:not(:first-child)::before {
   content: '.';
   @apply -mt-8px text-lg text-gray-400 pr-8px


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #21931

### User facing changelog

Visiting the Runs page will no longer cause list styles to look incorrect in the Spec Runner page and Header.


**Desired Behavior**

In this situation, Cypress should not show extra dots in the Runner UI that don’t belong there.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This is caused by styles leaking from this component: packages/app/src/runs/RunCard.vue and the fix is a one-line change, to add a `scoped` attribute to the `style` tag [here](https://github.com/cypress-io/cypress/blob/8d79472b7d569094c94836ecb6cd527ee5823111/packages/app/src/runs/RunCard.vue#L133).

### Steps to test

Before checking out this branch:

1. Open the cypress app
1. Visit the Runs page
1. Visit the Specs List
1. Open a Spec
1. See bad styles
1. Refresh
1. See good styles
1. Visit the Runs page and then visit a spec again - the bad styles return as soon as the Runs page mounts, you can see them pop in briefly during the navigation.

Repeat these steps after checking out this branch and the problem should be fixed.

### How has the user experience changed?

There are extra dots and big spaces between items in the command log, and extra dots on the far left of the inline specs list, that appear when you visit a spec after visiting the Specs.

![Screen Shot 2022-05-23 at 2 53 38 PM](https://user-images.githubusercontent.com/1271364/171213614-4e76da95-703e-4148-b68a-38b1de223745.png)

Some other side effects caused by same leaking styles - any list longer than one item is affected. It makes the docs menu look nested and the browser list look misaligned.

<img width="634" alt="Screen Shot 2022-05-25 at 6 43 01 AM" src="https://user-images.githubusercontent.com/1271364/171213666-10c02682-d326-48a3-8022-0b7f6d209502.png">

<img width="555" alt="Screen Shot 2022-05-25 at 6 42 56 AM" src="https://user-images.githubusercontent.com/1271364/171213696-c0bc4c3c-7f89-408f-a540-2690fabd89db.png">

This PR fixes all of that so that things look as expected whether we have visited the runs page or not. Here is a screenshot of part of the app after visiting the runs page:

![Screen Shot 2022-06-01 at 4 38 50 PM](https://user-images.githubusercontent.com/8340719/171497626-12c9f81d-8ec4-4f89-826c-e03d64b0c6a3.png)


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only) - no tag yet, not sure which release this will go into
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
