### PR TITLE
chore: Prevent npm-release failures in one package from stopping other releases

### DIFF
--- a/scripts/npm-release.js
+++ b/scripts/npm-release.js
@@ -169,7 +169,7 @@ const releasePackages = async (packages) => {
   }
 
   if (failures.length) {
-    console.log(`\nThe following packages failed to release:\n- ${failures.join('\n -')}`)
+    console.log(`\nThe following packages failed to release:\n- ${failures.join('\n- ')}`)
   } else {
     console.log(`\nAll packages released successfully`)
   }
@@ -234,4 +234,5 @@ if (require.main === module) {
 module.exports = {
   parseSemanticReleaseOutput,
   readPackageJson,
+  releasePackages,
 }

--- a/scripts/npm-release.js
+++ b/scripts/npm-release.js
@@ -137,22 +137,44 @@ const injectVersions = (packagesToRelease, versions, packages) => {
 const releasePackages = async (packages) => {
   console.log(`\nReleasing packages`)
 
+  let failures = []
+
   // it would make sense to run each release simultaneously with something like Promise.all()
   // however this can cause a race condition within git (git lock throws an error)
   // so we run them one by one to avoid this
   for (const name of packages) {
     console.log(`\nReleasing ${name}...`)
-    // semantic-release v19 upgraded to npm v8 which supports workspaces. When running semantic-release, npm thinks that our lerna workspace
-    // is an npm workspace. When npm executes commands that modify the workspace, it will check the validity of the workspace.
-    // We don't want this to happen since we don't use npm and our links/peerDependencies make npm unhappy.
-    // We disable the workspace update via the NPM_CONFIG_WORKSPACES_UDPATE=false env variable.
-    const { stdout } = await execa('npx', ['lerna', 'exec', '--scope', name, '--', 'npx', '--no-install', 'semantic-release'], { env: { NPM_CONFIG_WORKSPACES_UPDATE: false } })
+    // semantic-release v19 upgraded to npm v8 which supports workspaces. When
+    // running semantic-release, npm thinks that our lerna workspace is an npm
+    // workspace. When npm executes commands that modify the workspace, it will
+    // check the validity of the workspace. We don't want this to happen since
+    // since we don't use npm and our links/peerDependencies make npm unhappy.
+    // We disable the workspace update via the NPM_CONFIG_WORKSPACES_UDPATE=false
+    // env variable.
+    try {
+      const { stdout } = await execa(
+        'npx',
+        ['lerna', 'exec', '--scope', name, '--', 'npx', '--no-install', 'semantic-release'],
+        { env: { NPM_CONFIG_WORKSPACES_UPDATE: false } },
+      )
 
-    console.log(`Released ${name} successfully:`)
-    console.log(stdout)
+      console.log(`Released ${name} successfully:`)
+      console.log(stdout)
+    } catch (err) {
+      failures.push(name)
+
+      console.log(`Releasing ${name} failed:`)
+      console.log(err.stack)
+    }
   }
 
-  console.log(`\nAll packages released successfully`)
+  if (failures.length) {
+    console.log(`\nThe following packages failed to release:\n- ${failures.join('\n -')}`)
+  } else {
+    console.log(`\nAll packages released successfully`)
+  }
+
+  return failures.length
 }
 
 const getLernaPackages = async () => {
@@ -195,9 +217,13 @@ const main = async () => {
     return console.log(`Release process cannot be run on a PR`)
   }
 
-  await releasePackages(packagesToRelease)
+  const numFailures = await releasePackages(packagesToRelease)
 
-  console.log(`\n\nRelease process completed successfully!`)
+  if (numFailures) {
+    process.exit(numFailures)
+  } else {
+    console.log(`\n\nRelease process completed successfully!`)
+  }
 }
 
 // execute main function if called from command line


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog

N/A

### Additional details

Currently, if a package release fails in the npm-release CI workflow, it fails the workflow immediately and no subsequent packages will be released. See [this run](https://app.circleci.com/pipelines/github/cypress-io/cypress/44086/workflows/7b89abb1-992a-4604-a313-30086c1fb9f5/jobs/1845507) where the `@cypress/angular` fails and, since it's the first package alphabetically, numerous other packages fail to release.

This change makes it so that failures are logged and captured but don't immediately fail the workflow. All valid packages are released and then the workflow fails afterwards so we know something went wrong with at least one of the packages.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [N/A] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
