### PR TITLE
fix: Don't include project path with supportFile glob

### DIFF
--- a/packages/config/src/options.ts
+++ b/packages/config/src/options.ts
@@ -351,7 +351,6 @@ const resolvedOptions: Array<ResolvedConfigOption> = [
     name: 'supportFile',
     defaultValue: (options: Record<string, any> = {}) => options.testingType === 'component' ? 'cypress/support/component.{js,jsx,ts,tsx}' : 'cypress/support/e2e.{js,jsx,ts,tsx}',
     validation: validate.isStringOrFalse,
-    isFolder: true,
     canUpdateDuringTestTime: false,
     requireRestartOnChange: 'server',
   }, {

--- a/packages/launchpad/cypress/e2e/open-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/open-mode.cy.ts
@@ -211,4 +211,16 @@ describe('Launchpad: Open Mode', () => {
     cy.contains('Your project does not contain a default supportFile.')
     cy.contains('If a support file is not necessary for your project, set supportFile to false.')
   })
+
+  // Assert that we do not glob the absolute projectRoot
+  // and fail supportFile lookups during project initialization.
+  // https://github.com/cypress-io/cypress/issues/22040
+  it('opens projects with paths that contain glob syntax', () => {
+    cy.scaffoldProject('project-with-(glob)-[chars]')
+    cy.openProject('project-with-(glob)-[chars]', ['--e2e'])
+    cy.visitLaunchpad()
+
+    cy.get('body').should('not.contain.text', 'Your project does not contain a default supportFile.')
+    cy.get('h1').should('contain', 'Choose a Browser')
+  })
 })

--- a/packages/server/lib/config.ts
+++ b/packages/server/lib/config.ts
@@ -419,7 +419,7 @@ export async function setSupportFileAndFolder (obj) {
 
   const ctx = getCtx()
 
-  const supportFilesByGlob = await ctx.file.getFilesByGlob(obj.projectRoot, obj.supportFile, { absolute: false })
+  const supportFilesByGlob = await ctx.file.getFilesByGlob(obj.projectRoot, obj.supportFile)
 
   if (supportFilesByGlob.length > 1) {
     return errors.throwErr('MULTIPLE_SUPPORT_FILES_FOUND', obj.supportFile, supportFilesByGlob)

--- a/packages/server/test/unit/config_spec.js
+++ b/packages/server/test/unit/config_spec.js
@@ -2086,7 +2086,7 @@ describe('lib/config', () => {
       })
     })
 
