### PR TITLE
feat: Do not strip CSP headers from HTTPResponse

### DIFF
--- a/packages/driver/cypress/e2e/e2e/security.cy.js
+++ b/packages/driver/cypress/e2e/e2e/security.cy.js
@@ -3,4 +3,21 @@ describe('security', () => {
     cy.visit('/fixtures/security.html')
     cy.get('div').should('not.exist')
   })
+
+  it('works even with content-security-policy script-src', () => {
+    // create report URL
+    cy.intercept('/csp-report', (req) => {
+      throw new Error(`/csp-report should not be reached:${ req.body}`)
+    })
+
+    // inject script-src on visit
+    cy.intercept('/fixtures/empty.html', (req) => {
+      req.continue((res) => {
+        res.headers['content-security-policy'] = `script-src http://not-here.net; report-uri /csp-report`
+      })
+    })
+
+    cy.visit('/fixtures/empty.html')
+    .wait(1000)
+  })
 })

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -15,6 +15,8 @@ import { URL } from 'url'
 import { CookiesHelper } from './util/cookies'
 import { doesTopNeedToBeSimulated } from './util/top-simulation'
 import { toughCookieToAutomationCookie } from '@packages/server/lib/util/cookies'
+import { generateCspDirectives, hasCspHeader, parseCspHeaders } from './util/csp-header'
+import crypto from 'crypto'
 
 interface ResponseMiddlewareProps {
   /**
@@ -311,6 +313,36 @@ const SetInjectionLevel: ResponseMiddleware = function () {
     // We set the header here only for proxied requests that have scripts injected that set the domain.
     // Other proxied requests are ignored.
     this.res.setHeader('Origin-Agent-Cluster', '?0')
+
+    // Only patch the headers that are being supplied by the response
+    const incomingCSPHeaders = ['content-security-policy', 'content-security-policy-report-only']
+    .filter((headerName) => hasCspHeader(this.incomingRes.headers, headerName))
+
+    if (incomingCSPHeaders.length) {
+      // In order to allow the injected script to run on sites with a CSP header
+      // we must add a generated `nonce` into the response headers
+      const nonce = crypto.randomBytes(16).toString('base64')
+
+      this.res.injectionNonce = nonce
+
+      // Since CSP headers are not cumulative, the nonce policy must be set on each CSP header individually
+      const mapPolicies = (policy: Map<string, string[]>) => {
+        const cspScriptSrc = policy.get('script-src') || []
+
+        policy.set('script-src', [...cspScriptSrc, `'nonce-${nonce}'`])
+
+        return generateCspDirectives(policy)
+      }
+
+      // Iterate through each CSP header
+      incomingCSPHeaders.forEach((headerName) => {
+        // Map the nonce on each CSP header
+        const modifiedCSPHeaders = parseCspHeaders(this.incomingRes.headers, headerName).map(mapPolicies)
+
+        // To replicate original response CSP headers, we must apply all header values as an array
+        this.res.setHeader(headerName, modifiedCSPHeaders)
+      })
+    }
   }
 
   this.res.wantsSecurityRemoved = (this.config.modifyObstructiveCode || this.config.experimentalModifyObstructiveThirdPartyCode) &&
@@ -356,8 +388,6 @@ const OmitProblematicHeaders: ResponseMiddleware = function () {
     'x-frame-options',
     'content-length',
     'transfer-encoding',
-    'content-security-policy',
-    'content-security-policy-report-only',
     'connection',
   ])
 
@@ -540,6 +570,7 @@ const MaybeInjectHtml: ResponseMiddleware = function () {
 
     const decodedBody = iconv.decode(body, nodeCharset)
     const injectedBody = await rewriter.html(decodedBody, {
+      cspNonce: this.res.injectionNonce,
       domainName: cors.getDomainNameFromUrl(this.req.proxiedUrl),
       wantsInjection: this.res.wantsInjection,
       wantsSecurityRemoved: this.res.wantsSecurityRemoved,
@@ -613,8 +644,8 @@ export default {
   AttachPlainTextStreamFn,
   InterceptResponse,
   PatchExpressSetHeader,
+  OmitProblematicHeaders, // Since we might modify CSP headers, this middleware needs to come BEFORE SetInjectionLevel
   SetInjectionLevel,
-  OmitProblematicHeaders,
   MaybePreventCaching,
   MaybeStripDocumentDomainFeaturePolicy,
   MaybeCopyCookiesFromIncomingRes,

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -315,10 +315,10 @@ const SetInjectionLevel: ResponseMiddleware = function () {
     this.res.setHeader('Origin-Agent-Cluster', '?0')
 
     // Only patch the headers that are being supplied by the response
-    const incomingCSPHeaders = ['content-security-policy', 'content-security-policy-report-only']
+    const incomingCspHeaders = ['content-security-policy', 'content-security-policy-report-only']
     .filter((headerName) => hasCspHeader(this.incomingRes.headers, headerName))
 
-    if (incomingCSPHeaders.length) {
+    if (incomingCspHeaders.length) {
       // In order to allow the injected script to run on sites with a CSP header
       // we must add a generated `nonce` into the response headers
       const nonce = crypto.randomBytes(16).toString('base64')
@@ -335,12 +335,12 @@ const SetInjectionLevel: ResponseMiddleware = function () {
       }
 
       // Iterate through each CSP header
-      incomingCSPHeaders.forEach((headerName) => {
+      incomingCspHeaders.forEach((headerName) => {
         // Map the nonce on each CSP header
-        const modifiedCSPHeaders = parseCspHeaders(this.incomingRes.headers, headerName).map(mapPolicies)
+        const modifiedCspHeaders = parseCspHeaders(this.incomingRes.headers, headerName).map(mapPolicies)
 
         // To replicate original response CSP headers, we must apply all header values as an array
-        this.res.setHeader(headerName, modifiedCSPHeaders)
+        this.res.setHeader(headerName, modifiedCspHeaders)
       })
     }
   }

--- a/packages/proxy/lib/http/util/csp-header.ts
+++ b/packages/proxy/lib/http/util/csp-header.ts
@@ -1,0 +1,58 @@
+import type { OutgoingHttpHeaders } from 'http'
+
+const cspRegExp = /[; ]*(.+?) +([^\n\r;]*)/g
+
+const caseInsensitiveGetAllHeaders = (headers: OutgoingHttpHeaders, lowercaseProperty: string): string[] => {
+  return Object.entries(headers).reduce((acc: string[], [key, value]) => {
+    if (key.toLowerCase() === lowercaseProperty) {
+      // It's possible to set more than 1 CSP header, and in those instances CSP headers
+      // are NOT merged by the browser. Instead, the most **restrictive** CSP header
+      // that applies to the given resource will be used.
+      // https://www.w3.org/TR/CSP2/#content-security-policy-header-field
+      //
+      // Therefore, we need to return each header as it's own value so we can apply
+      // injection nonce values to each one, because we don't know which will be
+      // the most restrictive.
+      acc.push.apply(
+        acc,
+        `${value}`.split(',')
+        .filter(Boolean)
+        .map((policyString) => `${policyString}`.trim()),
+      )
+    }
+
+    return acc
+  }, [])
+}
+
+function getCspHeaders (headers: OutgoingHttpHeaders, headerName: string = 'content-security-policy'): string[] {
+  return caseInsensitiveGetAllHeaders(headers, headerName.toLowerCase())
+}
+
+export function hasCspHeader (headers: OutgoingHttpHeaders, headerName: string = 'content-security-policy') {
+  return getCspHeaders(headers, headerName).length > 0
+}
+
+export function parseCspHeaders (headers: OutgoingHttpHeaders, headerName: string = 'content-security-policy'): Map<string, string[]>[] {
+  const cspHeaders = getCspHeaders(headers, headerName)
+
+  // We must make an policy map for each CSP header individually
+  return cspHeaders.reduce((acc: Map<string, string[]>[], cspHeader) => {
+    const policies = new Map<string, string[]>()
+    let policy = cspRegExp.exec(cspHeader)
+
+    while (policy) {
+      const [/* regExpMatch */, directive, values] = policy
+      const currentDirective = policies.get(directive) || []
+
+      policies.set(directive, [...currentDirective, ...values.split(' ').filter(Boolean)])
+      policy = cspRegExp.exec(cspHeader)
+    }
+
+    return [...acc, policies]
+  }, [])
+}
+
+export function generateCspDirectives (policies: Map<string, string[]>): string {
+  return Array.from(policies.entries()).map(([directive, values]) => `${directive} ${values.join(' ')}`).join('; ')
+}

