### PR TITLE
fix: issue with loading typescript and v8 snapshot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ mainBuildFilters: &mainBuildFilters
     branches:
       only:
         - develop
-        - 'ryanm/fix/migrating-to-11-from-9-typescript'
+        - 'ryanm/fix/typescript-issue'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -36,7 +36,7 @@ macWorkflowFilters: &darwin-workflow-filters
   when:
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
-    - equal: [ 'ryanm/fix/migrating-to-11-from-9-typescript', << pipeline.git.branch >> ]
+    - equal: [ 'ryanm/fix/typescript-issue', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -45,7 +45,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
   when:
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
-    - equal: [ 'ryanm/fix/migrating-to-11-from-9-typescript', << pipeline.git.branch >> ]
+    - equal: [ 'ryanm/fix/typescript-issue', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -63,7 +63,7 @@ windowsWorkflowFilters: &windows-workflow-filters
   when:
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
-    - equal: [ 'ryanm/fix/migrating-to-11-from-9-typescript', << pipeline.git.branch >> ]
+    - equal: [ 'ryanm/fix/typescript-issue', << pipeline.git.branch >> ]
     - matches:
           pattern: "-release$"
           value: << pipeline.git.branch >>
@@ -130,7 +130,7 @@ commands:
       - run:
           name: Check current branch to persist artifacts
           command: |
-            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "ryanm/fix/migrating-to-11-from-9-typescript" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "ryanm/fix/typescript-issue" ]]; then
               echo "Not uploading artifacts or posting install comment for this branch."
               circleci-agent step halt
             fi

--- a/packages/packherd-require/src/loader.ts
+++ b/packages/packherd-require/src/loader.ts
@@ -898,8 +898,14 @@ export class PackherdModuleLoader {
       parent = this._createModule(fullPath, parent, moduleUri)
     }
 
+    const originalRequireResolve = require.resolve
+
     require.resolve = Object.assign(
-      (moduleUri: string, _options?: { paths?: string[] }) => {
+      (moduleUri: string, options?: { paths?: string[] }) => {
+        if (options && options.paths) {
+          return originalRequireResolve(moduleUri, options)
+        }
+
         return this.tryResolve(moduleUri, parent).fullPath
       },
       {

--- a/packages/packherd-require/src/loader.ts
+++ b/packages/packherd-require/src/loader.ts
@@ -902,6 +902,7 @@ export class PackherdModuleLoader {
 
     require.resolve = Object.assign(
       (moduleUri: string, options?: { paths?: string[] }) => {
+        // Handle the case where options populated. The module is expected to be outside of the cypress snapshot so use the original require.resolve.
         if (options && options.paths) {
           return originalRequireResolve(moduleUri, options)
         }


### PR DESCRIPTION
### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

No new functional fixes, but the combination of https://github.com/cypress-io/cypress/pull/24677 and https://github.com/cypress-io/cypress/pull/24675 exposed a timing problem. Specifically typescript is no longer detected in a consumer project. `require.resolve` was fixed on [this PR](https://github.com/cypress-io/cypress/pull/23732/files#diff-1b04229a5c2079a49a0dbfc1347476c1ffe708f89610952004c375d4a625a533) however there was a scenario that was missed to ensure that whenever we are calling `require.resolve` the original version is called when `paths` are provided.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Use the binary from this PR and try and migrate a project that uses typescript from 9 to 11 and ensure that typescript is properly detected

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
