### PR TITLE
chore: update Cypress package description

### DIFF
--- a/cli/__snapshots__/build_spec.js
+++ b/cli/__snapshots__/build_spec.js
@@ -3,7 +3,7 @@ exports['package.json build outputs expected properties 1'] = {
   "engines": "test engines",
   "version": "x.y.z",
   "buildInfo": "replaced by normalizePackageJson",
-  "description": "Cypress.io end to end testing tool",
+  "description": "Cypress is a next generation front end testing tool built for the modern web",
   "homepage": "https://github.com/cypress-io/cypress",
   "license": "MIT",
   "bugs": {

--- a/cli/__snapshots__/build_spec.js
+++ b/cli/__snapshots__/build_spec.js
@@ -21,6 +21,7 @@ exports['package.json build outputs expected properties 1'] = {
     "e2e",
     "end-to-end",
     "integration",
+    "component",
     "mocks",
     "runner",
     "spies",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cypress",
   "version": "10.10.0",
-  "description": "Cypress.io end to end testing tool",
+  "description": "Cypress is a next generation front end testing tool built for the modern web",
   "private": true,
   "scripts": {
     "binary-build": "node ./scripts/binary.js build",

--- a/package.json
+++ b/package.json
@@ -238,6 +238,7 @@
     "e2e",
     "end-to-end",
     "integration",
+    "component",
     "mocks",
     "runner",
     "spies",


### PR DESCRIPTION
The package description hasn't been updated in a while, and with Component Testing becoming GA soon, I figured we should better describe Cypress as a whole which is no longer just e2e testing.

This description is taken from our [docs landing page](https://docs.cypress.io/guides/overview/why-cypress#In-a-nutshell)