### PR TITLE
chore: Removed no longer used comments from lib/gui/events.ts

### DIFF
--- a/packages/server/lib/gui/events.ts
+++ b/packages/server/lib/gui/events.ts
@@ -24,16 +24,12 @@ const handleEvent = function (options, bus, event, id, type, arg) {
   switch (type) {
     case 'launch:browser':
       return
-
     case 'open:project':
       return
-
     case 'has:opened:cypress':
       return
-
     case 'ping:baseUrl':
       return
-      
     default:
       throw new Error(`No ipc event registered for: '${type}'`)
   }

--- a/packages/server/lib/gui/events.ts
+++ b/packages/server/lib/gui/events.ts
@@ -23,141 +23,17 @@ const handleEvent = function (options, bus, event, id, type, arg) {
 
   switch (type) {
     case 'launch:browser':
-      // TIM: Commented out for reference w/ the new implementation
-      // // is there a way to lint the arguments received?
-      // debug('launching browser for \'%s\' spec: %o', arg.specType, arg.spec)
-      // debug('full list of options %o', arg)
-
-      // // the "arg" should have objects for
-      // //   - browser
-      // //   - spec (with fields)
-      // //       name, absolute, relative
-      // //   - specType: "integration" | "component"
-      // //   - specFilter (optional): the string user searched for
-      // const fullSpec = _.merge({}, arg.spec, {
-      //   specType: arg.specType,
-      //   specFilter: arg.specFilter,
-      // })
-
-      // return openProject.launch(arg.browser, fullSpec, {
-      //   // TODO: Tim see why this "projectRoot" is passed along
-      //   projectRoot: options.projectRoot,
-      //   onBrowserOpen () {
-      //     return send({ browserOpened: true })
-      //   },
-      //   onBrowserClose () {
-      //     return send({ browserClosed: true })
-      //   },
-      // })
-      // .catch((err) => {
-      //   if (err.title == null) {
-      //     err.title = 'Error launching browser'
-      //   }
-
-      //   return sendErr(err)
-      // })
       return
 
     case 'open:project':
-      // debug('open:project')
-
-      // const onSpecChanged = (spec) => {
-      //   return bus.emit('spec:changed', spec)
-      // }
-
-      // const onFocusTests = function () {
-      //   if (_.isFunction(options.onFocusTests)) {
-      //     options.onFocusTests()
-      //   }
-
-      //   return bus.emit('focus:tests')
-      // }
-
-      // const onError = (err) => {
-      //   return bus.emit('project:error', errors.cloneErr(err, { html: true }))
-      // }
-
-      // const onWarning = function (warning) {
-      //   warning.message = stripAnsi(warning.message)
-
-      //   return bus.emit('project:warning', errors.cloneErr(warning, { html: true }))
-      // }
-
-      // return browsers.getAllBrowsersWith(options.browser)
-      // .then((browsers = []) => {
-      //   debug('setting found %s on the config', pluralize('browser', browsers.length, true))
-      //   options.config = _.assign(options.config, { browsers })
-      // }).then(() => {
-      //   chromePolicyCheck.run((err) => {
-      //     return options.config.browsers.forEach((browser) => {
-      //       if (browser.family === 'chromium') {
-      //         browser.warning = errors.getMsgByType('BAD_POLICY_WARNING_TOOLTIP')
-      //       }
-      //     })
-      //   })
-
-      //   return openProject.create(arg, options, {
-      //     onFocusTests,
-      //     onSpecChanged,
-      //     onError,
-      //     onWarning,
-      //   })
-      // }).call('getConfig')
-      // .then((config) => {
-      //   if (config.configFile && path.isAbsolute(config.configFile)) {
-      //     config.configFile = path.relative(arg, config.configFile)
-      //   }
-
-      //   // those two values make no sense to display in
-      //   // the GUI
-      //   if (config.resolved) {
-      //     config.resolved.configFile = undefined
-      //     config.resolved.testingType = undefined
-      //   }
-
-      //   return config
-      // })
-      // .then(send)
-      // .catch(sendErr)
       return
 
     case 'has:opened:cypress':
-      // return savedState.create()
-      // .then(async (state) => {
-      //   const currentState = await state.get()
-
-      //   // we check if there is any state at all so users existing before
-      //   // we added firstOpenedCypress are not marked as new
-      //   const hasOpenedCypress = !!Object.keys(currentState).length
-
-      //   if (!currentState.firstOpenedCypress) {
-      //     await state.set('firstOpenedCypress', Date.now())
-      //   }
-
-      //   return hasOpenedCypress
-      // })
-      // .then(send)
       return
 
     case 'ping:baseUrl':
-      // NOTE: Keeping this code around to ensure we keep this for v10
-      // const baseUrl = arg
-
-      // return ensureUrl.isListening(baseUrl)
-      // .then(send)
-      // .catch((err) => {
-      //   const warning = errors.get('CANNOT_CONNECT_BASE_URL_WARNING', baseUrl)
-
-      //   return sendErr(warning)
-      // })
       return
-
-      // TODO: setClipboardText mutation
-      // case 'set:clipboard:text':
-      //   clipboard.writeText(arg)
-
-      //   return sendNull()
-
+      
     default:
       throw new Error(`No ipc event registered for: '${type}'`)
   }


### PR DESCRIPTION
- Belongs to https://github.com/cypress-io/cypress/issues/21753

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/21753

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
