### PR TITLE
fix: Change cy.end() back to a command instead of a query

### DIFF
--- a/packages/driver/cypress/e2e/commands/misc.cy.js
+++ b/packages/driver/cypress/e2e/commands/misc.cy.js
@@ -10,6 +10,11 @@ describe('src/cy/commands/misc', () => {
     it('nulls out the subject', () => {
       cy.noop({}).end().then((subject) => {
         expect(subject).to.be.null
+
+        // We want cy.end() to break the subject chain - any previous entries
+        // (in this case `{}`) should be discarded. No re-running any previous
+        // query functions once you've used `.end()` on a chain.
+        expect(cy.subjectChain()).to.eql([null])
       })
     })
   })

--- a/packages/driver/src/cy/commands/misc.ts
+++ b/packages/driver/src/cy/commands/misc.ts
@@ -11,7 +11,8 @@ interface InternalWrapOptions extends Partial<Cypress.Loggable & Cypress.Timeout
 }
 
 export default (Commands, Cypress, cy, state) => {
-  Commands.addQuery('end', () => () => null)
+  Commands.add('end', () => null)
+  Commands.add('noop', (arg) => arg)
 
   Commands.addQuery('log', (msg, ...args) => {
     Cypress.log({
@@ -23,8 +24,6 @@ export default (Commands, Cypress, cy, state) => {
 
     return () => null
   })
-
-  Commands.add('noop', (arg) => arg)
 
   Commands.addAll({
     wrap (arg, userOptions: Partial<Cypress.Loggable & Cypress.Timeoutable> = {}) {


### PR DESCRIPTION
### User facing changelog
No user-facing changes.

### Additional details
Fix for issue introduced as part of https://github.com/cypress-io/cypress/pull/24628.

We want .end() not to be a query. This is because:

`cy.get('button').end().get('button')`

should end with a subject chain of `[null, get('button')]` and not `[get('button'), end(), get('button')]`. We want .end() to cut things off (which non-query commands do).


### Steps to test

### How has the user experience changed?

### PR Tasks

- [x] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? Updated as part of the in-flight detached dom docs PR (https://github.com/cypress-io/cypress-documentation/pull/4835)
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
