### PR TITLE
fix: Sort results in findCrossOriginLogs test helper to deterministic

### DIFF
--- a/packages/driver/cypress/support/utils.js
+++ b/packages/driver/cypress/support/utils.js
@@ -80,6 +80,8 @@ export const findCrossOriginLogs = (consolePropCommand, logMap, matchingOrigin) 
     return consoleProps.Command === consolePropCommand && props.id.includes(matchingOrigin)
   })
 
+  // While we'd expect the incoming log order to be deterministic, in practice we've found it fairly
+  // flakey. Sorting here eliminates this, resulting in far more reliable tests.
   const logAttrs = matchedLogs.map((log) => log.get()).sort()
 
   return logAttrs.length === 1 ? logAttrs[0] : logAttrs

--- a/packages/driver/cypress/support/utils.js
+++ b/packages/driver/cypress/support/utils.js
@@ -80,7 +80,7 @@ export const findCrossOriginLogs = (consolePropCommand, logMap, matchingOrigin) 
     return consoleProps.Command === consolePropCommand && props.id.includes(matchingOrigin)
   })
 
-  const logAttrs = matchedLogs.map((log) => log.get())
+  const logAttrs = matchedLogs.map((log) => log.get()).sort()
 
   return logAttrs.length === 1 ? logAttrs[0] : logAttrs
 }


### PR DESCRIPTION
### User facing changelog
No user facing changes

### Additional details
Many of the driver tests are watching `'log:changed'` events, then filtering the result with `findCrossOriginLogs`. While we'd expect this to be deterministic, in practice it doesn't seem to be, resulting in very flaky tests.

This PR `sort()`s the results, and removes this source of flake.

### Steps to test

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
