### PR TITLE
fix: prevent Cypress from crashing when getting machine-id fails

### DIFF
--- a/packages/data-context/src/sources/VersionsDataSource.ts
+++ b/packages/data-context/src/sources/VersionsDataSource.ts
@@ -182,7 +182,7 @@ export class VersionsDataSource {
 
   private static async machineId (): Promise<string | undefined> {
     try {
-      return nmi.machineId()
+      return await nmi.machineId()
     } catch (error) {
       return undefined
     }

--- a/packages/data-context/test/unit/sources/VersionsDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/VersionsDataSource.spec.ts
@@ -90,7 +90,7 @@ describe('VersionsDataSource', () => {
     it('resets telemetry data triggering a new call to get the latest version', async () => {
       const currentCypressVersion = pkg.version
 
-      nmiStub.throws()
+      nmiStub.rejects('Error while obtaining machine id')
       ctx.coreData.currentTestingType = 'component'
 
       fetchStub


### PR DESCRIPTION
- Closes #22110 

### User facing changelog
The GUI will continue to run if getting machine-id fails.

### Additional details
The underlying npm package `node-machine-id` requires admin rights on Windows to get the machine id. This is causing the Cypress GUI to crash for Windows users that do not have administrator rights. The fix will allow for the failure as the ID is optional.

### Steps to test
To test this it requires a Windows machine and a non-admin user. Perhaps also an extra setting to prevent the user from running `%windir%\System32\REG.exe`. Running Cypress without this change will cause the application to crash right after selecting the type of test to perform, and after the change the application will run as normal.

### How has the user experience changed?
The GUI will continue to run if getting machine-id fails.

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
