### PR TITLE
fix: #22081 Cypress crashing behind proxy

### DIFF
--- a/packages/data-context/src/sources/VersionsDataSource.ts
+++ b/packages/data-context/src/sources/VersionsDataSource.ts
@@ -100,8 +100,9 @@ export class VersionsDataSource {
   }
 
   private async getVersionMetadata (): Promise<Record<string, string>> {
+    const now = new Date().toISOString()
     const DEFAULT_RESPONSE = {
-      [pkg.version]: new Date().toISOString(),
+      [pkg.version]: now,
     }
 
     if (this.ctx.isRunMode) {
@@ -112,21 +113,18 @@ export class VersionsDataSource {
 
     try {
       response = await this.ctx.util.fetch(NPM_CYPRESS_REGISTRY)
+      const responseJson = await response.json() as { time: Record<string, string>}
+
+      debug('NPM release dates received %o', { modified: responseJson.time.modified })
+
+      return responseJson.time ?? now
     } catch (e) {
       // ignore any error from this fetch, they are gracefully handled
       // by showing the current version only
       debug('Error fetching %o', NPM_CYPRESS_REGISTRY, e)
-    }
 
-    if (!response) {
       return DEFAULT_RESPONSE
     }
-
-    const responseJson = await response.json() as { time: Record<string, string>}
-
-    debug('NPM release dates received %o', { modified: responseJson.time.modified })
-
-    return responseJson.time
   }
 
   private async getLatestVersion (): Promise<string> {
@@ -153,31 +151,27 @@ export class VersionsDataSource {
       manifestHeaders['x-machine-id'] = id
     }
 
-    let manifestResponse
-
     try {
-      manifestResponse = await this.ctx.util.fetch(url, {
+      const manifestResponse = await this.ctx.util.fetch(url, {
         headers: manifestHeaders,
       })
+
+      debug('retrieving latest version information with headers: %o', manifestHeaders)
+
+      const manifest = await manifestResponse.json() as { version: string }
+
+      debug('latest version information: %o', manifest)
+
+      return manifest.version ?? pkg.version
     } catch (e) {
       // ignore any error from this fetch, they are gracefully handled
       // by showing the current version only
       debug('Error fetching %o', url, e)
-    }
 
-    if (!manifestResponse) {
       return pkg.version
+    } finally {
+      this._initialLaunch = false
     }
-
-    debug('retrieving latest version information with headers: %o', manifestHeaders)
-
-    const manifest = await manifestResponse.json() as { version: string }
-
-    debug('latest version information: %o', manifest)
-
-    this._initialLaunch = false
-
-    return manifest.version
   }
 
   private static async machineId (): Promise<string | undefined> {

--- a/packages/data-context/test/unit/sources/VersionsDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/VersionsDataSource.spec.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai'
 import os from 'os'
 import sinon from 'sinon'
+import { Response } from 'cross-fetch'
+
 import { DataContext } from '../../../src'
 import { VersionsDataSource } from '../../../src/sources'
 import { createTestDataContext } from '../helper'
@@ -143,6 +145,40 @@ describe('VersionsDataSource', () => {
       versionsDataSource = new VersionsDataSource(ctx)
 
       const versionInfo = await versionsDataSource.versionData()
+
+      expect(versionInfo.current.version).to.eql(currentCypressVersion)
+    })
+
+    it('handles invalid response errors', async () => {
+      nmiStub.resolves('abcd123')
+
+      fetchStub
+      .withArgs('https://download.cypress.io/desktop.json', {
+        headers: {
+          'Content-Type': 'application/json',
+          'x-cypress-version': currentCypressVersion,
+          'x-os-name': 'darwin',
+          'x-arch': 'x64',
+          'x-initial-launch': String(true),
+          'x-machine-id': 'abcd123',
+          'x-testing-type': 'e2e',
+        },
+      })
+      .callsFake(async () => new Response('Error'))
+      .withArgs('https://registry.npmjs.org/cypress')
+      .callsFake(async () => new Response('Error'))
+
+      versionsDataSource = new VersionsDataSource(ctx)
+
+      const versionInfo = await versionsDataSource.versionData()
+
+      // Reset the testing type in the class
+      // @ts-ignore
+      versionsDataSource._currentTestingType = null
+
+      versionsDataSource.resetLatestVersionTelemetry()
+
+      await ctx.coreData.versionData.latestVersion
 
       expect(versionInfo.current.version).to.eql(currentCypressVersion)
     })


### PR DESCRIPTION
- Closes #22081

### User facing changelog

Fixes situations where Cypress launch would crash behind a network proxy due to unhandled promise rejection on non-json payload.

### Additional details

The response was valid, but the response payload was non-json, causing an error. Moved both the response handling & `res.json` promise inside the `try` block

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
