### PR TITLE
chore: downgrade windows resource class to large

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -98,7 +98,7 @@ executors:
     machine:
       image: windows-server-2019-vs2019:stable
       shell: bash.exe -eo pipefail
-    resource_class: windows.xlarge
+    resource_class: windows.large
     environment:
       PLATFORM: windows
 
@@ -2581,21 +2581,21 @@ windows-workflow: &windows-workflow
     - node_modules_install:
         name: windows-node-modules-install
         executor: windows
-        resource_class: windows.xlarge
+        resource_class: windows.large
         only-cache-for-root-user: true
 
     - build:
         name: windows-build
         context: test-runner:env-canary
         executor: windows
-        resource_class: windows.xlarge
+        resource_class: windows.large
         requires:
           - windows-node-modules-install
 
     - run-app-integration-tests-chrome:
         name: windows-run-app-integration-tests-chrome
         executor: windows
-        resource_class: windows.xlarge
+        resource_class: windows.large
         context: test-runner:launchpad-tests
         requires:
           - windows-build
@@ -2603,7 +2603,7 @@ windows-workflow: &windows-workflow
     - run-launchpad-integration-tests-chrome:
         name: windows-run-launchpad-integration-tests-chrome
         executor: windows
-        resource_class: windows.xlarge
+        resource_class: windows.large
         context: test-runner:launchpad-tests
         requires:
           - windows-build
@@ -2619,7 +2619,7 @@ windows-workflow: &windows-workflow
         <<: *full-windows-workflow-filters
         name: windows-unit-tests
         executor: windows
-        resource_class: windows.xlarge
+        resource_class: windows.large
         requires:
           - windows-build
 
@@ -2627,7 +2627,7 @@ windows-workflow: &windows-workflow
         <<: *full-windows-workflow-filters
         name: windows-create-build-artifacts
         executor: windows
-        resource_class: windows.xlarge
+        resource_class: windows.large
         context:
           - test-runner:sign-windows-binary
           - test-runner:upload


### PR DESCRIPTION
### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

After investigating for #22234 I started wondering whether "large" would be good enough for the resource class on Windows. Circle CI has the UI as:



but it appears that behind the scenes there *is* a difference in the size that allows these builds to succeed more reliably. I'd prefer to have a lower resource class while we're investigating what is necessitating more resources so that we can save money and spot any further issues.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Check Circle to ensure that the build passes

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
