### PR TITLE
fix: remove unused system-test project

### DIFF
--- a/system-tests/projects/config-cjs-and-esm/ts-cjs-with-invalid-esm-only-import/package.json
+++ b/system-tests/projects/config-cjs-and-esm/ts-cjs-with-invalid-esm-only-import/package.json
@@ -1,7 +1,0 @@
-{
-  "dependencies": {
-    "find-up": "6.3.0",
-    "typescript": "4.7.3"
-  },
-  "projectFixtureDirectory": "simple_passing"
-}


### PR DESCRIPTION
### User facing changelog
na

### Additional details
The project I removed is unused and does not contain a `yarn.lock`, causing `yarn workspace @tooling/system-tests projects:yarn:install` to fail locally. I believe this is being masked by the circleci cache, but it is causing [my PR against master](https://github.com/cypress-io/cypress/pull/22205) to fail.

### Steps to test
Run `yarn workspace @tooling/system-tests projects:yarn:install` locally. Without the changes from my PR, this will fail

### How has the user experience changed?
na

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
