### PR TITLE
feat: Support "Queued" latest run status

### DIFF
--- a/packages/app/src/specs/RunStatusDots.cy.tsx
+++ b/packages/app/src/specs/RunStatusDots.cy.tsx
@@ -48,7 +48,7 @@ describe('<RunStatusDots />', () => {
 
   context('runs scenario 2', () => {
     beforeEach(() => {
-      const runs = fakeRuns(['NOTESTS', 'OVERLIMIT', 'RUNNING', 'TIMEDOUT'])
+      const runs = fakeRuns(['NOTESTS', 'UNCLAIMED', 'RUNNING', 'TIMEDOUT'])
 
       mountWithRuns(runs)
     })

--- a/packages/app/src/specs/RunStatusDots.cy.tsx
+++ b/packages/app/src/specs/RunStatusDots.cy.tsx
@@ -2,29 +2,34 @@ import type { RunStatusDotsFragment } from '../generated/graphql'
 import RunStatusDots from './RunStatusDots.vue'
 import { fakeRuns } from '@packages/frontend-shared/cypress/support/mock-graphql/fakeCloudSpecRun'
 
+function mountWithGql (gql: RunStatusDotsFragment) {
+  cy.mount(() => {
+    return (
+      <div class="flex justify-center">
+        <RunStatusDots gql={gql} specFileExtension=".cy.ts" specFileName="spec"/>
+      </div>
+    )
+  })
+}
+
 describe('<RunStatusDots />', () => {
   it('mounts correctly for example scenario 1', () => {
     const runs = fakeRuns(['PASSED', 'FAILED', 'CANCELLED', 'ERRORED'])
-
-    cy.mount(() => {
-      const gql: RunStatusDotsFragment = {
+    const gql: RunStatusDotsFragment = {
+      id: 'id',
+      data: {
+        __typename: 'CloudProjectSpec',
+        retrievedAt: new Date().toISOString(),
         id: 'id',
-        data: {
-          __typename: 'CloudProjectSpec',
-          retrievedAt: new Date().toISOString(),
-          id: 'id',
-          specRuns: {
-            nodes: [
-              ...runs as any, // suppress TS compiler
-            ],
-          },
+        specRuns: {
+          nodes: [
+            ...runs as any, // suppress TS compiler
+          ],
         },
-      }
+      },
+    }
 
-      return (
-        <RunStatusDots gql={gql} specFileExtension=".cy.ts" specFileName="spec"/>
-      )
-    })
+    mountWithGql(gql)
 
     cy.findByTestId('run-status-dots').trigger('mouseenter')
     cy.get('.v-popper__popper--shown').contains('spec.cy.ts')
@@ -37,25 +42,21 @@ describe('<RunStatusDots />', () => {
   it('mounts correctly for example scenario 2', () => {
     const runs = fakeRuns(['NOTESTS', 'OVERLIMIT', 'RUNNING', 'TIMEDOUT'])
 
-    cy.mount(() => {
-      const gql: RunStatusDotsFragment = {
+    const gql: RunStatusDotsFragment = {
+      id: 'id',
+      data: {
+        __typename: 'CloudProjectSpec',
         id: 'id',
-        data: {
-          __typename: 'CloudProjectSpec',
-          id: 'id',
-          retrievedAt: new Date().toISOString(),
-          specRuns: {
-            nodes: [
-              ...runs as any, // suppress TS compiler
-            ],
-          },
+        retrievedAt: new Date().toISOString(),
+        specRuns: {
+          nodes: [
+            ...runs as any, // suppress TS compiler
+          ],
         },
-      }
+      },
+    }
 
-      return (
-        <RunStatusDots gql={gql} specFileExtension=".cy.ts" specFileName="spec"/>
-      )
-    })
+    mountWithGql(gql)
 
     cy.findByTestId('run-status-dots').trigger('mouseenter')
     cy.get('.v-popper__popper--shown').contains('spec.cy.ts')
@@ -68,25 +69,21 @@ describe('<RunStatusDots />', () => {
   it('mounts correctly for example scenario 3', () => {
     const runs = fakeRuns(['RUNNING'])
 
-    cy.mount(() => {
-      const gql: RunStatusDotsFragment = {
+    const gql: RunStatusDotsFragment = {
+      id: 'id',
+      data: {
+        __typename: 'CloudProjectSpec',
         id: 'id',
-        data: {
-          __typename: 'CloudProjectSpec',
-          id: 'id',
-          retrievedAt: new Date().toISOString(),
-          specRuns: {
-            nodes: [
-              ...runs as any, // suppress TS compiler
-            ],
-          },
+        retrievedAt: new Date().toISOString(),
+        specRuns: {
+          nodes: [
+            ...runs as any, // suppress TS compiler
+          ],
         },
-      }
+      },
+    }
 
-      return (
-        <RunStatusDots gql={gql} specFileExtension=".cy.ts" specFileName="spec"/>
-      )
-    })
+    mountWithGql(gql)
 
     cy.findByTestId('run-status-dots').trigger('mouseenter')
     cy.get('.v-popper__popper--shown').contains('spec.cy.ts')
@@ -96,24 +93,47 @@ describe('<RunStatusDots />', () => {
     cy.findAllByTestId('run-status-dot-latest').should('have.class', 'animate-spin')
   })
 
-  it('renders placeholder without tooltip or link', () => {
-    cy.mount(() => {
-      const gql: RunStatusDotsFragment = {
-        id: 'id',
-        data: {
-          __typename: 'CloudProjectSpec',
-          id: 'id',
-          retrievedAt: new Date().toISOString(),
-          specRuns: {
-            nodes: [],
-          },
-        },
-      }
+  it('handles UNCLAIMED status', () => {
+    const runs = fakeRuns(['UNCLAIMED'])
 
-      return (
-        <RunStatusDots gql={gql} specFileExtension=".cy.ts" specFileName="spec"/>
-      )
-    })
+    const gql: RunStatusDotsFragment = {
+      id: 'id',
+      data: {
+        __typename: 'CloudProjectSpec',
+        id: 'id',
+        retrievedAt: new Date().toISOString(),
+        specRuns: {
+          nodes: [
+            ...runs as any, // suppress TS compiler
+          ],
+        },
+      },
+    }
+
+    mountWithGql(gql)
+
+    cy.findByTestId('run-status-dots').trigger('mouseenter')
+    cy.get('.v-popper__popper--shown').contains('spec.cy.ts')
+    cy.findAllByTestId('run-status-dot-0').should('have.class', 'icon-light-gray-300')
+    cy.findAllByTestId('run-status-dot-1').should('have.class', 'icon-light-gray-300')
+    cy.findAllByTestId('run-status-dot-2').should('have.class', 'icon-light-gray-300')
+    cy.findAllByTestId('run-status-dot-latest').should('not.have.class', 'animate-spin')
+  })
+
+  it('renders placeholder without tooltip or link', () => {
+    const gql: RunStatusDotsFragment = {
+      id: 'id',
+      data: {
+        __typename: 'CloudProjectSpec',
+        id: 'id',
+        retrievedAt: new Date().toISOString(),
+        specRuns: {
+          nodes: [],
+        },
+      },
+    }
+
+    mountWithGql(gql)
 
     cy.findByTestId('external').should('not.exist')
     cy.findByTestId('run-status-dots').trigger('mouseenter')

--- a/packages/app/src/specs/RunStatusDots.cy.tsx
+++ b/packages/app/src/specs/RunStatusDots.cy.tsx
@@ -58,7 +58,7 @@ describe('<RunStatusDots />', () => {
       cy.get('.v-popper__popper--shown').contains('spec.cy.ts')
       cy.findAllByTestId('run-status-dot-0').should('have.class', 'icon-light-orange-400')
       cy.findAllByTestId('run-status-dot-1').should('have.class', 'icon-light-indigo-400')
-      cy.findAllByTestId('run-status-dot-2').should('have.class', 'icon-light-orange-400')
+      cy.findAllByTestId('run-status-dot-2').should('have.class', 'icon-light-gray-400')
       cy.findAllByTestId('run-status-dot-latest').should('not.have.class', 'animate-spin')
     })
   })

--- a/packages/app/src/specs/RunStatusDots.cy.tsx
+++ b/packages/app/src/specs/RunStatusDots.cy.tsx
@@ -1,8 +1,24 @@
 import type { RunStatusDotsFragment } from '../generated/graphql'
 import RunStatusDots from './RunStatusDots.vue'
 import { fakeRuns } from '@packages/frontend-shared/cypress/support/mock-graphql/fakeCloudSpecRun'
+import { fill } from 'lodash'
+import type { CloudSpecRun } from '@packages/graphql/src/gen/cloud-source-types.gen'
 
-function mountWithGql (gql: RunStatusDotsFragment) {
+function mountWithRuns (runs: Required<CloudSpecRun>[]) {
+  const gql: RunStatusDotsFragment = {
+    id: 'id',
+    data: {
+      __typename: 'CloudProjectSpec',
+      retrievedAt: new Date().toISOString(),
+      id: 'id',
+      specRuns: {
+        nodes: [
+          ...runs as any, // suppress TS compiler
+        ],
+      },
+    },
+  }
+
   cy.mount(() => {
     return (
       <div class="flex justify-center">
@@ -13,130 +29,100 @@ function mountWithGql (gql: RunStatusDotsFragment) {
 }
 
 describe('<RunStatusDots />', () => {
-  it('mounts correctly for example scenario 1', () => {
-    const runs = fakeRuns(['PASSED', 'FAILED', 'CANCELLED', 'ERRORED'])
-    const gql: RunStatusDotsFragment = {
-      id: 'id',
-      data: {
-        __typename: 'CloudProjectSpec',
-        retrievedAt: new Date().toISOString(),
-        id: 'id',
-        specRuns: {
-          nodes: [
-            ...runs as any, // suppress TS compiler
-          ],
-        },
-      },
-    }
+  context('runs scenario 1', () => {
+    beforeEach(() => {
+      const runs = fakeRuns(['PASSED', 'FAILED', 'CANCELLED', 'ERRORED'])
 
-    mountWithGql(gql)
+      mountWithRuns(runs)
+    })
 
-    cy.findByTestId('run-status-dots').trigger('mouseenter')
-    cy.get('.v-popper__popper--shown').contains('spec.cy.ts')
-    cy.findAllByTestId('run-status-dot-0').should('have.class', 'icon-light-orange-400')
-    cy.findAllByTestId('run-status-dot-1').should('have.class', 'icon-light-gray-300')
-    cy.findAllByTestId('run-status-dot-2').should('have.class', 'icon-light-red-400')
-    cy.findAllByTestId('run-status-dot-latest').should('not.have.class', 'animate-spin')
+    it('renders as expected', () => {
+      cy.findByTestId('run-status-dots').trigger('mouseenter')
+      cy.get('.v-popper__popper--shown').contains('spec.cy.ts')
+      cy.findAllByTestId('run-status-dot-0').should('have.class', 'icon-light-orange-400')
+      cy.findAllByTestId('run-status-dot-1').should('have.class', 'icon-light-gray-300')
+      cy.findAllByTestId('run-status-dot-2').should('have.class', 'icon-light-red-400')
+      cy.findAllByTestId('run-status-dot-latest').should('not.have.class', 'animate-spin')
+    })
   })
 
-  it('mounts correctly for example scenario 2', () => {
-    const runs = fakeRuns(['NOTESTS', 'OVERLIMIT', 'RUNNING', 'TIMEDOUT'])
+  context('runs scenario 2', () => {
+    beforeEach(() => {
+      const runs = fakeRuns(['NOTESTS', 'OVERLIMIT', 'RUNNING', 'TIMEDOUT'])
 
-    const gql: RunStatusDotsFragment = {
-      id: 'id',
-      data: {
-        __typename: 'CloudProjectSpec',
-        id: 'id',
-        retrievedAt: new Date().toISOString(),
-        specRuns: {
-          nodes: [
-            ...runs as any, // suppress TS compiler
-          ],
-        },
-      },
-    }
+      mountWithRuns(runs)
+    })
 
-    mountWithGql(gql)
-
-    cy.findByTestId('run-status-dots').trigger('mouseenter')
-    cy.get('.v-popper__popper--shown').contains('spec.cy.ts')
-    cy.findAllByTestId('run-status-dot-0').should('have.class', 'icon-light-orange-400')
-    cy.findAllByTestId('run-status-dot-1').should('have.class', 'icon-light-indigo-400')
-    cy.findAllByTestId('run-status-dot-2').should('have.class', 'icon-light-orange-400')
-    cy.findAllByTestId('run-status-dot-latest').should('not.have.class', 'animate-spin')
+    it('renders as expected', () => {
+      cy.findByTestId('run-status-dots').trigger('mouseenter')
+      cy.get('.v-popper__popper--shown').contains('spec.cy.ts')
+      cy.findAllByTestId('run-status-dot-0').should('have.class', 'icon-light-orange-400')
+      cy.findAllByTestId('run-status-dot-1').should('have.class', 'icon-light-indigo-400')
+      cy.findAllByTestId('run-status-dot-2').should('have.class', 'icon-light-orange-400')
+      cy.findAllByTestId('run-status-dot-latest').should('not.have.class', 'animate-spin')
+    })
   })
 
-  it('mounts correctly for example scenario 3', () => {
-    const runs = fakeRuns(['RUNNING'])
+  context('single RUNNING status', () => {
+    beforeEach(() => {
+      const runs = fakeRuns(['RUNNING'])
 
-    const gql: RunStatusDotsFragment = {
-      id: 'id',
-      data: {
-        __typename: 'CloudProjectSpec',
-        id: 'id',
-        retrievedAt: new Date().toISOString(),
-        specRuns: {
-          nodes: [
-            ...runs as any, // suppress TS compiler
-          ],
-        },
-      },
-    }
+      mountWithRuns(runs)
+    })
 
-    mountWithGql(gql)
-
-    cy.findByTestId('run-status-dots').trigger('mouseenter')
-    cy.get('.v-popper__popper--shown').contains('spec.cy.ts')
-    cy.findAllByTestId('run-status-dot-0').should('have.class', 'icon-light-gray-300')
-    cy.findAllByTestId('run-status-dot-1').should('have.class', 'icon-light-gray-300')
-    cy.findAllByTestId('run-status-dot-2').should('have.class', 'icon-light-gray-300')
-    cy.findAllByTestId('run-status-dot-latest').should('have.class', 'animate-spin')
+    it('renders as expected', () => {
+      cy.findByTestId('run-status-dots').trigger('mouseenter')
+      cy.get('.v-popper__popper--shown').contains('spec.cy.ts')
+      cy.findAllByTestId('run-status-dot-0').should('have.class', 'icon-light-gray-300')
+      cy.findAllByTestId('run-status-dot-1').should('have.class', 'icon-light-gray-300')
+      cy.findAllByTestId('run-status-dot-2').should('have.class', 'icon-light-gray-300')
+      cy.findAllByTestId('run-status-dot-latest').should('have.class', 'animate-spin')
+    })
   })
 
-  it('handles UNCLAIMED status', () => {
-    const runs = fakeRuns(['UNCLAIMED'])
+  context('single UNCLAIMED status', () => {
+    beforeEach(() => {
+      const runs = fakeRuns(['UNCLAIMED'])
 
-    const gql: RunStatusDotsFragment = {
-      id: 'id',
-      data: {
-        __typename: 'CloudProjectSpec',
-        id: 'id',
-        retrievedAt: new Date().toISOString(),
-        specRuns: {
-          nodes: [
-            ...runs as any, // suppress TS compiler
-          ],
-        },
-      },
-    }
+      mountWithRuns(runs)
+    })
 
-    mountWithGql(gql)
-
-    cy.findByTestId('run-status-dots').trigger('mouseenter')
-    cy.get('.v-popper__popper--shown').contains('spec.cy.ts')
-    cy.findAllByTestId('run-status-dot-0').should('have.class', 'icon-light-gray-300')
-    cy.findAllByTestId('run-status-dot-1').should('have.class', 'icon-light-gray-300')
-    cy.findAllByTestId('run-status-dot-2').should('have.class', 'icon-light-gray-300')
-    cy.findAllByTestId('run-status-dot-latest').should('not.have.class', 'animate-spin')
+    it('renders as expected', () => {
+      cy.findByTestId('run-status-dots').trigger('mouseenter')
+      cy.get('.v-popper__popper--shown').contains('spec.cy.ts')
+      cy.findAllByTestId('run-status-dot-0').should('have.class', 'icon-light-gray-300')
+      cy.findAllByTestId('run-status-dot-1').should('have.class', 'icon-light-gray-300')
+      cy.findAllByTestId('run-status-dot-2').should('have.class', 'icon-light-gray-300')
+      cy.findAllByTestId('run-status-dot-latest').should('not.have.class', 'animate-spin')
+    })
   })
 
-  it('renders placeholder without tooltip or link', () => {
-    const gql: RunStatusDotsFragment = {
-      id: 'id',
-      data: {
-        __typename: 'CloudProjectSpec',
-        id: 'id',
-        retrievedAt: new Date().toISOString(),
-        specRuns: {
-          nodes: [],
-        },
-      },
-    }
+  context('no runs', () => {
+    beforeEach(() => {
+      mountWithRuns([])
+    })
 
-    mountWithGql(gql)
+    it('renders placeholder without tooltip or link', () => {
+      cy.findByTestId('external').should('not.exist')
+      cy.findByTestId('run-status-dots').trigger('mouseenter')
+      cy.get('.v-popper__popper--shown').should('not.exist')
+    })
+  })
 
-    cy.findByTestId('external').should('not.exist')
-    cy.findByTestId('run-status-dots').trigger('mouseenter')
-    cy.get('.v-popper__popper--shown').should('not.exist')
+  context('unknown/unhandled statuses', () => {
+    beforeEach(() => {
+      const runs = fakeRuns(fill(['', '', '', ''], 'FAKE_UNKNOWN_STATUS' as any))
+
+      mountWithRuns(runs)
+    })
+
+    it('renders as expected', () => {
+      cy.findByTestId('run-status-dots').trigger('mouseenter')
+      cy.get('.v-popper__popper--shown').contains('spec.cy.ts')
+      cy.findAllByTestId('run-status-dot-0').should('have.class', 'icon-light-gray-300')
+      cy.findAllByTestId('run-status-dot-1').should('have.class', 'icon-light-gray-300')
+      cy.findAllByTestId('run-status-dot-2').should('have.class', 'icon-light-gray-300')
+      cy.findAllByTestId('run-status-dot-latest').should('not.have.class', 'animate-spin')
+    })
   })
 })

--- a/packages/app/src/specs/RunStatusDots.vue
+++ b/packages/app/src/specs/RunStatusDots.vue
@@ -156,7 +156,6 @@ const dotClasses = computed(() => {
       case 'FAILED':
         return 'icon-light-red-400'
       case 'ERRORED':
-      case 'OVERLIMIT':
       case 'TIMEDOUT':
         return 'icon-light-orange-400'
       case 'UNCLAIMED':

--- a/packages/app/src/specs/RunStatusDots.vue
+++ b/packages/app/src/specs/RunStatusDots.vue
@@ -190,7 +190,6 @@ const latestDot = computed(() => {
     case 'FAILED':
       return { icon: FailedIcon, spin: false, status }
     case 'ERRORED':
-    case 'OVERLIMIT':
     case 'TIMEDOUT':
       return { icon: ErroredIcon, spin: false, status }
     case 'NOTESTS':

--- a/packages/app/src/specs/RunStatusDots.vue
+++ b/packages/app/src/specs/RunStatusDots.vue
@@ -73,6 +73,7 @@ import ErroredIcon from '~icons/cy/errored-solid_x16.svg'
 import FailedIcon from '~icons/cy/failed-solid_x16.svg'
 import PassedIcon from '~icons/cy/passed-solid_x16.svg'
 import PlaceholderIcon from '~icons/cy/placeholder-solid_x16.svg'
+import QueuedIcon from '~icons/cy/queued-solid_x16.svg'
 import RunningIcon from '~icons/cy/running-outline_x16.svg'
 import SpecRunSummary from './SpecRunSummary.vue'
 import { gql } from '@urql/vue'
@@ -158,6 +159,7 @@ const dotClasses = computed(() => {
       case 'OVERLIMIT':
       case 'TIMEDOUT':
         return 'icon-light-orange-400'
+      case 'UNCLAIMED':
       case 'NOTESTS':
         return 'icon-light-gray-400'
       case 'CANCELLED':
@@ -183,6 +185,8 @@ const latestDot = computed(() => {
       return { icon: PassedIcon, spin: false, status }
     case 'RUNNING':
       return { icon: RunningIcon, spin: true, status }
+    case 'UNCLAIMED':
+      return { icon: QueuedIcon, spin: false, status }
     case 'FAILED':
       return { icon: FailedIcon, spin: false, status }
     case 'ERRORED':

--- a/packages/app/src/specs/SpecRunSummary.cy.tsx
+++ b/packages/app/src/specs/SpecRunSummary.cy.tsx
@@ -207,4 +207,25 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
       validateResultCountsVisible()
     })
   })
+
+  context('unhandled status', () => {
+    beforeEach(() => {
+      mountWithRun(runs[9])
+    })
+
+    it('should render expected content', () => {
+      // Gray border
+      validateTopBorder('rgb(144, 149, 173)')
+      validateFilename('mySpecFile.spec.ts')
+
+      // Should not render any status text
+      cy.findByTestId('spec-run-status')
+      .should('not.exist')
+
+      validateTimeAgo('1 year ago')
+      validateDuration1('2:23')
+      validateDuration2('2:39')
+      validateResultCountsVisible()
+    })
+  })
 })

--- a/packages/app/src/specs/SpecRunSummary.cy.tsx
+++ b/packages/app/src/specs/SpecRunSummary.cy.tsx
@@ -2,6 +2,40 @@ import SpecRunSummary from './SpecRunSummary.vue'
 import { exampleRuns } from '@packages/frontend-shared/cypress/support/mock-graphql/fakeCloudSpecRun'
 import type { CloudSpecRun } from '@packages/graphql/src/gen/cloud-source-types.gen'
 
+function validateTopBorder (color: string): void {
+  cy.findByTestId('spec-run-summary')
+  .should('have.css', 'border-top', `4px solid ${color}`)
+}
+
+function validateFilename (expected: string): void {
+  cy.findByTestId('spec-run-filename').should('have.text', expected)
+}
+
+function validateTimeAgo (expected: string): void {
+  cy.findByTestId('spec-run-time-ago')
+  .should('have.text', expected)
+}
+
+function validateStatus (status: string, color: string): void {
+  cy.findByTestId('spec-run-status')
+  .should('have.css', 'color', color)
+  .and('have.text', status)
+}
+
+function validateDuration1 (expected: string): void {
+  cy.findByTestId('spec-run-duration-1')
+  .should('have.text', expected)
+}
+
+function validateDuration2 (expected: string): void {
+  cy.findByTestId('spec-run-duration-2')
+  .should('have.text', expected)
+}
+
+function validateResultCountsVisible (): void {
+  cy.findByTestId('spec-run-result-counts').should('be.visible')
+}
+
 describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
   const runs = exampleRuns()
 
@@ -19,27 +53,15 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
     })
 
     it('should render expected content', () => {
-      cy.findByTestId('spec-run-summary')
-      // Green border at top
-      .should('have.css', 'border-top', '4px solid rgb(31, 169, 113)')
-
-      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
-
-      cy.findByTestId('spec-run-status')
-      // Green text with expected status text
-      .should('have.css', 'color', 'rgb(0, 129, 77)')
-      .and('have.text', 'Passed')
-
-      cy.findByTestId('spec-run-time-ago')
-      .should('have.text', '1 year ago')
-
-      cy.findByTestId('spec-run-duration-1')
-      .should('have.text', '2:23')
-
-      cy.findByTestId('spec-run-duration-2')
-      .should('have.text', '2:39')
-
-      cy.findByTestId('spec-run-result-counts').should('be.visible')
+      // Green border
+      validateTopBorder('rgb(31, 169, 113)')
+      validateFilename('mySpecFile.spec.ts')
+      // Green text
+      validateStatus('Passed', 'rgb(0, 129, 77)')
+      validateTimeAgo('1 year ago')
+      validateDuration1('2:23')
+      validateDuration2('2:39')
+      validateResultCountsVisible()
     })
   })
 
@@ -49,26 +71,15 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
     })
 
     it('should render expected content', () => {
-      cy.findByTestId('spec-run-summary')
-      // Red border at top
-      .should('have.css', 'border-top', '4px solid rgb(228, 87, 112)')
-
-      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
-
-      cy.findByTestId('spec-run-status')
-      // Red text with expected status text
-      .should('have.css', 'color', 'rgb(198, 43, 73)')
-      .and('have.text', 'Failed')
-
-      cy.findByTestId('spec-run-time-ago')
-      .should('have.text', '1 year ago')
-
-      cy.findByTestId('spec-run-duration-1')
-      .should('have.text', '1:02:40')
-
+      // Red border
+      validateTopBorder('rgb(228, 87, 112)')
+      validateFilename('mySpecFile.spec.ts')
+      // Red text
+      validateStatus('Failed', 'rgb(198, 43, 73)')
+      validateTimeAgo('1 year ago')
+      validateDuration1('1:02:40')
       cy.findByTestId('spec-run-duration-2').should('not.exist')
-
-      cy.findByTestId('spec-run-result-counts').should('be.visible')
+      validateResultCountsVisible()
     })
   })
 
@@ -78,27 +89,15 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
     })
 
     it('should render expected content', () => {
-      cy.findByTestId('spec-run-summary')
-      // Gray border at top
-      .should('have.css', 'border-top', '4px solid rgb(144, 149, 173)')
-
-      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
-
-      cy.findByTestId('spec-run-status')
-      // Gray text with expected status text
-      .should('have.css', 'color', 'rgb(90, 95, 122)')
-      .and('have.text', 'Canceled')
-
-      cy.findByTestId('spec-run-time-ago')
-      .should('have.text', '1 year ago')
-
-      cy.findByTestId('spec-run-duration-1')
-      .should('have.text', '2:23')
-
-      cy.findByTestId('spec-run-duration-2')
-      .should('have.text', '2:39')
-
-      cy.findByTestId('spec-run-result-counts').should('be.visible')
+      // Gray border
+      validateTopBorder('rgb(144, 149, 173)')
+      validateFilename('mySpecFile.spec.ts')
+      // Gray text
+      validateStatus('Canceled', 'rgb(90, 95, 122)')
+      validateTimeAgo('1 year ago')
+      validateDuration1('2:23')
+      validateDuration2('2:39')
+      validateResultCountsVisible()
     })
   })
 
@@ -108,27 +107,15 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
     })
 
     it('should render expected content', () => {
-      cy.findByTestId('spec-run-summary')
-      // Orange border at top
-      .should('have.css', 'border-top', '4px solid rgb(219, 121, 3)')
-
-      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
-
-      cy.findByTestId('spec-run-status')
-      // Orange text with expected status text
-      .should('have.css', 'color', 'rgb(189, 88, 0)')
-      .and('have.text', 'Errored')
-
-      cy.findByTestId('spec-run-time-ago')
-      .should('have.text', '1 year ago')
-
-      cy.findByTestId('spec-run-duration-1')
-      .should('have.text', '1:02:40')
-
-      cy.findByTestId('spec-run-duration-2')
-      .should('have.text', '10:26:40')
-
-      cy.findByTestId('spec-run-result-counts').should('be.visible')
+      // Orange border
+      validateTopBorder('rgb(219, 121, 3)')
+      validateFilename('mySpecFile.spec.ts')
+      // Orange text
+      validateStatus('Errored', 'rgb(189, 88, 0)')
+      validateTimeAgo('1 year ago')
+      validateDuration1('1:02:40')
+      validateDuration2('10:26:40')
+      validateResultCountsVisible()
     })
   })
 
@@ -138,27 +125,14 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
     })
 
     it('should render expected content', () => {
-      cy.findByTestId('spec-run-summary')
-      // Gray border at top
-      .should('have.css', 'border-top', '4px solid rgb(144, 149, 173)')
-
-      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
-
-      cy.findByTestId('spec-run-status')
-      // Gray text with expected status text
-      .should('have.css', 'color', 'rgb(90, 95, 122)')
-      .and('have.text', 'No tests')
-
-      cy.findByTestId('spec-run-time-ago')
-      .should('have.text', '1 year ago')
-
-      cy.findByTestId('spec-run-duration-1')
-      .should('have.text', '2:23')
-
-      cy.findByTestId('spec-run-duration-2')
-      .should('have.text', '2:39')
-
-      cy.findByTestId('spec-run-result-counts').should('be.visible')
+      // Gray border
+      validateTopBorder('rgb(144, 149, 173)')
+      validateFilename('mySpecFile.spec.ts')
+      validateStatus('No tests', 'rgb(90, 95, 122)')
+      validateTimeAgo('1 year ago')
+      validateDuration1('2:23')
+      validateDuration2('2:39')
+      validateResultCountsVisible()
     })
   })
 
@@ -168,27 +142,15 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
     })
 
     it('should render expected content', () => {
-      cy.findByTestId('spec-run-summary')
-      // Orange border at top
-      .should('have.css', 'border-top', '4px solid rgb(219, 121, 3)')
-
-      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
-
-      cy.findByTestId('spec-run-status')
-      // Orange text with expected status text
-      .should('have.css', 'color', 'rgb(189, 88, 0)')
-      .and('have.text', 'Over limit')
-
-      cy.findByTestId('spec-run-time-ago')
-      .should('have.text', '1 year ago')
-
-      cy.findByTestId('spec-run-duration-1')
-      .should('have.text', '2:23')
-
-      cy.findByTestId('spec-run-duration-2')
-      .should('have.text', '2:39')
-
-      cy.findByTestId('spec-run-result-counts').should('be.visible')
+      // Orange border
+      validateTopBorder('rgb(219, 121, 3)')
+      validateFilename('mySpecFile.spec.ts')
+      // Orange text
+      validateStatus('Over limit', 'rgb(189, 88, 0)')
+      validateTimeAgo('1 year ago')
+      validateDuration1('2:23')
+      validateDuration2('2:39')
+      validateResultCountsVisible()
     })
   })
 
@@ -198,27 +160,15 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
     })
 
     it('should render expected content', () => {
-      cy.findByTestId('spec-run-summary')
-      // Blue border at top
-      .should('have.css', 'border-top', '4px solid rgb(100, 112, 243)')
-
-      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
-
-      cy.findByTestId('spec-run-status')
-      // Blue text with expected status text
-      .should('have.css', 'color', 'rgb(73, 86, 227)')
-      .and('have.text', 'Running')
-
-      cy.findByTestId('spec-run-time-ago')
-      .should('have.text', '1 year ago')
-
-      cy.findByTestId('spec-run-duration-1')
-      .should('have.text', '2:23')
-
-      cy.findByTestId('spec-run-duration-2')
-      .should('have.text', '2:39')
-
-      cy.findByTestId('spec-run-result-counts').should('be.visible')
+      // Blue border
+      validateTopBorder('rgb(100, 112, 243)')
+      validateFilename('mySpecFile.spec.ts')
+      // Blue text
+      validateStatus('Running', 'rgb(73, 86, 227)')
+      validateTimeAgo('1 year ago')
+      validateDuration1('2:23')
+      validateDuration2('2:39')
+      validateResultCountsVisible()
     })
   })
 
@@ -228,27 +178,33 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
     })
 
     it('should render expected content', () => {
-      cy.findByTestId('spec-run-summary')
-      // Orange border at top
-      .should('have.css', 'border-top', '4px solid rgb(219, 121, 3)')
+      // Orange border
+      validateTopBorder('rgb(219, 121, 3)')
+      validateFilename('mySpecFile.spec.ts')
+      // Orange text
+      validateStatus('Timed out', 'rgb(189, 88, 0)')
+      validateTimeAgo('1 year ago')
+      validateDuration1('2:23')
+      validateDuration2('2:39')
+      validateResultCountsVisible()
+    })
+  })
 
-      cy.findByTestId('spec-run-filename').should('have.text', 'mySpecFile.spec.ts')
+  context('queued', () => {
+    beforeEach(() => {
+      mountWithRun(runs[8])
+    })
 
-      cy.findByTestId('spec-run-status')
-      // Orange text with expected status text
-      .should('have.css', 'color', 'rgb(189, 88, 0)')
-      .and('have.text', 'Timed out')
-
-      cy.findByTestId('spec-run-time-ago')
-      .should('have.text', '1 year ago')
-
-      cy.findByTestId('spec-run-duration-1')
-      .should('have.text', '2:23')
-
-      cy.findByTestId('spec-run-duration-2')
-      .should('have.text', '2:39')
-
-      cy.findByTestId('spec-run-result-counts').should('be.visible')
+    it('should render expected content', () => {
+      // Gray border
+      validateTopBorder('rgb(144, 149, 173)')
+      validateFilename('mySpecFile.spec.ts')
+      // Gray text
+      validateStatus('Queued', 'rgb(90, 95, 122)')
+      validateTimeAgo('1 year ago')
+      validateDuration1('2:23')
+      validateDuration2('2:39')
+      validateResultCountsVisible()
     })
   })
 })

--- a/packages/app/src/specs/SpecRunSummary.cy.tsx
+++ b/packages/app/src/specs/SpecRunSummary.cy.tsx
@@ -136,24 +136,6 @@ describe('<SpecRunSummary />', { keystrokeDelay: 0 }, () => {
     })
   })
 
-  context('over limit', () => {
-    beforeEach(() => {
-      mountWithRun(runs[5])
-    })
-
-    it('should render expected content', () => {
-      // Orange border
-      validateTopBorder('rgb(219, 121, 3)')
-      validateFilename('mySpecFile.spec.ts')
-      // Orange text
-      validateStatus('Over limit', 'rgb(189, 88, 0)')
-      validateTimeAgo('1 year ago')
-      validateDuration1('2:23')
-      validateDuration2('2:39')
-      validateResultCountsVisible()
-    })
-  })
-
   context('running', () => {
     beforeEach(() => {
       mountWithRun(runs[6])

--- a/packages/app/src/specs/SpecRunSummary.vue
+++ b/packages/app/src/specs/SpecRunSummary.vue
@@ -119,7 +119,6 @@ const statusText = computed(() => {
     case 'ERRORED': return 'Errored'
     case 'FAILED': return 'Failed'
     case 'NOTESTS': return 'No tests'
-    case 'OVERLIMIT': return 'Over limit'
     case 'PASSED': return 'Passed'
     case 'UNCLAIMED': return 'Queued'
     case 'RUNNING': return 'Running'
@@ -132,7 +131,6 @@ const statusColor = computed(() => {
   if (!props.run?.status) return 'gray'
 
   switch (props.run.status) {
-    case 'OVERLIMIT':
     case 'ERRORED':
     case 'TIMEDOUT':
       return 'orange'

--- a/packages/app/src/specs/SpecRunSummary.vue
+++ b/packages/app/src/specs/SpecRunSummary.vue
@@ -121,6 +121,7 @@ const statusText = computed(() => {
     case 'NOTESTS': return 'No tests'
     case 'OVERLIMIT': return 'Over limit'
     case 'PASSED': return 'Passed'
+    case 'UNCLAIMED': return 'Queued'
     case 'RUNNING': return 'Running'
     case 'TIMEDOUT': return 'Timed out'
     default: return null
@@ -143,6 +144,7 @@ const statusColor = computed(() => {
       return 'indigo'
     case 'CANCELLED':
     case 'NOTESTS':
+    case 'UNCLAIMED':
     default: return 'gray'
   }
 })

--- a/packages/app/src/specs/SpecsList.vue
+++ b/packages/app/src/specs/SpecsList.vue
@@ -184,7 +184,7 @@
               class="h-full grid justify-items-end items-center"
             >
               <RunStatusDots
-                v-if="row.data.isLeaf && row.data.data && row.data.data.cloudSpec?.fetchingStatus !== 'FETCHING'"
+                v-if="row.data.isLeaf && row.data.data?.cloudSpec?.data"
                 :gql="row.data.data.cloudSpec ?? null"
                 :spec-file-extension="row.data.data.fileExtension"
                 :spec-file-name="row.data.data.fileName"

--- a/packages/app/src/specs/SpecsList.vue
+++ b/packages/app/src/specs/SpecsList.vue
@@ -184,7 +184,7 @@
               class="h-full grid justify-items-end items-center"
             >
               <RunStatusDots
-                v-if="row.data.isLeaf && row.data.data?.cloudSpec?.data"
+                v-if="row.data.isLeaf && row.data.data && (row.data.data.cloudSpec?.data || row.data.data.cloudSpec?.fetchingStatus !== 'FETCHING')"
                 :gql="row.data.data.cloudSpec ?? null"
                 :spec-file-extension="row.data.data.fileExtension"
                 :spec-file-name="row.data.data.fileName"

--- a/packages/frontend-shared/cypress/support/mock-graphql/fakeCloudSpecRun.ts
+++ b/packages/frontend-shared/cypress/support/mock-graphql/fakeCloudSpecRun.ts
@@ -49,7 +49,7 @@ export const fakeRuns: (statuses: CloudRunStatus[]) => Required<CloudSpecRun>[] 
 }
 
 export const exampleRuns = () => {
-  const runs = fakeRuns(['PASSED', 'FAILED', 'CANCELLED', 'ERRORED', 'NOTESTS', 'OVERLIMIT', 'RUNNING', 'TIMEDOUT'])
+  const runs = fakeRuns(['PASSED', 'FAILED', 'CANCELLED', 'ERRORED', 'NOTESTS', 'OVERLIMIT', 'RUNNING', 'TIMEDOUT', 'UNCLAIMED'])
 
   const now = new Date()
   const twoYearsAgo = new Date(now.getFullYear() - 2, now.getMonth(), now.getDate())

--- a/packages/frontend-shared/cypress/support/mock-graphql/fakeCloudSpecRun.ts
+++ b/packages/frontend-shared/cypress/support/mock-graphql/fakeCloudSpecRun.ts
@@ -1,7 +1,7 @@
 import type { CloudSpecRun } from '../../../../graphql/src/gen/cloud-source-types.gen'
 import type { CloudRunStatus } from '@packages/app/src/generated/graphql'
 
-export const randomRunStatus: () => CloudRunStatus = () => {
+export const randomRunStatus = (): CloudRunStatus => {
   const r = Math.floor(Math.random() * 5)
 
   switch (r) {
@@ -13,7 +13,7 @@ export const randomRunStatus: () => CloudRunStatus = () => {
   }
 }
 
-export const fakeRuns: (statuses: CloudRunStatus[]) => Required<CloudSpecRun>[] = (statuses) => {
+export const fakeRuns = (statuses: CloudRunStatus[]): Required<CloudSpecRun>[] => {
   return statuses.map((s, idx) => {
     return {
       __typename: 'CloudSpecRun',
@@ -49,7 +49,7 @@ export const fakeRuns: (statuses: CloudRunStatus[]) => Required<CloudSpecRun>[] 
 }
 
 export const exampleRuns = () => {
-  const runs = fakeRuns(['PASSED', 'FAILED', 'CANCELLED', 'ERRORED', 'NOTESTS', 'OVERLIMIT', 'RUNNING', 'TIMEDOUT', 'UNCLAIMED'])
+  const runs = fakeRuns(['PASSED', 'FAILED', 'CANCELLED', 'ERRORED', 'NOTESTS', 'OVERLIMIT', 'RUNNING', 'TIMEDOUT', 'UNCLAIMED', 'FAKE_UNKNOWN_STATUS' as any])
 
   const now = new Date()
   const twoYearsAgo = new Date(now.getFullYear() - 2, now.getMonth(), now.getDate())

--- a/packages/frontend-shared/cypress/support/mock-graphql/fakeCloudSpecRun.ts
+++ b/packages/frontend-shared/cypress/support/mock-graphql/fakeCloudSpecRun.ts
@@ -1,7 +1,7 @@
 import type { CloudSpecRun } from '../../../../graphql/src/gen/cloud-source-types.gen'
-import type { CloudRunStatus } from '@packages/app/src/generated/graphql'
+import type { CloudSpecStatus } from '@packages/app/src/generated/graphql'
 
-export const randomRunStatus = (): CloudRunStatus => {
+export const randomRunStatus = (): CloudSpecStatus => {
   const r = Math.floor(Math.random() * 5)
 
   switch (r) {
@@ -13,7 +13,7 @@ export const randomRunStatus = (): CloudRunStatus => {
   }
 }
 
-export const fakeRuns = (statuses: CloudRunStatus[]): Required<CloudSpecRun>[] => {
+export const fakeRuns = (statuses: CloudSpecStatus[]): Required<CloudSpecRun>[] => {
   return statuses.map((s, idx) => {
     return {
       __typename: 'CloudSpecRun',

--- a/packages/frontend-shared/src/assets/icons/queued-solid_x16.svg
+++ b/packages/frontend-shared/src/assets/icons/queued-solid_x16.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Dimensions=x16">
+<circle id="Circle" cx="8" cy="8" r="6" stroke="#E1E3ED" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/packages/graphql/schemas/cloud.graphql
+++ b/packages/graphql/schemas/cloud.graphql
@@ -477,7 +477,7 @@ type CloudSpecRun implements Node {
   """
   Most important status for the spec shared between all groups
   """
-  status: CloudRunStatus
+  status: CloudSpecStatus
 
   """
   Aggregate information about how many tests failed in the groups
@@ -532,6 +532,20 @@ type CloudSpecRunEdge {
   https://facebook.github.io/relay/graphql/connections.htm#sec-Node
   """
   node: CloudSpecRun!
+}
+
+"""
+Possible check status of the spec within a run
+"""
+enum CloudSpecStatus {
+  CANCELLED
+  ERRORED
+  FAILED
+  NOTESTS
+  PASSED
+  RUNNING
+  TIMEDOUT
+  UNCLAIMED
 }
 
 """

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -397,7 +397,7 @@ type CloudSpecRun implements Node {
   specDuration: SpecDataAggregate
 
   """Most important status for the spec shared between all groups"""
-  status: CloudRunStatus
+  status: CloudSpecStatus
 
   """Aggregate information about how many tests failed in the groups"""
   testsFailed: SpecDataAggregate
@@ -436,6 +436,18 @@ type CloudSpecRunEdge {
 
   """https://facebook.github.io/relay/graphql/connections.htm#sec-Node"""
   node: CloudSpecRun!
+}
+
+"""Possible check status of the spec within a run"""
+enum CloudSpecStatus {
+  CANCELLED
+  ERRORED
+  FAILED
+  NOTESTS
+  PASSED
+  RUNNING
+  TIMEDOUT
+  UNCLAIMED
 }
 
 """A CloudUser represents an User stored in the Cypress Cloud"""

--- a/packages/graphql/test/stubCloudTypes.ts
+++ b/packages/graphql/test/stubCloudTypes.ts
@@ -87,7 +87,7 @@ export function createCloudRecordKey (config: ConfigFor<CloudRecordKey>) {
   return indexNode(cloudRecordKey)
 }
 
-const STATUS_ARRAY: CloudRunStatus[] = ['CANCELLED', 'ERRORED', 'FAILED', 'NOTESTS', 'OVERLIMIT', 'PASSED', 'RUNNING', 'TIMEDOUT']
+const STATUS_ARRAY: CloudRunStatus[] = ['CANCELLED', 'ERRORED', 'FAILED', 'NOTESTS', 'OVERLIMIT', 'PASSED', 'RUNNING', 'TIMEDOUT', 'UNCLAIMED']
 
 export function createCloudProject (config: Partial<ConfigFor<CloudProject>>) {
   const cloudProject = {

--- a/packages/graphql/test/stubCloudTypes.ts
+++ b/packages/graphql/test/stubCloudTypes.ts
@@ -87,7 +87,7 @@ export function createCloudRecordKey (config: ConfigFor<CloudRecordKey>) {
   return indexNode(cloudRecordKey)
 }
 
-const STATUS_ARRAY: CloudRunStatus[] = ['CANCELLED', 'ERRORED', 'FAILED', 'NOTESTS', 'OVERLIMIT', 'PASSED', 'RUNNING', 'TIMEDOUT', 'UNCLAIMED']
+const STATUS_ARRAY: CloudRunStatus[] = ['CANCELLED', 'ERRORED', 'FAILED', 'NOTESTS', 'OVERLIMIT', 'PASSED', 'RUNNING', 'TIMEDOUT']
 
 export function createCloudProject (config: Partial<ConfigFor<CloudProject>>) {
   const cloudProject = {


### PR DESCRIPTION
* Update GQL schema
* Add handling for `UNCLAIMED` status
* Only show loading indicator in Latest Runs section on initial fetch

### User facing changelog


### Additional details


### Steps to test
1. Open project and log in to cloud
2. Observe "latest run" data displays loading indicator on initial load of Specs Explorer
3. Start recording of project run in another terminal
4. Every 30 seconds app should poll for updated "latest run" data, observe that loading indicator is not shown during refetches
5. Mouse over the currently-running spec's "latest run" column, observe tooltip with "Queued" status

### How has the user experience changed?
https://user-images.githubusercontent.com/11482842/175427837-387cd142-0926-4ce4-8647-fe8125e70d2f.mov

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
