### PR TITLE
fix: detect chrome browser process and tab crashes to no longer hang in CI

### DIFF
--- a/packages/errors/__snapshot-html__/BROWSER_CRASHED.html
+++ b/packages/errors/__snapshot-html__/BROWSER_CRASHED.html
@@ -34,20 +34,15 @@
     </style>
   
     </head>
-    <body><pre><span style="color:#e05561">We detected that the Chromium Renderer process just crashed.<span style="color:#e6e6e6">
+    <body><pre><span style="color:#e05561">We detected that the <span style="color:#e5e510">Chrome<span style="color:#e05561"> process just crashed with code &#39;<span style="color:#e5e510">code<span style="color:#e05561">&#39; and signal &#39;<span style="color:#e5e510">signal<span style="color:#e05561">&#39;.<span style="color:#e6e6e6">
 <span style="color:#e05561"><span style="color:#e6e6e6">
-<span style="color:#e05561">This is the equivalent to seeing the &#39;sad face&#39; when Chrome dies.<span style="color:#e6e6e6">
+<span style="color:#e05561">We have failed the current test and have relaunched <span style="color:#e5e510">Chrome<span style="color:#e05561">.<span style="color:#e6e6e6">
 <span style="color:#e05561"><span style="color:#e6e6e6">
-<span style="color:#e05561">This can happen for a number of different reasons:<span style="color:#e6e6e6">
+<span style="color:#e05561">This can happen for many different reasons:<span style="color:#e6e6e6">
 <span style="color:#e05561"><span style="color:#e6e6e6">
 <span style="color:#e05561">- You wrote an endless loop and you must fix your own code<span style="color:#e6e6e6">
-<span style="color:#e05561">- You are running Docker (there is an easy fix for this: see link below)<span style="color:#e6e6e6">
 <span style="color:#e05561">- You are running lots of tests on a memory intense application<span style="color:#e6e6e6">
 <span style="color:#e05561">- You are running in a memory starved VM environment<span style="color:#e6e6e6">
 <span style="color:#e05561">- There are problems with your GPU / GPU drivers<span style="color:#e6e6e6">
-<span style="color:#e05561">- There are browser bugs in Chromium<span style="color:#e6e6e6">
-<span style="color:#e05561"><span style="color:#e6e6e6">
-<span style="color:#e05561">You can learn more including how to fix Docker here:<span style="color:#e6e6e6">
-<span style="color:#e05561"><span style="color:#e6e6e6">
-<span style="color:#e05561">https://on.cypress.io/renderer-process-crashed<span style="color:#e6e6e6"></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span>
+<span style="color:#e05561">- There are browser bugs<span style="color:#e6e6e6"></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span>
 </pre></body></html>

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -580,6 +580,20 @@ export const AllCypressErrors = {
 
         https://on.cypress.io/renderer-process-crashed`
   },
+  BROWSER_CRASHED: (browser: string, signal: string) => {
+    return errTemplate`\
+        We detected that the ${fmt.highlight(browser)} process just crashed with signal '${fmt.highlight(signal)}'.
+
+        We have failed the current test and have relaunched ${fmt.highlight(browser)}.
+
+        This can happen for many different reasons:
+
+        - You wrote an endless loop and you must fix your own code
+        - You are running lots of tests on a memory intense application
+        - You are running in a memory starved VM environment
+        - There are problems with your GPU / GPU drivers
+        - There are browser bugs`
+  },
   AUTOMATION_SERVER_DISCONNECTED: () => {
     return errTemplate`The automation client disconnected. Cannot continue running tests.`
   },

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -580,9 +580,9 @@ export const AllCypressErrors = {
 
         https://on.cypress.io/renderer-process-crashed`
   },
