### PR TITLE
fix: call screencastOpts as a function for starting a screencast on electron



### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress",
-  "version": "9.7.0",
+  "version": "9.7.1",
   "description": "Cypress.io end to end testing tool",
   "private": true,
   "scripts": {

--- a/packages/server/lib/browsers/electron.js
+++ b/packages/server/lib/browsers/electron.js
@@ -68,8 +68,7 @@ const _getAutomation = async function (win, options, parent) {
       if (message !== 'take:screenshot') {
         return fn(message, data)
       }
-
-      await sendCommand('Page.startScreencast', screencastOpts)
+      await sendCommand('Page.startScreencast', screencastOpts())
 
       const ret = await fn(message, data)
 
@@ -103,7 +102,6 @@ const _maybeRecordVideo = function (webContents, options) {
     if (!onScreencastFrame) {
       return
     }
-
     webContents.debugger.on('message', (event, method, params) => {
       if (method === 'Page.screencastFrame') {
         onScreencastFrame(params)
@@ -111,7 +109,7 @@ const _maybeRecordVideo = function (webContents, options) {
       }
     })
 
-    await webContents.debugger.sendCommand('Page.startScreencast', screencastOpts)
+    await webContents.debugger.sendCommand('Page.startScreencast', screencastOpts())
   }
 }
 

--- a/packages/server/lib/modes/record.js
+++ b/packages/server/lib/modes/record.js
@@ -791,6 +791,8 @@ const createRunAndRecordSpecs = (options = {}) => {
         })
 
         if (response === responseDidFail) {
+          debug('`responseDidFail` equals `response`, allowing browser to hang until it is killed: Response %o', { responseDidFail })
+
           // dont call the cb, let the browser hang until it's killed
           return
         }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
