### PR TITLE
fix: remove ctx.cloud.reset in tests, handle infinite loop in stale results

### DIFF
--- a/packages/app/cypress/e2e/reporter_header.cy.ts
+++ b/packages/app/cypress/e2e/reporter_header.cy.ts
@@ -24,13 +24,7 @@ describe('Reporter Header', () => {
       cy.get('[data-cy="spec-file-item"]').should('have.length', 3)
       .should('contain', 'dom-content.spec')
 
-      cy.get('body').type('f')
-
-      cy.get('input').clear()
-
-      cy.get('[data-cy="spec-file-item"]').should('have.length', '3')
-
-      cy.get('input').type('asdf', { force: true })
+      cy.get('input').clear().type('asdf', { force: true })
 
       cy.get('[data-cy="spec-file-item"]').should('have.length', 0)
     })

--- a/packages/app/cypress/e2e/runs.cy.ts
+++ b/packages/app/cypress/e2e/runs.cy.ts
@@ -107,12 +107,6 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
 
       cy.findByTestId('sidebar-link-runs-page').click()
 
-      // TODO: investigate the scenario for this test
-      cy.withCtx((ctx) => {
-        // clear cloud cache
-        ctx.cloud.reset()
-      })
-
       cy.findByText(defaultMessages.runs.connect.buttonProject).click()
       cy.get('[aria-modal="true"]').should('exist')
 
