### PR TITLE
refactor: move console logging out of run.ts

### DIFF
--- a/packages/server/lib/modes/run.ts
+++ b/packages/server/lib/modes/run.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, @cypress/dev/arrow-body-multiline-braces */
 import _ from 'lodash'
 import la from 'lazy-ass'
 import pkg from '@packages/root'
@@ -833,42 +833,34 @@ async function runSpecs (options: { config: Cfg, browser: Browser, sys: any, hea
   // Remap results for module API/after:run to remove private props and
   // rename props to make more user-friendly
   const moduleAPIResults = remapKeys(results, {
-    runs: each((run) => {
-      return {
-        tests: each((test) => {
-          return {
-            attempts: each((attempt, i) => {
-              return {
-                timings: remove,
-                failedFromHookId: remove,
-                wallClockDuration: renameKey('duration'),
-                wallClockStartedAt: renameKey('startedAt'),
-                wallClockEndedAt: renameKey('endedAt'),
-                screenshots: setValue(
-                  _(run.screenshots)
-                  .filter({ testId: test.testId, testAttemptIndex: i })
-                  .map((screenshot) => {
-                    return _.omit(screenshot,
-                      ['screenshotId', 'testId', 'testAttemptIndex'])
-                  })
-                  .value(),
-                ),
-              }
-            }),
-            testId: remove,
-          }
-        }),
-        hooks: each({
-          hookId: remove,
-        }),
-        stats: {
+    runs: each((run) => ({
+      tests: each((test) => ({
+        attempts: each((attempt, i) => ({
+          timings: remove,
+          failedFromHookId: remove,
           wallClockDuration: renameKey('duration'),
           wallClockStartedAt: renameKey('startedAt'),
           wallClockEndedAt: renameKey('endedAt'),
-        },
-        screenshots: remove,
-      }
-    }),
+          screenshots: setValue(
+            _(run.screenshots)
+            .filter({ testId: test.testId, testAttemptIndex: i })
+            .map((screenshot) => _.omit(screenshot,
+              ['screenshotId', 'testId', 'testAttemptIndex']))
+            .value(),
+          ),
+        })),
+        testId: remove,
+      })),
+      hooks: each({
+        hookId: remove,
+      }),
+      stats: {
+        wallClockDuration: renameKey('duration'),
+        wallClockStartedAt: renameKey('startedAt'),
+        wallClockEndedAt: renameKey('endedAt'),
+      },
+      screenshots: remove,
+    })),
   })
 
   if (testingType === 'component') {

--- a/packages/server/lib/modes/run.ts
+++ b/packages/server/lib/modes/run.ts
@@ -390,7 +390,7 @@ async function postProcessRecording (name, cname, videoCompression, shouldUpload
     return continueProcessing()
   }
 
-  const { onProgress } = printResults.displayVideoProcessingProgress({ videoCompression })
+  const { onProgress } = printResults.displayVideoProcessingProgress({ name, videoCompression })
 
   return continueProcessing(onProgress)
 }

--- a/packages/server/lib/util/print-run.ts
+++ b/packages/server/lib/util/print-run.ts
@@ -1,0 +1,536 @@
+/* eslint-disable no-console */
+import _ from 'lodash'
+import logSymbols from 'log-symbols'
+import chalk from 'chalk'
+import human from 'human-interval'
+import pkg from '@packages/root'
+import humanTime from './human_time'
+import duration from './duration'
+import newlines from './newlines'
+import env from './env'
+import terminal from './terminal'
+import * as experiments from '../experiments'
+import type { SpecFile } from '@packages/types'
+import type { Cfg } from '../project-base'
+import type { Browser } from '../browsers/types'
+
+type Screenshot = {
+  width: number
+  height: number
+  path: string
+  specName: string
+}
+
+function color (val, c) {
+  return chalk[c](val)
+}
+
+function gray (val) {
+  return color(val, 'gray')
+}
+
+function colorIf (val, c) {
+  if (val === 0 || val == null) {
+    val = '-'
+    c = 'gray'
+  }
+
+  return color(val, c)
+}
+
+function getWidth (table, index) {
+  // get the true width of a table's column,
+  // based off of calculated table options for that column
+  const columnWidth = table.options.colWidths[index]
+
+  if (columnWidth) {
+    return columnWidth - (table.options.style['padding-left'] + table.options.style['padding-right'])
+  }
+
+  throw new Error('Unable to get width for column')
+}
+
+function formatBrowser (browser) {
+  return _.compact([
+    browser.displayName,
+    browser.majorVersion,
+    browser.isHeadless && gray('(headless)'),
+  ]).join(' ')
+}
+
+function formatFooterSummary (results) {
+  const { totalFailed, runs } = results
+
+  const isCanceled = _.some(results.runs, { skippedSpec: true })
+
+  // pass or fail color
+  const c = isCanceled ? 'magenta' : totalFailed ? 'red' : 'green'
+
+  const phrase = (() => {
+    if (isCanceled) {
+      return 'The run was canceled'
+    }
+
+    // if we have any specs failing...
+    if (!totalFailed) {
+      return 'All specs passed!'
+    }
+
+    // number of specs
+    const total = runs.length
+    const failingRuns = _.filter(runs, 'stats.failures').length
+    const percent = Math.round((failingRuns / total) * 100)
+
+    return `${failingRuns} of ${total} failed (${percent}%)`
+  })()
+
+  return [
+    isCanceled ? '-' : formatSymbolSummary(totalFailed),
+    color(phrase, c),
+    gray(duration.format(results.totalDuration)),
+    colorIf(results.totalTests, 'reset'),
+    colorIf(results.totalPassed, 'green'),
+    colorIf(totalFailed, 'red'),
+    colorIf(results.totalPending, 'cyan'),
+    colorIf(results.totalSkipped, 'blue'),
+  ]
+}
+
+function formatSymbolSummary (failures) {
+  return failures ? logSymbols.error : logSymbols.success
+}
+
+function macOSRemovePrivate (str) {
+  // consistent snapshots when running system tests on macOS
+  if (process.platform === 'darwin' && str.startsWith('/private')) {
+    return str.slice(8)
+  }
+
+  return str
+}
+
+function collectTestResults (obj: { video?: boolean, screenshots?: Screenshot[] }, estimated) {
+  return {
+    name: _.get(obj, 'spec.name'),
+    baseName: _.get(obj, 'spec.baseName'),
+    tests: _.get(obj, 'stats.tests'),
+    passes: _.get(obj, 'stats.passes'),
+    pending: _.get(obj, 'stats.pending'),
+    failures: _.get(obj, 'stats.failures'),
+    skipped: _.get(obj, 'stats.skipped'),
+    duration: humanTime.long(_.get(obj, 'stats.wallClockDuration')),
+    estimated: estimated && humanTime.long(estimated),
+    screenshots: obj.screenshots && obj.screenshots.length,
+    video: Boolean(obj.video),
+  }
+}
+
+function formatPath (name, n, colour = 'reset') {
+  if (!name) return ''
+
+  const fakeCwdPath = env.get('FAKE_CWD_PATH')
+
+  if (fakeCwdPath && env.get('CYPRESS_INTERNAL_ENV') === 'test') {
+    // if we're testing within Cypress, we want to strip out
+    // the current working directory before calculating the stdout tables
+    // this will keep our snapshots consistent everytime we run
+    const cwdPath = process.cwd()
+
+    name = name
+    .split(cwdPath)
+    .join(fakeCwdPath)
+
+    name = macOSRemovePrivate(name)
+  }
+
+  // add newLines at each n char and colorize the path
+  if (n) {
+    let nameWithNewLines = newlines.addNewlineAtEveryNChar(name, n)
+
+    return `${color(nameWithNewLines, colour)}`
+  }
+
+  return `${color(name, colour)}`
+}
+
+function formatNodeVersion ({ resolvedNodeVersion, resolvedNodePath }: Pick<Cfg, 'resolvedNodeVersion' | 'resolvedNodePath'>, width) {
+  if (resolvedNodePath) return formatPath(`v${resolvedNodeVersion} ${gray(`(${resolvedNodePath})`)}`, width)
+
+  return
+}
+
+function formatRecordParams (runUrl, parallel, group, tag) {
+  if (runUrl) {
+    if (!group) {
+      group = false
+    }
+
+    if (!tag) {
+      tag = false
+    }
+
+    return `Tag: ${tag}, Group: ${group}, Parallel: ${Boolean(parallel)}`
+  }
+
+  return
+}
+
+export function displayRunStarting (options: { browser: Browser, config: Cfg, group: string | undefined, parallel?: boolean, runUrl?: string, specPattern: string | RegExp | string[], specs: SpecFile[], tag: string | undefined }) {
+  const { browser, config, group, parallel, runUrl, specPattern, specs, tag } = options
+
+  console.log('')
+
+  terminal.divider('=')
+
+  console.log('')
+
+  terminal.header('Run Starting', {
+    color: ['reset'],
+  })
+
+  console.log('')
+
+  const experimental = experiments.getExperimentsFromResolved(config.resolved)
+  const enabledExperiments = _.pickBy(experimental, _.property('enabled'))
+  const hasExperiments = !_.isEmpty(enabledExperiments)
+
+  // if we show Node Version, then increase 1st column width
+  // to include wider 'Node Version:'.
+  // Without Node version, need to account for possible "Experiments" label
+  const colWidths = config.resolvedNodePath ? [16, 84] : (
+    hasExperiments ? [14, 86] : [12, 88]
+  )
+
+  const table = terminal.table({
+    colWidths,
+    type: 'outsideBorder',
+  })
+
+  if (!specPattern) throw new Error('No specPattern in displayRunStarting')
+
+  const formatSpecs = (specs) => {
+    // 25 found: (foo.spec.js, bar.spec.js, baz.spec.js)
+    const names = _.map(specs, 'baseName')
+    const specsTruncated = _.truncate(names.join(', '), { length: 250 })
+
+    const stringifiedSpecs = [
+      `${names.length} found `,
+      '(',
+      specsTruncated,
+      ')',
+    ]
+    .join('')
+
+    return formatPath(stringifiedSpecs, getWidth(table, 1))
+  }
+
+  const data = _
+  .chain([
+    [gray('Cypress:'), pkg.version],
+    [gray('Browser:'), formatBrowser(browser)],
+    [gray('Node Version:'), formatNodeVersion(config, getWidth(table, 1))],
+    [gray('Specs:'), formatSpecs(specs)],
+    [gray('Searched:'), formatPath(Array.isArray(specPattern) ? specPattern.join(', ') : specPattern, getWidth(table, 1))],
+    [gray('Params:'), formatRecordParams(runUrl, parallel, group, tag)],
+    [gray('Run URL:'), runUrl ? formatPath(runUrl, getWidth(table, 1)) : ''],
+    [gray('Experiments:'), hasExperiments ? experiments.formatExperiments(enabledExperiments) : ''],
+  ])
+  .filter(_.property(1))
+  .value()
+
+  table.push(...data)
+
+  const heading = table.toString()
+
+  console.log(heading)
+
+  console.log('')
+
+  return heading
+}
+
+export function displaySpecHeader (name, curr, total, estimated) {
+  console.log('')
+
+  const PADDING = 2
+
+  const table = terminal.table({
+    colWidths: [10, 70, 20],
+    colAligns: ['left', 'left', 'right'],
+    type: 'pageDivider',
+    style: {
+      'padding-left': PADDING,
+      'padding-right': 0,
+    },
+  })
+
+  table.push(['', ''])
+  table.push([
+    'Running:',
+    `${formatPath(name, getWidth(table, 1), 'gray')}`,
+    gray(`(${curr} of ${total})`),
+  ])
+
+  console.log(table.toString())
+
+  if (estimated) {
+    const estimatedLabel = `${' '.repeat(PADDING)}Estimated:`
+
+    return console.log(estimatedLabel, gray(humanTime.long(estimated)))
+  }
+}
+
+export function renderSummaryTable (runUrl, results) {
+  const { runs } = results
+
+  console.log('')
+
+  terminal.divider('=')
+
+  console.log('')
+
+  terminal.header('Run Finished', {
+    color: ['reset'],
+  })
+
+  if (runs && runs.length) {
+    const colAligns = ['left', 'left', 'right', 'right', 'right', 'right', 'right', 'right']
+    const colWidths = [3, 41, 11, 9, 9, 9, 9, 9]
+
+    const table1 = terminal.table({
+      colAligns,
+      colWidths,
+      type: 'noBorder',
+      head: [
+        '',
+        gray('Spec'),
+        '',
+        gray('Tests'),
+        gray('Passing'),
+        gray('Failing'),
+        gray('Pending'),
+        gray('Skipped'),
+      ],
+    })
+
+    const table2 = terminal.table({
+      colAligns,
+      colWidths,
+      type: 'border',
+    })
+
+    const table3 = terminal.table({
+      colAligns,
+      colWidths,
+      type: 'noBorder',
+      head: formatFooterSummary(results),
+    })
+
+    _.each(runs, (run) => {
+      const { spec, stats } = run
+
+      const ms = duration.format(stats.wallClockDuration || 0)
+
+      const formattedSpec = formatPath(spec.baseName, getWidth(table2, 1))
+
+      if (run.skippedSpec) {
+        return table2.push([
+          '-',
+          formattedSpec, color('SKIPPED', 'gray'),
+          '-', '-', '-', '-', '-',
+        ])
+      }
+
+      return table2.push([
+        formatSymbolSummary(stats.failures),
+        formattedSpec,
+        color(ms, 'gray'),
+        colorIf(stats.tests, 'reset'),
+        colorIf(stats.passes, 'green'),
+        colorIf(stats.failures, 'red'),
+        colorIf(stats.pending, 'cyan'),
+        colorIf(stats.skipped, 'blue'),
+      ])
+    })
+
+    console.log('')
+    console.log('')
+    console.log(terminal.renderTables(table1, table2, table3))
+    console.log('')
+
+    if (runUrl) {
+      console.log('')
+
+      const table4 = terminal.table({
+        colWidths: [100],
+        type: 'pageDivider',
+        style: {
+          'padding-left': 2,
+        },
+      })
+
+      table4.push(['', ''])
+      console.log(terminal.renderTables(table4))
+
+      console.log(`  Recorded Run: ${formatPath(runUrl, undefined, 'gray')}`)
+      console.log('')
+    }
+  }
+}
+
+export function displayResults (obj: { screenshots?: Screenshot[] }, estimated) {
+  const results = collectTestResults(obj, estimated)
+
+  const c = results.failures ? 'red' : 'green'
+
+  console.log('')
+
+  terminal.header('Results', {
+    color: [c],
+  })
+
+  const table = terminal.table({
+    colWidths: [14, 86],
+    type: 'outsideBorder',
+  })
+
+  const data = _.chain([
+    ['Tests:', results.tests],
+    ['Passing:', results.passes],
+    ['Failing:', results.failures],
+    ['Pending:', results.pending],
+    ['Skipped:', results.skipped],
+    ['Screenshots:', results.screenshots],
+    ['Video:', results.video],
+    ['Duration:', results.duration],
+    estimated ? ['Estimated:', results.estimated] : undefined,
+    ['Spec Ran:', formatPath(results.baseName, getWidth(table, 1), c)],
+  ])
+  .compact()
+  .map((arr) => {
+    const [key, val] = arr
+
+    return [color(key, 'gray'), color(val, c)]
+  })
+  .value()
+
+  table.push(...data)
+
+  console.log('')
+  console.log(table.toString())
+  console.log('')
+
+  if (obj.screenshots?.length) displayScreenshots(obj.screenshots)
+}
+
+function displayScreenshots (screenshots: Screenshot[] = []) {
+  console.log('')
+
+  terminal.header('Screenshots', { color: ['yellow'] })
+
+  console.log('')
+
+  const table = terminal.table({
+    colWidths: [3, 82, 15],
+    colAligns: ['left', 'left', 'right'],
+    type: 'noBorder',
+    style: {
+      'padding-right': 0,
+    },
+    chars: {
+      'left': ' ',
+      'right': '',
+    },
+  })
+
+  screenshots.forEach((screenshot) => {
+    const dimensions = gray(`(${screenshot.width}x${screenshot.height})`)
+
+    table.push([
+      '-',
+      formatPath(`${screenshot.path}`, getWidth(table, 1)),
+      gray(dimensions),
+    ])
+  })
+
+  console.log(table.toString())
+
+  console.log('')
+}
+
+export function displayVideoProcessingProgress (opts: { videoCompression: number | false}) {
+  console.log('')
+
+  terminal.header('Video', {
+    color: ['cyan'],
+  })
+
+  console.log('')
+
+  const table = terminal.table({
+    colWidths: [3, 21, 76],
+    colAligns: ['left', 'left', 'left'],
+    type: 'noBorder',
+    style: {
+      'padding-right': 0,
+    },
+    chars: {
+      'left': ' ',
+      'right': '',
+    },
+  })
+
+  table.push([
+    gray('-'),
+    gray('Started processing:'),
+    chalk.cyan(`Compressing to ${opts.videoCompression} CRF`),
+  ])
+
+  console.log(table.toString())
+
+  const started = Date.now()
+  let progress = Date.now()
+  const throttle = env.get('VIDEO_COMPRESSION_THROTTLE') || human('10 seconds')
+
+  return {
+    onProgress (float: number) {
+      if (float === 1) {
+        const finished = Date.now() - started
+        const dur = `(${humanTime.long(finished)})`
+
+        const table = terminal.table({
+          colWidths: [3, 21, 61, 15],
+          colAligns: ['left', 'left', 'left', 'right'],
+          type: 'noBorder',
+          style: {
+            'padding-right': 0,
+          },
+          chars: {
+            'left': ' ',
+            'right': '',
+          },
+        })
+
+        table.push([
+          gray('-'),
+          gray('Finished processing:'),
+            `${formatPath(name, getWidth(table, 2), 'cyan')}`,
+            gray(dur),
+        ])
+
+        console.log(table.toString())
+
+        console.log('')
+      }
+
+      if (Date.now() - progress > throttle) {
+        // bump up the progress so we dont
+        // continuously get notifications
+        progress += throttle
+        const percentage = `${Math.ceil(float * 100)}%`
+
+        console.log('    Compression progress: ', chalk.cyan(percentage))
+      }
+    },
+  }
+}

--- a/packages/server/lib/util/print-run.ts
+++ b/packages/server/lib/util/print-run.ts
@@ -458,7 +458,7 @@ function displayScreenshots (screenshots: Screenshot[] = []) {
   console.log('')
 }
 
-export function displayVideoProcessingProgress (opts: { videoCompression: number | false}) {
+export function displayVideoProcessingProgress (opts: { name: string, videoCompression: number | false}) {
   console.log('')
 
   terminal.header('Video', {
@@ -514,7 +514,7 @@ export function displayVideoProcessingProgress (opts: { videoCompression: number
         table.push([
           gray('-'),
           gray('Finished processing:'),
-            `${formatPath(name, getWidth(table, 2), 'cyan')}`,
+            `${formatPath(opts.name, getWidth(table, 2), 'cyan')}`,
             gray(dur),
         ])
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details

- Makes `run.ts` easier to work on by factoring out all of the complicated display logic. Now `run.ts` is a measly ~1100 lines long, down from ~1700!

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
	- Existing snapshot coverage should not change.
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
