### PR TITLE
chore: fixing flaky tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -66,7 +66,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
     - equal: [ linux-arm64, << pipeline.git.branch >> ]
-    - equal: [ 'fix-windows', << pipeline.git.branch >> ]
+    - equal: [ 'lmiller/fixing-flake-1', << pipeline.git.branch >> ]
     - equal: [ 'skip-or-fix-flaky-tests-2', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"

--- a/packages/launchpad/cypress/e2e/config-warning.cy.ts
+++ b/packages/launchpad/cypress/e2e/config-warning.cy.ts
@@ -70,7 +70,6 @@ describe('baseUrl', () => {
 })
 
 describe('experimentalSingleTabRunMode', () => {
-  // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23158
   it('is a valid config for component testing', () => {
     cy.scaffoldProject('experimentalSingleTabRunMode')
     cy.openProject('experimentalSingleTabRunMode')

--- a/packages/launchpad/cypress/e2e/config-warning.cy.ts
+++ b/packages/launchpad/cypress/e2e/config-warning.cy.ts
@@ -71,10 +71,30 @@ describe('baseUrl', () => {
 
 describe('experimentalSingleTabRunMode', () => {
   // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23158
-  it.skip('is a valid config for component testing', () => {
+  it('is a valid config for component testing', () => {
     cy.scaffoldProject('experimentalSingleTabRunMode')
     cy.openProject('experimentalSingleTabRunMode')
     cy.visitLaunchpad()
+    cy.withCtx(async (ctx) => {
+      await ctx.actions.file.writeFileInProject('cypress.config.js', `
+        const { defineConfig } = require('cypress')
+
+        module.exports = defineConfig({
+          component: {
+            experimentalSingleTabRunMode: true,
+            devServer () {
+              // This test doesn't need to actually run any component tests
+              // so we create a fake dev server to make it run faster and
+              // avoid flake on CI.
+              return {
+                port: 1234,
+                close: () => {},
+              }
+            },
+          },
+        })`)
+    })
+
     cy.get('[data-cy-testingtype="component"]').click()
     cy.get('h1').contains('Initializing Config').should('not.exist')
     cy.get('h1').contains('Choose a Browser')
@@ -91,7 +111,7 @@ describe('experimentalSingleTabRunMode', () => {
 })
 
 describe('experimentalStudio', () => {
-  it('is not a valid config for component testing', () => {
+  it('is not a valid config for component testing', { defaultCommandTimeout: THIRTY_SECONDS }, () => {
     cy.scaffoldProject('experimentalSingleTabRunMode')
     cy.openProject('experimentalSingleTabRunMode')
     cy.visitLaunchpad()
@@ -102,8 +122,14 @@ describe('experimentalStudio', () => {
         module.exports = defineConfig({
           component: {
             experimentalStudio: true,
-            devServer: {
-              bundler: 'webpack',
+            devServer () {
+              // This test doesn't need to actually run any component tests
+              // so we create a fake dev server to make it run faster and
+              // avoid flake on CI.
+              return {
+                port: 1234,
+                close: () => {},
+              }
             },
           },
         })`)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

Partially https://github.com/cypress-io/cypress/issues/23158 (one of the flaky tests)

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Observe CI not failing and not flaky.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
