### PR TITLE
fix: Add component tests for ACI latest specs

### DIFF
--- a/packages/app/src/specs/AverageDuration.cy.tsx
+++ b/packages/app/src/specs/AverageDuration.cy.tsx
@@ -1,117 +1,116 @@
 import type { AverageDurationFragment } from '../generated/graphql'
 import AverageDuration from './AverageDuration.vue'
 
-function emptyAverageDurationFragment (milliseconds?: number): AverageDurationFragment {
-  return {
-    id: 'id',
-    data: {
-      id: 'id',
-      averageDuration: milliseconds ?? 0,
-      retrievedAt: new Date().toISOString(),
-      __typename: 'CloudProjectSpec',
-    },
-    __typename: 'RemoteFetchableCloudProjectSpecResult',
-  }
-}
-
 describe('<AverageDuration />', () => {
-  it('shows no time when 0 is passed', () => {
-    const gql = emptyAverageDurationFragment(0)
+  function mountWithDurationValue (duration: number) {
+    const gql: AverageDurationFragment = {
+      id: 'id',
+      data: {
+        __typename: 'CloudProjectSpec',
+        id: 'id',
+        averageDuration: duration,
+        retrievedAt: new Date().toISOString(),
+      },
+    }
 
-    cy.mount(() => {
-      return (
-        <AverageDuration gql={gql}/>
-      )
+    cy.mount(<AverageDuration gql={gql} />)
+  }
+
+  context('zero duration', () => {
+    beforeEach(() => {
+      mountWithDurationValue(0)
     })
 
-    cy.findByTestId('average-duration').should('not.exist')
+    it('renders nothing', () => {
+      cy.findByTestId('average-duration').should('not.exist')
+      cy.percySnapshot()
+    })
   })
 
-  it('shows correct time - small fractions of a second', () => {
-    const gql = emptyAverageDurationFragment(33)
+  context('duration less than 1 second', () => {
+    context('close to zero', () => {
+      beforeEach(() => {
+        mountWithDurationValue(33)
+      })
 
-    cy.mount(() => {
-      return (
-        <AverageDuration gql={gql}/>
-      )
+      it('renders zero duration', () => {
+        cy.findByTestId('average-duration').contains('0:00')
+        cy.percySnapshot()
+      })
     })
 
-    cy.findByTestId('average-duration').contains('0:00')
+    context('near one second', () => {
+      beforeEach(() => {
+        mountWithDurationValue(850)
+      })
+
+      it('shows correct time', () => {
+        cy.findByTestId('average-duration').contains('0:00')
+        cy.percySnapshot()
+      })
+    })
   })
 
-  it('shows correct time - almost a second', () => {
-    const gql = emptyAverageDurationFragment(850)
-
-    cy.mount(() => {
-      return (
-        <AverageDuration gql={gql}/>
-      )
+  context('duration more than 1 second but less than 1 minute', () => {
+    beforeEach(() => {
+      mountWithDurationValue(12 * 1000)
     })
 
-    cy.findByTestId('average-duration').contains('0:00')
+    it('shows correct time', () => {
+      cy.findByTestId('average-duration').contains('0:12')
+      cy.percySnapshot()
+    })
   })
 
-  it('shows correct time - seconds only', () => {
-    const gql = emptyAverageDurationFragment(12 * 1000)
+  context('duration more than one minute but less than one hour', () => {
+    context('even number of minutes', () => {
+      beforeEach(() => {
+        mountWithDurationValue(120 * 1000)
+      })
 
-    cy.mount(() => {
-      return (
-        <AverageDuration gql={gql}/>
-      )
+      it('shows correct time', () => {
+        // 2:00 = 120 seconds
+        cy.findByTestId('average-duration').contains('2:00')
+        cy.percySnapshot()
+      })
     })
 
-    cy.findByTestId('average-duration').contains('0:12')
+    context('mix of minutes and seconds', () => {
+      beforeEach(() => {
+        mountWithDurationValue(154 * 1000)
+      })
+
+      it('shows correct time', () => {
+        // 2:34 = 154 seconds
+        cy.findByTestId('average-duration').contains('2:34')
+        cy.percySnapshot()
+      })
+    })
   })
 
-  it('shows correct time - minutes only', () => {
-    // 2:00 = 120 seconds
-    const gql = emptyAverageDurationFragment(120 * 1000)
+  context('duration more than one hour', () => {
+    context('small number of hours', () => {
+      beforeEach(() => {
+        mountWithDurationValue(7354 * 1000)
+      })
 
-    cy.mount(() => {
-      return (
-        <AverageDuration gql={gql}/>
-      )
+      it('shows correct time', () => {
+        // 2:02:34 = 7354 seconds
+        cy.findByTestId('average-duration').contains('2:02:34')
+        cy.percySnapshot()
+      })
     })
 
-    cy.findByTestId('average-duration').contains('2:00')
-  })
+    context('large number of hours', () => {
+      beforeEach(() => {
+        mountWithDurationValue(151354 * 1000)
+      })
 
-  it('shows correct time - seconds and minutes', () => {
-    // 2:34 = 154 seconds
-    const gql = emptyAverageDurationFragment(154 * 1000)
-
-    cy.mount(() => {
-      return (
-        <AverageDuration gql={gql}/>
-      )
+      it('shows correct time', () => {
+        // 42:02:34 = 151354 seconds
+        cy.findByTestId('average-duration').contains('42:02:34')
+        cy.percySnapshot()
+      })
     })
-
-    cy.findByTestId('average-duration').contains('2:34')
-  })
-
-  it('shows correct time - hours, seconds and minutes', () => {
-    // 2:02:34 = 7354 seconds
-    const gql = emptyAverageDurationFragment(7354 * 1000)
-
-    cy.mount(() => {
-      return (
-        <AverageDuration gql={gql}/>
-      )
-    })
-
-    cy.findByTestId('average-duration').contains('2:02:34')
-  })
-
-  it('shows correct time - high number of hours, seconds and minutes', () => {
-    // 42:02:34 = 151354 seconds
-    const gql = emptyAverageDurationFragment(151354 * 1000)
-
-    cy.mount(() => {
-      return (
-        <AverageDuration gql={gql}/>
-      )
-    })
-
-    cy.findByTestId('average-duration').contains('42:02:34')
   })
 })

--- a/packages/app/src/specs/LastUpdatedHeader.cy.tsx
+++ b/packages/app/src/specs/LastUpdatedHeader.cy.tsx
@@ -6,24 +6,24 @@ describe('<LastUpdatedHeader />', () => {
   it('mounts correctly with git available', () => {
     cy.mount(<LastUpdatedHeader isGitAvailable/>)
     cy.findByTestId('last-updated-header').trigger('mouseenter')
-    const tooltipText = defaultMessages.specPage.lastUpdated.tooltip.gitInfoAvailable
 
-    const tooltipTextSplit = tooltipText.split('{0}').filter((s) => s)
+    const expectedTooltipText = defaultMessages.specPage.lastUpdated.tooltip.gitInfoAvailable
+    .replace('{0}', defaultMessages.specPage.lastUpdated.tooltip.gitStatus)
 
-    for (let i = 0; i < tooltipTextSplit.length; i++) {
-      cy.get('.v-popper__popper--shown').contains(tooltipTextSplit[i])
-    }
+    cy.get('.v-popper__popper--shown').should('have.text', expectedTooltipText)
+
+    cy.percySnapshot()
   })
 
   it('mounts correctly with git unavailable', () => {
     cy.mount(<LastUpdatedHeader isGitAvailable={false}/>)
     cy.findByTestId('last-updated-header').trigger('mouseenter')
-    const tooltipText = defaultMessages.specPage.lastUpdated.tooltip.gitInfoUnavailable
 
-    const tooltipTextSplit = tooltipText.split('{0}').filter((s) => s)
+    const expectedTooltipText = defaultMessages.specPage.lastUpdated.tooltip.gitInfoUnavailable
+    .replace('{0}', defaultMessages.specPage.lastUpdated.tooltip.gitInfo)
 
-    for (let i = 0; i < tooltipTextSplit.length; i++) {
-      cy.get('.v-popper__popper--shown').contains(tooltipTextSplit[i])
-    }
+    cy.get('.v-popper__popper--shown').should('have.text', expectedTooltipText)
+
+    cy.percySnapshot()
   })
 })

--- a/packages/app/src/specs/RunStatusDots.vue
+++ b/packages/app/src/specs/RunStatusDots.vue
@@ -6,6 +6,8 @@
     class="h-16px"
     :hide-delay="0"
     :show-group="props.gql?.id"
+    :distance="7"
+    popper-class="RunStatusDots_Tooltip"
   >
     <component
       :is="latestRun? ExternalLink : 'div'"
@@ -194,7 +196,7 @@ const latestStatus = computed(() => {
 <style lang="scss">
 .RunStatusDots_Tooltip {
   .v-popper__arrow-container {
-    margin-left: 14px;
+    margin-left: 13px;
   }
 }
 </style>

--- a/packages/app/src/specs/SpecHeaderCloudDataTooltip.cy.tsx
+++ b/packages/app/src/specs/SpecHeaderCloudDataTooltip.cy.tsx
@@ -1,0 +1,155 @@
+import { SpecHeaderCloudDataTooltipFragmentDoc } from '../generated/graphql-test'
+import SpecHeaderCloudDataTooltip from './SpecHeaderCloudDataTooltip.vue'
+import { set } from 'lodash'
+import { defaultMessages } from '@cy/i18n'
+
+describe('SpecHeaderCloudDataTooltip', () => {
+  function mountWithStatus (status: 'NOT_FOUND' | 'LOGGED_OUT' | 'CONNECTED' | 'NOT_CONNECTED' | 'UNAUTHORIZED') {
+    cy.mountFragment(SpecHeaderCloudDataTooltipFragmentDoc, {
+      onResult: (ctx) => {
+        set(ctx, 'cloudViewer', { __typename: 'CloudUser', id: 'abc123' })
+
+        switch (status) {
+          case 'LOGGED_OUT':
+            set(ctx, 'cloudViewer', null)
+            break
+          case 'NOT_CONNECTED':
+            set(ctx, 'currentProject.cloudProject.__typename', null)
+            break
+          case 'NOT_FOUND':
+            set(ctx, 'currentProject.cloudProject.__typename', 'CloudProjectNotFound')
+            break
+          case 'UNAUTHORIZED':
+            set(ctx, 'currentProject.cloudProject.__typename', 'CloudProjectUnauthorized')
+            break
+          case 'CONNECTED':
+          default:
+            set(ctx, 'currentProject.cloudProject.__typename', 'CloudProjectSpec')
+            break
+        }
+      },
+      render: (gql) => {
+        const showLoginSpy = cy.spy().as('showLoginSpy')
+        const showConnectToProjectSpy = cy.spy().as('showConnectToProjectSpy')
+
+        return (
+          <SpecHeaderCloudDataTooltip
+            gql={gql}
+            headerTextKeyPath="specPage.latestRuns.header"
+            connectedTextKeyPath="specPage.latestRuns.tooltip.connected"
+            notConnectedTextKeyPath="specPage.latestRuns.tooltip.notConnected"
+            noAccessTextKeyPath="specPage.latestRuns.tooltip.noAccess"
+            docsTextKeyPath="specPage.latestRuns.tooltip.linkText"
+            docsUrl="https://dummy.cypress.io/specs-latest-runs?utm_medium=Specs+Latest+Runs+Tooltip&utm_campaign=Latest+Runs"
+            data-cy="latest-runs-header"
+            onShowLogin={showLoginSpy}
+            onShowConnectToProject={showConnectToProjectSpy}
+          />)
+      },
+    })
+  }
+
+  context('connected', () => {
+    beforeEach(() => {
+      mountWithStatus('CONNECTED')
+    })
+
+    it('should render expected tooltip content', () => {
+      cy.get('.v-popper').trigger('mouseenter')
+
+      cy.findByTestId('cloud-data-tooltip-content')
+      .should('be.visible')
+      .and('contain', defaultMessages.specPage.latestRuns.tooltip.connected.replace('{0}', defaultMessages.specPage.latestRuns.tooltip.linkText))
+
+      cy.get('button').should('not.exist')
+
+      cy.percySnapshot()
+    })
+  })
+
+  context('not connected', () => {
+    beforeEach(() => {
+      mountWithStatus('NOT_CONNECTED')
+    })
+
+    it('should render expected tooltip content', () => {
+      cy.get('.v-popper').trigger('mouseenter')
+
+      cy.findByTestId('cloud-data-tooltip-content')
+      .should('be.visible')
+      .and('contain', defaultMessages.specPage.latestRuns.tooltip.notConnected.replace('{0}', defaultMessages.specPage.latestRuns.tooltip.linkText))
+
+      cy.findByTestId('connect-button')
+      .should('be.visible')
+      .click()
+
+      cy.get('@showConnectToProjectSpy').should('have.been.calledOnce')
+
+      cy.percySnapshot()
+    })
+  })
+
+  context('unauthorized', () => {
+    beforeEach(() => {
+      mountWithStatus('UNAUTHORIZED')
+    })
+
+    it('should render expected tooltip content', () => {
+      cy.get('.v-popper').trigger('mouseenter')
+
+      cy.findByTestId('cloud-data-tooltip-content')
+      .should('be.visible')
+      .and('contain', defaultMessages.specPage.latestRuns.tooltip.noAccess.replace('{0}', defaultMessages.specPage.latestRuns.tooltip.linkText))
+
+      cy.findByTestId('request-access-button')
+      .should('be.visible')
+      .click()
+
+      cy.percySnapshot()
+    })
+  })
+
+  context('logged out', () => {
+    beforeEach(() => {
+      mountWithStatus('LOGGED_OUT')
+    })
+
+    it('should render expected tooltip content', () => {
+      cy.get('.v-popper').trigger('mouseenter')
+
+      cy.findByTestId('cloud-data-tooltip-content')
+      .should('be.visible')
+      .and('contain', defaultMessages.specPage.latestRuns.tooltip.notConnected.replace('{0}', defaultMessages.specPage.latestRuns.tooltip.linkText))
+
+      cy.findByTestId('login-button')
+      .should('be.visible')
+      .click()
+
+      cy.get('@showLoginSpy').should('have.been.calledOnce')
+
+      cy.percySnapshot()
+    })
+  })
+
+  context('not found', () => {
+    beforeEach(() => {
+      mountWithStatus('NOT_FOUND')
+    })
+
+    it('should render expected tooltip content', () => {
+      cy.get('.v-popper').trigger('mouseenter')
+
+      cy.findByTestId('cloud-data-tooltip-content')
+      .should('be.visible')
+      .and('contain', defaultMessages.specPage.latestRuns.tooltip.notConnected.replace('{0}', defaultMessages.specPage.latestRuns.tooltip.linkText))
+
+      cy.findByTestId('reconnect-button')
+      .should('be.visible')
+      .click()
+
+      cy.get('@showConnectToProjectSpy').should('have.been.calledOnce')
+
+      cy.percySnapshot()
+    })
+  })
+})

--- a/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
+++ b/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
@@ -15,6 +15,7 @@
     >
       <div
         class="flex flex-col text-sm text-center p-4 items-center"
+        data-cy="cloud-data-tooltip-content"
       >
         <div
           :class="{'m-2': projectConnectionStatus!== 'CONNECTED'}"
@@ -37,6 +38,7 @@
             v-if="projectConnectionStatus === 'LOGGED_OUT'"
             :prefix-icon="ConnectIcon"
             prefix-icon-class="icon-dark-white icon-light-transparent"
+            data-cy="login-button"
             @click="emits('showLogin')"
           >
             {{ t('topNav.login.actionLogin') }}
@@ -45,6 +47,7 @@
             v-else-if="projectConnectionStatus === 'NOT_CONNECTED'"
             :prefix-icon="ConnectIcon"
             prefix-icon-class="icon-dark-white icon-light-transparent"
+            data-cy="connect-button"
             @click="emits('showConnectToProject')"
           >
             {{ t("specPage.connectProjectButton") }}
@@ -53,6 +56,7 @@
             v-else-if="projectConnectionStatus === 'NOT_FOUND'"
             :prefix-icon="ConnectIcon"
             prefix-icon-class="icon-dark-white icon-light-transparent"
+            data-cy="reconnect-button"
             @click="emits('showConnectToProject')"
           >
             {{ t("specPage.reconnectProjectButton") }}
@@ -61,6 +65,7 @@
             v-else-if="projectConnectionStatus === 'UNAUTHORIZED'"
             :prefix-icon="SendIcon"
             prefix-icon-class="icon-dark-white icon-light-transparent"
+            data-cy="request-access-button"
             @click="requestAccess"
           >
             {{ t("specPage.requestAccessButton") }}

--- a/packages/app/src/specs/SpecListGitInfo.cy.tsx
+++ b/packages/app/src/specs/SpecListGitInfo.cy.tsx
@@ -1,0 +1,80 @@
+import { SpecListRowFragmentDoc } from '../generated/graphql-test'
+import SpecListGitInfo from './SpecListGitInfo.vue'
+
+describe('SpecListGitInfo', () => {
+  const mountWithStatus = (status: 'created' | 'modified' | 'unmodified') => {
+    cy.mountFragment(SpecListRowFragmentDoc, {
+      onResult: (ctx) => {
+        ctx.author = 'Bob'
+        ctx.lastModifiedHumanReadable = 'Last Tuesday'
+        ctx.lastModifiedTimestamp = new Date('02-02-2022').toISOString()
+        ctx.statusType = status
+        ctx.shortHash = 'abc123'
+        ctx.subject = 'chore: did stuff'
+      },
+      render: (gql) => <SpecListGitInfo gql={gql} />,
+    })
+
+    cy.findByTestId('git-info-row').as('row')
+  }
+
+  context('created', () => {
+    beforeEach(() => {
+      mountWithStatus('created')
+    })
+
+    it('renders created icon and expected text', () => {
+      cy.get('@row').should('have.text', 'Last Tuesday')
+      cy.findByTestId('created-icon').should('be.visible')
+    })
+
+    it('provides expected tooltip content', () => {
+      cy.findByTestId('git-info-tooltip').should('not.exist')
+      cy.get('.v-popper').trigger('mouseenter')
+      cy.findByTestId('git-info-tooltip').should('be.visible')
+      .and('have.text', 'Created')
+
+      cy.percySnapshot()
+    })
+  })
+
+  context('modified', () => {
+    beforeEach(() => {
+      mountWithStatus('modified')
+    })
+
+    it('renders created icon and expected text', () => {
+      cy.get('@row').should('have.text', 'Last Tuesday')
+      cy.findByTestId('modified-icon').should('be.visible')
+    })
+
+    it('provides expected tooltip content', () => {
+      cy.findByTestId('git-info-tooltip').should('not.exist')
+      cy.get('.v-popper').trigger('mouseenter')
+      cy.findByTestId('git-info-tooltip').should('be.visible')
+      .and('have.text', 'Modified')
+
+      cy.percySnapshot()
+    })
+  })
+
+  context('unmodified', () => {
+    beforeEach(() => {
+      mountWithStatus('unmodified')
+    })
+
+    it('renders created icon and expected text', () => {
+      cy.get('@row').should('have.text', 'Last Tuesday')
+      cy.findByTestId('unmodified-icon').should('be.visible')
+    })
+
+    it('provides expected tooltip content', () => {
+      cy.findByTestId('git-info-tooltip').should('not.exist')
+      cy.get('.v-popper').trigger('mouseenter')
+      cy.findByTestId('git-info-tooltip').should('be.visible')
+      .and('have.text', 'chore: did stuffabc123 by Bob')
+
+      cy.percySnapshot()
+    })
+  })
+})

--- a/packages/app/src/specs/SpecListGitInfo.cy.tsx
+++ b/packages/app/src/specs/SpecListGitInfo.cy.tsx
@@ -72,7 +72,8 @@ describe('SpecListGitInfo', () => {
       cy.findByTestId('git-info-tooltip').should('not.exist')
       cy.get('.v-popper').trigger('mouseenter')
       cy.findByTestId('git-info-tooltip').should('be.visible')
-      .and('have.text', 'chore: did stuffabc123 by Bob')
+      .and('contain', 'chore: did stuff')
+      .and('contain', 'abc123 by Bob')
 
       cy.percySnapshot()
     })

--- a/packages/app/src/specs/SpecListGitInfo.vue
+++ b/packages/app/src/specs/SpecListGitInfo.vue
@@ -8,12 +8,14 @@
       :key="props.gql?.statusType ?? undefined"
       placement="top"
       class="h-full"
+      data-cy="tooltip"
     >
       <div class="flex h-full gap-9px justify-start items-center">
         <div>
           <component
             :is="classes.icon"
             :class="classes.iconClasses"
+            :data-cy="classes.testId"
           />
         </div>
         <div
@@ -25,7 +27,7 @@
       <template
         #popper
       >
-        <div>
+        <div data-cy="git-info-tooltip">
           <p class="max-w-sm text-sm truncate overflow-hidden">
             {{ tooltipMainText }}
           </p>
@@ -79,14 +81,17 @@ const classes = computed(() => {
     created: {
       icon: DocumentIconPlus,
       iconClasses: 'icon-dark-jade-400 icon-light-jade-50',
+      testId: 'created-icon',
     },
     modified: {
       icon: DocumentIconPlusMinus,
       iconClasses: 'icon-dark-orange-400 icon-light-orange-50',
+      testId: 'modified-icon',
     },
     unmodified: {
       icon: CommitIcon,
       iconClasses: 'icon-light-gray-500',
+      testId: 'unmodified-icon',
     },
     noGitInfo: {},
   }[props.gql?.statusType || 'unmodified']

--- a/packages/app/src/specs/SpecRunSummary.cy.tsx
+++ b/packages/app/src/specs/SpecRunSummary.cy.tsx
@@ -1,10 +1,11 @@
 import SpecRunSummary from './SpecRunSummary.vue'
 import { exampleRuns } from '@packages/frontend-shared/cypress/support/mock-graphql/fakeCloudSpecRun'
+import type { CloudSpecRun } from '@packages/graphql/src/gen/cloud-source-types.gen'
 
 describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
   const runs = exampleRuns()
 
-  function mountWithRun (run) {
+  function mountWithRun (run: CloudSpecRun) {
     const createdAt = new Date()
 
     createdAt.setFullYear(createdAt.getFullYear() - 1)
@@ -49,13 +50,13 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
 
     it('should render expected content', () => {
       cy.findByTestId('spec-run-summary')
-      // Green border at top
+      // Red border at top
       .should('have.css', 'border-top', '4px solid rgb(228, 87, 112)')
 
       cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
 
       cy.findByTestId('spec-run-status')
-      // Green text with expected status text
+      // Red text with expected status text
       .should('have.css', 'color', 'rgb(198, 43, 73)')
       .and('have.text', 'Failed')
 
@@ -78,13 +79,13 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
 
     it('should render expected content', () => {
       cy.findByTestId('spec-run-summary')
-      // Green border at top
+      // Gray border at top
       .should('have.css', 'border-top', '4px solid rgb(144, 149, 173)')
 
       cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
 
       cy.findByTestId('spec-run-status')
-      // Green text with expected status text
+      // Gray text with expected status text
       .should('have.css', 'color', 'rgb(90, 95, 122)')
       .and('have.text', 'Canceled')
 
@@ -108,13 +109,13 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
 
     it('should render expected content', () => {
       cy.findByTestId('spec-run-summary')
-      // Green border at top
+      // Orange border at top
       .should('have.css', 'border-top', '4px solid rgb(219, 121, 3)')
 
       cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
 
       cy.findByTestId('spec-run-status')
-      // Green text with expected status text
+      // Orange text with expected status text
       .should('have.css', 'color', 'rgb(189, 88, 0)')
       .and('have.text', 'Errored')
 
@@ -138,13 +139,13 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
 
     it('should render expected content', () => {
       cy.findByTestId('spec-run-summary')
-      // Green border at top
+      // Gray border at top
       .should('have.css', 'border-top', '4px solid rgb(144, 149, 173)')
 
       cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
 
       cy.findByTestId('spec-run-status')
-      // Green text with expected status text
+      // Gray text with expected status text
       .should('have.css', 'color', 'rgb(90, 95, 122)')
       .and('have.text', 'No tests')
 
@@ -168,13 +169,13 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
 
     it('should render expected content', () => {
       cy.findByTestId('spec-run-summary')
-      // Green border at top
+      // Orange border at top
       .should('have.css', 'border-top', '4px solid rgb(219, 121, 3)')
 
       cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
 
       cy.findByTestId('spec-run-status')
-      // Green text with expected status text
+      // Orange text with expected status text
       .should('have.css', 'color', 'rgb(189, 88, 0)')
       .and('have.text', 'Over limit')
 
@@ -198,13 +199,13 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
 
     it('should render expected content', () => {
       cy.findByTestId('spec-run-summary')
-      // Green border at top
+      // Blue border at top
       .should('have.css', 'border-top', '4px solid rgb(100, 112, 243)')
 
       cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
 
       cy.findByTestId('spec-run-status')
-      // Green text with expected status text
+      // Blue text with expected status text
       .should('have.css', 'color', 'rgb(73, 86, 227)')
       .and('have.text', 'Running')
 
@@ -228,13 +229,13 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
 
     it('should render expected content', () => {
       cy.findByTestId('spec-run-summary')
-      // Green border at top
+      // Orange border at top
       .should('have.css', 'border-top', '4px solid rgb(219, 121, 3)')
 
       cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
 
       cy.findByTestId('spec-run-status')
-      // Green text with expected status text
+      // Orange text with expected status text
       .should('have.css', 'color', 'rgb(189, 88, 0)')
       .and('have.text', 'Timed out')
 

--- a/packages/app/src/specs/SpecRunSummary.cy.tsx
+++ b/packages/app/src/specs/SpecRunSummary.cy.tsx
@@ -2,32 +2,252 @@ import SpecRunSummary from './SpecRunSummary.vue'
 import { exampleRuns } from '@packages/frontend-shared/cypress/support/mock-graphql/fakeCloudSpecRun'
 
 describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
-  it('playground', { viewportHeight: 800, viewportWidth: 720 }, () => {
-    const runs = exampleRuns()
+  const runs = exampleRuns()
 
-    cy.mount(() => {
-      return (
-        <div class="flex gap-2">
-          <div class="flex flex-col bg-light-900 p-5 gap-y-15px children:bg-white">
-            <SpecRunSummary run={runs[0]} specFileNoExtension="bankaccounts" specFileExtension=".spec.ts"/>
+  function mountWithRun (run) {
+    const createdAt = new Date()
 
-            <SpecRunSummary run={runs[1]} specFileNoExtension="singleGroup" specFileExtension=".spec.ts"/>
+    createdAt.setFullYear(createdAt.getFullYear() - 1)
+    run.createdAt = createdAt.toISOString()
+    cy.mount(<SpecRunSummary run={run} specFileNoExtension="mySpecFile" specFileExtension=".spec.ts" />)
+  }
 
-            <SpecRunSummary run={runs[2]} specFileNoExtension="noRangeForFailed" specFileExtension=".spec.ts"/>
+  context('passing', () => {
+    beforeEach(() => {
+      mountWithRun(runs[0])
+    })
 
-            <SpecRunSummary run={runs[3]} specFileNoExtension="veryVeryVeryVeryVeryVeryVeryVeryVeryLongSpecFileName" specFileExtension=".spec.ts"/>
-          </div>
-          <div class="flex flex-col bg-light-900 p-5 gap-y-15px children:bg-white">
-            <SpecRunSummary run={runs[4]} specFileNoExtension="bankaccounts" specFileExtension=".spec.ts"/>
+    it('should render expected content', () => {
+      cy.findByTestId('spec-run-summary')
+      // Green border at top
+      .should('have.css', 'border-top', '4px solid rgb(31, 169, 113)')
 
-            <SpecRunSummary run={runs[5]} specFileNoExtension="bankaccounts" specFileExtension=".spec.ts"/>
+      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
 
-            <SpecRunSummary run={runs[6]} specFileNoExtension="bankaccounts" specFileExtension=".spec.ts"/>
+      cy.findByTestId('spec-run-status')
+      // Green text with expected status text
+      .should('have.css', 'color', 'rgb(0, 129, 77)')
+      .and('have.text', 'Passed')
 
-            <SpecRunSummary run={runs[7]} specFileNoExtension="veryVeryVeryVeryVeryVeryVeryVeryVeryLongSpecFileName" specFileExtension=".spec.ts"/>
-          </div>
-        </div>
-      )
+      cy.findByTestId('spec-run-time-ago')
+      .should('have.text', '1 year ago')
+
+      cy.findByTestId('spec-run-duration-1')
+      .should('have.text', '2:23')
+
+      cy.findByTestId('spec-run-duration-2')
+      .should('have.text', '2:39')
+
+      cy.findByTestId('spec-run-result-counts').should('be.visible')
+    })
+  })
+
+  context('failed', () => {
+    beforeEach(() => {
+      mountWithRun(runs[1])
+    })
+
+    it('should render expected content', () => {
+      cy.findByTestId('spec-run-summary')
+      // Green border at top
+      .should('have.css', 'border-top', '4px solid rgb(228, 87, 112)')
+
+      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
+
+      cy.findByTestId('spec-run-status')
+      // Green text with expected status text
+      .should('have.css', 'color', 'rgb(198, 43, 73)')
+      .and('have.text', 'Failed')
+
+      cy.findByTestId('spec-run-time-ago')
+      .should('have.text', '1 year ago')
+
+      cy.findByTestId('spec-run-duration-1')
+      .should('have.text', '1:02:40')
+
+      cy.findByTestId('spec-run-duration-2').should('not.exist')
+
+      cy.findByTestId('spec-run-result-counts').should('be.visible')
+    })
+  })
+
+  context('canceled', () => {
+    beforeEach(() => {
+      mountWithRun(runs[2])
+    })
+
+    it('should render expected content', () => {
+      cy.findByTestId('spec-run-summary')
+      // Green border at top
+      .should('have.css', 'border-top', '4px solid rgb(144, 149, 173)')
+
+      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
+
+      cy.findByTestId('spec-run-status')
+      // Green text with expected status text
+      .should('have.css', 'color', 'rgb(90, 95, 122)')
+      .and('have.text', 'Canceled')
+
+      cy.findByTestId('spec-run-time-ago')
+      .should('have.text', '1 year ago')
+
+      cy.findByTestId('spec-run-duration-1')
+      .should('have.text', '2:23')
+
+      cy.findByTestId('spec-run-duration-2')
+      .should('have.text', '2:39')
+
+      cy.findByTestId('spec-run-result-counts').should('be.visible')
+    })
+  })
+
+  context('errored', () => {
+    beforeEach(() => {
+      mountWithRun(runs[3])
+    })
+
+    it('should render expected content', () => {
+      cy.findByTestId('spec-run-summary')
+      // Green border at top
+      .should('have.css', 'border-top', '4px solid rgb(219, 121, 3)')
+
+      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
+
+      cy.findByTestId('spec-run-status')
+      // Green text with expected status text
+      .should('have.css', 'color', 'rgb(189, 88, 0)')
+      .and('have.text', 'Errored')
+
+      cy.findByTestId('spec-run-time-ago')
+      .should('have.text', '1 year ago')
+
+      cy.findByTestId('spec-run-duration-1')
+      .should('have.text', '1:02:40')
+
+      cy.findByTestId('spec-run-duration-2')
+      .should('have.text', '10:26:40')
+
+      cy.findByTestId('spec-run-result-counts').should('be.visible')
+    })
+  })
+
+  context('no tests', () => {
+    beforeEach(() => {
+      mountWithRun(runs[4])
+    })
+
+    it('should render expected content', () => {
+      cy.findByTestId('spec-run-summary')
+      // Green border at top
+      .should('have.css', 'border-top', '4px solid rgb(144, 149, 173)')
+
+      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
+
+      cy.findByTestId('spec-run-status')
+      // Green text with expected status text
+      .should('have.css', 'color', 'rgb(90, 95, 122)')
+      .and('have.text', 'No tests')
+
+      cy.findByTestId('spec-run-time-ago')
+      .should('have.text', '1 year ago')
+
+      cy.findByTestId('spec-run-duration-1')
+      .should('have.text', '2:23')
+
+      cy.findByTestId('spec-run-duration-2')
+      .should('have.text', '2:39')
+
+      cy.findByTestId('spec-run-result-counts').should('be.visible')
+    })
+  })
+
+  context('over limit', () => {
+    beforeEach(() => {
+      mountWithRun(runs[5])
+    })
+
+    it('should render expected content', () => {
+      cy.findByTestId('spec-run-summary')
+      // Green border at top
+      .should('have.css', 'border-top', '4px solid rgb(219, 121, 3)')
+
+      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
+
+      cy.findByTestId('spec-run-status')
+      // Green text with expected status text
+      .should('have.css', 'color', 'rgb(189, 88, 0)')
+      .and('have.text', 'Over limit')
+
+      cy.findByTestId('spec-run-time-ago')
+      .should('have.text', '1 year ago')
+
+      cy.findByTestId('spec-run-duration-1')
+      .should('have.text', '2:23')
+
+      cy.findByTestId('spec-run-duration-2')
+      .should('have.text', '2:39')
+
+      cy.findByTestId('spec-run-result-counts').should('be.visible')
+    })
+  })
+
+  context('running', () => {
+    beforeEach(() => {
+      mountWithRun(runs[6])
+    })
+
+    it('should render expected content', () => {
+      cy.findByTestId('spec-run-summary')
+      // Green border at top
+      .should('have.css', 'border-top', '4px solid rgb(100, 112, 243)')
+
+      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
+
+      cy.findByTestId('spec-run-status')
+      // Green text with expected status text
+      .should('have.css', 'color', 'rgb(73, 86, 227)')
+      .and('have.text', 'Running')
+
+      cy.findByTestId('spec-run-time-ago')
+      .should('have.text', '1 year ago')
+
+      cy.findByTestId('spec-run-duration-1')
+      .should('have.text', '2:23')
+
+      cy.findByTestId('spec-run-duration-2')
+      .should('have.text', '2:39')
+
+      cy.findByTestId('spec-run-result-counts').should('be.visible')
+    })
+  })
+
+  context('timed out', () => {
+    beforeEach(() => {
+      mountWithRun(runs[7])
+    })
+
+    it('should render expected content', () => {
+      cy.findByTestId('spec-run-summary')
+      // Green border at top
+      .should('have.css', 'border-top', '4px solid rgb(219, 121, 3)')
+
+      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
+
+      cy.findByTestId('spec-run-status')
+      // Green text with expected status text
+      .should('have.css', 'color', 'rgb(189, 88, 0)')
+      .and('have.text', 'Timed out')
+
+      cy.findByTestId('spec-run-time-ago')
+      .should('have.text', '1 year ago')
+
+      cy.findByTestId('spec-run-duration-1')
+      .should('have.text', '2:23')
+
+      cy.findByTestId('spec-run-duration-2')
+      .should('have.text', '2:39')
+
+      cy.findByTestId('spec-run-result-counts').should('be.visible')
     })
   })
 })

--- a/packages/app/src/specs/SpecRunSummary.vue
+++ b/packages/app/src/specs/SpecRunSummary.vue
@@ -3,8 +3,12 @@
     v-if="props.run"
     class="flex flex-col p-4 gap-2 items-center"
     :class="highlightColor"
+    data-cy="spec-run-summary"
   >
-    <div class="max-w-60 truncate overflow-hidden">
+    <div
+      class="max-w-60 truncate overflow-hidden"
+      data-cy="spec-run-filename"
+    >
       <span class="font-semibold text-gray-800">{{ props.specFileNoExtension }}</span><span class="text-gray-600">{{ props.specFileExtension }}</span>
     </div>
     <div class="flex flex-row text-gray-700 text-size-14px gap-2 items-center">
@@ -12,6 +16,7 @@
         v-if="statusText"
         :class="'text-'+statusTextColor"
         class="font-medium"
+        data-cy="spec-run-status"
       >
         {{ statusText }}
       </div>
@@ -21,7 +26,10 @@
         height="4px"
         class="icon-light-gray-200"
       />
-      <div v-if="props.run.createdAt">
+      <div
+        v-if="props.run.createdAt"
+        data-cy="spec-run-time-ago"
+      >
         {{ getTimeAgo(props.run.createdAt!) }}
       </div>
       <i-cy-dot-solid_x4
@@ -29,14 +37,19 @@
         height="4px"
         class="icon-light-gray-200"
       />
-      <div>{{ durationText1 }}</div>
+      <div data-cy="spec-run-duration-1">
+        {{ durationText1 }}
+      </div>
       <div
         v-if="durationText2"
         class="m-[-5px] text-gray-200"
       >
         -
       </div>
-      <div v-if="durationText2">
+      <div
+        v-if="durationText2"
+        data-cy="spec-run-duration-2"
+      >
         {{ durationText2 }}
       </div>
     </div>
@@ -44,6 +57,7 @@
       v-if="runResults"
       v-bind="runResults"
       class="my-2"
+      data-cy="spec-run-result-counts"
     />
   </div>
 </template>

--- a/packages/app/src/specs/SpecsList.vue
+++ b/packages/app/src/specs/SpecsList.vue
@@ -101,6 +101,7 @@
           :no-access-text-key-path="'specPage.latestRuns.tooltip.noAccess'"
           :docs-text-key-path="'specPage.latestRuns.tooltip.linkText'"
           :docs-url="'https://on.cypress.io/specs-latest-runs?utm_medium=Specs+Latest+Runs+Tooltip&utm_campaign=Latest+Runs'"
+          data-cy="latest-runs-header"
           @showLogin="()=>showLogin('Specs Latest Runs Tooltip')"
           @showConnectToProject="showConnectToProject"
         />
@@ -114,6 +115,7 @@
           :no-access-text-key-path="'specPage.averageDuration.tooltip.noAccess'"
           :docs-text-key-path="'specPage.averageDuration.tooltip.linkText'"
           :docs-url="'https://on.cypress.io/specs-average-duration?utm_medium=Specs+Average+Duration+Tooltip&utm_campaign=Average+Duration'"
+          data-cy="average-duration-header"
           @showLogin="()=>showLogin('Specs Average Duration Tooltip')"
           @showConnectToProject="showConnectToProject"
         />

--- a/packages/frontend-shared/cypress/support/mock-graphql/clientTestUrqlClient.ts
+++ b/packages/frontend-shared/cypress/support/mock-graphql/clientTestUrqlClient.ts
@@ -63,13 +63,13 @@ export function testUrqlClient (context: ClientTestContext,
               }
 
               if (onResult) {
-                if (result.data.testFragmentMember) {
+                if (result.data?.testFragmentMember) {
                   const val = onResult(result.data.testFragmentMember, context)
 
                   if (val !== undefined) {
                     result.data.testFragmentMember = val
                   }
-                } else if (result.data.testFragmentMemberList) {
+                } else if (result.data?.testFragmentMemberList) {
                   const val = onResult(result.data.testFragmentMemberList, context)
 
                   if (val !== undefined) {

--- a/packages/frontend-shared/src/components/ResultCounts.cy.tsx
+++ b/packages/frontend-shared/src/components/ResultCounts.cy.tsx
@@ -1,0 +1,28 @@
+import { defaultMessages } from '@cy/i18n'
+import ResultCounts from './ResultCounts.vue'
+
+describe('<ResultCounts />', () => {
+  it('renders expected contents', () => {
+    cy.mount(() => (
+      <ResultCounts
+        totalFailed={1}
+        totalPassed={2}
+        totalPending={3}
+        totalSkipped={4}
+      />))
+
+    cy.get(`[data-cy="runResults-${defaultMessages.runs.results.skipped}-count"]`)
+    .should('contain', '4')
+
+    cy.get(`[data-cy="runResults-${defaultMessages.runs.results.pending}-count"]`)
+    .should('contain', '3')
+
+    cy.get(`[data-cy="runResults-${defaultMessages.runs.results.passed}-count"]`)
+    .should('contain', '2')
+
+    cy.get(`[data-cy="runResults-${defaultMessages.runs.results.failed}-count"]`)
+    .should('contain', '1')
+
+    cy.percySnapshot()
+  })
+})

--- a/packages/frontend-shared/src/components/ResultCounts.cy.tsx
+++ b/packages/frontend-shared/src/components/ResultCounts.cy.tsx
@@ -25,4 +25,28 @@ describe('<ResultCounts />', () => {
 
     cy.percySnapshot()
   })
+
+  it('renders string range values', () => {
+    cy.mount(() => (
+      <ResultCounts
+        totalFailed="1-2"
+        totalPassed="2-20"
+        totalPending="5-5"
+        totalSkipped="10-1"
+      />))
+
+    cy.get(`[data-cy="runResults-${defaultMessages.runs.results.skipped}-count"]`)
+    .should('contain', '10-1')
+
+    cy.get(`[data-cy="runResults-${defaultMessages.runs.results.pending}-count"]`)
+    .should('contain', '5-5')
+
+    cy.get(`[data-cy="runResults-${defaultMessages.runs.results.passed}-count"]`)
+    .should('contain', '2-20')
+
+    cy.get(`[data-cy="runResults-${defaultMessages.runs.results.failed}-count"]`)
+    .should('contain', '1-2')
+
+    cy.percySnapshot()
+  })
 })


### PR DESCRIPTION
* Adding component tests to cover new components and behaviors (more to come)
* Fix small issue disguising graphql resolver issues during component tests
* Styling fix for ACI latest runs tooltip so it points to the latest run dot

### User facing changelog


### Additional details


### Steps to test


### How has the user experience changed?


### PR Tasks

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
