### PR TITLE
fix: disable npm workspace update when running semantic-release

### DIFF
--- a/scripts/npm-release.js
+++ b/scripts/npm-release.js
@@ -142,7 +142,11 @@ const releasePackages = async (packages) => {
   // so we run them one by one to avoid this
   for (const name of packages) {
     console.log(`\nReleasing ${name}...`)
-    const { stdout } = await execa('npx', ['lerna', 'exec', '--scope', name, '--', 'npx', '--no-install', 'semantic-release'], { env: { NPM_CONFIG_LEGACY_PEER_DEPS: true } })
+    // semantic-release v19 upgraded to npm v8 which supports workspaces. When running semantic-release, npm thinks that our lerna workspace
+    // is an npm workspace. When npm executes commands that modify the workspace, it will check the validity of the workspace.
+    // We don't want this to happen since we don't use npm and our links/peerDependencies make npm unhappy.
+    // We disable the workspace update via the NPM_CONFIG_WORKSPACES_UDPATE=false env variable.
+    const { stdout } = await execa('npx', ['lerna', 'exec', '--scope', name, '--', 'npx', '--no-install', 'semantic-release'], { env: { NPM_CONFIG_WORKSPACES_UPDATE: false } })
 
     console.log(`Released ${name} successfully:`)
     console.log(stdout)


### PR DESCRIPTION
### User facing changelog
na

### Additional details
semantic-release v19 upgraded to npm v8 which supports workspaces. When running semantic-release, npm thinks that our lerna workspace is an npm workspace. When npm executes commands that modify the workspace, it will check the validity of the workspace. We don't want this to happen since we don't use npm and our links/peerDependencies make npm unhappy. We disable the workspace update via the NPM_CONFIG_WORKSPACES_UDPATE=false env variable.

I included this as a code comment for future reference

### Steps to test
A bit tricky to test but I was able to run the plugin that was causing the `npm-release` job to fail locally. To do so, I modified `node_modules/semantic-release/lib/definitions/plugins.js` to change the `prepare` plugin to have `dryRun: true`. This allows the plugin to be executed during a dry-run of semantic-release. You can then run `yarn npm-release` to verify the behavior (the script will error out later due to not being in CI, but the script executes a dry-run earlier).

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
