### PR TITLE
chore: Make improvements to release process doc and binary upload script

### DIFF
--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -21,10 +21,6 @@ The `@cypress/`-namespaced NPM packages that live inside the [`/npm`](../npm) di
     [prod]
     sso_start_url = <start_url>
     sso_region = <region>
-    sso_account_id = <account_id>
-    sso_role_name = <role_name>
-    region = <region>
-    cli_pager = <cli_pager>
     aws_access_key_id = <access_key_id>
     aws_secret_access_key = <secret_access_key>
     aws_session_token = <session_token>

--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -185,7 +185,7 @@ In the following instructions, "X.Y.Z" is used to denote the [next version of Cy
 24. Check all `cypress-test-*` and `cypress-example-*` repositories, and if there is a branch named `x.y.z` for testing the features or fixes from the newly published version `x.y.z`, update that branch to refer to the newly published NPM version in `package.json`. Then, get the changes approved and merged into that project's `master`. For projects without a `x.y.z` branch, you can go to the Renovate dependency issue and check the box next to `Update dependency cypress to X.Y.Z`. It will automatically create a PR. Once it passes, you can merge it. Try updating at least the following projects:
     - [cypress-example-todomvc](https://github.com/cypress-io/cypress-example-todomvc/issues/99)
     - [cypress-example-todomvc-redux](https://github.com/cypress-io/cypress-example-todomvc-redux/issues/1)
-    - [cypress-example-realworld](https://github.com/cypress-io/cypress-example-realworld/issues/2)
+    - [cypress-realworld-app](https://github.com/cypress-io/cypress-realworld-app/issues/41)
     - [cypress-example-recipes](https://github.com/cypress-io/cypress-example-recipes/issues/225)
     - [cypress-fiddle](https://github.com/cypress-io/cypress-fiddle/issues/5)
     - [cypress-example-docker-compose](https://github.com/cypress-io/cypress-example-docker-compose)

--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -15,6 +15,21 @@ The `@cypress/`-namespaced NPM packages that live inside the [`/npm`](../npm) di
   - Permissions for your npm account to publish the `cypress` package.
   - Permissions to update releases in ZenHub.
 
+- [Set up](https://cypress-io.atlassian.net/wiki/spaces/INFRA/pages/1534853121/AWS+SSO+Cypress) an AWS SSO profile with the [Team-CypressApp-Prod](https://cypress-io.atlassian.net/wiki/spaces/INFRA/pages/1534853121/AWS+SSO+Cypress#Team-CypressApp-Prod) role. The release scripts assumes the name of your profile is `prod`. Make sure to open the "App Developer" expando for some necessary config values. You AWS config file should end up looking like the following:
+
+    ```
+    [prod]
+    sso_start_url = <start_url>
+    sso_region = <region>
+    sso_account_id = <account_id>
+    sso_role_name = <role_name>
+    region = <region>
+    cli_pager = <cli_pager>
+    aws_access_key_id = <access_key_id>
+    aws_secret_access_key = <secret_access_key>
+    aws_session_token = <session_token>
+    ```
+
 - Set up the following environment variables:
   - For the `release-automations` steps, you will need setup the following envs:
     - GitHub token - generated yourself in github.
@@ -28,14 +43,15 @@ The `@cypress/`-namespaced NPM packages that live inside the [`/npm`](../npm) di
     GITHUB_PRIVATE_KEY=
     ```
 
-  - For purging the Cloudflare cache (part of the `move-binaries` step), you'll need `CF_ZONEID` and `CF_TOKEN` set. These can be found in 1Password. 
+  - For purging the Cloudflare cache (part of the `move-binaries` step), you'll need `CF_ZONEID` and `CF_TOKEN` set. These can be found in 1Password.
       ```text
       CF_ZONEID="..."
       CF_TOKEN="..."
       ```
 
-  - If you don't have access to 1Password, ask a team member who has done a deploy.
-  - Tip: Use [as-a](https://github.com/bahmutov/as-a) to manage environment variables for different situations.
+If you don't have access to 1Password, ask a team member who has done a deploy.
+
+Tip: Use [as-a](https://github.com/bahmutov/as-a) to manage environment variables for different situations.
 
 ### Before Publishing a New Version
 
@@ -57,9 +73,9 @@ of Cypress. You can see the progress of the test projects by opening the status 
 In the following instructions, "X.Y.Z" is used to denote the [next version of Cypress being published](./next-version.md).
 
 1. `develop` should contain all of the changes made in `master`. However, this occasionally may not be the case.
-   - Ensure that `master` does not have any additional commits that are not on `develop`.
-   - Ensure all auto-generated pull requests designed to merge master into develop have been successfully merged.
-   - If there are additional commits necessary to merge `master` to `develop`, submit, get approvals on, and merge a new PR
+    - Ensure that `master` does not have any additional commits that are not on `develop`.
+    - Ensure all auto-generated pull requests designed to merge master into develop have been successfully merged.
+    - If there are additional commits necessary to merge `master` to `develop`, submit, get approvals on, and merge a new PR
 
 2. Confirm that every issue labeled [stage: pending release](https://github.com/cypress-io/cypress/issues?q=label%3A%22stage%3A+pending+release%22+is%3Aclosed) has a ZenHub release set. **Tip:** there is a command in [`release-automations`](https://github.com/cypress-io/release-automations)'s `issues-in-release` tool to list and check such issues. Without a ZenHub release issues will not be included in the right changelog. Also ensure that every closed issue in any obsolete releases are moved to the appropriate release in ZehHub. For example, if the open releases are 9.5.5 and 9.6.0, the current release is 9.6.0, then all closed issues marked as 9.5.5 should be moved to 9.6.0. Ensure that there are no commits on `develop` since the last release that are user facing and aren't marked with the current release.
 
@@ -67,11 +83,19 @@ In the following instructions, "X.Y.Z" is used to denote the [next version of Cy
 
 4. Once the `develop` branch is passing for all test projects with the new changes and the `linux-x64` binary is present at `https://cdn.cypress.io/beta/binary/X.Y.Z/linux-x64/<sha>/cypress.zip`, and the `linux-x64` cypress npm package is present at `https://cdn.cypress.io/beta/binary/X.Y.Z/linux-x64/<sha>/cypress.tgz`, publishing can proceed.
 
-5. [Set up](https://cypress-io.atlassian.net/wiki/spaces/INFRA/pages/1534853121/AWS+SSO+Cypress) an AWS SSO profile with the [Team-CypressApp-Prod](https://cypress-io.atlassian.net/wiki/spaces/INFRA/pages/1534853121/AWS+SSO+Cypress#Team-CypressApp-Prod) role. The release scripts assumes the name of your profile is `prod`.
-    * Log into AWS SSO with `aws sso login --profile <name_of_profile>`.
-    * If you have setup your credentials under a different profile, be sure to set the `AWS_PROFILE` environment variable to that profile name for the remaining steps. For example, if you are using `production` instead of `prod`, do `export AWS_PROFILE=production`.
+5. Install and test the pre-release version to make sure everything is working.
+    - Get the pre-release version that matches your system from the latest develop commit.
+    - Install the new version: `npm install -g <cypress.tgz path>`
+    - Run a quick, manual smoke test:
+        - `cypress open`
+        - Go into a project, run a quick test, make sure things look right
+    - Optionally, install the new version into an established project and run the tests there
+        - [cypress-realworld-app](https://github.com/cypress-io/cypress-realworld-app) uses yarn and represents a typical consumer implementation.
+    - Optionally, do more thorough tests, for example test the new version of Cypress against the Cypress dashboard repo.
 
-6. Use the `prepare-release-artifacts` script (Mac/Linux only) to prepare the latest commit to a stable release. When you run this script, the following happens:
+6. Log into AWS SSO with `aws sso login --profile <name_of_profile>`. If you have setup your credentials under a different profile than `prod`, be sure to set the `AWS_PROFILE` environment variable to that profile name for the remaining steps. For example, if you are using `production` instead of `prod`, do `export AWS_PROFILE=production`.
+
+7. Use the `prepare-release-artifacts` script (Mac/Linux only) to prepare the latest commit to a stable release. When you run this script, the following happens:
     * the binaries for `<commit sha>` are moved from `beta` to the `desktop` folder for `<new target version>` in S3
     * the Cloudflare cache for this version is purged
     * the pre-prod `cypress.tgz` NPM package is converted to a stable NPM package ready for release
@@ -82,22 +106,22 @@ In the following instructions, "X.Y.Z" is used to denote the [next version of Cy
 
     You can pass `--dry-run` to see the commands this would run under the hood.
 
-7. Validate you are logged in to `npm` with `npm whoami`. Otherwise log in with `npm login`.
+8. Validate you are logged in to `npm` with `npm whoami`. Otherwise log in with `npm login`.
 
-8. Publish the generated npm package under the `dev` tag, using your personal npm account.
+9. Publish the generated npm package under the `dev` tag, using your personal npm account.
 
     ```shell
     npm publish /tmp/cypress-prod.tgz --tag dev
     ```
 
-9. Double-check that the new version has been published under the `dev` tag using `npm info cypress` or [available-versions](https://github.com/bahmutov/available-versions). `latest` should still point to the previous version. Example output:
+10. Double-check that the new version has been published under the `dev` tag using `npm info cypress` or [available-versions](https://github.com/bahmutov/available-versions). `latest` should still point to the previous version. Example output:
 
     ```shell
     dist-tags:
     dev: 3.4.0     latest: 3.3.2
     ```
 
-10. Test `cypress@X.Y.Z` to make sure everything is working.
+11. Test `cypress@X.Y.Z` to make sure everything is working.
     - Install the new version: `npm install -g cypress@X.Y.Z`
     - Run a quick, manual smoke test:
         - `cypress open`
@@ -106,7 +130,7 @@ In the following instructions, "X.Y.Z" is used to denote the [next version of Cy
         - [cypress-realworld-app](https://github.com/cypress-io/cypress-realworld-app) uses yarn and represents a typical consumer implementation.
     - Optionally, do more thorough tests, for example test the new version of Cypress against the Cypress dashboard repo.
 
-11. Create or review the release-specific documentation and changelog in [cypress-documentation](https://github.com/cypress-io/cypress-documentation). If there is not already a release-specific PR open, create one. This PR must be merged, built, and deployed before moving to the next step.
+12. Create or review the release-specific documentation and changelog in [cypress-documentation](https://github.com/cypress-io/cypress-documentation). If there is not already a release-specific PR open, create one. This PR must be merged, built, and deployed before moving to the next step.
      - Use [`release-automations`](https://github.com/cypress-io/release-automations)'s `issues-in-release` tool to generate a starting point for the changelog, based off of ZenHub:
         ```shell
         cd packages/issues-in-release
@@ -116,28 +140,28 @@ In the following instructions, "X.Y.Z" is used to denote the [next version of Cy
     - Merge any release-specific documentation changes into the main release PR.
     - You can view the doc's [branch deploy preview](https://github.com/cypress-io/cypress-documentation/blob/master/CONTRIBUTING.md#pull-requests) by clicking 'Details' on the PR's `netlify-cypress-docs/deploy-preview` GitHub status check.
 
-12. Make the new npm version the "latest" version by updating the dist-tag `latest` to point to the new version:
+13. Make the new npm version the "latest" version by updating the dist-tag `latest` to point to the new version:
 
     ```shell
     npm dist-tag add cypress@X.Y.Z
     ```
 
-13. Run `binary-release` to update the [download server's manifest](https://download.cypress.io/desktop.json). This will also ensure the binary for the version is downloadable for each system.
+14. Run `binary-release` to update the [download server's manifest](https://download.cypress.io/desktop.json). This will also ensure the binary for the version is downloadable for each system.
 
     ```shell
     yarn binary-release --version X.Y.Z
     ```
 
-14. If needed, push out any updated changes to the links manifest to [`on.cypress.io`](https://github.com/cypress-io/cypress-services/tree/develop/packages/on).
+15. If needed, push out any updated changes to the links manifest to [`on.cypress.io`](https://github.com/cypress-io/cypress-services/tree/develop/packages/on).
 
-15. If needed, deploy the updated [`cypress-example-kitchensink`][cypress-example-kitchensink] to `example.cypress.io` by following [these instructions under "Deployment"](../packages/example/README.md).
+16. If needed, deploy the updated [`cypress-example-kitchensink`][cypress-example-kitchensink] to `example.cypress.io` by following [these instructions under "Deployment"](../packages/example/README.md).
 
-16. Update the releases in [ZenHub](https://app.zenhub.com/workspaces/test-runner-5c3ea3baeb1e75374f7b0708/reports/release):
+17. Update the releases in [ZenHub](https://app.zenhub.com/workspaces/test-runner-5c3ea3baeb1e75374f7b0708/reports/release):
     - Close the current release in ZenHub.
     - Create a new patch release (and a new minor release, if this is a minor release) in ZenHub, and schedule them both to be completed 2 weeks from the current date.
     - Move all issues that are still open from the current release to the appropriate future release.
 
-17. Bump `version` in [`package.json`](package.json), submit, get approvals on, and merge a new PR for the change. After it merges:
+18. Bump `version` in [`package.json`](package.json), submit, get approvals on, and merge a new PR for the change. After it merges:
 
     ```shell
     git checkout develop
@@ -148,26 +172,21 @@ In the following instructions, "X.Y.Z" is used to denote the [next version of Cy
     git push origin vX.Y.Z
     ```
 
-18. Submit, get approvals on, and merge a new PR that merges `develop` to `master`
+19. Submit, get approvals on, and merge a new PR that merges `develop` to `master`. **Important**: make sure to use a merge commit, not a squash merge.
 
-19. Inside of [cypress-io/release-automations][release-automations]:
-    - Publish GitHub release to [cypress-io/cypress/releases](https://github.com/cypress-io/cypress/releases) using package `set-releases`:
+20. Create a new [GitHub release](https://github.com/cypress-io/cypress/releases). Choose the tag you created previously and add contents to match previous releases.
 
-        ```shell
-        cd packages/set-releases && npm run release-log -- --version X.Y.Z
-        ```
+21. Inside of [cypress-io/release-automations][release-automations], run the following to add a comment to each GH issue that has been resolved with the new published version:
 
-    - Add a comment to each GH issue that has been resolved with the new published version using package `issues-in-release`:
+    ```shell
+    cd packages/issues-in-release && npm run do:comment -- --release X.Y.Z
+    ```
 
-        ```shell
-        cd packages/issues-in-release && npm run do:comment -- --release X.Y.Z
-        ```
+22. Confirm there are no issues with the label [stage: pending release](https://github.com/cypress-io/cypress/issues?q=label%3A%22stage%3A+pending+release%22+is%3Aclosed) left
 
-    - Confirm there are no issues with the label [stage: pending release](https://github.com/cypress-io/cypress/issues?q=label%3A%22stage%3A+pending+release%22+is%3Aclosed) left
+23. Publish a new docker image in [`cypress-docker-images`](https://github.com/cypress-io/cypress-docker-images) under `included` for the new cypress version. Note: we use the base image with the Node version matching the bundled Node version. Instructions for updating `cypress-docker-images` can be found [here](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md#add-new-included-image).
 
-20. Publish a new docker image in [`cypress-docker-images`](https://github.com/cypress-io/cypress-docker-images) under `included` for the new cypress version. Note: we use the base image with the Node version matching the bundled Node version. Instructions for updating `cypress-docker-images` can be found [here](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md#add-new-included-image).
-
-21. Check all `cypress-test-*` and `cypress-example-*` repositories, and if there is a branch named `x.y.z` for testing the features or fixes from the newly published version `x.y.z`, update that branch to refer to the newly published NPM version in `package.json`. Then, get the changes approved and merged into that project's `master`. For projects without a `x.y.z` branch, you can go to the Renovate dependency issue and check the box next to `Update dependency cypress to X.Y.Z`. It will automatically create a PR. Once it passes, you can merge it. Try updating at least the following projects:
+24. Check all `cypress-test-*` and `cypress-example-*` repositories, and if there is a branch named `x.y.z` for testing the features or fixes from the newly published version `x.y.z`, update that branch to refer to the newly published NPM version in `package.json`. Then, get the changes approved and merged into that project's `master`. For projects without a `x.y.z` branch, you can go to the Renovate dependency issue and check the box next to `Update dependency cypress to X.Y.Z`. It will automatically create a PR. Once it passes, you can merge it. Try updating at least the following projects:
     - [cypress-example-todomvc](https://github.com/cypress-io/cypress-example-todomvc/issues/99)
     - [cypress-example-todomvc-redux](https://github.com/cypress-io/cypress-example-todomvc-redux/issues/1)
     - [cypress-example-realworld](https://github.com/cypress-io/cypress-example-realworld/issues/2)

--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -15,7 +15,7 @@ The `@cypress/`-namespaced NPM packages that live inside the [`/npm`](../npm) di
   - Permissions for your npm account to publish the `cypress` package.
   - Permissions to update releases in ZenHub.
 
-- [Set up](https://cypress-io.atlassian.net/wiki/spaces/INFRA/pages/1534853121/AWS+SSO+Cypress) an AWS SSO profile with the [Team-CypressApp-Prod](https://cypress-io.atlassian.net/wiki/spaces/INFRA/pages/1534853121/AWS+SSO+Cypress#Team-CypressApp-Prod) role. The release scripts assumes the name of your profile is `prod`. Make sure to open the "App Developer" expando for some necessary config values. You AWS config file should end up looking like the following:
+- [Set up](https://cypress-io.atlassian.net/wiki/spaces/INFRA/pages/1534853121/AWS+SSO+Cypress) an AWS SSO profile with the [Team-CypressApp-Prod](https://cypress-io.atlassian.net/wiki/spaces/INFRA/pages/1534853121/AWS+SSO+Cypress#Team-CypressApp-Prod) role. The release scripts assumes the name of your profile is `prod`. Make sure to open the "App Developer" expando for some necessary config values. Your AWS config file should end up looking like the following:
 
     ```
     [prod]

--- a/scripts/binary/util/upload.js
+++ b/scripts/binary/util/upload.js
@@ -80,20 +80,20 @@ const getDesktopUrl = function (version, osName, zipName) {
 }
 
 // purges desktop application url from Cloudflare cache
-const purgeDesktopAppFromCache = function ({ version, platform, zipName }) {
+const purgeDesktopAppFromCache = function ({ version, platformArch, zipName }) {
   la(check.unemptyString(version), 'missing desktop version', version)
-  la(check.unemptyString(platform), 'missing platform', platform)
+  la(check.unemptyString(platformArch), 'missing platformArch', platformArch)
   la(check.unemptyString(zipName), 'missing zip filename')
   la(check.extension('zip', zipName),
     'zip filename should end with .zip', zipName)
 
-  const osName = getUploadNameByOsAndArch(platform)
-
-  la(check.unemptyString(osName), 'missing osName', osName)
-  const url = getDesktopUrl(version, osName, zipName)
+  const url = getDesktopUrl(version, platformArch, zipName)
 
   return purgeCloudflareCache(url)
 }
+
+// all architectures we are building the test runner for
+const validPlatformArchs = ['darwin-arm64', 'darwin-x64', 'linux-x64', 'linux-arm64', 'win32-x64']
 
 // purges links to desktop app for all platforms
 // for a given version
@@ -101,17 +101,12 @@ const purgeDesktopAppAllPlatforms = function (version, zipName) {
   la(check.unemptyString(version), 'missing desktop version', version)
   la(check.unemptyString(zipName), 'missing zipName', zipName)
 
-  const platforms = ['darwin', 'linux', 'win32']
-
   console.log(`purging all desktop links for version ${version} from Cloudflare`)
 
-  return Promise.mapSeries(platforms, (platform) => {
-    return purgeDesktopAppFromCache({ version, platform, zipName })
+  return Promise.mapSeries(validPlatformArchs, (platformArch) => {
+    return purgeDesktopAppFromCache({ version, platformArch, zipName })
   })
 }
-
-// all architectures we are building the test runner for
-const validPlatformArchs = ['darwin-arm64', 'darwin-x64', 'linux-x64', 'linux-arm64', 'win32-x64']
 // simple check for platform-arch string
 // example: isValidPlatformArch("darwin") // FALSE
 const isValidPlatformArch = check.oneOf(validPlatformArchs)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog

N/A - internal only

### Additional details

1. Makes the following improvements to release-process.md:
	- Moves the AWS SSO setup to prerequisites since it should only need to be done once
	- Adds a step to test out the pre-release binary before moving it to beta or publishing to npm. This is the same as the later smoke test step after publishing to npm. It can help catch any issues that might invalidate the release after it's too late because it's taken up a version on npm.
	- Adds a note that the merge from develop to master should be a merge commit and not a squash commit.
	- Replaces the release-automation set-releases step with manual GitHub release creation since the release automation for it is broken.

2. Updates the binary upload script to use the list of valid platforms+arches when purging the cache. Before, it used the user's local arch, which meant it tried and failed to purge the cache for `win32-arm64`, which is not a valid configuration.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- N/A Have tests been added/updated?
- N/A Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- N/A Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- N/A Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
