### PR TITLE
chore: remove component testing beta badge

### DIFF
--- a/packages/frontend-shared/src/components/Card.vue
+++ b/packages/frontend-shared/src/components/Card.vue
@@ -53,21 +53,12 @@
       <slot>{{ description }}</slot>
     </p>
     <slot name="footer" />
-    <div
-      v-if="title === t('testingType.component.name')"
-      class="sr-only"
-    >
-      Support is in {{ t('versions.beta') }}
-    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import type { FunctionalComponent, SVGAttributes } from 'vue'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
-
-const { t } = useI18n()
 
 const props = withDefaults(defineProps<{
   title: string

--- a/packages/frontend-shared/src/gql-components/TestingTypePicker.vue
+++ b/packages/frontend-shared/src/gql-components/TestingTypePicker.vue
@@ -112,7 +112,7 @@ const testingTypes = computed(() => {
       icon: IconComponent,
       iconSolid: IconComponentSolid,
       status: componentStatus.value,
-      badgeText: t('versions.beta'),
+      badgeText: '',
     },
   ] as const
 })

--- a/packages/launchpad/src/setup/TestingTypeCards.cy.tsx
+++ b/packages/launchpad/src/setup/TestingTypeCards.cy.tsx
@@ -82,14 +82,4 @@ describe('TestingTypeCards', () => {
     cy.findAllByText(defaultMessages.setupPage.testingCard.running).should('have.length', 1)
     cy.percySnapshot()
   })
-
-  it('renders beta label for component testing', () => {
-    cy.mountFragment(TestingTypeCardsFragmentDoc, {
-      render: (gqlVal) => {
-        return <TestingTypeCards gql={gqlVal} />
-      },
-    })
-
-    cy.get('[data-cy-testingtype="component"]').contains('Beta')
-  })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #24382

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
Cypress component testing is no longer in Beta

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

The "beta" badge no longer appears on the component testing card when selecting a testing type.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Look at the testing type picker in Launchpad and in App and verify that the component testing card doesn't say "beta" anymore

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
