### PR TITLE
fix: Address windows test failures introduced by gql query changes

### DIFF
--- a/packages/app/src/runs/CloudConnectButton.vue
+++ b/packages/app/src/runs/CloudConnectButton.vue
@@ -11,7 +11,7 @@
     v-model="isLoginOpen"
     :gql="props.gql"
     utm-medium="Runs Tab"
-    :show-connect-button-after-login="!props.gql?.currentProject?.projectId"
+    :show-connect-button-after-login="!cloudProjectId"
     @connect-project="isProjectConnectOpen = true"
   />
   <CloudConnectModals
@@ -40,7 +40,7 @@ gql`
 fragment CloudConnectButton on Query {
   currentProject {
     id
-    projectId
+    config
   }
   ...CloudConnectModals
   ...LoginModal
@@ -69,5 +69,9 @@ function openConnection () {
     isProjectConnectOpen.value = true
   }
 }
+
+const cloudProjectId = computed(() => {
+  return props.gql?.currentProject?.config?.find((item: { field: string }) => item.field === 'projectId')?.value
+})
 
 </script>

--- a/packages/frontend-shared/src/gql-components/HeaderBarContent.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/HeaderBarContent.cy.tsx
@@ -370,7 +370,11 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
                 ...(options?.state ?? {}),
               }
 
-              result.currentProject.projectId = options?.projectId ?? null
+              const projectId = result.currentProject.config.find((item: {field: string, value: string}) => item.field = 'projectId')
+
+              if (projectId) {
+                projectId.value = options?.projectId
+              }
             },
             render: (gqlVal) => <div class="border-current border-1 h-700px resize overflow-auto"><HeaderBarContent gql={gqlVal} show-browsers={true} allowAutomaticPromptOpen={true} /></div>,
           })

--- a/packages/frontend-shared/src/gql-components/HeaderBarContent.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/HeaderBarContent.cy.tsx
@@ -370,11 +370,7 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
                 ...(options?.state ?? {}),
               }
 
-              const projectId = result.currentProject.config.find((item: {field: string, value: string}) => item.field = 'projectId')
-
-              if (projectId) {
-                projectId.value = options?.projectId
-              }
+              result.currentProject.projectId = options?.projectId ?? null
             },
             render: (gqlVal) => <div class="border-current border-1 h-700px resize overflow-auto"><HeaderBarContent gql={gqlVal} show-browsers={true} allowAutomaticPromptOpen={true} /></div>,
           })

--- a/packages/frontend-shared/src/gql-components/HeaderBarContent.vue
+++ b/packages/frontend-shared/src/gql-components/HeaderBarContent.vue
@@ -157,7 +157,7 @@
         v-model="isLoginOpen"
         :gql="props.gql"
         utm-medium="Nav"
-        :show-connect-button-after-login="isApp && !props.gql?.currentProject?.projectId"
+        :show-connect-button-after-login="isApp && !cloudProjectId"
         @connect-project="handleConnectProject"
       />
     </div>
@@ -234,7 +234,6 @@ fragment HeaderBar_HeaderBarContent on Query {
     savedState
     currentTestingType
     branch
-    projectId
   }
   isGlobalMode
   ...TopNav
@@ -252,6 +251,10 @@ const savedState = computed(() => {
 })
 
 const currentProject = computed(() => props.gql.currentProject)
+
+const cloudProjectId = computed(() => {
+  return props.gql?.currentProject?.config?.find((item: { field: string }) => item.field === 'projectId')?.value
+})
 
 const isLoginOpen = ref(false)
 const clearCurrentProjectMutation = useMutation(GlobalPageHeader_ClearCurrentProjectDocument)
@@ -336,7 +339,7 @@ function shouldShowPrompt (prompt: { slug: string, noProjectId: boolean, interva
 
   // if prompt requires no project id,
   // check if project id exists
-  if (prompt.noProjectId && props.gql?.currentProject?.projectId) {
+  if (prompt.noProjectId && cloudProjectId.value) {
     return false
   }
 

--- a/packages/frontend-shared/src/gql-components/HeaderBarContent.vue
+++ b/packages/frontend-shared/src/gql-components/HeaderBarContent.vue
@@ -157,7 +157,7 @@
         v-model="isLoginOpen"
         :gql="props.gql"
         utm-medium="Nav"
-        :show-connect-button-after-login="isApp && !props.gql?.currentProject?.projectId"
+        :show-connect-button-after-login="isApp && !cloudProjectId"
         @connect-project="handleConnectProject"
       />
     </div>
@@ -234,7 +234,6 @@ fragment HeaderBar_HeaderBarContent on Query {
     savedState
     currentTestingType
     branch
-    projectId
   }
   isGlobalMode
   ...TopNav
@@ -249,6 +248,10 @@ const userData = computed(() => {
 
 const savedState = computed(() => {
   return props.gql?.currentProject?.savedState
+})
+
+const cloudProjectId = computed(() => {
+  return props.gql?.currentProject?.config?.find((item: { field: string }) => item.field === 'projectId')?.value
 })
 
 const currentProject = computed(() => props.gql.currentProject)
@@ -336,7 +339,7 @@ function shouldShowPrompt (prompt: { slug: string, noProjectId: boolean, interva
 
   // if prompt requires no project id,
   // check if project id exists
-  if (prompt.noProjectId && props.gql?.currentProject?.projectId) {
+  if (prompt.noProjectId && cloudProjectId.value) {
     return false
   }
 

--- a/packages/frontend-shared/src/gql-components/HeaderBarContent.vue
+++ b/packages/frontend-shared/src/gql-components/HeaderBarContent.vue
@@ -157,7 +157,7 @@
         v-model="isLoginOpen"
         :gql="props.gql"
         utm-medium="Nav"
-        :show-connect-button-after-login="isApp && !cloudProjectId"
+        :show-connect-button-after-login="isApp && !props.gql?.currentProject?.projectId"
         @connect-project="handleConnectProject"
       />
     </div>
@@ -234,6 +234,7 @@ fragment HeaderBar_HeaderBarContent on Query {
     savedState
     currentTestingType
     branch
+    projectId
   }
   isGlobalMode
   ...TopNav
@@ -248,10 +249,6 @@ const userData = computed(() => {
 
 const savedState = computed(() => {
   return props.gql?.currentProject?.savedState
-})
-
-const cloudProjectId = computed(() => {
-  return props.gql?.currentProject?.config?.find((item: { field: string }) => item.field === 'projectId')?.value
 })
 
 const currentProject = computed(() => props.gql.currentProject)
@@ -339,7 +336,7 @@ function shouldShowPrompt (prompt: { slug: string, noProjectId: boolean, interva
 
   // if prompt requires no project id,
   // check if project id exists
-  if (prompt.noProjectId && cloudProjectId.value) {
+  if (prompt.noProjectId && props.gql?.currentProject?.projectId) {
     return false
   }
 


### PR DESCRIPTION
Addressing Windows e2e failure introduced by #23295 

### User facing changelog

### Additional details
New GQL fields were added to existing queries in some base components which introduced delays/failures in e2e tests. Happened to get green CI for the original PR but [CI builds on develop surfaced issues on the Windows runs](https://app.circleci.com/pipelines/github/cypress-io/cypress/41828/workflows/b91a66aa-6ba1-4147-9ef9-435b0c991a4c/jobs/1734268).

GQL fields for cloud connect modals (some of which are remote query fields) were added to the app default layout which caused failures in `authChange-subscription.cy.ts`. Updating to run the query on-demand instead so it doesn't impact majority of e2e tests.

Also reverting how two components are resolving `projectId` to how Mark originally had them. There is some delay/instability introduced by querying `projectId` directly that was causing some e2e failures and I wasn't able to track down precisely what was causing it. Given time we should be able to track down the proper way to stub/mock this out in the tests so we don't have to do this manually, but I didn't want to hold up the release since it wasn't obvious to me how to resolve

### Steps to test
Use test procedure from #23295

### How has the user experience changed?


### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
