### PR TITLE
fix: test isolation config validation

### DIFF
--- a/packages/config/src/browser.ts
+++ b/packages/config/src/browser.ts
@@ -156,7 +156,7 @@ export const matchesConfigKey = (key: string) => {
 }
 
 export const validate = (cfg: any, onErr: (property: ErrResult | string) => void, testingType: TestingType | null) => {
-  debug('validating configuration')
+  debug('validating configuration', cfg)
 
   return _.each(cfg, (value, key) => {
     const validationFn = validationRules[key]
@@ -166,7 +166,7 @@ export const validate = (cfg: any, onErr: (property: ErrResult | string) => void
       const result = validationFn(key, value, {
         testingType,
         // TODO: remove with experimentalSessionAndOrigin. Fixed with: https://github.com/cypress-io/cypress/issues/21471
-        experimentalSessionAndOrigin: cfg.experimentalSessionAndOrigin,
+        experimentalSessionAndOrigin: cfg.e2e?.experimentalSessionAndOrigin || cfg.experimentalSessionAndOrigin,
       })
 
       if (result !== true) {


### PR DESCRIPTION
- Closes #24497

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
Fix `testIsolation` configuration validation to allow configuration updates without restarting Cypress. Fixes [#24497](https://github.com/cypress-io/cypress/issues/24497).

### Steps to test
Open project with `experimentalSessionAndOrigin=true`. Modify the configuration file and see error. (Example in issue).

### How has the user experience changed?
Able to update and/all configuration in their cypress.config.js file and it successfully reflects in the App.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [n/a] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
