### PR TITLE
fix: for ELECTRON_RUN_AS_NODE=1 not working in Cypress 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ mainBuildFilters: &mainBuildFilters
     branches:
       only:
         - develop
-        - 'ryanm/fix/improve-binary-cleanup'
+        - 'issue-23636'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -36,7 +36,7 @@ macWorkflowFilters: &darwin-workflow-filters
   when:
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
-    - equal: [ 'ryanm/fix/improve-binary-cleanup', << pipeline.git.branch >> ]
+    - equal: [ 'issue-23636', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -45,7 +45,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
   when:
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
-    - equal: [ 'ryanm/fix/improve-binary-cleanup', << pipeline.git.branch >> ]
+    - equal: [ 'ryanm/fix/improve-binary-cleanuissue-23636p', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -63,7 +63,7 @@ windowsWorkflowFilters: &windows-workflow-filters
   when:
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
-    - equal: [ 'ryanm/fix/improve-binary-cleanup', << pipeline.git.branch >> ]
+    - equal: [ 'issue-23636', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -130,7 +130,7 @@ commands:
       - run:
           name: Check current branch to persist artifacts
           command: |
-            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "ryanm/fix/improve-binary-cleanup" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "issue-23636" ]]; then
               echo "Not uploading artifacts or posting install comment for this branch."
               circleci-agent step halt
             fi

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -172,6 +172,12 @@ module.exports = {
 
         if (stdioOptions.env.ELECTRON_RUN_AS_NODE) {
           // Since we are running electron as node, we need to add an entry point file.
+          if (isPlatform('darwin')) {
+            startScriptPath = path.join(state.getBinaryPkgPath(path.join(executable, '..', '..', '..')), '..', 'index.js')
+          } else {
+            startScriptPath = path.join(state.getBinaryPkgPath(path.dirname(executable)), '..', 'index.js')
+          }
+
           startScriptPath = path.join(state.getBinaryPkgPath(path.dirname(executable)), '..', 'index.js')
         } else {
           // Start arguments with "--" so Electron knows these are OUR


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #23636

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
Fix for user not able to use `ELECTRON_RUN_AS_NODE=1` to [run Cypress without xvfb](https://docs.cypress.io/guides/continuous-integration/introduction#Xvfb).
During the fix, also found a small bug about incorrect version check for `electron` browser.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Need to include package `electron` in one of packages' dependencies. Otherwise, the package will not be included in the binary's packages.
I included it in `server/package.json`, but probably can move `electron` in `devDependencies` to `dependencies`? @lmiller1990  https://github.com/cypress-io/cypress/blob/d52e610c0036a6c37196883b1c270a2e93ec91ff/package.json#L147


### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
Now running `ELECTRON_RUN_AS_NODE=1 npx cypress run --browser chrome --headless` will work.
But running `ELECTRON_RUN_AS_NODE=1 npx cypress run` with default `electron` browser still won't work with error:
```
electron_1.BrowserWindow is not a constructor
TypeError: electron_1.BrowserWindow is not a constructor
```
But I'm not sure if this is something this PR should fix.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
