### PR TITLE
refactor(angular): handle mounting teardown before tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ mainBuildFilters: &mainBuildFilters
     branches:
       only:
         - develop
-        - zachw/angular-ct-teardown
+        - tbiethman/electron-19
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -36,7 +36,7 @@ macWorkflowFilters: &darwin-workflow-filters
   when:
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
-    - equal: [ 'zachw/angular-ct-teardown', << pipeline.git.branch >> ]
+    - equal: [ 'tbiethman/electron-19', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -45,7 +45,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
   when:
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
-    - equal: [ 'zachw/angular-ct-teardown', << pipeline.git.branch >> ]
+    - equal: [ 'tbiethman/electron-19', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -65,7 +65,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
     - equal: [ linux-arm64, << pipeline.git.branch >> ]
-    - equal: [ 'zachw/angular-ct-teardown', << pipeline.git.branch >> ]
+    - equal: [ 'fix-system-test-glob-pattern', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -129,7 +129,7 @@ commands:
       - run:
           name: Check current branch to persist artifacts
           command: |
-            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "zachw/angular-ct-teardown" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "tbiethman/electron-19" ]]; then
               echo "Not uploading artifacts or posting install comment for this branch."
               circleci-agent step halt
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ mainBuildFilters: &mainBuildFilters
     branches:
       only:
         - develop
-        - tbiethman/electron-19
+        - zachw/angular-ct-teardown
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -36,7 +36,7 @@ macWorkflowFilters: &darwin-workflow-filters
   when:
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
-    - equal: [ 'tbiethman/electron-19', << pipeline.git.branch >> ]
+    - equal: [ 'zachw/angular-ct-teardown', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -45,7 +45,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
   when:
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
-    - equal: [ 'tbiethman/electron-19', << pipeline.git.branch >> ]
+    - equal: [ 'zachw/angular-ct-teardown', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -65,7 +65,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
     - equal: [ linux-arm64, << pipeline.git.branch >> ]
-    - equal: [ 'fix-system-test-glob-pattern', << pipeline.git.branch >> ]
+    - equal: [ 'zachw/angular-ct-teardown', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -129,7 +129,7 @@ commands:
       - run:
           name: Check current branch to persist artifacts
           command: |
-            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "tbiethman/electron-19" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "zachw/angular-ct-teardown" ]]; then
               echo "Not uploading artifacts or posting install comment for this branch."
               circleci-agent step halt
             fi

--- a/npm/webpack-dev-server/cypress/e2e/angular.cy.ts
+++ b/npm/webpack-dev-server/cypress/e2e/angular.cy.ts
@@ -75,7 +75,7 @@ for (const project of WEBPACK_REACT) {
 
       cy.contains('mount.cy.ts').click()
       cy.waitForSpecToFinish()
-      cy.get('.passed > .num').should('contain', 10)
+      cy.get('.passed > .num').should('contain', 11)
     })
   })
 }

--- a/npm/webpack-dev-server/cypress/e2e/angular.cy.ts
+++ b/npm/webpack-dev-server/cypress/e2e/angular.cy.ts
@@ -69,13 +69,5 @@ for (const project of WEBPACK_REACT) {
       cy.waitForSpecToFinish()
       cy.get('.passed > .num').should('contain', 1)
     })
-
-    it('proves out mount API', () => {
-      cy.visitApp()
-
-      cy.contains('mount.cy.ts').click()
-      cy.waitForSpecToFinish()
-      cy.get('.passed > .num').should('contain', 11)
-    })
   })
 }

--- a/system-tests/project-fixtures/angular/src/app/mount.cy.ts
+++ b/system-tests/project-fixtures/angular/src/app/mount.cy.ts
@@ -95,4 +95,14 @@ describe("angular mount", () => {
     cy.get('button').click()
     cy.get('@clickedSpy').should('have.been.calledWith', true)
   })
+
+  describe("teardown", () => {
+    beforeEach(() => {
+      cy.get("[id^=root]").should("not.exist");
+    });
+
+    it("should mount", () => {
+      cy.mount(ButtonOutputComponent);
+    });
+  });
 });

--- a/system-tests/test/component_testing_spec.ts
+++ b/system-tests/test/component_testing_spec.ts
@@ -106,3 +106,19 @@ describe(`React major versions with Webpack`, function () {
     })
   }
 })
+
+const ANGULAR_MAJOR_VERSIONS = ['13', '14']
+
+describe(`Angular CLI major versions`, () => {
+  systemTests.setup()
+
+  for (const majorVersion of ANGULAR_MAJOR_VERSIONS) {
+    systemTests.it(`v${majorVersion} with mount tests`, {
+      project: `angular-${majorVersion}`,
+      spec: 'src/app/mount.cy.ts',
+      testingType: 'component',
+      browser: 'chrome',
+      expectedExitCode: 0,
+    })
+  }
+})


### PR DESCRIPTION
- Closes #23096 

### User facing changelog
Teardown the previous component from the DOM before every test is run

### Additional details
This was pointed out by @brian-mann 

### Steps to test
run the `angular.cy.ts` system test

### How has the user experience changed?
Tests were setup to take a screenshot before each test...

Before:

https://user-images.githubusercontent.com/25158820/182721424-410b9e91-d26b-4c8e-aef6-f4f6582934f3.mov

After:


https://user-images.githubusercontent.com/25158820/182721441-ef4fde16-dbf9-49d3-a647-748d82fdcc88.mov



### PR Tasks

- [X ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
