### PR TITLE
chore: remove redundant runner-ct webpack script from watch

### DIFF
--- a/scripts/gulp/gulpfile.ts
+++ b/scripts/gulp/gulpfile.ts
@@ -17,7 +17,7 @@ import { makePathMap } from './utils/makePathMap'
 import { makePackage } from './tasks/gulpMakePackage'
 import { exitAfterAll } from './tasks/gulpRegistry'
 import { execSync } from 'child_process'
-import { webpackReporter, webpackRunner, webpackRunnerCT } from './tasks/gulpWebpack'
+import { webpackReporter, webpackRunner } from './tasks/gulpWebpack'
 import { e2eTestScaffold, e2eTestScaffoldWatch } from './tasks/gulpE2ETestScaffold'
 import dedent from 'dedent'
 
@@ -60,7 +60,6 @@ gulp.task(
   gulp.parallel(
     webpackReporter,
     webpackRunner,
-    webpackRunnerCT,
     gulp.series(
       makePathMap,
       // Before dev, fetch the latest "remote" schema from the Cypress dashboard

--- a/scripts/gulp/tasks/gulpWebpack.ts
+++ b/scripts/gulp/tasks/gulpWebpack.ts
@@ -15,14 +15,6 @@ export function webpackReporter () {
   })
 }
 
-export function webpackRunnerCT () {
-  return runWebpack({
-    cwd: monorepoPaths.pkgRunnerCt,
-    prefix: 'webpack:runner:ct',
-    args: ['-w'],
-  })
-}
-
 export function webpackRunner () {
   return runWebpack({
     cwd: monorepoPaths.pkgRunner,


### PR DESCRIPTION
### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
Removed a leftover runner-ct script that was throwing an error during `yarn watch`

![Screen Shot 2022-08-11 at 10 38 41 AM](https://user-images.githubusercontent.com/25158820/184174088-c8d802e1-98b8-4868-a909-0c6adc6d0440.png)


### Steps to test
Run `yarn watch` on latest develop to see the error in the terminal

Run` yarn watch` on my PR to see it _disappear_

### How has the user experience changed?
na

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
