### PR TITLE
feat: add template support, teardown & standalone

### DIFF
--- a/npm/angular/package.json
+++ b/npm/angular/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "tsc || echo 'built, with type errors'",
+    "build": "rollup -c rollup.config.js",
     "postbuild": "node ../../scripts/sync-exported-npm-with-cli.js",
     "build-prod": "yarn build",
     "check-ts": "tsc --noEmit"
@@ -15,6 +15,8 @@
     "@angular/common": "^14.0.6",
     "@angular/core": "^14.0.6",
     "@angular/platform-browser-dynamic": "^14.0.6",
+    "@rollup/plugin-node-resolve": "^11.1.1",
+    "rollup-plugin-typescript2": "^0.29.0",
     "typescript": "~4.2.3",
     "zone.js": "~0.11.4"
   },

--- a/npm/angular/rollup.config.js
+++ b/npm/angular/rollup.config.js
@@ -1,0 +1,61 @@
+import ts from 'rollup-plugin-typescript2'
+import resolve from '@rollup/plugin-node-resolve'
+
+import pkg from './package.json'
+
+const banner = `
+/**
+ * ${pkg.name} v${pkg.version}
+ * (c) ${new Date().getFullYear()} Cypress.io
+ * Released under the MIT License
+ */
+`
+
+function createEntry () {
+  const input = 'src/index.ts'
+  const format = 'es'
+
+  const config = {
+    input,
+    external: [
+      '@angular/core',
+      '@angular/core/testing',
+      '@angular/common',
+      '@angular/platform-browser-dynamic/testing',
+      'zone.js',
+      'zone.js/testing',
+    ],
+    plugins: [
+      resolve(),
+    ],
+    output: {
+      banner,
+      name: 'CypressAngular',
+      file: pkg.module,
+      format,
+      exports: 'auto',
+    },
+  }
+
+  console.log(`Building ${format}: ${config.output.file}`)
+
+  config.plugins.push(
+    ts({
+      check: true,
+      tsconfigOverride: {
+        compilerOptions: {
+          declaration: true,
+          target: 'es6', // not sure what this should be?
+          module: 'esnext',
+        },
+        exclude: [],
+      },
+    }),
+  )
+
+  return config
+}
+
+export default [
+  createEntry(),
+]

--- a/npm/angular/src/mount.ts
+++ b/npm/angular/src/mount.ts
@@ -115,7 +115,12 @@ function bootstrapModule<T> (
     testModuleMetaData.imports = []
   }
 
-  testModuleMetaData.declarations.push(component)
+  // check if the component is a standalone component
+  if ((component as any).ɵcmp.standalone) {
+    testModuleMetaData.imports.push(component)
+  } else {
+    testModuleMetaData.declarations.push(component)
+  }
 
   if (!testModuleMetaData.imports.includes(CommonModule)) {
     testModuleMetaData.imports.push(CommonModule)

--- a/npm/angular/src/mount.ts
+++ b/npm/angular/src/mount.ts
@@ -219,7 +219,7 @@ function setupComponent<T> (
   }
 
   if (config.autoSpyOutputs) {
-    Object.keys(component).map((key: string, index: number, keys: string[]) => {
+    Object.keys(component).forEach((key: string, index: number, keys: string[]) => {
       const property = component[key]
 
       if (property instanceof EventEmitter) {

--- a/npm/angular/tsconfig.json
+++ b/npm/angular/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "experimentalDecorators": true,
     "target": "es2020",
     "module": "es2020",
     "skipLibCheck": true,

--- a/npm/webpack-dev-server/cypress/e2e/angular.cy.ts
+++ b/npm/webpack-dev-server/cypress/e2e/angular.cy.ts
@@ -69,13 +69,5 @@ for (const project of WEBPACK_REACT) {
       cy.waitForSpecToFinish()
       cy.get('.passed > .num').should('contain', 1)
     })
-
-    it('proves out mount API', () => {
-      cy.visitApp()
-
-      cy.contains('mount.cy.ts').click()
-      cy.waitForSpecToFinish()
-      cy.get('.passed > .num').should('contain', 10)
-    })
   })
 }

--- a/npm/webpack-dev-server/cypress/e2e/angular.cy.ts
+++ b/npm/webpack-dev-server/cypress/e2e/angular.cy.ts
@@ -75,7 +75,7 @@ for (const project of WEBPACK_REACT) {
 
       cy.contains('mount.cy.ts').click()
       cy.waitForSpecToFinish()
-      cy.get('.passed > .num').should('contain', 6)
+      cy.get('.passed > .num').should('contain', 10)
     })
   })
 }

