### PR TITLE
fix(proxy/prerequests): fix duplicate key behavior, fallthrough

### DIFF
--- a/packages/proxy/lib/http/util/prerequests.ts
+++ b/packages/proxy/lib/http/util/prerequests.ts
@@ -64,7 +64,7 @@ class ShardedStackMap<T> {
 
     this.shards[shardKey].splice(i, 1)
   }
-  _length () {
+  get length () {
     return Object.values(this.shards).reduce((prev, cur) => prev + cur.length, 0)
   }
 }

--- a/packages/proxy/lib/http/util/prerequests.ts
+++ b/packages/proxy/lib/http/util/prerequests.ts
@@ -33,39 +33,39 @@ type PendingPreRequest = {
 }
 
 /**
- * Data structure that shards multiple items with duplicated keys into stacks.
+ * Data structure that organizes items with duplicated keys into stacks.
  */
-class ShardedStackMap<T> {
-  private shards: Record<string, Array<T>> = {}
-  push (shardKey: string, value: T) {
-    if (!this.shards[shardKey]) this.shards[shardKey] = []
+class StackMap<T> {
+  private stacks: Record<string, Array<T>> = {}
+  push (stackKey: string, value: T) {
+    if (!this.stacks[stackKey]) this.stacks[stackKey] = []
 
-    this.shards[shardKey].push(value)
+    this.stacks[stackKey].push(value)
   }
-  pop (shardKey: string): T | undefined {
-    const shard = this.shards[shardKey]
+  pop (stackKey: string): T | undefined {
+    const stack = this.stacks[stackKey]
 
-    if (!shard) return
+    if (!stack) return
 
-    const item = shard.pop()
+    const item = stack.pop()
 
-    if (shard.length === 0) delete this.shards[shardKey]
+    if (stack.length === 0) delete this.stacks[stackKey]
 
     return item
   }
   removeMatching (filterFn: (value: T) => boolean) {
-    Object.entries(this.shards).forEach(([shardKey, shard]) => {
-      this.shards[shardKey] = shard.filter(filterFn)
-      if (this.shards[shardKey].length === 0) delete this.shards[shardKey]
+    Object.entries(this.stacks).forEach(([stackKey, stack]) => {
+      this.stacks[stackKey] = stack.filter(filterFn)
+      if (this.stacks[stackKey].length === 0) delete this.stacks[stackKey]
     })
   }
-  removeExact (shardKey: string, value: T) {
-    const i = this.shards[shardKey].findIndex((v) => v === value)
+  removeExact (stackKey: string, value: T) {
+    const i = this.stacks[stackKey].findIndex((v) => v === value)
 
-    this.shards[shardKey].splice(i, 1)
+    this.stacks[stackKey].splice(i, 1)
   }
   get length () {
-    return Object.values(this.shards).reduce((prev, cur) => prev + cur.length, 0)
+    return Object.values(this.stacks).reduce((prev, cur) => prev + cur.length, 0)
   }
 }
 
@@ -77,8 +77,8 @@ class ShardedStackMap<T> {
 // ever comes in, we don't want to block proxied requests indefinitely.
 export class PreRequests {
   requestTimeout: number
-  pendingPreRequests = new ShardedStackMap<PendingPreRequest>()
-  pendingRequests = new ShardedStackMap<PendingRequest>()
+  pendingPreRequests = new StackMap<PendingPreRequest>()
+  pendingRequests = new StackMap<PendingRequest>()
   sweepInterval: ReturnType<typeof setInterval>
 
   constructor (requestTimeout = 500) {

--- a/packages/proxy/lib/http/util/prerequests.ts
+++ b/packages/proxy/lib/http/util/prerequests.ts
@@ -63,6 +63,7 @@ class StackMap<T> {
     const i = this.stacks[stackKey].findIndex((v) => v === value)
 
     this.stacks[stackKey].splice(i, 1)
+    if (this.stacks[stackKey].length === 0) delete this.stacks[stackKey]
   }
   get length () {
     return Object.values(this.stacks).reduce((prev, cur) => prev + cur.length, 0)

--- a/packages/proxy/test/unit/http/util/prerequests.spec.ts
+++ b/packages/proxy/test/unit/http/util/prerequests.spec.ts
@@ -6,6 +6,11 @@ import sinon from 'sinon'
 describe('http/util/prerequests', () => {
   let preRequests: PreRequests
 
+  function expectPendingCounts (pendingRequests: number, pendingPreRequests: number) {
+    expect(preRequests.pendingRequests._length()).to.eq(pendingRequests, 'wrong number of pending requests')
+    expect(preRequests.pendingPreRequests._length()).to.eq(pendingPreRequests, 'wrong number of pending prerequests')
+  }
+
   beforeEach(() => {
     preRequests = new PreRequests(10)
   })
@@ -18,6 +23,10 @@ describe('http/util/prerequests', () => {
     // should match in reverse order
     preRequests.addPending({ requestId: '1234', url: 'foo', method: 'WRONGMETHOD' } as BrowserPreRequest)
     preRequests.addPending({ requestId: '1234', url: 'foo', method: 'GET' } as BrowserPreRequest)
+    const thirdPreRequest = { requestId: '1234', url: 'foo', method: 'GET' } as BrowserPreRequest
+
+    preRequests.addPending(thirdPreRequest)
+    expectPendingCounts(0, 3)
 
     const cb = sinon.stub()
 
@@ -25,12 +34,15 @@ describe('http/util/prerequests', () => {
 
     const { args } = cb.getCall(0)
 
-    expect(args[0]).to.include({ requestId: '1234', url: 'foo', method: 'GET' })
+    expect(args[0]).to.eq(thirdPreRequest)
+
+    expectPendingCounts(0, 2)
   })
 
   it('synchronously matches a pre-request added after the request', (done) => {
     const cb = (preRequest) => {
       expect(preRequest).to.include({ requestId: '1234', url: 'foo', method: 'GET' })
+      expectPendingCounts(0, 0)
       done()
     }
 
@@ -41,6 +53,7 @@ describe('http/util/prerequests', () => {
   it('invokes a request callback after a timeout if no pre-request occurs', (done) => {
     const cb = (preRequest) => {
       expect(preRequest).to.be.undefined
+      expectPendingCounts(0, 0)
       done()
     }
 
@@ -57,6 +70,7 @@ describe('http/util/prerequests', () => {
     setTimeout(() => {
       const cb = (preRequest) => {
         expect(preRequest).to.be.undefined
+        expectPendingCounts(0, 0)
         done()
       }
 

--- a/packages/proxy/test/unit/http/util/prerequests.spec.ts
+++ b/packages/proxy/test/unit/http/util/prerequests.spec.ts
@@ -7,8 +7,8 @@ describe('http/util/prerequests', () => {
   let preRequests: PreRequests
 
   function expectPendingCounts (pendingRequests: number, pendingPreRequests: number) {
-    expect(preRequests.pendingRequests._length()).to.eq(pendingRequests, 'wrong number of pending requests')
-    expect(preRequests.pendingPreRequests._length()).to.eq(pendingPreRequests, 'wrong number of pending prerequests')
+    expect(preRequests.pendingRequests.length).to.eq(pendingRequests, 'wrong number of pending requests')
+    expect(preRequests.pendingPreRequests.length).to.eq(pendingPreRequests, 'wrong number of pending prerequests')
   }
 
   beforeEach(() => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog

- Fixed an issue introduced in 10.3.0 where network logs could be missing certain information or cause certain requests to be delayed by 500ms.

### Additional details

- Performance fixes in https://github.com/cypress-io/cypress/pull/22462 caused a couple of  unintended changes:
	 - Missing return statement on line 77 here causes a matched prerequest to be queued anyways: https://github.com/cypress-io/cypress/blob/8fb785a4664acf74ab9eacc243c09763e2730bf7/packages/proxy/lib/http/util/prerequests.ts#L69-L83
	 - More impactful, the `Record<string, ...>` data structure would clobber any duplicate `url+method` requests/pre-requests, which could manifest itself in incorrect pre-request data or unintended delays of requests by 500ms.
	 	- Replaced this with a `StackMap` which supports duplicate keys and `.pop` by key.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
