### PR TITLE
fix: SpecsList scrolling performance fixes

### DIFF
--- a/packages/app/src/specs/LastUpdatedHeader.vue
+++ b/packages/app/src/specs/LastUpdatedHeader.vue
@@ -4,7 +4,7 @@
     :is-interactive="true"
   >
     <div
-      class="decoration-dotted underline underline-gray-300 underline-offset-4"
+      class="cursor-default decoration-dotted underline underline-gray-300 underline-offset-4"
       tabindex="0"
       data-cy="last-updated-header"
     >

--- a/packages/app/src/specs/RunStatusDots.vue
+++ b/packages/app/src/specs/RunStatusDots.vue
@@ -8,8 +8,8 @@
       placement="top"
       :is-interactive="true"
       class="h-16px"
+      :hide-delay="0"
       :show-group="props.gql.id"
-      :instant-move="true"
       popper-class="RunStatusDots_Tooltip"
     >
       <component

--- a/packages/app/src/specs/RunStatusDots.vue
+++ b/packages/app/src/specs/RunStatusDots.vue
@@ -8,6 +8,8 @@
       placement="top"
       :is-interactive="true"
       class="h-16px"
+      :show-group="props.gql.id"
+      :instant-move="true"
       popper-class="RunStatusDots_Tooltip"
     >
       <component

--- a/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
+++ b/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
@@ -4,7 +4,7 @@
     :is-interactive="true"
   >
     <div
-      class="decoration-dotted underline underline-gray-300 underline-offset-4"
+      class="cursor-default decoration-dotted underline underline-gray-300 underline-offset-4"
       tabindex="0"
     >
       {{ headerText }}

