### PR TITLE
fix: Address GQL runs data being lost after navigation

### DIFF
--- a/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
@@ -352,6 +352,26 @@ describe('ACI - Latest runs and Average duration', { viewportWidth: 1200, viewpo
         .should('have.attr', 'aria-expanded', 'true')
       })
     })
+
+    it('should retain data after app navigation', () => {
+      // ACI data should load and render to start
+      specShouldShow('accounts_list.spec.js', ['orange-400', 'gray-300', 'red-400'], 'PASSED')
+      cy.get(averageDurationSelector('accounts_list.spec.js')).contains('0:12')
+
+      // Move to Settings page and wait for render
+      cy.get('a[href="#/settings"]').click()
+      cy.location('hash').should('include', '/settings')
+      cy.findByText('Project Settings').should('be.visible')
+
+      // Move back to Specs page and wait for render
+      cy.get('a[href="#/specs"]').click()
+      cy.location('hash').should('include', '/specs')
+      cy.findByText('E2E specs').should('be.visible')
+
+      // ACI data should still be loaded and rendered
+      specShouldShow('accounts_list.spec.js', ['orange-400', 'gray-300', 'red-400'], 'PASSED')
+      cy.get(averageDurationSelector('accounts_list.spec.js')).contains('0:12')
+    })
   })
 
   context('polling indicates new data', () => {

--- a/packages/app/src/specs/LastUpdatedHeader.vue
+++ b/packages/app/src/specs/LastUpdatedHeader.vue
@@ -3,6 +3,7 @@
     placement="top"
     :is-interactive="true"
     :hide-delay="0"
+    show-group="last-updated-header"
   >
     <div
       class="cursor-default decoration-dotted underline underline-gray-300 underline-offset-4"

--- a/packages/app/src/specs/LastUpdatedHeader.vue
+++ b/packages/app/src/specs/LastUpdatedHeader.vue
@@ -2,7 +2,6 @@
   <Tooltip
     placement="top"
     :is-interactive="true"
-    :hide-delay="0"
     show-group="last-updated-header"
   >
     <div

--- a/packages/app/src/specs/RunStatusDots.vue
+++ b/packages/app/src/specs/RunStatusDots.vue
@@ -84,7 +84,8 @@ fragment RunStatusDots on RemoteFetchableCloudProjectSpecResult {
     __typename
     ... on CloudProjectSpecNotFound {
       retrievedAt
-      message
+      # We query for message even though we don't use it so GQL can discriminate these two types properly
+      message 
     }
     ... on CloudProjectSpec {
       id

--- a/packages/app/src/specs/RunStatusDots.vue
+++ b/packages/app/src/specs/RunStatusDots.vue
@@ -81,8 +81,10 @@ gql`
 fragment RunStatusDots on RemoteFetchableCloudProjectSpecResult {
   id
   data {
+    __typename
     ... on CloudProjectSpecNotFound {
       retrievedAt
+      message
     }
     ... on CloudProjectSpec {
       id

--- a/packages/app/src/specs/RunStatusDots.vue
+++ b/packages/app/src/specs/RunStatusDots.vue
@@ -85,7 +85,7 @@ fragment RunStatusDots on RemoteFetchableCloudProjectSpecResult {
     ... on CloudProjectSpecNotFound {
       retrievedAt
       # We query for message even though we don't use it so GQL can discriminate these two types properly
-      message 
+      message
     }
     ... on CloudProjectSpec {
       id

--- a/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
+++ b/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
@@ -2,7 +2,6 @@
   <Tooltip
     placement="top"
     :is-interactive="true"
-    :hide-delay="0"
     :show-group="props.headerTextKeyPath"
   >
     <div

--- a/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
+++ b/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
@@ -3,6 +3,7 @@
     placement="top"
     :is-interactive="true"
     :hide-delay="0"
+    :show-group="props.headerTextKeyPath"
   >
     <div
       class="cursor-default decoration-dotted underline underline-gray-300 underline-offset-4"


### PR DESCRIPTION
* Average Runs data persistence
Update GQL query to work around issue that caused data to not hydrate properly when moving back from the Runs page

* Tooltip behavior
Minor tooltip tweaks to improve behavior when moving rapidly between SpecList headers

### User facing changelog

### Additional details


### Steps to test
1. Load project with recorded run(s)
2. Open Specs List, observe latest runs data load
3. Navigate to the Cloud Runs page then back to Specs
4. Observe previously-loaded latest runs data is still present
	* Without this fix, latest runs appear unloaded and do not trigger re-load
5. Move mouse rapidly between Specs List headers, it should no longer be possible to have multiple header tooltips remain open

### How has the user experience changed?

### PR Tasks

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
