### PR TITLE
fix: Refetch latest cloud data when opening cloud connect modals

### DIFF
--- a/packages/app/cypress/e2e/runs.cy.ts
+++ b/packages/app/cypress/e2e/runs.cy.ts
@@ -138,15 +138,9 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
       cy.openProject('component-tests', ['--config-file', 'cypressWithoutProjectId.config.js'])
       cy.startAppServer('component')
 
-      cy.remoteGraphQLIntercept(async (obj, testState) => {
-        if (obj.operationName === 'CloudConnectModals_RefreshCloudViewer_refreshCloudViewer_cloudViewer') {
-          testState.refetchCount = (testState.refetchCount || 0) + 1
-        }
-
-        if (obj.operationName === 'CheckCloudOrganizations_cloudViewerChange_cloudViewer' || obj.operationName === 'Runs_cloudViewer' || obj.operationName === 'SpecsPageContainer_cloudViewer' || (obj.operationName === 'CloudConnectModals_RefreshCloudViewer_refreshCloudViewer_cloudViewer' && testState.refetchCount <= 1)) {
-          if (obj?.result?.data?.cloudViewer?.organizations?.nodes) {
-            obj.result.data.cloudViewer.organizations.nodes = []
-          }
+      cy.remoteGraphQLIntercept(async (obj) => {
+        if (obj?.result?.data?.cloudViewer?.organizations?.nodes) {
+          obj.result.data.cloudViewer.organizations.nodes = []
         }
 
         return obj.result
@@ -159,6 +153,11 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
 
       cy.findByText(defaultMessages.runs.connect.buttonProject).click()
       cy.get('[aria-modal="true"]').should('exist')
+
+      // Clear existing remote GQL intercept to allow new queries to execute normally
+      cy.remoteGraphQLIntercept(async (obj) => {
+        return obj.result
+      })
 
       cy.contains('button', defaultMessages.runs.connect.modal.createOrg.refreshButton).click()
 

--- a/packages/app/cypress/e2e/subscriptions/createCloudOrgModal-subscription.cy.ts
+++ b/packages/app/cypress/e2e/subscriptions/createCloudOrgModal-subscription.cy.ts
@@ -18,10 +18,8 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
 
       // Simulate no orgs
       cy.remoteGraphQLIntercept(async (obj) => {
-        if ((obj.operationName === 'CheckCloudOrganizations_cloudViewerChange_cloudViewer' || obj.operationName === 'Runs_cloudViewer' || obj.operationName === 'SpecsPageContainer_cloudViewer')) {
-          if (obj.result.data?.cloudViewer?.organizations?.nodes) {
-            obj.result.data.cloudViewer.organizations.nodes = []
-          }
+        if (obj.result.data?.cloudViewer?.organizations?.nodes) {
+          obj.result.data.cloudViewer.organizations.nodes = []
         }
 
         return obj.result

--- a/packages/app/src/runs/modals/CloudConnectModals.spec.tsx
+++ b/packages/app/src/runs/modals/CloudConnectModals.spec.tsx
@@ -6,8 +6,13 @@ import { CloudConnectModalsFragmentDoc } from '../../generated/graphql-test'
 import CloudConnectModals from './CloudConnectModals.vue'
 import cloneDeep from 'lodash/cloneDeep'
 
+type MountOptions = {
+  hasOrg: boolean
+  hasProjects: boolean
+}
+
 describe('<CloudConnectModals />', () => {
-  function mountDialog (hasOrg: boolean, hasProjects: boolean) {
+  function mountDialog ({ hasOrg, hasProjects }: MountOptions) {
     cy.mountFragment(CloudConnectModalsFragmentDoc, {
       onResult: (result) => {
         result.currentProject = {
@@ -41,7 +46,7 @@ describe('<CloudConnectModals />', () => {
 
   context('has no organization', () => {
     beforeEach(() => {
-      mountDialog(false, false)
+      mountDialog({ hasOrg: false, hasProjects: false })
     })
 
     it('shows the create/select org modal when orgs are added', () => {
@@ -54,7 +59,7 @@ describe('<CloudConnectModals />', () => {
   context('has organizations', () => {
     context('with no projects', () => {
       beforeEach(() => {
-        mountDialog(true, false)
+        mountDialog({ hasOrg: true, hasProjects: false })
       })
 
       it('shows the select project modal with create new project action', () => {
@@ -68,7 +73,7 @@ describe('<CloudConnectModals />', () => {
 
     context('with projects', () => {
       beforeEach(() => {
-        mountDialog(true, true)
+        mountDialog({ hasOrg: true, hasProjects: true })
       })
 
       it('shows the select project modal with list of projects', () => {

--- a/packages/app/src/runs/modals/CloudConnectModals.spec.tsx
+++ b/packages/app/src/runs/modals/CloudConnectModals.spec.tsx
@@ -4,9 +4,10 @@ import { CloudUserStubs,
 } from '@packages/graphql/test/stubCloudTypes'
 import { CloudConnectModalsFragmentDoc } from '../../generated/graphql-test'
 import CloudConnectModals from './CloudConnectModals.vue'
+import cloneDeep from 'lodash/cloneDeep'
 
 describe('<CloudConnectModals />', () => {
-  function mountDialog (noOrg = false) {
+  function mountDialog (hasOrg: boolean, hasProjects: boolean) {
     cy.mountFragment(CloudConnectModalsFragmentDoc, {
       onResult: (result) => {
         result.currentProject = {
@@ -18,7 +19,16 @@ describe('<CloudConnectModals />', () => {
 
         result.cloudViewer = {
           ...CloudUserStubs.me,
-          organizations: noOrg ? null : CloudOrganizationConnectionStubs,
+          organizations: hasOrg ? cloneDeep(CloudOrganizationConnectionStubs) : null,
+        }
+
+        if (!hasProjects) {
+          result.cloudViewer.organizations?.nodes.forEach((org) => {
+            org.projects = {
+              ...org.projects,
+              nodes: [],
+            }
+          })
         }
       },
       render (gql) {
@@ -29,10 +39,43 @@ describe('<CloudConnectModals />', () => {
     })
   }
 
-  it('shows the select org modal when orgs are added', () => {
-    mountDialog()
-    cy.contains(defaultMessages.runs.connect.modal.selectProject.connectProject).should('be.visible')
+  context('has no organization', () => {
+    beforeEach(() => {
+      mountDialog(false, false)
+    })
 
-    cy.contains('a', defaultMessages.links.needHelp).should('have.attr', 'href', 'https://on.cypress.io/adding-new-project')
+    it('shows the create/select org modal when orgs are added', () => {
+      cy.contains(defaultMessages.runs.connect.modal.createOrg.button).should('be.visible')
+
+      cy.percySnapshot()
+    })
+  })
+
+  context('has organizations', () => {
+    context('with no projects', () => {
+      beforeEach(() => {
+        mountDialog(true, false)
+      })
+
+      it('shows the select project modal with create new project action', () => {
+        cy.contains(defaultMessages.runs.connect.modal.selectProject.createProject).should('be.visible')
+
+        cy.contains('a', defaultMessages.links.needHelp).should('have.attr', 'href', 'https://on.cypress.io/adding-new-project')
+
+        cy.percySnapshot()
+      })
+    })
+
+    context('with projects', () => {
+      beforeEach(() => {
+        mountDialog(true, true)
+      })
+
+      it('shows the select project modal with list of projects', () => {
+        cy.contains(defaultMessages.runs.connect.modal.selectProject.connectProject).should('be.visible')
+
+        cy.percySnapshot()
+      })
+    })
   })
 })

--- a/packages/app/src/runs/modals/CreateCloudOrgModal.vue
+++ b/packages/app/src/runs/modals/CreateCloudOrgModal.vue
@@ -92,7 +92,7 @@ fragment CreateCloudOrgModal on CloudUser {
 
 gql`
 mutation CreateCloudOrgModal_CloudOrganizationsCheck {
-  refreshOrganizations {
+  refreshCloudViewer {
     ...CloudConnectModals
   }
 }

--- a/packages/app/src/runs/modals/SelectCloudProjectModal.vue
+++ b/packages/app/src/runs/modals/SelectCloudProjectModal.vue
@@ -179,7 +179,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watchEffect } from 'vue'
 import { gql, useMutation } from '@urql/vue'
 import StandardModal from '@cy/components/StandardModal.vue'
 import Button from '@cy/components/Button.vue'
@@ -313,13 +313,13 @@ const projectOptions = computed(() => {
 const newProject = ref(projectOptions.value.length === 0)
 const pickedProject = ref<typeof projectOptions.value[number]>()
 
-watch([projectOptions], () => {
+watchEffect(() => {
   if (projectOptions.value.length === 1) {
     pickedProject.value = projectOptions.value[0]
   } else {
     pickedProject.value = projectOptions.value.find((p) => p.name === projectName.value)
   }
-}, { immediate: true })
+})
 
 const orgPlaceholder = t('runs.connect.modal.selectProject.placeholderOrganizations')
 const projectPlaceholder = computed(() => {

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -1294,8 +1294,8 @@ type Mutation {
   """
   refetchRemote: Query
 
-  """Clears the cloudViewer cache to refresh the organizations"""
-  refreshOrganizations: Query
+  """Clears the cloudViewer cache to refresh the organizations and projects"""
+  refreshCloudViewer: Query
 
   """Remove project from projects array and cache"""
   removeProject(path: String!): Query

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Mutation.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Mutation.ts
@@ -644,9 +644,9 @@ export const mutation = mutationType({
       },
     })
 
-    t.field('refreshOrganizations', {
+    t.field('refreshCloudViewer', {
       type: Query,
-      description: 'Clears the cloudViewer cache to refresh the organizations',
+      description: 'Clears the cloudViewer cache to refresh the organizations and projects',
       resolve: async (source, args, ctx) => {
         await ctx.cloud.invalidate('Query', 'cloudViewer')
 


### PR DESCRIPTION
- Closes #23538 

### User facing changelog
* Fixes an issue where outdated organization and project information could be shown in dialogs to connect a project to the Cypress Dashboard.

### Additional details
* Adding a refetch when opening any of the Cloud Connect modals (Create/Select organization, Create/Select project) to reflect any org/project changes that have occurred outside the Cypress app since the user last logged in/opened the app
* Fixed an issue in the Select Project dialog that would continue to use old data in select menus after an updated `gql` prop was passed in

### Steps to test
This procedure involves creating/deleting cloud data. We point to Prod for cloud data by default now, if you would be more comfortable testing against Staging you can do so by launching like so `CYPRESS_INTERNAL_ENV=staging yarn dev`

1. Open a project that is not connected to the cloud (no `projectId` config entry) in the app, CT or E2E
2. Ensure you are logged in.
3. Open the dashboard in your browser (`dashboard.cypress.io` or `dashboard-staging.cypress.io` depending on how you launched). Make note of your organization memberships and what projects are in each org.
4. In the app, when mousing over the "Latest runs" and "Average duration" header tooltips you should get a "Connect project" action. Click to open the connect project modal, verify list of orgs and projects matches what is in the dashboard. Close the modal without taking any action.
5. In the dashboard, create a new project and name it something distinctive
6. In Cypress, re-open the Connect Project modal. Verify newly-created project is reflected in the options. Close the modal without taking any action
7. In the dashboard, create a new organization and name it something distinctive
8. In Cypress, re-open the Connect Project modal. Verify newly-created organization is reflected in the options.

**[Regression Test]**
9. Verify select menus within the modal update appropriately when selecting different organizations (projects list should change, previous project selection should be wiped out).
10. Select an org and a project and save selection using "Connect project" button. Verify correct project ID is saved into project config.

### How has the user experience changed?

https://user-images.githubusercontent.com/11482842/187937181-4e4daa5b-37a5-4198-a9a7-8c90ec6071d1.mov


### PR Tasks
- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
