### PR TITLE
fix: run-all-specs duplicate directory matching

### DIFF
--- a/packages/app/src/specs/InlineSpecListTree.vue
+++ b/packages/app/src/specs/InlineSpecListTree.vue
@@ -166,23 +166,7 @@ const resetFocusIfNecessary = (row, index) => {
   }
 }
 
-const directoryChildren = computed(() => {
-  return collapsible.value.tree.reduce<Record<string, string[]>>((acc, node) => {
-    if (!node.isLeaf) {
-      acc[node.id] = []
-    } else {
-      Object.keys(acc).forEach((dir) => {
-        if (node.id.startsWith(dir)) {
-          acc[dir].push(node.id)
-        }
-      })
-    }
-
-    return acc
-  }, {})
-})
-
-const { runAllSpecs, isRunAllSpecsAllowed } = useRunAllSpecs()
+const { runAllSpecs, isRunAllSpecsAllowed, directoryChildren } = useRunAllSpecs(collapsible)
 
 function onRunAllSpecs (rowId: string) {
   runAllSpecs(directoryChildren.value[rowId])

--- a/packages/app/src/specs/SpecsList.vue
+++ b/packages/app/src/specs/SpecsList.vue
@@ -380,22 +380,6 @@ const treeSpecList = computed(() => collapsible.value.tree.filter(((item) => !it
 
 const { containerProps, list, wrapperProps, scrollTo } = useVirtualList(treeSpecList, { itemHeight: 40, overscan: 10 })
 
-const directoryChildren = computed(() => {
-  return collapsible.value.tree.reduce<{[key: string]: string[]}>((acc, node) => {
-    if (!node.isLeaf) {
-      acc[node.id] = []
-    } else {
-      Object.keys(acc).forEach((dir) => {
-        if (node.id.startsWith(dir)) {
-          acc[dir].push(node.id)
-        }
-      })
-    }
-
-    return acc
-  }, {})
-})
-
 const scrollbarOffset = ref(0)
 
 // Watch the sizing of the specs list so we can detect when a scrollbar is added/removed
@@ -443,7 +427,7 @@ const { refetchFailedCloudData } = useCloudSpecData(
   props.gql.currentProject?.specs as SpecsListFragment[] || [],
 )
 
-const { runAllSpecs, isRunAllSpecsAllowed } = useRunAllSpecs()
+const { runAllSpecs, isRunAllSpecsAllowed, directoryChildren } = useRunAllSpecs(collapsible)
 
 function onRunAllSpecs (rowId: string) {
   runAllSpecs(directoryChildren.value[rowId])

--- a/packages/app/src/specs/tree/useCollapsibleTree.ts
+++ b/packages/app/src/specs/tree/useCollapsibleTree.ts
@@ -40,7 +40,8 @@ export const getPlatform = (): string => {
 }
 
 const getRegexSeparator = () => getPlatform() === 'win32' ? /\\/ : /\//
-const getSeparator = () => getPlatform() === 'win32' ? '\\' : '/'
+
+export const getSeparator = () => getPlatform() === 'win32' ? '\\' : '/'
 
 export function buildSpecTree<T extends FoundSpec> (specs: FoundSpec[], root: SpecTreeNode<T> = { name: '', isLeaf: false, children: [], id: '', highlightIndexes: [] }): SpecTreeNode<T> {
   specs.forEach((spec) => buildSpecTreeRecursive(spec.relative, root, spec))


### PR DESCRIPTION
Needed to verify that, once we matched a file to a directory that the match ended with a separator, denoting it is the end of the dir path.

https://user-images.githubusercontent.com/25158820/203178798-b152faa8-0e9f-47a3-a195-0f34ef508443.mov

