### PR TITLE
fix(reporter): fix nested command styles

### DIFF
--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -81,8 +81,6 @@
     .command-wrapper-text {
       display: flex;
       flex-wrap: nowrap;
-      padding-top: 4px;
-      padding-bottom: 4px;
     }
 
     .command-interceptions {


### PR DESCRIPTION
Fix nested command style that were changed in https://github.com/cypress-io/cypress/pull/24089

### User facing changelog
n/a

### How has the user experience changed?
| Broken | Fixed |
|--|--|
| <img width="499" alt="Screen Shot 2022-10-05 at 11 08 42 AM" src="https://user-images.githubusercontent.com/14099737/194109512-bfe2724d-9c8a-497f-9ece-b11c64a804f5.png"> |  <img width="489" alt="Screen Shot 2022-10-05 at 11 12 00 AM" src="https://user-images.githubusercontent.com/14099737/194109644-c8c1a0c0-1f87-43ce-81c1-e7fa1a4db09a.png">
