### PR TITLE
feat: add debug messaging for startup times

### DIFF
--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -1,46 +1,8 @@
-// if running in production mode (CYPRESS_INTERNAL_ENV)
-// all transpile should have been done already
-// and these calls should do nothing
-require('@packages/ts/register')
+const { initializeStartTime } = require('./lib/util/performance_benchmark')
 
-const { patchFs } = require('./lib/util/patch-fs')
-const fs = require('fs')
-
-// prevent EMFILE errors
-patchFs(fs)
-
-// override tty if we're being forced to
-require('./lib/util/tty').override()
-
-const electronApp = require('./lib/util/electron-app')
-
-// are we in the main node process or the electron process?
-const isRunningElectron = electronApp.isRunning()
-
-if (process.env.CY_NET_PROFILE && isRunningElectron) {
-  const netProfiler = require('./lib/util/net_profiler')()
-
-  process.stdout.write(`Network profiler writing to ${netProfiler.logPath}\n`)
+const run = async () => {
+  initializeStartTime()
+  await require('./server-entry')
 }
 
-require('./lib/unhandled_exceptions')
-
-process.env.UV_THREADPOOL_SIZE = 128
-
-if (isRunningElectron) {
-  require('./lib/util/process_profiler').start()
-}
-
-// warn when deprecated callback apis are used in electron
-// https://github.com/electron/electron/blob/master/docs/api/process.md#processenablepromiseapis
-process.enablePromiseAPIs = process.env.CYPRESS_INTERNAL_ENV !== 'production'
-
-// don't show any electron deprecation warnings in prod
-process.noDeprecation = process.env.CYPRESS_INTERNAL_ENV === 'production'
-
-// always show stack traces for Electron deprecation warnings
-process.traceDeprecation = true
-
-require('./lib/util/suppress_warnings').suppress()
-
-module.exports = require('./lib/cypress').start(process.argv)
+module.exports = run()

--- a/packages/server/lib/modes/interactive.ts
+++ b/packages/server/lib/modes/interactive.ts
@@ -13,6 +13,8 @@ import { globalPubSub, getCtx, clearCtx } from '@packages/data-context'
 import type { WebContents } from 'electron'
 import type { LaunchArgs } from '@packages/types'
 
+import { debugElapsedTime } from '../util/performance_benchmark'
+
 import debugLib from 'debug'
 
 const debug = debugLib('cypress:server:interactive')
@@ -196,6 +198,8 @@ export = {
         app.quit()
       })
     })
+
+    debugElapsedTime('open mode ready')
 
     return this.ready(options, port)
   },

--- a/packages/server/lib/modes/run.js
+++ b/packages/server/lib/modes/run.js
@@ -29,6 +29,7 @@ const humanTime = require('../util/human_time')
 const chromePolicyCheck = require('../util/chrome_policy_check')
 const experiments = require('../experiments')
 const objUtils = require('../util/obj_utils')
+const { debugElapsedTime } = require('../util/performance_benchmark')
 
 const DELAY_TO_LET_VIDEO_FINISH_MS = 1000
 
@@ -1661,6 +1662,9 @@ module.exports = {
     }
 
     await loading
+
+    debugElapsedTime('run mode ready')
+
     try {
       return this.ready(options)
     } catch (e) {

--- a/packages/server/lib/util/performance_benchmark.js
+++ b/packages/server/lib/util/performance_benchmark.js
@@ -1,0 +1,26 @@
+const getTime = require('performance-now')
+const Debug = require('debug')
+
+const debug = Debug('cypress:server:performance-benchmark')
+
+function threeDecimals (n) {
+  return Math.round(n * 1000) / 1000
+}
+
+let startTime
+
+const initializeStartTime = () => {
+  startTime = getTime()
+}
+
+const debugElapsedTime = (event) => {
+  const now = getTime()
+  const delta = now - startTime
+
+  debug(`elapsed time at ${event}: ${threeDecimals(delta)}`)
+}
+
+module.exports = {
+  initializeStartTime,
+  debugElapsedTime,
+}

--- a/packages/server/server-entry.js
+++ b/packages/server/server-entry.js
@@ -1,0 +1,46 @@
+// if running in production mode (CYPRESS_INTERNAL_ENV)
+// all transpile should have been done already
+// and these calls should do nothing
+require('@packages/ts/register')
+
+const { patchFs } = require('./lib/util/patch-fs')
+const fs = require('fs')
+
+// prevent EMFILE errors
+patchFs(fs)
+
+// override tty if we're being forced to
+require('./lib/util/tty').override()
+
+const electronApp = require('./lib/util/electron-app')
+
+// are we in the main node process or the electron process?
+const isRunningElectron = electronApp.isRunning()
+
+if (process.env.CY_NET_PROFILE && isRunningElectron) {
+  const netProfiler = require('./lib/util/net_profiler')()
+
+  process.stdout.write(`Network profiler writing to ${netProfiler.logPath}\n`)
+}
+
+require('./lib/unhandled_exceptions')
+
+process.env.UV_THREADPOOL_SIZE = 128
+
+if (isRunningElectron) {
+  require('./lib/util/process_profiler').start()
+}
+
+// warn when deprecated callback apis are used in electron
+// https://github.com/electron/electron/blob/master/docs/api/process.md#processenablepromiseapis
+process.enablePromiseAPIs = process.env.CYPRESS_INTERNAL_ENV !== 'production'
+
+// don't show any electron deprecation warnings in prod
+process.noDeprecation = process.env.CYPRESS_INTERNAL_ENV === 'production'
+
+// always show stack traces for Electron deprecation warnings
+process.traceDeprecation = true
+
+require('./lib/util/suppress_warnings').suppress()
+
+module.exports = require('./lib/cypress').start(process.argv)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #22990 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

As part of the v8 snapshots project, I wanted to have a mechanism to check in on start up times easily. This is fairly quick and simple but I think it does the job. The numbers are fairly variable, but this will give a good ball park to ensure nothing major is regressing. 

Right now the numbers I'm seeing on this branch are:

* open - between 1.5 and 2.5 seconds
* run - between 5 and 6 seconds

The numbers I'm seeing in my prototype are:

* open - between .5 and .6 seconds
* run - between 2 and 3 seconds

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

You can see the output here by running cypress open or run with the environment variable `DEBUG` set to `cypress:server:performance-benchmark`

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
