### PR TITLE
fix: map framework name to dependency that contains webpack

### DIFF
--- a/npm/webpack-dev-server/src/devServer.ts
+++ b/npm/webpack-dev-server/src/devServer.ts
@@ -25,7 +25,7 @@ export type WebpackDevServerConfig = {
   webpackConfig?: unknown // Derived from the user's webpack
 }
 
-const ALL_FRAMEWORKS = ['create-react-app', 'nuxt', 'react', 'vue-cli', 'next', 'vue'] as const
+export const ALL_FRAMEWORKS = ['create-react-app', 'nuxt', 'react', 'vue-cli', 'next', 'vue'] as const
 
 /**
  * @internal

--- a/npm/webpack-dev-server/test/handlers/createReactAppHandler.spec.ts
+++ b/npm/webpack-dev-server/test/handlers/createReactAppHandler.spec.ts
@@ -55,14 +55,18 @@ describe('createReactAppHandler', function () {
 
     process.chdir(projectRoot)
 
-    const { frameworkConfig: webpackConfig } = createReactAppHandler({
+    const { frameworkConfig: webpackConfig, sourceWebpackModulesResult } = createReactAppHandler({
       cypressConfig: { projectRoot } as Cypress.PluginConfigOptions,
+      framework: 'create-react-app',
     } as WebpackDevServerConfig)
 
     expect(webpackConfig.mode).eq('development')
     expectEslintModifications(webpackConfig)
     expectModuleSourceInPlaceModifications(webpackConfig, projectRoot)
     expectBabelRuleModifications(webpackConfig, projectRoot)
+
+    expect(sourceWebpackModulesResult.framework?.importPath).to.include('react-scripts')
+    expect(sourceWebpackModulesResult.webpack.majorVersion).eq(4)
   })
 
   it('sources the config from react-scripts v5', async () => {
@@ -70,8 +74,9 @@ describe('createReactAppHandler', function () {
 
     process.chdir(projectRoot)
 
-    const { frameworkConfig: webpackConfig } = createReactAppHandler({
+    const { frameworkConfig: webpackConfig, sourceWebpackModulesResult } = createReactAppHandler({
       cypressConfig: { projectRoot } as Cypress.PluginConfigOptions,
+      framework: 'create-react-app',
     } as WebpackDevServerConfig)
 
     expect(webpackConfig.mode).eq('development')
@@ -79,6 +84,9 @@ describe('createReactAppHandler', function () {
     expectModuleSourceInPlaceModifications(webpackConfig, projectRoot)
     expectBabelRuleModifications(webpackConfig, projectRoot)
     expectReactScriptsFiveModifications(webpackConfig)
+
+    expect(sourceWebpackModulesResult.framework?.importPath).to.include('react-scripts')
+    expect(sourceWebpackModulesResult.webpack.majorVersion).eq(5)
   })
 
   it('sources the config from ejected cra', async () => {
@@ -86,8 +94,9 @@ describe('createReactAppHandler', function () {
 
     process.chdir(projectRoot)
 
-    const { frameworkConfig: webpackConfig } = createReactAppHandler({
+    const { frameworkConfig: webpackConfig, sourceWebpackModulesResult } = createReactAppHandler({
       cypressConfig: { projectRoot } as Cypress.PluginConfigOptions,
+      framework: 'create-react-app',
     } as WebpackDevServerConfig)
 
     expect(webpackConfig.mode).eq('development')
@@ -95,5 +104,8 @@ describe('createReactAppHandler', function () {
     expectModuleSourceInPlaceModifications(webpackConfig, projectRoot)
     expectBabelRuleModifications(webpackConfig, projectRoot)
     expectReactScriptsFiveModifications(webpackConfig)
+
+    expect(sourceWebpackModulesResult.framework).to.be.null
+    expect(sourceWebpackModulesResult.webpack.majorVersion).eq(5)
   })
 })

--- a/npm/webpack-dev-server/test/handlers/nextHandler.spec.ts
+++ b/npm/webpack-dev-server/test/handlers/nextHandler.spec.ts
@@ -31,7 +31,7 @@ describe('nextHandler', function () {
 
     process.chdir(projectRoot)
 
-    const { frameworkConfig: webpackConfig } = await nextHandler({
+    const { frameworkConfig: webpackConfig, sourceWebpackModulesResult } = await nextHandler({
       framework: 'next',
       cypressConfig: { projectRoot } as Cypress.PluginConfigOptions,
     } as WebpackDevServerConfig)
@@ -39,6 +39,9 @@ describe('nextHandler', function () {
     expectWatchOverrides(webpackConfig)
     expectPagesDir(webpackConfig, projectRoot)
     expectWebpackSpan(webpackConfig)
+
+    expect(sourceWebpackModulesResult.webpack.importPath).to.include('next')
+    expect(sourceWebpackModulesResult.webpack.majorVersion).eq(5)
   })
 
   it('sources from a next-11 project', async () => {
@@ -46,7 +49,7 @@ describe('nextHandler', function () {
 
     process.chdir(projectRoot)
 
-    const { frameworkConfig: webpackConfig } = await nextHandler({
+    const { frameworkConfig: webpackConfig, sourceWebpackModulesResult } = await nextHandler({
       framework: 'next',
       cypressConfig: { projectRoot } as Cypress.PluginConfigOptions,
     } as WebpackDevServerConfig)
@@ -54,6 +57,27 @@ describe('nextHandler', function () {
     expectWatchOverrides(webpackConfig)
     expectPagesDir(webpackConfig, projectRoot)
     expectWebpackSpan(webpackConfig)
+
+    expect(sourceWebpackModulesResult.webpack.importPath).to.include('next')
+    expect(sourceWebpackModulesResult.webpack.majorVersion).eq(5)
+  })
+
+  it('sources from a next-11-webpack-4 project', async () => {
+    const projectRoot = await scaffoldMigrationProject('next-11-webpack-4')
+
+    process.chdir(projectRoot)
+
+    const { frameworkConfig: webpackConfig, sourceWebpackModulesResult } = await nextHandler({
+      framework: 'next',
+      cypressConfig: { projectRoot, cypressBinaryRoot: __dirname } as Cypress.PluginConfigOptions,
+    } as WebpackDevServerConfig)
+
+    expectWatchOverrides(webpackConfig)
+    expectPagesDir(webpackConfig, projectRoot)
+    expectWebpackSpan(webpackConfig)
+
+    expect(sourceWebpackModulesResult.webpack.importPath).to.include('next')
+    expect(sourceWebpackModulesResult.webpack.majorVersion).eq(4)
   })
 
   it('throws if nodeVersion is set to bundled', async () => {

--- a/npm/webpack-dev-server/test/handlers/nuxtHandler.spec.ts
+++ b/npm/webpack-dev-server/test/handlers/nuxtHandler.spec.ts
@@ -13,12 +13,16 @@ describe('nuxtHandler', function () {
 
     process.chdir(projectRoot)
 
-    const { frameworkConfig: webpackConfig } = await nuxtHandler({
+    const { frameworkConfig: webpackConfig, sourceWebpackModulesResult } = await nuxtHandler({
       cypressConfig: { projectRoot } as Cypress.PluginConfigOptions,
+      framework: 'nuxt',
     } as WebpackDevServerConfig)
 
     // Verify it's a Vue-specific webpack config by seeing if VueLoader is present.
     expect(webpackConfig.plugins.find((plug) => plug.constructor.name === 'VueLoader'))
     expect(webpackConfig.performance).to.be.undefined
+
+    expect(sourceWebpackModulesResult.framework?.importPath).to.include('@nuxt/webpack')
+    expect(sourceWebpackModulesResult.webpack.majorVersion).eq(4)
   })
 })

--- a/npm/webpack-dev-server/test/handlers/vueCliHandler.spec.ts
+++ b/npm/webpack-dev-server/test/handlers/vueCliHandler.spec.ts
@@ -13,12 +13,16 @@ describe('vueCliHandler', function () {
 
     process.chdir(projectRoot)
 
-    const { frameworkConfig: webpackConfig } = vueCliHandler({
+    const { frameworkConfig: webpackConfig, sourceWebpackModulesResult } = vueCliHandler({
       cypressConfig: { projectRoot } as Cypress.PluginConfigOptions,
+      framework: 'vue-cli',
     } as WebpackDevServerConfig)
 
     // Verify it's a Vue-specific webpack config by seeing if VueLoader is present.
     expect(webpackConfig.plugins.find((plug) => plug.constructor.name === 'VueLoader'))
+
+    expect(sourceWebpackModulesResult.framework?.importPath).to.include('@vue/cli-service')
+    expect(sourceWebpackModulesResult.webpack.majorVersion).eq(5)
   })
 
   it('sources from a @vue/cli-service@4.x project with Vue 2', async () => {
@@ -26,11 +30,15 @@ describe('vueCliHandler', function () {
 
     process.chdir(projectRoot)
 
-    const { frameworkConfig: webpackConfig } = vueCliHandler({
+    const { frameworkConfig: webpackConfig, sourceWebpackModulesResult } = vueCliHandler({
       cypressConfig: { projectRoot } as Cypress.PluginConfigOptions,
+      framework: 'vue-cli',
     } as WebpackDevServerConfig)
 
     // Verify it's a Vue-specific webpack config by seeing if VueLoader is present.
     expect(webpackConfig.plugins.find((plug) => plug.constructor.name === 'VueLoader'))
+
+    expect(sourceWebpackModulesResult.framework?.importPath).to.include('@vue/cli-service')
+    expect(sourceWebpackModulesResult.webpack.majorVersion).eq(4)
   })
 })


### PR DESCRIPTION
### User facing changelog
na

### Additional details
When sourcing Webpack dependencies for `@cypress/webpack-dev-server`, we use the provided framework as the `require.resolve` searchRoot if provided. We need to map the provided framework to the corresponding dependency for this to make sense i.e. `create-react-app` -> `react-scripts`. This was working due to the recursive nature of `require.resolve` and our fallback to search `projectRoot` is we can't find the framework, but we want to start the search at the package that might contain webpack in case there are hoisting conflicts.

### Steps to test
All system tests for `@cypress/webpack-dev-server` are green, and I've added some unit tests to the handlers to confirm the new behavior.

### How has the user experience changed?
na, this should fix any bugs some users might have had if `webpack` wasn't hoisted to the root of their project's `node_modules`

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
