### PR TITLE
fix: #22038 esm import for windows

### DIFF
--- a/packages/launchpad/cypress/e2e/scaffold-project.cy.ts
+++ b/packages/launchpad/cypress/e2e/scaffold-project.cy.ts
@@ -44,6 +44,7 @@ function scaffoldAndOpenE2EProject (opts: {
   cy.contains('E2E Testing').click()
   cy.contains('We added the following files to your project:')
   cy.contains('Continue').click()
+  cy.contains('Choose a Browser')
 }
 
 function scaffoldAndOpenCTProject (opts: {

--- a/packages/server/lib/plugins/child/run_require_async_child.js
+++ b/packages/server/lib/plugins/child/run_require_async_child.js
@@ -1,6 +1,7 @@
 require('graceful-fs').gracefulify(require('fs'))
 const stripAnsi = require('strip-ansi')
 const debug = require('debug')(`cypress:lifecycle:child:run_require_async_child:${process.pid}`)
+const { pathToFileURL } = require('url')
 const tsNodeUtil = require('./ts_node')
 const util = require('../util')
 const { RunPlugins } = require('./run_plugins')
@@ -127,7 +128,8 @@ function run (ipc, file, projectRoot) {
         // Certain modules cannot be dynamically imported. If this throws, however, we want
         // to show the original error that was thrown, because that's ultimately the source of the problem
         try {
-          return await import(file)
+          // pathToFileURL for windows interop: https://github.com/nodejs/node/issues/31710
+          return await import(pathToFileURL(pathToFileURL).href)
         } catch (e) {
           // If we aren't able to import the file at all, throw the original error, since that has more accurate information
           // of what failed to begin with

--- a/packages/server/lib/plugins/child/run_require_async_child.js
+++ b/packages/server/lib/plugins/child/run_require_async_child.js
@@ -129,7 +129,8 @@ function run (ipc, file, projectRoot) {
         // to show the original error that was thrown, because that's ultimately the source of the problem
         try {
           // pathToFileURL for windows interop: https://github.com/nodejs/node/issues/31710
-          return await import(pathToFileURL(pathToFileURL).href)
+          // return await import(pathToFileURL(pathToFileURL).href)
+          return await import(pathToFileURL)
         } catch (e) {
           // If we aren't able to import the file at all, throw the original error, since that has more accurate information
           // of what failed to begin with


### PR DESCRIPTION
- Closes #22038

### User facing changelog

Improved support for ESM imports in windows

### Additional details

ESM imports on windows must be transformed to a proper `file://` prefixed path. The recommended way to handle this is with the `pathToFileURL` utility exported from `url`

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
