### PR TITLE
chore: remove react parallelism

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1831,7 +1831,6 @@ jobs:
 
   npm-react:
     <<: *defaults
-    parallelism: 8
     steps:
       - restore_cached_workspace
       - run:


### PR DESCRIPTION
### User facing changelog
n/a

### Additional details
the `npm-react` job was running with `parallelism = 8` but it wasn't splitting the files so it was duplicating the work across 8 machines. It only takes <5 minutes to run so I've removed it entirely.

### Steps to test
Check out the latest develop [npm-react job](https://app.circleci.com/pipelines/github/cypress-io/cypress/42516/workflows/7f322812-ea51-462d-b0e1-27c4c3be36ed/jobs/1768390), then compare it to [this PR's build](https://app.circleci.com/pipelines/github/cypress-io/cypress/42532/workflows/64a667f9-982a-4620-8167-cdd4c2387fff/jobs/1768899).

### How has the user experience changed?
na

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
