### PR TITLE
fix: Aliases properly retry commands from inside custom commands

### DIFF
--- a/packages/driver/cypress/e2e/commands/aliasing.cy.js
+++ b/packages/driver/cypress/e2e/commands/aliasing.cy.js
@@ -101,6 +101,15 @@ describe('src/cy/commands/aliasing', () => {
           expect(this.input).to.eq(obj)
         })
       })
+
+      it('retries previous commands invoked inside custom commands', () => {
+        Cypress.Commands.add('get2', (selector) => cy.get(selector))
+
+        cy.get2('body').children('div').as('divs')
+        cy.visit('/fixtures/dom.html')
+
+        cy.get('@divs')
+      })
     })
 
     context('#assign', () => {

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -1230,11 +1230,13 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
     }
 
     // A workaround to ensure that when looking back, aliases don't extend beyond the current
-    // chainer. This whole area (`replayCommandsFrom` for aliases) will be replaced with subject chains as
-    // part of the detached DOM work.
+    // chainer and commands invoked inside of it. This whole area (`replayCommandsFrom` for aliases)
+    // will be replaced with subject chains as part of the detached DOM work.
+    const chainerId = command.get('chainerId')
     const prev = command.get('prev')
+    const prevChainer = prev.get('chainerId')
 
-    if (prev.get('chainerId') !== command.get('chainerId')) {
+    if (prevChainer !== chainerId && cy.state('subjectLinks')[prevChainer] !== chainerId) {
       return memo
     }
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/23652

### User facing changelog
Fix: Mixing custom commands and aliases now works again. Fixes regression introduced between 10.4.0 and 10.5.0.

### Additional details
When a custom command invoked cypress commands, these 'internal' commands' return values are properly used as the subject for future commands, via the 'subjectLinks' internal Cypress state.

However, as of 10.5.0, aliases were not respecting these links, meaning they would end up with 'undefined' for a subject instead of the proper one (which would come from replaying the 'internal' commands).

See the test added by this PR for a more concrete example.

### Steps to test
Added automated test demonstrating the issue. Also see the repro in https://github.com/cypress-io/cypress/issues/23652 for external validation.

### How has the user experience changed?

### PR Tasks
- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
