### PR TITLE
feat: auto-collapse sidebar for window width < lg

### DIFF
--- a/packages/app/cypress/e2e/settings.cy.ts
+++ b/packages/app/cypress/e2e/settings.cy.ts
@@ -1,5 +1,7 @@
 import type { SinonStub } from 'sinon'
 
+const SidebarSettingsLinkSelector = '[data-cy="sidebar-link-settings-page"]'
+
 describe('App: Settings', () => {
   before(() => {
     cy.scaffoldProject('todos', { timeout: 50 * 1000 })
@@ -12,7 +14,7 @@ describe('App: Settings', () => {
   it('visits settings page', () => {
     cy.startAppServer('e2e')
     cy.visitApp()
-    cy.findByText('Settings').click()
+    cy.get(SidebarSettingsLinkSelector).click()
 
     cy.get('div[data-cy="app-header-bar"]').should('contain', 'Settings')
     cy.findByText('Device Settings').should('be.visible')
@@ -22,7 +24,7 @@ describe('App: Settings', () => {
   it('shows a button to log in if user is not connected', () => {
     cy.startAppServer('e2e')
     cy.visitApp()
-    cy.findByText('Settings').click()
+    cy.get(SidebarSettingsLinkSelector).click()
     cy.findByText('Project Settings').click()
     cy.get('button').contains('Log In')
   })
@@ -35,7 +37,7 @@ describe('App: Settings', () => {
 
       cy.startAppServer('e2e')
       cy.visitApp()
-      cy.findByText('Settings').click()
+      cy.get(SidebarSettingsLinkSelector).click()
       cy.findByText('Dashboard Settings').click()
       cy.findByText('Project ID').should('be.visible')
       cy.get('[data-cy="code-box"]').should('contain', 'fromCli')
@@ -51,7 +53,7 @@ describe('App: Settings', () => {
       cy.loginUser()
 
       cy.visitApp()
-      cy.findByText('Settings').click()
+      cy.get(SidebarSettingsLinkSelector).click()
       cy.findByText('Dashboard Settings').click()
       cy.findByText('Record Key').should('be.visible')
     })
@@ -61,7 +63,7 @@ describe('App: Settings', () => {
       cy.loginUser()
 
       cy.visitApp()
-      cy.findByText('Settings').click()
+      cy.get(SidebarSettingsLinkSelector).click()
       cy.findByText('Dashboard Settings').click()
       cy.get('[data-cy="code-box"]').should('contain', '***')
       cy.get('[aria-label="Record Key Visibility Toggle"]').click()
@@ -99,7 +101,7 @@ describe('App: Settings', () => {
       cy.waitForSpecToFinish()
       // Wait for the test to pass, so the test is completed
       cy.get('.passed > .num').should('contain', 1)
-      cy.findByTestId('sidebar-link-settings-page').click()
+      cy.get(SidebarSettingsLinkSelector).click()
       cy.contains('Dashboard Settings').click()
       // Assert the data is not there before it arrives
       cy.contains('Record Key').should('not.exist')
@@ -139,7 +141,7 @@ describe('App: Settings', () => {
       cy.loginUser()
 
       cy.visitApp()
-      cy.findByText('Settings').click()
+      cy.findByTestId('sidebar-link-settings-page').click()
       cy.findByText('Project Settings').click()
       cy.get('[data-cy="file-match-indicator"]').contains('2 Matches')
       cy.get('[data-cy="spec-pattern"]').contains('**/*.cy.{js,jsx,ts,tsx}')
@@ -157,7 +159,7 @@ describe('App: Settings', () => {
       cy.loginUser()
 
       cy.visitApp()
-      cy.findByText('Settings').click()
+      cy.get(SidebarSettingsLinkSelector).click()
       cy.findByText('Project Settings').click()
       cy.get('[data-cy="file-match-indicator"]').contains('41 Matches')
       cy.get('[data-cy="spec-pattern"]').contains('tests/**/*')
@@ -168,7 +170,7 @@ describe('App: Settings', () => {
       cy.loginUser()
 
       cy.visitApp()
-      cy.findByText('Settings').click()
+      cy.get(SidebarSettingsLinkSelector).click()
       cy.findByText('Project Settings').click()
       cy.get('[data-cy="settings-experiments"]').within(() => {
         cy.validateExternalLink({
@@ -231,7 +233,7 @@ describe('App: Settings', () => {
       cy.loginUser()
 
       cy.visitApp()
-      cy.findByText('Settings').click()
+      cy.get(SidebarSettingsLinkSelector).click()
       cy.findByText('Project Settings').click()
       cy.get('[data-cy="config-code"]').contains('{')
     })
@@ -241,7 +243,7 @@ describe('App: Settings', () => {
       cy.loginUser()
 
       cy.visitApp()
-      cy.findByText('Settings').click()
+      cy.get(SidebarSettingsLinkSelector).click()
       cy.findByText('Project Settings').click()
       cy.get('[data-cy="config-legend"]').within(() => {
         cy.get('.bg-gray-50').contains('default')
@@ -284,7 +286,7 @@ describe('App: Settings', () => {
       cy.loginUser()
 
       cy.visitApp()
-      cy.findByText('Settings').click()
+      cy.get(SidebarSettingsLinkSelector).click()
       cy.findByText('Project Settings').click()
       cy.get('[data-cy="config-legend"]').within(() => {
         cy.get('.bg-gray-50').contains('default')
@@ -410,7 +412,7 @@ describe('App: Settings without cloud', () => {
     cy.startAppServer('component')
 
     cy.visitApp()
-    cy.findByText('Settings').click()
+    cy.get(SidebarSettingsLinkSelector).click()
     cy.findByText('Dashboard Settings').click()
     cy.findByText('Project ID').should('exist')
     cy.contains('button', 'Log in to the Cypress Dashboard').should('be.visible')
@@ -422,7 +424,7 @@ describe('App: Settings without cloud', () => {
     cy.startAppServer('component')
 
     cy.visitApp()
-    cy.findByText('Settings').click()
+    cy.get(SidebarSettingsLinkSelector).click()
     cy.findByText('Project Settings').click()
 
     cy.get('[data-cy=config-code]').within(() => {

--- a/packages/app/cypress/e2e/sidebar_navigation.cy.ts
+++ b/packages/app/cypress/e2e/sidebar_navigation.cy.ts
@@ -1,6 +1,6 @@
 import type { SinonStub } from 'sinon'
 
-describe('Sidebar Navigation', () => {
+describe('Sidebar Navigation', { viewportWidth: 1280 }, () => {
   context('accessibility', () => {
     beforeEach(() => {
       cy.scaffoldProject('todos')

--- a/packages/app/cypress/e2e/specs_list_e2e.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_e2e.cy.ts
@@ -29,11 +29,11 @@ describe('App: Spec List (E2E)', () => {
 
   it('shows the "Specs" navigation as highlighted in the lefthand nav bar', () => {
     cy.findByTestId('sidebar').within(() => {
-      cy.findByText('Specs').should('be.visible')
-      cy.findByText('Specs').click()
+      cy.findByTestId('sidebar-link-specs-page').should('be.visible')
+      cy.findByTestId('sidebar-link-specs-page').click()
     })
 
-    cy.get('[data-selected="true"]').contains('Specs').should('be.visible')
+    cy.findByTestId('sidebar-link-specs-page').find('[data-selected="true"]').should('be.visible')
   })
 
   it('displays the App Top Nav', () => {

--- a/packages/app/src/navigation/SidebarNavigation.cy.tsx
+++ b/packages/app/src/navigation/SidebarNavigation.cy.tsx
@@ -14,7 +14,7 @@ function mountComponent (initialNavExpandedVal = true) {
 }
 
 describe('SidebarNavigation', () => {
-  it('expands the bar when clicking the expand button', () => {
+  it('expands the bar when clicking the expand button', { viewportWidth: 1280 }, () => {
     mountComponent()
 
     cy.findByText('test-project').should('not.be.visible')
@@ -29,6 +29,32 @@ describe('SidebarNavigation', () => {
     cy.findByText('test-project').should('be.visible')
 
     cy.percySnapshot()
+  })
+
+  it('automatically collapses when viewport decreases < 1024px', () => {
+    cy.viewport(1280, 1000)
+    mountComponent()
+
+    // Collapsed by default
+    cy.findByText('test-project').should('not.be.visible')
+
+    // Expand
+    cy.findByLabelText(defaultMessages.sidebar.toggleLabel.collapsed, {
+      selector: 'button',
+    }).click()
+
+    // Verify expanded - project title should display
+    cy.findByText('test-project').should('be.visible')
+
+    // Shrink viewport, should collapse
+    cy.viewport(1000, 1000)
+
+    // Project title should not be visible anymore
+    cy.findByText('test-project').should('not.be.visible')
+    // Expand control should not be available
+    cy.findByLabelText(defaultMessages.sidebar.toggleLabel.collapsed, {
+      selector: 'button',
+    }).should('not.exist')
   })
 
   it('shows tooltips on hover', () => {

--- a/packages/app/src/navigation/SidebarNavigation.vue
+++ b/packages/app/src/navigation/SidebarNavigation.vue
@@ -103,6 +103,7 @@ import CypressLogo from '@packages/frontend-shared/src/assets/logos/cypress_s.pn
 import { useI18n } from '@cy/i18n'
 import { useRoute } from 'vue-router'
 import SidebarNavigationHeader from './SidebarNavigationHeader.vue'
+import { useWindowSize } from '@vueuse/core'
 
 const { t } = useI18n()
 
@@ -140,6 +141,8 @@ query SideBarNavigation {
 }
 `
 
+const NAV_EXPAND_MIN_SCREEN_WIDTH = 1024
+
 const query = useQuery({ query: SideBarNavigationDocument })
 
 const setPreferences = useMutation(SideBarNavigation_SetPreferencesDocument)
@@ -148,12 +151,14 @@ const bindingsOpen = ref(false)
 
 const route = useRoute()
 
-const navIsAlwaysCollapsed = computed(() => route.meta?.navBarExpandedAllowed !== false)
+const navIsAlwaysCollapsed = computed(() => width.value >= NAV_EXPAND_MIN_SCREEN_WIDTH && route.meta?.navBarExpandedAllowed !== false)
 
 const isNavBarExpanded = ref(true)
 
+const { width } = useWindowSize()
+
 watchEffect(() => {
-  if (route.meta?.navBarExpandedAllowed === false) {
+  if (width.value < NAV_EXPAND_MIN_SCREEN_WIDTH || route.meta?.navBarExpandedAllowed === false) {
     isNavBarExpanded.value = false
   } else {
     isNavBarExpanded.value = query.data?.value?.localSettings.preferences.isSideNavigationOpen ?? true
@@ -161,7 +166,7 @@ watchEffect(() => {
 })
 
 const toggleNavbarIfAllowed = () => {
-  if (route.meta?.navBarExpandedAllowed === false) {
+  if (width.value < NAV_EXPAND_MIN_SCREEN_WIDTH || route.meta?.navBarExpandedAllowed === false) {
     return
   }
 


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### User facing changelog

Automatically collapse sidebar, and keep it collapsed, when window width is narrow to better utilize screen real estate.

### Additional details

### Steps to test

1. Start with a window width >=1024px, make sure the sidebar is expanded.
2. Decrease the window width to become below 1024px, the sidebar should automatically collapse.
3. As long as window width is below 1024px, the sidebar should be collapsed with no option to be expanded.
4. Going back to a window width >=1024px should automatically expand the sidebar if it was expanded before.
5. Going back to a window width >=1024px should keep the sidebar collapsed if it was collapsed before.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
