### PR TITLE
chore: prep npm packages for use with Cypress v10

### DIFF
--- a/npm/vue2/package.json
+++ b/npm/vue2/package.json
@@ -52,7 +52,6 @@
   "unpkg": "dist/cypress-vue2.browser.js",
   "module": "dist/cypress-vue2.esm-bundler.js",
   "publishConfig": {
-    "access": "public",
-    "registry": "http://registry.npmjs.org/"
+    "access": "public"
   }
 }

--- a/npm/webpack-dev-server/package.json
+++ b/npm/webpack-dev-server/package.json
@@ -44,5 +44,15 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cypress-io/cypress.git"
+  },
+  "homepage": "https://github.com/cypress-io/cypress/tree/master/npm/webpack-dev-server#readme",
+  "bugs": "https://github.com/cypress-io/cypress/issues/new?template=1-bug-report.md",
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
### User facing changelog
na

### Additional details
[npm-release](https://app.circleci.com/pipelines/github/cypress-io/cypress/39434/workflows/5ea799d1-79dc-4326-8f0b-8fc80caff111/jobs/1611883) is timing out on `@cypress/webpack-dev-server`. It is failing with 
```
The authenticity of host 'github.com (140.82.112.3)' can't be established.`
```
The package.json for `@cypress/webpack-dev-server` is missing some required fields. It used to have these but we dropped them when doing the overhaul. I tested this change by ssh-ing into the npm-release job and verifying that it was able to move past this timeout.

I also removed the configured registry for `@cypress/vue2` as we have had issues in the past releasing a pakcage configured with the `http://` since it's deprecated in favor of `https://` which is the default value.

### Steps to test
Job shows what's going on, I was only able to reproduce it on the CI machine

### How has the user experience changed?
na

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
BREAKING CHANGE: new version of packages for Cypress v10