### PR TITLE
fix: Make spec row clickable across entire width

### DIFF
--- a/packages/app/src/specs/RowDirectory.vue
+++ b/packages/app/src/specs/RowDirectory.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    class="h-full grid gap-8px grid-cols-[14px,16px,auto] items-center focus:outline-transparent"
+    class="h-full grid gap-8px grid-cols-[14px,16px,auto] items-center focus:outline-none"
     :data-cy="`row-directory-depth-${depth}`"
     :aria-expanded="expanded"
   >

--- a/packages/app/src/specs/SpecItem.vue
+++ b/packages/app/src/specs/SpecItem.vue
@@ -4,14 +4,14 @@
     data-cy="spec-item"
   >
     <i-cy-document-blank_x16
-      class="icon-light-gray-50 icon-dark-gray-200"
+      class="icon-light-gray-50 icon-dark-gray-200 group-hocus:icon-light-indigo-200 group-hocus:icon-dark-indigo-400"
     />
 
     <div class="text-gray-400 text-indigo-500 group-hocus:text-indigo-600">
       <HighlightedText
         :text="fileName"
         :indexes="indexes.filter((idx) => idx < fileName.length)"
-        class="font-medium text-indigo-500 group-hocus:text-indigo-600"
+        class="font-medium text-indigo-500 group-hocus:text-indigo-700"
         highlight-classes="text-gray-1000"
       />
       <HighlightedText

--- a/packages/app/src/specs/SpecsList.vue
+++ b/packages/app/src/specs/SpecsList.vue
@@ -69,24 +69,18 @@
           :key="row.index"
           :data-cy="row.data.isLeaf ? 'spec-list-file' : 'spec-list-directory'"
           :data-cy-row="row.data.data?.baseName"
+          :is-leaf="row.data.isLeaf"
+          :route="{ path: '/specs/runner', query: { file: row.data.data?.relative?.replace(/\\/g, '/') } }"
+          @toggleRow="row.data.toggle"
         >
           <template #file>
-            <RouterLink
-              v-if="row.data.isLeaf && row.data"
-              :key="row.data.data?.absolute"
-              class="focus:outline-transparent"
-              :to="{ path: '/specs/runner', query: { file: row.data.data?.relative?.replace(/\\/g, '/') } }"
-              data-cy="spec-item-link"
-              @click.meta.prevent="handleCtrlClick"
-              @click.ctrl.prevent="handleCtrlClick"
-            >
-              <SpecItem
-                :file-name="row.data.data?.fileName || row.data.name"
-                :extension="row.data.data?.specFileExtension || ''"
-                :indexes="row.data.data?.fileIndexes"
-                :style="{ paddingLeft: `${((row.data.depth - 2) * 10) + 22}px` }"
-              />
-            </RouterLink>
+            <SpecItem
+              v-if="row.data.isLeaf"
+              :file-name="row.data.data?.fileName || row.data.name"
+              :extension="row.data.data?.specFileExtension || ''"
+              :indexes="row.data.data?.fileIndexes"
+              :style="{ paddingLeft: `${((row.data.depth - 2) * 10) + 22}px` }"
+            />
 
             <RowDirectory
               v-else
@@ -96,7 +90,7 @@
               :style="{ paddingLeft: `${(row.data.depth - 2) * 10}px` }"
               :indexes="getDirIndexes(row.data)"
               :aria-controls="getIdIfDirectory(row)"
-              @click="row.data.toggle"
+              @click.stop="row.data.toggle"
             />
           </template>
 
