### PR TITLE
fix: Require react-dom as a dependency for React projects

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2390,22 +2390,22 @@ linux-x64-workflow: &linux-x64-workflow
         requires:
           - build
     - run-frontend-shared-component-tests-chrome:
-        context: [test-runner:launchpad-tests, test-runner:percy]
+        context: [test-runner:cypress-record-key, test-runner:launchpad-tests, test-runner:percy]
         percy: true
         requires:
           - build
     - run-launchpad-integration-tests-chrome:
-        context: [test-runner:launchpad-tests, test-runner:percy]
+        context: [test-runner:cypress-record-key, test-runner:launchpad-tests, test-runner:percy]
         percy: true
         requires:
           - build
     - run-launchpad-component-tests-chrome:
-        context: [test-runner:launchpad-tests, test-runner:percy]
+        context: [test-runner:cypress-record-key, test-runner:launchpad-tests, test-runner:percy]
         percy: true
         requires:
           - build
     - run-app-integration-tests-chrome:
-        context: [test-runner:launchpad-tests, test-runner:percy]
+        context: [test-runner:cypress-record-key, test-runner:launchpad-tests, test-runner:percy]
         percy: true
         requires:
           - build
@@ -2418,7 +2418,7 @@ linux-x64-workflow: &linux-x64-workflow
         requires:
           - system-tests-node-modules-install          
     - run-app-component-tests-chrome:
-        context: [test-runner:launchpad-tests, test-runner:percy]
+        context: [test-runner:cypress-record-key, test-runner:launchpad-tests, test-runner:percy]
         percy: true
         requires:
           - build

--- a/packages/data-context/test/unit/sources/WizardDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/WizardDataSource.spec.ts
@@ -123,7 +123,7 @@ describe('packagesToInstall', () => {
 
     const actual = ctx.wizard.installDependenciesCommand()
 
-    expect(actual).to.eq(`npm install -D next react`)
+    expect(actual).to.eq(`npm install -D next react react-dom`)
   })
 
   it('nuxtjs-vue2-unconfigured', async () => {

--- a/packages/data-context/test/unit/sources/WizardDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/WizardDataSource.spec.ts
@@ -27,7 +27,7 @@ describe('packagesToInstall', () => {
 
     const actual = ctx.wizard.installDependenciesCommand()
 
-    expect(actual).to.eq(`npm install -D react-scripts webpack react`)
+    expect(actual).to.eq(`npm install -D react-scripts webpack react-dom react`)
   })
 
   it('vueclivue2-unconfigured', async () => {
@@ -91,7 +91,7 @@ describe('packagesToInstall', () => {
 
     const actual = ctx.wizard.installDependenciesCommand()
 
-    expect(actual).to.eq(`npm install -D vite react`)
+    expect(actual).to.eq(`npm install -D vite react react-dom`)
   })
 
   it('regular vue project with vite', async () => {

--- a/packages/scaffold-config/src/dependencies.ts
+++ b/packages/scaffold-config/src/dependencies.ts
@@ -34,6 +34,15 @@ export const WIZARD_DEPENDENCY_REACT = {
   minVersion: '>=16.x',
 } as const
 
+export const WIZARD_DEPENDENCY_REACT_DOM = {
+  type: 'react-dom',
+  name: 'React DOM',
+  package: 'react-dom',
+  installer: 'react-dom',
+  description: 'This package serves as the entry point to the DOM and server renderers for React',
+  minVersion: '>=16.x',
+} as const
+
 export const WIZARD_DEPENDENCY_TYPESCRIPT = {
   type: 'typescript',
   name: 'TypeScript',
@@ -97,6 +106,7 @@ export const WIZARD_DEPENDENCIES = [
   WIZARD_DEPENDENCY_NUXT,
   WIZARD_DEPENDENCY_NEXT,
   WIZARD_DEPENDENCY_REACT,
+  WIZARD_DEPENDENCY_REACT_DOM,
   WIZARD_DEPENDENCY_VUE_2,
   WIZARD_DEPENDENCY_VUE_3,
 ] as const

--- a/packages/scaffold-config/src/frameworks.ts
+++ b/packages/scaffold-config/src/frameworks.ts
@@ -129,6 +129,7 @@ export const WIZARD_FRAMEWORKS = [
       return [
         inPkgJson(dependencies.WIZARD_DEPENDENCY_NEXT, projectPath),
         inPkgJson(dependencies.WIZARD_DEPENDENCY_REACT, projectPath),
+        inPkgJson(dependencies.WIZARD_DEPENDENCY_REACT_DOM, projectPath),
       ]
     },
     codeGenFramework: 'react',

--- a/packages/scaffold-config/src/frameworks.ts
+++ b/packages/scaffold-config/src/frameworks.ts
@@ -71,6 +71,7 @@ export const WIZARD_FRAMEWORKS = [
       return [
         inPkgJson(dependencies.WIZARD_DEPENDENCY_REACT_SCRIPTS, projectPath),
         inPkgJson(dependencies.WIZARD_DEPENDENCY_WEBPACK, projectPath),
+        inPkgJson(dependencies.WIZARD_DEPENDENCY_REACT_DOM, projectPath),
         inPkgJson(dependencies.WIZARD_DEPENDENCY_REACT, projectPath),
       ]
     },
@@ -207,6 +208,7 @@ export const WIZARD_FRAMEWORKS = [
       return [
         getBundlerDependency(bundler, projectPath),
         inPkgJson(dependencies.WIZARD_DEPENDENCY_REACT, projectPath),
+        inPkgJson(dependencies.WIZARD_DEPENDENCY_REACT_DOM, projectPath),
       ]
     },
     codeGenFramework: 'react',


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #22371 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

React DOM has been explicitly named as a required dependency for component testing in React applications

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

For component testing in applications that use React, we require both `react` and `react-dom` libraries, but only `react` is listed as a required dependency, so the wizard will allow users to continue without notifying them if their project doesn't have `react-dom` as a dependency, and then when they try to run a test, it will fail because `react-dom` is required.

This PR adds `react-dom` as a required dependency for React applications using Vite and ones created with Create React App so that users know to install `react-dom` in their project if it wasn't already installed.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
Follow these steps with a Create React App app and a React app using Vite:

- Create a new application
- Either load the project into Cypress via global mode or run `yarn cypress open` in the project directory
- Select component testing
- Verify that when the wizard checks the project's dependencies, it includes `react-dom`
- Verify that if `react-dom` doesn't exist in the project, the wizard reflects this and prompts you to install it

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

![Screen Shot 2022-06-28 at 3 33 50 PM](https://user-images.githubusercontent.com/14275198/176270125-0be1ce71-b64d-44b7-966f-319a4d11240b.png)


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
