### PR TITLE
fix: On focus, outline is only highlighting header on 'Rename existing specs' step

### DIFF
--- a/packages/launchpad/src/migration/MigrationWizard.cy.tsx
+++ b/packages/launchpad/src/migration/MigrationWizard.cy.tsx
@@ -1,0 +1,37 @@
+import type { MigrationStep } from '@packages/frontend-shared/cypress/support/generated/test-graphql-types.gen'
+import { MigrationWizard_RenameSpecsDocument } from '../generated/graphql-test'
+import MigrationWizard from './MigrationWizard.vue'
+
+describe('<MigrationWizard />', { viewportWidth: 1280, viewportHeight: 1000 }, () => {
+  it('outline focus should highlight current step block', () => {
+    cy.stubMutationResolver(MigrationWizard_RenameSpecsDocument, (defineResult) => {
+      const filteredSteps = cy.gqlStub.Migration.filteredSteps as MigrationStep[]
+
+      filteredSteps[0].isCompleted = true
+      filteredSteps[0].isCurrentStep = false
+      filteredSteps[1].isCurrentStep = true
+
+      return defineResult({
+        migrateRenameSpecs: {
+          baseError: null,
+          migration: {
+            filteredSteps,
+          },
+          __typename: 'Query',
+        },
+      })
+    })
+
+    cy.mount(() => <MigrationWizard class='m-4' />)
+
+    const button = cy.get('button').contains('Rename these specs for me')
+
+    button.should('be.visible')
+
+    cy.percySnapshot('1st step')
+
+    button.click()
+
+    cy.percySnapshot('moved to 2nd step')
+  })
+})

--- a/packages/launchpad/src/migration/fragments/MigrationStep.vue
+++ b/packages/launchpad/src/migration/fragments/MigrationStep.vue
@@ -2,13 +2,13 @@
   <div
     v-if="step"
     :data-cy="`migration-step ${step?.name}`"
-    class="border rounded bg-light-50 border-gray-100 mb-4 w-full block"
+    class="border rounded bg-light-50 mb-4 w-full block"
+    :class="{
+      'default-ring': step.isCurrentStep,
+      'bg-gray-50 ': !step.isCurrentStep
+    }"
   >
     <ListRowHeader
-      :class="{
-        'rounded-b-none default-ring': step.isCurrentStep,
-        'bg-gray-50': !step.isCurrentStep
-      }"
       class="-m-1px w-auto"
       :description="description"
       @click="emit('toggle')"


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress/issues/21847

### User-facing changelog
Fixed an issue where On focus, outline is only highlighting header on 'Rename existing specs' step

### Steps to test
- Run app on this current branch
- Add a project with a lower version of cypress installed, to trigger the migration helper flow
- Click on each migration steps
- Verify that the box shadow is added around the complete container, and not just collapse header.

### How has the user experience changed?
#### Before
![pic](https://user-images.githubusercontent.com/1271364/171219535-63d9fae4-dfba-4495-9c5b-f510b19086b7.png)
#### After
![Screenshot from 2022-08-15 13-28-02](https://user-images.githubusercontent.com/14766581/184620076-84c59e24-0db0-478e-8cbe-6afeb8841d7a.png)

### PR Tasks
- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?