-    it('sets the supportFile to default *.js if it does not exist, support folder does not exist, and supportFile is the default', () => {
+    it('sets the supportFile to default e2e.js if it does not exist, support folder does not exist, and supportFile is the default', () => {
       const projectRoot = Fixtures.projectPath('no-scaffolding')
 
       const obj = config.setAbsolutePaths({

--- a/packages/server/test/unit/config_spec.js
+++ b/packages/server/test/unit/config_spec.js
@@ -2086,8 +2086,26 @@ describe('lib/config', () => {
       })
     })
 
-    it('sets the supportFile to default index.js if it does not exist, support folder does not exist, and supportFile is the default', () => {
+    it('sets the supportFile to default *.js if it does not exist, support folder does not exist, and supportFile is the default', () => {
       const projectRoot = Fixtures.projectPath('no-scaffolding')
+
+      const obj = config.setAbsolutePaths({
+        projectRoot,
+        supportFile: 'cypress/support/e2e.js',
+      })
+
+      return config.setSupportFileAndFolder(obj)
+      .then((result) => {
+        expect(result).to.eql({
+          projectRoot,
+          supportFile: `${projectRoot}/cypress/support/e2e.js`,
+          supportFolder: `${projectRoot}/cypress/support`,
+        })
+      })
+    })
+
+    it('finds support file in project path that contains glob syntax', () => {
+      const projectRoot = Fixtures.projectPath('project-with-(glob)-[chars]')
 
       const obj = config.setAbsolutePaths({
         projectRoot,

--- a/packages/server/test/unit/config_spec.js
+++ b/packages/server/test/unit/config_spec.js
@@ -2218,7 +2218,7 @@ describe('lib/config', () => {
       expect(config.setAbsolutePaths(obj)).to.deep.eq(obj)
     })
 
-    return ['fileServerFolder', 'fixturesFolder', 'supportFile'].forEach((folder) => {
+    return ['fileServerFolder', 'fixturesFolder'].forEach((folder) => {
       it(`converts relative ${folder} to absolute path`, () => {
         const obj = {
           projectRoot: '/_test-output/path/to/project',

--- a/system-tests/__snapshots__/config_spec.js
+++ b/system-tests/__snapshots__/config_spec.js
@@ -423,3 +423,62 @@ Please remove this option or add this as an e2e testing type property: e2e.exper
 https://on.cypress.io/migration-guide
 
 `
+
+exports['e2e config finds supportFiles in projects containing glob syntax 1'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      1 found (app.cy.js)                                                                │
+  │ Searched:   cypress/e2e/**/*.cy.{js,jsx,ts,tsx}                                                │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  app.cy.js                                                                       (1 of 1)
+
+
+  ✓ is true
+
+  1 passing
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        1                                                                                │
+  │ Passing:      1                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     app.cy.js                                                                        │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/app.cy.js.mp4                       (X second)
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✔  app.cy.js                                XX:XX        1        1        -        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✔  All specs passed!                        XX:XX        1        1        -        -        -  
+
+
+`

--- a/system-tests/__snapshots__/multiple_support_files_spec.js
+++ b/system-tests/__snapshots__/multiple_support_files_spec.js
@@ -1,7 +1,7 @@
 exports['e2e multiple support files passes 1'] = `
 There were multiple support files found matching your supportFile pattern.
 
-Your supportFile is set to: /foo/bar/.projects/multiple-support-files/cypress/support/e2e.{js,jsx,ts,tsx}
+Your supportFile is set to: cypress/support/e2e.{js,jsx,ts,tsx}
 
 We found the following files:
 

--- a/system-tests/projects/project-with-(glob)-[chars]/cypress.config.js
+++ b/system-tests/projects/project-with-(glob)-[chars]/cypress.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  e2e: { },
+}

--- a/system-tests/projects/project-with-(glob)-[chars]/cypress/e2e/app.cy.js
+++ b/system-tests/projects/project-with-(glob)-[chars]/cypress/e2e/app.cy.js
@@ -1,0 +1,3 @@
+it('is true', () => {
+  expect(true).to.be.true
+})

--- a/system-tests/test/config_spec.js
+++ b/system-tests/test/config_spec.js
@@ -236,4 +236,13 @@ describe('e2e config', () => {
       snapshot: true,
     })
   })
+
+  it('finds supportFiles in projects containing glob syntax', async function () {
+    await Fixtures.scaffoldProject('project-with-(glob)-[chars]')
+
+    return systemTests.exec(this, {
+      project: 'project-with-(glob)-[chars]',
+      snapshot: true,
+    })
+  })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #22040

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

* The `supportFile` can now be detected within projects that contain glob syntax characters in their absolute paths.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We glob the `supportFile` config value to determine whether the file exists during project setup. We were using the supportFile's absolute path as the glob pattern, which could fail the lookup if the absolute path contained glob syntax: `()`, `[]`, `{}`, `*`, `?`, etc. Some of these are more common than others in certain OSs. The issue was originally logged due to a lookup failure when the project was located within `C:\Program Files (x86)\...` on Windows, but it can be reproduced on Mac/Linux by placing the project in a directory containing these characters: `~/projects (foo)/test-project`

I took a look at why the absolute path was being used here, and I think it was a holdover from the previous non-glob implementation that directly used module resolution. I updated the glob lookup to no longer include the projectRoot, which corrects this issue.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

1. Place a project using cypress in a local directory containing glob syntax chars: `~/projects (foo)/my{test}project`. Feel free to get creative.
2. Make sure that project doesn't have `supportFile: false` in its config and has a default support file for its project type (likely `cypress/support/e2e.js`).
3. Open the project in Cypress and make sure the config is initialized appropriately (no errors in launchpad, you can open the browser and run tests).

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [X] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