--- a/packages/proxy/lib/http/util/inject.ts
+++ b/packages/proxy/lib/http/util/inject.ts
@@ -3,6 +3,7 @@ import { getRunnerInjectionContents, getRunnerCrossOriginInjectionContents } fro
 import type { AutomationCookie } from '@packages/server/lib/automation/cookies'
 
 interface InjectionOpts {
+  cspNonce?: string
   shouldInjectDocumentDomain: boolean
 }
 interface FullCrossOriginOpts {
@@ -12,6 +13,7 @@ interface FullCrossOriginOpts {
 }
 
 export function partial (domain, options: InjectionOpts) {
+  const { cspNonce } = options
   let documentDomainInjection = `document.domain = '${domain}';`
 
   if (!options.shouldInjectDocumentDomain) {
@@ -21,13 +23,17 @@ export function partial (domain, options: InjectionOpts) {
   // With useDefaultDocumentDomain=true we continue to inject an empty script tag in order to be consistent with our other forms of injection.
   // This is also diagnostic in nature is it will allow us to debug easily to make sure injection is still occurring.
   return oneLine`
-    <script type='text/javascript'>
+    <script type='text/javascript'${
+      cspNonce ? ` nonce="${cspNonce}"` : ''
+    }>
       ${documentDomainInjection}
     </script>
   `
 }
 
 export function full (domain, options: InjectionOpts) {
+  const { cspNonce } = options
+
   return getRunnerInjectionContents().then((contents) => {
     let documentDomainInjection = `document.domain = '${domain}';`
 
@@ -36,7 +42,9 @@ export function full (domain, options: InjectionOpts) {
     }
 
     return oneLine`
-      <script type='text/javascript'>
+      <script type='text/javascript'${
+        cspNonce ? ` nonce="${cspNonce}"` : ''
+      }>
         ${documentDomainInjection}
 
         ${contents}
@@ -47,6 +55,7 @@ export function full (domain, options: InjectionOpts) {
 
 export async function fullCrossOrigin (domain, options: InjectionOpts & FullCrossOriginOpts) {
   const contents = await getRunnerCrossOriginInjectionContents()
+  const { cspNonce, ...crossOriginOptions } = options
 
   let documentDomainInjection = `document.domain = '${domain}';`
 
@@ -55,12 +64,14 @@ export async function fullCrossOrigin (domain, options: InjectionOpts & FullCros
   }
 
   return oneLine`
-    <script type='text/javascript'>
+    <script type='text/javascript'${
+      cspNonce ? ` nonce="${cspNonce}"` : ''
+    }>
       ${documentDomainInjection}
 
       (function (cypressConfig) {
         ${contents}
-      }(${JSON.stringify(options)}));
+      }(${JSON.stringify(crossOriginOptions)}));
     </script>
   `
 }

--- a/packages/proxy/lib/http/util/rewriter.ts
+++ b/packages/proxy/lib/http/util/rewriter.ts
@@ -14,6 +14,7 @@ export type SecurityOpts = {
 }
 
 export type InjectionOpts = {
+  cspNonce?: string
   domainName: string
   wantsInjection: CypressWantsInjection
   wantsSecurityRemoved: any
@@ -32,6 +33,7 @@ function getRewriter (useAstSourceRewriting: boolean) {
 
 function getHtmlToInject (opts: InjectionOpts & SecurityOpts) {
   const {
+    cspNonce,
     domainName,
     wantsInjection,
     modifyObstructiveThirdPartyCode,
@@ -44,9 +46,11 @@ function getHtmlToInject (opts: InjectionOpts & SecurityOpts) {
     case 'full':
       return inject.full(domainName, {
         shouldInjectDocumentDomain,
+        cspNonce,
       })
     case 'fullCrossOrigin':
       return inject.fullCrossOrigin(domainName, {
+        cspNonce,
         modifyObstructiveThirdPartyCode,
         modifyObstructiveCode,
         simulatedCookies,
@@ -55,6 +59,7 @@ function getHtmlToInject (opts: InjectionOpts & SecurityOpts) {
     case 'partial':
       return inject.partial(domainName, {
         shouldInjectDocumentDomain,
+        cspNonce,
       })
     default:
       return

--- a/packages/proxy/lib/types.ts
+++ b/packages/proxy/lib/types.ts
@@ -32,6 +32,7 @@ export type CypressWantsInjection = 'full' | 'fullCrossOrigin' | 'partial' | fal
  * An outgoing response to an incoming request to the Cypress web server.
  */
 export type CypressOutgoingResponse = Response & {
+  injectionNonce?: string
   isInitial: null | boolean
   wantsInjection: CypressWantsInjection
   wantsSecurityRemoved: null | boolean

--- a/packages/proxy/test/integration/net-stubbing.spec.ts
+++ b/packages/proxy/test/integration/net-stubbing.spec.ts
@@ -72,9 +72,27 @@ context('network stubbing', () => {
 
     destinationApp.get('/', (req, res) => res.send('it worked'))
 
+    destinationApp.get('/csp-header', (req, res) => {
+      const headerName = req.query.headerName
+
+      res.setHeader('content-type', 'text/html')
+      res.setHeader(headerName, 'fake-directive fake-value')
+      res.send('<foo>bar</foo>')
+    })
+
+    destinationApp.get('/csp-header-multiple', (req, res) => {
+      const headerName = req.query.headerName
+
+      res.setHeader('content-type', 'text/html')
+      res.setHeader(headerName, ['default \'self\'', 'script-src \'self\' localhost'])
+      res.send('<foo>bar</foo>')
+    })
+
     server = allowDestroy(destinationApp.listen(() => {
       destinationPort = server.address().port
       remoteStates.set(`http://localhost:${destinationPort}`)
+      remoteStates.set(`http://localhost:${destinationPort}/csp-header`)
+      remoteStates.set(`http://localhost:${destinationPort}/csp-header-multiple`)
       done()
     }))
   })
