### PR TITLE
fix: log intercept information when getting the alias.

### DIFF
--- a/packages/driver/cypress/e2e/commands/querying/querying.cy.js
+++ b/packages/driver/cypress/e2e/commands/querying/querying.cy.js
@@ -502,7 +502,7 @@ describe('src/cy/commands/querying', () => {
           expect(this.lastLog.invoke('consoleProps')).to.deep.eq({
             Command: 'get',
             Alias: '@getUsers',
-            // Yielded: obj, TODO: get does not log this out from an intercept
+            Yielded: obj,
           })
         })
       })

--- a/packages/driver/src/cy/commands/querying/querying.ts
+++ b/packages/driver/src/cy/commands/querying/querying.ts
@@ -237,10 +237,12 @@ export default (Commands, Cypress, cy, state) => {
               return requests[Number(index) - 1] || null
             }
 
-            log(requests, command.get('name'))
+            const lastRequest = _.last(requests)
+
+            log(lastRequest, command.get('name'))
 
             // by default return the latest match
-            return _.last(requests) || null
+            return lastRequest || null
           }
 
           // log as primitive

--- a/packages/driver/src/cy/commands/querying/querying.ts
+++ b/packages/driver/src/cy/commands/querying/querying.ts
@@ -98,7 +98,7 @@ export default (Commands, Cypress, cy, state) => {
               })
 
               break
-            case 'route':
+            case 'intercept':
               _.extend(consoleProps, {
                 Yielded: value,
               })

--- a/packages/net-stubbing/lib/server/middleware/request.ts
+++ b/packages/net-stubbing/lib/server/middleware/request.ts
@@ -64,6 +64,9 @@ export const InterceptRequest: RequestMiddleware = async function () {
 
   debug('intercepting request %o', { requestId: request.id, req: _.pick(this.req, 'url') })
 
+  // Break caching, remove this header to prevent the downstream server from returning a 304 so we can return an up to date body.
+  delete this.req.headers['if-none-match']
+
   // attach requestId to the original req object for later use
   this.req.requestId = request.id
 

--- a/packages/net-stubbing/lib/server/middleware/request.ts
+++ b/packages/net-stubbing/lib/server/middleware/request.ts
@@ -64,9 +64,6 @@ export const InterceptRequest: RequestMiddleware = async function () {
 
   debug('intercepting request %o', { requestId: request.id, req: _.pick(this.req, 'url') })
 
-  // Break caching, remove this header to prevent the downstream server from returning a 304 so we can return an up to date body.
-  delete this.req.headers['if-none-match']
-
   // attach requestId to the original req object for later use
   this.req.requestId = request.id
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Getting an alias for an intercepted call will now log the yielded object.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Super minor fix to  remove a todo

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
See the updated test.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
