### PR TITLE
fix: make virtual-list loading more efficient

### DIFF
--- a/packages/app/src/specs/SpecsListRowItem.vue
+++ b/packages/app/src/specs/SpecsListRowItem.vue
@@ -2,7 +2,7 @@
   <div data-cy="specs-list-row">
     <component
       :is="isLeaf ? 'RouterLink' : 'div'"
-      class="h-full outline-none border-gray-50 pr-20px ring-inset grid grid-cols-7 md:grid-cols-9 group focus:outline-transparent focus-within:ring-indigo-300 focus-within:ring-1 children:cursor-pointer"
+      class="h-full outline-none border-gray-50 ring-inset grid pr-20px grid-cols-7 group md:grid-cols-9 focus:outline-transparent focus-within:ring-indigo-300 focus-within:ring-1 children:cursor-pointer"
       :to="route"
       :data-cy="isLeaf ? 'spec-item-link' : 'spec-item-directory'"
       @click="emit('toggleRow')"
@@ -15,23 +15,28 @@
       >
         <slot name="file" />
       </div>
-      <div
-        data-cy="specs-list-row-git-info"
-        class="col-span-2"
+      <template
+        v-if="lazyRender"
       >
-        <slot name="git-info" />
-      </div>
-      <div>
-        <slot name="latest-runs" />
-      </div>
-      <div class="invisible md:visible md:col-span-2">
-        <slot name="average-duration" />
-      </div>
+        <div
+          data-cy="specs-list-row-git-info"
+          class="col-span-2"
+        >
+          <slot name="git-info" />
+        </div>
+        <div>
+          <slot name="latest-runs" />
+        </div>
+        <div class="invisible md:col-span-2 md:visible">
+          <slot name="average-duration" />
+        </div>
+      </template>
     </component>
   </div>
 </template>
 
 <script setup lang="ts">
+import { useTimeout } from '@vueuse/core'
 import type { RouteLocationRaw } from 'vue-router'
 
 defineProps<{
@@ -42,6 +47,8 @@ defineProps<{
 const emit = defineEmits<{
   (event: 'toggleRow'): void
 }>()
+
+const lazyRender = useTimeout(50)
 
 function handleCtrlClick (): void {
   // noop intended to reduce the chances of opening tests multiple tabs


### PR DESCRIPTION
### User facing changelog
Increase rendering speed of items in spec-list

### Additional details
When quickly scrolling the spec list, there is a flash of un-rendered content due to the the virtual list having to re-render so many elements. This only became an issue with the recent ACI work that added more components to each row.

This fix defers the rendering of many of the columns such that the row + filename is given priority, leading to a more responsive feel to the table. It doesn't fix the issue entirely as fast scrolls can still cause a white flash, but it does improve the experience.

This PR __DOES NOT__ fix the scroll jank on Chrome. That is an issue in [Chrome v102](https://github.com/petyosi/react-virtuoso/issues/675) that has been fixed in v103. The scroll behavior works find in Firefox + Electron

### Steps to test
Check out muaz/CLOUD-577-spec-list-display-latest-runs and choose a project with a decent amount of tests. Scroll through the list quickly (or use the scrollbar) to see flashes on run-rendered content

### How has the user experience changed?
Before:

https://user-images.githubusercontent.com/25158820/174340939-a5043086-1ddf-40c0-aa60-88a6be58b145.mov

After:

https://user-images.githubusercontent.com/25158820/174340957-81ef1e3a-2108-4b98-9bc8-2a3e56dfb7a9.mov


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