-  BROWSER_CRASHED: (browser: string, signal: string) => {
+  BROWSER_CRASHED: (browser: string, code: string | number, signal: string) => {
     return errTemplate`\
-        We detected that the ${fmt.highlight(browser)} process just crashed with signal '${fmt.highlight(signal)}'.
+        We detected that the ${fmt.highlight(browser)} process just crashed with code '${fmt.highlight(code)}' and signal '${fmt.highlight(signal)}'.
 
         We have failed the current test and have relaunched ${fmt.highlight(browser)}.
 

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -570,7 +570,6 @@ export const AllCypressErrors = {
         This can happen for a number of different reasons:
 
         - You wrote an endless loop and you must fix your own code
-        - There is a memory leak in Cypress (unlikely but possible)
         - You are running Docker (there is an easy fix for this: see link below)
         - You are running lots of tests on a memory intense application
         - You are running in a memory starved VM environment

--- a/packages/errors/test/unit/visualSnapshotErrors_spec.ts
+++ b/packages/errors/test/unit/visualSnapshotErrors_spec.ts
@@ -646,6 +646,11 @@ describe('visual error templates', () => {
         default: [],
       }
     },
+    BROWSER_CRASHED: () => {
+      return {
+        default: ['Chrome', 'code', 'signal'],
+      }
+    },
     AUTOMATION_SERVER_DISCONNECTED: () => {
       return {
         default: [],

--- a/packages/server/lib/browsers/electron.ts
+++ b/packages/server/lib/browsers/electron.ts
@@ -146,9 +146,10 @@ export = {
       onCrashed () {
         const err = errors.get('RENDERER_CRASHED')
 
-        errors.log(err)
-
-        if (!options.onError) throw new Error('Missing onError in onCrashed')
+        if (!options.onError) {
+          errors.log(err)
+          throw new Error('Missing onError in onCrashed')
+        }
 
         options.onError(err)
       },
@@ -470,6 +471,11 @@ export = {
       proxyBypassRules: '<-loopback>',
     })
   },
+
+  /**
+   * Clear instance state for the electron instance, this is normally called in on kill or on exit for electron there isn't state to clear.
+   */
+  clearInstanceState () {},
 
   async connectToNewSpec (browser: Browser, options: ElectronOpts, automation: Automation) {
     if (!options.url) throw new Error('Missing url in connectToNewSpec')

--- a/packages/server/lib/browsers/firefox.ts
+++ b/packages/server/lib/browsers/firefox.ts
@@ -371,6 +371,17 @@ export function _createDetachedInstance (browserInstance: BrowserInstance, brows
   return detachedInstance
 }
 
+/**
+* Clear instance state for the chrome instance, this is normally called in on kill or on exit.
+*/
+export function clearInstanceState () {
+  debug('closing remote interface client')
+  if (browserCriClient) {
+    browserCriClient.close().catch()
+    browserCriClient = undefined
+  }
+}
+
 export async function connectToNewSpec (browser: Browser, options: BrowserNewTabOpts, automation: Automation) {
   await firefoxUtil.connectToNewSpec(options, automation, browserCriClient)
 }
@@ -552,13 +563,8 @@ export async function open (browser: Browser, url: string, options: BrowserLaunc
     const originalBrowserKill = browserInstance.kill
 
     browserInstance.kill = (...args) => {
-      debug('closing remote interface client')
-
       // Do nothing on failure here since we're shutting down anyway
-      if (browserCriClient) {
-        browserCriClient.close().catch()
-        browserCriClient = undefined
-      }
+      clearInstanceState()
 
       debug('closing firefox')
 

--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -171,7 +171,7 @@ export = {
       // We want to avoid adding signals in here that may intentionally be caused by a user.
       // For example exiting firefox through either force quitting or quitting via cypress will fire a 'SIGTERM' event which
       // would result in constantly relaunching the browser when the user actively wants to quit.
-      // On windows the crash produces 2147483651 as an exit node. We should add to the list of crashes we handle as we see them.
+      // On windows the crash produces 2147483651 as an exit code. We should add to the list of crashes we handle as we see them.
       // In the future we may consider delegating to the browsers to determine if an exit is a crash since it might be different
       // depending on what browser has crashed.
       if (code === null && ['SIGTRAP', 'SIGABRT'].includes(signal) || code === 2147483651 && signal === null) {

--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import Bluebird from 'bluebird'
 import Debug from 'debug'
 import utils from './utils'
+import * as errors from '../errors'
 import check from 'check-more-types'
 import { exec } from 'child_process'
 import util from 'util'
@@ -155,13 +156,33 @@ export = {
     // TODO: normalizing opening and closing / exiting
     // so that there is a default for each browser but
     // enable the browser to configure the interface
-    instance.once('exit', () => {
+    instance.once('exit', async (code, signal) => {
       ctx.browser.setBrowserStatus('closed')
       // TODO: make this a required property
       if (!options.onBrowserClose) throw new Error('onBrowserClose did not exist in interactive mode')
 
+      const browserDisplayName = instance?.browser?.displayName || 'unknown'
+
       options.onBrowserClose()
+      browserLauncher.clearInstanceState()
       instance = null
+
+      // We are being very narrow on when to restart the browser here. The only case we can reliably test the 'SIGTRAP' signal.
+      // We want to avoid adding signals in here that may intentionally be caused by a user.
+      // For example exiting firefox through either force quitting or quitting via cypress will fire a 'SIGTERM' event which
+      // would result in constantly relaunching the browser went he user actively wants to quit.
+      if (code === null && ['SIGTRAP', 'SIGABRT'].includes(signal)) {
+        const err = errors.get('BROWSER_CRASHED', browserDisplayName, signal)
+
+        if (!options.onError) {
+          errors.log(err)
+          throw new Error('Missing onError in attachListeners')
+        }
+
+        await options.onError(err)
+
+        await options.relaunchBrowser!()
+      }
     })
 
     // TODO: instead of waiting an arbitrary

--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -172,6 +172,8 @@ export = {
       // For example exiting firefox through either force quitting or quitting via cypress will fire a 'SIGTERM' event which
       // would result in constantly relaunching the browser went he user actively wants to quit.
       // On windows the crash produces 2147483651 as an exit node. We should add to the list of crashes we handle as we see them.
+      // In the future we may consider delegating to the browsers to determine if an exit is a crash since it might be different
+      // depending on what browser has crashed.
       if (code === null && ['SIGTRAP', 'SIGABRT'].includes(signal) || code === 2147483651 && signal === null) {
         const err = errors.get('BROWSER_CRASHED', browserDisplayName, code, signal)
 

--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -171,8 +171,9 @@ export = {
       // We want to avoid adding signals in here that may intentionally be caused by a user.
       // For example exiting firefox through either force quitting or quitting via cypress will fire a 'SIGTERM' event which
       // would result in constantly relaunching the browser went he user actively wants to quit.
-      if (code === null && ['SIGTRAP', 'SIGABRT'].includes(signal)) {
-        const err = errors.get('BROWSER_CRASHED', browserDisplayName, signal)
+      // On windows the crash produces 2147483651 as an exit node. We should add to the list of crashes we handle as we see them.
+      if (code === null && ['SIGTRAP', 'SIGABRT'].includes(signal) || code === 2147483651 && signal === null) {
+        const err = errors.get('BROWSER_CRASHED', browserDisplayName, code, signal)
 
         if (!options.onError) {
           errors.log(err)

--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -170,7 +170,7 @@ export = {
       // We are being very narrow on when to restart the browser here. The only case we can reliably test the 'SIGTRAP' signal.
       // We want to avoid adding signals in here that may intentionally be caused by a user.
       // For example exiting firefox through either force quitting or quitting via cypress will fire a 'SIGTERM' event which
-      // would result in constantly relaunching the browser went he user actively wants to quit.
+      // would result in constantly relaunching the browser when the user actively wants to quit.
       // On windows the crash produces 2147483651 as an exit node. We should add to the list of crashes we handle as we see them.
       // In the future we may consider delegating to the browsers to determine if an exit is a crash since it might be different
       // depending on what browser has crashed.

--- a/packages/server/lib/browsers/types.ts
+++ b/packages/server/lib/browsers/types.ts
@@ -35,4 +35,8 @@ export type BrowserLauncher = {
    * Used in Cypress-in-Cypress tests to connect to the existing browser instance.
    */
   connectToExisting: (browser: Browser, options: BrowserLaunchOpts, automation: Automation) => void | Promise<void>
+  /**
+   * Used to clear instance state after the browser has been exited.
+   */
+  clearInstanceState: () => void
 }

--- a/packages/server/lib/browsers/webkit.ts
+++ b/packages/server/lib/browsers/webkit.ts
@@ -25,6 +25,13 @@ export async function connectToNewSpec (browser: Browser, options: BrowserNewTab
   })
 }
 
+/**
+ * Clear instance state for the webkit instance, this is normally called in on kill or on exit.
+ */
+export function clearInstanceState () {
+  wkAutomation = undefined
+}
+
 export function connectToExisting () {
   throw new Error('Cypress-in-Cypress is not supported for WebKit.')
 }
@@ -120,7 +127,7 @@ export async function open (browser: Browser, url: string, options: BrowserLaunc
     async kill () {
       debug('closing pwBrowser')
       await pwBrowser.close()
-      wkAutomation = undefined
+      clearInstanceState()
     }
 
     /**

--- a/packages/server/lib/open_project.ts
+++ b/packages/server/lib/open_project.ts
@@ -186,6 +186,8 @@ export class OpenProject {
         return await browsers.connectToNewSpec(browser, { onInitializeNewBrowserTab, ...options }, automation)
       }
 
+      options.relaunchBrowser = this.relaunchBrowser
+
       return await browsers.open(browser, options, automation, this._ctx)
     }
 

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -103,7 +103,9 @@ export class ProjectBase<TServer extends Server> extends EE {
     this.options = {
       report: false,
       onFocusTests () {},
-      onError () {},
+      onError (error) {
+        errors.log(error)
+      },
       onWarning: this.ctx.onWarning,
       ...options,
     }

--- a/packages/server/lib/socket-base.ts
+++ b/packages/server/lib/socket-base.ts
@@ -253,17 +253,12 @@ export class SocketBase {
               return
             }
 
-            // If we're in run mode we should bail since there is nothing the user can do.
-            if (getCtx().isRunMode) {
-              errors.throwErr('AUTOMATION_SERVER_DISCONNECTED')
-            } else {
-              // TODO: if all of our clients have also disconnected
-              // then don't warn anything
-              errors.warning('AUTOMATION_SERVER_DISCONNECTED')
+            // TODO: if all of our clients have also disconnected
+            // then don't warn anything
+            errors.warning('AUTOMATION_SERVER_DISCONNECTED')
 
-              // TODO: no longer emit this, just close the browser and display message in reporter
-              io.emit('automation:disconnected')
-            }
+            // TODO: no longer emit this, just close the browser and display message in reporter
+            io.emit('automation:disconnected')
           })
         })
 

--- a/packages/server/lib/socket-base.ts
+++ b/packages/server/lib/socket-base.ts
@@ -253,12 +253,17 @@ export class SocketBase {
               return
             }
 
-            // TODO: if all of our clients have also disconnected
-            // then don't warn anything
-            errors.warning('AUTOMATION_SERVER_DISCONNECTED')
+            // If we're in run mode we should bail since there is nothing the user can do.
+            if (getCtx().isRunMode) {
+              errors.throwErr('AUTOMATION_SERVER_DISCONNECTED')
+            } else {
+              // TODO: if all of our clients have also disconnected
+              // then don't warn anything
+              errors.warning('AUTOMATION_SERVER_DISCONNECTED')
 
-            // TODO: no longer emit this, just close the browser and display message in reporter
-            io.emit('automation:disconnected')
+              // TODO: no longer emit this, just close the browser and display message in reporter
+              io.emit('automation:disconnected')
+            }
           })
         })
 

--- a/packages/types/src/server.ts
+++ b/packages/types/src/server.ts
@@ -20,6 +20,7 @@ export type BrowserLaunchOpts = {
   isTextTerminal: boolean
   onBrowserClose?: (...args: unknown[]) => void
   onBrowserOpen?: (...args: unknown[]) => void
+  relaunchBrowser?: () => Promise<any>
 } & Partial<OpenProjectLaunchOpts> // TODO: remove the `Partial` here by making it impossible for openProject.launch to be called w/o OpenProjectLaunchOpts
 & Pick<ReceivedCypressOptions, 'userAgent' | 'proxyUrl' | 'socketIoRoute' | 'chromeWebSecurity' | 'downloadsFolder' | 'experimentalSessionAndOrigin' | 'experimentalModifyObstructiveThirdPartyCode' | 'experimentalWebKitSupport'>
 

--- a/system-tests/__snapshots__/browser_crash_handling_spec.js
+++ b/system-tests/__snapshots__/browser_crash_handling_spec.js
@@ -228,7 +228,7 @@ exports['Browser Crash Handling / when the browser process crashes in chrome / f
 
 
 
-We detected that the Chrome process just crashed with signal 'SIGTRAP'.
+We detected that the Chrome process just crashed with code 'null' and signal 'SIGTRAP'.
 
 We have failed the current test and have relaunched Chrome.
 

--- a/system-tests/__snapshots__/browser_crash_handling_spec.js
+++ b/system-tests/__snapshots__/browser_crash_handling_spec.js
@@ -1,0 +1,331 @@
+exports['Browser Crash Handling / when the tab crashes in chrome / fails'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      2 found (chrome_tab_crash.cy.js, simple.cy.js)                                     │
+  │ Searched:   cypress/e2e/chrome_tab_crash.cy.js, cypress/e2e/simple.cy.js                       │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  chrome_tab_crash.cy.js                                                          (1 of 2)
+
+
+
+We detected that the Chromium Renderer process just crashed.
+
+This is the equivalent to seeing the 'sad face' when Chrome dies.
+
+This can happen for a number of different reasons:
+
+- You wrote an endless loop and you must fix your own code
+- You are running Docker (there is an easy fix for this: see link below)
+- You are running lots of tests on a memory intense application
+- You are running in a memory starved VM environment
+- There are problems with your GPU / GPU drivers
+- There are browser bugs in Chromium
+
+You can learn more including how to fix Docker here:
+
+https://on.cypress.io/renderer-process-crashed
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        0                                                                                │
+  │ Passing:      0                                                                                │
+  │ Failing:      1                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     chrome_tab_crash.cy.js                                                           │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/chrome_tab_crash.cy.js.mp4          (X second)
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  simple.cy.js                                                                    (2 of 2)
+
+
+  ✓ is true
+
+  1 passing
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        1                                                                                │
+  │ Passing:      1                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     simple.cy.js                                                                     │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/simple.cy.js.mp4                    (X second)
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✖  chrome_tab_crash.cy.js                   XX:XX        -        -        1        -        - │
+  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ ✔  simple.cy.js                             XX:XX        1        1        -        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✖  1 of 2 failed (50%)                      XX:XX        1        1        1        -        -  
+
+
+`
+
+exports['Browser Crash Handling / when the tab crashes in electron / fails'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      2 found (chrome_tab_crash.cy.js, simple.cy.js)                                     │
+  │ Searched:   cypress/e2e/chrome_tab_crash.cy.js, cypress/e2e/simple.cy.js                       │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  chrome_tab_crash.cy.js                                                          (1 of 2)
+
+
+
+We detected that the Chromium Renderer process just crashed.
+
+This is the equivalent to seeing the 'sad face' when Chrome dies.
+
+This can happen for a number of different reasons:
+
+- You wrote an endless loop and you must fix your own code
+- You are running Docker (there is an easy fix for this: see link below)
+- You are running lots of tests on a memory intense application
+- You are running in a memory starved VM environment
+- There are problems with your GPU / GPU drivers
+- There are browser bugs in Chromium
+
+You can learn more including how to fix Docker here:
+
+https://on.cypress.io/renderer-process-crashed
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        0                                                                                │
+  │ Passing:      0                                                                                │
+  │ Failing:      1                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     chrome_tab_crash.cy.js                                                           │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/chrome_tab_crash.cy.js.mp4          (X second)
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  simple.cy.js                                                                    (2 of 2)
+
+
+  ✓ is true
+
+  1 passing
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        1                                                                                │
+  │ Passing:      1                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     simple.cy.js                                                                     │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/simple.cy.js.mp4                    (X second)
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✖  chrome_tab_crash.cy.js                   XX:XX        -        -        1        -        - │
+  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ ✔  simple.cy.js                             XX:XX        1        1        -        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✖  1 of 2 failed (50%)                      XX:XX        1        1        1        -        -  
+
+
+`
+
+exports['Browser Crash Handling / when the browser process crashes in chrome / fails'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      2 found (chrome_process_crash.cy.js, simple.cy.js)                                 │
+  │ Searched:   cypress/e2e/chrome_process_crash.cy.js, cypress/e2e/simple.cy.js                   │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  chrome_process_crash.cy.js                                                      (1 of 2)
+
+
+
+We detected that the Chrome process just crashed with signal 'SIGTRAP'.
+
+We have failed the current test and have relaunched Chrome.
+
+This can happen for many different reasons:
+
+- You wrote an endless loop and you must fix your own code
+- You are running lots of tests on a memory intense application
+- You are running in a memory starved VM environment
+- There are problems with your GPU / GPU drivers
+- There are browser bugs
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        0                                                                                │
+  │ Passing:      0                                                                                │
+  │ Failing:      1                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     chrome_process_crash.cy.js                                                       │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/chrome_process_crash.cy.js.mp4      (X second)
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  simple.cy.js                                                                    (2 of 2)
+
+
+  ✓ is true
+
+  1 passing
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        1                                                                                │
+  │ Passing:      1                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        true                                                                             │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     simple.cy.js                                                                     │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Video)
+
+  -  Started processing:  Compressing to 32 CRF                                                     
+  -  Finished processing: /XXX/XXX/XXX/cypress/videos/simple.cy.js.mp4                    (X second)
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✖  chrome_process_crash.cy.js               XX:XX        -        -        1        -        - │
+  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ ✔  simple.cy.js                             XX:XX        1        1        -        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✖  1 of 2 failed (50%)                      XX:XX        1        1        1        -        -  
+
+
+`
+
+exports['Browser Crash Handling / when the browser process crashes in electron / fails'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      2 found (chrome_process_crash.cy.js, simple.cy.js)                                 │
+  │ Searched:   cypress/e2e/chrome_process_crash.cy.js, cypress/e2e/simple.cy.js                   │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  chrome_process_crash.cy.js                                                      (1 of 2)
+
+
+
+`

--- a/system-tests/projects/e2e/cypress/e2e/chrome_process_crash.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/chrome_process_crash.cy.js
@@ -1,0 +1,4 @@
+it('crashes the chrome process', () => {
+  Cypress.automation('remote:debugger:protocol', { command: 'Browser.crash', params: {} })
+  cy.visit('localhost')
+})

--- a/system-tests/projects/e2e/cypress/e2e/chrome_tab_crash.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/chrome_tab_crash.cy.js
@@ -1,0 +1,4 @@
+it('crashes the chrome tab', () => {
+  Cypress.automation('remote:debugger:protocol', { command: 'Page.navigate', params: { url: 'chrome://crash', transitionType: 'typed' } })
+  cy.visit('localhost')
+})

--- a/system-tests/projects/e2e/cypress/e2e/web_security.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/web_security.cy.js
@@ -25,7 +25,7 @@ describe('web security', function () {
     .contains('success!', { timeout: 500 })
   })
 
-  it('finds the correct spec bridge even if a previous spec bridge host is a subset of the current host', () => {
+  it('finds the correct spec bridge even if a previous spec bridge host is a subset of the current host', { defaultCommandTimeout: 4000 }, () => {
     // Establish a spec bridge with a 'bar.com' host prior to loading 'foobar.com'
     if (Cypress.config('experimentalSessionAndOrigin')) {
       cy.origin('http://www.bar.com:4466', () => undefined)

--- a/system-tests/test/browser_crash_handling_spec.js
+++ b/system-tests/test/browser_crash_handling_spec.js
@@ -1,0 +1,49 @@
+const systemTests = require('../lib/system-tests').default
+
+describe('Browser Crash Handling', () => {
+  systemTests.setup({
+    settings: {
+      e2e: {},
+    },
+  })
+
+  // It should fail the chrome_tab_crash spec, but the simple spec should run and succeed
+  context('when the tab crashes in chrome', () => {
+    systemTests.it('fails', {
+      browser: 'chrome',
+      spec: 'chrome_tab_crash.cy.js,simple.cy.js',
+      snapshot: true,
+      expectedExitCode: 1,
+    })
+  })
+
+  // It should fail the chrome_tab_crash spec, but the simple spec should run and succeed
+  context('when the tab crashes in electron', () => {
+    systemTests.it('fails', {
+      browser: 'electron',
+      spec: 'chrome_tab_crash.cy.js,simple.cy.js',
+      snapshot: true,
+      expectedExitCode: 1,
+    })
+  })
+
+  // It should fail the chrome_tab_crash spec, but the simple spec should run and succeed
+  context('when the browser process crashes in chrome', () => {
+    systemTests.it('fails', {
+      browser: 'chrome',
+      spec: 'chrome_process_crash.cy.js,simple.cy.js',
+      snapshot: true,
+      expectedExitCode: 1,
+    })
+  })
+
+  // If chrome crashes, all of cypress crashes when in electron
+  context('when the browser process crashes in electron', () => {
+    systemTests.it('fails', {
+      browser: 'electron',
+      spec: 'chrome_process_crash.cy.js,simple.cy.js',
+      snapshot: true,
+      expectedExitCode: 1,
+    })
+  })
+})


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #6170
- Related to #22631

### User facing changelog
* When a chromium based browser tab or process crashes, Cypress will no longer hang indefinitely but close fail the current test and move on to the next.
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We are detecting tab crashes when cdp tells us it crashed and process crashes when the process exits with specific code/signal combinations.

This affects run mode much more than open mode. In run mode we will move on to the next spec. In open mode we will re-launch the browser to the home screen if it crashes.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

I've created to specs that use CDP to crash the browser process and tab in the system tests e2e project. These work for any chromium based browser. This fix 'may' work for firefox but we have no way to test to see what signal/code combination we should be handling.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Browser tab crash - before: process hangs indefinitely 

https://user-images.githubusercontent.com/1588747/197219147-305298dc-2673-4cb4-93f1-f4666558d5f0.mov

Browser tab crash - after: process fails current spec and moves on to the next.

https://user-images.githubusercontent.com/1588747/197216997-dee9f4d7-82bc-4109-b159-2c83779995ce.mov

Browser process crash - before: process hangs indefinitely 

https://user-images.githubusercontent.com/1588747/197219174-9d4a4e3d-cd77-43c1-adab-8e92a24583a8.mov

Browser process crash - after: process fails current spec and moves on to the next.

https://user-images.githubusercontent.com/1588747/197217877-8dd96604-d436-4ad5-89f5-28ee87278eeb.mov

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
