### PR TITLE
fix: cypress-schematic add exception for nguniversal ssr dev server

### DIFF
--- a/npm/cypress-schematic/src/builders/cypress/index.ts
+++ b/npm/cypress-schematic/src/builders/cypress/index.ts
@@ -119,7 +119,7 @@ export function startDevServer ({
   return scheduleTargetAndForget(context, targetFromTargetString(devServerTarget), overrides).pipe(
     //@ts-ignore
     map((output: any) => {
-      if (!output.success) {
+      if (!output.success && !watch) {
         throw new Error('Could not compile application files')
       }
 

--- a/npm/cypress-schematic/src/builders/cypress/index.ts
+++ b/npm/cypress-schematic/src/builders/cypress/index.ts
@@ -46,8 +46,8 @@ function runCypress (
     }),
     switchMap((options: CypressBuilderOptions) => {
       return (options.devServerTarget
-        ? forkJoin(startDevServer({ devServerTarget: options.devServerTarget, watch: options.watch, context })).pipe(
-          map((devServerBaseUrlArray: [string]) => options.baseUrl || devServerBaseUrlArray[0]),
+        ? startDevServer({ devServerTarget: options.devServerTarget, watch: options.watch, context }).pipe(
+          map((devServerBaseUrl: string) => options.baseUrl || devServerBaseUrl),
         )
         : of(options.baseUrl)
       ).pipe(

--- a/npm/cypress-schematic/src/builders/cypress/index.ts
+++ b/npm/cypress-schematic/src/builders/cypress/index.ts
@@ -9,7 +9,7 @@ import { asWindowsPath, normalize } from '@angular-devkit/core'
 import * as os from 'os'
 import { dirname, join } from 'path'
 import { open, run } from 'cypress'
-import { forkJoin, from, noop, Observable, of } from 'rxjs'
+import { from, noop, Observable, of } from 'rxjs'
 import { catchError, concatMap, first, map, switchMap, tap } from 'rxjs/operators'
 import { CypressBuilderOptions } from './cypressBuilderOptions'
 
@@ -19,7 +19,7 @@ Partial<CypressCommandLine.CypressOpenOptions>;
 type CypressStartDevServerProps = {
   devServerTarget: string
   watch: boolean
-  context: any
+  context: BuilderContext
 }
 
 function runCypress (

--- a/npm/cypress-schematic/src/builders/cypress/index.ts
+++ b/npm/cypress-schematic/src/builders/cypress/index.ts
@@ -99,10 +99,6 @@ export function startDevServer ({
   devServerTarget,
   watch,
   context }: CypressStartDevServerProps): Observable<string> {
-  // @NOTE: Do not forward watch option if not supported by the target dev server,
-  // this is relevant for running Cypress against dev server target that does not support this option,
-  // for instance @nguniversal/builders:ssr-dev-server.
-  // see https://github.com/nrwl/nx/blob/f930117ed6ab13dccc40725c7e9551be081cc83d/packages/cypress/src/executors/cypress/cypress.impl.ts
   const buildTarget = targetFromTargetString(devServerTarget)
 
   return from(context.getBuilderNameForTarget(buildTarget)).pipe(

--- a/npm/cypress-schematic/src/builders/cypress/index.ts
+++ b/npm/cypress-schematic/src/builders/cypress/index.ts
@@ -16,9 +16,9 @@ import { CypressBuilderOptions } from './cypressBuilderOptions'
 type CypressOptions = Partial<CypressCommandLine.CypressRunOptions> &
 Partial<CypressCommandLine.CypressOpenOptions>;
 
-type StartDevServerProps = {
+type CypressStartDevServerProps = {
   devServerTarget: string
-  watch?: boolean
+  watch: boolean
   context: any
 }
 
@@ -98,7 +98,7 @@ function initCypress (userOptions: CypressBuilderOptions): Observable<BuilderOut
 export function startDevServer ({
   devServerTarget,
   watch,
-  context }: StartDevServerProps): Observable<string> {
+  context }: CypressStartDevServerProps): Observable<string> {
   // @NOTE: Do not forward watch option if not supported by the target dev server,
   // this is relevant for running Cypress against dev server target that does not support this option,
   // for instance @nguniversal/builders:ssr-dev-server.

--- a/npm/cypress-schematic/src/builders/cypress/index.ts
+++ b/npm/cypress-schematic/src/builders/cypress/index.ts
@@ -109,7 +109,7 @@ export function startDevServer ({
   let overrides = {}
 
   if (devServerConfig.builder !== '@nguniversal/builders:ssr-dev-server') {
-    console.info('DevServer will be started in watch mode.')
+    console.info(`Passing watch mode to DevServer - watch mode is ${watch}`)
     overrides = {
       watch,
     }

--- a/npm/cypress-schematic/src/builders/cypress/index.ts
+++ b/npm/cypress-schematic/src/builders/cypress/index.ts
@@ -103,12 +103,16 @@ export function startDevServer ({
   // this is relevant for running Cypress against dev server target that does not support this option,
   // for instance @nguniversal/builders:ssr-dev-server.
   // see https://github.com/nrwl/nx/blob/f930117ed6ab13dccc40725c7e9551be081cc83d/packages/cypress/src/executors/cypress/cypress.impl.ts
-  if (!devServerTarget.includes('watch')) {
-    watch = undefined;
-  }
+  const angularJson = require(`${context.workspaceRoot }/angular.json`)
+  const { project, target } = targetFromTargetString(devServerTarget)
+  const devServerConfig = angularJson.projects[project].architect[target]
+  let overrides = {}
 
-  const overrides = {
-    watch,
+  if (devServerConfig.builder !== '@nguniversal/builders:ssr-dev-server') {
+    console.info('DevServer will be started in watch mode.')
+    overrides = {
+      watch,
+    }
   }
 
   //@ts-ignore


### PR DESCRIPTION

- Closes https://github.com/cypress-io/cypress/issues/23345

### User facing changelog
Allow optional watch option for angular universal dev server 

### How has the user experience changed?
It will now work with angular universal dev server 

### PR Tasks

- [ na] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
