### PR TITLE
fix: make component derived info not throw

### DIFF
--- a/npm/angular/src/mount.ts
+++ b/npm/angular/src/mount.ts
@@ -156,7 +156,7 @@ function bootstrapModule<T> (
   })
 
   // check if the component is a standalone component
-  if ((component as any).ɵcmp.standalone) {
+  if ((component as any).ɵcmp?.standalone) {
     testModuleMetaData.imports.push(component)
   } else {
     testModuleMetaData.declarations.push(component)

--- a/npm/react/src/createMount.ts
+++ b/npm/react/src/createMount.ts
@@ -40,12 +40,6 @@ export const makeMountFn = (
 
   mountCleanup = internalMountOptions.cleanup
 
-  // Get the display name property via the component constructor
-  // @ts-ignore FIXME
-  const componentName = getDisplayName(jsx.type)
-
-  const jsxComponentName = `<${componentName} ... />`
-
   return cy
   .then(() => {
     const reactDomToUse = internalMountOptions.reactDom
@@ -99,6 +93,12 @@ export const makeMountFn = (
       .wait(0, { log: false })
       .then(() => {
         if (options.log !== false) {
+          // Get the display name property via the component constructor
+          // @ts-ignore FIXME
+          const componentName = getDisplayName(jsx)
+
+          const jsxComponentName = `<${componentName} ... />`
+
           Cypress.log({
             name: type,
             type: 'parent',
@@ -108,7 +108,7 @@ export const makeMountFn = (
             consoleProps: () => {
               return {
               // @ts-ignore protect the use of jsx functional components use ReactNode
-                props: jsx.props,
+                props: jsx?.props,
                 description: type === 'mount' ? 'Mounts React component' : 'Rerenders mounted React component',
                 home: 'https://github.com/cypress-io/cypress',
               }

--- a/npm/react/src/getDisplayName.ts
+++ b/npm/react/src/getDisplayName.ts
@@ -1,6 +1,6 @@
-type JSX = Function & { displayName: string }
+import type { ReactNode } from 'react'
 
-const cachedDisplayNames: WeakMap<JSX, string> = new WeakMap()
+type JSX = Function & { displayName: string }
 
 /**
  * Gets the display name of the component when possible.
@@ -9,13 +9,13 @@ const cachedDisplayNames: WeakMap<JSX, string> = new WeakMap()
  * @link https://github.com/facebook/react-devtools/blob/master/backend/getDisplayName.js
  */
 export default function getDisplayName (
-  type: JSX,
+  node: ReactNode,
   fallbackName: string = 'Unknown',
 ): string {
-  const nameFromCache = cachedDisplayNames.get(type)
+  const type: JSX | undefined = (node as any)?.type
 
-  if (nameFromCache != null) {
-    return nameFromCache
+  if (!type) {
+    return fallbackName
   }
 
   let displayName: string | null = null
@@ -47,12 +47,6 @@ export default function getDisplayName (
         displayName = componentName
       }
     }
-  }
-
-  try {
-    cachedDisplayNames.set(type, displayName)
-  } catch (e) {
-    // do nothing
   }
 
   return displayName

--- a/npm/vue/src/index.ts
+++ b/npm/vue/src/index.ts
@@ -370,7 +370,7 @@ export function mount<
  * Mounts a component and returns an object containing the component and VueWrapper
  * @param componentOptions
  * @param options
- * @returns {Cypress.Chainable<{wrapper: VueWrapper<T>, component: T}
+ * @returns {Cypress.Chainable<{wrapper: VueWrapper<T>, component: T}>}
  * @see {@link https://on.cypress.io/mounting-vue} for more details.
  * @example
  * import { mount } from '@cypress/vue'
@@ -386,9 +386,6 @@ export function mount (componentOptions: any, options: any = {}) {
   checkForRemovedStyleOptions(options)
   // Remove last mounted component if cy.mount is called more than once in a test
   cleanup()
-
-  // TODO: get the real displayName and props from VTU shallowMount
-  const componentName = getComponentDisplayName(componentOptions)
 
   // then wait for cypress to load
   return cy.then(() => {

--- a/system-tests/__snapshots__/component_testing_spec.ts.js
+++ b/system-tests/__snapshots__/component_testing_spec.ts.js
@@ -156,19 +156,20 @@ exports['React major versions with Webpack executes all of the tests for React v
 
 
   mount
+    ✓ does not error when rendering primitives
     teardown
       ✓ should mount
       ✓ should remove previous mounted component
 
 
-  2 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        2                                                                                │
-  │ Passing:      2                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -200,9 +201,9 @@ exports['React major versions with Webpack executes all of the tests for React v
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
   │ ✔  Rerendering.cy.jsx                       XX:XX        1        1        -        -        - │
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
-  │ ✔  mount.cy.jsx                             XX:XX        2        2        -        -        - │
+  │ ✔  mount.cy.jsx                             XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        9        9        -        -        -  
+    ✔  All specs passed!                        XX:XX       10       10        -        -        -  
 
 
 `
@@ -365,19 +366,20 @@ exports['React major versions with Webpack executes all of the tests for React v
 
 
   mount
+    ✓ does not error when rendering primitives
     teardown
       ✓ should mount
       ✓ should remove previous mounted component
 
 
-  2 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        2                                                                                │
-  │ Passing:      2                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -409,9 +411,9 @@ exports['React major versions with Webpack executes all of the tests for React v
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
   │ ✔  Rerendering.cy.jsx                       XX:XX        1        1        -        -        - │
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
-  │ ✔  mount.cy.jsx                             XX:XX        2        2        -        -        - │
+  │ ✔  mount.cy.jsx                             XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        9        9        -        -        -  
+    ✔  All specs passed!                        XX:XX       10       10        -        -        -  
 
 
 `
@@ -573,19 +575,20 @@ exports['React major versions with Vite executes all of the tests for React v17 
 
 
   mount
+    ✓ does not error when rendering primitives
     teardown
       ✓ should mount
       ✓ should remove previous mounted component
 
 
-  2 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        2                                                                                │
-  │ Passing:      2                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -617,9 +620,9 @@ exports['React major versions with Vite executes all of the tests for React v17 
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
   │ ✔  Rerendering.cy.jsx                       XX:XX        1        1        -        -        - │
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
-  │ ✔  mount.cy.jsx                             XX:XX        2        2        -        -        - │
+  │ ✔  mount.cy.jsx                             XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        9        9        -        -        -  
+    ✔  All specs passed!                        XX:XX       10       10        -        -        -  
 
 
 `
@@ -781,19 +784,20 @@ exports['React major versions with Vite executes all of the tests for React v18 
 
 
   mount
+    ✓ does not error when rendering primitives
     teardown
       ✓ should mount
       ✓ should remove previous mounted component
 
 
-  2 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        2                                                                                │
-  │ Passing:      2                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -825,9 +829,9 @@ exports['React major versions with Vite executes all of the tests for React v18 
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
   │ ✔  Rerendering.cy.jsx                       XX:XX        1        1        -        -        - │
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
-  │ ✔  mount.cy.jsx                             XX:XX        2        2        -        -        - │
+  │ ✔  mount.cy.jsx                             XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        9        9        -        -        -  
+    ✔  All specs passed!                        XX:XX       10       10        -        -        -  
 
 
 `

--- a/system-tests/__snapshots__/vite_dev_server_fresh_spec.ts.js
+++ b/system-tests/__snapshots__/vite_dev_server_fresh_spec.ts.js
@@ -363,19 +363,20 @@ https://on.cypress.io/uncaught-exception-from-application
 
 
   mount
+    ✓ does not error when rendering primitives
     teardown
       ✓ should mount
       ✓ should remove previous mounted component
 
 
-  2 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        2                                                                                │
-  │ Passing:      2                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -413,9 +414,9 @@ https://on.cypress.io/uncaught-exception-from-application
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
   │ ✔  Unmount.cy.jsx                           XX:XX        3        3        -        -        - │
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
-  │ ✔  mount.cy.jsx                             XX:XX        2        2        -        -        - │
+  │ ✔  mount.cy.jsx                             XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✖  4 of 8 failed (50%)                      XX:XX       15        8        7        -        -  
+    ✖  4 of 8 failed (50%)                      XX:XX       16        9        7        -        -  
 
 
 `
@@ -785,19 +786,20 @@ https://on.cypress.io/uncaught-exception-from-application
 
 
   mount
+    ✓ does not error when rendering primitives
     teardown
       ✓ should mount
       ✓ should remove previous mounted component
 
 
-  2 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        2                                                                                │
-  │ Passing:      2                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -835,9 +837,9 @@ https://on.cypress.io/uncaught-exception-from-application
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
   │ ✔  Unmount.cy.jsx                           XX:XX        3        3        -        -        - │
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
-  │ ✔  mount.cy.jsx                             XX:XX        2        2        -        -        - │
+  │ ✔  mount.cy.jsx                             XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✖  4 of 8 failed (50%)                      XX:XX       15        8        7        -        -  
+    ✖  4 of 8 failed (50%)                      XX:XX       16        9        7        -        -  
 
 
 `
@@ -1207,19 +1209,20 @@ https://on.cypress.io/uncaught-exception-from-application
 
 
   mount
+    ✓ does not error when rendering primitives
     teardown
       ✓ should mount
       ✓ should remove previous mounted component
 
 
-  2 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        2                                                                                │
-  │ Passing:      2                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -1257,9 +1260,9 @@ https://on.cypress.io/uncaught-exception-from-application
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
   │ ✔  Unmount.cy.jsx                           XX:XX        3        3        -        -        - │
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
-  │ ✔  mount.cy.jsx                             XX:XX        2        2        -        -        - │
+  │ ✔  mount.cy.jsx                             XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✖  4 of 8 failed (50%)                      XX:XX       15        8        7        -        -  
+    ✖  4 of 8 failed (50%)                      XX:XX       16        9        7        -        -  
 
 
 `

--- a/system-tests/__snapshots__/webpack_dev_server_fresh_spec.ts.js
+++ b/system-tests/__snapshots__/webpack_dev_server_fresh_spec.ts.js
@@ -374,19 +374,20 @@ https://on.cypress.io/uncaught-exception-from-application
 
 
   mount
+    ✓ does not error when rendering primitives
     teardown
       ✓ should mount
       ✓ should remove previous mounted component
 
 
-  2 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        2                                                                                │
-  │ Passing:      2                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -424,9 +425,9 @@ https://on.cypress.io/uncaught-exception-from-application
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
   │ ✔  Unmount.cy.jsx                           XX:XX        3        3        -        -        - │
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
-  │ ✔  mount.cy.jsx                             XX:XX        2        2        -        -        - │
+  │ ✔  mount.cy.jsx                             XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✖  4 of 8 failed (50%)                      XX:XX       15        8        7        -        -  
+    ✖  4 of 8 failed (50%)                      XX:XX       16        9        7        -        -  
 
 
 `
@@ -816,19 +817,20 @@ https://on.cypress.io/uncaught-exception-from-application
 
 
   mount
+    ✓ does not error when rendering primitives
     teardown
       ✓ should mount
       ✓ should remove previous mounted component
 
 
-  2 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        2                                                                                │
-  │ Passing:      2                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -866,9 +868,9 @@ https://on.cypress.io/uncaught-exception-from-application
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
   │ ✔  Unmount.cy.jsx                           XX:XX        3        3        -        -        - │
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
-  │ ✔  mount.cy.jsx                             XX:XX        2        2        -        -        - │
+  │ ✔  mount.cy.jsx                             XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✖  4 of 8 failed (50%)                      XX:XX       15        8        7        -        -  
+    ✖  4 of 8 failed (50%)                      XX:XX       16        9        7        -        -  
 
 
 `
@@ -1249,19 +1251,20 @@ https://on.cypress.io/uncaught-exception-from-application
 
 
   mount
+    ✓ does not error when rendering primitives
     teardown
       ✓ should mount
       ✓ should remove previous mounted component
 
 
-  2 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        2                                                                                │
-  │ Passing:      2                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -1299,9 +1302,9 @@ https://on.cypress.io/uncaught-exception-from-application
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
   │ ✔  Unmount.cy.jsx                           XX:XX        3        3        -        -        - │
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
-  │ ✔  mount.cy.jsx                             XX:XX        2        2        -        -        - │
+  │ ✔  mount.cy.jsx                             XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✖  4 of 8 failed (50%)                      XX:XX       15        8        7        -        -  
+    ✖  4 of 8 failed (50%)                      XX:XX       16        9        7        -        -  
 
 
 `
@@ -1694,19 +1697,20 @@ https://on.cypress.io/uncaught-exception-from-application
 
 
   mount
+    ✓ does not error when rendering primitives
     teardown
       ✓ should mount
       ✓ should remove previous mounted component
 
 
-  2 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        2                                                                                │
-  │ Passing:      2                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -1744,9 +1748,9 @@ https://on.cypress.io/uncaught-exception-from-application
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
   │ ✔  Unmount.cy.jsx                           XX:XX        3        3        -        -        - │
   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
-  │ ✔  mount.cy.jsx                             XX:XX        2        2        -        -        - │
+  │ ✔  mount.cy.jsx                             XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✖  4 of 8 failed (50%)                      XX:XX       15        8        7        -        -  
+    ✖  4 of 8 failed (50%)                      XX:XX       16        9        7        -        -  
 
 
 `

--- a/system-tests/project-fixtures/angular/src/app/mount.cy.ts
+++ b/system-tests/project-fixtures/angular/src/app/mount.cy.ts
@@ -447,4 +447,16 @@ describe('angular mount', () => {
       cy.get('[id^=root]').children().should('have.length', 1)
     })
   });
+
+  it('should error when passing in undecorated component', () => {
+    Cypress.on('fail', (err) => {
+      expect(err.message).contain("Please add a @Pipe/@Directive/@Component");
+
+      return false
+    })
+
+    class MyClass {}
+
+    cy.mount(MyClass)
+  })
 });

--- a/system-tests/project-fixtures/react/src/mount.cy.jsx
+++ b/system-tests/project-fixtures/react/src/mount.cy.jsx
@@ -24,4 +24,11 @@ describe('mount', () => {
       cy.get('[data-cy-root]').children().should('have.length', 1)
     })
   });
+
+  it('does not error when rendering primitives', () => {
+    cy.mount('Hello World')
+    cy.mount(5)
+    cy.mount(null)
+    cy.mount(undefined)
+  })
 })


### PR DESCRIPTION
- Closes #24344

### User facing changelog
Do not throw error/throw better error when providing improper but still valid arguments to `mount`

### Additional details
We derive information from the component/class passed into `cy.mount` such as the name of the component or whether it is a standalone component (Angular). Our mount would error in certain scenarios:

- React: calling `cy.mount(some_primitive_value)` e.g. `cy.mount('Hello World')`
- Angular: calling mount with an undecorated component e.g. `class MyClass {}; cy.mount(MyClass)`

The goal of this PR isn't to validate what is passed. If `cy.mount(null)` is called, stuff should break and that's expected but if the types allow for certain values like `cy.mount(5)` then it shouldn't throw an error. If it does throw an error, it should be the render throwing the error and not `Cannot read "displayName" of undefined` where we are trying to pull info from the component passed in.

### Steps to test
System-tests help here. If you want to test an external project, you'll first have to build the mount package and then symlink/copy it to your project's `node_modules/cypress/{framework}`

### How has the user experience changed?
Before:

https://user-images.githubusercontent.com/25158820/200407940-e9588d1f-e240-449f-ae47-b0e2a85d7fc9.mov

After:


https://user-images.githubusercontent.com/25158820/200407996-65bcdb5d-b0d7-45b0-8f8a-6e77c2b5582c.mov





### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
