### PR TITLE
feat: add MaybeSimulateSecHeaders code to prevent 403 issues with google

### DIFF
--- a/packages/proxy/lib/http/request-middleware.ts
+++ b/packages/proxy/lib/http/request-middleware.ts
@@ -31,6 +31,21 @@ const ExtractIsAUTFrameHeader: RequestMiddleware = function () {
   this.next()
 }
 
+const MaybeSimulateSecHeaders: RequestMiddleware = function () {
+  if (!this.config.experimentalModifyObstructiveThirdPartyCode) {
+    this.next()
+
+    return
+  }
+
+  // Do NOT disclose destination to an iframe and simulate if iframe was top
+  if (this.req.isAUTFrame && this.req.headers['sec-fetch-dest'] === 'iframe') {
+    this.req.headers['sec-fetch-dest'] = 'document'
+  }
+
+  this.next()
+}
+
 const MaybeAttachCrossOriginCookies: RequestMiddleware = function () {
   const currentAUTUrl = this.getAUTUrl()
 
@@ -233,6 +248,7 @@ const SendRequestOutgoing: RequestMiddleware = function () {
 export default {
   LogRequest,
   ExtractIsAUTFrameHeader,
+  MaybeSimulateSecHeaders,
   MaybeAttachCrossOriginCookies,
   MaybeEndRequestWithBufferedResponse,
   CorrelateBrowserPreRequest,

--- a/packages/proxy/test/unit/http/request-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/request-middleware.spec.ts
@@ -12,6 +12,7 @@ describe('http/request-middleware', () => {
     expect(_.keys(RequestMiddleware)).to.have.ordered.members([
       'LogRequest',
       'ExtractIsAUTFrameHeader',
+      'MaybeSimulateSecHeaders',
       'MaybeAttachCrossOriginCookies',
       'MaybeEndRequestWithBufferedResponse',
       'CorrelateBrowserPreRequest',
@@ -56,6 +57,81 @@ describe('http/request-middleware', () => {
         expect(ctx.req.headers['x-cypress-is-aut-frame']).not.to.exist
         expect(ctx.req.isAUTFrame).to.be.false
       })
+    })
+  })
+
+  describe('MaybeSimulateSecHeaders', () => {
+    const { MaybeSimulateSecHeaders } = RequestMiddleware
+
+    it('is a noop if experimental modify third party code is off', async () => {
+      const ctx = {
+        config: {
+          experimentalModifyObstructiveThirdPartyCode: false,
+        },
+        req: {
+          headers: {
+            'sec-fetch-dest': 'iframe',
+          },
+        },
+      }
+
+      await testMiddleware([MaybeSimulateSecHeaders], ctx)
+
+      expect(ctx.req.headers['sec-fetch-dest']).to.equal('iframe')
+    })
+
+    it('is a noop if the request is not the AUT Frame', async () => {
+      const ctx = {
+        config: {
+          experimentalModifyObstructiveThirdPartyCode: true,
+        },
+        req: {
+          isAUTFrame: false,
+          headers: {
+            'sec-fetch-dest': 'iframe',
+          },
+        },
+      }
+
+      await testMiddleware([MaybeSimulateSecHeaders], ctx)
+
+      expect(ctx.req.headers['sec-fetch-dest']).to.equal('iframe')
+    })
+
+    it('is a noop if the request is the AUT Frame, but the sec-fetch-dest isn\t an iframe', async () => {
+      const ctx = {
+        config: {
+          experimentalModifyObstructiveThirdPartyCode: true,
+        },
+        req: {
+          isAUTFrame: true,
+          headers: {
+            'sec-fetch-dest': 'video',
+          },
+        },
+      }
+
+      await testMiddleware([MaybeSimulateSecHeaders], ctx)
+
+      expect(ctx.req.headers['sec-fetch-dest']).to.equal('video')
+    })
+
+    it('rewrites the sec-fetch-dest header if the experimental modify third party code is enabled, the request came from the AUT frame, and is an iframe', async () => {
+      const ctx = {
+        config: {
+          experimentalModifyObstructiveThirdPartyCode: true,
+        },
+        req: {
+          isAUTFrame: true,
+          headers: {
+            'sec-fetch-dest': 'iframe',
+          },
+        },
+      }
+
+      await testMiddleware([MaybeSimulateSecHeaders], ctx)
+
+      expect(ctx.req.headers['sec-fetch-dest']).to.equal('document')
     })
   })
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #23599

### User facing changelog
sets the `Sec-Fetch-Dest` request header to `document` in the case the AUT iframe is making a request. This is to better simulate top when the `experimentalModifyObstructiveThirdPartyCode` flag is enabled.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
The goal of this change is to better simulate top from the AUT iframe by setting the `Sec-Fetch-Dest` [metadata header](https://developer.mozilla.org/en-US/docs/Glossary/Fetch_metadata_request_header) to `document` when the AUT iframe itself is making a request and the `Sec-Fetch-Dest` is `iframe`. This change it the proxy allows the AUT iframe to appear more like top. This should NOT effect nested iframes in the AUT and only impacts the AUT iframe, which we can safely assume would be top otherwise. 

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
