### PR TITLE
feat: restore full spec name in run mode log

### DIFF
--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -370,7 +370,7 @@ const renderSummaryTable = (runUrl) => {
 
         const ms = duration.format(stats.wallClockDuration || 0)
 
-        const formattedSpec = formatPath(spec.baseName, getWidth(table2, 1))
+        const formattedSpec = formatPath(spec.name, getWidth(table2, 1))
 
         if (run.skippedSpec) {
           return table2.push([
@@ -1333,7 +1333,7 @@ module.exports = {
 
     const runEachSpec = (spec, index, length, estimated) => {
       if (!options.quiet) {
-        displaySpecHeader(spec.baseName, index + 1, length, estimated)
+        displaySpecHeader(spec.name, index + 1, length, estimated)
       }
 
       return this.runSpec(config, spec, options, estimated, isFirstSpec, index === length - 1)


### PR DESCRIPTION
- restore full name in spec header
- restore full in result table
- don't restore in spec footer (duplicated info)

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/22304

### User facing changelog

In the terminal log of cypress run, the full names (path + file name) of specs are now reported again, instead of just the file name.

### Additional details
I don't know why the baseName is used in Cypress 10, but the full name is better if you have spec files with the same name in different folders. So this might even be considered a regression.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

(I don't know if the output of the log is tested anywhere)

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
