### PR TITLE
fix: Time out loading embed html for migration video, stub in e2e tests

### DIFF
--- a/packages/data-context/src/sources/MigrationDataSource.ts
+++ b/packages/data-context/src/sources/MigrationDataSource.ts
@@ -104,8 +104,11 @@ export class MigrationDataSource {
     const versionData = await this.ctx.versions.versionData()
     const embedOnLink = `https://on.cypress.io/v10-video-embed/${versionData.current.version}`
 
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 3000)
+
     try {
-      const response = await this.ctx.util.fetch(embedOnLink, { method: 'GET' })
+      const response = await this.ctx.util.fetch(embedOnLink, { method: 'GET', signal: controller.signal })
       const { videoHtml } = await response.json()
 
       this.ctx.update((d) => {
@@ -116,6 +119,8 @@ export class MigrationDataSource {
     } catch {
       // fail silently, no user-facing error is needed
       return null
+    } finally {
+      clearTimeout(timeoutId)
     }
   }
 

--- a/packages/data-context/src/sources/MigrationDataSource.ts
+++ b/packages/data-context/src/sources/MigrationDataSource.ts
@@ -104,6 +104,7 @@ export class MigrationDataSource {
     const versionData = await this.ctx.versions.versionData()
     const embedOnLink = `https://on.cypress.io/v10-video-embed/${versionData.current.version}`
 
+    // Time out request if it takes longer than 3 seconds
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 3000)
 

--- a/packages/data-context/test/unit/sources/MigrationDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/MigrationDataSource.spec.ts
@@ -1,0 +1,69 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+
+import { DataContext } from '../../../src'
+import { MigrationDataSource } from '../../../src/sources'
+import { createTestDataContext } from '../helper'
+
+const pkg = require('@packages/root')
+
+describe('MigrationDataSource', () => {
+  context('.migration', () => {
+    let ctx: DataContext
+    let fetchStub: sinon.SinonStub
+    let migrationDataSource: MigrationDataSource
+
+    beforeEach(() => {
+      ctx = createTestDataContext('open')
+
+      ctx.coreData.currentTestingType = 'e2e'
+
+      fetchStub = sinon.stub()
+
+      sinon.stub(ctx.util, 'fetch').callsFake(fetchStub)
+    })
+
+    afterEach(() => {
+      fetchStub.reset()
+      sinon.restore()
+    })
+
+    describe('getVideoEmbedHtml', () => {
+      const expectedPayload = {
+        videoHtml: '<iframe\n  src=\"https://player.vimeo.com/video/668764401?h=0cbc785eef\"\n  class=\"rounded h-full bg-gray-1000 w-full\"\n  frameborder=\"0\"\n  allow=\"autoplay; fullscreen; picture-in-picture\"\n  allowfullscreen\n/>\n',
+      }
+
+      it('loads the video embed html', async () => {
+        fetchStub
+        .withArgs(`https://on.cypress.io/v10-video-embed/${pkg.version}`)
+        .resolves({
+          json: sinon.stub().resolves(expectedPayload),
+        })
+
+        migrationDataSource = new MigrationDataSource(ctx)
+
+        const videoEmbedHtml = await migrationDataSource.getVideoEmbedHtml()
+
+        expect(videoEmbedHtml).to.eql(expectedPayload.videoHtml)
+      })
+
+      it('gracefully returns null when request fails', async () => {
+        const jsonStub = sinon.fake(async () => {
+          throw new Event('abort')
+        })
+
+        fetchStub
+        .withArgs(`https://on.cypress.io/v10-video-embed/${pkg.version}`)
+        .resolves({
+          json: jsonStub,
+        })
+
+        migrationDataSource = new MigrationDataSource(ctx)
+
+        const videoEmbedHtml = await migrationDataSource.getVideoEmbedHtml()
+
+        expect(videoEmbedHtml).to.eql(null)
+      })
+    })
+  })
+})

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -80,6 +80,27 @@ function renameSupport (lang: 'js' | 'ts' | 'coffee' = 'js') {
   }, { lang })
 }
 
+function stubVideoHtml (): void {
+  // ctx.migration.getVideoEmbedHtml
+  cy.withCtx((ctx, o) => {
+    o.sinon.stub(ctx.migration, 'getVideoEmbedHtml').callsFake(async () => {
+      return '<span>Stubbed Video Content</span>'
+    })
+  })
+}
+
+function unstubVideoHtml (): void {
+  cy.withCtx((ctx, o) => {
+    const restoreFn = (ctx.migration.getVideoEmbedHtml as SinonStub).restore
+
+    restoreFn && restoreFn()
+  })
+}
+
+beforeEach(() => {
+  stubVideoHtml()
+})
+
 describe('global mode', () => {
   it('migrates 2 projects in global mode', () => {
     cy.openGlobalMode()
@@ -146,6 +167,8 @@ describe('Opening unmigrated project', () => {
   })
 
   it('migration landing page appears with a video', () => {
+    unstubVideoHtml()
+
     cy.intercept(/vimeo.com/).as('iframeDocRequest')
     cy.intercept(/vimeocdn/).as('vimeoCdnRequest')
     cy.scaffoldProject('migration')
@@ -172,6 +195,8 @@ describe('Opening unmigrated project', () => {
   })
 
   it('landing page does not appear if there is no video embed code', () => {
+    unstubVideoHtml()
+
     cy.scaffoldProject('migration')
     cy.openProject('migration')
     cy.withCtx((ctx, o) => {
@@ -186,6 +211,8 @@ describe('Opening unmigrated project', () => {
   })
 
   it('should only hit the video on link once & cache it', () => {
+    unstubVideoHtml()
+
     cy.scaffoldProject('migration')
     cy.openProject('migration')
 


### PR DESCRIPTION
- Closes #21955 

### User facing changelog
* Skip migration video if loading embed HTML takes longer than 3 seconds

### Additional details
* Stubbing embed HTML for migration e2e tests to reduce hits on Vimeo cdn

### Steps to test
1. Create a pre-v10 Cypress project that will need to be migrated
  * This can be quickly done by copying `system-tests/projects/migration` to a new local directory
2. Configure a delay against the HTTP fetch to `https://on.cypress.io/v10-video-embed/*`
  * The easy way to simulate this is to temporarily replace the on-link URL at `MigrationDataSource.ts:105` with this `http://httpstat.us/200?sleep=15000` - this service pauses for 15 seconds before returning with a 200 response
3. Open Cypress in global mode
4. Add project that will need migration and open
5. Observe that project opening delays for 3 seconds before skipping migration video and opening to test mode selection
  * On `develop` this will delay the full 15 seconds

### How has the user experience changed?
* In the event the on-link is very slow we now timeout and skip over the migration video

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?