### PR TITLE
fix: ignore WebSwapCGLLayer warning

### DIFF
--- a/cli/lib/exec/open.js
+++ b/cli/lib/exec/open.js
@@ -76,7 +76,6 @@ module.exports = {
         return spawn.start(args, {
           dev: options.dev,
           detached: Boolean(options.detached),
-          stdio: 'inherit',
         })
       } catch (err) {
         if (err.details) {

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -38,7 +38,13 @@ const isDbusWarning = /Failed to connect to the bus:/
 // ERROR: No matching issuer found
 const isCertVerifyProcBuiltin = /(^\[.*ERROR:cert_verify_proc_builtin\.cc|^----- Certificate i=0 \(OU=Cypress Proxy|^ERROR: No matching issuer found$)/
 
-const GARBAGE_WARNINGS = [isXlibOrLibudevRe, isHighSierraWarningRe, isRenderWorkerRe, isDbusWarning, isCertVerifyProcBuiltin]
+// Electron logs a benign warning about WebSwapCGLLayer on MacOS v12 and Electron v18 due to a naming collision in shared libraries.
+// Once this is fixed upstream this regex can be removed: https://github.com/electron/electron/issues/33685
+// Sample:
+// objc[60540]: Class WebSwapCGLLayer is implemented in both /System/Library/Frameworks/WebKit.framework/Versions/A/Frameworks/WebCore.framework/Versions/A/Frameworks/libANGLE-shared.dylib (0x7ffa5a006318) and /{path/to/app}/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libGLESv2.dylib (0x10f8a89c8). One of the two will be used. Which one is undefined.
+const isMacOSElectronWebSwapCGLLayerWarning = /^objc\[\d+\]: Class WebSwapCGLLayer is implemented in both.*Which one is undefined\./
+
+const GARBAGE_WARNINGS = [isXlibOrLibudevRe, isHighSierraWarningRe, isRenderWorkerRe, isDbusWarning, isCertVerifyProcBuiltin, isMacOSElectronWebSwapCGLLayerWarning]
 
 const isGarbageLineWarning = (str) => {
   return _.some(GARBAGE_WARNINGS, (re) => {

--- a/cli/test/lib/exec/open_spec.js
+++ b/cli/test/lib/exec/open_spec.js
@@ -25,7 +25,6 @@ describe('exec open', function () {
       .then(() => {
         expect(spawn.start).to.be.calledWith([], {
           detached: false,
-          stdio: 'inherit',
           dev: true,
         })
       })

--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -75,6 +75,8 @@ describe('lib/exec/spawn', function () {
         [3801:0606/152837.383892:ERROR:cert_verify_proc_builtin.cc(681)] CertVerifyProcBuiltin for www.googletagmanager.com failed:
         ----- Certificate i=0 (OU=Cypress Proxy Server Certificate,O=Cypress Proxy CA,L=Internet,ST=Internet,C=Internet,CN=www.googletagmanager.com) -----
         ERROR: No matching issuer found
+
+        objc[60540]: Class WebSwapCGLLayer is implemented in both /System/Library/Frameworks/WebKit.framework/Versions/A/Frameworks/WebCore.framework/Versions/A/Frameworks/libANGLE-shared.dylib (0x7ffa5a006318) and /{path/to/app}/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libGLESv2.dylib (0x10f8a89c8). One of the two will be used. Which one is undefined.
       `
 
       const lines = _


### PR DESCRIPTION
- Closes #21615

### User facing changelog
Removes "Class WebSwapCGLLayer is implemented in both" terminal log when opening Cypress

### Additional details
This warning is benign (at least, it hasn't been confirmed to be causing any issues with Cypress) and confuses users who see this log in their terminal. We are now filtering this error.

Note that this is only an issue for Electron v18 and MacOS v12. I was on MacOS v11 and never saw this log until I updated.

Cypress open was forcing `stdio: 'inherit'` for the child process which bypasses all of our stdout filtering. I did not see any difference in terminal output after the removal of this option. We are piping all of the output of the child process so it makes sense that we wouldn't see any difference here. Since we are no longer forcing `stdio: 'inherit'`, we will now be filtering the common (benign) warnings in open mode which seems desired.

### Steps to test
This is an OS specific issue (MacOS Monterey). I was on v11 before trying to debug this issue and had to upgrade.

Before: Running `yarn workspace @packages/driver cypress:run`
![Screen Shot 2022-06-29 at 4 22 51 PM](https://user-images.githubusercontent.com/25158820/176547268-8d211b15-5b8f-4d83-b026-ab807629e1b5.png)

After:
![Screen Shot 2022-06-29 at 4 22 12 PM](https://user-images.githubusercontent.com/25158820/176547176-be272ddf-05a2-4754-85ca-81f399c37816.png)


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
