### PR TITLE
fix: make the file name in <BaseError> wrap anywhere.

### DIFF
--- a/packages/frontend-shared/src/gql-components/error/BaseError.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/error/BaseError.cy.tsx
@@ -175,4 +175,42 @@ describe('<BaseError />', () => {
 
     cy.findByText('cypress/e2e/file.cy.js:12:25').should('be.visible')
   })
+
+  // https://github.com/cypress-io/cypress/issues/22103
+  it('wraps the long file path correctly', () => {
+    cy.mountFragment(BaseErrorFragmentDoc, {
+      onResult: (result) => {
+        result.codeFrame = {
+          __typename: 'CodeFrame',
+          line: 12,
+          column: 25,
+          codeBlock: codeFrameColumns(dedent`
+            const x = 1;
+            
+            throw new Error('Some Error');
+
+            const y = 2;
+          `, {
+            start: {
+              line: 3,
+              column: 5,
+            },
+          }, {
+            linesAbove: 2,
+            linesBelow: 4,
+          }),
+          file: {
+            id: `FileParts:/absolute/full/path/cypress/e2e/file.cy.js`,
+            __typename: 'FileParts',
+            relative: 'veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong/cypress/e2e/file.cy.js',
+            absolute: '/absolute/full/path/cypress/e2e/file.cy.js',
+          },
+        }
+      },
+      render: (gqlVal) => (
+        <BaseError gql={gqlVal} />),
+    })
+
+    cy.findByText('veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong/cypress/e2e/file.cy.js:12:25').should('have.css', 'overflow-wrap', 'anywhere')
+  })
 })

--- a/packages/frontend-shared/src/gql-components/error/ErrorCodeFrame.vue
+++ b/packages/frontend-shared/src/gql-components/error/ErrorCodeFrame.vue
@@ -12,7 +12,7 @@
       @click="onClick"
     >
       <i-cy-document-text_x16 class="h-16px m-12px mr-8px w-16px icon-dark-indigo-500 icon-light-indigo-100" />
-      <code>{{ fileText }}</code>
+      <code class="fileText">{{ fileText }}</code>
     </div>
   </OpenFileInIDE>
   <ShikiHighlight
@@ -53,3 +53,9 @@ const fileText = computed(() => {
   return `${file.relative}${(line && column) ? `:${line}:${column}` : ''}`
 })
 </script>
+
+<style lang="scss" scoped>
+.fileText {
+  overflow-wrap: anywhere;
+}
+</style>


### PR DESCRIPTION
- Closes #22103

### User facing changelog

File name in error message wrap anywhere.

### Additional details
- Why was this change necessary? => File name in `<BaseError>` didn't wrap correctly. It is not a severe bug, but it's a bit annoying. 
- What is affected by this change? => N/A

### Any implementation details to explain?



### Steps to test

The best way to see this failure is to use the `renders the header and message slots with codeframe` test at `BaseError.cy.tsx`. Make the relative path very long like `veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong/cypress/e2e/file.cy.js`. 

### How has the user experience changed?

**Before:**

![image](https://user-images.githubusercontent.com/8130013/173299749-f75123c6-81fd-412d-803e-fb563068c6fb.png)

**After:**

![image](https://user-images.githubusercontent.com/8130013/173299852-8bffd959-62ab-4147-a719-45c91809f5ce.png)


### PR Tasks

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
