### PR TITLE
fix: #21798 cypress should be capitalized in Step 3 of migration text

### DIFF
--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -605,7 +605,7 @@
       },
       "step4": {
         "title": "Migrate to the new Cypress configuration file",
-        "description": "In this step, we'll automatically migrate your existing cypress configuration to the new Cypress configuration file.",
+        "description": "In this step, we'll automatically migrate your existing Cypress configuration to the new Cypress configuration file.",
         "button": "Migrate the configuration for me"
       },
       "step5": {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #21798 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
Capitalize the "C" of "cypress" in migration text.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

- Why was this change necessary?
Brand consistency.


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Before:
![text-before_000](https://user-images.githubusercontent.com/8095975/172078340-750f6ad3-3217-4a0e-a26b-6e73e1651e04.png)

After:
![text-migration](https://user-images.githubusercontent.com/8095975/172078346-0cbe40b8-6d27-4389-a2ee-9efea17f4b54.png)


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
