### PR TITLE
fix: Add delay to showing ACI header tooltips

### DIFF
--- a/packages/app/src/runner/selector-playground/SelectorPlayground.cy.tsx
+++ b/packages/app/src/runner/selector-playground/SelectorPlayground.cy.tsx
@@ -165,21 +165,21 @@ describe('SelectorPlayground', () => {
     cy.get('[data-cy="playground-toggle"]').focus()
     cy.get('[data-cy="selector-playground-tooltip"]').should('be.visible').contains('Click an element to see a suggested selector')
     cy.get('[data-cy="playground-toggle"]').blur()
-    cy.get('[data-cy="selector-playground-tooltip"]').should('not.be.visible')
+    cy.get('[data-cy="selector-playground-tooltip"]').should('not.exist')
 
     cy.get('[data-cy="playground-copy"]').focus()
     cy.get('[data-cy="selector-playground-tooltip"]').should('be.visible').contains('Copy to clipboard')
     cy.get('[data-cy="playground-copy"]').click()
     cy.get('[data-cy="selector-playground-tooltip"]').should('be.visible').contains('Copied')
     cy.get('[data-cy="playground-copy"]').blur()
-    cy.get('[data-cy="selector-playground-tooltip"]').should('not.be.visible')
+    cy.get('[data-cy="selector-playground-tooltip"]').should('not.exist')
 
     cy.get('[data-cy="playground-print"]').focus()
     cy.get('[data-cy="selector-playground-tooltip"]').should('be.visible').contains('Print to console')
     cy.get('[data-cy="playground-print"]').click()
     cy.get('[data-cy="selector-playground-tooltip"]').should('be.visible').contains('Printed')
     cy.get('[data-cy="playground-print"]').blur()
-    cy.get('[data-cy="selector-playground-tooltip"]').should('not.be.visible')
+    cy.get('[data-cy="selector-playground-tooltip"]').should('not.exist')
   })
 
   it('ensures input autocomplete is disabled', () => {

--- a/packages/app/src/specs/LastUpdatedHeader.cy.tsx
+++ b/packages/app/src/specs/LastUpdatedHeader.cy.tsx
@@ -3,6 +3,8 @@ import LastUpdatedHeader from './LastUpdatedHeader.vue'
 import { defaultMessages } from '@cy/i18n'
 
 describe('<LastUpdatedHeader />', () => {
+  const popperContentSelector = '.v-popper__popper--shown'
+
   function mountWithProps (isGitAvailable: boolean) {
     cy.mount(() => <div class="flex justify-around"><LastUpdatedHeader isGitAvailable={isGitAvailable} /></div>)
   }
@@ -15,7 +17,7 @@ describe('<LastUpdatedHeader />', () => {
     const expectedTooltipText = defaultMessages.specPage.lastUpdated.tooltip.gitInfoAvailable
     .replace('{0}', defaultMessages.specPage.lastUpdated.tooltip.gitStatus)
 
-    cy.get('.v-popper__popper--shown').should('have.text', expectedTooltipText)
+    cy.get(popperContentSelector).should('have.text', expectedTooltipText)
 
     cy.percySnapshot()
   })
@@ -28,8 +30,17 @@ describe('<LastUpdatedHeader />', () => {
     const expectedTooltipText = defaultMessages.specPage.lastUpdated.tooltip.gitInfoUnavailable
     .replace('{0}', defaultMessages.specPage.lastUpdated.tooltip.gitInfo)
 
-    cy.get('.v-popper__popper--shown').should('have.text', expectedTooltipText)
+    cy.get(popperContentSelector).should('have.text', expectedTooltipText)
 
     cy.percySnapshot()
+  })
+
+  it('delays popping tooltip', () => {
+    cy.clock()
+    mountWithProps(true)
+    cy.findByTestId('last-updated-header').trigger('mouseenter')
+    cy.get(popperContentSelector).should('not.exist')
+    cy.tick(500)
+    cy.get(popperContentSelector).should('be.visible')
   })
 })

--- a/packages/app/src/specs/LastUpdatedHeader.vue
+++ b/packages/app/src/specs/LastUpdatedHeader.vue
@@ -3,6 +3,7 @@
     placement="top"
     :is-interactive="true"
     show-group="last-updated-header"
+    :show-delay="250"
   >
     <button
       type="button"

--- a/packages/app/src/specs/SpecHeaderCloudDataTooltip.cy.tsx
+++ b/packages/app/src/specs/SpecHeaderCloudDataTooltip.cy.tsx
@@ -205,6 +205,19 @@ describe('<SpecHeaderCloudDataTooltip />', () => {
           cy.percySnapshot()
         })
       })
+
+      it('delays popping tooltip', () => {
+        cy.clock()
+        mountWithStatus('CONNECTED', mode, msgKeys)
+        cy.get(tooltipContentSelector).trigger('mouseenter')
+        cy.findByTestId('cloud-data-tooltip-content')
+        .should('not.exist')
+
+        cy.tick(500)
+
+        cy.findByTestId('cloud-data-tooltip-content')
+        .should('be.visible')
+      })
     })
   })
 })

