### PR TITLE
fix: Fix cross-origin cy.pause()

### DIFF
--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -11,6 +11,7 @@ import { automation, useRunnerUiStore } from '../store'
 import { useScreenshotStore } from '../store/screenshot-store'
 import { useStudioStore } from '../store/studio-store'
 import { getAutIframeModel } from '.'
+import { handlePausing } from './events/pausing'
 
 export type CypressInCypressMochaEvent = Array<Array<string | Record<string, any>>>
 
@@ -33,7 +34,6 @@ interface AddGlobalListenerOptions {
   randomString: string
 }
 
-const driverToReporterEvents = 'paused'.split(' ')
 const driverToLocalAndReporterEvents = 'run:start run:end'.split(' ')
 const driverToSocketEvents = 'backend:request automation:request mocha recorder:frame'.split(' ')
 const driverTestEvents = 'test:before:run:async test:after:run'.split(' ')
@@ -224,18 +224,6 @@ export class EventManager {
     })
 
     this.reporterBus.on('runner:unpin:snapshot', this._unpinSnapshot.bind(this))
-
-    this.reporterBus.on('runner:resume', () => {
-      if (!Cypress) return
-
-      Cypress.emit('resume:all')
-    })
-
-    this.reporterBus.on('runner:next', () => {
-      if (!Cypress) return
-
-      Cypress.emit('resume:next')
-    })
 
     this.reporterBus.on('runner:stop', () => {
       if (!Cypress) return
@@ -538,12 +526,6 @@ export class EventManager {
 
     Cypress.on('after:screenshot', handleAfterScreenshot)
 
-    driverToReporterEvents.forEach((event) => {
-      Cypress.on(event, (...args) => {
-        this.reporterBus.emit(event, ...args)
-      })
-    })
-
     driverTestEvents.forEach((event) => {
       Cypress.on(event, (test, cb) => {
         this.reporterBus.emit(event, test, cb)
@@ -595,6 +577,8 @@ export class EventManager {
         this.studioStore.testFailed()
       }
     })
+
+    handlePausing(this.getCypress, this.reporterBus)
 
     Cypress.on('test:before:run', (...args) => {
       Cypress.primaryOriginCommunicator.toAllSpecBridges('test:before:run', ...args)

--- a/packages/app/src/runner/events/pausing.ts
+++ b/packages/app/src/runner/events/pausing.ts
@@ -1,0 +1,50 @@
+export const handlePausing = (getCypress, reporterBus) => {
+  const Cypress = getCypress()
+  // tracks whether the cy.pause() was called from the primary driver
+  // (value === null) or from a cross-origin spec bridge (value is the origin
+  // matching that spec bridge)
+  let sendEventsToOrigin = null
+
+  reporterBus.on('runner:next', () => {
+    const Cypress = getCypress()
+
+    if (!Cypress) return
+
+    // if paused from within a cy.origin() callback, send the event to the
+    // corresponding spec bridge
+    if (sendEventsToOrigin) {
+      Cypress.primaryOriginCommunicator.toSpecBridge(sendEventsToOrigin, 'resume:next')
+    } else {
+      Cypress.emit('resume:next')
+    }
+  })
+
+  reporterBus.on('runner:resume', () => {
+    const Cypress = getCypress()
+
+    if (!Cypress) return
+
+    // if paused from within a cy.origin() callback, send the event to the
+    // corresponding spec bridge
+    if (sendEventsToOrigin) {
+      Cypress.primaryOriginCommunicator.toSpecBridge(sendEventsToOrigin, 'resume:all')
+    } else {
+      Cypress.emit('resume:all')
+    }
+
+    // pause sequence is over - reset this for subsequent pauses
+    sendEventsToOrigin = null
+  })
+
+  // from the primary driver
+  Cypress.on('paused', (nextCommandName) => {
+    reporterBus.emit('paused', nextCommandName)
+  })
+
+  // from a cross-origin spec bridge
+  Cypress.primaryOriginCommunicator.on('paused', ({ nextCommandName, origin }) => {
+    sendEventsToOrigin = origin
+
+    reporterBus.emit('paused', nextCommandName)
+  })
+}

--- a/packages/driver/src/cross-origin/events/misc.ts
+++ b/packages/driver/src/cross-origin/events/misc.ts
@@ -35,4 +35,16 @@ export const handleMiscEvents = (Cypress: Cypress.Cypress, cy: $Cy) => {
     Cypress.action('app:window:load', undefined, url)
     Cypress.emit('internal:window:load', { type: 'same:origin', url })
   })
+
+  Cypress.on('paused', (nextCommandName: string) => {
+    Cypress.specBridgeCommunicator.toPrimary('paused', { nextCommandName, origin: window.origin })
+  })
+
+  Cypress.specBridgeCommunicator.on('resume:next', () => {
+    Cypress.emit('resume:next')
+  })
+
+  Cypress.specBridgeCommunicator.on('resume:all', () => {
+    Cypress.emit('resume:all')
+  })
 }

--- a/packages/driver/src/cy/commands/origin/index.ts
+++ b/packages/driver/src/cy/commands/origin/index.ts
@@ -64,6 +64,7 @@ export default (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, state: State
         name: 'origin',
         type: 'parent',
         message: urlOrDomain,
+        timeout: 0,
         // @ts-ignore TODO: revisit once log-grouping has more implementations
       }, (_log) => {
         log = _log

--- a/packages/driver/types/internal-types.d.ts
+++ b/packages/driver/types/internal-types.d.ts
@@ -58,6 +58,7 @@ declare namespace Cypress {
     (action: 'clear:cookies', fn: () => void)
     (action: 'cross:origin:cookies', fn: (cookies: AutomationCookie[]) => void)
     (action: 'before:stability:release', fn: () => void)
+    (action: 'paused', fn: (nextCommandName: string) => void)
   }
 
   interface Backend {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #21495

### User facing changelog

- `cy.pause()` now functions correctly when called within the `cy.origin()` callback

### Additional details

The 'paused' event sent by `cy.pause()` was not making its way to the reporter via the runner, causing the correct UI not to show. The subsequent 'resume:next' and 'resume:all' events also needed to be wired up to be sent back to the spec bridge that sent the 'paused' event.

### Steps to test

Running the following should pause on the `cy.pause()`, with ▶️⏭ buttons in the reporter that function correctly for moving to the next command and resuming.

```js
cy.visit('http://localhost:3500/fixtures/primary-origin.html')
cy.get('a[href="http://www.foobar.com:3500/fixtures/secondary-origin.html"]').click()

cy.origin('http://www.foobar.com:3500', () => {
  cy.pause()
  cy.get('div')
  cy.log('something')
})
```

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
