### PR TITLE
feat(breaking): Remove whitespaces from screenshot names to make it terminal friendly

### DIFF
--- a/packages/server/lib/screenshots.js
+++ b/packages/server/lib/screenshots.js
@@ -11,7 +11,7 @@ let debug = require('debug')('cypress:server:screenshot')
 const plugins = require('./plugins')
 const { fs } = require('./util/fs')
 
-const RUNNABLE_SEPARATOR = ' -- '
+const RUNNABLE_SEPARATOR = '--'
 const pathSeparatorRe = /[\\\/]/g
 
 // internal id incrementor
@@ -178,7 +178,7 @@ const pixelConditionFn = function (data, image) {
 
   const subject = app ? 'app' : 'runner'
 
-  // if we are app, we dont need helper pixels else we do!
+  // if we are app, we don't need helper pixels else we do!
   const passes = app ? !hasPixels : hasPixels
 
   debug('pixelConditionFn %o', {
@@ -360,14 +360,18 @@ const getPath = function (data, ext, screenshotsFolder, overwrite) {
 
   const index = names.length - 1
 
-  // append (failed) to the last name
+  // append _(failed) to the last name
   if (data.testFailure) {
-    names[index] = `${names[index]} (failed)`
+    names[index] = `${names[index]}_(failed)`
   }
 
+  // append _(attempt_x) to the last name
   if (data.testAttemptIndex > 0) {
-    names[index] = `${names[index]} (attempt ${data.testAttemptIndex + 1})`
+    names[index] = `${names[index]}_(attempt_${data.testAttemptIndex + 1})`
   }
+
+  // remove whitespaces to make screenshot link terminal friendly
+  names = names.map((title) => title.replace(/\s/g, '_'))
 
   const withoutExt = path.join(screenshotsFolder, ...specNames, ...names)
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/23510

### User facing changelog
The saved screenshots and videos names  saved in a terminal friendly way so we can cmd+click them to immediately open it

### Additional details
Removed whitespaces from the failed test screenshot name

### Steps to test
Run a test that fails and try to cmd+click the screenshot link

### How has the user experience changed?
<img width="755" alt="зображення" src="https://user-images.githubusercontent.com/30954131/197390906-28231112-b384-4cbd-997c-9445c30eb46c.png">
<img width="787" alt="зображення" src="https://user-images.githubusercontent.com/30954131/197390910-3eef6445-060f-4072-b903-a546670bd9b9.png">


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
