### PR TITLE
chore: fix flake for experimentalStudio config error test

### DIFF
--- a/packages/launchpad/cypress/e2e/config-warning.cy.ts
+++ b/packages/launchpad/cypress/e2e/config-warning.cy.ts
@@ -111,29 +111,9 @@ describe('experimentalSingleTabRunMode', () => {
 })
 
 describe('experimentalStudio', () => {
-  // TODO: fix this flaky test. https://github.com/cypress-io/cypress/issues/23743
-  it.skip('is not a valid config for component testing', { defaultCommandTimeout: THIRTY_SECONDS }, () => {
+  it('is not a valid config for component testing', () => {
     cy.scaffoldProject('experimentalSingleTabRunMode')
-    cy.openProject('experimentalSingleTabRunMode')
-    cy.withCtx(async (ctx) => {
-      await ctx.actions.file.writeFileInProject('cypress.config.js', `
-        const { defineConfig } = require('cypress')
-
-        module.exports = defineConfig({
-          component: {
-            experimentalStudio: true,
-            devServer () {
-              // This test doesn't need to actually run any component tests
-              // so we create a fake dev server to make it run faster and
-              // avoid flake on CI.
-              return {
-                port: 1234,
-                close: () => {},
-              }
-            },
-          },
-        })`)
-    })
+    cy.openProject('experimentalSingleTabRunMode', ['--config-file', 'cypress-invalid-studio-experiment.config.js'])
 
     cy.visitLaunchpad()
     cy.get('[data-cy-testingtype="component"]').click()

--- a/system-tests/projects/experimentalSingleTabRunMode/cypress-invalid-studio-experiment.config.js
+++ b/system-tests/projects/experimentalSingleTabRunMode/cypress-invalid-studio-experiment.config.js
@@ -1,0 +1,17 @@
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  component: {
+    // This property is invalid as `experimentalStudio` is only available for e2e
+    experimentalStudio: true,
+    devServer () {
+      // This test doesn't need to actually run any component tests
+      // so we create a fake dev server to make it run faster and
+      // avoid flake on CI.
+      return {
+        port: 1234,
+        close: () => {},
+      }
+    },
+  },
+})


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #23743

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This test was failing seemingly because there was a race condition between when `writeFileInProject` was finished writing the new config file and when the config was loaded for the project. This resulted in `experimentalStudio` not being set for `component`, which resulted in the error not showing in the launchpad. This caused the test to fail intermittently.

I fixed this by creating a separate configuration file in the `experimentalSingleTabRunMode` project and then passed the file (`cypress-invalid-studio-experiment.config.js`) in as the `--config-file` option to `cy.openProject` during the test setup. This seemed to work more reliably. My guess is that's because we're not waiting on a file to be written to the project; it's already there. 

We should probably do some more investigation into why this race condition is happening. There are a bunch of other tests that I see using this pattern, so I wonder why this isn't an issue for those tests, as it seems like this was only an issue for this specific test. Something to think about.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Run `config-warning.cy.ts` in `launchpad` on your machine multiple times (throw a `.only` on line 114 to speed things up) and make sure that the test doesn't fail. I ran this on my machine about 15-20 times and didn't see a failure with my change, whereas before it would fail about every 3-4 runs. It's not great to rely on this type of testing but I'm not sure of a better way to check if it's still flaky.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
