### PR TITLE
chore: remove angular integration

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -107,8 +107,7 @@
     "vue",
     "react",
     "vue2",
-    "react18",
-    "angular"
+    "react18"
   ],
   "bin": {
     "cypress": "bin/cypress"
@@ -150,11 +149,6 @@
     "./mount-utils": {
       "require": "./mount-utils/dist/index.js",
       "types": "./mount-utils/dist/index.d.ts"
-    },
-    "./angular": {
-      "import": "./angular/dist/index.js",
-      "require": "./angular/dist/index.js",
-      "types": "./angular/dist/index.d.ts"
     }
   },
   "workspaces": {

--- a/cli/scripts/post-build.js
+++ b/cli/scripts/post-build.js
@@ -12,7 +12,6 @@ const npmModulesToCopy = [
   'react18',
   'vue',
   'vue2',
-  'angular',
 ]
 
 npmModulesToCopy.forEach((folder) => {

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3044,7 +3044,7 @@ declare namespace Cypress {
 
   type DevServerConfigOptions = {
     bundler: 'webpack'
-    framework: 'react' | 'vue' | 'vue-cli' | 'nuxt' | 'create-react-app' | 'next' | 'angular'
+    framework: 'react' | 'vue' | 'vue-cli' | 'nuxt' | 'create-react-app' | 'next'
     webpackConfig?: PickConfigOpt<'webpackConfig'>
   } | {
     bundler: 'vite'

--- a/npm/angular/package.json
+++ b/npm/angular/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc || echo 'built, with type errors'",
-    "postbuild": "node ../../scripts/sync-exported-npm-with-cli.js",
     "build-prod": "yarn build",
     "check-ts": "tsc --noEmit"
   },

--- a/npm/webpack-dev-server/cypress/e2e/angular.cy.ts
+++ b/npm/webpack-dev-server/cypress/e2e/angular.cy.ts
@@ -12,7 +12,8 @@ for (const project of WEBPACK_REACT) {
     continue
   }
 
-  describe(`Working with ${project}`, () => {
+  // TODO: revert once Angular is slated for release
+  describe.skip(`Working with ${project}`, () => {
     beforeEach(() => {
       cy.scaffoldProject(project)
       cy.openProject(project)

--- a/npm/webpack-dev-server/src/devServer.ts
+++ b/npm/webpack-dev-server/src/devServer.ts
@@ -12,7 +12,6 @@ import { nuxtHandler } from './helpers/nuxtHandler'
 import { createReactAppHandler } from './helpers/createReactAppHandler'
 import { nextHandler } from './helpers/nextHandler'
 import { sourceDefaultWebpackDependencies, SourceRelativeWebpackResult } from './helpers/sourceRelativeWebpackModules'
-import { angularHandler } from './helpers/angularHandler'
 
 const debug = debugLib('cypress:webpack-dev-server:devServer')
 
@@ -26,7 +25,7 @@ export type WebpackDevServerConfig = {
   webpackConfig?: unknown // Derived from the user's webpack
 }
 
-export const ALL_FRAMEWORKS = ['create-react-app', 'nuxt', 'react', 'vue-cli', 'next', 'vue', 'angular'] as const
+export const ALL_FRAMEWORKS = ['create-react-app', 'nuxt', 'react', 'vue-cli', 'next', 'vue'] as const
 
 /**
  * @internal
@@ -116,8 +115,9 @@ async function getPreset (devServerConfig: WebpackDevServerConfig): Promise<Opti
     case 'next':
       return await nextHandler(devServerConfig)
 
-    case 'angular':
-      return await angularHandler(devServerConfig)
+      // TODO: revert once Angular is slated for release
+      // case 'angular':
+      //   return await angularHandler(devServerConfig)
 
     case 'react':
     case 'vue':

--- a/npm/webpack-dev-server/src/helpers/sourceRelativeWebpackModules.ts
+++ b/npm/webpack-dev-server/src/helpers/sourceRelativeWebpackModules.ts
@@ -65,7 +65,8 @@ const frameworkWebpackMapper: FrameworkWebpackMapper = {
   react: undefined,
   vue: undefined,
   next: 'next',
-  'angular': '@angular-devkit/build-angular',
+  // TODO: revert once Angular is slated for release
+  // 'angular': '@angular-devkit/build-angular',
 }
 
 // Source the users framework from the provided projectRoot. The framework, if available, will serve

--- a/npm/webpack-dev-server/src/makeDefaultWebpackConfig.ts
+++ b/npm/webpack-dev-server/src/makeDefaultWebpackConfig.ts
@@ -38,8 +38,9 @@ export function makeDefaultWebpackConfig (
     plugins: [
       new HtmlWebpackPlugin({
         template: indexHtmlFile,
+        // TODO: revert once Angular is slated for release
         // Angular generates all of it's scripts with <script type="module">. Live-reloading breaks without this option.
-        ...(config.devServerConfig.framework === 'angular' ? { scriptLoading: 'module' } : {}),
+        // ...(config.devServerConfig.framework === 'angular' ? { scriptLoading: 'module' } : {}),
       }),
     ],
   } as any

--- a/npm/webpack-dev-server/test/handlers/angularHandler.spec.ts
+++ b/npm/webpack-dev-server/test/handlers/angularHandler.spec.ts
@@ -40,7 +40,8 @@ const projectConfig: AngularJsonProjectConfig = {
   },
 }
 
-describe('angularHandler', function () {
+// TODO: revert once Angular is slated for release
+describe.skip('angularHandler', function () {
   this.timeout(1000 * 60)
 
   it('sources the config from angular-13', async () => {
@@ -53,7 +54,7 @@ describe('angularHandler', function () {
         projectRoot,
         specPattern: 'src/**/*.cy.ts',
       } as Cypress.PluginConfigOptions,
-      framework: 'angular',
+      // framework: 'angular',
     } as WebpackDevServerConfig
 
     const { frameworkConfig: webpackConfig, sourceWebpackModulesResult } = await angularHandler(devServerConfig)
@@ -78,7 +79,7 @@ describe('angularHandler', function () {
         projectRoot,
         specPattern: 'src/**/*.cy.ts',
       } as Cypress.PluginConfigOptions,
-      framework: 'angular',
+      // framework: 'angular',
     } as WebpackDevServerConfig
 
     const { frameworkConfig: webpackConfig, sourceWebpackModulesResult } = await angularHandler(devServerConfig)

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -870,7 +870,6 @@ type FileParts implements Node {
 }
 
 enum FrontendFrameworkEnum {
-  angular
   nextjs
   nuxtjs
   react

--- a/packages/launchpad/cypress/e2e/scaffold-component-testing.cy.ts
+++ b/packages/launchpad/cypress/e2e/scaffold-component-testing.cy.ts
@@ -108,7 +108,8 @@ describe('scaffolding component testing', {
     })
   })
 
-  context('angular-cli-unconfigured', () => {
+  // TODO: revert once Angular is slated for release
+  context.skip('angular-cli-unconfigured', () => {
     it('scaffolds component testing for Angular', () => {
       startSetupFor('angular-cli-unconfigured')
 

--- a/packages/launchpad/src/utils/icons.ts
+++ b/packages/launchpad/src/utils/icons.ts
@@ -4,7 +4,7 @@ import LogoNext from '../images/logos/nextjs.svg'
 import LogoNuxt from '../images/logos/nuxt.svg'
 import LogoVue from '../images/logos/vue.svg'
 import LogoReact from '../images/logos/react.svg'
-import LogoAngular from '../images/logos/angular.svg'
+// import LogoAngular from '../images/logos/angular.svg'
 
 import type { FrontendFrameworkEnum, SupportedBundlers } from '../generated/graphql'
 
@@ -19,5 +19,6 @@ export const FrameworkBundlerLogos: Record<FrontendFrameworkEnum | SupportedBund
   nuxtjs: LogoNuxt,
   react: LogoReact,
   reactscripts: LogoReact,
-  angular: LogoAngular,
+  // TODO: revert once Angular is slated for release
+  // angular: LogoAngular,
 }

--- a/packages/scaffold-config/src/frameworks.ts
+++ b/packages/scaffold-config/src/frameworks.ts
@@ -217,26 +217,27 @@ export const WIZARD_FRAMEWORKS = [
     supportStatus: 'full',
     componentIndexHtml: componentIndexHtmlGenerator(),
   },
-  {
-    type: 'angular',
-    configFramework: 'angular',
-    category: 'template',
-    name: 'Angular',
-    detectors: [dependencies.WIZARD_DEPENDENCY_ANGULAR_CLI],
-    supportedBundlers: [dependencies.WIZARD_DEPENDENCY_WEBPACK],
-    dependencies: (bundler: WizardBundler['type'], projectPath: string): DependencyToInstall[] => {
-      return [
-        inPkgJson(dependencies.WIZARD_DEPENDENCY_ANGULAR_CLI, projectPath),
-        inPkgJson(dependencies.WIZARD_DEPENDENCY_ANGULAR_DEVKIT_BUILD_ANGULAR, projectPath),
-        inPkgJson(dependencies.WIZARD_DEPENDENCY_ANGULAR_CORE, projectPath),
-        inPkgJson(dependencies.WIZARD_DEPENDENCY_ANGULAR_COMMON, projectPath),
-        inPkgJson(dependencies.WIZARD_DEPENDENCY_ANGULAR_PLATFORM_BROWSER_DYNAMIC, projectPath),
-      ]
-    },
-    codeGenFramework: 'angular',
-    mountModule: 'cypress/angular',
-    supportStatus: 'full',
-    componentIndexHtml: componentIndexHtmlGenerator(),
-    specPattern: '**/*.cy.ts',
-  },
+  // TODO: revert once Angular is slated for release
+  // {
+  //   type: 'angular',
+  //   configFramework: 'angular',
+  //   category: 'template',
+  //   name: 'Angular',
+  //   detectors: [dependencies.WIZARD_DEPENDENCY_ANGULAR_CLI],
+  //   supportedBundlers: [dependencies.WIZARD_DEPENDENCY_WEBPACK],
+  //   dependencies: (bundler: WizardBundler['type'], projectPath: string): DependencyToInstall[] => {
+  //     return [
+  //       inPkgJson(dependencies.WIZARD_DEPENDENCY_ANGULAR_CLI, projectPath),
+  //       inPkgJson(dependencies.WIZARD_DEPENDENCY_ANGULAR_DEVKIT_BUILD_ANGULAR, projectPath),
+  //       inPkgJson(dependencies.WIZARD_DEPENDENCY_ANGULAR_CORE, projectPath),
+  //       inPkgJson(dependencies.WIZARD_DEPENDENCY_ANGULAR_COMMON, projectPath),
+  //       inPkgJson(dependencies.WIZARD_DEPENDENCY_ANGULAR_PLATFORM_BROWSER_DYNAMIC, projectPath),
+  //     ]
+  //   },
+  //   codeGenFramework: 'angular',
+  //   mountModule: 'cypress/angular',
+  //   supportStatus: 'full',
+  //   componentIndexHtml: componentIndexHtmlGenerator(),
+  //   specPattern: '**/*.cy.ts',
+  // },
 ] as const

--- a/packages/scaffold-config/test/unit/detect.spec.ts
+++ b/packages/scaffold-config/test/unit/detect.spec.ts
@@ -205,7 +205,8 @@ describe('detectFramework', () => {
   })
 
   ;['13.0.0', '14.0.0'].forEach((v) => {
-    it(`Angular CLI v${v}`, async () => {
+    // TODO: revert once Angular is slated for release
+    it.skip(`Angular CLI v${v}`, async () => {
       const projectPath = await scaffoldMigrationProject('angular-cli-unconfigured')
 
       fakeDepsInNodeModules(projectPath, [


### PR DESCRIPTION
### User facing changelog
na

### Additional details
Product wants to push the delay of Angular CT to next release (GTM), so this PR disables all features of Angular CT. Will revert this after our next release.

### Steps to test
You can point Angular at an angular cli application. There won't be any Angular detection. Even with a pre-setup application like `system-tests/projects/angular-cli-configured`, the dev-server will throw with `no matching framework`

### How has the user experience changed?
na

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
