### PR TITLE
chore: Revert "feat: _addQuery() (#23665)"

### DIFF
--- a/npm/cypress-schematic/src/e2e.spec.ts
+++ b/npm/cypress-schematic/src/e2e.spec.ts
@@ -27,7 +27,7 @@ const cypressSchematicPackagePath = path.join(__dirname, '..')
 const ANGULAR_PROJECTS: ProjectFixtureDir[] = ['angular-13', 'angular-14']
 
 describe('ng add @cypress/schematic / only e2e', function () {
-  this.timeout(1000 * 60 * 5)
+  this.timeout(1000 * 60 * 4)
 
   for (const project of ANGULAR_PROJECTS) {
     it('should install e2e files by default', async () => {

--- a/packages/driver/cypress/e2e/commands/agents.cy.js
+++ b/packages/driver/cypress/e2e/commands/agents.cy.js
@@ -323,6 +323,10 @@ describe('src/cy/commands/agents', () => {
           expect(cy.state('aliases').myStub).to.exist
         })
 
+        it('stores the agent as the subject', function () {
+          expect(cy.state('aliases').myStub.subject).to.eq(this.stub)
+        })
+
         it('assigns subject to runnable ctx', function () {
           expect(this.myStub).to.eq(this.stub)
         })
@@ -398,6 +402,10 @@ describe('src/cy/commands/agents', () => {
 
         it('stores the lookup as an alias', () => {
           expect(cy.state('aliases')['my.stub']).to.exist
+        })
+
+        it('stores the agent as the subject', function () {
+          expect(cy.state('aliases')['my.stub'].subject).to.eq(this.stub)
         })
 
         it('assigns subject to runnable ctx', function () {

--- a/packages/driver/cypress/e2e/commands/aliasing.cy.js
+++ b/packages/driver/cypress/e2e/commands/aliasing.cy.js
@@ -1,5 +1,5 @@
 const { assertLogLength } = require('../../support/utils')
-const { _ } = Cypress
+const { _, $ } = Cypress
 
 describe('src/cy/commands/aliasing', () => {
   beforeEach(() => {
@@ -7,6 +7,14 @@ describe('src/cy/commands/aliasing', () => {
   })
 
   context('#as', () => {
+    it('is special utility command', () => {
+      cy.wrap('foo').as('f').then(() => {
+        const cmd = cy.queue.find({ name: 'as' })
+
+        expect(cmd.get('type')).to.eq('utility')
+      })
+    })
+
     it('does not change the subject', () => {
       const body = cy.$$('body')
 
@@ -26,13 +34,11 @@ describe('src/cy/commands/aliasing', () => {
       cy.get('@body')
     })
 
-    it('stores the resulting subject chain as the alias', () => {
-      cy.get('body').as('b').then(() => {
-        const { subjectChain } = cy.state('aliases').b
+    it('stores the resulting subject as the alias', () => {
+      const $body = cy.$$('body')
 
-        expect(subjectChain.length).to.eql(2)
-        expect(subjectChain[0]).to.be.undefined
-        expect(subjectChain[1].commandName).to.eq('get')
+      cy.get('body').as('b').then(() => {
+        expect(cy.state('aliases').b.subject.get(0)).to.eq($body.get(0))
       })
     })
 
@@ -42,15 +48,6 @@ describe('src/cy/commands/aliasing', () => {
       cy.get('#list li').eq(0).as('firstLi').then(($li) => {
         expect($li).to.match(li)
       })
-    })
-
-    it('retries previous commands invoked inside custom commands', () => {
-      Cypress.Commands.add('get2', (selector) => cy.get(selector))
-
-      cy.get2('body').children('div').as('divs')
-      cy.visit('/fixtures/dom.html')
-
-      cy.get('@divs')
     })
 
     it('retries primitives and assertions', () => {
@@ -90,13 +87,29 @@ describe('src/cy/commands/aliasing', () => {
       })
     })
 
-    it('retries previous commands invoked inside custom commands', () => {
-      Cypress.Commands.add('get2', (selector) => cy.get(selector))
+    context('DOM subjects', () => {
+      it('assigns the remote jquery instance', () => {
+        const obj = {}
 
-      cy.get2('body').children('div').as('divs')
-      cy.visit('/fixtures/dom.html')
+        const jquery = () => {
+          return obj
+        }
 
-      cy.get('@divs')
+        cy.state('jQuery', jquery)
+
+        cy.get('input:first').as('input').then(function () {
+          expect(this.input).to.eq(obj)
+        })
+      })
+
+      it('retries previous commands invoked inside custom commands', () => {
+        Cypress.Commands.add('get2', (selector) => cy.get(selector))
+
+        cy.get2('body').children('div').as('divs')
+        cy.visit('/fixtures/dom.html')
+
+        cy.get('@divs')
+      })
     })
 
     context('#assign', () => {
@@ -315,8 +328,9 @@ describe('src/cy/commands/aliasing', () => {
         // sanity check without command overwrite
         cy.wrap('alias value').as('myAlias')
         .then(() => {
-          expect(cy.getAlias('@myAlias')).to.exist
-          expect(cy.getAlias('@myAlias').subjectChain).to.eql(['alias value'])
+          expect(cy.getAlias('@myAlias'), 'alias exists').to.exist
+          expect(cy.getAlias('@myAlias'), 'alias value')
+          .to.have.property('subject', 'alias value')
         })
         .then(() => {
           // cy.get returns the alias
@@ -335,9 +349,10 @@ describe('src/cy/commands/aliasing', () => {
 
         cy.wrap('alias value').as('myAlias')
         .then(() => {
-          expect(wrapCalled).to.be.true
-          expect(cy.getAlias('@myAlias')).to.exist
-          expect(cy.getAlias('@myAlias').subjectChain).to.eql(['alias value'])
+          expect(wrapCalled, 'overwrite was called').to.be.true
+          expect(cy.getAlias('@myAlias'), 'alias exists').to.exist
+          expect(cy.getAlias('@myAlias'), 'alias value')
+          .to.have.property('subject', 'alias value')
         })
         .then(() => {
           // verify cy.get works in arrow function
@@ -367,8 +382,9 @@ describe('src/cy/commands/aliasing', () => {
         .then(() => {
           expect(wrapCalled, 'overwrite was called').to.be.true
           expect(thenCalled, 'then was called').to.be.true
-          expect(cy.getAlias('@myAlias')).to.exist
-          expect(cy.getAlias('@myAlias').subjectChain).to.eql(['alias value'])
+          expect(cy.getAlias('@myAlias'), 'alias exists').to.exist
+          expect(cy.getAlias('@myAlias'), 'alias value')
+          .to.have.property('subject', 'alias value')
         })
         .then(() => {
           // verify cy.get works in arrow function
@@ -384,9 +400,9 @@ describe('src/cy/commands/aliasing', () => {
         // sanity test before the next one
         cy.wrap(1).as('myAlias')
         cy.wrap(2).then(function (subj) {
-          expect(subj).to.equal(2)
-          expect(this).to.not.be.undefined
-          expect(this.myAlias).to.eq(1)
+          expect(subj, 'subject').to.equal(2)
+          expect(this, 'this is defined').to.not.be.undefined
+          expect(this.myAlias, 'this has the alias as a property').to.eq(1)
         })
       })
 
@@ -398,8 +414,8 @@ describe('src/cy/commands/aliasing', () => {
 
         cy.wrap(1).as('myAlias')
         cy.wrap(2).then(function (subj) {
-          expect(subj).to.equal(2)
-          expect(this).to.not.be.undefined
+          expect(subj, 'subject').to.equal(2)
+          expect(this, 'this is defined').to.not.be.undefined
           expect(this.myAlias).to.eq(1)
         })
       })
@@ -412,61 +428,166 @@ describe('src/cy/commands/aliasing', () => {
 
         cy.wrap(1).as('myAlias')
         cy.wrap(2).then(function (subj) {
-          expect(subj).to.equal(2)
-          expect(this).to.not.be.undefined
+          expect(subj, 'subject').to.equal(2)
+          expect(this, 'this is defined').to.not.be.undefined
           expect(this.myAlias).to.eq(1)
         })
       })
     })
   })
 
-  context('#replaying subjects', () => {
-    it('returns if subject is still in the document', () => {
-      cy.get('#list').as('list').then((firstList) => {
-        cy.get('@list').then((secondList) => {
-          expect(firstList).to.eql(secondList)
+  context('#replayCommandsFrom', () => {
+    describe('subject in document', () => {
+      it('returns if subject is still in the document', () => {
+        cy.get('#list').as('list').then(() => {
+          const currentLength = cy.queue.length
+
+          cy.get('@list').then(() => {
+            // should only add the .get() and the .then()
+            expect(cy.queue.length).to.eq(currentLength + 2)
+          })
         })
       })
     })
 
-    it('requeries when reading alias', () => {
-      cy
-      .get('#list li')
-      .as('items').then((firstItems) => {
-        cy.$$('#list').append('<li class="foobar">123456789</li>')
+    describe('subject not in document', () => {
+      it('inserts into the queue', () => {
+        const existingNames = cy.queue.names()
 
-        cy.get('@items').then((secondItems) => {
-          expect(firstItems).to.have.length(3)
-          expect(secondItems).to.have.length(4)
+        cy
+        .get('#list li').eq(0).as('firstLi').then(($li) => {
+          return $li.remove()
+        })
+        .get('@firstLi').then(() => {
+          expect(cy.queue.names()).to.deep.eq(
+            existingNames.concat(
+              ['get', 'eq', 'as', 'then', 'get', 'get', 'eq', 'then'],
+            ),
+          )
         })
       })
-    })
 
-    it('requeries when subject is not in the DOM', () => {
-      cy
-      .get('#list li')
-      .as('items').then((firstItems) => {
-        firstItems.remove()
-        setTimeout(() => {
-          cy.$$('#list').append('<li class="foobar">123456789</li>')
-        }, 50)
+      it('replays from last root to current', () => {
+        const first = cy.$$('#list li').eq(0)
+        const second = cy.$$('#list li').eq(1)
 
-        cy.get('@items').then((secondItems) => {
-          expect(secondItems).to.have.length(1)
+        cy
+        .get('#list li').eq(0).as('firstLi').then(($li) => {
+          expect($li.get(0)).to.eq(first.get(0))
+
+          return $li.remove()
+        })
+        .get('@firstLi').then(($li) => {
+          expect($li.get(0)).to.eq(second.get(0))
         })
       })
-    })
 
-    it('only retries up to last command', () => {
-      cy
-      .get('#list li')
-      .then((items) => items.length)
-      .as('itemCount')
-      .then(() => cy.$$('#list li').remove())
+      it('replays up until first root command', () => {
+        const existingNames = cy.queue.names()
 
-      // Even though the list items have been removed from the DOM, 'then' can't be retried
-      // so we just have the primitive value "3" as our subject.
-      cy.get('@itemCount').should('eq', 3)
+        cy
+        .get('body').noop({})
+        .get('#list li').eq(0).as('firstLi').then(($li) => {
+          return $li.remove()
+        })
+        .get('@firstLi').then(() => {
+          expect(cy.queue.names()).to.deep.eq(
+            existingNames.concat(
+              ['get', 'noop', 'get', 'eq', 'as', 'then', 'get', 'get', 'eq', 'then'],
+            ),
+          )
+        })
+      })
+
+      it('resets the chainerId allow subjects to be carried on', () => {
+        cy.get('#dom').find('#button').as('button').then(($button) => {
+          $button.remove()
+
+          cy.$$('#dom').append($('<button />', { id: 'button' }))
+
+          return null
+        })
+
+        // when cy is a separate chainer there *was* a bug
+        // that cause the subject to null because of different
+        // chainer id's
+        cy.get('@button').then(($button) => {
+          expect($button).to.have.id('button')
+        })
+      })
+
+      it('skips commands which did not change, and starts at the first valid subject or parent command', () => {
+        const existingNames = cy.queue.names()
+
+        cy.$$('#list li').click(function () {
+          const ul = $(this).parent()
+          const lis = ul.children().clone()
+
+          // this simulates a re-render
+          ul.children().remove()
+          ul.append(lis)
+
+          return lis.first().remove()
+        })
+
+        cy
+        .get('#list li')
+        .then(($lis) => {
+          return $lis
+        })
+        .as('items')
+        .first()
+        .click()
+        .as('firstItem')
+        .then(() => {
+          expect(cy.queue.names()).to.deep.eq(
+            existingNames.concat(
+              ['get', 'then', 'as', 'first', 'click', 'as', 'then', 'get', 'should', 'then', 'get', 'should', 'then'],
+            ),
+          )
+        })
+        .get('@items')
+        .should('have.length', 2)
+        .then(() => {
+          expect(cy.queue.names()).to.deep.eq(
+            existingNames.concat(
+              ['get', 'then', 'as', 'first', 'click', 'as', 'then', 'get', 'get', 'should', 'then', 'get', 'should', 'then'],
+            ),
+          )
+        })
+        .get('@firstItem')
+        .should('contain', 'li 1')
+        .then(() => {
+          expect(cy.queue.names()).to.deep.eq(
+            existingNames.concat(
+              ['get', 'then', 'as', 'first', 'click', 'as', 'then', 'get', 'get', 'should', 'then', 'get', 'get', 'first', 'should', 'then'],
+            ),
+          )
+        })
+      })
+
+      it('inserts assertions', (done) => {
+        const existingNames = cy.queue.names()
+
+        cy
+        .get('#checkboxes input')
+        .eq(0)
+        .should('be.checked', 'cockatoo')
+        .as('firstItem')
+        .then(($input) => {
+          return $input.remove()
+        })
+        .get('@firstItem')
+        .then(() => {
+          expect(cy.queue.names()).to.deep.eq(
+            existingNames.concat(
+              ['get', 'eq', 'should', 'as', 'then', 'get', 'get', 'eq', 'should', 'then'],
+            ),
+          )
+
+          done()
+        })
+      })
     })
   })
 

--- a/packages/driver/cypress/e2e/commands/assertions.cy.js
+++ b/packages/driver/cypress/e2e/commands/assertions.cy.js
@@ -843,8 +843,23 @@ describe('src/cy/commands/assertions', () => {
         done()
       })
 
-      cy.get('body').then((subject) => {
-        expect(subject).to.match('body')
+      cy.get('body').then(() => {
+        expect(cy.currentSubject()).to.match('body')
+      })
+    })
+
+    it('sets type to child when subject matches', (done) => {
+      cy.on('log:added', (attrs, log) => {
+        if (attrs.name === 'assert') {
+          cy.removeAllListeners('log:added')
+          expect(log.get('type')).to.eq('child')
+
+          done()
+        }
+      })
+
+      cy.wrap('foo').then(() => {
+        expect('foo').to.eq('foo')
       })
     })
 

--- a/packages/driver/cypress/e2e/commands/commands.cy.js
+++ b/packages/driver/cypress/e2e/commands/commands.cy.js
@@ -88,21 +88,6 @@ describe('src/cy/commands/commands', () => {
       })
     })
 
-    it('throws when attempting to add an existing query', (done) => {
-      cy.on('fail', (err) => {
-        expect(err.message).to.eq('`Cypress.Commands._addQuery()` is used to create new queries, but `get` is an existing Cypress command or query, or is reserved internally by Cypress.\n\n If you want to override an existing command or query, use `Cypress.Commands.overrideQuery()` instead.')
-        expect(err.docsUrl).to.eq('https://on.cypress.io/custom-commands')
-
-        done()
-      })
-
-      Cypress.Commands._addQuery('get', () => {
-        cy
-        .get('[contenteditable]')
-        .first()
-      })
-    })
-
     it('allows calling .add with hover / mount', () => {
       let calls = 0
 
@@ -130,21 +115,6 @@ describe('src/cy/commands/commands', () => {
       })
 
       Cypress.Commands.add('addCommand', () => {
-        cy
-        .get('[contenteditable]')
-        .first()
-      })
-    })
-
-    it('throws when attempting to add a query with the same name as an internal function', (done) => {
-      cy.on('fail', (err) => {
-        expect(err.message).to.eq('`Cypress.Commands._addQuery()` cannot create a new query named `addCommand` because that name is reserved internally by Cypress.')
-        expect(err.docsUrl).to.eq('https://on.cypress.io/custom-commands')
-
-        done()
-      })
-
-      Cypress.Commands._addQuery('addCommand', () => {
         cy
         .get('[contenteditable]')
         .first()

--- a/packages/driver/cypress/e2e/commands/navigation.cy.js
+++ b/packages/driver/cypress/e2e/commands/navigation.cy.js
@@ -1013,10 +1013,10 @@ describe('src/cy/commands/navigation', () => {
           expect(win.location.href).to.include('/fixtures/jquery.html?foo=bar#dashboard?baz=quux')
         })
 
-        this.cyWin = cy.state('window')
+        this.win = cy.state('window')
 
         this.eq = (attr, str) => {
-          expect(this.cyWin.location[attr]).to.eq(str)
+          expect(this.win.location[attr]).to.eq(str)
         }
       })
 
@@ -2340,7 +2340,7 @@ describe('src/cy/commands/navigation', () => {
           expect(this.lastLog).to.exist
           expect(this.lastLog.get('state')).to.eq('pending')
           expect(this.lastLog.get('message')).to.eq('--waiting for new page to load--')
-          expect(this.lastLog.get('snapshots')).to.have.length(0)
+          expect(this.lastLog.get('snapshots')).to.not.exist
         })
       }).get('#dimensions').click()
       .then(function () {
@@ -2367,7 +2367,7 @@ describe('src/cy/commands/navigation', () => {
           expect(this.lastLog).to.exist
           expect(this.lastLog.get('state')).to.eq('pending')
           expect(this.lastLog.get('message')).to.eq('--waiting for new page to load--')
-          expect(this.lastLog.get('snapshots')).to.have.length(0)
+          expect(this.lastLog.get('snapshots')).to.not.exist
         })
 
         cy

--- a/packages/driver/cypress/e2e/commands/querying/querying.cy.js
+++ b/packages/driver/cypress/e2e/commands/querying/querying.cy.js
@@ -18,6 +18,23 @@ describe('src/cy/commands/querying', () => {
       })
     })
 
+    // NOTE: FLAKY in CI, need to investigate further
+    it.skip('retries finding elements until something is found', () => {
+      const missingEl = $('<div />', { id: 'missing-el' })
+
+      // wait until we're ALMOST about to time out before
+      // appending the missingEl
+      cy.on('command:retry', (options) => {
+        if ((options.total + (options._interval * 4)) > options._runnableTimeout) {
+          cy.$$('body').append(missingEl)
+        }
+      })
+
+      cy.get('#missing-el').then(($div) => {
+        expect($div).to.match(missingEl)
+      })
+    })
+
     it('can increase the timeout', () => {
       const missingEl = $('<div />', { id: 'missing-el' })
 
@@ -270,7 +287,7 @@ describe('src/cy/commands/querying', () => {
         })
       })
 
-      it('retries an alias when too many elements found', () => {
+      it('retries an alias when too many elements found without replaying commands', () => {
         // add 500ms to the delta
         cy.timeout(500, true)
 
@@ -278,15 +295,24 @@ describe('src/cy/commands/querying', () => {
 
         const length = buttons.length - 2
 
+        const replayCommandsFrom = cy.spy(cy, 'replayCommandsFrom')
+
         cy.on('command:retry', () => {
           buttons.last().remove()
           buttons = cy.$$('button')
         })
 
+        const existingLen = cy.queue.length
+
         // should eventually resolve after adding 1 button
         cy
         .get('button').as('btns')
         .get('@btns').should('have.length', length).then(($buttons) => {
+          expect(replayCommandsFrom).not.to.be.called
+
+          // get, as, get, should, then == 5
+          expect(cy.queue.length - existingLen).to.eq(5) // we should not have replayed any commands
+
           expect($buttons.length).to.eq(length)
         })
       })
@@ -371,22 +397,30 @@ describe('src/cy/commands/querying', () => {
         })
       })
 
-      it('logs primitive aliases', () => {
-        cy.noop('foo').as('f')
-        .get('@f').then(function () {
-          expect(this.lastLog.pick('$el', 'numRetries', 'referencesAlias', 'aliasType')).to.deep.eq({
-            referencesAlias: { name: 'f' },
-            aliasType: 'primitive',
-          })
+      it('logs primitive aliases', (done) => {
+        cy.on('log:added', (attrs, log) => {
+          if (attrs.name === 'get') {
+            expect(log.pick('$el', 'numRetries', 'referencesAlias', 'aliasType')).to.deep.eq({
+              referencesAlias: { name: 'f' },
+              aliasType: 'primitive',
+            })
+
+            done()
+          }
         })
+
+        cy
+        .noop('foo').as('f')
+        .get('@f')
       })
 
       it('logs immediately before resolving', (done) => {
         cy.on('log:added', (attrs, log) => {
           if (attrs.name === 'get') {
-            expect(log.pick('state', 'referencesAlias')).to.deep.eq({
+            expect(log.pick('state', 'referencesAlias', 'aliasType')).to.deep.eq({
               state: 'pending',
               referencesAlias: undefined,
+              aliasType: 'dom',
             })
 
             done()
@@ -419,7 +453,7 @@ describe('src/cy/commands/querying', () => {
             referencesAlias: undefined,
           }
 
-          expect(this.lastLog.get('$el')).to.eq($body)
+          expect(this.lastLog.get('$el').get(0)).to.eq($body.get(0))
 
           _.each(obj, (value, key) => {
             expect(this.lastLog.get(key)).deep.eq(value, `expected key: ${key} to eq value: ${value}`)
@@ -705,8 +739,11 @@ describe('src/cy/commands/querying', () => {
         this.logs = []
 
         cy.on('log:added', (attrs, log) => {
-          this.lastLog = log
-          this.logs.push(log)
+          if (attrs.name === 'get') {
+            this.lastLog = log
+
+            this.logs.push(log)
+          }
         })
 
         return null
@@ -883,6 +920,32 @@ describe('src/cy/commands/querying', () => {
         .get('@getUsers.0')
       })
 
+      it('throws when alias property isnt just a digit', (done) => {
+        cy.on('fail', (err) => {
+          expect(err.message).to.include('`1b` is not a valid alias property. Only `numbers` or `all` is permitted.')
+
+          done()
+        })
+
+        cy
+        .server()
+        .route(/users/, {}).as('getUsers')
+        .get('@getUsers.1b')
+      })
+
+      it('throws when alias property isnt a digit or `all`', (done) => {
+        cy.on('fail', (err) => {
+          expect(err.message).to.include('`all ` is not a valid alias property. Only `numbers` or `all` is permitted.')
+
+          done()
+        })
+
+        cy
+        .server()
+        .route(/users/, {}).as('getUsers')
+        .get('@getUsers.all ')
+      })
+
       _.each(['', 'foo', [], 1, null], (value) => {
         it(`throws when options property is not an object. Such as: ${value}`, (done) => {
           cy.on('fail', (err) => {
@@ -904,8 +967,7 @@ describe('src/cy/commands/querying', () => {
           expect(lastLog.get('state')).to.eq('failed')
           expect(lastLog.get('error')).to.eq(err)
           expect(lastLog.get('$el').get(0)).to.eq(button.get(0))
-
-          const consoleProps = this.logs[0].invoke('consoleProps')
+          const consoleProps = lastLog.invoke('consoleProps')
 
           expect(consoleProps.Yielded).to.eq(button.get(0))
           expect(consoleProps.Elements).to.eq(button.length)
@@ -1470,20 +1532,16 @@ space
     })
 
     describe('special characters', () => {
-      const specialCharacters = '\' " [ ] { } . @ # $ % ^ & * ( ) , ; :'.split(' ')
-
-      it(`finds content by string with characters`, () => {
-        _.each(specialCharacters, (char) => {
+      _.each('\' " [ ] { } . @ # $ % ^ & * ( ) , ; :'.split(' '), (char) => {
+        it(`finds content by string with character: ${char}`, () => {
           const span = $(`<span>special char ${char} content</span>`).appendTo(cy.$$('body'))
 
           cy.contains('span', char).then(($span) => {
             expect($span.get(0)).to.eq(span.get(0))
           })
         })
-      })
 
-      it(`finds content by regex with characters`, () => {
-        _.each(specialCharacters, (char) => {
+        it(`finds content by regex with character: ${char}`, () => {
           const span = $(`<span>special char ${char} content</span>`).appendTo(cy.$$('body'))
 
           cy.contains('span', new RegExp(_.escapeRegExp(char))).then(($span) => {
@@ -1614,18 +1672,16 @@ space
     }, () => {
       beforeEach(function () {
         this.logs = []
-        this.listener = (attrs, log) => {
-          this.lastLog = log
-          this.logs.push(log)
-        }
 
-        cy.on('log:added', this.listener)
+        cy.on('log:added', (attrs, log) => {
+          if (attrs.name === 'contains') {
+            this.lastLog = log
+
+            this.logs.push(log)
+          }
+        })
 
         return null
-      })
-
-      afterEach(function () {
-        cy.removeListener('log:added', this.listener)
       })
 
       _.each([undefined, null], (val) => {
@@ -1724,13 +1780,10 @@ space
         const button = cy.$$('#button')
 
         cy.on('fail', (err) => {
-          const [containsLog, shouldLog] = this.logs
-
-          expect(shouldLog.get('state')).to.eq('failed')
-          expect(shouldLog.get('error')).to.eq(err)
-          expect(shouldLog.get('$el').get(0)).to.eq(button.get(0))
-
-          const consoleProps = containsLog.invoke('consoleProps')
+          expect(this.lastLog.get('state')).to.eq('failed')
+          expect(this.lastLog.get('error')).to.eq(err)
+          expect(this.lastLog.get('$el').get(0)).to.eq(button.get(0))
+          const consoleProps = this.lastLog.invoke('consoleProps')
 
           expect(consoleProps.Yielded).to.eq(button.get(0))
           expect(consoleProps.Elements).to.eq(button.length)
@@ -1743,7 +1796,7 @@ space
 
       it('throws when assertion is have.length > 1', function (done) {
         cy.on('fail', (err) => {
-          assertLogLength(this.logs, 2)
+          assertLogLength(this.logs, 1)
           expect(err.message).to.eq('`cy.contains()` cannot be passed a `length` option because it will only ever return 1 element.')
           expect(err.docsUrl).to.eq('https://on.cypress.io/contains')
 

--- a/packages/driver/cypress/e2e/commands/querying/shadow_dom.cy.js
+++ b/packages/driver/cypress/e2e/commands/querying/shadow_dom.cy.js
@@ -1,3 +1,5 @@
+const helpers = require('../../../support/helpers')
+
 const { _ } = Cypress
 
 describe('src/cy/commands/querying - shadow dom', () => {
@@ -216,7 +218,7 @@ describe('src/cy/commands/querying - shadow dom', () => {
         cy.get('#shadow-element-1').shadow()
         .then(function ($el) {
           expect(this.lastLog.invoke('consoleProps')).to.deep.eq({
-            'Applied To': cy.$$('#shadow-element-1')[0],
+            'Applied To': helpers.getFirstSubjectByName('get').get(0),
             Yielded: Cypress.dom.getElements($el),
             Elements: $el.length,
             Command: 'shadow',

--- a/packages/driver/cypress/e2e/commands/querying/within.cy.js
+++ b/packages/driver/cypress/e2e/commands/querying/within.cy.js
@@ -287,7 +287,7 @@ describe('src/cy/commands/querying/within', () => {
         })
 
         cy.on('fail', (err) => {
-          expect(err.message).to.include('`cy.within()` failed because it requires a DOM element')
+          expect(err.message).to.include('`cy.within()` failed because this element')
 
           done()
         })

--- a/packages/driver/cypress/e2e/commands/traversals.cy.js
+++ b/packages/driver/cypress/e2e/commands/traversals.cy.js
@@ -1,6 +1,8 @@
 const { assertLogLength } = require('../../support/utils')
 const { _, $, dom } = Cypress
 
+const helpers = require('../../support/helpers')
+
 describe('src/cy/commands/traversals', () => {
   beforeEach(() => {
     cy.visit('/fixtures/dom.html')
@@ -93,7 +95,7 @@ describe('src/cy/commands/traversals', () => {
           })
 
           cy.on('fail', (err) => {
-            expect(err.message).to.include(`\`cy.${name}()\` failed because it requires a DOM element`)
+            expect(err.message).to.include(`\`cy.${name}()\` failed because this element`)
 
             done()
           })
@@ -206,7 +208,7 @@ describe('src/cy/commands/traversals', () => {
             const yielded = Cypress.dom.getElements($el)
 
             _.extend(obj, {
-              'Applied To': cy.$$('#list')[0],
+              'Applied To': helpers.getFirstSubjectByName('get').get(0),
               Yielded: yielded,
               Elements: $el.length,
             })

--- a/packages/driver/cypress/e2e/cypress/command_queue.cy.ts
+++ b/packages/driver/cypress/e2e/cypress/command_queue.cy.ts
@@ -11,6 +11,7 @@ const createCommand = (props = {}) => {
     type: 'parent',
     chainerId: _.uniqueId('ch'),
     userInvocationStack: '',
+    injected: false,
     fn () {},
   }, props))
 }
@@ -24,18 +25,16 @@ const log = (props = {}) => {
 describe('src/cypress/command_queue', () => {
   let queue
   const state = (() => {}) as StateFunc
+  const timeout = () => {}
   const whenStable = {} as IStability
-  const stubCy = {
-    timeout: () => {},
-    cleanup: () => 0,
-    fail: () => {},
-    isCy: () => true,
-    clearTimeout: () => {},
-    setSubjectForChainer: () => {},
-  }
+  const cleanup = () => 0
+  const fail = () => {}
+  const isCy = () => true
+  const clearTimeout = () => {}
+  const setSubjectForChainer = () => {}
 
   beforeEach(() => {
-    queue = new CommandQueue(state, whenStable, stubCy as any)
+    queue = new CommandQueue(state, timeout, whenStable, cleanup, fail, isCy, clearTimeout, setSubjectForChainer)
 
     queue.add(createCommand({
       name: 'get',

--- a/packages/driver/cypress/e2e/cypress/cy.cy.js
+++ b/packages/driver/cypress/e2e/cypress/cy.cy.js
@@ -493,46 +493,4 @@ describe('driver/src/cypress/cy', () => {
       cy.bar()
     })
   })
-
-  context('queries', {
-    defaultCommandTimeout: 30,
-  }, () => {
-    it('throws when queries return a promise', (done) => {
-      cy.on('fail', (err) => {
-        expect(err.message).to.include('`cy.aQuery()` failed because you returned a promise from a query.\n\nQueries must be synchronous functions that return a function. You cannot invoke commands or return promises inside of them.')
-        done()
-      })
-
-      Cypress.Commands._overwriteQuery('aQuery', () => Promise.resolve())
-      cy.aQuery()
-    })
-
-    it('throws when a query returns a non-function value', (done) => {
-      cy.on('fail', (err) => {
-        expect(err.message).to.include('`cy.aQuery()` failed because you returned a value other than a function from a query.\n\nQueries must be synchronous functions that return a function.\n\nThe returned value was:\n\n  > `1`')
-        done()
-      })
-
-      Cypress.Commands._overwriteQuery('aQuery', () => 1)
-      cy.aQuery()
-    })
-
-    it('throws when a command is invoked inside a query', (done) => {
-      cy.on('fail', (err) => {
-        expect(err.message).to.include('`cy.aQuery()` failed because you invoked a command inside a query.\n\nQueries must be synchronous functions that return a function. You cannot invoke commands or return promises inside of them.\n\nThe command invoked was:\n\n  > `cy.visit()`')
-        done()
-      })
-
-      Cypress.Commands._overwriteQuery('aQuery', () => cy.visit('/'))
-      cy.aQuery()
-    })
-
-    // TODO: Make this work. Setting aside for now.
-    it.skip('does allow queries to use other queries', () => {
-      Cypress.Commands._overwriteQuery('aQuery', () => cy.bQuery())
-      Cypress.Commands._overwriteQuery('bQuery', () => {})
-
-      cy.aQuery()
-    })
-  })
 })

--- a/packages/driver/cypress/e2e/e2e/origin/commands/misc.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/commands/misc.cy.ts
@@ -201,10 +201,10 @@ it('verifies number of cy commands', () => {
   const actualCommands = Cypress._.reject(Object.keys(cy.commandFns), (command) => customCommands.includes(command))
   const expectedCommands = [
     'check', 'uncheck', 'click', 'dblclick', 'rightclick', 'focus', 'blur', 'hover', 'scrollIntoView', 'scrollTo', 'select',
-    'selectFile', 'submit', 'type', 'clear', 'trigger', 'ng', 'should', 'and', 'clock', 'tick', 'spread', 'each', 'then',
+    'selectFile', 'submit', 'type', 'clear', 'trigger', 'as', 'ng', 'should', 'and', 'clock', 'tick', 'spread', 'each', 'then',
     'invoke', 'its', 'getCookie', 'getCookies', 'setCookie', 'clearCookie', 'clearCookies', 'pause', 'debug', 'exec', 'readFile',
     'writeFile', 'fixture', 'clearLocalStorage', 'url', 'hash', 'location', 'end', 'noop', 'log', 'wrap', 'reload', 'go', 'visit',
-    'focused', 'get', 'contains', 'shadow', 'within', 'request', 'session', 'screenshot', 'task', 'find', 'filter', 'not',
+    'focused', 'get', 'contains', 'root', 'shadow', 'within', 'request', 'session', 'screenshot', 'task', 'find', 'filter', 'not',
     'children', 'eq', 'closest', 'first', 'last', 'next', 'nextAll', 'nextUntil', 'parent', 'parents', 'parentsUntil', 'prev',
     'prevAll', 'prevUntil', 'siblings', 'wait', 'title', 'window', 'document', 'viewport', 'server', 'route', 'intercept', 'origin',
     'mount',

--- a/packages/driver/cypress/support/helpers.js
+++ b/packages/driver/cypress/support/helpers.js
@@ -1,5 +1,9 @@
 const { _ } = Cypress
 
+const getFirstSubjectByName = (name) => {
+  return cy.queue.find({ name }).get('subject')
+}
+
 const getQueueNames = () => {
   return _.map(cy.queue, 'name')
 }
@@ -24,5 +28,6 @@ function allowTsModuleStubbing () {
 
 module.exports = {
   getQueueNames,
+  getFirstSubjectByName,
   allowTsModuleStubbing,
 }

--- a/packages/driver/src/cy/aliases.ts
+++ b/packages/driver/src/cy/aliases.ts
@@ -1,13 +1,9 @@
 import _ from 'lodash'
 import type { $Cy } from '../cypress/cy'
 
-import $utils from '../cypress/utils'
 import $errUtils from '../cypress/error_utils'
 
-export const aliasRe = /^@.+/
-
-export const aliasIndexRe = /\.(all|[\d]+)$/
-
+const aliasRe = /^@.+/
 const aliasDisplayRe = /^([@]+)/
 const requestXhrRe = /\.request$/
 
@@ -20,14 +16,16 @@ const aliasDisplayName = (name) => {
 // eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
 export const create = (cy: $Cy) => ({
   addAlias (ctx, aliasObj) {
-    const { alias } = aliasObj
+    const { alias, subject } = aliasObj
 
     const aliases = cy.state('aliases') || {}
 
     aliases[alias] = aliasObj
     cy.state('aliases', aliases)
 
-    ctx[alias] = $utils.getSubjectFromChain(aliasObj.subjectChain, cy)
+    const remoteSubject = cy.getRemotejQueryInstance(subject)
+
+    ctx[alias] = remoteSubject ?? subject
   },
 
   getAlias (name, cmd, log) {

--- a/packages/driver/src/cy/commands/actions/selectFile.ts
+++ b/packages/driver/src/cy/commands/actions/selectFile.ts
@@ -4,7 +4,6 @@ import mime from 'mime-types'
 
 import $dom from '../../../dom'
 import $errUtils from '../../../cypress/error_utils'
-import $utils from '../../../cypress/utils'
 import $actionability from '../../actionability'
 import { addEventCoords, dispatch } from './trigger'
 
@@ -128,17 +127,15 @@ export default (Commands, Cypress, cy, state, config) => {
       return
     }
 
-    const contents = $utils.getSubjectFromChain(aliasObj.subjectChain, cy)
-
-    if (contents == null) {
+    if (aliasObj.subject == null) {
       $errUtils.throwErrByPath('selectFile.invalid_alias', {
         onFail: options._log,
-        args: { alias: file.contents, subject: contents },
+        args: { alias: file.contents, subject: aliasObj.subject },
       })
     }
 
-    if ($dom.isElement(contents)) {
-      const subject = $dom.stringify(contents)
+    if ($dom.isElement(aliasObj.subject)) {
+      const subject = $dom.stringify(aliasObj.subject)
 
       $errUtils.throwErrByPath('selectFile.invalid_alias', {
         onFail: options._log,
@@ -149,7 +146,7 @@ export default (Commands, Cypress, cy, state, config) => {
     return {
       fileName: aliasObj.fileName,
       ...file,
-      contents,
+      contents: aliasObj.subject,
     }
   }
 

--- a/packages/driver/src/cy/commands/agents.ts
+++ b/packages/driver/src/cy/commands/agents.ts
@@ -235,7 +235,7 @@ export default function (Commands, Cypress, cy, state) {
     agent.as = (alias) => {
       cy.validateAlias(alias)
       cy.addAlias(ctx, {
-        subjectChain: [agent],
+        subject: agent,
         command: log,
         alias,
       })

--- a/packages/driver/src/cy/commands/misc.ts
+++ b/packages/driver/src/cy/commands/misc.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 import Promise from 'bluebird'
 
+import $Command from '../../cypress/command'
 import $dom from '../../dom'
 import $errUtils from '../../cypress/error_utils'
 import type { Log } from '../../cypress/log'
@@ -23,6 +24,22 @@ export default (Commands, Cypress, cy, state) => {
     },
 
     log (msg, ...args) {
+      // https://github.com/cypress-io/cypress/issues/8084
+      // The return value of cy.log() corrupts the command stack, so cy.then() returned the wrong value
+      // when cy.log() is used inside it.
+      // The code below restore the stack when cy.log() is injected in cy.then().
+      if (state('current').get('injected')) {
+        const restoreCmdIndex = state('index') + 1
+
+        cy.queue.insert(restoreCmdIndex, $Command.create({
+          args: [cy.currentSubject()],
+          name: 'log-restore',
+          fn: (subject) => subject,
+        }))
+
+        state('index', restoreCmdIndex)
+      }
+
       Cypress.log({
         end: true,
         snapshot: true,

--- a/packages/driver/src/cy/commands/navigation.ts
+++ b/packages/driver/src/cy/commands/navigation.ts
@@ -300,11 +300,6 @@ const stabilityChanged = async (Cypress, state, config, stable) => {
     message: '--waiting for new page to load--',
     event: true,
     timeout: options.timeout,
-    // If this was triggered as part of a cypress command, eg, clicking a form submit button, we don't want our
-    // snapshot timing tied to when the current command resolves. This empty 'snapshots' array prevents
-    // command.snapshotLogs() - which the command queue calls as part of resolving each command - from creating a
-    // snapshot too early.
-    snapshots: [],
     consoleProps () {
       return {
         Note: 'This event initially fires when your application fires its \'beforeunload\' event and completes when your application fires its \'load\' event after the next page loads.',

--- a/packages/driver/src/cy/commands/querying/querying.ts
+++ b/packages/driver/src/cy/commands/querying/querying.ts
@@ -5,148 +5,8 @@ import $dom from '../../../dom'
 import $elements from '../../../dom/elements'
 import $errUtils from '../../../cypress/error_utils'
 import type { Log } from '../../../cypress/log'
-import $utils from '../../../cypress/utils'
 import { resolveShadowDomInclusion } from '../../../cypress/shadow_dom_utils'
 import { getAliasedRequests, isDynamicAliasingPossible } from '../../net-stubbing/aliasing'
-import { aliasRe, aliasIndexRe } from '../../aliases'
-
-function getAlias (selector, log, cy) {
-  const alias = selector.slice(1)
-
-  return () => {
-    let toSelect
-
-    // Aliases come in two types: raw names, or names followed by an index.
-    // For example, "@foo.bar" or "@foo.bar.1" or "@foo.bar.all", where 1 or all are the index.
-    if ((cy.state('aliases') || {})[alias]) {
-      toSelect = selector
-    } else {
-      // If the name isn't in our state, then this is probably a dynamic alias -
-      // which is to say, it includes an index.
-      toSelect = selector.replace(/\.(\d+|all)$/, '')
-    }
-
-    let aliasObj
-
-    try {
-      aliasObj = cy.getAlias(toSelect)
-    } catch (err) {
-      // possibly this is a dynamic alias, check to see if there is a request
-      const requests = getAliasedRequests(alias, cy.state)
-
-      if (!isDynamicAliasingPossible(cy.state) || !requests.length) {
-        err.retry = false
-        throw err
-      }
-
-      aliasObj = {
-        alias,
-        command: cy.state('routes')[requests[0].routeId].command,
-      }
-    }
-
-    if (!aliasObj) {
-      return
-    }
-
-    const { command } = aliasObj
-
-    log && log.set('referencesAlias', { name: alias })
-
-    /*
-     * There are three cases for aliases, each explained in more detail below:
-     * 1. Route aliases
-     * 2. Intercept aliases
-     * 3. Subject aliases (either DOM elements or primitives).
-     */
-
-    if (command.get('name') === 'route') {
-      // In the case of a route alias, getRequestsByAlias handles selecting the proper index
-      // and returns one or more requests.
-      const requests = cy.getRequestsByAlias(alias) || null
-
-      log && log.set({
-        aliasType: 'route',
-        consoleProps: () => {
-          return {
-            Alias: selector,
-            Yielded: requests,
-          }
-        },
-      })
-
-      return requests
-    }
-
-    if (command.get('name') === 'intercept') {
-      // Intercept aliases are fairly similar, but `getAliasedRequests` does *not* handle indexes
-      // and we have to do it ourselves here.
-
-      // Posible TODO: Unify this index identifying and selecting logic with that from `getRequestsByAlias`
-      const requests = getAliasedRequests(aliasObj.alias, cy.state)
-
-      // If the user provides an index ("@foo.1" or "@foo.all"), use that. Otherwise, return the most recent request.
-      const match = selector.match(aliasIndexRe)
-      const index = match ? match[1] : (requests.length - 1)
-
-      const returnValue = index === 'all' ? requests : (requests[parseInt(index, 10)] || null)
-
-      log && log.set({
-        aliasType: 'intercept',
-        consoleProps: () => {
-          return {
-            Alias: selector,
-            Yielded: returnValue,
-          }
-        },
-      })
-
-      return returnValue
-    }
-
-    // If we've fallen through to here, then this is a subject alias - the result of one or more previous
-    // cypress commands. We replay their subject chain (including possibly re-quering the DOM)
-    // and use this as the result of the alias.
-
-    // If we have a test similar to
-    // cy.get('li').as('alias').then(li => li.remove())
-    // cy.get('@alias').should('not.exist')
-
-    // then Cypress can be very confused: the original 'get' command was not followed by 'should not exist'
-    // but when reinvoked, it is! We therefore set a special piece of state,
-    // which the 'should exist' assertion can read to determine if the *current* command is followed by a 'should not
-    // exist' assertion.
-    cy.state('aliasCurrentCommand', this)
-    const subject = $utils.getSubjectFromChain(aliasObj.subjectChain, cy)
-
-    cy.state('aliasCurrentCommand', undefined)
-
-    if ($dom.isElement(subject)) {
-      log && log.set({
-        aliasType: 'dom',
-        consoleProps: () => {
-          return {
-            Alias: selector,
-            Yielded: $dom.getElements(subject),
-            Elements: (subject as JQuery<HTMLElement>).length,
-          }
-        },
-      })
-    } else {
-      log && log.set({
-        aliasType: 'primitive',
-        consoleProps: () => {
-          return {
-            Alias: selector,
-            Yielded: subject,
-          }
-        },
-      })
-    }
-
-    return subject
-  }
-}
 
 interface InternalGetOptions extends Partial<Cypress.Loggable & Cypress.Timeoutable & Cypress.Withinable & Cypress.Shadow> {
   _log?: Log
@@ -161,21 +21,6 @@ interface InternalContainsOptions extends Partial<Cypress.Loggable & Cypress.Tim
 }
 
 export default (Commands, Cypress, cy, state) => {
-  /*
-   * cy.get() is currently in a strange state: There are two implementations of it in this file, registered one after
-   * another. It first is registered as a command (Commands.addAll()) - but below it, we *also* add .get()
-   * via Commands._overwriteQuery(), which overwrites it.
-   *
-   * This is because other commands in the driver rely on the original .get() implementation, via
-   * `cy.now('get', selector, getOptions)`.
-   *
-   * The key is that cy.now() relies on `cy.commandFns[name]` - which addAll() sets, but _overwriteQuery() does not.
-   *
-   * The upshot is that any test that relies on `cy.get()` is using the query-based implementation, but various
-   * driver commands have access to the original implementation of .get() via cy.now(). This is a temporary state
-   * of affairs while we refactor other commands to also be queries - we'll eventually be able to delete this
-   * original version of .get() entirely.
-   */
   Commands.addAll({
     get (selector, userOptions: Partial<Cypress.Loggable & Cypress.Timeoutable & Cypress.Withinable & Cypress.Shadow> = {}) {
       const ctx = this
@@ -311,8 +156,7 @@ export default (Commands, Cypress, cy, state) => {
       }
 
       if (aliasObj) {
-        let { alias, command } = aliasObj
-        let subject = $utils.getSubjectFromChain(aliasObj.subjectChain, cy)
+        let { subject, alias, command } = aliasObj
 
         const resolveAlias = () => {
           // if this is a DOM element
@@ -514,81 +358,6 @@ export default (Commands, Cypress, cy, state) => {
 
       return cy.retryIfCommandAUTOriginMismatch(resolveElements, options.timeout)
     },
-  })
-
-  Commands._overwriteQuery('get', function get (selector, userOptions: Partial<Cypress.Loggable & Cypress.Withinable & Cypress.Shadow & Cypress.Timeoutable> = {}) {
-    if ((userOptions === null) || _.isArray(userOptions) || !_.isPlainObject(userOptions)) {
-      $errUtils.throwErrByPath('get.invalid_options', {
-        args: { options: userOptions },
-      })
-    }
-
-    const log = userOptions.log !== false && Cypress.log({
-      message: selector,
-      timeout: userOptions.timeout,
-      consoleProps: () => ({}),
-    })
-
-    cy.state('current').set('timeout', userOptions.timeout)
-    cy.state('current').set('_log', log)
-
-    if (aliasRe.test(selector)) {
-      return getAlias.call(this, selector, log, cy)
-    }
-
-    const withinSubject = cy.state('withinSubject')
-    const includeShadowDom = resolveShadowDomInclusion(Cypress, userOptions.includeShadowDom)
-
-    return () => {
-      cy.ensureCommandCanCommunicateWithAUT()
-
-      let $el
-
-      try {
-        let scope: (typeof withinSubject) | Node[] = withinSubject
-
-        if (includeShadowDom) {
-          const root = withinSubject ? withinSubject[0] : cy.state('document')
-          const elementsWithShadow = $dom.findAllShadowRoots(root)
-
-          scope = elementsWithShadow.concat(root)
-        }
-
-        $el = cy.$$(selector, scope)
-
-        // jQuery v3 has removed its deprecated properties like ".selector"
-        // https://jquery.com/upgrade-guide/3.0/breaking-change-deprecated-context-and-selector-properties-removed
-        // but our error messages use this property to actually show the missing element
-        // so let's put it back
-        if ($el.selector == null) {
-          $el.selector = selector
-        }
-      } catch (err: any) {
-        if (err.message.startsWith('Syntax error')) {
-          err.retry = false
-        }
-
-        // this is usually a sizzle error (invalid selector)
-        if (log) {
-          err.onFail = () => log.error(err)
-        }
-
-        throw err
-      }
-
-      log && log.set({
-        $el,
-        consoleProps: () => {
-          return {
-            Selector: selector,
-            Yielded: $dom.getElements($el),
-            Elements: $el.length,
-          }
-        },
-      })
-
-      return $el
-    }
   })
 
   Commands.addAll({ prevSubject: ['optional', 'window', 'document', 'element'] }, {

--- a/packages/driver/src/cy/commands/querying/root.ts
+++ b/packages/driver/src/cy/commands/querying/root.ts
@@ -1,26 +1,40 @@
+import _ from 'lodash'
+import type { Log } from '../../../cypress/log'
+
+interface InternalRootOptions extends Partial<Cypress.Loggable & Cypress.Timeoutable> {
+  _log?: Log
+}
+
 export default (Commands, Cypress, cy, state) => {
-  Commands._addQuery('root', function root (options: Partial<Cypress.Loggable & Cypress.Timeoutable> = {}) {
-    const log = options.log !== false && Cypress.log({
-      timeout: options.timeout,
-    })
+  Commands.addAll({
+    root (userOptions: Partial<Cypress.Loggable & Cypress.Timeoutable> = {}) {
+      const options: InternalRootOptions = _.defaults({}, userOptions, { log: true })
 
-    cy.state('current').set('timeout', options.timeout)
+      if (options.log !== false) {
+        options._log = Cypress.log({
+          message: '',
+          timeout: options.timeout,
+        })
+      }
 
-    return () => {
-      cy.ensureCommandCanCommunicateWithAUT()
-      const $el = state('withinSubject') || cy.$$('html')
+      const log = ($el) => {
+        if (options._log) {
+          options._log!.set({ $el })
+        }
 
-      log && log.set({
-        $el,
-        consoleProps: () => {
-          return {
-            Command: 'root',
-            Yielded: $el.get(0),
-          }
-        },
-      })
+        return $el
+      }
 
-      return $el
-    }
+      const withinSubject = state('withinSubject')
+
+      if (withinSubject) {
+        return log(withinSubject)
+      }
+
+      return cy.now('get', 'html', {
+        log: false,
+        timeout: options.timeout,
+      }).then(log)
+    },
   })
 }

--- a/packages/driver/src/cy/commands/waiting.ts
+++ b/packages/driver/src/cy/commands/waiting.ts
@@ -205,7 +205,7 @@ export default (Commands, Cypress, cy, state) => {
 
         // cy.route aliases have subject that has all XHR properties
         // let's check one of them
-        return aliasObj.subjectChain.length && Boolean((_.last(aliasObject.subjectChain) as any).xhrUrl)
+        return aliasObj.subject && Boolean(aliasObject.subject.xhrUrl)
       }
 
       if (command && !isNetworkInterceptCommand(command)) {

--- a/packages/driver/src/cy/commands/xhr.ts
+++ b/packages/driver/src/cy/commands/xhr.ts
@@ -540,7 +540,7 @@ export default (Commands, Cypress, cy, state, config) => {
         if (_.isString(o.response) && aliasObj) {
           // reset the route's response to be the
           // aliases subject
-          options.response = $utils.getSubjectFromChain(aliasObj.subjectChain, cy)
+          options.response = aliasObj.subject
         }
 
         const url = getUrl(options)

--- a/packages/driver/src/cy/ensures.ts
+++ b/packages/driver/src/cy/ensures.ts
@@ -48,7 +48,7 @@ export const create = (state: StateFunc, expect: $Cy['expect']) => {
   const ensureSubjectByType = (subject, type) => {
     const current = state('current')
 
-    let types: (string | boolean)[] = [].concat(type)
+    let types: string[] = [].concat(type)
 
     // if we have an optional subject and nothing's
     // here then just return cuz we good to go
@@ -98,21 +98,6 @@ export const create = (state: StateFunc, expect: $Cy['expect']) => {
       $errUtils.throwErrByPath('miscellaneous.outside_test_with_cmd', {
         args: {
           cmd: name,
-        },
-      })
-    }
-  }
-
-  const ensureChildCommand = (command, args) => {
-    const subjects = cy.state('subjects')
-
-    if (subjects[command.get('chainerId')] === undefined) {
-      const stringifiedArg = $utils.stringifyActual(args[0])
-
-      $errUtils.throwErrByPath('miscellaneous.invoking_child_without_parent', {
-        args: {
-          cmd: command.get('name'),
-          args: _.isString(args[0]) ? `\"${stringifiedArg}\"` : stringifiedArg,
         },
       })
     }
@@ -272,6 +257,9 @@ export const create = (state: StateFunc, expect: $Cy['expect']) => {
   }
 
   const ensureElExistence = ($el) => {
+    // dont throw if this isnt even a DOM object
+    // return if not $dom.isJquery($el)
+
     // ensure that we either had some assertions
     // or that the element existed
     if ($el && $el.length) {
@@ -444,7 +432,6 @@ export const create = (state: StateFunc, expect: $Cy['expect']) => {
     // internal functions
     ensureSubjectByType,
     ensureRunnable,
-    ensureChildCommand,
   }
 }
 

--- a/packages/driver/src/cy/xhrs.ts
+++ b/packages/driver/src/cy/xhrs.ts
@@ -3,6 +3,8 @@ import _ from 'lodash'
 import $errUtils from '../cypress/error_utils'
 import type { StateFunc } from '../cypress/state'
 
+const validAliasApiRe = /^(\d+|all)$/
+
 const xhrNotWaitedOnByIndex = (state: StateFunc, alias: string, index: number, prop: 'requests' | 'responses') => {
   // find the last request or response
   // which hasnt already been used.
@@ -65,6 +67,12 @@ export const create = (state: StateFunc) => ({
 
       alias = _.join(_.dropRight(allParts, 1), '.')
       prop = _.last(allParts)
+    }
+
+    if (prop && !validAliasApiRe.test(prop)) {
+      $errUtils.throwErrByPath('get.alias_invalid', {
+        args: { prop },
+      })
     }
 
     if (prop === '0') {

--- a/packages/driver/src/cypress/chainer.ts
+++ b/packages/driver/src/cypress/chainer.ts
@@ -1,6 +1,5 @@
+import _ from 'lodash'
 import $stackUtils from './stack_utils'
-
-let idCounter = 1
 
 export class $Chainer {
   specWindow: Window
@@ -11,7 +10,7 @@ export class $Chainer {
     // The id prefix needs to be unique per origin, so there are not
     // collisions when chainers created in a secondary origin are passed
     // to the primary origin for the command log, etc.
-    this.chainerId = `ch-${window.location.origin}-${idCounter++}`
+    this.chainerId = _.uniqueId(`ch-${window.location.origin}-`)
   }
 
   static remove (key) {

--- a/packages/driver/src/cypress/commands.ts
+++ b/packages/driver/src/cypress/commands.ts
@@ -4,8 +4,6 @@ import { addCommand as addNetstubbingCommand } from '../cy/net-stubbing'
 import $errUtils from './error_utils'
 import $stackUtils from './stack_utils'
 
-import type { QueryFunction } from './utils'
-
 const PLACEHOLDER_COMMANDS = ['mount', 'hover']
 
 const builtInCommands = [
@@ -27,31 +25,79 @@ const getTypeByPrevSubject = (prevSubject) => {
   return 'parent'
 }
 
-const internalError = (path, name) => {
-  $errUtils.throwErrByPath(path, {
-    args: {
-      name,
-    },
-    stack: (new cy.state('specWindow').Error('add command stack')).stack,
-    errProps: {
-      appendToStack: {
-        title: 'From Cypress Internals',
-        content: $stackUtils.stackWithoutMessage((new Error('add command internal stack')).stack || ''),
-      } },
-  })
-}
-
 export default {
   create: (Cypress, cy, state, config) => {
     const reservedCommandNames = new Set(Object.keys(cy))
+    // create a single instance
+    // of commands
     const commands = {}
-
+    const commandBackups = {}
     // we track built in commands to ensure users cannot
     // add custom commands with the same name
     const builtInCommandNames = {}
     let addingBuiltIns
 
+    const store = (obj) => {
+      commands[obj.name] = obj
+
+      return cy.addCommand(obj)
+    }
+
+    const storeOverride = (name, fn) => {
+      // grab the original function if its been backed up
+      // or grab it from the command store
+      const original = commandBackups[name] || commands[name]
+
+      if (!original) {
+        $errUtils.throwErrByPath('miscellaneous.invalid_overwrite', {
+          args: {
+            name,
+          },
+        })
+      }
+
+      // store the backup again now
+      commandBackups[name] = original
+
+      function originalFn (...args) {
+        const current = state('current')
+        let storedArgs = args
+
+        if (current.get('type') === 'child') {
+          storedArgs = args.slice(1)
+        }
+
+        current.set('args', storedArgs)
+
+        return original.fn.apply(this, args)
+      }
+
+      const overridden = _.clone(original)
+
+      overridden.fn = function (...args) {
+        args = ([] as any).concat(originalFn, args)
+
+        return fn.apply(this, args)
+      }
+
+      return cy.addCommand(overridden)
+    }
+
     const Commands = {
+      _commands: commands, // for testing
+
+      each (fn) {
+        // perf loop
+        for (let name in commands) {
+          const command = commands[name]
+
+          fn(command)
+        }
+
+        // prevent loop comprehension
+        return null
+      },
+
       addAllSync (obj) {
         // perf loop
         for (let name in obj) {
@@ -87,11 +133,31 @@ export default {
 
       add (name, options, fn) {
         if (builtInCommandNames[name]) {
-          internalError('miscellaneous.invalid_new_command', name)
+          $errUtils.throwErrByPath('miscellaneous.invalid_new_command', {
+            args: {
+              name,
+            },
+            stack: (new state('specWindow').Error('add command stack')).stack,
+            errProps: {
+              appendToStack: {
+                title: 'From Cypress Internals',
+                content: $stackUtils.stackWithoutMessage((new Error('add command internal stack')).stack || ''),
+              } },
+          })
         }
 
         if (reservedCommandNames.has(name)) {
-          internalError('miscellaneous.reserved_command', name)
+          $errUtils.throwErrByPath('miscellaneous.reserved_command', {
+            args: {
+              name,
+            },
+            stack: (new state('specWindow').Error('add command stack')).stack,
+            errProps: {
+              appendToStack: {
+                title: 'From Cypress Internals',
+                content: $stackUtils.stackWithoutMessage((new Error('add command internal stack')).stack!),
+              } },
+          })
         }
 
         // .hover & .mount are special case commands. allow as builtins so users
@@ -109,68 +175,27 @@ export default {
 
         // normalize type by how they validate their
         // previous subject (unless they're explicitly set)
-        const type = options.type ?? getTypeByPrevSubject(prevSubject)
+        options.type = options.type ?? getTypeByPrevSubject(prevSubject)
+        const type = options.type
 
-        commands[name] = {
+        return store({
           name,
           fn,
           type,
           prevSubject,
-        }
-
-        return cy.addCommand(commands[name])
+        })
       },
 
       overwrite (name, fn) {
-        const original = commands[name]
-
-        if (!original) {
-          internalError('miscellaneous.invalid_overwrite', name)
-        }
-
-        function originalFn (...args) {
-          const current = state('current')
-          let storedArgs = args
-
-          if (current.get('type') === 'child') {
-            storedArgs = args.slice(1)
-          }
-
-          current.set('args', storedArgs)
-
-          return original.fn.apply(this, args)
-        }
-
-        const overridden = _.clone(original)
-
-        overridden.fn = function (...args) {
-          args = ([] as any).concat(originalFn, args)
-
-          return fn.apply(this, args)
-        }
-
-        return cy.addCommand(overridden)
-      },
-
-      _addQuery (name: string, fn: () => QueryFunction) {
-        if (reservedCommandNames.has(name)) {
-          internalError('miscellaneous.reserved_command_query', name)
-        }
-
-        if (cy[name]) {
-          internalError('miscellaneous.invalid_new_query', name)
-        }
-
-        cy._addQuery({ name, fn })
-      },
-
-      _overwriteQuery (name, fn) {
-        cy._addQuery({ name, fn })
+        return storeOverride(name, fn)
       },
     }
 
     addingBuiltIns = true
+    // perf loop
     for (let cmd of builtInCommands) {
+      // support "export default" syntax
+      cmd = cmd.default || cmd
       cmd(Commands, Cypress, cy, state, config)
     }
     addingBuiltIns = false

--- a/packages/driver/src/cypress/error_messages.ts
+++ b/packages/driver/src/cypress/error_messages.ts
@@ -563,6 +563,10 @@ export default {
   },
 
   get: {
+    alias_invalid: {
+      message: '`{{prop}}` is not a valid alias property. Only `numbers` or `all` is permitted.',
+      docsUrl: 'https://on.cypress.io/get',
+    },
     alias_zero: {
       message: '`0` is not a valid alias property. Are you trying to ask for the first response? If so write `@{{alias}}.1`',
       docsUrl: 'https://on.cypress.io/get',
@@ -859,14 +863,6 @@ export default {
     },
     reserved_command: {
       message: '`Cypress.Commands.add()` cannot create a new command named `{{name}}` because that name is reserved internally by Cypress.',
-      docsUrl: 'https://on.cypress.io/custom-commands',
-    },
-    invalid_new_query: {
-      message: '`Cypress.Commands._addQuery()` is used to create new queries, but `{{name}}` is an existing Cypress command or query, or is reserved internally by Cypress.\n\n If you want to override an existing command or query, use `Cypress.Commands.overrideQuery()` instead.',
-      docsUrl: 'https://on.cypress.io/custom-commands',
-    },
-    reserved_command_query: {
-      message: '`Cypress.Commands._addQuery()` cannot create a new query named `{{name}}` because that name is reserved internally by Cypress.',
       docsUrl: 'https://on.cypress.io/custom-commands',
     },
     invalid_overwrite: {
@@ -1647,37 +1643,6 @@ export default {
     optgroup_disabled: {
       message: `${cmd('select')} failed because this \`<option>\` you are trying to select is within an \`<optgroup>\` that is currently disabled:\n\n\`{{node}}\``,
       docsUrl: 'https://on.cypress.io/select',
-    },
-  },
-
-  query_command: {
-    docsUrl: 'https://on.cypress.io/custom-commands',
-
-    returned_promise (obj) {
-      return stripIndent`
-        ${cmd(obj.name)} failed because you returned a promise from a query.
-
-        Queries must be synchronous functions that return a function. You cannot invoke commands or return promises inside of them.`
-    },
-    invoked_action (obj) {
-      return stripIndent`
-        ${cmd(obj.name)} failed because you invoked a command inside a query.
-
-        Queries must be synchronous functions that return a function. You cannot invoke commands or return promises inside of them.
-
-        The command invoked was:
-
-          > ${cmd(obj.action)}`
-    },
-    returned_non_function (obj) {
-      return stripIndent`
-        ${cmd(obj.name)} failed because you returned a value other than a function from a query.
-
-        Queries must be synchronous functions that return a function.
-
-        The returned value was:
-
-          > \`${obj.returned}\``
     },
   },
 

--- a/packages/driver/src/cypress/error_utils.ts
+++ b/packages/driver/src/cypress/error_utils.ts
@@ -147,7 +147,6 @@ const getUserInvocationStack = (err, state) => {
     !userInvocationStack
     || err.isDefaultAssertionErr
     || (currentAssertionCommand && !current?.get('followedByShouldCallback'))
-    || withInvocationStack?.get('selector')
   ) {
     userInvocationStack = withInvocationStack?.get('userInvocationStack')
   }

--- a/packages/driver/src/cypress/utils.ts
+++ b/packages/driver/src/cypress/utils.ts
@@ -8,10 +8,6 @@ import $dom from '../dom'
 import $jquery from '../dom/jquery'
 import { $Location } from './location'
 
-export type QueryFunction = (any) => any
-
-export type SubjectChain = [any, ...QueryFunction[]];
-
 const tagOpen = /\[([a-z\s='"-]+)\]/g
 const tagClosed = /\[\/([a-z]+)\]/g
 
@@ -402,29 +398,5 @@ export default {
 
   isPromiseLike (ret) {
     return ret && _.isFunction(ret.then)
-  },
-
-  /* Given a chain of functions, return the actual subject. `subjectChain` might look like any of:
-   * [<input>]
-   * ['foobar', f()]
-   * [undefined, f(), f()]
-   */
-  getSubjectFromChain (subjectChain: SubjectChain, cy) {
-    // If we're getting the subject of a previous command, then any log messages have already
-    // been added to the command log; We don't want to re-add them every time we query
-    // the current subject.
-    cy.state('onBeforeLog', () => false)
-
-    let subject = subjectChain[0]
-
-    try {
-      for (let i = 1; i < subjectChain.length; i++) {
-        subject = subjectChain[i](subject)
-      }
-    } finally {
-      cy.state('onBeforeLog', null)
-    }
-
-    return subject
   },
 }


### PR DESCRIPTION
This reverts commit 41fc535dca51cda4e40b5d9fc827d8bff534f3d1.

### User facing changelog
No user-facing change, just reverting https://github.com/cypress-io/cypress/pull/23665

### Additional details
This PR caused a regression around aliases with a mix of queries and commands.

### Steps to test

### How has the user experience changed?


### PR Tasks

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
