### PR TITLE
chore: avoid removing the types from vue, vue2 when yarn install

### DIFF
--- a/npm/mount-utils/package.json
+++ b/npm/mount-utils/package.json
@@ -17,6 +17,7 @@
   "files": [
     "dist"
   ],
+  "types": "dist/index.d.ts",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/npm/vue/package.json
+++ b/npm/vue/package.json
@@ -50,7 +50,7 @@
   "engines": {
     "node": ">=8"
   },
-  "types": "dist",
+  "types": "dist/index.d.ts",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/npm/vue2/package.json
+++ b/npm/vue2/package.json
@@ -37,7 +37,7 @@
   "engines": {
     "node": ">=8"
   },
-  "types": "dist",
+  "types": "dist/index.d.ts",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/scripts/sync-exported-npm-with-cli.js
+++ b/scripts/sync-exported-npm-with-cli.js
@@ -49,6 +49,7 @@ packlist({ path: currentPackageDir })
 
   // After everything is copied, let's update the Cypress cli package.json['exports'] map.
   const isModule = currentPackageConfig.type === 'module'
+  const types = currentPackageConfig.types
 
   const cliPackageConfig = require(path.join(cliPath, 'package.json'))
 
@@ -63,6 +64,11 @@ packlist({ path: currentPackageDir })
   if (!isModule) {
     // ./react/dist/cypress-react-cjs.js, etc
     subPackageExports.require = `./${exportName}/${currentPackageConfig.main}`
+  }
+
+  if (types) {
+    // ./react/dist/cypress-react-cjs.js, etc
+    subPackageExports.types = `./${exportName}/${types}`
   }
 
   if (!cliPackageConfig.files.includes(exportName)) {


### PR DESCRIPTION
To try this out, checkout the last commit of develop and run yarn install.

You should see the `cli/package.json` be modified without you asking.

## FIX

1. In the generation script, take the missing `types` field into account
2. Fix the typings target of `vue` and `vue2` 
3. Add `types` field for `mount-utils`.