### PR TITLE
fix: Standardize colors for runs in queued status

### DIFF
--- a/packages/app/src/specs/RunStatusDots.cy.tsx
+++ b/packages/app/src/specs/RunStatusDots.cy.tsx
@@ -58,7 +58,7 @@ describe('<RunStatusDots />', () => {
       cy.get('.v-popper__popper--shown').contains('spec.cy.ts')
       cy.findAllByTestId('run-status-dot-0').should('have.class', 'icon-light-orange-400')
       cy.findAllByTestId('run-status-dot-1').should('have.class', 'icon-light-indigo-400')
-      cy.findAllByTestId('run-status-dot-2').should('have.class', 'icon-light-gray-400')
+      cy.findAllByTestId('run-status-dot-2').should('have.class', 'icon-light-gray-300')
       cy.findAllByTestId('run-status-dot-latest').should('not.have.class', 'animate-spin')
     })
   })

--- a/packages/app/src/specs/RunStatusDots.vue
+++ b/packages/app/src/specs/RunStatusDots.vue
@@ -157,10 +157,10 @@ const dotClasses = computed(() => {
       case 'ERRORED':
       case 'TIMEDOUT':
         return 'icon-light-orange-400'
-      case 'UNCLAIMED':
       case 'NOTESTS':
         return 'icon-light-gray-400'
       case 'CANCELLED':
+      case 'UNCLAIMED':
       default:
         return 'icon-light-gray-300'
     }

--- a/packages/frontend-shared/src/assets/icons/queued-solid_x16.svg
+++ b/packages/frontend-shared/src/assets/icons/queued-solid_x16.svg
@@ -1,5 +1,4 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g id="Dimensions=x16">
-<circle id="Circle" cx="8" cy="8" r="7" stroke="#E1E3ED" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</g>
+  <circle id="InnerCircle" class="icon-light" cx="8" cy="8" r="6" fill="none" />
+  <circle id="OuterCircle" class="icon-dark" cx="8" cy="8" r="7" stroke="#BFC2D4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
 </svg>


### PR DESCRIPTION
- Closes #22601 

### User facing changelog
* Fix icon colors in "Latest Runs" section for queued/pending runs

### Additional details
Also updating the "queued" icon's SVG to support the `icon-light*` and `icon-dark*` style pattern if it gets used elsewhere

### Steps to test


### How has the user experience changed?
**Before**
Latest run icon for "Queued" status is lighter gray than dots
![178307071-472aa381-23cf-48ce-a22d-2c500d720928](https://user-images.githubusercontent.com/11482842/181772975-5d462e75-ea45-40fe-af97-78a5304570b2.png)

**After**
Latest run icon for "Queued" status is same gray color as dots
![Screen Shot 2022-07-29 at 8 38 27 AM](https://user-images.githubusercontent.com/11482842/181773107-fa143315-9d16-4196-ad7e-bc1727601317.png)


### PR Tasks
- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
