### PR TITLE
feat(webpack-preprocessor): add support for cy.origin() dependencies

### DIFF
--- a/npm/webpack-preprocessor/index.ts
+++ b/npm/webpack-preprocessor/index.ts
@@ -14,8 +14,8 @@ const debugStats = Debug('cypress:webpack:stats')
 
 declare global {
   // this indicates which commands should be acted upon by the
-  // cross-origin-callback-loader. its absense means the loader should not
-  // be utilized at all
+  // cross-origin-callback-loader. its absense means the loader
+  // should not be utilized at all
   // eslint-disable-next-line no-var
   var __cypressCallbackReplacementCommands: string[] | undefined
 }

--- a/npm/webpack-preprocessor/index.ts
+++ b/npm/webpack-preprocessor/index.ts
@@ -14,7 +14,7 @@ const debugStats = Debug('cypress:webpack:stats')
 
 declare global {
   // this indicates which commands should be acted upon by the
-  // cross-origin-callback-loader. its absense means the loader
+  // cross-origin-callback-loader. its absence means the loader
   // should not be utilized at all
   // eslint-disable-next-line no-var
   var __cypressCallbackReplacementCommands: string[] | undefined


### PR DESCRIPTION
Want to trigger a release of `@cypress/webpack-preprocessor` with the changes made in https://github.com/cypress-io/cypress/pull/23283. I think merging that PR didn't trigger a release of the package since it was squashed in with other changes.