### PR TITLE
chore: try bumping timeout for Angular webpack-dev-server tests

### DIFF
--- a/npm/webpack-dev-server/cypress/e2e/angular.cy.ts
+++ b/npm/webpack-dev-server/cypress/e2e/angular.cy.ts
@@ -22,7 +22,7 @@ for (const project of WEBPACK_REACT) {
     it('should mount a passing test', () => {
       cy.visitApp()
       cy.contains('app.component.cy.ts').click()
-      cy.waitForSpecToFinish({ passCount: 1 })
+      cy.waitForSpecToFinish({ passCount: 1 }, 60000)
 
       cy.get('li.command').first().within(() => {
         cy.get('.command-method').should('contain', 'mount')
@@ -33,7 +33,7 @@ for (const project of WEBPACK_REACT) {
     it('should live-reload on src changes', () => {
       cy.visitApp()
       cy.contains('app.component.cy.ts').click()
-      cy.waitForSpecToFinish({ passCount: 1 })
+      cy.waitForSpecToFinish({ passCount: 1 }, 60000)
 
       cy.withCtx(async (ctx) => {
         await ctx.actions.file.writeFileInProject(
@@ -42,7 +42,7 @@ for (const project of WEBPACK_REACT) {
         )
       })
 
-      cy.waitForSpecToFinish({ failCount: 1 })
+      cy.waitForSpecToFinish({ failCount: 1 }, 60000)
 
       cy.withCtx(async (ctx) => {
         await ctx.actions.file.writeFileInProject(
@@ -51,14 +51,14 @@ for (const project of WEBPACK_REACT) {
         )
       })
 
-      cy.waitForSpecToFinish({ passCount: 1 })
+      cy.waitForSpecToFinish({ passCount: 1 }, 60000)
     })
 
     it('should show compilation errors on src changes', () => {
       cy.visitApp()
 
       cy.contains('app.component.cy.ts').click()
-      cy.waitForSpecToFinish({ passCount: 1 })
+      cy.waitForSpecToFinish({ passCount: 1 }, 60000)
 
       // Create compilation error
       cy.withCtx(async (ctx) => {
@@ -71,7 +71,7 @@ for (const project of WEBPACK_REACT) {
       })
 
       // The test should fail and the stack trace should appear in the command log
-      cy.waitForSpecToFinish({ failCount: 1 })
+      cy.waitForSpecToFinish({ failCount: 1 }, 60000)
       cy.contains('The following error originated from your test code, not from Cypress.').should('exist')
       cy.get('.test-err-code-frame').should('be.visible')
     })
@@ -88,7 +88,7 @@ for (const project of WEBPACK_REACT) {
       })
 
       cy.contains('new.component.cy.ts').click()
-      cy.waitForSpecToFinish({ passCount: 1 })
+      cy.waitForSpecToFinish({ passCount: 1 }, 60000)
     })
   })
 }

--- a/npm/webpack-dev-server/cypress/support/commands.ts
+++ b/npm/webpack-dev-server/cypress/support/commands.ts
@@ -13,7 +13,7 @@ declare global {
        * 3. Waits (with a timeout of 30s) for the Rerun all tests button to be present. This ensures all tests have completed
        *
        */
-      waitForSpecToFinish(expectedResults?: ExpectedResults): void
+      waitForSpecToFinish(expectedResults?: ExpectedResults, timeout?: number): void
     }
   }
 }

--- a/packages/app/cypress/e2e/support/execute-spec.ts
+++ b/packages/app/cypress/e2e/support/execute-spec.ts
@@ -18,7 +18,7 @@ declare global {
        * 3. Waits (with a timeout of 30s) for the Rerun all tests button to be present. This ensures all tests have completed
        *
        */
-      waitForSpecToFinish(expectedResults?: ExpectedResults): void
+      waitForSpecToFinish(expectedResults?: ExpectedResults, timeout?: number): void
     }
   }
 }
@@ -26,16 +26,16 @@ declare global {
 // Here we export the function with no intention to import it
 // This only tells the typescript type checker that this definitely is a module
 // This way, we are allowed to use the global namespace declaration
-export const waitForSpecToFinish = (expectedResults) => {
+export const waitForSpecToFinish = (expectedResults, timeout?: number) => {
   // First ensure the test is loaded
   cy.get('.passed > .num').should('contain', '--')
   cy.get('.failed > .num').should('contain', '--')
 
   // Then ensure the tests are running
-  cy.contains('Your tests are loading...', { timeout: 20000 }).should('not.exist')
+  cy.contains('Your tests are loading...', { timeout: timeout || 20000 }).should('not.exist')
 
   // Then ensure the tests have finished
-  cy.get('[aria-label="Rerun all tests"]', { timeout: 30000 })
+  cy.get('[aria-label="Rerun all tests"]', { timeout: timeout || 30000 })
 
   if (expectedResults) {
     shouldHaveTestResults(expectedResults)


### PR DESCRIPTION
These Angular test projects take forever to compile, so these tests frequently fail timing out on the tests loading screen. I bumped the timeout to 60 seconds for each project. This should immediately help, but in the future we should figure out ways to slim down our Angular system test projects so that they don't take as long to compile.