### PR TITLE
fix: top nav browsers list scroll

### DIFF
--- a/packages/app/src/runner/SpecRunnerHeaderOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerHeaderOpenMode.vue
@@ -57,12 +57,12 @@
         </template>
 
         <template #default>
-          <ul class="max-h-50vh overflow-auto">
+          <div class="max-h-50vh overflow-auto">
             <VerticalBrowserListItems
               :gql="props.gql"
               :spec-path="activeSpecPath"
             />
-          </ul>
+          </div>
         </template>
       </SpecRunnerDropdown>
       <SpecRunnerDropdown

--- a/packages/app/src/runner/SpecRunnerHeaderOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerHeaderOpenMode.vue
@@ -57,12 +57,12 @@
         </template>
 
         <template #default>
-          <div class="max-h-50vh overflow-auto">
+          <ul class="max-h-50vh overflow-auto">
             <VerticalBrowserListItems
               :gql="props.gql"
               :spec-path="activeSpecPath"
             />
-          </div>
+          </ul>
         </template>
       </SpecRunnerDropdown>
       <SpecRunnerDropdown
@@ -98,9 +98,9 @@
             >
               <!-- disable rule to prevent trailing space from being added to <InlineCodeFragment/> -->
               <!-- eslint-disable-next-line vue/singleline-html-element-content-newline -->
-              <InlineCodeFragment class="text-xs font-medium leading-5">{{ props.gql.configFile }}</InlineCodeFragment>
+              <InlineCodeFragment class="font-medium text-xs leading-5">{{ props.gql.configFile }}</InlineCodeFragment>
               <!-- eslint-disable-next-line vue/singleline-html-element-content-newline -->
-              <InlineCodeFragment class="text-xs font-medium leading-5">cy.viewport()</InlineCodeFragment>
+              <InlineCodeFragment class="font-medium text-xs leading-5">cy.viewport()</InlineCodeFragment>
             </i18n-t>
             <div class="flex justify-center">
               <Button

--- a/packages/app/src/runner/automation/AutomationMissing.vue
+++ b/packages/app/src/runner/automation/AutomationMissing.vue
@@ -27,11 +27,11 @@
           </template>
 
           <template #default>
-            <ul class="max-h-50vh overflow-auto">
+            <div class="max-h-50vh overflow-auto">
               <VerticalBrowserListItems
                 :gql="props.gql"
               />
-            </ul>
+            </div>
           </template>
         </SpecRunnerDropdown>
         <ExternalLink

--- a/packages/app/src/runner/automation/AutomationMissing.vue
+++ b/packages/app/src/runner/automation/AutomationMissing.vue
@@ -27,11 +27,11 @@
           </template>
 
           <template #default>
-            <div class="max-h-50vh overflow-auto">
+            <ul class="max-h-50vh overflow-auto">
               <VerticalBrowserListItems
                 :gql="props.gql"
               />
-            </div>
+            </ul>
           </template>
         </SpecRunnerDropdown>
         <ExternalLink

--- a/packages/frontend-shared/src/gql-components/HeaderBarContent.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/HeaderBarContent.cy.tsx
@@ -26,9 +26,8 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
       .should('not.exist')
     })
 
-    cy.get('[data-cy="top-nav-browser-list-item"]')
-    .last().should('not.be.visible')
-    .scrollIntoView().should('be.visible')
+    cy.get('[data-cy="top-nav-browser-list-item"]').parent()
+    .should('have.class', 'overflow-auto')
 
     cy.contains('Version unsupported')
     .scrollIntoView()
@@ -40,7 +39,7 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
       .trigger('mouseenter')
     })
 
-    cy.contains('Unsupported browser')
+    cy.contains('Unsupported browser').should('be.visible')
 
     cy.percySnapshot('unsupported browser tooltip')
   }),

--- a/packages/frontend-shared/src/gql-components/HeaderBarContent.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/HeaderBarContent.cy.tsx
@@ -16,6 +16,8 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
     .should('be.visible')
     .click()
 
+    cy.percySnapshot('after browsers open')
+
     cy.contains('Edge Canary')
     .should('be.visible')
     .closest('[data-cy="top-nav-browser-list-item"]')
@@ -24,15 +26,23 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
       .should('not.exist')
     })
 
+    cy.get('[data-cy="top-nav-browser-list-item"]')
+    .last().should('not.be.visible')
+    .scrollIntoView().should('be.visible')
+
     cy.contains('Version unsupported')
+    .scrollIntoView()
     .should('be.visible')
     .closest('[data-cy="top-nav-browser-list-item"]')
     .within(() => {
       cy.get('[data-cy="unsupported-browser-tooltip-trigger"]')
       .should('exist')
+      .trigger('mouseenter')
     })
 
-    cy.percySnapshot('after browsers open')
+    cy.contains('Unsupported browser')
+
+    cy.percySnapshot('unsupported browser tooltip')
   }),
 
   it('renders without browser menu by default and other items work', () => {

--- a/packages/frontend-shared/src/gql-components/topnav/TopNavList.vue
+++ b/packages/frontend-shared/src/gql-components/topnav/TopNavList.vue
@@ -30,7 +30,7 @@
       >
         <ul
           v-if="variant !== 'panel'"
-          class="flex flex-col"
+          class="flex flex-col max-h-50vh overflow-auto"
         >
           <slot />
         </ul>


### PR DESCRIPTION
- Closes #22032

### User facing changelog
Allow browsers list in top nav to be scrollable

### Additional details
We didn't have any scroll css on the browsers list in the top nav. This PR fixes this for all use cases of the `VerticalBrowserListItems.vue`.

I've added a test to verify it can scroll, and also added a missing percy snapshot for the unsupported browser tooltip

### Steps to test
You can run the `renders with functional browser menu when show-browsers prop is true` from `HeaderBarContent.cy.tsx`. It has a long list of browsers and there is no scrolling on the element other than the full page scroll.

### How has the user experience changed?
Before:

<img width="1035" alt="Screen Shot 2022-06-03 at 10 41 12 AM" src="https://user-images.githubusercontent.com/25158820/171896780-67809bc2-dfa8-42d2-8633-5befd75c3725.png">

After:

<img width="1031" alt="Screen Shot 2022-06-03 at 10 40 54 AM" src="https://user-images.githubusercontent.com/25158820/171896945-f65727b5-be71-4e35-80c0-d64bc04d9234.png">


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
