### PR TITLE
test: add e2e test confirming login/connect button displays on hover

### DIFF
--- a/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
@@ -200,6 +200,29 @@ describe('App/Cloud Integration - Latest runs and Average duration', { viewportW
 
       cy.findByTestId('average-duration-header').trigger('mouseleave')
     })
+
+    it('shows login/connect button in row when hovering', () => {
+      cy.get('[data-cy="spec-list-file"] [data-cy="specs-list-row-latest-runs"]')
+      .eq(0)
+      .as('latestRunsCell')
+      .trigger('mouseenter')
+
+      cy.contains('[data-cy="specs-list-row-latest-runs"] [data-cy="cloud-button"]', 'Connect').should('be.visible')
+
+      cy.get('@latestRunsCell').trigger('mouseleave')
+
+      cy.contains('[data-cy="cloud-button"]', 'Connect').should('not.exist')
+
+      cy.get('[data-cy="spec-list-file"] [data-cy="specs-list-row-average-duration"]')
+      .eq(0)
+      .as('averageDurationCell')
+      .trigger('mouseenter')
+
+      cy.contains('[data-cy="specs-list-row-average-duration"] [data-cy="cloud-button"]', 'Connect').should('be.visible')
+      cy.get('@averageDurationCell').trigger('mouseleave')
+
+      cy.contains('[data-cy="cloud-button"]', 'Connect').should('not.exist')
+    })
   })
 
   context('when project disconnected', () => {


### PR DESCRIPTION
Here's a way to test this from e2e to ensure the component appears in the right place on hover. @warrensplayer feel free to merge to your branch or just use this as an example.