@@ -284,5 +302,96 @@ context('network stubbing', () => {
 
     expect(sendContentLength).to.eq(receivedContentLength)
     expect(sendContentLength).to.eq(realContentLength)
+  })
+
+  describe('CSP Headers', () => {
+    // Loop through valid CSP header names can verify that we handle them
+    [
+      'content-security-policy',
+      'Content-Security-Policy',
+      'content-security-policy-report-only',
+      'Content-Security-Policy-Report-Only',
+    ].forEach((headerName) => {
+      describe(`${headerName}`, () => {
+        it('does not add CSP header if injecting JS and original response had no CSP header', () => {
+          netStubbingState.routes.push({
+            id: '1',
+            routeMatcher: {
+              url: '*',
+            },
+            hasInterceptor: false,
+            staticResponse: {
+              body: '<foo>bar</foo>',
+            },
+            getFixture: async () => {},
+            matches: 1,
+          })
+
+          return supertest(app)
+          .get(`/http://localhost:${destinationPort}`)
+          .set('Accept', 'text/html,application/xhtml+xml')
+          .then((res) => {
+            expect(res.headers[headerName]).to.be.undefined
+            expect(res.headers[headerName.toLowerCase()]).to.be.undefined
+          })
+        })
+
+        it('does not modify CSP header if not injecting JS and original response had CSP header', () => {
+          return supertest(app)
+          .get(`/http://localhost:${destinationPort}/csp-header?headerName=${headerName}`)
+          .then((res) => {
+            expect(res.headers[headerName.toLowerCase()]).to.equal('fake-directive fake-value')
+          })
+        })
+
+        it('modifies CSP header if injecting JS and original response had CSP header', () => {
+          return supertest(app)
+          .get(`/http://localhost:${destinationPort}/csp-header?headerName=${headerName}`)
+          .set('Accept', 'text/html,application/xhtml+xml')
+          .then((res) => {
+            expect(res.headers[headerName.toLowerCase()]).to.match(/^fake-directive fake-value; script-src 'nonce-[^-A-Za-z0-9+/=]|=[^=]|={3,}'/)
+          })
+        })
+
+        it('modifies CSP header if injecting JS and original response had multiple CSP headers', () => {
+          return supertest(app)
+          .get(`/http://localhost:${destinationPort}/csp-header-multiple?headerName=${headerName}`)
+          .set('Accept', 'text/html,application/xhtml+xml')
+          .then((res) => {
+            expect(res.headers[headerName.toLowerCase()]).to.match(/default 'self'; script-src 'nonce-[^-A-Za-z0-9+/=]|=[^=]|={3,}'/)
+            expect(res.headers[headerName.toLowerCase()]).to.match(/script-src 'self' localhost 'nonce-[^-A-Za-z0-9+/=]|=[^=]|={3,}'/)
+          })
+        })
+
+        if (headerName !== headerName.toLowerCase()) {
+          // Do not add a non-lowercase version of a CSP header, because most-restrictive is used
+          it('removes non-lowercase CSP header to avoid conflicts on unmodified CSP headers', () => {
+            return supertest(app)
+            .get(`/http://localhost:${destinationPort}/csp-header?headerName=${headerName}`)
+            .then((res) => {
+              expect(res.headers[headerName]).to.be.undefined
+            })
+          })
+
+          it('removes non-lowercase CSP header to avoid conflicts on modified CSP headers', () => {
+            return supertest(app)
+            .get(`/http://localhost:${destinationPort}/csp-header?headerName=${headerName}`)
+            .set('Accept', 'text/html,application/xhtml+xml')
+            .then((res) => {
+              expect(res.headers[headerName]).to.be.undefined
+            })
+          })
+
+          it('removes non-lowercase CSP header to avoid conflicts on multiple CSP headers', () => {
+            return supertest(app)
+            .get(`/http://localhost:${destinationPort}/csp-header-multiple?headerName=${headerName}`)
+            .set('Accept', 'text/html,application/xhtml+xml')
+            .then((res) => {
+              expect(res.headers[headerName]).to.be.undefined
+            })
+          })
+        }
+      })
+    })
   })
 })