@@ -240,11 +234,6 @@ const { containerProps, list, wrapperProps, scrollTo } = useVirtualList(treeSpec
 // If you are scrolled down the virtual list and list changes,
 // reset scroll position to top of list
 watch(() => treeSpecList.value, () => scrollTo(0))
-
-function handleCtrlClick () {
-  // noop intended to reduce the chances of opening tests multiple tabs
-  // which is not a supported state in Cypress
-}
 
 function getIdIfDirectory (row) {
   if (row.data.isLeaf && row.data) {

--- a/packages/app/src/specs/SpecsListRowItem.cy.tsx
+++ b/packages/app/src/specs/SpecsListRowItem.cy.tsx
@@ -1,0 +1,53 @@
+import SpecsListRowItem from './SpecsListRowItem.vue'
+
+describe('SpecItem', () => {
+  it('renders a SpecsListRowItem as leaf', () => {
+    const toggleRowHandler = cy.stub()
+
+    cy.mount(() => (
+      <SpecsListRowItem
+        isLeaf={true}
+        route={{ path: '/specs/runner', query: { file: '' } }}
+        onToggleRow={toggleRowHandler}
+        // @ts-ignore - doesn't know about vSlots
+        vSlots={{
+          file: () => <span>File Name</span>,
+          'git-info': () => <span>Git Info</span>,
+        }}
+      />))
+
+    // Clicking directly on file name section should trigger row
+    cy.get('[data-cy="specs-list-row-file"]').click()
+    cy.wrap(toggleRowHandler).should('have.callCount', 1)
+
+    // Clicking directory on git info section should trigger row
+    cy.get('[data-cy="specs-list-row-git-info"]').click()
+    cy.wrap(toggleRowHandler).should('have.callCount', 2)
+
+    // Clicking elsewhere on row should trigger row
+    cy.get('[data-cy="spec-item-link"]').click('right')
+    cy.wrap(toggleRowHandler).should('have.callCount', 3)
+  })
+
+  it('renders a SpecsListRowItem as non-leaf', () => {
+    const toggleRowHandler = cy.stub()
+
+    cy.mount(() => (
+      <SpecsListRowItem
+        isLeaf={false}
+        onToggleRow={toggleRowHandler}
+        // @ts-ignore - doesn't know about vSlots
+        vSlots={{
+          file: () => <span>Directory Name</span>,
+        }}
+      />))
+
+    // Clicking directly on file name section should trigger row
+    cy.get('[data-cy="specs-list-row-file"]').click()
+    cy.wrap(toggleRowHandler).should('have.callCount', 1)
+
+    // Clicking elsewhere on row should trigger row
+    cy.get('[data-cy="spec-item-directory"]').click('right')
+    cy.wrap(toggleRowHandler).should('have.callCount', 2)
+  })
+})

--- a/packages/app/src/specs/SpecsListRowItem.vue
+++ b/packages/app/src/specs/SpecsListRowItem.vue
@@ -10,11 +10,11 @@
       @click.meta.prevent="handleCtrlClick"
       @click.ctrl.prevent="handleCtrlClick"
     >
-      <div>
+      <div data-cy="specs-list-row-file">
         <slot name="file" />
       </div>
 
-      <div>
+      <div data-cy="specs-list-row-git-info">
         <slot name="git-info" />
       </div>
     </component>

--- a/packages/app/src/specs/SpecsListRowItem.vue
+++ b/packages/app/src/specs/SpecsListRowItem.vue
@@ -1,7 +1,13 @@
 <template>
-  <div
-    class="h-full outline-none border-gray-50 ring-inset grid grid-cols-2 group focus-within:ring-indigo-300 focus-within:ring-1 children:cursor-pointer"
+  <component
+    :is="isLeaf ? 'RouterLink' : 'div'"
+    class="h-full outline-none border-gray-50 ring-inset grid group focus:outline-transparent focus-within:ring-indigo-300 focus-within:ring-1 children:cursor-pointer"
+    :class="[isLeaf ? 'grid-cols-2' : 'grid-cols-1']"
+    :to="route"
     data-cy="specs-list-row"
+    @click="emit('toggleRow')"
+    @click.meta.prevent="handleCtrlClick"
+    @click.ctrl.prevent="handleCtrlClick"
   >
     <div>
       <slot name="file" />
@@ -10,5 +16,23 @@
     <div>
       <slot name="git-info" />
     </div>
-  </div>
+  </component>
 </template>
+
+<script setup lang="ts">
+import type { RouteLocationRaw } from 'vue-router'
+
+defineProps<{
+  isLeaf: boolean
+  route?: RouteLocationRaw
+}>()
+
+const emit = defineEmits<{
+  (event: 'toggleRow'): void
+}>()
+
+function handleCtrlClick (): void {
+  // noop intended to reduce the chances of opening tests multiple tabs
+  // which is not a supported state in Cypress
+}
+</script>

--- a/packages/app/src/specs/SpecsListRowItem.vue
+++ b/packages/app/src/specs/SpecsListRowItem.vue
@@ -1,22 +1,24 @@
 <template>
-  <component
-    :is="isLeaf ? 'RouterLink' : 'div'"
-    class="h-full outline-none border-gray-50 ring-inset grid group focus:outline-transparent focus-within:ring-indigo-300 focus-within:ring-1 children:cursor-pointer"
-    :class="[isLeaf ? 'grid-cols-2' : 'grid-cols-1']"
-    :to="route"
-    data-cy="specs-list-row"
-    @click="emit('toggleRow')"
-    @click.meta.prevent="handleCtrlClick"
-    @click.ctrl.prevent="handleCtrlClick"
-  >
-    <div>
-      <slot name="file" />
-    </div>
+  <div data-cy="specs-list-row">
+    <component
+      :is="isLeaf ? 'RouterLink' : 'div'"
+      class="h-full outline-none border-gray-50 ring-inset grid group focus:outline-transparent focus-within:ring-indigo-300 focus-within:ring-1 children:cursor-pointer"
+      :class="[isLeaf ? 'grid-cols-2' : 'grid-cols-1']"
+      :to="route"
+      :data-cy="isLeaf ? 'spec-item-link' : 'spec-item-directory'"
+      @click="emit('toggleRow')"
+      @click.meta.prevent="handleCtrlClick"
+      @click.ctrl.prevent="handleCtrlClick"
+    >
+      <div>
+        <slot name="file" />
+      </div>
 
-    <div>
-      <slot name="git-info" />
-    </div>
-  </component>
+      <div>
+        <slot name="git-info" />
+      </div>
+    </component>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/packages/app/src/specs/SpecsListRowItem.vue
+++ b/packages/app/src/specs/SpecsListRowItem.vue
@@ -2,8 +2,7 @@
   <div data-cy="specs-list-row">
     <component
       :is="isLeaf ? 'RouterLink' : 'div'"
-      class="h-full outline-none border-gray-50 ring-inset grid group focus:outline-transparent focus-within:ring-indigo-300 focus-within:ring-1 children:cursor-pointer"
-      :class="[isLeaf ? 'grid-cols-2' : 'grid-cols-1']"
+      class="h-full outline-none border-gray-50 ring-inset grid grid-cols-2 group focus:outline-transparent focus-within:ring-indigo-300 focus-within:ring-1 children:cursor-pointer"
       :to="route"
       :data-cy="isLeaf ? 'spec-item-link' : 'spec-item-directory'"
       @click="emit('toggleRow')"


### PR DESCRIPTION
* Move click-sensitive row action wrapper to surround entire row
* Add styles to highlight spec icon on hocus to match Figma
* Small text highlight style change to match Figma

- Closes #21783 

### User facing changelog
* Entire row in Specs List will respond to clicks
* Styling updates to make current row in Specs List more obvious

### Additional details

[Figma design](https://www.figma.com/proto/PAOozuCxtfetqP8fUVvg0y/branch/xqSbhaPZdYYMax8LMOi8UP/Cypress-App?page-id=0%3A1&node-id=3799%3A60922&viewport=-7970%2C-3439%2C0.5&scaling=scale-down&starting-point-node-id=427%3A3959)

According to #21783 this was brought up a lot during v10 feedback testing. Current behavior only performs the row's action (toggle expansion for directories or navigate to spec for Spec rows) if you click directly on the row title item. This makes the entire row actionable by default.

Theoretically we may introduce row items that themselves want to respond to click events (opening a tooltip permanently, for example) - in that case the child can ensure the click event is not propagated upwards thus preventing the row from actioning.

### Steps to test
1. Open Cypress app into a project with existing tests within directories
2. Navigate to Specs List
3. Validate that clicking directly on a Spec Name navigates, validate that clicking the row *away from* the spec name also navigates
4. Validate that keyboard navigation to Spec row is operational and that pressing `enter` triggers navigation
5. Validate that clicking directly on a directory name/icon toggles expansion, validate that clicking the row *away from* the directory name/icon also toggles expansion
6. Validate that keyboard navigation to Directory row is operational and that pressing `enter` toggles expansion
7. Validate that hovering over a Spec row adds indigo coloration to spec icon

### How has the user experience changed?
**Current**

https://user-images.githubusercontent.com/11482842/171961246-5ce90429-cf41-4f3b-95ac-df5456e0bc79.mov

**Updated**

https://user-images.githubusercontent.com/11482842/171961261-40ace242-5555-4292-ac2b-e7e502882344.mov

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [ na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
