### PR TITLE
fix: absolute positioning element blackouts in cy.screenshot

### DIFF
--- a/packages/driver/src/dom/blackout.ts
+++ b/packages/driver/src/dom/blackout.ts
@@ -32,11 +32,12 @@ function addBlackoutForElement ($body, $el) {
   $(`<div class="__cypress-blackout" style="${style}">`).appendTo($body)
 }
 
-function addBlackouts ($body, selector) {
+function addBlackouts ($body, $container, selector) {
   let $el
 
   try {
-    $el = $body.find(selector)
+    // only scope blacked out elements to to screenshotted element, not necessarily the whole body
+    $el = $container.find(selector)
     if (!$el.length) return
   } catch (err) {
     // if it's an invalid selector, just ignore it

--- a/system-tests/__snapshots__/screenshot_viewport_capture_spec.js
+++ b/system-tests/__snapshots__/screenshot_viewport_capture_spec.js
@@ -18,19 +18,20 @@ exports['e2e screenshot viewport capture / passes'] = `
 
 
   ✓ takes consistent viewport captures
+  ✓ properly blacks out absolute elements within a relative container
 
-  1 passing
+  2 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        1                                                                                │
-  │ Passing:      1                                                                                │
+  │ Tests:        2                                                                                │
+  │ Passing:      2                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  26                                                                               │
+  │ Screenshots:  27                                                                               │
   │ Video:        true                                                                             │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     screenshot_viewport_capture.cy.js                                                │
@@ -91,6 +92,8 @@ exports['e2e screenshot viewport capture / passes'] = `
      are (23).png                                                                                   
   -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
      are (24).png                                                                                   
+  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/properly blac      (400x400)
+     ks out absolute elements within a relative container.png                                       
 
 
   (Video)
@@ -107,9 +110,9 @@ exports['e2e screenshot viewport capture / passes'] = `
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  screenshot_viewport_capture.cy.js        XX:XX        1        1        -        -        - │
+  │ ✔  screenshot_viewport_capture.cy.js        XX:XX        2        2        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        1        1        -        -        -  
+    ✔  All specs passed!                        XX:XX        2        2        -        -        -  
 
 
 `

--- a/system-tests/projects/e2e/cypress/e2e/screenshot_viewport_capture.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/screenshot_viewport_capture.cy.js
@@ -27,6 +27,7 @@ it('takes consistent viewport captures', () => {
   })
 })
 
+// @see https://github.com/cypress-io/cypress/issues/22173
 it('properly blacks out absolute elements within a relative container', () => {
   cy.visit('cypress/fixtures/screenshot-blackout.html')
   .get('.centered-container')

--- a/system-tests/projects/e2e/cypress/e2e/screenshot_viewport_capture.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/screenshot_viewport_capture.cy.js
@@ -26,3 +26,61 @@ it('takes consistent viewport captures', () => {
     Cypress._.times(25, fn)
   })
 })
+
+it('properly blacks out absolute elements within a relative container', () => {
+  cy.visit('cypress/fixtures/screenshot-blackout.html')
+  .get('.centered-container')
+  .screenshot({
+    blackout: ['.blue'],
+    onBeforeScreenshot () {
+      const blackedOutElementCoordinates = Cypress.$(
+        '#__cypress-animation-disabler+div.__cypress-blackout',
+      )[0].getBoundingClientRect()
+
+      const actualElementCoordinates = Cypress.$(
+        '.centered-container .blue',
+      )[0].getBoundingClientRect()
+
+      // make sure blackout element is within 1 pixel of it's element it is supposed to black out
+      expect(blackedOutElementCoordinates.bottom).to.be.closeTo(
+        actualElementCoordinates.bottom,
+        1,
+      )
+
+      expect(blackedOutElementCoordinates.height).to.be.closeTo(
+        actualElementCoordinates.height,
+        1,
+      )
+
+      expect(blackedOutElementCoordinates.left).to.be.closeTo(
+        actualElementCoordinates.left,
+        1,
+      )
+
+      expect(blackedOutElementCoordinates.right).to.be.closeTo(
+        actualElementCoordinates.right,
+        1,
+      )
+
+      expect(blackedOutElementCoordinates.top).to.be.closeTo(
+        actualElementCoordinates.top,
+        1,
+      )
+
+      expect(blackedOutElementCoordinates.width).to.be.closeTo(
+        actualElementCoordinates.width,
+        1,
+      )
+
+      expect(blackedOutElementCoordinates.x).to.be.closeTo(
+        actualElementCoordinates.x,
+        1,
+      )
+
+      expect(blackedOutElementCoordinates.y).to.be.closeTo(
+        actualElementCoordinates.y,
+        1,
+      )
+    },
+  })
+})

--- a/system-tests/projects/e2e/cypress/e2e/screenshots.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/screenshots.cy.js
@@ -204,64 +204,6 @@ describe('taking screenshots', () => {
     })
   })
 
