### PR TITLE
fix: Truncate spec directories and file names instead of wrapping

### DIFF
--- a/packages/app/src/specs/DirectoryItem.vue
+++ b/packages/app/src/specs/DirectoryItem.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    :title="props.name"
     class="flex text-sm py-4px items-center"
   >
     <i-cy-chevron-down-small_x16
@@ -9,7 +10,6 @@
     <i-cy-folder_x16 class="h-16px mr-8px w-16px group-hocus:icon-light-indigo-300 group-hocus:icon-dark-indigo-400" />
     <HighlightedText
       :text="props.name"
-      :title-text="props.name"
       :indexes="props.indexes"
       class="text-gray-400 group-focus:text-indigo-300"
       highlight-classes="font-bold text-white"

--- a/packages/app/src/specs/DirectoryItem.vue
+++ b/packages/app/src/specs/DirectoryItem.vue
@@ -9,6 +9,7 @@
     <i-cy-folder_x16 class="h-16px mr-8px w-16px group-hocus:icon-light-indigo-300 group-hocus:icon-dark-indigo-400" />
     <HighlightedText
       :text="props.name"
+      :title-text="props.name"
       :indexes="props.indexes"
       class="text-gray-400 group-focus:text-indigo-300"
       highlight-classes="font-bold text-white"

--- a/packages/app/src/specs/HighlightedText.vue
+++ b/packages/app/src/specs/HighlightedText.vue
@@ -1,7 +1,6 @@
 <template>
   <span
     :title="props.titleText"
-    :class="{'truncate': truncate}"
   >
     <span
       v-for="({char, highlighted}, idx) in characters"
