### PR TITLE
fix: remove webpack entrypoints from for ct webpack projects

### DIFF
--- a/npm/webpack-dev-server/src/helpers/createReactAppHandler.ts
+++ b/npm/webpack-dev-server/src/helpers/createReactAppHandler.ts
@@ -77,8 +77,6 @@ function loadWebpackConfig (devServerConfig: WebpackDevServerConfig): Configurat
       webpackConfig = webpackConfig('development')
     }
 
-    delete webpackConfig.entry
-
     return webpackConfig
   } catch (err) {
     throw new Error(`Failed to require webpack config at ${webpackConfigPath} with error: ${err}`)

--- a/npm/webpack-dev-server/src/helpers/nextHandler.ts
+++ b/npm/webpack-dev-server/src/helpers/nextHandler.ts
@@ -72,8 +72,6 @@ async function loadWebpackConfig (devServerConfig: WebpackDevServerConfig): Prom
     },
   )
 
-  delete webpackConfig.entry
-
   return webpackConfig
 }
 

--- a/npm/webpack-dev-server/src/helpers/nuxtHandler.ts
+++ b/npm/webpack-dev-server/src/helpers/nuxtHandler.ts
@@ -19,7 +19,6 @@ export async function nuxtHandler (devServerConfig: WebpackDevServerConfig): Pro
     // Nuxt has asset size warnings configured by default which will cause webpack overlays to appear
     // in the browser which we don't want.
     delete webpackConfig.performance
-    delete webpackConfig.entry
 
     debug('webpack config %o', webpackConfig)
 

--- a/npm/webpack-dev-server/src/helpers/vueCliHandler.ts
+++ b/npm/webpack-dev-server/src/helpers/vueCliHandler.ts
@@ -17,8 +17,6 @@ export function vueCliHandler (devServerConfig: WebpackDevServerConfig): PresetH
 
     debug('webpack config %o', webpackConfig)
 
-    delete webpackConfig.entry
-
     return { frameworkConfig: webpackConfig, sourceWebpackModulesResult }
   } catch (e) {
     console.error(e) // eslint-disable-line no-console

--- a/npm/webpack-dev-server/src/makeWebpackConfig.ts
+++ b/npm/webpack-dev-server/src/makeWebpackConfig.ts
@@ -2,7 +2,7 @@ import { debug as debugFn } from 'debug'
 import * as path from 'path'
 import { merge } from 'webpack-merge'
 import { importModule } from 'local-pkg'
-import type { Configuration } from 'webpack'
+import type { Configuration, EntryObject } from 'webpack'
 import { makeDefaultWebpackConfig } from './makeDefaultWebpackConfig'
 import { CypressCTWebpackPlugin } from './CypressCTWebpackPlugin'
 import type { CreateFinalWebpackConfig } from './createWebpackDevServer'
@@ -41,7 +41,7 @@ if (process.platform === 'linux') {
 const OsSeparatorRE = RegExp(`\\${path.sep}`, 'g')
 const posixSeparator = '/'
 
-const CYPRESS_WEBPACK_ENTRYPOINT = path.resolve(__dirname, 'browser.js')
+export const CYPRESS_WEBPACK_ENTRYPOINT = path.resolve(__dirname, 'browser.js')
 
 /**
  * Removes and/or modifies certain plugins known to conflict
@@ -72,29 +72,6 @@ function modifyWebpackConfigForCypress (webpackConfig: Partial<Configuration>) {
   return webpackConfig
 }
 
-async function addEntryPoint (webpackConfig: Configuration) {
-  let entry = webpackConfig.entry
-
-  if (typeof entry === 'function') {
-    entry = await entry()
-  }
-
-  if (typeof entry === 'string') {
-    entry = [entry, CYPRESS_WEBPACK_ENTRYPOINT]
-  } else if (Array.isArray(entry)) {
-    entry.push(CYPRESS_WEBPACK_ENTRYPOINT)
-  } else if (typeof entry === 'object') {
-    entry = {
-      ...entry,
-      ['cypress-entry']: CYPRESS_WEBPACK_ENTRYPOINT,
-    }
-  } else {
-    entry = CYPRESS_WEBPACK_ENTRYPOINT
-  }
-
-  webpackConfig.entry = entry
-}
-
 /**
  * Creates a webpack 4/5 compatible webpack "configuration"
  * to pass to the sourced webpack function
@@ -113,6 +90,7 @@ export async function makeWebpackConfig (
     },
     specs: files,
     devServerEvents,
+    framework,
   } = config.devServerConfig
 
   let configFile: string | undefined = undefined
@@ -184,7 +162,15 @@ export async function makeWebpackConfig (
     dynamicWebpackConfig,
   )
 
-  await addEntryPoint(mergedConfig)
+  // Angular loads global styles and polyfills via script injection in the index.html
+  if (framework === 'angular') {
+    mergedConfig.entry = {
+      ...(mergedConfig.entry as EntryObject) || {},
+      'cypress-entry': CYPRESS_WEBPACK_ENTRYPOINT,
+    }
+  } else {
+    mergedConfig.entry = CYPRESS_WEBPACK_ENTRYPOINT
+  }
 
   debug('Merged webpack config %o', mergedConfig)
 


### PR DESCRIPTION
- Closes #23224

### User facing changelog
Webpack entrypoints are no longer preserved for CT Webpack projects

### Additional details
Fixes a regression from https://github.com/cypress-io/cypress/pull/22314 where webpack entrypoints were being preserved. This is mostly a revert of the changes made to entrypoints in that PR. It made sense for frameworks as their was logic added for removing entrypoints that would cause problems in each handler, but users who pass in a custom webpack config (don't use a higher-order framework like Next or create-react-app) were facing issues with their entrypoint being included and executed.

### Steps to test
Checkout the repo provided in the original issue: https://gitlab.com/souf/react-webpack-playground/-/tree/cypress-webpack-entry

Install Cypress and walk through CT setup.

Create a simple spec:

```js
// src/components/App.cy.jsx
import React from "react";
import App from "./App";

it("should render", () => {
  cy.mount(<App />);
});
```

Then run the spec. Nothing will load, and the console will display:

<img width="852" alt="Screen Shot 2022-08-11 at 5 09 20 PM" src="https://user-images.githubusercontent.com/25158820/184251032-ce551ad0-09c3-44b3-aed2-72d98b4f2a7a.png">

Checkout my branch and run `yarn workspace @cypress/webpack-dev-server build && yarn cypress:open`. Open the same project and no more error!


### How has the user experience changed?

https://user-images.githubusercontent.com/25158820/184251849-0a3145ca-9b7e-472d-b920-be401c79c4c7.mov



### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
