### PR TITLE
fix(server): use correct property for spec name in CLI

### DIFF
--- a/packages/server/lib/modes/run.ts
+++ b/packages/server/lib/modes/run.ts
@@ -718,7 +718,7 @@ async function runSpecs (options: { config: Cfg, browser: Browser, sys: any, hea
 
   async function runEachSpec (spec: SpecWithRelativeRoot, index: number, length: number, estimated: number) {
     if (!options.quiet) {
-      printResults.displaySpecHeader(spec.baseName, index + 1, length, estimated)
+      printResults.displaySpecHeader(spec.relativeToCommonRoot, index + 1, length, estimated)
     }
 
     const { results } = await runSpec(config, spec, options, estimated, isFirstSpec, index === length - 1)

--- a/packages/server/lib/util/print-run.ts
+++ b/packages/server/lib/util/print-run.ts
@@ -325,7 +325,7 @@ export function renderSummaryTable (runUrl: string | undefined, results: any) {
 
       const ms = duration.format(stats.wallClockDuration || 0)
 
-      const formattedSpec = formatPath(spec.baseName, getWidth(table2, 1))
+      const formattedSpec = formatPath(spec.relativeToCommonRoot, getWidth(table2, 1))
 
       if (run.skippedSpec) {
         return table2.push([

--- a/packages/server/lib/util/print-run.ts
+++ b/packages/server/lib/util/print-run.ts
@@ -113,7 +113,7 @@ function macOSRemovePrivate (str: string) {
 function collectTestResults (obj: { video?: boolean, screenshots?: Screenshot[], spec?: any, stats?: any }, estimated: number) {
   return {
     name: _.get(obj, 'spec.name'),
-    baseName: _.get(obj, 'spec.baseName'),
+    relativeToCommonRoot: _.get(obj, 'spec.relativeToCommonRoot'),
     tests: _.get(obj, 'stats.tests'),
     passes: _.get(obj, 'stats.passes'),
     pending: _.get(obj, 'stats.pending'),
@@ -203,7 +203,7 @@ export function displayRunStarting (options: { browser: Browser, config: Cfg, gr
 
   const formatSpecs = (specs) => {
     // 25 found: (foo.spec.js, bar.spec.js, baz.spec.js)
-    const names = _.map(specs, 'baseName')
+    const names = _.map(specs, 'relativeToCommonRoot')
     const specsTruncated = _.truncate(names.join(', '), { length: 250 })
 
     const stringifiedSpecs = [
@@ -398,7 +398,7 @@ export function displayResults (obj: { screenshots?: Screenshot[] }, estimated: 
     ['Video:', results.video],
     ['Duration:', results.duration],
     estimated ? ['Estimated:', results.estimated] : undefined,
-    ['Spec Ran:', formatPath(results.baseName, getWidth(table, 1), c)],
+    ['Spec Ran:', formatPath(results.relativeToCommonRoot, getWidth(table, 1), c)],
   ])
   .compact()
   .map((arr) => {

--- a/system-tests/__snapshots__/stdout_spec.js
+++ b/system-tests/__snapshots__/stdout_spec.js
@@ -276,7 +276,7 @@ exports['e2e stdout displays fullname of nested specfile 1'] = `
   │ Cypress:    1.2.3                                                                              │
   │ Browser:    FooBrowser 88                                                                      │
   │ Specs:      4 found (spec.cy.js, stdout_specfile.cy.js, stdout_specfile_display_spec_with_a_re │
-  │             ally_long_name_that_never_has_a_line_break_or_new_line.cy.js, spec.cy.js)          │
+  │             ally_long_name_that_never_has_a_line_break_or_new_line.cy.js, nested-4/spec.cy.js) │
   │ Searched:   cypress/e2e/nested-1/nested-2/nested-3/**/*                                        │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
 
@@ -414,7 +414,7 @@ exports['e2e stdout displays fullname of nested specfile 1'] = `
   │ Screenshots:  0                                                                                │
   │ Video:        true                                                                             │
   │ Duration:     X seconds                                                                        │
-  │ Spec Ran:     spec.cy.js                                                                       │
+  │ Spec Ran:     nested-4/spec.cy.js                                                              │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
 
 

--- a/system-tests/__snapshots__/stdout_spec.js
+++ b/system-tests/__snapshots__/stdout_spec.js
@@ -275,15 +275,15 @@ exports['e2e stdout displays fullname of nested specfile 1'] = `
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
   │ Cypress:    1.2.3                                                                              │
   │ Browser:    FooBrowser 88                                                                      │
-  │ Specs:      3 found (spec.cy.js, stdout_specfile.cy.js, stdout_specfile_display_spec_with_a_re │
-  │             ally_long_name_that_never_has_a_line_break_or_new_line.cy.js)                      │
-  │ Searched:   cypress/e2e/nested-1/nested-2/nested-3/*                                           │
+  │ Specs:      4 found (spec.cy.js, stdout_specfile.cy.js, stdout_specfile_display_spec_with_a_re │
+  │             ally_long_name_that_never_has_a_line_break_or_new_line.cy.js, spec.cy.js)          │
+  │ Searched:   cypress/e2e/nested-1/nested-2/nested-3/**/*                                        │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                     
-  Running:  spec.cy.js                                                                      (1 of 3)
+  Running:  spec.cy.js                                                                      (1 of 4)
 
 
   stdout_specfile_display_spec
@@ -316,7 +316,7 @@ exports['e2e stdout displays fullname of nested specfile 1'] = `
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                     
-  Running:  stdout_specfile.cy.js                                                           (2 of 3)
+  Running:  stdout_specfile.cy.js                                                           (2 of 4)
 
 
   stdout_specfile_display_spec
@@ -349,7 +349,7 @@ exports['e2e stdout displays fullname of nested specfile 1'] = `
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                     
-  Running:  stdout_specfile_display_spec_with_a_really_long_name_that_never_has_            (3 of 3)
+  Running:  stdout_specfile_display_spec_with_a_really_long_name_that_never_has_            (3 of 4)
             a_line_break_or_new_line.cy.js                                                          
 
 
@@ -391,6 +391,39 @@ exports['e2e stdout displays fullname of nested specfile 1'] = `
                           ne.cy.js.mp4                                                              
 
 
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  nested-4/spec.cy.js                                                             (4 of 4)
+
+
+  stdout_specfile_display_spec
+    ✓ passes
+
+
+  1 passing
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        1                                                                                │
+  │ Passing:      1                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     spec.cy.js                                                                       │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/nested-4/spec.cy.js.mp4             (X second)
+
+
 ====================================================================================================
 
   (Run Finished)
@@ -405,8 +438,10 @@ exports['e2e stdout displays fullname of nested specfile 1'] = `
   │ ✔  stdout_specfile_display_spec_with_a      XX:XX        1        1        -        -        - │
   │    _really_long_name_that_never_has_a_                                                         │
   │    line_break_or_new_line.cy.js                                                                │
+  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ ✔  nested-4/spec.cy.js                      XX:XX        1        1        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        3        3        -        -        -  
+    ✔  All specs passed!                        XX:XX        4        4        -        -        -  
 
 
 `

--- a/system-tests/projects/e2e/cypress/e2e/nested-1/nested-2/nested-3/nested-4/spec.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/nested-1/nested-2/nested-3/nested-4/spec.cy.js
@@ -1,0 +1,3 @@
+describe('stdout_specfile_display_spec', () => {
+  it('passes', () => {})
+})

--- a/system-tests/test/stdout_spec.js
+++ b/system-tests/test/stdout_spec.js
@@ -66,7 +66,7 @@ describe('e2e stdout', () => {
     return systemTests.exec(this, {
       port: 2020,
       snapshot: true,
-      spec: 'nested-1/nested-2/nested-3/*',
+      spec: 'nested-1/nested-2/nested-3/**/*',
     })
   })
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/22304

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Improve the output of `cypress run` by showing the path of a spec, not just the name.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

In Cypress 9 we would show the spec name minus the `integrationFolder` in the run report. Here's an image from [this user](https://github.com/cypress-io/cypress/issues/22304#issuecomment-1155301230) showing left (Cypress 10, now) right (Cypress 9).

![image](https://user-images.githubusercontent.com/19196536/190321919-d65f5e65-26d7-440b-9ade-bda6badd9667.png)

When we merged `integrationFolder` and `testFiles` into `specPattern`, we DID account for this, but we are using the wrong property in the report - `baseName` is the spec name (no directory). We want `relativeToCommonRoot`, which is the closest thing to Cypress 9 - remove the common prefix (like `cypress/e2e`) and just show the spec path from there.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

You can do

```sh
cd packages/frontend-shared
yarn cypress:run:ct --config video=false --spec "**/Co*"       
```

in the monorepo to see the difference. Or look below. 

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Including screenshots and text. Left is BEFORE (develop) right is AFTER (this branch). The main difference is the **report** - the specs names are now all unique, including the file path, not just the file name.

![image](https://user-images.githubusercontent.com/19196536/190321675-02778525-1ffa-4a9c-812b-394ea28704f3.png)

![image](https://user-images.githubusercontent.com/19196536/190321712-7bf8d5f1-6327-4948-baa5-491b92585c95.png)


Example from monorepo:

```sh
cd packages/frontend-shared
yarn cypress:run:ct --config video=false --spec "**/Co*"       
```

## Before

```sh
yarn run v1.22.11
$ cross-env TZ=America/New_York node ../../scripts/cypress run --component --project . --config video=false --spec '**/Co*'

====================================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        10.7.0                                                                         │
  │ Browser:        Electron 102 (headless)                                                        │
  │ Node Version:   v16.17.0 (/home/lachlan/.nvm/versions/node/v16.17.0/bin/node)                  │
  │ Specs:          4 found (CodeTag.cy.tsx, Collapsible.cy.tsx, CopyText.cy.tsx, CopyButton.cy.ts │
  │                 x)                                                                             │
  │ Searched:       **/Co*                                                                         │
  │ Experiments:    experimentalSingleTabRunMode=true                                              │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  CodeTag.cy.tsx                                                                  (1 of 4)


  <CodeTag />
    ✓ looks good in code
    ✓ displays colored code
    ✓ displays colored code on a background


  3 passing (207ms)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        3                                                                                │
  │ Passing:      3                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     0 seconds                                                                        │
  │ Spec Ran:     CodeTag.cy.tsx                                                                   │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  Collapsible.cy.tsx                                                              (2 of 4)


  <Collapsible />
    ✓ renders the target and content slots (262ms)
    ✓ does not render default slot if lazy (222ms)
    ✓ overflows properly (159ms)
    ✓ does not toggle when clicking on content (223ms)
    ✓ playground
    initiallyOpen
      ✓ defaults to closed
      ✓ can be set to open initially
    slotProps
      toggle
        ✓ passes the toggle slot prop to the default slot (217ms)
      open
        ✓ passes the open slot props to the header and default slots (152ms)


  9 passing (1s)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        9                                                                                │
  │ Passing:      9                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     1 second                                                                         │
  │ Spec Ran:     Collapsible.cy.tsx                                                               │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  CopyText.cy.tsx                                                                 (3 of 4)


  <CopyText />
    ✓ renders without overflow
    ✓ overflows nicely


  2 passing (231ms)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        2                                                                                │
  │ Passing:      2                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     0 seconds                                                                        │
  │ Spec Ran:     CopyText.cy.tsx                                                                  │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  CopyButton.cy.tsx                                                               (4 of 4)


  <CopyButton />
    ✓ copies text to clipboard (288ms)
    ✓ noIcon hides the icon


  2 passing (361ms)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        2                                                                                │
  │ Passing:      2                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     0 seconds                                                                        │
  │ Spec Ran:     CopyButton.cy.tsx                                                                │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  CodeTag.cy.tsx                           204ms        3        3        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  Collapsible.cy.tsx                       00:01        9        9        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  CopyText.cy.tsx                          227ms        2        2        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  CopyButton.cy.tsx                        357ms        2        2        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        00:02       16       16        -        -        -  


```

## After

```
==================================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        10.7.0                                                                         │
  │ Browser:        Electron 102 (headless)                                                        │
  │ Node Version:   v16.17.0 (/home/lachlan/.nvm/versions/node/v16.17.0/bin/node)                  │
  │ Specs:          4 found (components/CodeTag.cy.tsx, components/Collapsible.cy.tsx, components/ │
  │                 CopyText.cy.tsx, gql-components/CopyButton.cy.tsx)                             │
  │ Searched:       **/Co*                                                                         │
  │ Experiments:    experimentalSingleTabRunMode=true                                              │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  components/CodeTag.cy.tsx                                                       (1 of 4)


  <CodeTag />
    ✓ looks good in code
    ✓ displays colored code
    ✓ displays colored code on a background


  3 passing (187ms)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        3                                                                                │
  │ Passing:      3                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     0 seconds                                                                        │
  │ Spec Ran:     components/CodeTag.cy.tsx                                                        │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  components/Collapsible.cy.tsx                                                   (2 of 4)


  <Collapsible />
    ✓ renders the target and content slots (262ms)
    ✓ does not render default slot if lazy (217ms)
    ✓ overflows properly (157ms)
    ✓ does not toggle when clicking on content (222ms)
    ✓ playground
    initiallyOpen
      ✓ defaults to closed
      ✓ can be set to open initially
    slotProps
      toggle
        ✓ passes the toggle slot prop to the default slot (205ms)
      open
        ✓ passes the open slot props to the header and default slots (140ms)


  9 passing (1s)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        9                                                                                │
  │ Passing:      9                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     1 second                                                                         │
  │ Spec Ran:     components/Collapsible.cy.tsx                                                    │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  components/CopyText.cy.tsx                                                      (3 of 4)


  <CopyText />
    ✓ renders without overflow
    ✓ overflows nicely


  2 passing (232ms)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        2                                                                                │
  │ Passing:      2                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     0 seconds                                                                        │
  │ Spec Ran:     components/CopyText.cy.tsx                                                       │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  gql-components/CopyButton.cy.tsx                                                (4 of 4)


  <CopyButton />
    ✓ copies text to clipboard (484ms)
    ✓ noIcon hides the icon


  2 passing (561ms)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        2                                                                                │
  │ Passing:      2                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     0 seconds                                                                        │
  │ Spec Ran:     gql-components/CopyButton.cy.tsx                                                 │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


==================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  components/CodeTag.cy.tsx                186ms        3        3        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  components/Collapsible.cy.tsx            00:01        9        9        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  components/CopyText.cy.tsx               229ms        2        2        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  gql-components/CopyButton.cy.tsx         557ms        2        2        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        00:02       16       16        -        -        -  

Done in 30.50s.
$                                                                                     issue-22304


```

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
