### PR TITLE
chore: update typescript

### DIFF
--- a/npm/angular/package.json
+++ b/npm/angular/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser-dynamic": "^14.0.6",
     "@rollup/plugin-node-resolve": "^11.1.1",
     "rollup-plugin-typescript2": "^0.29.0",
-    "typescript": "~4.2.3",
+    "typescript": "^4.7.4",
     "zone.js": "~0.11.4"
   },
   "peerDependencies": {

--- a/npm/create-cypress-tests/package.json
+++ b/npm/create-cypress-tests/package.json
@@ -41,7 +41,7 @@
     "mock-fs": "5.1.1",
     "shx": "0.3.3",
     "snap-shot-it": "7.9.3",
-    "typescript": "^4.2.3"
+    "typescript": "^4.7.4"
   },
   "files": [
     "dist",

--- a/npm/cypress-schematic/package.json
+++ b/npm/cypress-schematic/package.json
@@ -24,7 +24,7 @@
     "@types/node": "^18.0.6",
     "chai": "4.2.0",
     "mocha": "3.5.3",
-    "typescript": "~4.2.3"
+    "typescript": "^4.7.4"
   },
   "peerDependencies": {
     "@angular/cli": ">=14.1.0",

--- a/npm/mount-utils/package.json
+++ b/npm/mount-utils/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "typescript": "^4.2.3"
+    "typescript": "^4.7.4"
   },
   "files": [
     "dist"

--- a/npm/react/package.json
+++ b/npm/react/package.json
@@ -30,7 +30,7 @@
     "rollup": "^2.38.5",
     "rollup-plugin-typescript2": "^0.29.0",
     "semver": "^7.3.2",
-    "typescript": "^4.2.3",
+    "typescript": "^4.7.4",
     "vite": "3.0.3",
     "vite-plugin-require-transform": "1.0.3"
   },

--- a/npm/react18/package.json
+++ b/npm/react18/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^16",
     "rollup": "^2.38.5",
     "rollup-plugin-typescript2": "^0.29.0",
-    "typescript": "^4.2.3"
+    "typescript": "^4.7.4"
   },
   "peerDependencies": {
     "@types/react": "^18",

--- a/npm/vue/package.json
+++ b/npm/vue/package.json
@@ -29,7 +29,7 @@
     "rollup-plugin-istanbul": "2.0.1",
     "rollup-plugin-typescript2": "^0.29.0",
     "tailwindcss": "1.1.4",
-    "typescript": "^4.2.3",
+    "typescript": "^4.7.4",
     "vite": "3.0.3",
     "vue": "3.2.31",
     "vue-i18n": "9.0.0-rc.6",

--- a/npm/vue2/package.json
+++ b/npm/vue2/package.json
@@ -23,7 +23,7 @@
     "@rollup/plugin-replace": "^2.3.1",
     "rollup-plugin-typescript2": "^0.29.0",
     "tslib": "^2.1.0",
-    "typescript": "^4.2.3",
+    "typescript": "^4.7.4",
     "vue": "2.6.12"
   },
   "peerDependencies": {

--- a/npm/webpack-batteries-included-preprocessor/package.json
+++ b/npm/webpack-batteries-included-preprocessor/package.json
@@ -19,7 +19,7 @@
     "coffee-loader": "^0.9.0",
     "coffeescript": "^1.12.7",
     "pnp-webpack-plugin": "^1.7.0",
-    "ts-loader": "^8.0.2",
+    "ts-loader": "8.4.0",
     "tsconfig-package": "npm:tsconfig@^7.0.0",
     "tsconfig-paths-webpack-plugin": "^3.3.0",
     "webpack": "^4.44.2"
@@ -41,7 +41,7 @@
     "graphql": "14.0.0",
     "mocha": "^8.1.1",
     "react": "^16.13.1",
-    "typescript": "^4.2.3"
+    "typescript": "^4.7.4"
   },
   "peerDependencies": {
     "@cypress/webpack-preprocessor": "^5.4.4"

--- a/npm/webpack-preprocessor/examples/use-ts-loader/package.json
+++ b/npm/webpack-preprocessor/examples/use-ts-loader/package.json
@@ -9,8 +9,8 @@
     "types": "tsc --noEmit --lib es2015,dom --types cypress cypress/e2e/*.ts"
   },
   "devDependencies": {
-    "ts-loader": "7.0.4",
-    "typescript": "^4.2.3"
+    "ts-loader": "8.4.0",
+    "typescript": "^4.7.4"
   },
   "license": "ISC",
   "keywords": []

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
     "through2": "^4.0.2",
     "tree-kill": "1.2.2",
     "ts-node": "^10.2.1",
