### PR TITLE
fix: Update "Request Access" button state after requesting access (ACI)

### DIFF
--- a/packages/app/src/specs/SpecHeaderCloudDataTooltip.cy.tsx
+++ b/packages/app/src/specs/SpecHeaderCloudDataTooltip.cy.tsx
@@ -1,4 +1,4 @@
-import { SpecHeaderCloudDataTooltipFragmentDoc } from '../generated/graphql-test'
+import { SpecHeaderCloudDataTooltipFragmentDoc, SpecHeaderCloudDataTooltip_RequestAccessDocument } from '../generated/graphql-test'
 import SpecHeaderCloudDataTooltip from './SpecHeaderCloudDataTooltip.vue'
 import { get, set } from 'lodash'
 import { defaultMessages } from '@cy/i18n'
@@ -136,11 +136,29 @@ describe('SpecHeaderCloudDataTooltip', () => {
           .should('be.visible')
           .and('contain', get(defaultMessages, msgKeys.noAccess).replace('{0}', get(defaultMessages, msgKeys.docs)))
 
+          cy.percySnapshot()
+        })
+
+        it('should update to "Request Sent" when button is triggered', () => {
+          cy.stubMutationResolver(SpecHeaderCloudDataTooltip_RequestAccessDocument, (defineResult) => {
+            return defineResult({
+              cloudProjectRequestAccess: {
+                __typename: 'CloudProjectUnauthorized',
+                message: 'msg',
+                hasRequestedAccess: true,
+              },
+            })
+          })
+
+          cy.get('.v-popper').trigger('mouseenter')
+
           cy.findByTestId('request-access-button')
           .should('be.visible')
           .click()
 
-          cy.percySnapshot()
+          cy.findByTestId('access-requested-button')
+          .should('be.visible')
+          .should('be.disabled')
         })
       })
 


### PR DESCRIPTION
* Fix state tracking so that button properly updates after requesting access
* Refactor improper cross-component GQL doc use

### User facing changelog

### Additional details
Implementation adapted from `RunsErrorRenderer.vue`

### Steps to test
1. Open cypress app and log into dashboard
2. Open a project that is cloud-connected but that you do not have access to
3. Mouse over "latest runs" header, observe the "Request Access" button
4. Click button, observe button updates to "Request Sent"
5. Close and reopen tooltip, observe button still reports "Request Sent"

### How has the user experience changed?

https://user-images.githubusercontent.com/11482842/175435214-77c19733-3a29-4642-9f85-c43a203cd973.mov


### PR Tasks

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
