### PR TITLE
feat: support vite.config.mts and vite.config.cts

### DIFF
--- a/npm/vite-dev-server/src/constants.ts
+++ b/npm/vite-dev-server/src/constants.ts
@@ -3,4 +3,6 @@ export const configFiles = [
   'vite.config.js',
   'vite.config.mjs',
   'vite.config.cjs',
+  'vite.config.mts',
+  'vite.config.cts',
 ]

--- a/packages/launchpad/cypress/e2e/error-handling.cy.ts
+++ b/packages/launchpad/cypress/e2e/error-handling.cy.ts
@@ -68,7 +68,7 @@ describe('Error handling', () => {
       cy.openProject('missing-vite-config', ['--component'])
       cy.visitLaunchpad()
 
-      ;['vite.config.js', 'vite.config.ts', 'vite.config.mjs', 'vite.config.cjs'].forEach((idiomaticConfigFile) => {
+      ;['vite.config.js', 'vite.config.ts', 'vite.config.mjs', 'vite.config.cjs', 'vite.config.mts', 'vite.config.cts'].forEach((idiomaticConfigFile) => {
         cy.contains(idiomaticConfigFile)
       })
 


### PR DESCRIPTION
It's added in Vite 3.0:
https://github.com/vitejs/vite/pull/8729


### User facing changelog

Features:
- Support `vite.config.mts` and `vite.config.cts`

### Additional details

- Why was this change necessary?

As of Vite 3.0, `.mts` and `.cts` extensions are properly supported.
So, in a package without `"type": "module"`, using `import.meta` in a plain `.ts` file is equivalent to using it in a `.cts` file, which leads to a syntax error.

<img width="855" alt="image" src="https://user-images.githubusercontent.com/3277634/178904772-ed6ffe94-37da-417a-ba5a-f5af9fa9ab3e.png">

The fix is to either convert the package to `type: "module"` as a whole (which would bring many unexpected side effects), or use a proper `.mts` extension (which Cypress 10.3.0 doesn't yet support). Thus this PR.


### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
