### PR TITLE
fix: add tooltip to New Spec button

### DIFF
--- a/packages/app/src/specs/SpecsListHeader.cy.tsx
+++ b/packages/app/src/specs/SpecsListHeader.cy.tsx
@@ -62,6 +62,14 @@ describe('<SpecsListHeader />', { keystrokeDelay: 0 }, () => {
     .should('have.been.called')
   })
 
+  it('provides expected tooltip content', () => {
+    cy.get('.v-popper').trigger('mouseenter')
+    cy.findByTestId('new-spec-tooltip').should('be.visible')
+        .and('have.text', 'Create New Spec')
+
+    cy.percySnapshot()
+  })
+
   it('emits a spec pattern event', () => {
     const onShowSpecPatternModal = cy.stub().as('show-spec-pattern-modal')
     const search = ref('')

--- a/packages/app/src/specs/SpecsListHeader.vue
+++ b/packages/app/src/specs/SpecsListHeader.vue
@@ -44,16 +44,32 @@
     </Input>
 
     <div class="flex h-40px min-w-127px gap-16px">
-      <Button
-        data-cy="new-spec-button"
-        :prefix-icon="IconAdd"
-        prefix-icon-class="justify-center text-lg text-center icon-light-transparent icon-dark-white"
-        class="min-w-127px"
-        size="lg"
-        @click="emit('showCreateSpecModal')"
+      <Tooltip
+          class="h-full truncate"
+          data-cy="tooltip"
+          placement="top"
       >
-        {{ t('specPage.newSpecButton') }}
-      </Button>
+        <Button
+            data-cy="new-spec-button"
+            :prefix-icon="IconAdd"
+            prefix-icon-class="justify-center text-lg text-center icon-light-transparent icon-dark-white"
+            class="min-w-127px"
+            size="lg"
+            @click="emit('showCreateSpecModal')"
+        >
+          {{ t('specPage.newSpecButton') }}
+        </Button>
+        <template
+            #popper
+        >
+          <p
+              data-cy="new-spec-tooltip"
+              class="max-w-sm text-sm truncate overflow-hidden"
+          >
+            Create New Spec
+          </p>
+        </template>
+      </Tooltip>
     </div>
   </div>
 </template>
@@ -66,6 +82,7 @@ import type { Ref } from 'vue'
 import { useI18n } from '@cy/i18n'
 import Button from '@cy/components/Button.vue'
 import Input from '@cy/components/Input.vue'
+import Tooltip from '@cy/components/Tooltip.vue'
 import IconMagnifyingGlass from '~icons/cy/magnifying-glass_x16'
 import IconAdd from '~icons/cy/add-large_x16'
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes [Issue 21858](https://github.com/cypress-io/cypress/issues/21858)

### User facing changelog
n/a

### Additional details
**Implementation Details:**
We have a few different tooltip styles in the project. Specifically the affected page has 2 (Created, SpecHeaderCloudDataTooltip). In lieu of introducing a third tooltip style to the page (exactly matching "Run All Tests") I opted to match the Created tooltip:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/66479094/176960483-ec3afeb9-907d-4e23-ae67-8dc36d1211a0.png">

### Steps to test
1. Mouse Hover over New Spec button

### How has the user experience changed?
**Before:**
Note: Screenshot is on New Spec hover
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/66479094/176961121-86b49510-8434-457f-91d8-6e56039f7715.png">

**After:**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/66479094/176959604-f0850a0a-a644-4f75-87e6-9f803ab31304.png">


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
