### PR TITLE
fix: add keyboard shortcut for focusing specs search (9.x parity)

### DIFF
--- a/packages/app/cypress/e2e/runner/runner.shortcuts.cy.ts
+++ b/packages/app/cypress/e2e/runner/runner.shortcuts.cy.ts
@@ -1,0 +1,16 @@
+import { loadSpec } from './support/spec-loader'
+
+describe('runner shortcuts', () => {
+  it('should run a spec', () => {
+    loadSpec({
+      filePath: 'runner/simple-single-test.runner.cy.js',
+      passCount: 1,
+      failCount: 0,
+    })
+
+    cy.findByRole('button', { name: 'Specs' }).should('have.attr', 'aria-expanded', 'false')
+    cy.get('body').type('{ctrl+k}')
+    cy.findByRole('button', { name: 'Specs' }).should('have.attr', 'aria-expanded', 'true')
+    cy.findByLabelText('Search Specs').should('be.focused')
+  })
+})

--- a/packages/app/src/runner/SpecRunnerOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerOpenMode.vue
@@ -294,6 +294,10 @@ onMounted(() => {
     preferences.update('isSpecsListOpen', state.isSpecsListOpen)
     preferences.update('autoScrollingEnabled', state.autoScrollingEnabled)
   })
+
+  eventManager.on('focus:app:search', () => {
+    runnerUiStore.setPreference('isSpecsListInputFocused', true)
+  })
 })
 
 onBeforeUnmount(() => {

--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -255,6 +255,10 @@ export class EventManager {
       this.saveState(state)
     })
 
+    this.reporterBus.on('focus:search', () => {
+      this.localBus.emit('focus:app:search')
+    })
+
     this.reporterBus.on('clear:session', () => {
       if (!Cypress) return
 

--- a/packages/app/src/specs/InlineSpecListHeader.vue
+++ b/packages/app/src/specs/InlineSpecListHeader.vue
@@ -10,7 +10,7 @@
         class="flex h-full inset-y-0 w-32px absolute items-center pointer-events-none"
       >
         <i-cy-magnifying-glass_x16
-          :class="inputFocused ? 'icon-dark-indigo-300' : 'icon-dark-gray-800'"
+          :class="runnerUiStore.isSpecsListInputFocused ? 'icon-dark-indigo-300' : 'icon-dark-gray-800'"
           class="icon-light-gray-1000"
         />
       </div>
@@ -26,22 +26,22 @@
           placeholder-gray-700
           text-gray-500
         "
-        :class="inputFocused || props.specFilterModel.length ? 'w-full' : 'w-16px'"
+        :class="runnerUiStore.isSpecsListInputFocused || props.specFilterModel.length ? 'w-full' : 'w-16px'"
         :value="props.specFilterModel"
         type="search"
         minlength="1"
         autocapitalize="off"
         autocomplete="off"
         spellcheck="false"
-        @focus="inputFocused = true"
-        @blur="inputFocused = false"
+        @focus="handleFocus"
+        @blur="handleBlur"
         @input="onInput"
       >
       <label
         for="inline-spec-list-header-search"
         class="cursor-text font-light bottom-4px left-24px text-gray-500 pointer-events-none absolute"
         :class="{
-          'sr-only': inputFocused || props.specFilterModel
+          'sr-only': runnerUiStore.isSpecsListInputFocused || props.specFilterModel
         }"
       >
         {{ t('specPage.searchPlaceholder') }}
@@ -56,7 +56,7 @@
       >
         <i-cy-delete_x16
           class="icon-light-gray-1000 group-hocus:icon-dark-indigo-300"
-          :class="inputFocused ? 'icon-dark-indigo-300' : 'icon-dark-gray-800'"
+          :class="runnerUiStore.isSpecsListInputFocused ? 'icon-dark-indigo-300' : 'icon-dark-gray-800'"
         />
       </button>
     </div>
@@ -90,8 +90,9 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue'
+import { ref, watchEffect } from 'vue'
 import { useI18n } from '@cy/i18n'
+import { useRunnerUiStore } from '../store'
 
 const { t } = useI18n()
 const props = defineProps<{
@@ -104,8 +105,19 @@ const emit = defineEmits<{
   (e: 'newSpec'): void
 }>()
 
-const inputFocused = ref(false)
+const runnerUiStore = useRunnerUiStore()
+
 const input = ref<HTMLInputElement>()
+
+watchEffect(() => {
+  if (runnerUiStore.isSpecsListInputFocused) {
+    // Wrapping in timeout since the inline spec tree auto-focuses
+    // the active spec after mount.
+    setTimeout(() => {
+      input.value?.focus()
+    }, 100)
+  }
+})
 
 const onInput = (e: Event) => {
   const value = (e.target as HTMLInputElement).value
@@ -115,6 +127,14 @@ const onInput = (e: Event) => {
 
 const clearInput = (e: Event) => {
   emit('update:specFilterModel', '')
+}
+
+const handleFocus = () => {
+  runnerUiStore.setPreference('isSpecsListInputFocused', true)
+}
+
+const handleBlur = () => {
+  runnerUiStore.setPreference('isSpecsListInputFocused', false)
 }
 </script>
 

--- a/packages/app/src/store/runner-ui-store.ts
+++ b/packages/app/src/store/runner-ui-store.ts
@@ -27,6 +27,7 @@ export interface RunnerUiState {
   automationStatus: AutomationStatus
   randomString: string
   hideCommandLog: boolean
+  isSpecsListInputFocused: boolean
 }
 
 export const useRunnerUiStore = defineStore({
@@ -42,6 +43,7 @@ export const useRunnerUiStore = defineStore({
       automationStatus: automation.CONNECTING,
       randomString: `${Math.random()}`,
       hideCommandLog: window.__CYPRESS_CONFIG__.hideCommandLog,
+      isSpecsListInputFocused: false,
     }
   },
 

--- a/packages/reporter/cypress/e2e/shortcuts.cy.ts
+++ b/packages/reporter/cypress/e2e/shortcuts.cy.ts
@@ -161,5 +161,25 @@ describe('shortcuts', function () {
         expect(runner.emit).not.to.have.been.calledWith('focus:tests')
       })
     })
+
+    context('focus search', () => {
+      ['{ctrl+k}', '{meta+k}'].forEach((shortcut) => {
+        it(`emits "focus:search" and toggles spec list with ${shortcut}`, () => {
+          cy.get('body').type(shortcut).then(() => {
+            expect(runner.emit).to.have.been.calledWith('save:state')
+            expect(runner.emit).to.have.been.calledWith('focus:search')
+            cy.contains('button', 'Specs').should('have.attr', 'aria-expanded', 'true')
+
+            // Reset call history to verify we don't toggle spec list if it's already open
+            runner.emit.resetHistory()
+          })
+
+          cy.get('body').type(shortcut).then(() => {
+            expect(runner.emit).to.not.have.been.calledWith('save:state')
+            expect(runner.emit).to.have.been.calledWith('focus:search')
+          })
+        })
+      })
+    })
   })
 })

--- a/packages/reporter/src/lib/events.ts
+++ b/packages/reporter/src/lib/events.ts
@@ -207,6 +207,10 @@ const events: Events = {
       })
     })
 