-    "typescript": "^4.4.4",
+    "typescript": "^4.7.4",
     "yarn-deduplicate": "3.1.0"
   },
   "engines": {

--- a/packages/driver/src/dom/elements/nativeProps.ts
+++ b/packages/driver/src/dom/elements/nativeProps.ts
@@ -238,7 +238,7 @@ export const getNativeProp = function<T, K extends keyof T> (obj: T, prop: K): T
   if (!nativeProp) {
     const props = _.keys(nativeGetters).join(', ')
 
-    throw new Error(`attempted to use a native getter prop called: ${prop as string}. Available props are: ${props}`)
+    throw new Error(`attempted to use a native getter prop called: ${String(prop)}. Available props are: ${props}`)
   }
 
   let retProp = nativeProp.call(obj, prop)

--- a/packages/driver/src/dom/elements/nativeProps.ts
+++ b/packages/driver/src/dom/elements/nativeProps.ts
@@ -258,7 +258,7 @@ export const setNativeProp = function<T, K extends keyof T> (obj: T, prop: K, va
   if (!nativeProp) {
     const fns = _.keys(nativeSetters).join(', ')
 
-    throw new Error(`attempted to use a native setter prop called: ${prop as string}. Available props are: ${fns}`)
+    throw new Error(`attempted to use a native setter prop called: ${String(prop)}. Available props are: ${fns}`)
   }
 
   let retProp = nativeProp.call(obj, val)

--- a/packages/driver/src/dom/elements/nativeProps.ts
+++ b/packages/driver/src/dom/elements/nativeProps.ts
@@ -12,7 +12,7 @@ const descriptor = <T extends keyof Window, K extends keyof Window[T]['prototype
   const desc = Object.getOwnPropertyDescriptor(window[klass].prototype, prop)
 
   if (desc === undefined) {
-    throw new Error(`Error, could not get property descriptor for ${klass}  ${prop}. This should never happen`)
+    throw new Error(`Error, could not get property descriptor for ${klass}  ${prop as string}. This should never happen`)
   }
 
   return desc
@@ -238,7 +238,7 @@ export const getNativeProp = function<T, K extends keyof T> (obj: T, prop: K): T
   if (!nativeProp) {
     const props = _.keys(nativeGetters).join(', ')
 
-    throw new Error(`attempted to use a native getter prop called: ${prop}. Available props are: ${props}`)
+    throw new Error(`attempted to use a native getter prop called: ${prop as string}. Available props are: ${props}`)
   }
 
   let retProp = nativeProp.call(obj, prop)
@@ -258,7 +258,7 @@ export const setNativeProp = function<T, K extends keyof T> (obj: T, prop: K, va
   if (!nativeProp) {
     const fns = _.keys(nativeSetters).join(', ')
 
-    throw new Error(`attempted to use a native setter prop called: ${prop}. Available props are: ${fns}`)
+    throw new Error(`attempted to use a native setter prop called: ${prop as string}. Available props are: ${fns}`)
   }
 
   let retProp = nativeProp.call(obj, val)

--- a/packages/driver/src/dom/elements/nativeProps.ts
+++ b/packages/driver/src/dom/elements/nativeProps.ts
@@ -12,7 +12,7 @@ const descriptor = <T extends keyof Window, K extends keyof Window[T]['prototype
   const desc = Object.getOwnPropertyDescriptor(window[klass].prototype, prop)
 
   if (desc === undefined) {
-    throw new Error(`Error, could not get property descriptor for ${klass}  ${prop as string}. This should never happen`)
+    throw new Error(`Error, could not get property descriptor for ${klass}  ${String(prop)}. This should never happen`)
   }
 
   return desc

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -32,7 +32,7 @@
     "rimraf": "3.0.2",
     "sinon": "7.3.2",
     "sinon-chai": "3.3.0",
-    "ts-loader": "8.0.13",
+    "ts-loader": "8.4.0",
     "webextension-polyfill": "0.4.0",
     "webpack": "4.44.2"
   },

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -32,7 +32,7 @@
     "rimraf": "3.0.2",
     "sinon": "^10.0.0",
     "sinon-chai": "3.4.0",
-    "typescript": "^4.2.3"
+    "typescript": "^4.7.4"
   },
   "files": [
     "index.js",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -35,7 +35,7 @@
     "rimraf": "3.0.2",
     "sinon": "7.3.1",
     "sinon-chai": "3.3.0",
-    "typescript": "^4.2.3"
+    "typescript": "^4.7.4"
   },
   "files": [
     "lib"

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -37,7 +37,7 @@
     "express": "4.17.1",
     "rimraf": "3.0.2",
     "supertest": "6.0.1",
-    "typescript": "^4.2.3"
+    "typescript": "^4.7.4"
   },
   "files": [
     "lib"

--- a/packages/scaffold-config/src/frameworks.ts
+++ b/packages/scaffold-config/src/frameworks.ts
@@ -61,11 +61,9 @@ function getBundlerDependency (bundler: WizardBundler['type'], projectPath: stri
   }
 }
 
-export const WIZARD_MOUNT_MODULES = ['cypress/react', 'cypress/react18', 'cypress/vue', 'cypress/vue2', 'cypress/angular'] as const
+export type WizardMountModule = Awaited<ReturnType<typeof WIZARD_FRAMEWORKS[number]['mountModule']>>
 
-export type WizardMountModule = 'cypress/react' | 'cypress/react18' | 'cypress/vue' | 'cypress/vue2' | 'cypress/angular'
-
-const mountModule = (mountModule: WizardMountModule) => (projectPath: string) => Promise.resolve(mountModule)
+const mountModule = <T extends string>(mountModule: T) => (projectPath: string) => Promise.resolve(mountModule)
 
 const reactMountModule = async (projectPath: string) => {
   const reactPkg = await isDependencyInstalled(dependencies.WIZARD_DEPENDENCY_REACT, projectPath)

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -181,7 +181,7 @@
     "supertest": "4.0.2",
     "supertest-session": "4.0.0",
     "through2": "2.0.5",
-    "ts-loader": "7.0.4",
+    "ts-loader": "8.4.0",
     "tsconfig-paths": "3.10.1",
     "tslint": "^6.1.3",
     "webpack": "^4.44.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/node": "14.14.31",
     "rimraf": "3.0.2",
-    "typescript": "^4.2.3"
+    "typescript": "^4.7.4"
   },
   "files": [
     "src/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -32761,32 +32761,10 @@ tryor@~0.1.2:
   resolved "https://registry.yarnpkg.com/tryor/-/tryor-0.1.2.tgz#8145e4ca7caff40acde3ccf946e8b8bb75b4172b"
   integrity sha1-gUXkynyv9ArN48z5Rui4u3W0Fys=
 
-ts-loader@7.0.4:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-7.0.4.tgz#5d9b95227de5afb91fdd9668f8920eb193cfe0cc"
-  integrity sha512-5du6OQHl+4ZjO4crEyoYUyWSrmmo7bAO+inkaILZ68mvahqrfoa4nn0DRmpQ4ruT4l+cuJCgF0xD7SBIyLeeow==
-  dependencies:
-    chalk "^2.3.0"
-    enhanced-resolve "^4.0.0"
-    loader-utils "^1.0.2"
-    micromatch "^4.0.0"
-    semver "^6.0.0"
-
-ts-loader@8.0.13:
-  version "8.0.13"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.0.13.tgz#2bebeb833570ca46bb9338322a9a29900e988535"
-  integrity sha512-1o1nO6aqouA23d2nlcMSEyPMAWRhnYUU0EQUJSc60E0TUyBNX792RHFYUN1ZM29vhMUNayrsbj2UVdZwKhXCDA==
-  dependencies:
-    chalk "^2.3.0"
-    enhanced-resolve "^4.0.0"
-    loader-utils "^1.0.2"
-    micromatch "^4.0.0"
-    semver "^6.0.0"
-
-ts-loader@^8.0.2:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.1.0.tgz#d6292487df279c7cc79b6d3b70bb9d31682b693e"
-  integrity sha512-YiQipGGAFj2zBfqLhp28yUvPP9jUGqHxRzrGYuc82Z2wM27YIHbElXiaZDc93c3x0mz4zvBmS6q/DgExpdj37A==
+ts-loader@8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.4.0.tgz#e845ea0f38d140bdc3d7d60293ca18d12ff2720f"
+  integrity sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==
   dependencies:
     chalk "^4.1.0"
     enhanced-resolve "^4.0.0"
@@ -33115,15 +33093,10 @@ typescript-cached-transpile@^0.0.6:
     fs-extra "^8.1.0"
     tslib "^1.10.0"
 
-typescript@^4.2.3, typescript@^4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
-
-typescript@~4.2.3:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 ua-parser-js@0.7.24, ua-parser-js@^0.7.18:
   version "0.7.24"


### PR DESCRIPTION
### User facing changelog
n/a

### Additional details
Update to latest version of typescript. Had to bump `ts-loader` as `@packages/extension` was failing with the new version of TS.

### Steps to test
Counting on CI here, everything worked well locally.

### How has the user experience changed?
na

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
