### PR TITLE
chore: Skip flaky navigation tests in webkit

### DIFF
--- a/packages/driver/cypress/e2e/commands/navigation.cy.js
+++ b/packages/driver/cypress/e2e/commands/navigation.cy.js
@@ -753,7 +753,8 @@ describe('src/cy/commands/navigation', () => {
     })
 
     // https://github.com/cypress-io/cypress/issues/14445
-    it('should eventually fail on assertion despite redirects', (done) => {
+    // FIXME: fix flaky test (webkit): https://github.com/cypress-io/cypress/issues/24600
+    it('should eventually fail on assertion despite redirects', { browser: '!webkit' }, (done) => {
       cy.on('fail', (err) => {
         expect(err.message).to.contain('The application redirected to')
         done()
@@ -2287,7 +2288,8 @@ describe('src/cy/commands/navigation', () => {
       return null
     })
 
-    it('emits \'page:loading\' before and after initial visit', () => {
+    // FIXME: fix flaky test (webkit): https://github.com/cypress-io/cypress/issues/24600
+    it('emits \'page:loading\' before and after initial visit', { browser: '!webkit' }, () => {
       const emit = cy.spy(Cypress, 'emit').log(false).withArgs('page:loading')
 
       cy
@@ -2303,7 +2305,8 @@ describe('src/cy/commands/navigation', () => {
       })
     })
 
-    it('emits during page navigation', () => {
+    // FIXME: fix flaky test (webkit): https://github.com/cypress-io/cypress/issues/24600
+    it('emits during page navigation', { browser: '!webkit' }, () => {
       const emit = cy.spy(Cypress, 'emit').log(false).withArgs('page:loading')
       let expected = false
 
@@ -2329,7 +2332,8 @@ describe('src/cy/commands/navigation', () => {
       })
     })
 
-    it('logs during page navigation', () => {
+    // FIXME: fix flaky test (webkit): https://github.com/cypress-io/cypress/issues/24600
+    it('logs during page navigation', { browser: '!webkit' }, () => {
       let expected = false
 
       cy
@@ -2352,7 +2356,8 @@ describe('src/cy/commands/navigation', () => {
       })
     })
 
-    it('logs during form submission and yields stale element', () => {
+    // FIXME: fix flaky test (webkit): https://github.com/cypress-io/cypress/issues/24600
+    it('logs during form submission and yields stale element', { browser: '!webkit' }, () => {
       let expected = false
 
       const names = cy.queue.names()
@@ -2972,7 +2977,8 @@ describe('src/cy/commands/navigation', () => {
       return null
     })
 
-    it('logs \'form sub\'', () => {
+    // FIXME: fix flaky test (webkit): https://github.com/cypress-io/cypress/issues/24600
+    it('logs \'form sub\'', { browser: '!webkit' }, () => {
       let event = null
 
       cy


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

N/A

### Additional details

Didn't dig into why these are flaky, but want to keep them from frequently failing for the time being.

Documented in https://github.com/cypress-io/cypress/issues/24600

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [N/A] Have tests been added/updated?
- [N/A] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
