### PR TITLE
fix: Fix static time references in aci tests

### DIFF
--- a/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
@@ -31,21 +31,17 @@ function assertCorrectRunsLink (specFileName: string, status: string) {
 }
 
 function validateTooltip (status: string) {
-  cy.validateExternalLink({
-    // TODO: (#23778) This name is so long because the entire tooltip is wrapped in a link,
-    // we can make this more accessible by having the name of the link describe the destination
-    // (which is currently not described) and keeping the other content separate.
-    name: `accounts_new.spec.js ${status} 4 months ago 2:23 - 2:39 skipped pending passed failed`,
-    // the main thing about testing this link is that is gets composed with the expected UTM params
-    href: makeTestingCloudLink(status),
-  })
+  cy.get(`a[href="${makeTestingCloudLink(status)}"]`)
   .should('contain.text', 'accounts_new.spec.js')
-  .and('contain.text', '4 months ago')
   .and('contain.text', '2:23 - 2:39')
   .and('contain.text', 'skipped 0')
   .and('contain.text', 'pending 1-2')
   .and('contain.text', `passed 22-23`)
   .and('contain.text', 'failed 1-2')
+  .invoke('text')
+  .should((text) => {
+    expect(text).to.match(/\d+ (day|week|month|year)s? ago/)
+  })
 }
 
 function specShouldShow (specFileName: string, runDotsClasses: string[], latestRunStatus: CloudRunStatus|'PLACEHOLDER') {


### PR DESCRIPTION
- Closes 

### User facing changelog
N/A

### Additional details
Make some assertions in ACI tests more flexible against relative time content

### Steps to test


### How has the user experience changed?


### PR Tasks

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
