### PR TITLE
fix: Add "Switch testing type" tooltip to main nav button

### DIFF
--- a/packages/app/src/navigation/SidebarNavigationHeader.cy.tsx
+++ b/packages/app/src/navigation/SidebarNavigationHeader.cy.tsx
@@ -28,4 +28,30 @@ describe('SidebarNavigationHeader', () => {
     cy.contains('test-project')
     cy.percySnapshot()
   })
+
+  describe('rendering tooltip message', () => {
+    it('nav expanded', () => {
+      cy.mountFragment(SidebarNavigationHeaderFragmentDoc, {
+        render: (gql) => <div style={{ width: '300px' }}><div class="p-16px"><SidebarNavigationHeader gql={gql} isNavBarExpanded /></div></div>,
+      })
+
+      cy.get('[data-cy="sidebar-header"]').realHover()
+      cy.get('[data-cy="project-name-tooltip"]').should('not.exist')
+      cy.get('[data-cy="switch-testing-tooltip"]').should('be.visible')
+
+      cy.percySnapshot()
+    })
+
+    it('nav collapsed', () => {
+      cy.mountFragment(SidebarNavigationHeaderFragmentDoc, {
+        render: (gql) => <div style={{ width: '300px' }}><div class="p-16px"><SidebarNavigationHeader gql={gql} isNavBarExpanded={false} /></div></div>,
+      })
+
+      cy.get('[data-cy="sidebar-header"]').realHover()
+      cy.get('[data-cy="project-name-tooltip"]').should('be.visible')
+      cy.get('[data-cy="switch-testing-tooltip"]').should('be.visible')
+
+      cy.percySnapshot()
+    })
+  })
 })

--- a/packages/app/src/navigation/SidebarNavigationHeader.vue
+++ b/packages/app/src/navigation/SidebarNavigationHeader.vue
@@ -39,7 +39,10 @@
     <template #popper>
       <div class="flex">
         <template v-if="!isNavBarExpanded">
-          <div class="text-left text-gray-50 text-size-16px leading-16px truncate">
+          <div
+            class="text-left text-gray-50 text-size-16px leading-16px truncate"
+            data-cy="project-name-tooltip"
+          >
             {{ props.gql.currentProject?.title ?? 'Cypress' }}
             <p class="text-gray-600 text-size-14px leading-20px truncate">
               {{ props.gql.currentProject?.branch }}
@@ -47,7 +50,10 @@
           </div>
           <div class="border-r-1 ml-12px mr-12px" />
         </template>
-        <div class="flex items-center">
+        <div
+          class="flex items-center"
+          data-cy="switch-testing-tooltip"
+        >
           {{ tooltipText.switchTestingType }}
         </div>
       </div>

--- a/packages/app/src/navigation/SidebarNavigationHeader.vue
+++ b/packages/app/src/navigation/SidebarNavigationHeader.vue
@@ -2,7 +2,6 @@
   <Tooltip
     v-if="testingType"
     placement="right"
-    :disabled="isNavBarExpanded"
     :distance="8"
   >
     <div
@@ -38,11 +37,19 @@
       </div>
     </div>
     <template #popper>
-      <div class="text-left text-gray-50 text-size-16px leading-16px truncate">
-        {{ props.gql.currentProject?.title ?? 'Cypress' }}
-        <p class="text-gray-600 text-size-14px leading-20px truncate">
-          {{ props.gql.currentProject?.branch }}
-        </p>
+      <div class="flex">
+        <template v-if="!isNavBarExpanded">
+          <div class="text-left text-gray-50 text-size-16px leading-16px truncate">
+            {{ props.gql.currentProject?.title ?? 'Cypress' }}
+            <p class="text-gray-600 text-size-14px leading-20px truncate">
+              {{ props.gql.currentProject?.branch }}
+            </p>
+          </div>
+          <div class="border-r-1 ml-12px mr-12px" />
+        </template>
+        <div class="flex items-center">
+          {{ tooltipText.switchTestingType }}
+        </div>
       </div>
     </template>
   </Tooltip>
@@ -104,6 +111,12 @@ const TESTING_TYPE_MAP = {
 
 const testingType = computed(() => {
   return props.gql.currentProject?.currentTestingType ? TESTING_TYPE_MAP[props.gql.currentProject.currentTestingType] : null
+})
+
+const tooltipText = computed(() => {
+  return {
+    switchTestingType: t('openBrowser.switchTestingType'),
+  }
 })
 
 </script>


### PR DESCRIPTION
- Closes #21918

### User facing changelog

Add "Switch testing type" tooltip to main nav button.

### Additional details
- Why was this change necessary? => This button looks like a "Home" button. It can confuse users. 
- What is affected by this change? => N/A
- Any implementation details to explain? => I used the text from "openbrowser.switchTestingType". 

### Steps to test

1. Open the app. 
2. Hover over the main nav button. 
3. Tooltip appears.

### How has the user experience changed?

**Before:**

![Screenshot from 2022-06-03 16-29-35](https://user-images.githubusercontent.com/8130013/171809045-50f66dea-1d2c-4bd8-a71a-9011d6f6ea82.png)

![Screenshot from 2022-06-03 16-29-43](https://user-images.githubusercontent.com/8130013/171809082-8684128a-30e0-4ad0-a710-719220ca8137.png)


**After:**

![Screenshot from 2022-06-03 16-27-53](https://user-images.githubusercontent.com/8130013/171808984-830d3b31-d19d-4c9a-9a1b-56145afa5acf.png)

![Screenshot from 2022-06-03 16-28-07](https://user-images.githubusercontent.com/8130013/171809003-2ecf90a0-e658-490b-bd61-148fb16cdbe3.png)


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated? => It seems that there's not test for tooltip. 
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