-  it('properly blacks out absolute elements within a relative container', () => {
-    cy.visit('cypress/fixtures/screenshot-blackout.html')
-    .get('.centered-container')
-    .screenshot({
-      blackout: ['.blue'],
-      onBeforeScreenshot () {
-        const blackedOutElementCoordinates = Cypress.$(
-          '#__cypress-animation-disabler+div.__cypress-blackout',
-        )[0].getBoundingClientRect()
-
-        const actualElementCoordinates = Cypress.$(
-          '.centered-container .blue',
-        )[0].getBoundingClientRect()
-
-        // make sure blackout element is within 1 pixel of it's element it is supposed to black out
-        expect(blackedOutElementCoordinates.bottom).to.be.closeTo(
-          actualElementCoordinates.bottom,
-          1,
-        )
-
-        expect(blackedOutElementCoordinates.height).to.be.closeTo(
-          actualElementCoordinates.height,
-          1,
-        )
-
-        expect(blackedOutElementCoordinates.left).to.be.closeTo(
-          actualElementCoordinates.left,
-          1,
-        )
-
-        expect(blackedOutElementCoordinates.right).to.be.closeTo(
-          actualElementCoordinates.right,
-          1,
-        )
-
-        expect(blackedOutElementCoordinates.top).to.be.closeTo(
-          actualElementCoordinates.top,
-          1,
-        )
-
-        expect(blackedOutElementCoordinates.width).to.be.closeTo(
-          actualElementCoordinates.width,
-          1,
-        )
-
-        expect(blackedOutElementCoordinates.x).to.be.closeTo(
-          actualElementCoordinates.x,
-          1,
-        )
-
-        expect(blackedOutElementCoordinates.y).to.be.closeTo(
-          actualElementCoordinates.y,
-          1,
-        )
-      },
-    })
-  })
-
   describe('clipping', () => {
     it('can clip app screenshots', () => {
       cy.viewport(600, 200)

--- a/system-tests/projects/e2e/cypress/e2e/screenshots.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/screenshots.cy.js
@@ -204,6 +204,64 @@ describe('taking screenshots', () => {
     })
   })
 
+  it('properly blacks out absolute elements within a relative container', () => {
+    cy.visit('cypress/fixtures/screenshot-blackout.html')
+    .get('.centered-container')
+    .screenshot({
+      blackout: ['.blue'],
+      onBeforeScreenshot () {
+        const blackedOutElementCoordinates = Cypress.$(
+          '#__cypress-animation-disabler+div.__cypress-blackout',
+        )[0].getBoundingClientRect()
+
+        const actualElementCoordinates = Cypress.$(
+          '.centered-container .blue',
+        )[0].getBoundingClientRect()
+
+        // make sure blackout element is within 1 pixel of it's element it is supposed to black out
+        expect(blackedOutElementCoordinates.bottom).to.be.closeTo(
+          actualElementCoordinates.bottom,
+          1,
+        )
+
+        expect(blackedOutElementCoordinates.height).to.be.closeTo(
+          actualElementCoordinates.height,
+          1,
+        )
+
+        expect(blackedOutElementCoordinates.left).to.be.closeTo(
+          actualElementCoordinates.left,
+          1,
+        )
+
+        expect(blackedOutElementCoordinates.right).to.be.closeTo(
+          actualElementCoordinates.right,
+          1,
+        )
+
+        expect(blackedOutElementCoordinates.top).to.be.closeTo(
+          actualElementCoordinates.top,
+          1,
+        )
+
+        expect(blackedOutElementCoordinates.width).to.be.closeTo(
+          actualElementCoordinates.width,
+          1,
+        )
+
+        expect(blackedOutElementCoordinates.x).to.be.closeTo(
+          actualElementCoordinates.x,
+          1,
+        )
+
+        expect(blackedOutElementCoordinates.y).to.be.closeTo(
+          actualElementCoordinates.y,
+          1,
+        )
+      },
+    })
+  })
+
   describe('clipping', () => {
     it('can clip app screenshots', () => {
       cy.viewport(600, 200)

--- a/system-tests/projects/e2e/cypress/fixtures/screenshot-blackout.html
+++ b/system-tests/projects/e2e/cypress/fixtures/screenshot-blackout.html
@@ -1,0 +1,47 @@
+<html>
+  <head>
+    <style>
+      .centered-container {
+        position: relative;
+        height: 400px;
+        width: 400px;
+        max-width: 100%;
+        margin: 0 auto;
+        text-align: center;
+        vertical-align: middle;
+      }
+      .third-container {
+        color: white;
+      }
+      .grey {
+        background-color: grey;
+      }
+      .blue {
+        background-color: blue;
+        position: absolute;
+        top: 0;
+        right: 0%;
+      }
+      .red {
+        background-color: red;
+        position: absolute;
+        top: 0;
+        right: 33.33%;
+      }
+      .purple {
+        background-color: purple;
+        position: absolute;
+        top: 0;
+        right: 66.66%;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Screenshot Blackout Test Absolute Positioning</h1>
+    <div class="centered-container grey">
+      <div class="third-container blue"> Blue Container</div>
+      <div class="third-container red"> Red Container</div>
+      <div class="third-container purple"> Purple Container</div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #22173

### User facing changelog
Fixes a regression in 9.6 where absolute elements that are blacked out with `cy.screenshot` are positioned off the container element and not the body.

### Additional details
This PR attempts to fix a regression when screenshots were refactored for `cy.origin` in #20949 where element dimensions are calculated from the screenshotted element. This works in most cases, but causes some trouble with absolute elements. To fix this, since we no longer have access to the `AutIframe` class, is to reference the body to calculate dimensions for elements. 

### Steps to test
See changes to the `screenshot_viewport_capture_spec.js`

### How has the user experience changed?
##### Before code changes with added regression test in `screenshot_viewport_capture_spec.js`
![](https://user-images.githubusercontent.com/3980464/178596430-1f7faff8-b951-4efb-b6a3-d2fef94292cf.png)

##### After code changes with added regression test in `screenshot_viewport_capture_spec.js`
![](https://user-images.githubusercontent.com/3980464/178596458-cf83f01d-8143-4595-9802-1ed434680f70.png)

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
