### PR TITLE
test: Addressing yet more flaky windows tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2712,7 +2712,7 @@ windows-workflow: &windows-workflow
         name: windows-run-app-integration-tests-chrome
         executor: windows
         resource_class: windows.large
-        context: test-runner:launchpad-tests
+        context: [test-runner:cypress-record-key, test-runner:launchpad-tests]
         requires:
           - windows-build
 
@@ -2720,7 +2720,7 @@ windows-workflow: &windows-workflow
         name: windows-run-launchpad-integration-tests-chrome
         executor: windows
         resource_class: windows.large
-        context: test-runner:launchpad-tests
+        context: [test-runner:cypress-record-key, test-runner:launchpad-tests]
         requires:
           - windows-build
 

--- a/packages/launchpad/cypress/e2e/global-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/global-mode.cy.ts
@@ -30,8 +30,11 @@ describe('Launchpad: Global Mode', () => {
         .dropFileWithPath(projectPath)
       })
 
-      cy.contains('Welcome to Cypress!')
-      cy.get('a').contains('Projects').click()
+      cy.contains('Welcome to Cypress!').should('be.visible')
+      cy.findByRole('link', { name: 'Projects' })
+      .should('have.attr', 'aria-disabled', 'false')
+      .click()
+
       cy.get('[data-cy="project-card"]')
       .should('have.length', 1)
       .should('contain', 'todos')


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Changes include:

* Tweaked a test in global-mode.cy.ts to avoid clicking a link before it was enabled
* Updated the circle config to provide appropriate context vars to the windows ui (app/launchpad) builds. Shoutout to @ZachJW34 for noticing that I missed these earlier!

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

The app/launchpad tests in windows should be green now, I think this covers the recent flake we've seen. So PRs should be happier. The kitchensink build that executes in develop is still failing though.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
