### PR TITLE
fix(webpack-preprocessor): Move md5 from devDependencies to dependencies

### DIFF
--- a/npm/webpack-preprocessor/package.json
+++ b/npm/webpack-preprocessor/package.json
@@ -25,6 +25,7 @@
     "fs-extra": "^10.1.0",
     "loader-utils": "^2.0.0",
     "lodash": "^4.17.20",
+    "md5": "2.3.0",
     "webpack-virtual-modules": "^0.4.4"
   },
   "devDependencies": {
@@ -50,7 +51,6 @@
     "eslint-plugin-mocha": "8.1.0",
     "fast-glob": "3.1.1",
     "find-webpack": "1.5.0",
-    "md5": "2.3.0",
     "mocha": "^7.1.0",
     "mockery": "2.1.0",
     "proxyquire": "2.1.3",


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #24051 

### User facing changelog

N/A - fixes an issue with webpack-preprocessor, not the binary

### Additional details

Fixes an issue with `@cypress/webpack-preprocessor@5.13.0` caused by the `md5` being mistakenly added as a `devDependency` instead of a `dependency`.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [N/A] Have tests been added/updated?
- [N/A] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
