### PR TITLE
chore: remove Cookies.defaults/preserveOnce

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -493,16 +493,6 @@ declare namespace Cypress {
      */
     Cookies: {
       debug(enabled: boolean, options?: Partial<DebugOptions>): void
-      /**
-       * @deprecated Use `cy.session()` instead.
-       * @see https://on.cypress.io/session
-       */
-      preserveOnce(...names: string[]): void
-      /**
-       * @deprecated Use `cy.session()` instead.
-       * @see https://on.cypress.io/session
-       */
-      defaults(options: Partial<CookieDefaults>): CookieDefaults
     }
 
     /**
@@ -2393,10 +2383,6 @@ declare namespace Cypress {
   }
 
   type Agent<T extends sinon.SinonSpy> = SinonSpyAgent<T> & T
-
-  interface CookieDefaults {
-    preserve: string | string[] | RegExp | ((cookie: Cookie) => boolean)
-  }
 
   interface Failable {
     /**

--- a/packages/driver/cross-origin-testing.md
+++ b/packages/driver/cross-origin-testing.md
@@ -152,4 +152,3 @@ All deprecated APIs are not supported in the **cy.origin()** callback and we do 
 - **cy.route()**: Superseded by **cy.intercept()**
 - **cy.server()**: Superseded by **cy.intercept()**
 - **Cypress.Server.defaults()**: Superseded by **cy.intercept()**
-- **Cypress.Cookies.preserveOnce()**: Superseded by sessions

--- a/packages/driver/cypress/e2e/commands/cookies.cy.js
+++ b/packages/driver/cypress/e2e/commands/cookies.cy.js
@@ -1221,4 +1221,30 @@ describe('src/cy/commands/cookies', () => {
       })
     })
   })
+
+  context('Cypress.Cookies.defaults', () => {
+    it('throws error on use of Cookies.defaults()', (done) => {
+      cy.on('fail', (err) => {
+        expect(err.message).to.equal('`Cypress.Cookies.defaults()` was removed in Cypress version 11.0.0. Please update to use `cy.session()` instead.')
+        expect(err.docsUrl).to.equal('https://on.cypress.io/session')
+
+        done()
+      })
+
+      Cypress.Cookies.defaults({})
+    })
+  })
+
+  context('Cypress.Cookies.preserveOnce', () => {
+    it('throws error on use of Cookies.preserveOnce', () => {
+      // cy.on('fail', (err) => {
+      //   expect(err.message).to.equal('`Cypress.Cookies.preserveOnce()` was removed in Cypress version 11.0.0. Please update to use `cy.session()` instead.')
+      //   expect(err.docsUrl).to.equal('https://on.cypress.io/session')
+
+      //   done()
+      // })
+
+      Cypress.Cookies.preserveOnce({})
+    })
+  })
 })

--- a/packages/driver/cypress/e2e/commands/cookies.cy.js
+++ b/packages/driver/cypress/e2e/commands/cookies.cy.js
@@ -955,35 +955,7 @@ describe('src/cy/commands/cookies', () => {
       })
     })
 
-    it('calls \'clear:cookies\' only with clearableCookies', () => {
-      Cypress.automation
-      .withArgs('get:cookies')
-      .resolves([
-        { name: 'foo' },
-        { name: 'bar' },
-      ])
-      .withArgs('clear:cookies', [
-        { name: 'foo', domain: 'localhost' },
-      ])
-      .resolves({
-        name: 'foo',
-      })
-
-      cy.stub(Cypress.Cookies, 'getClearableCookies')
-      .withArgs([{ name: 'foo' }, { name: 'bar' }])
-      .returns([{ name: 'foo' }])
-
-      cy.clearCookies().should('be.null').then(() => {
-        expect(Cypress.automation).to.be.calledWith(
-          'clear:cookies',
-          [{ name: 'foo', domain: 'localhost' }],
-        )
-      })
-    })
-
     it('calls \'clear:cookies\' with all cookies', () => {
-      Cypress.Cookies.preserveOnce('bar', 'baz')
-
       Cypress.automation
       .withArgs('get:cookies')
       .resolves([
@@ -991,12 +963,6 @@ describe('src/cy/commands/cookies', () => {
         { name: 'bar' },
         { name: 'baz' },
       ])
-      .withArgs('clear:cookies', [
-        { name: 'foo', domain: 'localhost' },
-      ])
-      .resolves({
-        name: 'foo',
-      })
       .withArgs('clear:cookies', [
         { name: 'foo', domain: 'localhost' },
         { name: 'bar', domain: 'localhost' },
@@ -1008,11 +974,6 @@ describe('src/cy/commands/cookies', () => {
 
       cy
       .clearCookies().should('be.null').then(() => {
-        expect(Cypress.automation).to.be.calledWith(
-          'clear:cookies',
-          [{ name: 'foo', domain: 'localhost' }],
-        )
-      }).clearCookies().should('be.null').then(() => {
         expect(Cypress.automation).to.be.calledWith(
           'clear:cookies', [
             { name: 'foo', domain: 'localhost' },
@@ -1258,36 +1219,6 @@ describe('src/cy/commands/cookies', () => {
           expect(c['Note']).to.eq('No cookies were found or removed.')
         })
       })
-    })
-  })
-
-  context('Cypress.Cookies.defaults', () => {
-    it('throws error on use of renamed whitelist option', (done) => {
-      cy.on('fail', (err) => {
-        expect(err.message).to.include('`Cypress.Cookies.defaults` `whitelist` option has been renamed to `preserve`. Please rename `whitelist` to `preserve`.')
-
-        done()
-      })
-
-      Cypress.Cookies.defaults({
-        whitelist: 'session_id',
-      })
-    })
-
-    it('logs deprecation warning', () => {
-      cy.stub(Cypress.utils, 'warning')
-
-      Cypress.Cookies.defaults({})
-      expect(Cypress.utils.warning).to.be.calledWith('`Cypress.Cookies.defaults()` has been deprecated and will be removed in a future release. Consider using `cy.session()` instead.\n\nhttps://on.cypress.io/session')
-    })
-  })
-
-  context('Cypress.Cookies.preserveOnce', () => {
-    it('logs deprecation warning', () => {
-      cy.stub(Cypress.utils, 'warning')
-
-      Cypress.Cookies.preserveOnce({})
-      expect(Cypress.utils.warning).to.be.calledWith('`Cypress.Cookies.preserveOnce()` has been deprecated and will be removed in a future release. Consider using `cy.session()` instead.\n\nhttps://on.cypress.io/session')
     })
   })
 })

--- a/packages/driver/cypress/e2e/e2e/origin/cypress_api.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/cypress_api.cy.ts
@@ -216,18 +216,6 @@ describe('cy.origin Cypress API', () => {
       })
     })
 
-    it('throws an error when a user attempts to configure Cypress.Cookies.preserveOnce() inside of cy.origin', (done) => {
-      cy.on('fail', (err) => {
-        expect(err.message).to.equal('`Cypress.Cookies.preserveOnce` use is not supported in the `cy.origin()` callback. Consider using `cy.session()` (outside of the callback) instead.')
-        expect(err.docsUrl).to.equal('https://on.cypress.io/session')
-        done()
-      })
-
-      cy.origin('http://foobar.com:3500', () => {
-        Cypress.Cookies.preserveOnce('')
-      })
-    })
-
     it('throws an error when a user attempts to call Cypress.session.clearAllSavedSessions() inside of cy.origin', (done) => {
       cy.on('fail', (err) => {
         expect(err.message).to.equal('`Cypress.session.*` methods are not supported in the `cy.switchToDomain()` callback. Consider using them outside of the callback instead.')

--- a/packages/driver/src/cross-origin/unsupported_apis.ts
+++ b/packages/driver/src/cross-origin/unsupported_apis.ts
@@ -14,9 +14,6 @@ export const handleUnsupportedAPIs = (Cypress: Cypress.Cypress, cy: $Cy) => {
     set: () => $errUtils.throwErrByPath('origin.unsupported.Server'),
   })
 
-  // @ts-ignore
-  Cypress.Cookies.preserveOnce = () => $errUtils.throwErrByPath('origin.unsupported.Cookies_preserveOnce')
-
   // Nested `origin` is not currently supported, but will be in the future
   // @ts-ignore
   cy.origin = () => $errUtils.throwErrByPath('origin.unsupported.origin')

--- a/packages/driver/src/cy/commands/cookies.ts
+++ b/packages/driver/src/cy/commands/cookies.ts
@@ -141,11 +141,7 @@ export default function (Commands, Cypress, cy, state, config) {
         return resp
       }
 
-      // iterate over all of these and ensure none are allowed
-      // or preserved
-      const cookies = Cypress.Cookies.getClearableCookies(resp)
-
-      return automateCookies('clear:cookies', cookies, log, timeout)
+      return automateCookies('clear:cookies', resp, log, timeout)
     })
     .then(pickCookieProps)
   }

--- a/packages/driver/src/cypress/cookies.ts
+++ b/packages/driver/src/cypress/cookies.ts
@@ -2,58 +2,12 @@ import _ from 'lodash'
 import Cookies from 'js-cookie'
 import { CookieJar, toughCookieToAutomationCookie } from '@packages/server/lib/util/cookies'
 
-import $errUtils from './error_utils'
-
 let isDebugging = false
 let isDebuggingVerbose = false
-
-const preserved = {}
-
-const defaults: any = {
-  preserve: null,
-}
-
-const warnOnWhitelistRenamed = (obj, type) => {
-  if (obj.whitelist) {
-    $errUtils.throwErrByPath('cookies.whitelist_renamed', { args: { type } })
-  }
-}
 
 export const $Cookies = (namespace, domain) => {
   const isNamespaced = (name) => {
     return _.startsWith(name, namespace)
-  }
-
-  const isAllowed = (cookie) => {
-    const w = defaults.preserve
-
-    if (w) {
-      if (_.isString(w)) {
-        return cookie.name === w
-      }
-
-      if (_.isArray(w)) {
-        return w.includes(cookie.name)
-      }
-
-      if (_.isFunction(w)) {
-        return w(cookie)
-      }
-
-      if (_.isRegExp(w)) {
-        return w.test(cookie.name)
-      }
-
-      return false
-    }
-  }
-
-  const removePreserved = (name) => {
-    if (preserved[name]) {
-      return delete preserved[name]
-    }
-
-    return false
   }
 
   const API = {
@@ -83,15 +37,8 @@ export const $Cookies = (namespace, domain) => {
       return console[m].apply(console, args)
     },
 
-    getClearableCookies (cookies: any[] = []) {
-      return _.filter(cookies, (cookie) => {
-        return !isAllowed(cookie) && !removePreserved(cookie.name)
-      })
-    },
-
     _set (name, value, options = {}) {
-      // dont set anything if we've been
-      // told to unload
+      // don't set anything if we've been told to unload
       if (this.getCy('unload') === 'true') {
         return
       }
@@ -119,14 +66,6 @@ export const $Cookies = (namespace, domain) => {
       return this._get(`${namespace}.${name}`)
     },
 
-    preserveOnce (...keys) {
-      $errUtils.warnByPath('cookies.deprecated', { args: { cmd: 'Cypress.Cookies.preserveOnce' } })
-
-      return _.each(keys, (key) => {
-        return preserved[key] = true
-      })
-    },
-
     clearCypressCookies () {
       return _.each(Cookies.get(), (value, key) => {
         if (isNamespaced(key)) {
@@ -140,14 +79,6 @@ export const $Cookies = (namespace, domain) => {
 
     setInitial () {
       return this.setCy('initial', true)
-    },
-
-    defaults (obj = {}) {
-      $errUtils.warnByPath('cookies.deprecated', { args: { cmd: 'Cypress.Cookies.defaults' } })
-      warnOnWhitelistRenamed(obj, 'Cypress.Cookies.defaults')
-
-      // merge obj into defaults
-      return _.extend(defaults, obj)
     },
 
     parse (cookieString: string) {

--- a/packages/driver/src/cypress/cookies.ts
+++ b/packages/driver/src/cypress/cookies.ts
@@ -2,6 +2,8 @@ import _ from 'lodash'
 import Cookies from 'js-cookie'
 import { CookieJar, toughCookieToAutomationCookie } from '@packages/server/lib/util/cookies'
 
+import $errUtils from './error_utils'
+
 let isDebugging = false
 let isDebuggingVerbose = false
 
@@ -66,6 +68,10 @@ export const $Cookies = (namespace, domain) => {
       return this._get(`${namespace}.${name}`)
     },
 
+    preserveOnce () {
+      return $errUtils.throwErrByPath('cookies.removed', { args: { cmd: 'Cypress.Cookies.preserveOnce' } })
+    },
+
     clearCypressCookies () {
       return _.each(Cookies.get(), (value, key) => {
         if (isNamespaced(key)) {
@@ -79,6 +85,10 @@ export const $Cookies = (namespace, domain) => {
 
     setInitial () {
       return this.setCy('initial', true)
+    },
+
+    defaults () {
+      return $errUtils.throwErrByPath('cookies.removed', { args: { cmd: 'Cypress.Cookies.defaults' } })
     },
 
     parse (cookieString: string) {

--- a/packages/driver/src/cypress/error_messages.ts
+++ b/packages/driver/src/cypress/error_messages.ts
@@ -315,11 +315,6 @@ export default {
         docsUrl: `https://on.cypress.io/${_.toLower(obj.cmd)}`,
       }
     },
-    whitelist_renamed (obj) {
-      return {
-        message: `\`${obj.type}\` \`whitelist\` option has been renamed to \`preserve\`. Please rename \`whitelist\` to \`preserve\`.`,
-      }
-    },
   },
 
   dom: {
@@ -1206,10 +1201,6 @@ export default {
       Server: {
         message: `\`Cypress.Server.*\` has been deprecated and its use is not supported in the ${cmd('origin')} callback. Consider using ${cmd('intercept')} (outside of the callback) instead.`,
         docsUrl: 'https://on.cypress.io/intercept',
-      },
-      Cookies_preserveOnce: {
-        message: `\`Cypress.Cookies.preserveOnce\` use is not supported in the ${cmd('origin')} callback. Consider using ${cmd('session')} (outside of the callback) instead.`,
-        docsUrl: 'https://on.cypress.io/session',
       },
       origin: {
         message: `${cmd('origin')} use is not currently supported in the ${cmd('origin')} callback, but is planned for a future release. Please 👍 the following issue and leave a comment with your use-case:`,

--- a/packages/driver/src/cypress/error_messages.ts
+++ b/packages/driver/src/cypress/error_messages.ts
@@ -297,9 +297,9 @@ export default {
         docsUrl: `https://on.cypress.io/${_.toLower(obj.cmd)}`,
       }
     },
-    deprecated (obj) {
+    removed (obj) {
       return {
-        message: `${cmd(obj.cmd)} has been deprecated and will be removed in a future release. Consider using ${cmd('session')} instead.`,
+        message: `${cmd(obj.cmd)} was removed in Cypress version 11.0.0. Please update to use ${cmd('session')} instead.`,
         docsUrl: 'https://on.cypress.io/session',
       }
     },

--- a/system-tests/__snapshots__/cookies_spec.ts.js
+++ b/system-tests/__snapshots__/cookies_spec.ts.js
@@ -18,60 +18,54 @@ exports['e2e cookies with baseurl'] = `
 
 
   cookies
-    with preserve
-      ✓ can get all cookies
-      ✓ resets cookies between tests correctly
-      ✓ should be only two left now
-      ✓ handles undefined cookies
-    without preserve
-      ✓ sends set cookies to path
-      ✓ handles expired cookies secure
-      ✓ issue: #224 sets expired cookies between redirects
-      ✓ issue: #1321 failing to set or parse cookie
-      ✓ issue: #2724 does not fail on invalid cookies
-      ✓ can set and clear cookie
-      in a cy.visit
-        ✓ can successfully send cookies as a Cookie header
-        ✓ ignores invalid set-cookie headers that contain control chars
-        with Domain = superdomain
-          ✓ is set properly with no redirects
-          ✓ is set properly with redirects
-        with SameSite
-          ✓ None is set and sent with subsequent requests
-          ✓ Strict is set and sent with subsequent requests
-          ✓ Lax is set and sent with subsequent requests
-        when redirected to a HTTP URL
-          ✓ can set cookies on lots of redirects, ending with different domain
-          ✓ can set cookies on lots of redirects, ending with same domain
-        when redirected to a HTTPS URL
-          ✓ can set cookies on lots of redirects, ending with different domain
-          ✓ can set cookies on lots of redirects, ending with same domain
-      in a cy.request
-        ✓ can successfully send cookies as a Cookie header
-        ✓ ignores invalid set-cookie headers that contain control chars
-        with Domain = superdomain
-          ✓ is set properly with no redirects
-          ✓ is set properly with redirects
-        with SameSite
-          ✓ None is set and sent with subsequent requests
-          ✓ Strict is set and sent with subsequent requests
-          ✓ Lax is set and sent with subsequent requests
-        when redirected to a HTTP URL
-          ✓ can set cookies on lots of redirects, ending with different domain
-          ✓ can set cookies on lots of redirects, ending with same domain
-        when redirected to a HTTPS URL
-          ✓ can set cookies on lots of redirects, ending with different domain
-          ✓ can set cookies on lots of redirects, ending with same domain
+    ✓ sends set cookies to path
+    ✓ handles expired cookies secure
+    ✓ issue: #224 sets expired cookies between redirects
+    ✓ issue: #1321 failing to set or parse cookie
+    ✓ issue: #2724 does not fail on invalid cookies
+    ✓ can set and clear cookie
+    in a cy.visit
+      ✓ can successfully send cookies as a Cookie header
+      ✓ ignores invalid set-cookie headers that contain control chars
+      with Domain = superdomain
+        ✓ is set properly with no redirects
+        ✓ is set properly with redirects
+      with SameSite
+        ✓ None is set and sent with subsequent requests
+        ✓ Strict is set and sent with subsequent requests
+        ✓ Lax is set and sent with subsequent requests
+      when redirected to a HTTP URL
+        ✓ can set cookies on lots of redirects, ending with different domain
+        ✓ can set cookies on lots of redirects, ending with same domain
+      when redirected to a HTTPS URL
+        ✓ can set cookies on lots of redirects, ending with different domain
+        ✓ can set cookies on lots of redirects, ending with same domain
+    in a cy.request
+      ✓ can successfully send cookies as a Cookie header
+      ✓ ignores invalid set-cookie headers that contain control chars
+      with Domain = superdomain
+        ✓ is set properly with no redirects
+        ✓ is set properly with redirects
+      with SameSite
+        ✓ None is set and sent with subsequent requests
+        ✓ Strict is set and sent with subsequent requests
+        ✓ Lax is set and sent with subsequent requests
+      when redirected to a HTTP URL
+        ✓ can set cookies on lots of redirects, ending with different domain
+        ✓ can set cookies on lots of redirects, ending with same domain
+      when redirected to a HTTPS URL
+        ✓ can set cookies on lots of redirects, ending with different domain
+        ✓ can set cookies on lots of redirects, ending with same domain
 
 
-  32 passing
+  28 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        32                                                                               │
-  │ Passing:      32                                                                               │
+  │ Tests:        28                                                                               │
+  │ Passing:      28                                                                               │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -95,9 +89,9 @@ exports['e2e cookies with baseurl'] = `
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  cookies_spec_baseurl.cy.js               XX:XX       32       32        -        -        - │
+  │ ✔  cookies_spec_baseurl.cy.js               XX:XX       28       28        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX       32       32        -        -        -  
+    ✔  All specs passed!                        XX:XX       28       28        -        -        -  
 
 
 `
@@ -122,27 +116,21 @@ exports['e2e cookies with no baseurl'] = `
 
 
   cookies
-    with preserve
-      ✓ can get all cookies
-      ✓ resets cookies between tests correctly
-      ✓ should be only two left now
-      ✓ handles undefined cookies
-    without preserve
-      ✓ sends cookies to localhost:2121
-      ✓ handles expired cookies secure
-      ✓ issue: #224 sets expired cookies between redirects
-      ✓ issue: #1321 failing to set or parse cookie
-      ✓ issue: #2724 does not fail on invalid cookies
+    ✓ sends cookies to url
+    ✓ handles expired cookies secure
+    ✓ issue: #224 sets expired cookies between redirects
+    ✓ issue: #1321 failing to set or parse cookie
+    ✓ issue: #2724 does not fail on invalid cookies
 
 
-  9 passing
+  5 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        9                                                                                │
-  │ Passing:      9                                                                                │
+  │ Tests:        5                                                                                │
+  │ Passing:      5                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -167,9 +155,9 @@ exports['e2e cookies with no baseurl'] = `
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  cookies_spec_no_baseurl.cy.js            XX:XX        9        9        -        -        - │
+  │ ✔  cookies_spec_no_baseurl.cy.js            XX:XX        5        5        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        9        9        -        -        -  
+    ✔  All specs passed!                        XX:XX        5        5        -        -        -  
 
 
 `

--- a/system-tests/projects/cookies/cypress/e2e/app.cy.js
+++ b/system-tests/projects/cookies/cypress/e2e/app.cy.js
@@ -1,7 +1,3 @@
-Cypress.Cookies.defaults({
-  preserve: 'foo1',
-})
-
 describe('Cookies', () => {
   beforeEach(() => {
     cy.wrap({ foo: 'bar' })
@@ -61,24 +57,6 @@ describe('Cookies', () => {
     cy.document()
     .its('cookie')
     .should('be.empty')
-  })
-
-  it('resets cookies between tests correctly', () => {
-    beforeEach(() => {
-      Cypress.Cookies.preserveOnce('foo2')
-    })
-
-    for (let i = 1; i <= 100; i++) {
-      (((i) => {
-        cy.setCookie(`foo${i}`, `${i}`)
-      }))(i)
-    }
-
-    cy.getCookies().should('have.length', 100)
-  })
-
-  it('should be zero now', () => {
-    cy.getCookies().should('have.length', 2)
   })
 
   it('sends cookies to localhost:2121', () => {

--- a/system-tests/projects/e2e/cypress/e2e/cookies_spec_baseurl.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/cookies_spec_baseurl.cy.js
@@ -41,330 +41,244 @@ describe('cookies', () => {
     cy.wrap({ foo: 'bar' })
   })
 
-  context('with preserve', () => {
-    before(() => {
-      Cypress.Cookies.defaults({
-        preserve: 'foo1',
-      })
-    })
-
-    it('can get all cookies', () => {
-      let expectedCookieKeys = ['domain', 'name', 'value', 'path', 'secure', 'httpOnly', 'expiry']
-
-      if (defaultSameSite) {
-        // samesite will only be present if it is defined
-        expectedCookieKeys.push('sameSite')
-      }
-
-      const assertFirstCookie = (c) => {
-        expect(c.domain).to.eq(setCookieDomain)
-        expect(c.httpOnly).to.eq(false)
-        expect(c.name).to.eq('foo')
-        expect(c.value).to.eq('bar')
-        expect(c.path).to.eq('/')
-        expect(c.secure).to.eq(false)
-        expect(c.expiry).to.be.a('number')
-        expect(c.sameSite).to.eq(defaultSameSite)
-        expect(c).to.have.keys(expectedCookieKeys)
-      }
-
-      cy.clearCookie('foo1')
-      cy.setCookie('foo', 'bar').then(assertFirstCookie)
-      cy.getCookies()
-      .should('have.length', 1)
-      .its(0)
-      .then(assertFirstCookie)
-
-      cy.clearCookies()
-      .should('be.null')
-
-      cy.setCookie('wtf', 'bob', { httpOnly: true, path: '/foo', secure: true })
-      cy.getCookie('wtf').then((c) => {
-        expect(c.domain).to.eq(setCookieDomain)
-        expect(c.httpOnly).to.eq(true)
-        expect(c.name).to.eq('wtf')
-        expect(c.value).to.eq('bob')
-        expect(c.path).to.eq('/foo')
-        expect(c.secure).to.eq(true)
-        expect(c.expiry).to.be.a('number')
-        expect(c.sameSite).to.eq(defaultSameSite)
-        expect(c).to.have.keys(expectedCookieKeys)
-      })
-
-      cy.clearCookie('wtf').should('be.null')
-
-      cy.getCookie('doesNotExist').should('be.null')
-
-      cy.document()
-      .its('cookie')
-      .should('be.empty')
-    })
-
-    it('resets cookies between tests correctly', () => {
-      Cypress.Cookies.preserveOnce('foo2')
-
-      Cypress._.times(100, (i) => {
-        cy.setCookie(`foo${i}`, `${i}`)
-      })
-
-      cy.getCookies().should('have.length', 100)
-    })
-
-    it('should be only two left now', () => {
-      cy.getCookies().should('have.length', 2)
-    })
-
-    it('handles undefined cookies', () => {
-      cy.visit('/cookieWithNoName')
-    })
+  it('sends set cookies to path', () => {
+    cy.clearCookies()
+    cy.setCookie('asdf', 'jkl')
+    .request('/requestCookies')
+    .its('body').should('deep.eq', { asdf: 'jkl' })
   })
 
-  context('without preserve', () => {
-    before(() => {
-      Cypress.Cookies.defaults({
-        preserve: [],
-      })
-    })
+  it('handles expired cookies secure', () => {
+    cy.visit('/set')
+    cy.getCookie('shouldExpire').should('exist')
+    cy.visit('/expirationMaxAge')
+    cy.getCookie('shouldExpire').should('not.exist')
+    cy.visit('/set')
+    cy.getCookie('shouldExpire').should('exist')
+    cy.visit('/expirationExpires')
+    cy.getCookie('shouldExpire').should('not.exist')
+  })
 
-    it('sends set cookies to path', () => {
-      cy.clearCookies()
-      cy.setCookie('asdf', 'jkl')
-      .request('/requestCookies')
-      .its('body').should('deep.eq', { asdf: 'jkl' })
-    })
+  it('issue: #224 sets expired cookies between redirects', () => {
+    cy.visit('/set')
+    cy.getCookie('shouldExpire').should('exist')
+    cy.visit('/expirationRedirect')
+    cy.url().should('include', '/logout')
+    cy.getCookie('shouldExpire').should('not.exist')
 
-    it('handles expired cookies secure', () => {
-      cy.visit('/set')
-      cy.getCookie('shouldExpire').should('exist')
-      cy.visit('/expirationMaxAge')
-      cy.getCookie('shouldExpire').should('not.exist')
-      cy.visit('/set')
-      cy.getCookie('shouldExpire').should('exist')
-      cy.visit('/expirationExpires')
-      cy.getCookie('shouldExpire').should('not.exist')
-    })
+    cy.visit('/set')
+    cy.getCookie('shouldExpire').should('exist')
+    cy.request('/expirationRedirect')
+    cy.getCookie('shouldExpire').should('not.exist')
+  })
 
-    it('issue: #224 sets expired cookies between redirects', () => {
-      cy.visit('/set')
-      cy.getCookie('shouldExpire').should('exist')
-      cy.visit('/expirationRedirect')
-      cy.url().should('include', '/logout')
-      cy.getCookie('shouldExpire').should('not.exist')
+  it('issue: #1321 failing to set or parse cookie', () => {
+    // this is happening because the original cookie was set
+    // with a secure flag, and then expired without the secure flag.
+    cy.visit(`${httpsUrl}/setOneHourFromNowAndSecure`)
+    cy.getCookies().should('have.length', 1)
 
-      cy.visit('/set')
-      cy.getCookie('shouldExpire').should('exist')
-      cy.request('/expirationRedirect')
-      cy.getCookie('shouldExpire').should('not.exist')
-    })
+    // secure cookies should have been attached
+    cy.request(`${httpsUrl}/requestCookies`)
+    .its('body').should('deep.eq', { shouldExpire: 'oneHour' })
 
-    it('issue: #1321 failing to set or parse cookie', () => {
-      // this is happening because the original cookie was set
-      // with a secure flag, and then expired without the secure flag.
-      cy.visit(`${httpsUrl}/setOneHourFromNowAndSecure`)
-      cy.getCookies().should('have.length', 1)
+    // secure cookies should not have been attached
+    cy.request(`${httpUrl}/requestCookies`)
+    .its('body').should('deep.eq', {})
 
-      // secure cookies should have been attached
-      cy.request(`${httpsUrl}/requestCookies`)
-      .its('body').should('deep.eq', { shouldExpire: 'oneHour' })
+    cy.visit(`${httpsUrl}/expirationMaxAge`)
+    cy.getCookies().should('be.empty')
+  })
 
-      // secure cookies should not have been attached
-      cy.request(`${httpUrl}/requestCookies`)
-      .its('body').should('deep.eq', {})
+  it('issue: #2724 does not fail on invalid cookies', () => {
+    cy.request(`${httpsUrl}/invalidCookies`)
+  })
 
-      cy.visit(`${httpsUrl}/expirationMaxAge`)
-      cy.getCookies().should('be.empty')
-    })
+  // https://github.com/cypress-io/cypress/issues/5453
+  it('can set and clear cookie', () => {
+    cy.setCookie('foo', 'bar')
+    cy.clearCookie('foo')
+    cy.getCookie('foo').should('be.null')
+  });
 
-    it('issue: #2724 does not fail on invalid cookies', () => {
-      cy.request(`${httpsUrl}/invalidCookies`)
-    })
-
-    // https://github.com/cypress-io/cypress/issues/5453
-    it('can set and clear cookie', () => {
-      cy.setCookie('foo', 'bar')
-      cy.clearCookie('foo')
-      cy.getCookie('foo').should('be.null')
-    });
-
-    [
-      'visit',
-      'request',
-    ].forEach((cmd) => {
-      context(`in a cy.${cmd}`, () => {
+  [
+    'visit',
+    'request',
+  ].forEach((cmd) => {
+    context(`in a cy.${cmd}`, () => {
       // https://github.com/cypress-io/cypress/issues/5894
-        it('can successfully send cookies as a Cookie header', () => {
-          cy[cmd]({
-            url: `/requestCookies${cmd === 'visit' ? 'Html' : ''}`,
-            headers: {
-              Cookie: 'a=b;b=c;c=s%3APtCc3lNiuqN0AtR9ffgKUnUsDzR5n_4B.qzFDJDvqx8PZNvmOkmcexDs7fRJLOel56Z8Ii6PL%2BFo',
-            },
-            method: cmd === 'visit' ? 'POST' : 'PATCH',
+      it('can successfully send cookies as a Cookie header', () => {
+        cy[cmd]({
+          url: `/requestCookies${cmd === 'visit' ? 'Html' : ''}`,
+          headers: {
+            Cookie: 'a=b;b=c;c=s%3APtCc3lNiuqN0AtR9ffgKUnUsDzR5n_4B.qzFDJDvqx8PZNvmOkmcexDs7fRJLOel56Z8Ii6PL%2BFo',
+          },
+          method: cmd === 'visit' ? 'POST' : 'PATCH',
+        })
+        .then((res) => {
+          if (cmd === 'visit') {
+            return cy.get('body').then((body) => {
+              return JSON.parse(body.text())
+            })
+          }
+
+          return res.body
+        }).then((cookies) => {
+          expect(cookies).to.deep.eq({
+            a: 'b',
+            b: 'c',
+            c: 's:PtCc3lNiuqN0AtR9ffgKUnUsDzR5n_4B.qzFDJDvqx8PZNvmOkmcexDs7fRJLOel56Z8Ii6PL+Fo',
           })
-          .then((res) => {
-            if (cmd === 'visit') {
-              return cy.get('body').then((body) => {
+        })
+      })
+
+      // https://github.com/cypress-io/cypress/issues/6890
+      it('ignores invalid set-cookie headers that contain control chars', () => {
+        cy[cmd]('/invalidControlCharCookie')
+
+        cy.request('/requestCookies')
+        .then((res) => {
+          return res.body
+        }).then((cookies) => {
+          expect(cookies).to.deep.eq({
+            _valid: 'true',
+          })
+        })
+      })
+
+      context('with Domain = superdomain', () => {
+        const requestCookiesUrl = `${Cypress.config('baseUrl')}/requestCookies`
+        const setDomainCookieUrl = `${Cypress.config('baseUrl')}/setDomainCookie?domain=${setCookieDomain}`
+
+        it('is set properly with no redirects', () => {
+          cy[cmd](setDomainCookieUrl)
+
+          cy.getCookies()
+          .then((cookies) => {
+            expect(cookies).to.have.length(1)
+            expect(cookies[0]).to.include({
+              name: 'domaincookie',
+              value: 'foo',
+            })
+          })
+
+          cy.request(requestCookiesUrl).its('body').should('include', { 'domaincookie': 'foo' })
+          cy.request('POST', requestCookiesUrl).its('body').should('include', { 'domaincookie': 'foo' })
+        })
+
+        it('is set properly with redirects', () => {
+          cy[cmd](`${setDomainCookieUrl}&redirect=/requestCookiesHtml`)
+
+          cy.getCookies()
+          .then((cookies) => {
+            expect(cookies).to.have.length(1)
+            expect(cookies[0]).to.include({
+              name: 'domaincookie',
+              value: 'foo',
+            })
+          })
+
+          if (cmd === 'visit') {
+            cy.url().should('include', requestCookiesUrl)
+            cy.contains('domaincookie')
+          }
+
+          cy.request(requestCookiesUrl).its('body').should('include', { 'domaincookie': 'foo' })
+          cy.request('POST', requestCookiesUrl).its('body').should('include', { 'domaincookie': 'foo' })
+        })
+      })
+
+      context('with SameSite', () => {
+        [
+          { header: 'None', sameSite: 'no_restriction' },
+          { header: 'Strict', sameSite: 'strict' },
+          { header: 'Lax', sameSite: 'lax' },
+        ].forEach(({ header, sameSite }) => {
+          it(`${header} is set and sent with subsequent requests`, () => {
+            const name = `ss${header}`
+
+            cy.getCookie(name).should('be.null')
+
+            let sameSiteUrl = `/samesite/${header}`
+            let cookieDumpUrl = '/requestCookies'
+
+            if (header === 'None') {
+              // None should only be sent + set with HTTPS requests
+              cookieDumpUrl = [httpsUrl, cookieDumpUrl].join('')
+              sameSiteUrl = [httpsUrl, sameSiteUrl].join('')
+            }
+
+            cy[cmd](sameSiteUrl)
+
+            cy.getCookie(name).should('include', {
+              name,
+              value: 'someval',
+              sameSite,
+            })
+
+            cy.visit(`${cookieDumpUrl}Html`)
+            .then((res) => {
+              cy.get('body').then((body) => {
                 return JSON.parse(body.text())
               })
-            }
+            }).then((body) => {
+              expect(body).to.have.property(name).and.eq('someval')
+            })
 
-            return res.body
-          }).then((cookies) => {
-            expect(cookies).to.deep.eq({
-              a: 'b',
-              b: 'c',
-              c: 's:PtCc3lNiuqN0AtR9ffgKUnUsDzR5n_4B.qzFDJDvqx8PZNvmOkmcexDs7fRJLOel56Z8Ii6PL+Fo',
+            cy.request(cookieDumpUrl)
+            .then(({ body }) => {
+              expect(body).to.have.property(name).and.eq('someval')
             })
           })
         })
+      });
 
-        // https://github.com/cypress-io/cypress/issues/6890
-        it('ignores invalid set-cookie headers that contain control chars', () => {
-          cy[cmd]('/invalidControlCharCookie')
-
-          cy.request('/requestCookies')
-          .then((res) => {
-            return res.body
-          }).then((cookies) => {
-            expect(cookies).to.deep.eq({
-              _valid: 'true',
-            })
-          })
-        })
-
-        context('with Domain = superdomain', () => {
-          const requestCookiesUrl = `${Cypress.config('baseUrl')}/requestCookies`
-          const setDomainCookieUrl = `${Cypress.config('baseUrl')}/setDomainCookie?domain=${setCookieDomain}`
-
-          it('is set properly with no redirects', () => {
-            cy[cmd](setDomainCookieUrl)
-
-            cy.getCookies()
-            .then((cookies) => {
-              expect(cookies).to.have.length(1)
-              expect(cookies[0]).to.include({
-                name: 'domaincookie',
-                value: 'foo',
-              })
-            })
-
-            cy.request(requestCookiesUrl).its('body').should('include', { 'domaincookie': 'foo' })
-            cy.request('POST', requestCookiesUrl).its('body').should('include', { 'domaincookie': 'foo' })
-          })
-
-          it('is set properly with redirects', () => {
-            cy[cmd](`${setDomainCookieUrl}&redirect=/requestCookiesHtml`)
-
-            cy.getCookies()
-            .then((cookies) => {
-              expect(cookies).to.have.length(1)
-              expect(cookies[0]).to.include({
-                name: 'domaincookie',
-                value: 'foo',
-              })
-            })
-
-            if (cmd === 'visit') {
-              cy.url().should('include', requestCookiesUrl)
-              cy.contains('domaincookie')
-            }
-
-            cy.request(requestCookiesUrl).its('body').should('include', { 'domaincookie': 'foo' })
-            cy.request('POST', requestCookiesUrl).its('body').should('include', { 'domaincookie': 'foo' })
-          })
-        })
-
-        context('with SameSite', () => {
+      [
+        ['HTTP', otherUrl],
+        ['HTTPS', otherHttpsUrl],
+      ].forEach(([protocol, altUrl]) => {
+        context(`when redirected to a ${protocol} URL`, () => {
           [
-            { header: 'None', sameSite: 'no_restriction' },
-            { header: 'Strict', sameSite: 'strict' },
-            { header: 'Lax', sameSite: 'lax' },
-          ].forEach(({ header, sameSite }) => {
-            it(`${header} is set and sent with subsequent requests`, () => {
-              const name = `ss${header}`
+            ['different domain', 7],
+            ['same domain', 8],
+          ].forEach(([title, n]) => {
+            it(`can set cookies on lots of redirects, ending with ${title}`, () => {
+              const altDomain = (new Cypress.Location(altUrl)).getHostName()
 
-              cy.getCookie(name).should('be.null')
+              let expectedGetCookiesArray = []
 
-              let sameSiteUrl = `/samesite/${header}`
-              let cookieDumpUrl = '/requestCookies'
+              _.times(n + 1, (i) => {
+                ['foo', 'bar'].forEach((tag) => {
+                  const expectedCookie = {
+                    'name': `name${tag}${i}`,
+                    'value': `val${tag}${i}`,
+                    'path': '/',
+                    'domain': (i % 2) === (8 - n) ? expectedDomain : altDomain,
+                    'secure': false,
+                    'httpOnly': false,
+                  }
 
-              if (header === 'None') {
-              // None should only be sent + set with HTTPS requests
-                cookieDumpUrl = [httpsUrl, cookieDumpUrl].join('')
-                sameSiteUrl = [httpsUrl, sameSiteUrl].join('')
-              }
+                  if (defaultSameSite) {
+                    expectedCookie.sameSite = defaultSameSite
+                  }
 
-              cy[cmd](sameSiteUrl)
-
-              cy.getCookie(name).should('include', {
-                name,
-                value: 'someval',
-                sameSite,
-              })
-
-              cy.visit(`${cookieDumpUrl}Html`)
-              .then((res) => {
-                cy.get('body').then((body) => {
-                  return JSON.parse(body.text())
+                  expectedGetCookiesArray.push(expectedCookie)
                 })
-              }).then((body) => {
-                expect(body).to.have.property(name).and.eq('someval')
               })
 
-              cy.request(cookieDumpUrl)
-              .then(({ body }) => {
-                expect(body).to.have.property(name).and.eq('someval')
-              })
-            })
-          })
-        });
+              expectedGetCookiesArray = _.reverse(_.sortBy(expectedGetCookiesArray, _.property('name')))
 
-        [
-          ['HTTP', otherUrl],
-          ['HTTPS', otherHttpsUrl],
-        ].forEach(([protocol, altUrl]) => {
-          context(`when redirected to a ${protocol} URL`, () => {
-            [
-              ['different domain', 7],
-              ['same domain', 8],
-            ].forEach(([title, n]) => {
-              it(`can set cookies on lots of redirects, ending with ${title}`, () => {
-                const altDomain = (new Cypress.Location(altUrl)).getHostName()
+              // sanity check
+              cy.clearCookies({ domain: null })
+              cy.getCookies({ domain: null }).should('have.length', 0)
 
-                let expectedGetCookiesArray = []
+              cy[cmd](`/setCascadingCookies?n=${n}&a=${altUrl}&b=${Cypress.env('baseUrl')}`)
 
-                _.times(n + 1, (i) => {
-                  ['foo', 'bar'].forEach((tag) => {
-                    const expectedCookie = {
-                      'name': `name${tag}${i}`,
-                      'value': `val${tag}${i}`,
-                      'path': '/',
-                      'domain': (i % 2) === (8 - n) ? expectedDomain : altDomain,
-                      'secure': false,
-                      'httpOnly': false,
-                    }
-
-                    if (defaultSameSite) {
-                      expectedCookie.sameSite = defaultSameSite
-                    }
-
-                    expectedGetCookiesArray.push(expectedCookie)
-                  })
-                })
-
-                expectedGetCookiesArray = _.reverse(_.sortBy(expectedGetCookiesArray, _.property('name')))
-
-                // sanity check
-                cy.clearCookies({ domain: null })
-                cy.getCookies({ domain: null }).should('have.length', 0)
-
-                cy[cmd](`/setCascadingCookies?n=${n}&a=${altUrl}&b=${Cypress.env('baseUrl')}`)
-
-                cy.getCookies({ domain: null }).then((cookies) => {
+              cy.getCookies({ domain: null }).then((cookies) => {
                 // reverse them so they'll be in the order they were set
-                  cookies = _.reverse(_.sortBy(cookies, _.property('name')))
+                cookies = _.reverse(_.sortBy(cookies, _.property('name')))
 
-                  expect(cookies).to.deep.eq(expectedGetCookiesArray)
-                })
+                expect(cookies).to.deep.eq(expectedGetCookiesArray)
               })
             })
           })

--- a/system-tests/projects/e2e/cypress/e2e/cookies_spec_no_baseurl.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/cookies_spec_no_baseurl.cy.js
@@ -3,151 +3,59 @@ const httpUrl = Cypress.env('httpUrl')
 const httpsUrl = Cypress.env('httpsUrl')
 
 describe('cookies', () => {
-  beforeEach(() => {
-    cy.wrap({ foo: 'bar' })
+  it('sends cookies to url', () => {
+    cy.visit(`${httpUrl}/`)
+    cy.clearCookies()
+    cy.setCookie('asdf', 'jkl')
+    cy.request(`${httpUrl}/requestCookies`)
+    .its('body').should('deep.eq', { asdf: 'jkl' })
   })
 
-  context('with preserve', () => {
-    before(() => {
-      Cypress.Cookies.defaults({
-        preserve: 'foo1',
-      })
-    })
-
-    it('can get all cookies', () => {
-      let expectedKeys = ['domain', 'name', 'value', 'path', 'secure', 'httpOnly', 'expiry']
-
-      if (Cypress.isBrowser('firefox')) {
-        expectedKeys.push('sameSite')
-      }
-
-      cy.clearCookie('foo1')
-      cy.setCookie('foo', 'bar').then((c) => {
-        expect(c.domain).to.eq('localhost')
-        expect(c.httpOnly).to.eq(false)
-        expect(c.name).to.eq('foo')
-        expect(c.value).to.eq('bar')
-        expect(c.path).to.eq('/')
-        expect(c.secure).to.eq(false)
-        expect(c.expiry).to.be.a('number')
-        expect(c).to.have.keys(expectedKeys)
-      })
-
-      cy.getCookies()
-      .should('have.length', 1)
-      .then((cookies) => {
-        const c = cookies[0]
-
-        expect(c.domain).to.eq('localhost')
-        expect(c.httpOnly).to.eq(false)
-        expect(c.name).to.eq('foo')
-        expect(c.value).to.eq('bar')
-        expect(c.path).to.eq('/')
-        expect(c.secure).to.eq(false)
-        expect(c.expiry).to.be.a('number')
-        expect(c).to.have.keys(expectedKeys)
-      })
-
-      cy.clearCookies().should('be.null')
-
-      cy.setCookie('wtf', 'bob', { httpOnly: true, path: '/foo', secure: true })
-      cy.getCookie('wtf').then((c) => {
-        expect(c.domain).to.eq('localhost')
-        expect(c.httpOnly).to.eq(true)
-        expect(c.name).to.eq('wtf')
-        expect(c.value).to.eq('bob')
-        expect(c.path).to.eq('/foo')
-        expect(c.secure).to.eq(true)
-        expect(c.expiry).to.be.a('number')
-        expect(c).to.have.keys(expectedKeys)
-      })
-
-      cy.clearCookie('wtf').should('be.null')
-      cy.getCookie('doesNotExist').should('be.null')
-
-      cy.document()
-      .its('cookie')
-      .should('be.empty')
-    })
-
-    it('resets cookies between tests correctly', () => {
-      Cypress.Cookies.preserveOnce('foo2')
-
-      Cypress._.times(100, (i) => {
-        cy.setCookie(`foo${i}`, `${i}`)
-      })
-
-      cy.getCookies().should('have.length', 100)
-    })
-
-    it('should be only two left now', () => {
-      cy.getCookies().should('have.length', 2)
-    })
-
-    it('handles undefined cookies', () => {
-      cy.visit(`${httpUrl}/cookieWithNoName`)
-    })
+  it('handles expired cookies secure', () => {
+    cy.visit(`${httpUrl}/set`)
+    cy.getCookie('shouldExpire').should('exist')
+    cy.visit(`${httpUrl}/expirationMaxAge`)
+    cy.getCookie('shouldExpire').should('not.exist')
+    cy.visit(`${httpUrl}/set`)
+    cy.getCookie('shouldExpire').should('exist')
+    cy.visit(`${httpUrl}/expirationExpires`)
+    cy.getCookie('shouldExpire').should('not.exist')
   })
 
-  context('without preserve', () => {
-    before(() => {
-      Cypress.Cookies.defaults({
-        preserve: [],
-      })
-    })
+  it('issue: #224 sets expired cookies between redirects', () => {
+    cy.visit(`${httpUrl}/set`)
+    cy.getCookie('shouldExpire').should('exist')
+    cy.visit(`${httpUrl}/expirationRedirect`)
+    cy.url().should('include', '/logout')
+    cy.getCookie('shouldExpire').should('not.exist')
 
-    it('sends cookies to localhost:2121', () => {
-      cy.clearCookies()
-      cy.setCookie('asdf', 'jkl')
-      cy.request(`${httpUrl}/requestCookies`)
-      .its('body').should('deep.eq', { asdf: 'jkl' })
-    })
+    cy.visit(`${httpUrl}/set`)
+    cy.getCookie('shouldExpire').should('exist')
+    cy.request(`${httpUrl}/expirationRedirect`)
+    cy.getCookie('shouldExpire').should('not.exist')
+  })
 
-    it('handles expired cookies secure', () => {
-      cy.visit(`${httpUrl}/set`)
-      cy.getCookie('shouldExpire').should('exist')
-      cy.visit(`${httpUrl}/expirationMaxAge`)
-      cy.getCookie('shouldExpire').should('not.exist')
-      cy.visit(`${httpUrl}/set`)
-      cy.getCookie('shouldExpire').should('exist')
-      cy.visit(`${httpUrl}/expirationExpires`)
-      cy.getCookie('shouldExpire').should('not.exist')
-    })
+  it('issue: #1321 failing to set or parse cookie', () => {
+    // this is happening because the original cookie was set
+    // with a secure flag, and then expired without the secure
+    // flag.
+    cy.visit(`${httpsUrl}/setOneHourFromNowAndSecure`)
+    cy.getCookies().should('have.length', 1)
 
-    it('issue: #224 sets expired cookies between redirects', () => {
-      cy.visit(`${httpUrl}/set`)
-      cy.getCookie('shouldExpire').should('exist')
-      cy.visit(`${httpUrl}/expirationRedirect`)
-      cy.url().should('include', '/logout')
-      cy.getCookie('shouldExpire').should('not.exist')
+    // secure cookies should have been attached
+    cy.request(`${httpsUrl}/requestCookies`)
+    .its('body').should('deep.eq', { shouldExpire: 'oneHour' })
 
-      cy.visit(`${httpUrl}/set`)
-      cy.getCookie('shouldExpire').should('exist')
-      cy.request(`${httpUrl}/expirationRedirect`)
-      cy.getCookie('shouldExpire').should('not.exist')
-    })
+    // secure cookies should not have been attached
+    cy.request(`${httpUrl}/requestCookies`)
+    .its('body').should('deep.eq', {})
 
-    it('issue: #1321 failing to set or parse cookie', () => {
-      // this is happening because the original cookie was set
-      // with a secure flag, and then expired without the secure
-      // flag.
-      cy.visit(`${httpsUrl}/setOneHourFromNowAndSecure`)
-      cy.getCookies().should('have.length', 1)
+    cy.visit(`${httpsUrl}/expirationMaxAge`)
+    cy.getCookies().should('be.empty')
+  })
 
-      // secure cookies should have been attached
-      cy.request(`${httpsUrl}/requestCookies`)
-      .its('body').should('deep.eq', { shouldExpire: 'oneHour' })
-
-      // secure cookies should not have been attached
-      cy.request(`${httpUrl}/requestCookies`)
-      .its('body').should('deep.eq', {})
-
-      cy.visit(`${httpsUrl}/expirationMaxAge`)
-      cy.getCookies().should('be.empty')
-    })
-
-    it('issue: #2724 does not fail on invalid cookies', () => {
-      cy.request(`${httpsUrl}/invalidCookies`)
-    })
+  it('issue: #2724 does not fail on invalid cookies', () => {
+    cy.visit(`${httpsUrl}/`)
+    cy.request(`${httpsUrl}/invalidCookies`)
   })
 })

--- a/system-tests/test/cookies_spec.ts
+++ b/system-tests/test/cookies_spec.ts
@@ -10,6 +10,10 @@ const it = systemTests.it
 const onServer = function (app) {
   app.use(parser())
 
+  app.get('/', (req, res) => {
+    return res.send('<html></html>')
+  })
+
   app.get('/logout', (req, res) => {
     return res.send('<html>logged out</html>')
   })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #21472 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
- `Cookies.defaults` and `Cookies.preserveOnce` have been removed. Please update to use [`cy.session()`](/api/commands/session) to preserve session details between tests. Addresses [#21472](https://github.com/cypress-io/cypress/issues/21472).

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
* Throws an error if Cookies.defaults/preserveOnce is used

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/4779
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
