### PR TITLE
fix: Increase timeout for npm-webpack-dev-server tests

### DIFF
--- a/npm/webpack-dev-server/test/.mocharc.js
+++ b/npm/webpack-dev-server/test/.mocharc.js
@@ -1,4 +1,4 @@
 module.exports = {
   spec: 'test/**/*.spec.ts',
-  timeout: 10000,
+  timeout: 15000,
 }


### PR DESCRIPTION
### User facing changelog
No user facing changes.

### Additional details
The system tests in `sourceRelativeWebpackModules.spec.ts` have been extremely flaky the past few days, to the point where it's more "consistent failure" than it is "flake".

It seems to be simply a timeout issue - the 10s we've allocated aren't enough to successfully yarn install all the dependencies for `webpack5_wds4-react` and similar system test projects.

While I'd very much like to rewrite these tests so as not to take so long, there's no quick solution here and it would probably involve changing how we install system test dependencies entirely (or mocking them out not to actually install), something beyond the scope of my efforts at the moment.

Therefore, timeout increase. Green builds are super important.

### Steps to test

### How has the user experience changed?

### PR Tasks

- [x] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
