### PR TITLE
fix: add context for run-new-ui-tests dependent jobs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2390,22 +2390,22 @@ linux-x64-workflow: &linux-x64-workflow
         requires:
           - build
     - run-frontend-shared-component-tests-chrome:
-        context: [test-runner:launchpad-tests, test-runner:percy]
+        context: [test-runner:cypress-record-key, test-runner:launchpad-tests, test-runner:percy]
         percy: true
         requires:
           - build
     - run-launchpad-integration-tests-chrome:
-        context: [test-runner:launchpad-tests, test-runner:percy]
+        context: [test-runner:cypress-record-key, test-runner:launchpad-tests, test-runner:percy]
         percy: true
         requires:
           - build
     - run-launchpad-component-tests-chrome:
-        context: [test-runner:launchpad-tests, test-runner:percy]
+        context: [test-runner:cypress-record-key, test-runner:launchpad-tests, test-runner:percy]
         percy: true
         requires:
           - build
     - run-app-integration-tests-chrome:
-        context: [test-runner:launchpad-tests, test-runner:percy]
+        context: [test-runner:cypress-record-key, test-runner:launchpad-tests, test-runner:percy]
         percy: true
         requires:
           - build
@@ -2418,7 +2418,7 @@ linux-x64-workflow: &linux-x64-workflow
         requires:
           - system-tests-node-modules-install          
     - run-app-component-tests-chrome:
-        context: [test-runner:launchpad-tests, test-runner:percy]
+        context: [test-runner:cypress-record-key, test-runner:launchpad-tests, test-runner:percy]
         percy: true
         requires:
           - build
@@ -2712,7 +2712,7 @@ windows-workflow: &windows-workflow
         name: windows-run-app-integration-tests-chrome
         executor: windows
         resource_class: windows.large
-        context: test-runner:launchpad-tests
+        context: [test-runner:cypress-record-key, test-runner:launchpad-tests]
         requires:
           - windows-build
 
@@ -2720,7 +2720,7 @@ windows-workflow: &windows-workflow
         name: windows-run-launchpad-integration-tests-chrome
         executor: windows
         resource_class: windows.large
-        context: test-runner:launchpad-tests
+        context: [test-runner:cypress-record-key, test-runner:launchpad-tests]
         requires:
           - windows-build
 


### PR DESCRIPTION
### User facing changelog
n/a

### Additional details
With https://github.com/cypress-io/cypress/pull/22326 merged in, internal PRs were no longer recording to the dashboard since the jobs didn't have the `test-runner:cypress-record-key` context and thus didn't have `MAIN_RECORD_KEY` available.

I thought about changing the `MAIN_RECORD_KEY` to `TEST_LAUNCHPAD_RECORD_KEY` but there is a fallback to `MAIN_RECORD_KEY` in the script so I settled on adding the additional context.

### Steps to test
Look at a PR from an internal contributor after https://github.com/cypress-io/cypress/pull/22326 was merged, [example](https://app.circleci.com/pipelines/github/cypress-io/cypress/40055/workflows/1ba7683d-1699-4bac-9cf9-1147d37ac467/jobs/1643475/steps):

![Screen Shot 2022-06-28 at 11 01 12 AM](https://user-images.githubusercontent.com/25158820/176226547-f52bb7dc-21c1-47da-8fd0-c2b8cacb574f.png)

notice the use of `--spec` which should only be used for external contributor test splitting.

A build from this PR looks like:
![Screen Shot 2022-06-28 at 11 03 42 AM](https://user-images.githubusercontent.com/25158820/176227041-ac49284d-3521-4953-99e2-8ab6f6ab0332.png)

This build is now using the `--record` flag as intended


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
