### PR TITLE
refactor: make shiki load all its deps upfront

### DIFF
--- a/packages/frontend-shared/package.json
+++ b/packages/frontend-shared/package.json
@@ -61,7 +61,7 @@
     "modern-normalize": "1.1.0",
     "patch-package": "6.4.7",
     "rimraf": "3.0.2",
-    "shiki": "^0.9.12",
+    "shiki": "^0.10.1",
     "unplugin-icons": "0.13.2",
     "unplugin-vue-components": "^0.15.4",
     "vite": "2.9.0-beta.3",

--- a/packages/frontend-shared/src/components/ShikiHighlight.vue
+++ b/packages/frontend-shared/src/components/ShikiHighlight.vue
@@ -73,18 +73,25 @@ shikiWrapperClasses computed property.
 </template>
 
 <script lang="ts">
-import type { Highlighter } from 'shiki'
-import { getHighlighter, setOnigasmWASM, setCDN } from 'shiki'
+import type { Highlighter, ILanguageRegistration } from 'shiki'
+import { getHighlighter, setOnigasmWASM } from 'shiki'
 import onigasm from 'onigasm/lib/onigasm.wasm?url'
+import shikiCyTheme from '../public/shiki/themes/cypress.theme.json'
+const langTmsRaw = import.meta.globEager('../public/shiki/languages/*.tmLanguage.json')
+
+const langTms: ILanguageRegistration[] = Object.values(langTmsRaw).map((grammar: any) => {
+  return {
+    grammar,
+    id: grammar.name,
+    scopeName: grammar.scopeName,
+  }
+})
 
 setOnigasmWASM(onigasm)
-setCDN(`${import.meta.env.BASE_URL}shiki/`)
 
 let highlighter: Highlighter
 
 export const langsSupported = ['typescript', 'javascript', 'ts', 'js', 'css', 'jsx', 'tsx', 'json', 'yaml', 'html'] as const
-
-let langs = langsSupported.concat([])
 
 export type CyLangType = typeof langsSupported[number] | 'plaintext' | 'txt'| 'text'
 
@@ -94,8 +101,8 @@ export async function initHighlighter () {
   }
 
   highlighter = await getHighlighter({
-    themes: ['cypress.theme'],
-    langs,
+    theme: shikiCyTheme as any,
+    langs: langTms,
   })
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #21676

### User facing changelog
None 

### Additional details
I saw [this doc](https://github.com/shikijs/shiki/blob/main/docs/languages.md) on shiki, and thought it might work. it does...

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
