### PR TITLE
fix: app crashing on websocket upgrade request over https

### DIFF
--- a/packages/network/lib/agent.ts
+++ b/packages/network/lib/agent.ts
@@ -179,10 +179,10 @@ export class CombinedAgent {
         hostname: options.host,
         port: options.port,
       }) + options.path
+    }
 
-      if (!options.uri) {
-        options.uri = url.parse(options.href)
-      }
+    if (!options.uri) {
+      options.uri = url.parse(options.href)
     }
 
     debug('addRequest called %o', { isHttps, ..._.pick(options, 'href') })
@@ -284,10 +284,6 @@ class HttpsAgent extends https.Agent {
   }
 
   addRequest (req: http.ClientRequest, options: http.RequestOptions) {
-    if (!options.uri) {
-      options.uri = url.parse(options.href)
-    }
-
     // Ensure we have a proper port defined otherwise node has assumed we are port 80
     // (https://github.com/nodejs/node/blob/master/lib/_http_client.js#L164) since we are a combined agent
     // rather than an http or https agent. This will cause issues with fetch requests (@cypress/request already handles it:

--- a/packages/network/lib/agent.ts
+++ b/packages/network/lib/agent.ts
@@ -179,6 +179,10 @@ export class CombinedAgent {
         hostname: options.host,
         port: options.port,
       }) + options.path
+
+      if (!options.uri) {
+        options.uri = url.parse(options.href)
+      }
     }
 
     debug('addRequest called %o', { isHttps, ..._.pick(options, 'href') })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #22217 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

App no longer crashes on websocket upgrade request over https

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

A change was made on on #20107 to support `fetch` requests in the proxy. For that change, we needed to set `options.uri` in our `HttpsAgent.addRequest` method. It was assumed that this would cover the [existing logic](https://github.com/cypress-io/cypress/pull/20107/files#diff-0eefefc0f7a3eb51d155cb5b640d42389dd1ce4d220bd1aeca28bfa7ff3bf458L182-L185) to set `options.uri` as well, however, this didn't cover the case where we have a client certificate over https. This PR restores that functionality.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

You can test this by uncommenting the code change and running the new test and see that there is a failure. You can also use the test project provided by @AtofStryker [here](https://github.com/cypress-io/cypress/issues/22217#issuecomment-1159283912)

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

The app no longer crashes when there is 

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [X] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