--- a/packages/proxy/test/unit/http/response-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/response-middleware.spec.ts
@@ -15,8 +15,8 @@ describe('http/response-middleware', function () {
       'AttachPlainTextStreamFn',
       'InterceptResponse',
       'PatchExpressSetHeader',
-      'SetInjectionLevel',
       'OmitProblematicHeaders',
+      'SetInjectionLevel',
       'MaybePreventCaching',
       'MaybeStripDocumentDomainFeaturePolicy',
       'MaybeCopyCookiesFromIncomingRes',
@@ -355,6 +355,87 @@ describe('http/response-middleware', function () {
       return testMiddleware([SetInjectionLevel], ctx)
       .then(() => {
         expect(ctx.res.setHeader).to.be.calledWith('Origin-Agent-Cluster', '?0')
+      })
+    })
+
+    describe('modify CSP headers', () => {
+      // Loop through valid CSP header names can verify that we handle them
+      [
+        'content-security-policy',
+        'Content-Security-Policy',
+        'content-security-policy-report-only',
+        'Content-Security-Policy-Report-Only',
+      ].forEach((headerName) => {
+        describe(`${headerName}`, () => {
+          it(`modifies "${headerName}" header if injection is requested, and header exists`, () => {
+            prepareContext({
+              res: {
+                wantsInjection: 'full',
+              },
+              incomingRes: {
+                headers: {
+                  [`${headerName}`]: 'fake-csp-directive fake-csp-value',
+                },
+              },
+            })
+
+            return testMiddleware([SetInjectionLevel], ctx)
+            .then(() => {
+              expect(ctx.res.setHeader).to.be.calledWith(headerName.toLowerCase(), sinon.match.every(sinon.match(/^fake-csp-directive fake-csp-value; script-src 'nonce-[^-A-Za-z0-9+/=]|=[^=]|={3,}'/)))
+            })
+          })
+
+          it(`modifies all "${headerName}" headers if injection is requested, and multiple headers exists`, () => {
+            prepareContext({
+              res: {
+                wantsInjection: 'full',
+              },
+              incomingRes: {
+                headers: {
+                  [`${headerName}`]: 'fake-csp-directive-0 fake-csp-value-0,fake-csp-directive-1 fake-csp-value-1',
+                },
+              },
+            })
+
+            return testMiddleware([SetInjectionLevel], ctx)
+            .then(() => {
+              expect(ctx.res.setHeader).to.be.calledWith(headerName.toLowerCase(), sinon.match.every(sinon.match(/^fake-csp-directive-[0-1] fake-csp-value-[0-1]; script-src 'nonce-[^-A-Za-z0-9+/=]|=[^=]|={3,}'/)))
+            })
+          })
+
+          it(`does not modify "${headerName}" header if full injection is requested, and header does not exist`, () => {
+            prepareContext({
+              res: {
+                wantsInjection: 'full',
+              },
+            })
+
+            return testMiddleware([SetInjectionLevel], ctx)
+            .then(() => {
+              expect(ctx.res.setHeader).not.to.be.calledWith(headerName, sinon.match.array)
+              expect(ctx.res.setHeader).not.to.be.calledWith(headerName.toLowerCase(), sinon.match.array)
+            })
+          })
+
+          it(`does not modify "${headerName}" header when no injection is requested, and header exists`, () => {
+            prepareContext({
+              res: {
+                wantsInjection: false,
+              },
+              incomingRes: {
+                headers: {
+                  [`${headerName}`]: 'fake-csp-directive fake-csp-value',
+                },
+              },
+            })
+
+            return testMiddleware([SetInjectionLevel], ctx)
+            .then(() => {
+              expect(ctx.res.setHeader).not.to.be.calledWith(headerName, sinon.match.array)
+              expect(ctx.res.setHeader).not.to.be.calledWith(headerName.toLowerCase(), sinon.match.array)
+            })
+          })
+        })
       })
     })
 
@@ -1390,6 +1471,7 @@ describe('http/response-middleware', function () {
       .then(() => {
         expect(htmlStub).to.be.calledOnce
         expect(htmlStub).to.be.calledWith('foo', {
+          'cspNonce': undefined,
           'deferSourceMapRewrite': undefined,
           'domainName': 'foobar.com',
           'isNotJavascript': true,
@@ -1414,6 +1496,7 @@ describe('http/response-middleware', function () {
       .then(() => {
         expect(htmlStub).to.be.calledOnce
         expect(htmlStub).to.be.calledWith('foo', {
+          'cspNonce': undefined,
           'deferSourceMapRewrite': undefined,
           'domainName': '127.0.0.1',
           'isNotJavascript': true,
@@ -1446,11 +1529,43 @@ describe('http/response-middleware', function () {
       .then(() => {
         expect(htmlStub).to.be.calledOnce
         expect(htmlStub).to.be.calledWith('foo', {
+          'cspNonce': undefined,
           'deferSourceMapRewrite': undefined,
           'domainName': 'foobar.com',
           'isNotJavascript': true,
           'modifyObstructiveCode': false,
           'modifyObstructiveThirdPartyCode': false,
+          'shouldInjectDocumentDomain': true,
+          'url': 'http://www.foobar.com:3501/primary-origin.html',
+          'useAstSourceRewriting': undefined,
+          'wantsInjection': 'full',
+          'wantsSecurityRemoved': true,
+          'simulatedCookies': [],
+        })
+      })
+    })
+
+    it('cspNonce is set to the value stored in res.injectionNonce', function () {
+      prepareContext({
+        req: {
+          proxiedUrl: 'http://www.foobar.com:3501/primary-origin.html',
+        },
+        res: {
+          injectionNonce: 'fake-nonce',
+        },
+        simulatedCookies: [],
+      })
+
+      return testMiddleware([MaybeInjectHtml], ctx)
+      .then(() => {
+        expect(htmlStub).to.be.calledOnce
+        expect(htmlStub).to.be.calledWith('foo', {
+          'cspNonce': 'fake-nonce',
+          'deferSourceMapRewrite': undefined,
+          'domainName': 'foobar.com',
+          'isNotJavascript': true,
+          'modifyObstructiveCode': true,
+          'modifyObstructiveThirdPartyCode': true,
           'shouldInjectDocumentDomain': true,
           'url': 'http://www.foobar.com:3501/primary-origin.html',
           'useAstSourceRewriting': undefined,

--- a/packages/proxy/test/unit/http/util/csp-header.spec.ts
+++ b/packages/proxy/test/unit/http/util/csp-header.spec.ts
@@ -1,0 +1,73 @@
+import { generateCspDirectives, hasCspHeader, parseCspHeaders } from '../../../../lib/http/util/csp-header'
+
+import { expect } from 'chai'
+
+const patchedHeaders = [
+  'content-security-policy',
+  'Content-Security-Policy',
+  'content-security-policy-report-only',
+  'Content-Security-Policy-Report-Only',
+]
+
+describe('http/util/csp-header', () => {
+  describe('hasCspHeader', () => {
+    patchedHeaders.forEach((headerName) => {
+      it(`should be \`true\` for a CSP header using "${headerName}"`, () => {
+        expect(hasCspHeader({
+          [`${headerName}`]: 'fake-csp-directive fake-csp-value;',
+        }, headerName)).equal(true)
+      })
+
+      it(`should be \`true\` for a CSP header using multiple "${headerName}" headers`, () => {
+        expect(hasCspHeader({
+          [`${headerName}`]: 'fake-csp-directive-0 fake-csp-value-0;,fake-csp-directive-1 fake-csp-value-1;',
+        }, headerName)).equal(true)
+      })
+
+      it('should be `false` when a CSP header is not present', () => {
+        expect(hasCspHeader({
+          'Content-Type': 'fake-content-type',
+        }, headerName)).equal(false)
+      })
+    })
+  })
+
+  describe('parseCspHeader', () => {
+    patchedHeaders.forEach((headerName) => {
+      it(`should parse a CSP header using "${headerName}"`, () => {
+        const policyArray = parseCspHeaders({
+          'Content-Type': 'fake-content-type',
+          [`${headerName}`]: 'fake-csp-directive fake-csp-value;',
+        }, headerName)
+
+        expect(policyArray.length).to.equal(1)
+        policyArray.forEach((policyMap) => {
+          expect(policyMap.get('fake-csp-directive')).to.have.members(['fake-csp-value'])
+        }, headerName)
+      })
+
+      it(`should parse a CSP header using multiple "${headerName}" headers`, () => {
+        const policyArray = parseCspHeaders({
+          'Content-Type': 'fake-content-type',
+          [`${headerName}`]: 'fake-csp-directive-0 fake-csp-value-0,fake-csp-directive-1 fake-csp-value-1',
+        }, headerName)
+
+        expect(policyArray.length).to.equal(2)
+        policyArray.forEach((policyMap, idx) => {
+          expect(policyMap.get(`fake-csp-directive-${idx}`)).to.have.members([`fake-csp-value-${idx}`])
+        }, headerName)
+      })
+    })
+  })
+
+  describe('generateCspDirectives', () => {
+    it(`should generate a CSP directive string from a policy map`, () => {
+      const policyMap = new Map<string, string[]>()
+
+      policyMap.set('fake-csp-directive', ['\'self\'', 'unsafe-inline', 'fake-csp-value'])
+      policyMap.set('default', ['\'self\''])
+
+      expect(generateCspDirectives(policyMap)).equal('fake-csp-directive \'self\' unsafe-inline fake-csp-value; default \'self\'')
+    })
+  })
+})


### PR DESCRIPTION
- Closes [Issue #1030](https://github.com/cypress-io/cypress/issues/1030)

### User facing changelog

- Cypress no longer strips `Content-Security-Policy` and `Content-Security-Policy-Report-Only` headers from requests.

### Additional details
- add generated `nonce` to inline script injection
- append generated `nonce` policy value to each CSP header `script-src` directive
- remove `content-security-policy` and `content-security-policy-report-only` header stripping

### Steps to test
`// TODO`

### How has the user experience changed?
This change does not affect UI/UX

### PR Tasks
- [X] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