@@ -24,8 +23,8 @@
 import { computed } from 'vue'
 
 const props = withDefaults(
-  defineProps<{text: string, indexes: number[], highlightClasses?: string, titleText?: string, truncate?: boolean}>(),
-  { text: '', indexes: () => [], highlightClasses: 'text-white', titleText: '', truncate: false },
+  defineProps<{text: string, indexes: number[], highlightClasses?: string, titleText?: string}>(),
+  { text: '', indexes: () => [], highlightClasses: 'text-white', titleText: '' },
 )
 
 const characters = computed(() => {

--- a/packages/app/src/specs/HighlightedText.vue
+++ b/packages/app/src/specs/HighlightedText.vue
@@ -1,7 +1,5 @@
 <template>
-  <span
-    :title="props.titleText"
-  >
+  <span>
     <span
       v-for="({char, highlighted}, idx) in characters"
       :key="idx"
@@ -23,8 +21,8 @@
 import { computed } from 'vue'
 
 const props = withDefaults(
-  defineProps<{text: string, indexes: number[], highlightClasses?: string, titleText?: string}>(),
-  { text: '', indexes: () => [], highlightClasses: 'text-white', titleText: '' },
+  defineProps<{text: string, indexes: number[], highlightClasses?: string}>(),
+  { text: '', indexes: () => [], highlightClasses: 'text-white' },
 )
 
 const characters = computed(() => {

--- a/packages/app/src/specs/HighlightedText.vue
+++ b/packages/app/src/specs/HighlightedText.vue
@@ -1,5 +1,8 @@
 <template>
-  <span>
+  <span
+    :title="props.titleText"
+    :class="{'truncate': truncate}"
+  >
     <span
       v-for="({char, highlighted}, idx) in characters"
       :key="idx"
@@ -21,8 +24,8 @@
 import { computed } from 'vue'
 
 const props = withDefaults(
-  defineProps<{text: string, indexes: number[], highlightClasses?: string}>(),
-  { text: '', indexes: () => [], highlightClasses: 'text-white' },
+  defineProps<{text: string, indexes: number[], highlightClasses?: string, titleText?: string, truncate?: boolean}>(),
+  { text: '', indexes: () => [], highlightClasses: 'text-white', titleText: '', truncate: false },
 )
 
 const characters = computed(() => {

--- a/packages/app/src/specs/RowDirectory.vue
+++ b/packages/app/src/specs/RowDirectory.vue
@@ -15,13 +15,15 @@
       :is="IconFolder"
       class="icon-dark-white icon-light-gray-200"
     />
-    <div class="text-gray-600 truncate">
+    <div
+      :title="props.name"
+      class="text-gray-600 truncate"
+    >
       <HighlightedText
         :text="props.name"
         :indexes="props.indexes"
         class="font-medium"
         highlight-classes="text-gray-1000"
-        :title-text="props.name"
       />
     </div>
     <span class="sr-only">{{ expanded ? 'collapse' : 'expand' }}</span>

--- a/packages/app/src/specs/RowDirectory.vue
+++ b/packages/app/src/specs/RowDirectory.vue
@@ -15,14 +15,15 @@
       :is="IconFolder"
       class="icon-dark-white icon-light-gray-200"
     />
-    <HighlightedText
-      :text="props.name"
-      :indexes="props.indexes"
-      class="font-medium text-gray-600"
-      highlight-classes="text-gray-1000"
-      :title-text="props.name"
-      truncate
-    />
+    <div class="text-gray-600 truncate">
+      <HighlightedText
+        :text="props.name"
+        :indexes="props.indexes"
+        class="font-medium"
+        highlight-classes="text-gray-1000"
+        :title-text="props.name"
+      />
+    </div>
     <span class="sr-only">{{ expanded ? 'collapse' : 'expand' }}</span>
   </button>
 </template>

--- a/packages/app/src/specs/RowDirectory.vue
+++ b/packages/app/src/specs/RowDirectory.vue
@@ -20,6 +20,8 @@
       :indexes="props.indexes"
       class="font-medium text-gray-600"
       highlight-classes="text-gray-1000"
+      :title-text="props.name"
+      truncate
     />
     <span class="sr-only">{{ expanded ? 'collapse' : 'expand' }}</span>
   </button>

--- a/packages/app/src/specs/SpecFileItem.cy.tsx
+++ b/packages/app/src/specs/SpecFileItem.cy.tsx
@@ -24,7 +24,7 @@ describe('SpecFileItem', () => {
   })
 
   it('truncates spec name if it exceeds container width and provides title for full spec name', () => {
-    const specFileName = 'VeryLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongSpecName'
+    const specFileName = `${'Long'.repeat(20)}Name`
 
     // Shrink viewport width so spec name is truncated
     cy.viewport(400, 850)
@@ -36,7 +36,7 @@ describe('SpecFileItem', () => {
 
     // We should be able to see at least the first 20 characters of the spec name
     // It should have a title attribute that is equal to the full file name
-    cy.contains(specFileName.substring(0, 20)).should('be.visible').should('have.attr', 'title', `${specFileName}.cy.tsx`)
+    cy.contains(specFileName.substring(0, 20)).should('be.visible').parent().should('have.attr', 'title', `${specFileName}.cy.tsx`)
 
     // The file extension shouldn't be visible because it is past the truncation point
     cy.contains('.cy.tsx').should('not.be.visible')

--- a/packages/app/src/specs/SpecFileItem.cy.tsx
+++ b/packages/app/src/specs/SpecFileItem.cy.tsx
@@ -22,4 +22,23 @@ describe('SpecFileItem', () => {
 
     cy.percySnapshot()
   })
+
+  it('truncates spec name if it exceeds container width and provides title for full spec name', () => {
+    const specFileName = 'VeryLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongSpecName'
+
+    // Shrink viewport width so spec name is truncated
+    cy.viewport(400, 850)
+
+    cy.mount(() => (
+      <div>
+        <SpecFileItem fileName={specFileName} extension=".cy.tsx"></SpecFileItem>
+      </div>))
+
+    // We should be able to see at least the first 20 characters of the spec name
+    // It should have a title attribute that is equal to the full file name
+    cy.contains(specFileName.substring(0, 20)).should('be.visible').should('have.attr', 'title', `${specFileName}.cy.tsx`)
+
+    // The file extension shouldn't be visible because it is past the truncation point
+    cy.contains('.cy.tsx').should('not.be.visible')
+  })
 })

--- a/packages/app/src/specs/SpecFileItem.vue
+++ b/packages/app/src/specs/SpecFileItem.vue
@@ -9,17 +9,18 @@
       group-hocus:icon-light-indigo-600"
       :class="selected ? 'icon-dark-indigo-300 icon-light-indigo-600' : 'icon-dark-gray-800 icon-light-gray-1000'"
     />
-    <div class="text-gray-400 truncate">
+    <div
+      :title="fileName + extension"
+      class="text-gray-400 truncate"
+    >
       <HighlightedText
         :text="fileName"
-        :title-text="fileName + extension"
         :indexes="indexes.filter((idx) => idx < fileName.length)"
         class="font-medium pl-8px whitespace-nowrap"
         :class="selected ? 'text-white' : 'group-focus:text-indigo-300 text-gray-400 group-hover:text-indigo-300'"
       />
       <HighlightedText
         :text="extension"
-        :title-text="fileName + extension"
         :indexes="indexes.filter((idx) => idx >= fileName.length).map(idx => idx - fileName.length)"
         class="text-gray-700"
       />

--- a/packages/app/src/specs/SpecFileItem.vue
+++ b/packages/app/src/specs/SpecFileItem.vue
@@ -9,17 +9,21 @@
       group-hocus:icon-light-indigo-600"
       :class="selected ? 'icon-dark-indigo-300 icon-light-indigo-600' : 'icon-dark-gray-800 icon-light-gray-1000'"
     />
-    <HighlightedText
-      :text="fileName"
-      :indexes="indexes.filter((idx) => idx < fileName.length)"
-      class="font-medium pl-8px whitespace-nowrap"
-      :class="selected ? 'text-white' : 'group-focus:text-indigo-300 text-gray-400 group-hover:text-indigo-300'"
-    />
-    <HighlightedText
-      :text="extension"
-      :indexes="indexes.filter((idx) => idx >= fileName.length).map(idx => idx - fileName.length)"
-      class="text-gray-700"
-    />
+    <div class="text-gray-400 truncate">
+      <HighlightedText
+        :text="fileName"
+        :title-text="fileName + extension"
+        :indexes="indexes.filter((idx) => idx < fileName.length)"
+        class="font-medium pl-8px whitespace-nowrap"
+        :class="selected ? 'text-white' : 'group-focus:text-indigo-300 text-gray-400 group-hover:text-indigo-300'"
+      />
+      <HighlightedText
+        :text="extension"
+        :title-text="fileName + extension"
+        :indexes="indexes.filter((idx) => idx >= fileName.length).map(idx => idx - fileName.length)"
+        class="text-gray-700"
+      />
+    </div>
   </div>
 </template>
 <script lang="ts" setup>

--- a/packages/app/src/specs/SpecItem.cy.tsx
+++ b/packages/app/src/specs/SpecItem.cy.tsx
@@ -40,5 +40,23 @@ describe('SpecItem', () => {
     })
 
     cy.percySnapshot()
+  }),
+  it('truncates spec name if it exceeds container width and provides title for full spec name', () => {
+    const specFileName = 'VeryLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongSpecName'
+
+    // Shrink viewport width so spec name is truncated
+    cy.viewport(400, 850)
+
+    cy.mount(() => (
+      <div>
+        <SpecItem fileName={specFileName} extension=".cy.tsx"></SpecItem>
+      </div>))
+
+    // We should be able to see at least the first 20 characters of the spec name
+    // It should have a title attribute that is equal to the full file name
+    cy.contains(specFileName.substring(0, 20)).should('be.visible').should('have.attr', 'title', `${specFileName}.cy.tsx`)
+
+    // The file extension shouldn't be visible because it is past the truncation point
+    cy.contains('.cy.tsx').should('not.be.visible')
   })
 })

--- a/packages/app/src/specs/SpecItem.cy.tsx
+++ b/packages/app/src/specs/SpecItem.cy.tsx
@@ -42,7 +42,7 @@ describe('SpecItem', () => {
     cy.percySnapshot()
   }),
   it('truncates spec name if it exceeds container width and provides title for full spec name', () => {
-    const specFileName = 'VeryLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongSpecName'
+    const specFileName = `${'Long'.repeat(20)}Name`
 
     // Shrink viewport width so spec name is truncated
     cy.viewport(400, 850)
@@ -54,7 +54,7 @@ describe('SpecItem', () => {
 
     // We should be able to see at least the first 20 characters of the spec name
     // It should have a title attribute that is equal to the full file name
-    cy.contains(specFileName.substring(0, 20)).should('be.visible').should('have.attr', 'title', `${specFileName}.cy.tsx`)
+    cy.contains(specFileName.substring(0, 20)).should('be.visible').parent().should('have.attr', 'title', `${specFileName}.cy.tsx`)
 
     // The file extension shouldn't be visible because it is past the truncation point
     cy.contains('.cy.tsx').should('not.be.visible')

--- a/packages/app/src/specs/SpecItem.vue
+++ b/packages/app/src/specs/SpecItem.vue
@@ -7,15 +7,17 @@
       class="icon-light-gray-50 icon-dark-gray-200 group-hocus:icon-light-indigo-200 group-hocus:icon-dark-indigo-400"
     />
 
-    <div class="text-gray-400 text-indigo-500 group-hocus:text-indigo-600">
+    <div class="text-gray-400 text-indigo-500 truncate group-hocus:text-indigo-600">
       <HighlightedText
         :text="fileName"
+        :title-text="fileName + extension"
         :indexes="indexes.filter((idx) => idx < fileName.length)"
         class="font-medium text-indigo-500 group-hocus:text-indigo-700"
         highlight-classes="text-gray-1000"
       />
       <HighlightedText
         :text="extension"
+        :title-text="fileName + extension"
         :indexes="indexes.filter((idx) => idx >= fileName.length).map(idx => idx - fileName.length)"
         class="font-light group-hocus:text-gray-400"
         highlight-classes="text-gray-1000"

--- a/packages/app/src/specs/SpecItem.vue
+++ b/packages/app/src/specs/SpecItem.vue
@@ -7,17 +7,18 @@
       class="icon-light-gray-50 icon-dark-gray-200 group-hocus:icon-light-indigo-200 group-hocus:icon-dark-indigo-400"
     />
 
-    <div class="text-gray-400 text-indigo-500 truncate group-hocus:text-indigo-600">
+    <div
+      :title="fileName + extension"
+      class="text-gray-400 text-indigo-500 truncate group-hocus:text-indigo-600"
+    >
       <HighlightedText
         :text="fileName"
-        :title-text="fileName + extension"
         :indexes="indexes.filter((idx) => idx < fileName.length)"
         class="font-medium text-indigo-500 group-hocus:text-indigo-700"
         highlight-classes="text-gray-1000"
       />
       <HighlightedText
         :text="extension"
-        :title-text="fileName + extension"
         :indexes="indexes.filter((idx) => idx >= fileName.length).map(idx => idx - fileName.length)"
         class="font-light group-hocus:text-gray-400"
         highlight-classes="text-gray-1000"


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #21895

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Spec directories and file names are now truncated if they exceed a certain width

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

In the spec list, directory paths and file names were wrapping to show the entire value rather than truncating when they overflowed max width. This lead to long file/dir names clogging up the UI and overflowing the set height for the row.

This change affects the spec lists for e2e and component testing. See the related issue for more details

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

- Open the spec list for an application (e2e or ct) and create a directory and/or spec file with a long name (shrink window width if necessary)
- Verify that when the file/dir name is longer than the width of the spec column in the table, the name is truncated
- Verify that you can view the full name of the file/dir by hovering over the truncated text

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

**Before**
![Screen Shot 2022-06-09 at 12 08 29 PM](https://user-images.githubusercontent.com/14275198/172900052-d2f5c440-1f21-4ec0-8df1-c07cc96df8ff.png)

**After**
![Screen Shot 2022-06-09 at 12 14 37 PM](https://user-images.githubusercontent.com/14275198/172900116-cf0f21cc-53e0-4a5d-a56f-a990c8fe59bf.png)


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