--- a/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
+++ b/packages/app/src/specs/SpecHeaderCloudDataTooltip.vue
@@ -3,6 +3,7 @@
     placement="top"
     :is-interactive="true"
     :show-group="VALUES[mode].header"
+    :show-delay="250"
   >
     <button
       type="button"

--- a/packages/frontend-shared/src/components/StandardModal.cy.tsx
+++ b/packages/frontend-shared/src/components/StandardModal.cy.tsx
@@ -97,7 +97,7 @@ describe('<StandardModal />', { viewportWidth: 800, viewportHeight: 400 }, () =>
 
       // Verify tooltip is no longer open once modal was opened
       cy.findByTestId('tooltip-content')
-      .should('not.be.visible')
+      .should('not.exist')
 
       cy.percySnapshot()
     })

--- a/packages/frontend-shared/src/components/Tooltip.cy.tsx
+++ b/packages/frontend-shared/src/components/Tooltip.cy.tsx
@@ -38,18 +38,40 @@ describe('<Tooltip />', () => {
     cy.get('.default-slot0')
     .realHover()
 
+    cy.contains('Tooltip 0')
+
     cy.get('.default-slot1')
     .realHover()
+
+    cy.contains('Tooltip 1')
 
     cy.get('.default-slot2')
     .realHover()
 
+    cy.contains('Tooltip 2')
+
     cy.get('.default-slot3')
     .realHover()
 
-    cy.contains('Tooltip 0')
-    cy.contains('Tooltip 1')
-    cy.contains('Tooltip 2')
     cy.contains('Tooltip 3')
+  })
+
+  it('should dispose immediately on hide', () => {
+    cy.mount(() => {
+      return (
+        <div class="flex m-100px p-4 w-100px gap-160px">
+          {/* @ts-ignore */}
+          <Tooltip v-slots={slotContents(0)} placement="bottom" isInteractive />
+        </div>
+      )
+    })
+
+    cy.get('.default-slot0')
+    .realHover()
+
+    cy.get('.v-popper__popper').should('be.visible')
+
+    cy.get('body').realHover()
+    cy.get('.v-popper__popper').should('not.exist', { timeout: 250 })
   })
 })

--- a/packages/frontend-shared/src/components/Tooltip.vue
+++ b/packages/frontend-shared/src/components/Tooltip.vue
@@ -8,7 +8,7 @@
     :distance="distance"
     :skidding="skidding"
     :auto-hide="false /* to prevent the popper from getting focus */"
-    :delay="{show: 0, hide: hideDelay }"
+    :delay="{show: showDelay, hide: hideDelay }"
     :show-group="showGroup"
   >
     <slot />
@@ -25,7 +25,10 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { Tooltip, Menu } from 'floating-vue'
+import { Tooltip, Menu, options } from 'floating-vue'
+
+// Override default of 5000 so that DOM elements are disposed immediately when tooltip closes
+options.disposeTimeout = 0
 
 const props = withDefaults(defineProps<{
   color?: string
@@ -36,6 +39,7 @@ const props = withDefaults(defineProps<{
   skidding?: number
   placement?: 'top' | 'right' | 'bottom' | 'left'
   popperClass?: string
+  showDelay?: number
   hideDelay?: number
   instantMove?: boolean
   showGroup?: string
@@ -48,6 +52,7 @@ const props = withDefaults(defineProps<{
   skidding: undefined,
   placement: undefined,
   popperClass: undefined,
+  showDelay: 0,
   hideDelay: 100,
   instantMove: undefined,
   showGroup: undefined,

--- a/packages/frontend-shared/src/gql-components/topnav/LoginModal.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/topnav/LoginModal.cy.tsx
@@ -230,7 +230,7 @@ describe('<LoginModal />', { viewportWidth: 1000, viewportHeight: 750 }, () => {
 
     // Verify tooltip is no longer open once modal was opened
     cy.findByTestId('tooltip-content')
-    .should('not.be.visible')
+    .should('not.exist')
 
     cy.percySnapshot()
   })


### PR DESCRIPTION
- Closes #23115 

### User facing changelog
* Add delay to header tooltips so they don't pop open unless hovered on

### Additional details
Had to make two fixes here:
1. Add a "show-delay" to both header components and pass thru to base Tooltip
2. `floating-vue` by default keeps tooltip content in the DOM for 5 seconds after the tooltip closes before disposing of it. This caused the delay to be ignored if you moused back over the tooltip within that 5 second period. The disposal period is a global conflg for the library - I don't foresee any issues with reducing it to immediately dispose (it may actually clean up some of the weird tooltip behaviors we have currently) but let me know if you have concerns

### Steps to test
1. Open a project in the app
2. From the specs list, move your mouse to the "New Spec" button (crossing over the "Average Duration" header in the process). Observe the header tooltip does not pop open, blocking the button
3. Hover over the "Last Updated", "Latest Runs" and "Average duration" headers, observe tooltips display after a brief delay
4. Validate that other uses of `Tooltip` in the app are unaffected (collapsed sidebar icons, selector playground, last updated row elements, etc)

### How has the user experience changed?

https://user-images.githubusercontent.com/11482842/184014634-9a3f76ca-82b6-43de-8e59-ca82e2230f11.mov

### PR Tasks
- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
