### PR TITLE
fix: angular and nuxt ct tests now fail on uncaught exceptions

### DIFF
--- a/npm/angular/src/mount.ts
+++ b/npm/angular/src/mount.ts
@@ -8,7 +8,7 @@ window.Mocha['__zone_patch__'] = false
 import 'zone.js/testing'
 
 import { CommonModule } from '@angular/common'
-import { Component, EventEmitter, SimpleChange, SimpleChanges, Type } from '@angular/core'
+import { Component, ErrorHandler, EventEmitter, Injectable, SimpleChange, SimpleChanges, Type } from '@angular/core'
 import {
   ComponentFixture,
   getTestBed,
@@ -99,6 +99,13 @@ export type MountResponse<T> = {
 // so we'll patch here pending a fix in that library
 globalThis.it.skip = globalThis.xit
 
+@Injectable()
+class CypressAngularErrorHandler implements ErrorHandler {
+  handleError (error: Error): void {
+    throw error
+  }
+}
+
 /**
  * Bootstraps the TestModuleMetaData passed to the TestBed
  *
@@ -119,6 +126,17 @@ function bootstrapModule<T> (
   if (!testModuleMetaData.imports) {
     testModuleMetaData.imports = []
   }
+
+  if (!testModuleMetaData.providers) {
+    testModuleMetaData.providers = []
+  }
+
+  // Replace default error handler since it will swallow uncaught exceptions.
+  // We want these to be uncaught so Cypress catches it and fails the test
+  testModuleMetaData.providers.push({
+    provide: ErrorHandler,
+    useClass: CypressAngularErrorHandler,
+  })
 
   // check if the component is a standalone component
   if ((component as any).ɵcmp.standalone) {

--- a/npm/vue2/src/index.ts
+++ b/npm/vue2/src/index.ts
@@ -273,11 +273,11 @@ declare global {
  * @see https://github.com/cypress-io/cypress/issues/7910
  */
 function failTestOnVueError (err, vm, info) {
-  console.error(`Vue error`)
-  console.error(err)
-  console.error('component:', vm)
-  console.error('info:', info)
-  window.top.onerror(err)
+  // Vue 2 try catches the error-handler so push the error to be caught outside
+  // of the handler.
+  setTimeout(() => {
+    throw err
+  })
 }
 
 function registerAutoDestroy ($destroy: () => void) {

--- a/system-tests/project-fixtures/angular/src/app/components/errors.ts
+++ b/system-tests/project-fixtures/angular/src/app/components/errors.ts
@@ -17,6 +17,6 @@ export class ErrorsComponent {
   asyncError() {
     setTimeout(() => {
       throw new Error('async error')
-    }, 50)
+    })
   }
 }


### PR DESCRIPTION
### User facing changelog
Fixes issue where Angular and Nuxt CT uncaught exceptions would allow test to pass. CT Tests that have uncaught exceptions will now cause the test to fail.

### Additional details
The fix for Nuxt was to remove some outdated code from the `vue2` package and force the error outside of Nuxt's default error handling. For Angular, a custom ErrorHandler was added that just re-throws the error.

### Steps to test
I tested by checking out my branch and making sure `npm/angular` and `npm/vue2` were built with the latest changes (normally by just running `yarn` at root). Then, I copied and pasted the contents of `dist` for each package into `node_modules/cypress/<framework>/dist` of an external project. For Angular, you have to remove the `.angular` directory otherwise the module will be cached.

The system-tests added can also be run as they scaffold an entire Nuxt/Angular application

### How has the user experience changed?
Before:

https://user-images.githubusercontent.com/25158820/193910636-b105fa29-57a1-46c2-9602-33524d0fdf68.mov

After:

https://user-images.githubusercontent.com/25158820/193910694-800722f8-983b-4a77-850a-88775b63999c.mov

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

### Other

Keeping in draft for now, this would be a breaking change but these frameworks are listed as Alpha so we might move ahead. Will bring up in CT product sync.