### PR TITLE
fix: update way that cohorts are cached to remove duplicate key

### DIFF
--- a/packages/server/lib/cache.js
+++ b/packages/server/lib/cache.js
@@ -186,7 +186,13 @@ module.exports = {
   },
 
   getCohorts () {
-    return fileUtil.get('COHORTS', {})
+    return fileUtil.get('COHORTS', {}).then((cohorts) => {
+      Object.keys(cohorts).forEach((key) => {
+        cohorts[key].name = key
+      })
+
+      return cohorts
+    })
   },
 
   insertCohort (cohort) {
@@ -194,7 +200,9 @@ module.exports = {
       return tx.get('COHORTS', {}).then((cohorts) => {
         return tx.set('COHORTS', {
           ...cohorts,
-          [cohort.name]: cohort,
+          [cohort.name]: {
+            cohort: cohort.cohort,
+          },
         })
       })
     })

--- a/packages/server/test/unit/cohort_spec.ts
+++ b/packages/server/test/unit/cohort_spec.ts
@@ -55,7 +55,7 @@ describe('lib/cohort', () => {
 
       return cohorts.set(cohortTest).then(() => {
         return cohorts.getByName(cohortTest.name).then((cohort) => {
-          expect(cohort).to.eq(cohortTest)
+          expect(cohort).to.deep.eq(cohortTest)
         })
       })
     })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Updating the way that the cohorts are stored in the `cache` file to remove a duplicate value being stored.  The original implementation had the "COHORTS" section of the cache file that would look like:
```
"COHORTS": {
    "aci_082022_login": {
      "cohort": "A",
      "name": "aci_082022_login"
    }
  }
```
This duplicated the key in the main COHORTS object into the "name" field of the value for that key.  The updated code will store the value like:
```
"COHORTS": {
    "aci_082022_login": {
      "cohort": "A"
    }
  }
```
The API for the cohorts section of the cache does not change.  The `cache.js` file encapsulates modifying the structure on the way to and from the file to keep the expected values the same.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

The unit test  `cache_spec.js` should verify that the internal change did not change the overall output.  The original code was implemented in this PR: https://github.com/cypress-io/cypress/pull/23735

Follow the steps in the linked PR and check that the values stored in the `cache` file match the expected structure above.


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [n/a] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
