### PR TITLE
chore: Update release process doc

### DIFF
--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -77,7 +77,7 @@ In the following instructions, "X.Y.Z" is used to denote the [next version of Cy
 
 3. If there is a new [`cypress-example-kitchensink`](https://github.com/cypress-io/cypress-example-kitchensink/releases) version, update the corresponding dependency in [`packages/example`](../packages/example) to that new version.
 
-4. Once the `develop` branch is passing for all test projects with the new changes and the `linux-x64` binary is present at `https://cdn.cypress.io/beta/binary/X.Y.Z/linux-x64/<sha>/cypress.zip`, and the `linux-x64` cypress npm package is present at `https://cdn.cypress.io/beta/binary/X.Y.Z/linux-x64/<sha>/cypress.tgz`, publishing can proceed.
+4. Once the `develop` branch is passing for all test projects with the new changes and the `linux-x64` binary is present at `https://cdn.cypress.io/beta/binary/X.Y.Z/linux-x64/develop-<sha>/cypress.zip`, and the `linux-x64` cypress npm package is present at `https://cdn.cypress.io/beta/npm/X.Y.Z/linux-x64/develop-<sha>/cypress.tgz`, publishing can proceed.
 
 5. Install and test the pre-release version to make sure everything is working.
     - Get the pre-release version that matches your system from the latest develop commit.
@@ -169,7 +169,7 @@ In the following instructions, "X.Y.Z" is used to denote the [next version of Cy
     git pull origin develop
     git log --pretty=oneline
     # copy sha of the previous commit
-    git tag -a vX.Y.Z <sha>
+    git tag -a vX.Y.Z -m vX.Y.Z <sha>
     git push origin vX.Y.Z
     ```
 


### PR DESCRIPTION
- Closes 

### User facing changelog
N/A

### Additional details
Minor updates to release doc based on discrepancies I found during 10.7.0 release

### Steps to test


### How has the user experience changed?


### PR Tasks
- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
