### PR TITLE
test: fix flaky config error test

### DIFF
--- a/packages/launchpad/cypress/e2e/config-files-error-handling.cy.ts
+++ b/packages/launchpad/cypress/e2e/config-files-error-handling.cy.ts
@@ -158,6 +158,7 @@ describe('Launchpad: Error System Tests', () => {
   })
 
   it(`clears the error correctly after first 'try again' attempt`, () => {
+    cy.intercept('mutation-Main_ResetErrorsAndLoadConfig').as('resetErrorsAndLoadConfig')
     cy.scaffoldProject('config-with-ts-syntax-error')
     cy.openProject('config-with-ts-syntax-error')
     cy.visitLaunchpad()
@@ -165,6 +166,8 @@ describe('Launchpad: Error System Tests', () => {
 
     // Try again while the config is still invalid
     cy.findByRole('button', { name: 'Try again' }).click()
+
+    cy.wait('@resetErrorsAndLoadConfig')
 
     // Wait until config error is on screen again
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle)


### PR DESCRIPTION
### User facing changelog
na

### Additional details
the `clears the error correctly after first 'try again' attempt` test has been flaky on CI. The problem was that, without waiting for the mutation to finish executing, elements could be grabbed and the test could proceed without the config processing finishing.

### Steps to test
I ran this locally 100 times before and after the changes. Before, the test failed 15/100 times. After, no failures.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
