### PR TITLE
feat: Add icons to headers that have tooltips

### DIFF
--- a/packages/app/src/specs/LastUpdatedHeader.vue
+++ b/packages/app/src/specs/LastUpdatedHeader.vue
@@ -6,10 +6,11 @@
   >
     <button
       type="button"
-      class="cursor-default decoration-dotted underline underline-gray-300 underline-offset-4 font-medium"
+      class="cursor-default flex font-medium items-center decoration-dotted underline underline-gray-300 underline-offset-4"
       data-cy="last-updated-header"
     >
       {{ t('specPage.lastUpdated.header') }}
+      <i-cy-action-question-mark-outline_x16 class="ml-1 icon-dark-gray-600" />
     </button>
     <template
       #popper

--- a/packages/app/src/specs/LastUpdatedHeader.vue
+++ b/packages/app/src/specs/LastUpdatedHeader.vue
@@ -10,13 +10,13 @@
       data-cy="last-updated-header"
     >
       {{ t('specPage.lastUpdated.header') }}
-      <i-cy-action-question-mark-outline_x16 class="ml-1 icon-dark-gray-600" />
+      <i-cy-circle-bg-question-mark_x16 class="ml-1 icon-dark-indigo-500 icon-light-indigo-100" />
     </button>
     <template
       #popper
     >
       <div
-        class="flex flex-col text-sm text-center max-w-300px p-4 items-center"
+        class="flex flex-col border-t-indigo-400 border-t-4px text-sm text-center max-w-300px p-4 items-center"
       >
         <i18n-t
           v-if="props.isGitAvailable"

--- a/packages/app/src/specs/LastUpdatedHeader.vue
+++ b/packages/app/src/specs/LastUpdatedHeader.vue
@@ -16,7 +16,7 @@
       #popper
     >
       <div
-        class="flex flex-col border-t-indigo-400 border-t-4px text-sm text-center max-w-300px p-4 items-center"
+        class="flex flex-col text-sm text-center max-w-300px p-4 items-center"
       >
         <i18n-t
           v-if="props.isGitAvailable"

--- a/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
+++ b/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
@@ -22,7 +22,7 @@
       #popper
     >
       <div
-        class="flex flex-col border-t-indigo-400 border-t-4px text-sm text-center p-4 items-center"
+        class="flex flex-col text-sm text-center p-4 items-center"
         data-cy="cloud-data-tooltip-content"
       >
         <div

--- a/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
+++ b/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
@@ -6,7 +6,7 @@
   >
     <button
       type="button"
-      class="cursor-default font-medium decoration-dotted underline underline-gray-300 underline-offset-4"
+      class="cursor-default flex font-medium items-center decoration-dotted underline underline-gray-300 underline-offset-4"
     >
       <span
         class="hidden lg:flex"
@@ -16,6 +16,7 @@
         class="lg:hidden"
         data-cy="short-header-text"
       >{{ t(VALUES[mode].shortHeader || VALUES[mode].header) }}</span>
+      <i-cy-action-question-mark-outline_x16 class="ml-1 icon-dark-gray-600" />
     </button>
     <template
       #popper

--- a/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
+++ b/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
@@ -16,13 +16,13 @@
         class="lg:hidden"
         data-cy="short-header-text"
       >{{ t(VALUES[mode].shortHeader || VALUES[mode].header) }}</span>
-      <i-cy-action-question-mark-outline_x16 class="ml-1 icon-dark-gray-600" />
+      <i-cy-circle-bg-question-mark_x16 class="ml-1 icon-dark-indigo-500 icon-light-indigo-100" />
     </button>
     <template
       #popper
     >
       <div
-        class="flex flex-col mx-4 text-sm text-center py-4 px-2 items-center"
+        class="flex flex-col border-t-indigo-400 border-t-4px text-sm text-center p-4 items-center"
         data-cy="cloud-data-tooltip-content"
       >
         <div

--- a/packages/app/src/specs/SpecsList.cy.tsx
+++ b/packages/app/src/specs/SpecsList.cy.tsx
@@ -172,8 +172,7 @@ describe('<SpecsList />', { keystrokeDelay: 0 }, () => {
 
         cy.wait(100) // there's an intentional 50ms delay in the code, lets just wait it out
 
-        cy.viewport(500, 850)
-        cy.percySnapshot('narrowest')
+        // Specs List has a min width of ~650px in the app, so there's no need to snapshot below that
         cy.viewport(650, 850)
         cy.percySnapshot('narrow')
         cy.viewport(800, 850)

--- a/packages/app/src/specs/SpecsList.cy.tsx
+++ b/packages/app/src/specs/SpecsList.cy.tsx
@@ -126,7 +126,7 @@ describe('<SpecsList />', { keystrokeDelay: 0 }, () => {
 
       it('should display last updated column', () => {
         cy.findByTestId('last-updated-header').as('header')
-        cy.get('@header').should('be.visible').and('have.text', 'Last updated')
+        cy.get('@header').should('be.visible').and('contain', 'Last updated')
       })
 
       context('when screen is wide', { viewportWidth: 1200 }, () => {


### PR DESCRIPTION
- Closes #22638 

### User facing changelog
* Add icons to help indicate that column headers provide more information on hover

### Additional details
N/A

### Steps to test
1. Open a project in the app, navigate to the Specs Explorer
2. Validate that the "Last Updated", "Latest Runs", and "Average Duration" columns display a "question mark" icon
3. Validate that the tooltip for each column is triggered on hover of text *and* icon
4. Validate that columns do not overlap as viewport shrinks
    * Note: This depends on behavior being introduced in #22393 to automatically collapse the sidebar

### How has the user experience changed?

https://user-images.githubusercontent.com/11482842/179297441-a1948f2d-698d-46a2-97ce-83792bc312dc.mov

### PR Tasks

- [na] Have tests been added/updated? _Covered by percy_
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
