### PR TITLE
fix: memory leak caused by storing base64 encoded files recieved by CDP `Network.requestWillBeSent`

### DIFF
--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -202,6 +202,15 @@ export class CdpAutomation {
     // in Firefox, the hash is incorrectly included in the URL: https://bugzilla.mozilla.org/show_bug.cgi?id=1715366
     if (url.includes('#')) url = url.slice(0, url.indexOf('#'))
 
+    // Filter out "data:" urls from being cached - should fix: https://github.com/cypress-io/cypress/issues/17853
+    // Chrome sends `Network.requestWillBeSent` events with data: urls which it won't actually fetch
+    // Example data url: "data:font/woff;base64,<base64 encoded string>"
+    if (url.startsWith('data:')) {
+      debugVerbose('skipping `data:` url %s', url)
+
+      return
+    }
+
     // Firefox: https://searchfox.org/mozilla-central/rev/98a9257ca2847fad9a19631ac76199474516b31e/remote/cdp/domains/parent/Network.jsm#397
     // Firefox lacks support for urlFragment and initiator, two nice-to-haves
     const browserPreRequest: BrowserPreRequest = {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/17853

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
Fixed a memory leak caused by storing `data:` url containing base64 encoded files unnecessarily. Fixed: #17853 

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
#### Summary
There is a memory leak in the `CdpAutomation` class that causes Cypress to store data urls as requests in the `pendingBrowserPreRequests` array.

#### Background
After updating to Cypress any version higher than 8.2, my e2e suite crashes with the following error after about an hour:
```
8672:0000371000344000]  3709798 ms: Mark-sweep 1952.5 (2070.7) -> 1946.9 (2071.4) MB, 450.0 / 0.0 ms  (average mu = 0.789, current mu = 0.668) task; scavenge might not succeed
[8672:0000371000344000]  3711538 ms: Mark-sweep 1953.7 (2071.4) -> 1947.8 (2072.4) MB, 350.9 / 0.0 ms  (average mu = 0.793, current mu = 0.798) task; scavenge might not succeed

<--- JS stacktrace --->

[8672:0622/112740.931:ERROR:node_bindings.cc(143)] Fatal error in V8: Reached heap limit Allocation failed - JavaScript heap out of memory
```

While the tests run, I inspected task manager and I noticed the Cypress server process growing in size until the machine's memory is exhausted causes this issue.

#### Investigation
I started off by adding code to Cypress to have it dump it's heap memory every 90 seconds. After inspecting the heap memory in the DevTools console I discovered that Cypress is storing hundreds/thousands of copies of a font file.

![image](https://user-images.githubusercontent.com/26153156/175113864-27571b1a-d9a2-4813-a099-922420d46dae.png)

This is a font-file used by my application and it's referenced like so:

![image](https://user-images.githubusercontent.com/26153156/175114973-e5794c3b-e9e9-4e59-a3c6-b6e4336a496e.png)

I discovered in Chrome, when a CSS style sheet uses the `url()` function in the `src` field with a base64 encoded file ([a `data:` url](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)), it still trigger Chrome to "send" a network request even though it's not actually going to send one.

![image](https://user-images.githubusercontent.com/26153156/175117183-c2f0e884-0d0f-4071-8d46-b119a7935cb5.png)

Cypress subscribes to the `Network.requestWillBeSent` event in CDP. When Chrome goes to 'fetch' the base64 encoded file, it sends a `requestWillBeSent` event to Cypress which stores the url (literally a whole file) in the `pendingBrowserPreRequests` array. Every time the page is loaded a request would be sent adding to this buffer until it eventually crashes.

#### Solution
The solution I went with is very basic. Simply filtering out `data:` urls from from the `Network.requestWillBeSent` event handling logic should clear it up.

Another thought was to have logic clear out stale entries from the array, but that's a lot of work for URLs that shouldn't be stored to begin with.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
I can generate a test repo that reproduces this issue if anyone requests it.

I tested this with on version 8.2 and 10.2 and verified the issue existed on both versions. (Currently, my team is on 8.0 where this issue doesn't happen. This issue has stopped us from upgrading for a very long time).

I verified after implementing this fix on 10.2, the memory leak no longer happens and data urls are no longer stored in the `pendingBrowserPreRequests` array.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Nothing has changed!

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated? There weren't any tests for the function I modified. It seems this private function is difficult to hit due CDP being used to trigger the private function. If anyone has suggestions or examples, I'd be more than happy to add tests.
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
