### PR TITLE
fix: use legacy-peer-deps for semantic-release process

### DIFF
--- a/npm/cypress-schematic/src/e2e.spec.ts
+++ b/npm/cypress-schematic/src/e2e.spec.ts
@@ -27,7 +27,7 @@ const cypressSchematicPackagePath = path.join(__dirname, '..')
 const ANGULAR_PROJECTS: ProjectFixtureDir[] = ['angular-13', 'angular-14']
 
 describe('cypress-schematic-e2e', function () {
-  this.timeout(1000 * 60 * 2)
+  this.timeout(1000 * 60 * 4)
 
   for (const project of ANGULAR_PROJECTS) {
     it('should', async () => {

--- a/scripts/npm-release.js
+++ b/scripts/npm-release.js
@@ -142,7 +142,7 @@ const releasePackages = async (packages) => {
   // so we run them one by one to avoid this
   for (const name of packages) {
     console.log(`\nReleasing ${name}...`)
-    const { stdout } = await execa('npx', ['lerna', 'exec', '--scope', name, '--', 'npx', '--no-install', 'semantic-release'])
+    const { stdout } = await execa('npx', ['lerna', 'exec', '--scope', name, '--', 'npx', '--no-install', 'semantic-release'], { env: { NPM_CONFIG_LEGACY_PEER_DEPS: true } })
 
     console.log(`Released ${name} successfully:`)
     console.log(stdout)


### PR DESCRIPTION
### User facing changelog
na

### Additional details
The `npm-release` job is broken due to peer-dependency issues. Before reverting the semantic-release dep (which has security implications), I'd like to try the `NPM_CONFIG_LEGACY_PEER_DEPS` option.

Link to latest master `npm-release` failure: https://app.circleci.com/pipelines/github/cypress-io/cypress/41450/workflows/e56453d4-5d77-4e96-8262-82517d9668aa/jobs/1716530

### Steps to test
I have no good way to test this since semantic-release requires valid npm_tokens. The build is failing when running `npm version` but I can't reproduce this locally.

### How has the user experience changed?
na

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
