### PR TITLE
fix: Use tsconfig from build if exists (closes #23673)

### DIFF
--- a/npm/webpack-dev-server/src/helpers/angularHandler.ts
+++ b/npm/webpack-dev-server/src/helpers/angularHandler.ts
@@ -133,7 +133,7 @@ export async function generateTsConfig (devServerConfig: AngularWebpackDevServer
   includePaths.push(cypressTypes)
 
   const tsConfigContent = JSON.stringify({
-    extends: getProjectFilePath('tsconfig.json'),
+    extends: getProjectFilePath(buildOptions.tsConfig ?? 'tsconfig.json'),
     compilerOptions: {
       outDir: getProjectFilePath('out-tsc/cy'),
       allowSyntheticDefaultImports: true,

--- a/npm/webpack-dev-server/test/handlers/angularHandler.spec.ts
+++ b/npm/webpack-dev-server/test/handlers/angularHandler.spec.ts
@@ -195,7 +195,8 @@ const expectGeneratesTsConfig = async (devServerConfig: AngularWebpackDevServerC
   let tsConfig = JSON.parse(await fs.readFile(tsConfigPath, 'utf8'))
 
   expect(tsConfig).to.deep.eq({
-    extends: toPosix(path.join(projectRoot, 'tsconfig.json')),
+    // verifies the default `tsconfig.app.json` is extended
+    extends: toPosix(path.join(projectRoot, 'tsconfig.app.json')),
     compilerOptions: {
       outDir: toPosix(path.join(projectRoot, 'out-tsc/cy')),
       allowSyntheticDefaultImports: true,
@@ -211,6 +212,7 @@ const expectGeneratesTsConfig = async (devServerConfig: AngularWebpackDevServerC
   const modifiedBuildOptions = cloneDeep(buildOptions)
 
   delete modifiedBuildOptions.polyfills
+  modifiedBuildOptions.tsConfig = 'tsconfig.cy.json'
 
   const modifiedDevServerConfig = cloneDeep(devServerConfig)
   const supportFile = path.join(projectRoot, 'cypress', 'support', 'component.ts')
@@ -220,9 +222,18 @@ const expectGeneratesTsConfig = async (devServerConfig: AngularWebpackDevServerC
   tsConfigPath = await generateTsConfig(modifiedDevServerConfig, modifiedBuildOptions)
   tsConfig = JSON.parse(await fs.readFile(tsConfigPath, 'utf8'))
 
-  expect(tsConfig.include).to.deep.equal([
-    toPosix(path.join(projectRoot, 'src/**/*.cy.ts')),
-    toPosix(supportFile),
-    toPosix(path.join(projectRoot, 'node_modules/cypress/types/index.d.ts')),
-  ])
+  expect(tsConfig).to.deep.eq({
+    // verifies the custom `tsconfig.cy.json` is extended
+    extends: toPosix(path.join(projectRoot, 'tsconfig.cy.json')),
+    compilerOptions: {
+      outDir: toPosix(path.join(projectRoot, 'out-tsc/cy')),
+      allowSyntheticDefaultImports: true,
+      skipLibCheck: true,
+    },
+    include: [
+      toPosix(path.join(projectRoot, 'src/**/*.cy.ts')),
+      toPosix(supportFile),
+      toPosix(path.join(projectRoot, 'node_modules/cypress/types/index.d.ts')),
+    ],
+  })
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #23673

### User facing changelog
Change that allows passing in a default tsConfig flag in buildOptions to angularHandler

### Additional details
Allow users to pass in a specific tsconfig.json (e.g to avoid collisions with jest and similar)
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
N/A

### How has the user experience changed?
N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

As a quick note - I was wondering if I should add any tests for this, but seemed like such a small change it should not warrant one. However if it seems necessary, I can look into adding a test for it.

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
