### PR TITLE
fix: Assertions properly remain pending when paired with some commands

### DIFF
--- a/packages/driver/cypress/e2e/commands/assertions.cy.js
+++ b/packages/driver/cypress/e2e/commands/assertions.cy.js
@@ -635,7 +635,7 @@ describe('src/cy/commands/assertions', () => {
         cy.get('button:first').should('have.class', 'does-not-have-class')
       })
 
-      it('has a pending state while retrying', (done) => {
+      it('has a pending state while retrying queries', (done) => {
         cy.on('command:retry', (command) => {
           const [getLog, shouldLog] = cy.state('current').get('logs')
 
@@ -646,6 +646,19 @@ describe('src/cy/commands/assertions', () => {
         })
 
         cy.get('button:first', { timeout: 100 }).should('have.class', 'does-not-have-class')
+      })
+
+      it('has a pending state while retrying for commands with onFail', (done) => {
+        cy.on('command:retry', (command) => {
+          const [readFileLog, shouldLog] = cy.state('current').get('logs')
+
+          expect(readFileLog.get('state')).to.eq('pending')
+          expect(shouldLog.get('state')).to.eq('pending')
+
+          done()
+        })
+
+        cy.readFile('does-not-exist.json').should('exist')
       })
 
       it('throws when the subject isnt in the DOM', function (done) {

--- a/packages/driver/src/cy/assertions.ts
+++ b/packages/driver/src/cy/assertions.ts
@@ -330,7 +330,6 @@ export const create = (Cypress: ICypress, cy: $Cy) => {
         try {
           if (_.isFunction(onFail)) {
             // pass in the err and the upcoming assertion commands
-            finishAssertions()
             onFail.call(this, err, isDefaultAssertionErr, cmds)
           }
         } catch (e3) {


### PR DESCRIPTION
### User facing changelog
Fixes a regression where assertions would show as "failed" while they were still retrying

### Additional details
Commands that pass `onFail` callbacks to `verifyingUpcomingAssertions` - such as cypress-testing-library's `findByTestId()` and our own `readFile()` - were showing assertions as "failed" while they were in fact still retrying. See the attached video for an example.

### Steps to test
```
cd packages/app
yarn dev
```

Open e2e testing then run `cypress/e2e/runs.cy.ts`.

`when a project is created, injects new projectId into the config file, and sends expected UTM params` is the test featured in the video, and is a good example of the behavior. `it.only()` that one.

### How has the user experience changed?

Regression behavior:

https://user-images.githubusercontent.com/3003404/192853596-b97004e7-6c4a-47ac-9ac9-e1d6f8d62dde.mp4

With this PR, there is no longer a flash of red on each assertion - it shows grey (pending) until it resolves with either success or failure.

### PR Tasks
- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
