### PR TITLE
chore: update mocha-junit-reporter to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "minimist": "1.2.6",
     "mocha": "3.5.3",
     "mocha-banner": "1.1.2",
-    "mocha-junit-reporter": "2.0.0",
+    "mocha-junit-reporter": "2.1.0",
     "mocha-multi-reporters": "1.1.7",
     "mock-fs": "5.1.1",
     "p-defer": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23884,6 +23884,17 @@ mocha-junit-reporter@2.0.0:
     strip-ansi "^4.0.0"
     xml "^1.0.0"
 
+mocha-junit-reporter@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mocha-junit-reporter/-/mocha-junit-reporter-2.1.0.tgz#7997348c2e757686c54e42b3756930b55a4518a4"
+  integrity sha512-Zhz1J+XqJUaAOuSFtHgi2+b+W3rP1SZtaU3HHNNp1iEKMSeoC1/EQUVkGknkLNOBxJhXJ4xLgOr8TbYAZOkUIw==
+  dependencies:
+    debug "^2.2.0"
+    md5 "^2.1.0"
+    mkdirp "~0.5.1"
+    strip-ansi "^6.0.1"
+    xml "^1.0.0"
+
 mocha-multi-reporters@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/mocha-multi-reporters/-/mocha-multi-reporters-1.1.7.tgz#cc7f3f4d32f478520941d852abb64d9988587d82"


### PR DESCRIPTION
Updates mocha-junit-reporter to 2.1.0 to resolve intermittent pipeline failures reported in michaelleeallen/mocha-junit-reporter#171

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
