### PR TITLE
chore: Refactor chainer / Commands.add for readability

### DIFF
--- a/packages/driver/cypress/e2e/commands/commands.cy.js
+++ b/packages/driver/cypress/e2e/commands/commands.cy.js
@@ -107,13 +107,13 @@ describe('src/cy/commands/commands', () => {
 
     it('throws when attempting to add a command with the same name as an internal function', (done) => {
       cy.on('fail', (err) => {
-        expect(err.message).to.eq('`Cypress.Commands.add()` cannot create a new command named `addChainer` because that name is reserved internally by Cypress.')
+        expect(err.message).to.eq('`Cypress.Commands.add()` cannot create a new command named `addCommand` because that name is reserved internally by Cypress.')
         expect(err.docsUrl).to.eq('https://on.cypress.io/custom-commands')
 
         done()
       })
 
-      Cypress.Commands.add('addChainer', () => {
+      Cypress.Commands.add('addCommand', () => {
         cy
         .get('[contenteditable]')
         .first()

--- a/packages/driver/src/cy/commands/commands.ts
+++ b/packages/driver/src/cy/commands/commands.ts
@@ -16,7 +16,7 @@ const command = function (ctx, name, ...args) {
 }
 
 export default function (Commands, Cypress, cy) {
-  $Chainer.add('command', function command (chainer, userInvocationStack, args) {
+  $Chainer.add('command', function (chainer, userInvocationStack, args) {
     // `...args` below is the shorthand of `args[0], ...args.slice(1)`
     // TypeScript doesn't allow this.
     // @ts-ignore

--- a/packages/driver/src/cy/commands/commands.ts
+++ b/packages/driver/src/cy/commands/commands.ts
@@ -16,14 +16,11 @@ const command = function (ctx, name, ...args) {
 }
 
 export default function (Commands, Cypress, cy) {
-  Commands.addChainer({
-    // userInvocationStack has to be passed in here, but can be ignored
-    command (chainer, userInvocationStack, args) {
-      // `...args` below is the shorthand of `args[0], ...args.slice(1)`
-      // TypeScript doesn't allow this.
-      // @ts-ignore
-      return command(chainer, ...args)
-    },
+  $Chainer.add('command', function command (chainer, userInvocationStack, args) {
+    // `...args` below is the shorthand of `args[0], ...args.slice(1)`
+    // TypeScript doesn't allow this.
+    // @ts-ignore
+    return command(chainer, ...args)
   })
 
   Commands.addAllSync({

--- a/packages/driver/src/cypress/chainer.ts
+++ b/packages/driver/src/cypress/chainer.ts
@@ -2,21 +2,17 @@ import _ from 'lodash'
 import $stackUtils from './stack_utils'
 
 export class $Chainer {
-  userInvocationStack: any
   specWindow: Window
   chainerId: string
   firstCall: boolean
-  useInitialStack: boolean | null
 
-  constructor (userInvocationStack, specWindow) {
-    this.userInvocationStack = userInvocationStack
+  constructor (specWindow) {
     this.specWindow = specWindow
     // the id prefix needs to be unique per origin, so there are not
     // collisions when chainers created in a secondary origin are passed
     // to the primary origin for the command log, etc.
     this.chainerId = _.uniqueId(`ch-${window.location.origin}-`)
     this.firstCall = true
-    this.useInitialStack = null
   }
 
   static remove (key) {
@@ -25,40 +21,17 @@ export class $Chainer {
 
   static add (key, fn) {
     $Chainer.prototype[key] = function (...args) {
-      const userInvocationStack = this.useInitialStack
-        ? this.userInvocationStack
-        : $stackUtils.normalizedUserInvocationStack(
-          (new this.specWindow.Error('command invocation stack')).stack,
-        )
+      const userInvocationStack = $stackUtils.normalizedUserInvocationStack(
+        (new this.specWindow.Error('command invocation stack')).stack,
+      )
 
       // call back the original function with our new args
       // pass args an as array and not a destructured invocation
-      if (fn(this, userInvocationStack, args)) {
-        // no longer the first call
-        this.firstCall = false
-      }
+      fn(this, userInvocationStack, args)
 
       // return the chainer so additional calls
       // are slurped up by the chainer instead of cy
       return this
     }
-  }
-
-  // creates a new chainer instance
-  static create (key, userInvocationStack, specWindow, args) {
-    const chainer = new $Chainer(userInvocationStack, specWindow)
-
-    // this is the first command chained off of cy, so we use
-    // the stack passed in from that call instead of the stack
-    // from this invocation
-    chainer.useInitialStack = true
-
-    // since this is the first function invocation
-    // we need to pass through onto our instance methods
-    const chain = chainer[key].apply(chainer, args)
-
-    chain.useInitialStack = false
-
-    return chain
   }
 }

--- a/packages/driver/src/cypress/chainer.ts
+++ b/packages/driver/src/cypress/chainer.ts
@@ -8,10 +8,17 @@ export class $Chainer {
 
   constructor (specWindow) {
     this.specWindow = specWindow
-    // the id prefix needs to be unique per origin, so there are not
+    // The id prefix needs to be unique per origin, so there are not
     // collisions when chainers created in a secondary origin are passed
     // to the primary origin for the command log, etc.
     this.chainerId = _.uniqueId(`ch-${window.location.origin}-`)
+
+    // firstCall is used to throw a useful error if the user leads off with a
+    // parent command.
+
+    // TODO: Refactor firstCall out of the chainer and into the command function,
+    // since cy.ts already has all the necessary information to throw this error
+    // without an instance variable, in one localized place in the code.
     this.firstCall = true
   }
 

--- a/packages/driver/src/cypress/commands.ts
+++ b/packages/driver/src/cypress/commands.ts
@@ -15,7 +15,6 @@ const builtInCommands = [
 
 const reservedCommandNames = {
   addAlias: true,
-  addChainer: true,
   addCommand: true,
   addCommandSync: true,
   aliasNotFoundFor: true,
@@ -255,16 +254,9 @@ export default {
         })
       },
 
-      addChainer (obj) {
-        // perp loop
-        for (let name in obj) {
-          const fn = obj[name]
-
-          cy.addChainer(name, fn)
-        }
-
-        // prevent loop comprehension
-        return null
+      addSelector (name, fn) {
+        // TODO: Add overriding stuff.
+        return cy.addSelector(name, fn)
       },
 
       overwrite (name, fn) {


### PR DESCRIPTION
### User facing changelog
No user-facing changes.

### Additional details
This PR is the first of hopefully several with some cleanup and refactoring of a very hard to read and central part of our code base: How commands are added, queued, and executed.

There are no functional changes. The code is logically identical - but hopefully easier to read, with less internal state tracking and passing around of variables "to be used at some later point."

### Steps to test
All cypress tests execute identically. The CI build passing without test changes should show this well enough, but feel free to manually play with it as well.

### How has the user experience changed?
UX is unchanged. DX, reading this code, should be far better.

### PR Tasks
- [n/a] Have tests been added/updated? No test changes, because new code is functionally equivalent.
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