--- a/system-tests/project-fixtures/angular/src/app/components/button-output.component.ts
+++ b/system-tests/project-fixtures/angular/src/app/components/button-output.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Output } from "@angular/core";
 
 @Component({
+  selector: 'app-button-output',
   template: `<button (click)="clicked.emit(true)">Click Me</button>`
 })
 export class ButtonOutputComponent {

--- a/system-tests/project-fixtures/angular/src/app/components/projection.component.ts
+++ b/system-tests/project-fixtures/angular/src/app/components/projection.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core'
+
+@Component({
+  selector: 'app-projection',
+  template: `<h3><ng-content></ng-content></h3>`
+})
+export class ProjectionComponent {}

--- a/system-tests/project-fixtures/angular/src/app/mount.cy.ts
+++ b/system-tests/project-fixtures/angular/src/app/mount.cy.ts
@@ -138,15 +138,7 @@ describe("angular mount", () => {
     cy.get('@clickedSpy').should('have.been.calledWith', true)
   })
 
-  describe("teardown", () => {
-    beforeEach(() => {
-      cy.get("[id^=root]").should("not.exist");
-    });
-
-    it("should mount", () => {
-      cy.mount(ButtonOutputComponent);
-    });
-  });
+  
   it('can reference the autoSpyOutput alias on component @Outputs() with a template', () => {
     cy.mount('<app-button-output (clicked)="clicked.emit($event)"></app-button-output>', {
       declarations: [ButtonOutputComponent],
@@ -158,20 +150,28 @@ describe("angular mount", () => {
     cy.get('button').click()
     cy.get('@clickedSpy').should('have.been.calledWith', true)
   })
-
-
-
+  
   it('can handle content projection with a WrapperComponent', () => {
     cy.mount(WrapperComponent, {
       declarations: [ProjectionComponent]
     })
     cy.get('h3').contains('Hello World')
   })
-
+  
   it('can handle content projection using template', () => {
     cy.mount('<app-projection>Hello World</app-projection>', {
       declarations: [ProjectionComponent]
     })
     cy.get('h3').contains('Hello World')
   })
+  
+  describe("teardown", () => {
+    beforeEach(() => {
+      cy.get("[id^=root]").should("not.exist");
+    });
+
+    it("should mount", () => {
+      cy.mount(ButtonOutputComponent);
+    });
+  });
 });

--- a/system-tests/project-fixtures/angular/src/app/mount.cy.ts
+++ b/system-tests/project-fixtures/angular/src/app/mount.cy.ts
@@ -95,4 +95,14 @@ describe("angular mount", () => {
     cy.get('button').click()
     cy.get('@clickedSpy').should('have.been.calledWith', true)
   })
+
+  describe("teardown", () => {
+    beforeEach(() => {
+      cy.get("[id^=root]").should("not.exist");
+    });
+
+    it("should mount", () => {
+      cy.mount(ButtonOutputComponent);
+    });
+  });
 });

--- a/system-tests/projects/angular-14/src/app/components/standalone.component.cy.ts
+++ b/system-tests/projects/angular-14/src/app/components/standalone.component.cy.ts
@@ -1,0 +1,21 @@
+import { StandaloneComponent } from './standalone.component'
+
+describe('StandaloneComponent', () => {
+  it('can mount a standalone component', () => {
+    cy.mount(StandaloneComponent, {
+      componentProperties: {
+        name: 'Angular',
+      },
+    })
+
+    cy.get('h1').contains('Hello Angular')
+  })
+
+  it('can mount a standalone component using template', () => {
+    cy.mount('<app-standalone name="Angular"></app-standalone>', {
+      imports: [StandaloneComponent],
+    })
+
+    cy.get('h1').contains('Hello Angular')
+  })
+})

--- a/system-tests/projects/angular-14/src/app/components/standalone.component.ts
+++ b/system-tests/projects/angular-14/src/app/components/standalone.component.ts
@@ -1,0 +1,10 @@
+import { Component, Input } from '@angular/core'
+
+@Component({
+  standalone: true,
+  selector: 'app-standalone',
+  template: `<h1>Hello {{ name }}</h1>`,
+})
+export class StandaloneComponent {
+  @Input() name!: string
+}

--- a/system-tests/test/component_testing_spec.ts
+++ b/system-tests/test/component_testing_spec.ts
@@ -106,3 +106,19 @@ describe(`React major versions with Webpack`, function () {
     })
   }
 })
+
+const ANGULAR_MAJOR_VERSIONS = ['13', '14']
+
+describe(`Angular CLI major versions`, () => {
+  systemTests.setup()
+
+  for (const majorVersion of ANGULAR_MAJOR_VERSIONS) {
+    systemTests.it(`v${majorVersion} with mount tests`, {
+      project: `angular-${majorVersion}`,
+      spec: 'src/app/mount.cy.ts',
+      testingType: 'component',
+      browser: 'chrome',
+      expectedExitCode: 0,
+    })
+  }
+})

--- a/system-tests/test/component_testing_spec.ts
+++ b/system-tests/test/component_testing_spec.ts
@@ -113,9 +113,11 @@ describe(`Angular CLI major versions`, () => {
   systemTests.setup()
 
   for (const majorVersion of ANGULAR_MAJOR_VERSIONS) {
+    const spec = `${majorVersion === '14' ? 'src/app/components/standalone.component.cy.ts,src/app/mount.cy.ts' : 'src/app/mount.cy.ts'}`
+
     systemTests.it(`v${majorVersion} with mount tests`, {
       project: `angular-${majorVersion}`,
-      spec: 'src/app/mount.cy.ts',
+      spec,
       testingType: 'component',
       browser: 'chrome',
       expectedExitCode: 0,


### PR DESCRIPTION
- Closes #22819 #23096 #23000 #22991 #23125 

### User facing changelog
Adds Angular Component Testing Support
Adds Angular Template Support
Adds Support for Angular Standalone Components
Fixes bug where previous component was not torn down before remounting the next component

### Steps to test
You can run system tests for `angular-13` & `angular-14` & `component_testing_spec.ts`


### How has the user experience changed?

![project-setup-angular c21fe57](https://user-images.githubusercontent.com/3605268/182934031-50bd3e94-c401-4afa-b938-ac45f8f1a6d6.png)


### PR Tasks

- [X] Have tests been added/updated?
- [X] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [X] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/4624
- [X] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
