### PR TITLE
chore: Use the same dashboard project ID for all Cypress monorepo packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -559,7 +559,7 @@ commands:
               cmd=$([[ <<parameters.percy>> == 'true' ]] && echo 'yarn percy exec --parallel -- --') || true
               DEBUG=<<parameters.debug>> \
               CYPRESS_KONFIG_ENV=production \
-              CYPRESS_RECORD_KEY=${TEST_LAUNCHPAD_RECORD_KEY:-$MAIN_RECORD_KEY} \
+              CYPRESS_RECORD_KEY=$MAIN_RECORD_KEY \
               PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_WORKSPACE_ID \
               PERCY_ENABLE=${PERCY_TOKEN:-0} \
               PERCY_PARALLEL_TOTAL=-1 \

--- a/packages/app/cypress.config.ts
+++ b/packages/app/cypress.config.ts
@@ -2,11 +2,8 @@ import { defineConfig } from 'cypress'
 import getenv from 'getenv'
 import { initGitRepoForTestProject, resetGitRepoForTestProject } from './cypress/tasks/git'
 
-const CYPRESS_INTERNAL_CLOUD_ENV = getenv('CYPRESS_INTERNAL_CLOUD_ENV', process.env.CYPRESS_INTERNAL_ENV || 'development')
-const CYPRESS_INTERNAL_DEV_PROJECT_ID = getenv('CYPRESS_INTERNAL_DEV_PROJECT_ID', process.env.CYPRESS_INTERNAL_DEV_PROJECT_ID || 'sehy69')
-
 export default defineConfig({
-  projectId: CYPRESS_INTERNAL_CLOUD_ENV === 'staging' ? 'ypt4pf' : CYPRESS_INTERNAL_DEV_PROJECT_ID,
+  projectId: getenv('CYPRESS_INTERNAL_DEV_PROJECT_ID', process.env.CYPRESS_INTERNAL_DEV_PROJECT_ID || 'ypt4pf'),
   retries: {
     runMode: 2,
     openMode: 0,

--- a/packages/app/cypress.config.ts
+++ b/packages/app/cypress.config.ts
@@ -1,9 +1,8 @@
 import { defineConfig } from 'cypress'
-import getenv from 'getenv'
 import { initGitRepoForTestProject, resetGitRepoForTestProject } from './cypress/tasks/git'
 
 export default defineConfig({
-  projectId: getenv('CYPRESS_INTERNAL_DEV_PROJECT_ID', process.env.CYPRESS_INTERNAL_DEV_PROJECT_ID || 'ypt4pf'),
+  projectId: 'ypt4pf',
   retries: {
     runMode: 2,
     openMode: 0,

--- a/packages/frontend-shared/cypress.config.ts
+++ b/packages/frontend-shared/cypress.config.ts
@@ -1,8 +1,7 @@
 import { defineConfig } from 'cypress'
-import getenv from 'getenv'
 
 export default defineConfig({
-  projectId: getenv('CYPRESS_INTERNAL_DEV_PROJECT_ID', process.env.CYPRESS_INTERNAL_DEV_PROJECT_ID || 'ypt4pf'),
+  projectId: 'ypt4pf',
   viewportWidth: 800,
   viewportHeight: 850,
   retries: {

--- a/packages/frontend-shared/cypress.config.ts
+++ b/packages/frontend-shared/cypress.config.ts
@@ -1,11 +1,8 @@
 import { defineConfig } from 'cypress'
-
 import getenv from 'getenv'
 
-const CYPRESS_INTERNAL_CLOUD_ENV = getenv('CYPRESS_INTERNAL_CLOUD_ENV', process.env.CYPRESS_INTERNAL_ENV || 'development')
-
 export default defineConfig({
-  projectId: CYPRESS_INTERNAL_CLOUD_ENV === 'staging' ? 'ypt4pf' : 'sehy69',
+  projectId: getenv('CYPRESS_INTERNAL_DEV_PROJECT_ID', process.env.CYPRESS_INTERNAL_DEV_PROJECT_ID || 'ypt4pf'),
   viewportWidth: 800,
   viewportHeight: 850,
   retries: {

--- a/packages/frontend-shared/cypress/fixtures/config.json
+++ b/packages/frontend-shared/cypress/fixtures/config.json
@@ -158,7 +158,7 @@
     "field": "port"
   },
   {
-    "value": "sehy69",
+    "value": "ypt4pf",
     "from": "config",
     "field": "projectId"
   },

--- a/packages/launchpad/cypress.config.ts
+++ b/packages/launchpad/cypress.config.ts
@@ -3,11 +3,8 @@ import getenv from 'getenv'
 import { snapshotCypressDirectory } from './cypress/tasks/snapshotsScaffold'
 import { uninstallDependenciesInScaffoldedProject } from './cypress/tasks/uninstallDependenciesInScaffoldedProject'
 
-const CYPRESS_INTERNAL_CLOUD_ENV = getenv('CYPRESS_INTERNAL_CLOUD_ENV', process.env.CYPRESS_INTERNAL_ENV || 'development')
-const CYPRESS_INTERNAL_DEV_PROJECT_ID = getenv('CYPRESS_INTERNAL_DEV_PROJECT_ID', process.env.CYPRESS_INTERNAL_DEV_PROJECT_ID || 'sehy69')
-
 export default defineConfig({
-  projectId: CYPRESS_INTERNAL_CLOUD_ENV === 'staging' ? 'ypt4pf' : CYPRESS_INTERNAL_DEV_PROJECT_ID,
+  projectId: getenv('CYPRESS_INTERNAL_DEV_PROJECT_ID', process.env.CYPRESS_INTERNAL_DEV_PROJECT_ID || 'ypt4pf'),
   viewportWidth: 800,
   viewportHeight: 850,
   retries: {

--- a/packages/launchpad/cypress.config.ts
+++ b/packages/launchpad/cypress.config.ts
@@ -1,10 +1,9 @@
 import { defineConfig } from 'cypress'
-import getenv from 'getenv'
 import { snapshotCypressDirectory } from './cypress/tasks/snapshotsScaffold'
 import { uninstallDependenciesInScaffoldedProject } from './cypress/tasks/uninstallDependenciesInScaffoldedProject'
 
 export default defineConfig({
-  projectId: getenv('CYPRESS_INTERNAL_DEV_PROJECT_ID', process.env.CYPRESS_INTERNAL_DEV_PROJECT_ID || 'ypt4pf'),
+  projectId: 'ypt4pf',
   viewportWidth: 800,
   viewportHeight: 850,
   retries: {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/23964

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We have two separate projects for the Cypress monorepo in the Cypress Dashboard:

`cypress-launchpad` - the `app`, `frontend-shared`, and `launchpad` packages record to this project
`cypress` - all of the other packages record to this project

This PR makes it so that all of the packages in the monorepo record runs to the same project in the dashboard, namely the `cypress` project. This means that the `cypress-launchpad` project will not be updated with anymore recorded runs and will serve only as a historical project.

It will take a little while for us to build up run history in the `cypress` project for the packages that have been moved over, so for the first few days, viewing the specs list for these packages might show an empty state for "latest runs" or flakiness.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

1. Check out this branch
2. Open CT or e2e for the following packages: `app`, `frontend-shared`, `launchpad`
3. Verify that there is at least one "latest run" for each test in each of the packages (this tells us that CI is successfully recording runs to the new project and app is ingesting them correctly)

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
