### PR TITLE
fix: wrong version of webpack-dev-server displayed

### DIFF
--- a/npm/webpack-dev-server/src/createWebpackDevServer.ts
+++ b/npm/webpack-dev-server/src/createWebpackDevServer.ts
@@ -52,7 +52,7 @@ export async function createWebpackDevServer (
   }
 
   if (webpackDevServerMajorVersion === 3) {
-    debug('using webpack-dev-server v4')
+    debug('using webpack-dev-server v3')
 
     return webpackDevServer3(config, webpackCompiler, finalWebpackConfig)
   }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

it always displayed:
`using webpack-dev-server v4` even when webpack-dev-server@3 is used.
This can be confusing while debugging.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
