### PR TITLE
fix: Allow for urlOriginsMatch to ignore port unless url scheme is HTTPS to fit same origin policy

### DIFF
--- a/packages/network/lib/cors.ts
+++ b/packages/network/lib/cors.ts
@@ -71,14 +71,14 @@ export function getDomainNameFromParsedHost (parsedHost: ParsedHost) {
   return _.compact([parsedHost.domain, parsedHost.tld]).join('.')
 }
 
-export function urlMatchesOriginPolicyProps (urlStr, props) {
+export function urlMatchesDomainTLDAndPortProps (url: string, props?: ParsedHost) {
   // take a shortcut here in the case
   // where remoteHostAndPort is null
   if (!props) {
     return false
   }
 
-  const parsedUrl = parseUrlIntoDomainTldPort(urlStr)
+  const parsedUrl = parseUrlIntoDomainTldPort(url)
 
   // does the parsedUrl match the parsedHost?
   return _.isEqual(parsedUrl, props)

--- a/packages/network/lib/cors.ts
+++ b/packages/network/lib/cors.ts
@@ -84,13 +84,16 @@ export function urlMatchesDomainTLDAndPortProps (url: string, props?: ParsedHost
   return _.isEqual(parsedUrl, props)
 }
 
-export function urlOriginsMatch (url1, url2) {
+export function urlOriginsMatch (url1: string, url2: string) {
   if (!url1 || !url2) return false
 
-  const parsedUrl1 = parseUrlIntoDomainTldPort(url1)
-  const parsedUrl2 = parseUrlIntoDomainTldPort(url2)
+  const { port: port1, ...parsedUrl1 } = parseUrlIntoDomainTldPort(url1)
+  const { port: port2, ...parsedUrl2 } = parseUrlIntoDomainTldPort(url2)
 
-  return _.isEqual(parsedUrl1, parsedUrl2)
+  // If HTTPS, ports NEED to match. Otherwise, HTTP ports can be different and are same origin
+  const doPortsPassSameSchemeCheck = port1 !== port2 ? (port1 !== '443' && port2 !== '443') : true
+
+  return doPortsPassSameSchemeCheck && _.isEqual(parsedUrl1, parsedUrl2)
 }
 
 declare module 'url' {

--- a/packages/network/test/unit/cors_spec.ts
+++ b/packages/network/test/unit/cors_spec.ts
@@ -92,14 +92,14 @@ describe('lib/cors', () => {
     })
   })
 
-  context('.urlMatchesOriginPolicyProps', () => {
+  context('.urlMatchesDomainTLDAndPortProps', () => {
     beforeEach(function () {
       this.isFalse = (url, props) => {
-        expect(cors.urlMatchesOriginPolicyProps(url, props)).to.be.false
+        expect(cors.urlMatchesDomainTLDAndPortProps(url, props)).to.be.false
       }
 
       this.isTrue = (url, props) => {
-        expect(cors.urlMatchesOriginPolicyProps(url, props)).to.be.true
+        expect(cors.urlMatchesDomainTLDAndPortProps(url, props)).to.be.true
       }
     })
 

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -55,7 +55,7 @@ function getNodeCharsetFromResponse (headers: IncomingHttpHeaders, body: Buffer,
 
 function reqMatchesOriginPolicy (req: CypressIncomingRequest, remoteState) {
   if (remoteState.strategy === 'http') {
-    return cors.urlMatchesOriginPolicyProps(req.proxiedUrl, remoteState.props)
+    return cors.urlMatchesDomainTLDAndPortProps(req.proxiedUrl, remoteState.props)
   }
 
   if (remoteState.strategy === 'file') {

--- a/packages/server/lib/server-e2e.ts
+++ b/packages/server/lib/server-e2e.ts
@@ -139,7 +139,7 @@ export class ServerE2E extends ServerBase<SocketE2E> {
     return super.startWebsockets(automation, config, options)
   }
 
-  _onResolveUrl (urlStr, headers, automationRequest, options: Record<string, any> = { headers: {} }) {
+  _onResolveUrl (urlStr: string, headers: { [key: string]: any }, automationRequest, options: Record<string, any> = { headers: {} }) {
     let p
 
     debug('resolving visit %o', {
@@ -169,9 +169,12 @@ export class ServerE2E extends ServerBase<SocketE2E> {
     // nuke any hashes from our url since
     // those those are client only and do
     // not apply to http requests
-    urlStr = url.parse(urlStr)
-    urlStr.hash = null
-    urlStr = urlStr.format()
+    {
+      const urlWithStringQuery = url.parse(urlStr)
+
+      urlWithStringQuery.hash = null
+      urlStr = urlWithStringQuery.format()
+    }
 
     const originalUrl = urlStr
 
@@ -305,7 +308,7 @@ export class ServerE2E extends ServerBase<SocketE2E> {
                 // TODO: think about moving this logic back into the frontend so that the driver can be in control
                 // of when to buffer and set the remote state
                 if (isOk && details.isHtml &&
-                  !((options.hasAlreadyVisitedUrl || options.isCrossOrigin) && !cors.urlOriginsMatch(previousRemoteState.origin, newUrl))) {
+                  !((options.hasAlreadyVisitedUrl || options.isCrossOrigin) && !cors.urlOriginsMatch(previousRemoteState.origin, newUrl as string))) {
                   // if we're not handling a local file set the remote state
                   if (!handlingLocalFile) {
                     this._remoteStates.set(newUrl as string, options)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