--- a/packages/app/src/specs/SpecsList.vue
+++ b/packages/app/src/specs/SpecsList.vue
@@ -394,7 +394,7 @@ useResizeObserver(containerProps.ref, (entries) => {
 
 // If you are scrolled down the virtual list and list changes,
 // reset scroll position to top of list
-watch(() => treeSpecList.value, () => scrollTo(0))
+watch(() => hashCode(treeSpecList.value.map((spec) => spec.id)), () => scrollTo(0))
 
 function getIdIfDirectory (row) {
   if (row.data.isLeaf && row.data) {
@@ -429,6 +429,18 @@ function refetchFailedCloudData () {
 
 function refreshPage () {
   location.reload()
+}
+
+/**
+ * Generate a quasi-hash value to decompose an array of strings into a single numeric value that can be used to
+ * see whether it has changed from previous value(s).
+ */
+function hashCode (values: string[]): number {
+  return values.reduce((a, b) => {
+    a = ((a << 5) - a) + b.charCodeAt(0)
+
+    return a & a
+  }, 0)
 }
 
 </script>

--- a/packages/app/src/specs/SpecsList.vue
+++ b/packages/app/src/specs/SpecsList.vue
@@ -392,9 +392,9 @@ useResizeObserver(containerProps.ref, (entries) => {
   }
 })
 
-// If you are scrolled down the virtual list and list changes,
+// If you are scrolled down the virtual list and the search filter changes,
 // reset scroll position to top of list
-watch(() => hashCode(treeSpecList.value.map((spec) => spec.id)), () => scrollTo(0))
+watch(() => debouncedSearchString.value, () => scrollTo(0))
 
 function getIdIfDirectory (row) {
   if (row.data.isLeaf && row.data) {
@@ -429,18 +429,6 @@ function refetchFailedCloudData () {
 
 function refreshPage () {
   location.reload()
-}
-
-/**
- * Generate a quasi-hash value to decompose an array of strings into a single numeric value that can be used to
- * see whether it has changed from previous value(s).
- */
-function hashCode (values: string[]): number {
-  return values.reduce((a, b) => {
-    a = ((a << 5) - a) + b.charCodeAt(0)
-
-    return a & a
-  }, 0)
 }
 
 </script>

--- a/packages/frontend-shared/src/components/Tooltip.vue
+++ b/packages/frontend-shared/src/components/Tooltip.vue
@@ -8,7 +8,7 @@
     :distance="distance"
     :skidding="skidding"
     :auto-hide="false /* to prevent the popper from getting focus */"
-    :instant-move="instantMove"
+    :delay="{show: 0, hide: hideDelay }"
     :show-group="showGroup"
   >
     <slot />
@@ -36,6 +36,7 @@ const props = withDefaults(defineProps<{
   skidding?: number
   placement?: 'top' | 'right' | 'bottom' | 'left'
   popperClass?: string
+  hideDelay?: number
   instantMove?: boolean
   showGroup?: string
 }>(), {
@@ -47,6 +48,7 @@ const props = withDefaults(defineProps<{
   skidding: undefined,
   placement: undefined,
   popperClass: undefined,
+  hideDelay: 100,
   instantMove: undefined,
   showGroup: undefined,
 })

--- a/packages/frontend-shared/src/components/Tooltip.vue
+++ b/packages/frontend-shared/src/components/Tooltip.vue
@@ -8,7 +8,8 @@
     :distance="distance"
     :skidding="skidding"
     :auto-hide="false /* to prevent the popper from getting focus */"
-    :delay="{show: 0, hide: 100 }"
+    :instant-move="instantMove"
+    :show-group="showGroup"
   >
     <slot />
     <template
@@ -35,6 +36,8 @@ const props = withDefaults(defineProps<{
   skidding?: number
   placement?: 'top' | 'right' | 'bottom' | 'left'
   popperClass?: string
+  instantMove?: boolean
+  showGroup?: string
 }>(), {
   color: 'dark',
   hideArrow: false,
@@ -44,6 +47,8 @@ const props = withDefaults(defineProps<{
   skidding: undefined,
   placement: undefined,
   popperClass: undefined,
+  instantMove: undefined,
+  showGroup: undefined,
 })
 
 const theme = computed(() => {

--- a/packages/frontend-shared/src/composables/useVirtualList.ts
+++ b/packages/frontend-shared/src/composables/useVirtualList.ts
@@ -2,7 +2,7 @@ import type { Ref, CSSProperties } from 'vue'
 import { watch, ref, computed, shallowRef } from 'vue'
 import type { MaybeRef } from '@vueuse/core'
 import { useElementSize } from '@vueuse/core'
-import { debounce, isEqual } from 'lodash'
+import { isEqual } from 'lodash'
 
 export type UseVirtualListApi = ReturnType<typeof useVirtualList>['api']
 
@@ -161,9 +161,9 @@ export function useVirtualList<T = any> (list: MaybeRef<T[]>, options: UseVirtua
     scrollTo,
     containerProps: {
       ref: containerRef,
-      onScroll: debounce(() => {
+      onScroll: () => {
         calculateRange()
-      }, 100),
+      },
       style: containerStyle,
     },
     wrapperProps,

--- a/packages/frontend-shared/src/composables/useVirtualList.ts
+++ b/packages/frontend-shared/src/composables/useVirtualList.ts
@@ -2,7 +2,7 @@ import type { Ref, CSSProperties } from 'vue'
 import { watch, ref, computed, shallowRef } from 'vue'
 import type { MaybeRef } from '@vueuse/core'
 import { useElementSize } from '@vueuse/core'
-import { isEqual } from 'lodash'
+import { debounce, isEqual } from 'lodash'
 
 export type UseVirtualListApi = ReturnType<typeof useVirtualList>['api']
 
@@ -161,9 +161,9 @@ export function useVirtualList<T = any> (list: MaybeRef<T[]>, options: UseVirtua
     scrollTo,
     containerProps: {
       ref: containerRef,
-      onScroll: () => {
+      onScroll: debounce(() => {
         calculateRange()
-      },
+      }, 100),
       style: containerStyle,
     },
     wrapperProps,


### PR DESCRIPTION
* Fix watcher to prevent Specs Explorer from scrolling back to top when row data is updated
* Small fixes to reduce likelihood of Latest Runs tooltip from not cleaning up

### User facing changelog


### Additional details


### Steps to test


### How has the user experience changed?


### PR Tasks

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
