### PR TITLE
fix: cypress-schematic ci issue with @types/eslint

### DIFF
--- a/npm/cypress-schematic/sandbox12/angular.json
+++ b/npm/cypress-schematic/sandbox12/angular.json
@@ -102,5 +102,8 @@
       }
     }
   },
-  "defaultProject": "sandbox"
+  "defaultProject": "sandbox",
+  "cli": {
+    "packageManager": "yarn"
+  }
 }

--- a/npm/cypress-schematic/sandbox12/package.json
+++ b/npm/cypress-schematic/sandbox12/package.json
@@ -35,5 +35,8 @@
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "^1.5.0",
     "typescript": "~4.5.5"
+  },
+  "resolutions": {
+    "@types/eslint": "8.4.3"
   }
 }


### PR DESCRIPTION
### User facing changelog
na

### Additional details
There is an issue with @types/eslint causing the cypress-schematic tests to fail. Pinning the version resolves this for now.
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/61032

### Steps to test
`yarn workspace @cypress/schematic launch:test12` now passes

### How has the user experience changed?
na

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
