### PR TITLE
chore: skip windows canary check

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -957,7 +957,6 @@ commands:
           # notarization on Mac can take a while
           no_output_timeout: "45m"
           command: |
-            [[ $PLATFORM == 'darwin' ]] xcode-select -r || true
             node --version
             yarn binary-build --platform $PLATFORM --version $(node ./scripts/get-next-version.js)
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -1083,7 +1083,7 @@ jobs:
           name: Check env canaries on Mac/Linux
           command: |
             # Windows CircleCI does not have a way to pull per-job env
-            [[ $PLATFORM != 'windows' ]] && node ./scripts/circle-env.js --check-canaries
+            [[ $PLATFORM != 'windows' ]] && node ./scripts/circle-env.js --check-canaries || true
       - build-and-persist
       - store-npm-logs
 

--- a/circle.yml
+++ b/circle.yml
@@ -957,6 +957,7 @@ commands:
           # notarization on Mac can take a while
           no_output_timeout: "45m"
           command: |
+            [[ $PLATFORM == 'darwin' ]] xcode-select -r || true
             node --version
             yarn binary-build --platform $PLATFORM --version $(node ./scripts/get-next-version.js)
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -384,7 +384,7 @@ commands:
             nvm install ${node_version}
             echo "Using Node $node_version"
             nvm use ${node_version}
-            [[ $PLATFORM != 'windows' ]] && nvm alias default ${node_version} || true
+            [[ $PLATFORM != 'windows' ]] && nvm alias default ${node_version} || sleep 2s
             echo "Installing Yarn"
             npm install yarn -g # ensure yarn is installed with the correct node engine
             yarn check-node-version

--- a/circle.yml
+++ b/circle.yml
@@ -384,7 +384,7 @@ commands:
             nvm install ${node_version}
             echo "Using Node $node_version"
             nvm use ${node_version}
-            [[ $PLATFORM != 'windows' ]] && nvm alias default ${node_version} || sleep 2s
+            [[ $PLATFORM != 'windows' ]] && nvm alias default ${node_version} || true
             echo "Installing Yarn"
             npm install yarn -g # ensure yarn is installed with the correct node engine
             yarn check-node-version
@@ -1080,8 +1080,10 @@ jobs:
           name: Top level packages
           command: yarn list --depth=0 || true
       - run:
-          name: Check env canaries
-          command: node ./scripts/circle-env.js --check-canaries
+          name: Check env canaries on Mac/Linux
+          command: |
+            # Windows CircleCI does not have a way to pull per-job env
+            [[ $PLATFORM != 'windows' ]] && node ./scripts/circle-env.js --check-canaries
       - build-and-persist
       - store-npm-logs
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details

- Env checking added in #21211 began to fail on Windows-build jobs due to missing CIRCLE_INTERNAL_CONFIG: https://app.circleci.com/pipelines/github/cypress-io/cypress/39166/workflows/0c0a6261-bc78-4748-87aa-4512f2e66ea2/jobs/1597828
- I tried SSHing into a Circle Windows box but could not find another source for this info
- This PR disables the check on Windows

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
