### PR TITLE
fix: additionally set electron user agent through CDP

### DIFF
--- a/packages/server/lib/browsers/electron.ts
+++ b/packages/server/lib/browsers/electron.ts
@@ -437,6 +437,11 @@ export = {
     // set both because why not
     webContents.userAgent = userAgent
 
+    // In addition to the session, also set the user-agent optimistically through CDP. @see https://github.com/cypress-io/cypress/issues/23597
+    webContents.debugger.sendCommand('Network.setUserAgentOverride', {
+      userAgent,
+    })
+
     return webContents.session.setUserAgent(userAgent)
   },
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #23597

### User facing changelog
Additionally overrides the electron user agent via CDP if the [userAgent](https://docs.cypress.io/guides/references/configuration#Browser) config option is provided or `experimentalModifyObstructiveThirdPartyCode` is enabled.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
It looks like the changes in #22958 did not fully override the electron user agent as expected (see #23597). In addition to setting the userAgent via the Electron's [webContents.session](https://www.electronjs.org/docs/latest/api/session#sessetuseragentuseragent-acceptlanguages) API, we now optimistically set the user agent via CDP, which resolves the issue entirely.


### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