+    localBus.on('focus:search', () => {
+      runner.emit('focus:search')
+    })
+
     localBus.on('external:open', (url) => {
       runner.emit('external:open', url)
     })

--- a/packages/reporter/src/lib/shortcuts.ts
+++ b/packages/reporter/src/lib/shortcuts.ts
@@ -19,7 +19,26 @@ class Shortcuts {
     const isTextLike = $dom.isTextLike(event.target)
     const isAnyModifierKeyPressed = event.altKey || event.ctrlKey || event.shiftKey || event.metaKey
 
-    if (isAnyModifierKeyPressed || isTextLike) return
+    if (isTextLike) return
+
+    if (isAnyModifierKeyPressed) {
+      switch (event.key) {
+        case 'k': {
+          if (event.ctrlKey || event.metaKey) {
+            action('toggle:spec:list', () => {
+              if (!appState.isSpecsListOpen) {
+                appState.toggleSpecList()
+                events.emit('save:state')
+              }
+
+              events.emit('focus:search')
+            })()
+          }
+
+          break
+        } default: return
+      }
+    }
 
     switch (event.key) {
       case 'r': !appState.studioActive && events.emit('restart')
@@ -42,6 +61,7 @@ class Shortcuts {
       })()
 
         break
+
       default: return
     }
   }


### PR DESCRIPTION
- Closes #21836

### User facing changelog
Adds back in the keyboard shortcut for searching specs in the runner

### Additional details
We already have a system in place for shortcuts so rather than implementing it in Vue-land I decided to use the existing system. I initially tried it out in Vue (using `useMagicKeys`) but since the `isSpecsListOpen` property is disconnected from the app and the reporter, the state of the `Toggle Specs List` button in the reporter was falling out of sync. Initiating the flow from the reporter and using the event emitter to communicate back kept everything in sync.

The original issue has an [Update text label](https://github.com/cypress-io/cypress/issues/21836#issuecomment-1203145980) task for updating the placeholder of the search to include the shortcut (from `Search Specs` => `Search Specs (Cmd + K)`) but adding the extra text to the label is not ideal since there is little space to work with. Most of the time, the text would be truncated and the user would see `Search Specs...`.

@mapsandapps tagging you to see what we should add to surface this shortcut. @marktnoonan you stated in the original issue to skip adding to the "Keyboard Shortcuts Modal" but in my mind that seems like the best place to put it.

### Steps to test
Open up any app and navigate to the runner (click on a spec). Press `Cmd + k` or `Ctrl + k` to have the Search Specs input focused. It will auto-open the specs list if it is closed.

### How has the user experience changed?

https://user-images.githubusercontent.com/25158820/184994119-a88fb9ec-204d-452c-a51e-f094c2d5021f.mov

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
