### PR TITLE
fix: Don't install jest in circle ci job because of broken 3rd party …

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2060,9 +2060,12 @@ jobs:
             CYPRESS_INSTALL_BINARY: /root/cypress/cypress.zip
           # let's install Cypress, Jest and any other package that might conflict
           # https://github.com/cypress-io/cypress/issues/6690
+
+          # Todo: Add `jest` back into the list once https://github.com/yargs/yargs-parser/issues/452
+          # is resolved.
           command: |
             npm install /root/cypress/cypress.tgz \
-              typescript jest @types/jest enzyme @types/enzyme
+              typescript @types/jest enzyme @types/enzyme
       - run:
           name: Test types clash ⚔️
           working_directory: <<parameters.wd>>


### PR DESCRIPTION
…deps

### User facing changelog
No user-facing changes.

### Additional details
`yargs-parser` recently shipped a version with broken / conflicting types. https://github.com/yargs/yargs-parser/issues/452. Because of this, one of our CI tasks (`test-types-cypress-and-jest`) that `npm install jest` is failing.

This PR temporarily disables that job, until yargs-parser / jest sort out their problems. @BlueWinds is watching the above issue, and will follow up to re-enable this when it's safe to do so.

### Steps to test
CI build passes in this branch, and in no other branches.

### How has the user experience changed?

### PR Tasks

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