@@ -142,7 +136,7 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
       cy.visitApp()
 
       cy.remoteGraphQLIntercept(async (obj) => {
-        if ((obj.operationName === 'CheckCloudOrganizations_cloudViewerChange_cloudViewer' || obj.operationName === 'Runs_cloudViewer')) {
+        if ((obj.operationName === 'CheckCloudOrganizations_cloudViewerChange_cloudViewer' || obj.operationName === 'Runs_cloudViewer' || obj.operationName === 'SpecsPageContainer_cloudViewer')) {
           if (obj.result.data?.cloudViewer?.organizations?.nodes) {
             obj.result.data.cloudViewer.organizations.nodes = []
           }
@@ -152,12 +146,6 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
       })
 
       cy.findByTestId('sidebar-link-runs-page').click()
-
-      // TODO: investigate the scenario for this test
-      cy.withCtx((ctx) => {
-        // clear cloud cache
-        ctx.cloud.reset()
-      })
 
       cy.findByText(defaultMessages.runs.connect.buttonProject).click()
       cy.get('[aria-modal="true"]').should('exist')
@@ -609,8 +597,6 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
       let cloudData: any
 
       cy.loginUser()
-      cy.visitApp()
-
       cy.remoteGraphQLIntercept((obj) => {
         if (obj.operationName === 'Runs_currentProject_cloudProject_cloudProjectBySlug') {
           cloudData = obj.result
@@ -622,12 +608,9 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
         return obj.result
       })
 
+      cy.visitApp()
+
       cy.findByTestId('sidebar-link-runs-page').click()
-      // TODO: investigate the scenario for this test
-      cy.withCtx((ctx) => {
-        // clear cloud cache
-        ctx.cloud.reset()
-      })
 
       cy.contains('h2', 'Cannot connect to the Cypress Dashboard')
       cy.percySnapshot()

--- a/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
@@ -128,20 +128,8 @@ describe('ACI - Latest runs and Average duration', { viewportWidth: 1200, viewpo
     cy.openProject('cypress-in-cypress')
     cy.startAppServer()
 
-    cy.withCtx((ctx) => {
-      // clear cloud cache
-      ctx.cloud.reset()
-    })
-
     cy.withCtx((ctx, o) => {
       o.sinon.stub(ctx.lifecycleManager.git!, 'currentBranch').value('fakeBranch')
-    })
-  })
-
-  afterEach(() => {
-    cy.withCtx((ctx) => {
-      // clear cloud cache
-      ctx.cloud.reset()
     })
   })
 
@@ -596,11 +584,6 @@ describe('ACI - Latest runs and Average duration', { viewportWidth: 1200 }, () =
       cy.openProject('cypress-in-cypress')
       cy.startAppServer()
 
-      cy.withCtx((ctx) => {
-        // clear cloud cache
-        ctx.cloud.reset()
-      })
-
       cy.loginUser()
 
       simulateRunData()
@@ -610,13 +593,6 @@ describe('ACI - Latest runs and Average duration', { viewportWidth: 1200 }, () =
 
       // after navigating to a new page, the browser needs to go offline again
       cy.goOffline()
-    })
-
-    afterEach(() => {
-      cy.withCtx((ctx) => {
-        // clear cloud cache
-        ctx.cloud.reset()
-      })
     })
 
     it('shows placeholders for all visible specs', () => {

--- a/packages/app/cypress/e2e/subscriptions/createCloudOrgModal-subscription.cy.ts
+++ b/packages/app/cypress/e2e/subscriptions/createCloudOrgModal-subscription.cy.ts
@@ -15,11 +15,10 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
       cy.startAppServer('component')
 
       cy.loginUser()
-      cy.visitApp()
 
       // Simulate no orgs
       cy.remoteGraphQLIntercept(async (obj) => {
-        if ((obj.operationName === 'CheckCloudOrganizations_cloudViewerChange_cloudViewer' || obj.operationName === 'Runs_cloudViewer')) {
+        if ((obj.operationName === 'CheckCloudOrganizations_cloudViewerChange_cloudViewer' || obj.operationName === 'Runs_cloudViewer' || obj.operationName === 'SpecsPageContainer_cloudViewer')) {
           if (obj.result.data?.cloudViewer?.organizations?.nodes) {
             obj.result.data.cloudViewer.organizations.nodes = []
           }
@@ -28,13 +27,9 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
         return obj.result
       })
 
-      cy.findByTestId('sidebar-link-runs-page').click()
+      cy.visitApp()
 
-      // TODO: investigate the scenario for this test
-      cy.withCtx((ctx) => {
-        // clear cloud cache
-        ctx.cloud.reset()
-      })
+      cy.findByTestId('sidebar-link-runs-page').click()
 
       cy.findByText(defaultMessages.runs.connect.buttonProject).click()
       cy.get('[aria-modal="true"]').should('exist')

--- a/packages/app/cypress/e2e/support/execute-spec.ts
+++ b/packages/app/cypress/e2e/support/execute-spec.ts
@@ -9,7 +9,7 @@ declare global {
        * 3. Waits (with a timeout of 30s) for the Rerun all tests button to be present. This ensures all tests have completed
        *
        */
-      waitForSpecToFinish()
+      waitForSpecToFinish(): void
     }
   }
 }

--- a/packages/app/src/runs/RunsError.spec.tsx
+++ b/packages/app/src/runs/RunsError.spec.tsx
@@ -6,17 +6,19 @@ describe('<RunsError />', () => {
     cy.mount({
       name: 'RunsError',
       render () {
-        return (<div class="h-screen">
-          <RunsError
-            message="Cannot connect to the Cypress Dashboard"
-            icon="error"
-            buttonText="Request Access"
-            buttonIcon={PaperAirplaneIcon}
-          >
-          The request timed out when trying to retrieve the recorded runs from the Cypress Dashboard. <br/>
-          Please refresh the page to try again and visit our Status Page if this behavior continues.
-          </RunsError>
-        </div>)
+        return (
+          <div class="h-screen">
+            <RunsError
+              message="Cannot connect to the Cypress Dashboard"
+              icon="error"
+              buttonText="Request Access"
+              buttonIcon={PaperAirplaneIcon}
+            >
+            The request timed out when trying to retrieve the recorded runs from the Cypress Dashboard. <br/>
+            Please refresh the page to try again and visit our Status Page if this behavior continues.
+            </RunsError>
+          </div>
+        )
       },
     })
   })

--- a/packages/data-context/src/DataContext.ts
+++ b/packages/data-context/src/DataContext.ts
@@ -230,6 +230,7 @@ export class DataContext {
       fetch: (...args) => this.util.fetch(...args),
       getUser: () => this.user,
       logout: () => this.actions.auth.logout().catch(this.logTraceError),
+      invalidateClientUrqlCache: () => this.graphql.invalidateClientUrqlCache(this),
     })
   }
 

--- a/packages/data-context/src/actions/AuthActions.ts
+++ b/packages/data-context/src/actions/AuthActions.ts
@@ -35,6 +35,7 @@ export class AuthActions {
   async checkAuth () {
     const operation = `query Cypress_CheckAuth { cloudViewer { id email fullName } }`
     const result = await this.ctx.cloud.executeRemoteGraphQL({
+      fieldName: 'cloudViewer',
       operationType: 'query',
       operation,
       operationDoc: parse(operation),

--- a/packages/data-context/src/actions/AuthActions.ts
+++ b/packages/data-context/src/actions/AuthActions.ts
@@ -40,9 +40,6 @@ export class AuthActions {
       operation,
       operationDoc: parse(operation),
       operationVariables: {},
-      invalidateCache: () => {
-        this.ctx.graphql.invalidateCache(this.ctx)
-      },
     })
 
     if (!result.data?.cloudViewer && !result.error?.networkError) {

--- a/packages/data-context/src/actions/AuthActions.ts
+++ b/packages/data-context/src/actions/AuthActions.ts
@@ -41,7 +41,7 @@ export class AuthActions {
       operationDoc: parse(operation),
       operationVariables: {},
       invalidateCache: () => {
-        this.ctx.cloud.invalidate({ __typename: 'Query' })
+        this.ctx.graphql.invalidateCache(this.ctx)
       },
     })
 

--- a/packages/data-context/src/actions/AuthActions.ts
+++ b/packages/data-context/src/actions/AuthActions.ts
@@ -40,6 +40,9 @@ export class AuthActions {
       operation,
       operationDoc: parse(operation),
       operationVariables: {},
+      invalidateCache: () => {
+        this.ctx.cloud.invalidate({ __typename: 'Query' })
+      },
     })
 
     if (!result.data?.cloudViewer && !result.error?.networkError) {

--- a/packages/data-context/src/actions/DataEmitterActions.ts
+++ b/packages/data-context/src/actions/DataEmitterActions.ts
@@ -8,6 +8,7 @@ export interface PushFragmentData {
   target: string
   fragment: string
   variables?: any
+  invalidateCache?: boolean
 }
 
 abstract class DataEmitterEvents {

--- a/packages/data-context/src/sources/CloudDataSource.ts
+++ b/packages/data-context/src/sources/CloudDataSource.ts
@@ -52,12 +52,6 @@ export interface CloudExecuteRemote extends CloudExecuteQuery {
   operationType?: OperationTypeNode
   requestPolicy?: RequestPolicy
   onUpdatedResult?: (data: any) => any
-  /**
-   * Triggered when we have an initial stale response that is not fulfilled
-   * by an additional fetch to the server. This means we've gotten into a bad state
-   * and we need to clear both the server & client side cache
-   */
-  invalidateCache: () => any
 }
 
 export interface CloudExecuteDelegateFieldParams<F extends CloudQueryField> {
@@ -71,6 +65,12 @@ export interface CloudDataSourceParams {
   fetch: typeof fetch
   getUser(): AuthenticatedUserShape | null
   logout(): void
+  /**
+   * Triggered when we have an initial stale response that is not fulfilled
+   * by an additional fetch to the server. This means we've gotten into a bad state
+   * and we need to clear both the server & client side cache
+   */
+  invalidateClientUrqlCache(): void
 }
 
 /**
@@ -217,9 +217,9 @@ export class CloudDataSource {
       if (initialResult) {
         const eagerResult = this.readFromCache(config)
 
-        if (eagerResult && eagerResult.stale) {
+        if (eagerResult?.stale) {
           await this.invalidate({ __typename: 'Query' })
-          config.invalidateCache()
+          this.params.invalidateClientUrqlCache()
 
           return op
         }

--- a/packages/data-context/src/sources/CloudDataSource.ts
+++ b/packages/data-context/src/sources/CloudDataSource.ts
@@ -48,9 +48,16 @@ export interface CloudExecuteQuery {
 }
 
 export interface CloudExecuteRemote extends CloudExecuteQuery {
+  fieldName: string
   operationType?: OperationTypeNode
   requestPolicy?: RequestPolicy
   onUpdatedResult?: (data: any) => any
+  /**
+   * Triggered when we have an initial stale response that is not fulfilled
+   * by an additional fetch to the server. This means we've gotten into a bad state
+   * and we need to clear both the server & client side cache
+   */
+  invalidateCache: () => any
 }
 
 export interface CloudExecuteDelegateFieldParams<F extends CloudQueryField> {
@@ -147,10 +154,6 @@ export class CloudDataSource {
     })
   }
 
-  isLoadingRemote (config: CloudExecuteRemote) {
-    return Boolean(this.#pendingPromises.get(this.#hashRemoteRequest(config)))
-  }
-
   delegateCloudField <F extends CloudQueryField> (params: CloudExecuteDelegateFieldParams<F>) {
     return delegateToSchema({
       operation: 'query',
@@ -193,6 +196,7 @@ export class CloudDataSource {
       errors: data.error?.graphQLErrors,
     }
   }
+
   #maybeQueueDeferredExecute (config: CloudExecuteRemote, initialResult?: OperationResult) {
     const stableKey = this.#hashRemoteRequest(config)
 
@@ -203,8 +207,23 @@ export class CloudDataSource {
     }
 
     loading = this.#cloudUrqlClient.query(config.operationDoc, config.operationVariables, { requestPolicy: 'network-only' }).toPromise().then(this.#formatWithErrors)
-    .then((op) => {
+    .then(async (op) => {
       this.#pendingPromises.delete(stableKey)
+
+      // If we have an initial result, by this point we expect that the query should be fully resolved in the cache.
+      // If it's not, it means that we need to clear the cache on the client/server, otherwise it's going to fall into
+      // an infinite loop trying to resolve the stale data. This likely only happens in contrived test cases, but
+      // it's good to handle regardless.
+      if (initialResult) {
+        const eagerResult = this.readFromCache(config)
+
+        if (eagerResult && eagerResult.stale) {
+          await this.invalidate({ __typename: 'Query' })
+          config.invalidateCache()
+
+          return op
+        }
+      }
 
       if (initialResult && !_.isEqual(op.data, initialResult.data)) {
         debug('Different Query Value %j, %j', op.data, initialResult.data)

--- a/packages/data-context/src/sources/GraphQLDataSource.ts
+++ b/packages/data-context/src/sources/GraphQLDataSource.ts
@@ -108,6 +108,16 @@ export class GraphQLDataSource {
     return Buffer.from(str, 'base64').toString('utf8')
   }
 
+  invalidateCache (ctx: DataContext) {
+    ctx.emitter.pushFragment([{
+      data: null,
+      errors: [],
+      target: 'Query',
+      fragment: '{}',
+      invalidateCache: true,
+    }])
+  }
+
   pushResult ({ source, info, ctx, result }: PushResultParams) {
     if (info.parentType.name === 'Query') {
       this.#pushFragment({ result, ctx, info })
@@ -129,6 +139,7 @@ export class GraphQLDataSource {
       parentType: params.info.parentType,
       fieldNodes: params.info.fieldNodes,
       variableDefinitions: params.info.operation.variableDefinitions,
+      operationName: params.info.operation.name?.value ?? params.info.fieldNodes.map((n) => n.name.value).sort().join('_'),
     })
 
     Promise.resolve(execute({

--- a/packages/data-context/src/sources/GraphQLDataSource.ts
+++ b/packages/data-context/src/sources/GraphQLDataSource.ts
@@ -108,7 +108,7 @@ export class GraphQLDataSource {
     return Buffer.from(str, 'base64').toString('utf8')
   }
 
-  invalidateCache (ctx: DataContext) {
+  invalidateClientUrqlCache (ctx: DataContext) {
     ctx.emitter.pushFragment([{
       data: null,
       errors: [],

--- a/packages/data-context/src/sources/RemotePollingDataSource.ts
+++ b/packages/data-context/src/sources/RemotePollingDataSource.ts
@@ -50,6 +50,7 @@ export class RemotePollingDataSource {
 
   async #sendSpecPollingRequest (commitBranch: string, projectSlug: string) {
     const result = await this.ctx.cloud.executeRemoteGraphQL<Pick<Query, 'cloudLatestRunUpdateSpecData'>>({
+      fieldName: 'cloudLatestRunUpdateSpecData',
       operationDoc: LATEST_RUN_UPDATE_OPERATION_DOC,
       operation: LATEST_RUN_UPDATE_OPERATION,
       operationVariables: {
@@ -57,6 +58,7 @@ export class RemotePollingDataSource {
         projectSlug,
       },
       requestPolicy: 'network-only', // we never want to hit local cache for this request
+      invalidateCache: () => this.ctx.graphql.invalidateCache(this.ctx),
     })
 
     debug(`%s Response for startPollingForSpecs %o`, new Date().toISOString(), result)

--- a/packages/data-context/src/sources/RemotePollingDataSource.ts
+++ b/packages/data-context/src/sources/RemotePollingDataSource.ts
@@ -58,7 +58,6 @@ export class RemotePollingDataSource {
         projectSlug,
       },
       requestPolicy: 'network-only', // we never want to hit local cache for this request
-      invalidateCache: () => this.ctx.graphql.invalidateCache(this.ctx),
     })
 
     debug(`%s Response for startPollingForSpecs %o`, new Date().toISOString(), result)

--- a/packages/data-context/src/sources/RemoteRequestDataSource.ts
+++ b/packages/data-context/src/sources/RemoteRequestDataSource.ts
@@ -159,9 +159,6 @@ export class RemoteRequestDataSource {
       operationHash,
       operationVariables,
       requestPolicy: 'network-only',
-      invalidateCache: () => {
-        ctx.graphql.invalidateCache(ctx)
-      },
     }))
     .then((result) => {
       const toPushDefinition = this.#operationRegistryPushToFrontend.get(operationHash)

--- a/packages/data-context/src/sources/RemoteRequestDataSource.ts
+++ b/packages/data-context/src/sources/RemoteRequestDataSource.ts
@@ -150,9 +150,10 @@ export class RemoteRequestDataSource {
   }
 
   #executeRemote (params: MaybeLoadRemoteFetchable) {
-    const { ctx, operation, operationDoc, operationHash, operationVariables } = params
+    const { ctx, operation, operationDoc, operationHash, operationVariables, remoteQueryField } = params
 
     Promise.resolve(ctx.cloud.executeRemoteGraphQL({
+      fieldName: remoteQueryField,
       operation,
       operationDoc,
       operationHash,
@@ -246,6 +247,7 @@ export class RemoteRequestDataSource {
             parentType: info.schema.getType(fieldType) as GraphQLObjectType,
             fieldNodes: info.fieldNodes[0]?.selectionSet?.selections.filter((f) => f.kind === 'Field' && FIELDS_TO_PUSH.includes(f.name.value)) as FieldNode[],
             variableDefinitions: info.operation.variableDefinitions,
+            operationName: info.operation.name?.value ?? info.fieldNodes.map((n) => n.name.value).sort().join('_'),
           })
 
           this.#operationRegistry.set(operationDef.operationHash, operationDef)

--- a/packages/data-context/src/sources/RemoteRequestDataSource.ts
+++ b/packages/data-context/src/sources/RemoteRequestDataSource.ts
@@ -160,7 +160,7 @@ export class RemoteRequestDataSource {
       operationVariables,
       requestPolicy: 'network-only',
       invalidateCache: () => {
-        ctx.cloud.invalidate({ __typename: 'Query' })
+        ctx.graphql.invalidateCache(ctx)
       },
     }))
     .then((result) => {

--- a/packages/data-context/src/sources/RemoteRequestDataSource.ts
+++ b/packages/data-context/src/sources/RemoteRequestDataSource.ts
@@ -159,6 +159,9 @@ export class RemoteRequestDataSource {
       operationHash,
       operationVariables,
       requestPolicy: 'network-only',
+      invalidateCache: () => {
+        ctx.cloud.invalidate({ __typename: 'Query' })
+      },
     }))
     .then((result) => {
       const toPushDefinition = this.#operationRegistryPushToFrontend.get(operationHash)

--- a/packages/data-context/src/util/DocumentNodeBuilder.ts
+++ b/packages/data-context/src/util/DocumentNodeBuilder.ts
@@ -5,7 +5,7 @@ export interface RemoteQueryConfig {
   variableDefinitions: VariableDefinitionNode[]
 }
 
-export type DocumentNodeBuilderParams = Pick<GraphQLResolveInfo, 'fieldNodes' | 'parentType'> & {isNode?: boolean, isRemoteFetchable?: boolean, variableDefinitions: readonly VariableDefinitionNode[] | undefined}
+export type DocumentNodeBuilderParams = Pick<GraphQLResolveInfo, 'fieldNodes' | 'parentType'> & {isNode?: boolean, isRemoteFetchable?: boolean, variableDefinitions: readonly VariableDefinitionNode[] | undefined, operationName: string}
 
 /**
  * Builds a DocumentNode from a given GraphQLResolveInfo payload
@@ -109,6 +109,10 @@ export class DocumentNodeBuilder {
         {
           kind: 'OperationDefinition',
           operation: 'query',
+          name: {
+            kind: 'Name',
+            value: this.info.operationName,
+          },
           selectionSet: {
             kind: 'SelectionSet',
             selections: [
@@ -132,6 +136,10 @@ export class DocumentNodeBuilder {
         {
           kind: 'OperationDefinition',
           operation: 'query',
+          name: {
+            kind: 'Name',
+            value: this.info.operationName,
+          },
           selectionSet: {
             kind: 'SelectionSet',
             selections: [

--- a/packages/data-context/test/unit/sources/CloudDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/CloudDataSource.spec.ts
@@ -27,7 +27,7 @@ describe('CloudDataSource', () => {
   let fetchStub: sinon.SinonStub
   let getUserStub: sinon.SinonStub
   let logoutStub: sinon.SinonStub
-  let invalidateCache: sinon.SinonStub
+  let invalidateCacheStub: sinon.SinonStub
   let ctx: DataContext
 
   beforeEach(() => {
@@ -37,12 +37,13 @@ describe('CloudDataSource', () => {
     getUserStub = sinon.stub()
     getUserStub.returns({ authToken: '1234' })
     logoutStub = sinon.stub()
-    invalidateCache = sinon.stub()
+    invalidateCacheStub = sinon.stub()
     ctx = createTestDataContext('open')
     cloudDataSource = new CloudDataSource({
       fetch: fetchStub,
       getUser: getUserStub,
       logout: logoutStub,
+      invalidateClientUrqlCache: invalidateCacheStub,
     })
   })
 
@@ -59,7 +60,6 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
-        invalidateCache,
       })
 
       expect(result).to.eql({ data: null })
@@ -73,7 +73,6 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
-        invalidateCache,
       })
 
       const resolved = await result
@@ -88,7 +87,6 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
-        invalidateCache,
       })
       const result2 = cloudDataSource.executeRemoteGraphQL({
         fieldName: 'cloudViewer',
@@ -96,7 +94,6 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
-        invalidateCache,
       })
 
       expect(result1).to.eq(result2)
@@ -114,7 +111,6 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
-        invalidateCache,
       })
 
       await result
@@ -125,7 +121,6 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
-        invalidateCache,
       })
 
       expect((immediateResult as ExecutionResult).data).to.eql(FAKE_USER_RESPONSE.data)
@@ -139,7 +134,6 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
-        invalidateCache,
       })
 
       await result
@@ -152,7 +146,6 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_WITH_OPTIONAL_MISSING,
         operationVariables: {},
         operationType: 'query',
-        invalidateCache,
       })
 
       expect((immediateResult as CloudDataResponse).data).to.eql(FAKE_USER_WITH_OPTIONAL_MISSING_RESPONSE.data)
@@ -172,7 +165,6 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
-        invalidateCache,
       })
 
       await result
@@ -185,7 +177,6 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_WITH_REQUIRED_MISSING,
         operationVariables: {},
         operationType: 'query',
-        invalidateCache,
       })
 
       expect(requiredResult).to.be.instanceOf(Promise)
@@ -204,7 +195,6 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
-        invalidateCache,
       })
 
       const resolved = await result
@@ -223,7 +213,6 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
-        invalidateCache,
       })
 
       const resolved = await result
@@ -254,7 +243,6 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
-        invalidateCache,
       })
 
       const result = cloudDataSource.isResolving({
@@ -285,7 +273,6 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
-        invalidateCache,
       })
 
       const result = cloudDataSource.hasResolved({
@@ -306,7 +293,6 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
-        invalidateCache,
       })
 
       expect(cloudDataSource.hasResolved({

--- a/packages/data-context/test/unit/sources/CloudDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/CloudDataSource.spec.ts
@@ -52,6 +52,7 @@ describe('CloudDataSource', () => {
     it('returns immediately with { data: null } when no user is defined', () => {
       getUserStub.returns(null)
       const result = cloudDataSource.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
         operation: print(FAKE_USER_QUERY),
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
@@ -64,6 +65,7 @@ describe('CloudDataSource', () => {
 
     it('issues a fetch request for the data when the user is defined', async () => {
       const result = cloudDataSource.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
         operation: print(FAKE_USER_QUERY),
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
@@ -77,12 +79,14 @@ describe('CloudDataSource', () => {
 
     it('only issues a single fetch if the operation is called twice', async () => {
       const result1 = cloudDataSource.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
         operation: print(FAKE_USER_QUERY),
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
       })
       const result2 = cloudDataSource.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
         operation: print(FAKE_USER_QUERY),
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
@@ -99,6 +103,7 @@ describe('CloudDataSource', () => {
 
     it('resolves eagerly with the cached data if the data has already been resolved', async () => {
       const result = cloudDataSource.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
         operation: print(FAKE_USER_QUERY),
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
@@ -108,6 +113,7 @@ describe('CloudDataSource', () => {
       await result
 
       const immediateResult = cloudDataSource.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
         operation: print(FAKE_USER_QUERY),
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
@@ -120,6 +126,7 @@ describe('CloudDataSource', () => {
 
     it('when there is a nullable field missing, resolves with the eager result & fetches for the rest', async () => {
       const result = cloudDataSource.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
         operation: print(FAKE_USER_QUERY),
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
@@ -131,6 +138,7 @@ describe('CloudDataSource', () => {
       fetchStub.resolves(new Response(JSON.stringify(FAKE_USER_WITH_OPTIONAL_RESOLVED_RESPONSE), { status: 200 }))
 
       const immediateResult = cloudDataSource.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
         operation: print(FAKE_USER_WITH_OPTIONAL_MISSING),
         operationDoc: FAKE_USER_WITH_OPTIONAL_MISSING,
         operationVariables: {},
@@ -149,6 +157,7 @@ describe('CloudDataSource', () => {
 
     it('when there is a non-nullable field missing, issues the remote query immediately', async () => {
       const result = cloudDataSource.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
         operation: print(FAKE_USER_QUERY),
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
@@ -160,6 +169,7 @@ describe('CloudDataSource', () => {
       fetchStub.resolves(new Response(JSON.stringify(FAKE_USER_WITH_REQUIRED_RESOLVED_RESPONSE), { status: 200 }))
 
       const requiredResult = cloudDataSource.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
         operation: print(FAKE_USER_WITH_REQUIRED_MISSING),
         operationDoc: FAKE_USER_WITH_REQUIRED_MISSING,
         operationVariables: {},
@@ -177,6 +187,7 @@ describe('CloudDataSource', () => {
       fetchStub.resolves(new Response(JSON.stringify(new Error('Unauthorized')), { status: 200 }))
 
       const result = cloudDataSource.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
         operation: print(FAKE_USER_QUERY),
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
@@ -194,6 +205,7 @@ describe('CloudDataSource', () => {
       fetchStub.resolves(new Response(JSON.stringify(new Error('Unauthorized')), { status: 401 }))
 
       const result = cloudDataSource.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
         operation: print(FAKE_USER_QUERY),
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
@@ -223,6 +235,7 @@ describe('CloudDataSource', () => {
 
     it('returns true if we are currently resolving the request', () => {
       cloudDataSource.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
         operation: print(FAKE_USER_QUERY),
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
@@ -252,6 +265,7 @@ describe('CloudDataSource', () => {
 
     it('returns true if we have resolved the data for the query', async () => {
       await cloudDataSource.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
         operation: print(FAKE_USER_QUERY),
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
@@ -271,6 +285,7 @@ describe('CloudDataSource', () => {
   describe('invalidate', () => {
     it('allows us to issue a cache.invalidate on individual fields in the cloud schema', async () => {
       await cloudDataSource.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
         operation: print(FAKE_USER_QUERY),
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},

--- a/packages/data-context/test/unit/sources/CloudDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/CloudDataSource.spec.ts
@@ -27,6 +27,7 @@ describe('CloudDataSource', () => {
   let fetchStub: sinon.SinonStub
   let getUserStub: sinon.SinonStub
   let logoutStub: sinon.SinonStub
+  let invalidateCache: sinon.SinonStub
   let ctx: DataContext
 
   beforeEach(() => {
@@ -36,6 +37,7 @@ describe('CloudDataSource', () => {
     getUserStub = sinon.stub()
     getUserStub.returns({ authToken: '1234' })
     logoutStub = sinon.stub()
+    invalidateCache = sinon.stub()
     ctx = createTestDataContext('open')
     cloudDataSource = new CloudDataSource({
       fetch: fetchStub,
@@ -57,6 +59,7 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
+        invalidateCache,
       })
 
       expect(result).to.eql({ data: null })
@@ -70,6 +73,7 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
+        invalidateCache,
       })
 
       const resolved = await result
@@ -84,6 +88,7 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
+        invalidateCache,
       })
       const result2 = cloudDataSource.executeRemoteGraphQL({
         fieldName: 'cloudViewer',
@@ -91,6 +96,7 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
+        invalidateCache,
       })
 
       expect(result1).to.eq(result2)
@@ -108,6 +114,7 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
+        invalidateCache,
       })
 
       await result
@@ -118,6 +125,7 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
+        invalidateCache,
       })
 
       expect((immediateResult as ExecutionResult).data).to.eql(FAKE_USER_RESPONSE.data)
@@ -131,6 +139,7 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
+        invalidateCache,
       })
 
       await result
@@ -143,6 +152,7 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_WITH_OPTIONAL_MISSING,
         operationVariables: {},
         operationType: 'query',
+        invalidateCache,
       })
 
       expect((immediateResult as CloudDataResponse).data).to.eql(FAKE_USER_WITH_OPTIONAL_MISSING_RESPONSE.data)
@@ -162,6 +172,7 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
+        invalidateCache,
       })
 
       await result
@@ -174,6 +185,7 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_WITH_REQUIRED_MISSING,
         operationVariables: {},
         operationType: 'query',
+        invalidateCache,
       })
 
       expect(requiredResult).to.be.instanceOf(Promise)
@@ -192,6 +204,7 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
+        invalidateCache,
       })
 
       const resolved = await result
@@ -210,6 +223,7 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
+        invalidateCache,
       })
 
       const resolved = await result
@@ -240,6 +254,7 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
+        invalidateCache,
       })
 
       const result = cloudDataSource.isResolving({
@@ -270,6 +285,7 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
+        invalidateCache,
       })
 
       const result = cloudDataSource.hasResolved({
@@ -290,6 +306,7 @@ describe('CloudDataSource', () => {
         operationDoc: FAKE_USER_QUERY,
         operationVariables: {},
         operationType: 'query',
+        invalidateCache,
       })
 
       expect(cloudDataSource.hasResolved({

--- a/packages/data-context/test/unit/util/DocumentNodeBuilder.spec.ts
+++ b/packages/data-context/test/unit/util/DocumentNodeBuilder.spec.ts
@@ -36,8 +36,9 @@ describe('DocumentNodeBuilder', () => {
   it('frag: should generate a fragment', () => {
     const docNodeBuilder = new DocumentNodeBuilder({
       fieldNodes: ((CLOUD_VIEWER_QUERY.definitions[0] as OperationDefinitionNode).selectionSet.selections as ReadonlyArray<FieldNode>),
-      parentType: graphqlSchema.getQueryType(),
+      parentType: graphqlSchema.getQueryType()!,
       variableDefinitions: [],
+      operationName: 'CLOUD_VIEWER_QUERY',
     })
 
     expect(print(docNodeBuilder.frag)).to.eql(dedent`
@@ -54,8 +55,9 @@ describe('DocumentNodeBuilder', () => {
   it('query: should create a query + fragment', () => {
     const docNodeBuilder = new DocumentNodeBuilder({
       fieldNodes: ((CLOUD_VIEWER_QUERY.definitions[0] as OperationDefinitionNode).selectionSet.selections as ReadonlyArray<FieldNode>),
-      parentType: graphqlSchema.getQueryType(),
+      parentType: graphqlSchema.getQueryType()!,
       variableDefinitions: [],
+      operationName: 'CLOUD_VIEWER_QUERY',
     })
 
     expect(print(docNodeBuilder.query).trimEnd()).to.eql(dedent`
@@ -78,9 +80,10 @@ describe('DocumentNodeBuilder', () => {
 
     const docNodeBuilder = new DocumentNodeBuilder({
       isNode: true,
-      fieldNodes: (selections[0].selectionSet.selections) as ReadonlyArray<FieldNode>,
+      fieldNodes: (selections[0].selectionSet!.selections) as ReadonlyArray<FieldNode>,
       parentType: graphqlSchema.getType('CloudProject') as GraphQLObjectType,
       variableDefinitions: [],
+      operationName: 'CLOUD_PROJECT_QUERY',
     })
 
     expect(print(docNodeBuilder.queryNode).trimRight()).to.eql(dedent`

--- a/packages/data-context/test/unit/util/DocumentNodeBuilder.spec.ts
+++ b/packages/data-context/test/unit/util/DocumentNodeBuilder.spec.ts
@@ -69,7 +69,7 @@ describe('DocumentNodeBuilder', () => {
         }
       }
 
-      {
+      query CLOUD_VIEWER_QUERY {
         ...GeneratedFragment
       }
     `)
@@ -101,7 +101,7 @@ describe('DocumentNodeBuilder', () => {
         }
       }
 
-      {
+      query CLOUD_PROJECT_QUERY {
         node(id: "PUSH_FRAGMENT_PLACEHOLDER") {
           __typename
           id

--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -215,7 +215,7 @@ async function makeE2ETasks () {
 
           if (remoteGraphQLIntercept) {
             try {
-              result = await remoteGraphQLIntercept({
+              result = await Promise.resolve(remoteGraphQLIntercept({
                 operationName,
                 variables,
                 document,
@@ -223,7 +223,7 @@ async function makeE2ETasks () {
                 result,
                 callCount: operationCount[operationName ?? 'unknown'],
                 Response,
-              }, testState)
+              }, testState))
             } catch (e) {
               const err = e as Error
 

--- a/packages/frontend-shared/src/graphql/urqlGlobalSubscriptions.ts
+++ b/packages/frontend-shared/src/graphql/urqlGlobalSubscriptions.ts
@@ -10,6 +10,7 @@ gql`
      data
      errors
      variables
+     invalidateCache
    }
  }
 `

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -1348,10 +1348,18 @@ type ProjectPreferences {
 }
 
 type PushFragmentPayload {
+  """Raw data associated with the fragment to be written into the cache"""
   data: JSON
+
+  """Any errors encountered when executing the operation"""
   errors: JSON
   fragment: JSON!
+
+  """If present, indicates we need to invalidate the client-side cache"""
+  invalidateCache: Boolean
   target: String!
+
+  """Variables associated with the fragment"""
   variables: JSON
 }
 
@@ -1656,7 +1664,7 @@ type Subscription {
   """
   When we have resolved a section of a query, and want to update the local normalized cache, we "push" the fragment to the frontend to merge in the client side cache
   """
-  pushFragment: [PushFragmentPayload]
+  pushFragment: [PushFragmentPayload!]!
 
   """Issued when the watched specs for the project changes"""
   specsChange: CurrentProject

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Subscription.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Subscription.ts
@@ -85,18 +85,30 @@ export const Subscription = subscriptionType({
       resolve: (source, args, ctx) => ctx.lifecycleManager,
     })
 
-    t.field('pushFragment', {
+    t.nonNull.field('pushFragment', {
       description: 'When we have resolved a section of a query, and want to update the local normalized cache, we "push" the fragment to the frontend to merge in the client side cache',
-      type: list(objectType({
+      type: list(nonNull(objectType({
         name: 'PushFragmentPayload',
         definition (t) {
           t.nonNull.string('target')
           t.nonNull.json('fragment')
-          t.json('data')
-          t.json('variables')
-          t.json('errors')
+          t.json('data', {
+            description: 'Raw data associated with the fragment to be written into the cache',
+          })
+
+          t.json('variables', {
+            description: 'Variables associated with the fragment',
+          })
+
+          t.json('errors', {
+            description: 'Any errors encountered when executing the operation',
+          })
+
+          t.boolean('invalidateCache', {
+            description: 'If present, indicates we need to invalidate the client-side cache',
+          })
         },
-      })),
+      }))),
       subscribe: (source, args, ctx) => ctx.emitter.subscribeTo('pushFragment', { sendInitial: false }),
       resolve: (source: PushFragmentData[], args, ctx) => source,
     })

--- a/packages/graphql/src/stitching/remoteSchemaWrapped.ts
+++ b/packages/graphql/src/stitching/remoteSchemaWrapped.ts
@@ -56,7 +56,10 @@ export const remoteSchemaWrapped = wrapSchema<DataContext>({
       },
     })
 
-    return obj.context.cloud.executeRemoteGraphQL({
+    const context = obj.context
+
+    return context.cloud.executeRemoteGraphQL({
+      fieldName: info.fieldName,
       requestPolicy,
       operationType: obj.operationType ?? 'query',
       operation: print(operationDoc),
@@ -65,12 +68,15 @@ export const remoteSchemaWrapped = wrapSchema<DataContext>({
       // When we respond eagerly with a result, but receive an updated value
       // for the query, we can "push" the data down using the pushFragment subscription
       onUpdatedResult (result) {
-        obj.context?.graphql.pushResult({
+        context.graphql.pushResult({
           result: result?.[info.fieldName] ?? null,
           source: obj.rootValue,
           info,
-          ctx: obj.context,
+          ctx: context,
         })
+      },
+      invalidateCache () {
+        context.graphql.invalidateCache(context)
       },
     }) as any
   },

--- a/packages/graphql/src/stitching/remoteSchemaWrapped.ts
+++ b/packages/graphql/src/stitching/remoteSchemaWrapped.ts
@@ -75,9 +75,6 @@ export const remoteSchemaWrapped = wrapSchema<DataContext>({
           ctx: context,
         })
       },
-      invalidateCache () {
-        context.graphql.invalidateCache(context)
-      },
     }) as any
   },
 })

--- a/packages/server/lib/saved_state.ts
+++ b/packages/server/lib/saved_state.ts
@@ -7,6 +7,7 @@ import cwd from './cwd'
 import FileUtil from './util/file'
 import { fs } from './util/fs'
 import { AllowedState, allowedKeys } from '@packages/types'
+import { globalPubSub } from '@packages/data-context'
 
 const debug = Debug('cypress:server:saved_state')
 
@@ -113,6 +114,10 @@ export const create = (projectRoot?: string, isTextTerminal: boolean = false): B
     debug('making new state file around %s', fullStatePath)
     const stateFile = new FileUtil({
       path: fullStatePath,
+    })
+
+    globalPubSub.on('test:cleanup', () => {
+      stateFile.__resetForTest()
     })
 
     stateFile.set = _.wrap(stateFile.set.bind(stateFile), normalizeAndAllowSet)


### PR DESCRIPTION
Related to #21250

### Additional details
Correctly fixes tests failing due to the introduction of the new queries on the specs page, properly handles an infinite loop that was occurring when an incomplete response was sent back for a `stale` fetch result. This would cause an infinite re-fetch loop while the server was looking to fulfill the stale value. Instead, now if we detect this situation we clear the urql cache in both the electron process and the client.

### Steps to test

Existing tests should be passing with only minor, expected modifications

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
