### PR TITLE
fix: A docblock pointing to a non-existent online tool

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2695,7 +2695,7 @@ declare namespace Cypress {
      */
     env: { [key: string]: any }
     /**
-     * A String or Array of glob patterns used to ignore test files that would otherwise be shown in your list of tests. Cypress uses minimatch with the options: {dot: true, matchBase: true}. We suggest using https://toools.cloud/miscellaneous/glob-tester to test what files would match.
+     * A String or Array of glob patterns used to ignore test files that would otherwise be shown in your list of tests. Cypress uses minimatch with the options: {dot: true, matchBase: true}. We suggest using a tool to test what files would match.
      * @default "*.hot-update.js"
      */
     excludeSpecPattern: string | string[]

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2695,7 +2695,7 @@ declare namespace Cypress {
      */
     env: { [key: string]: any }
     /**
-     * A String or Array of glob patterns used to ignore test files that would otherwise be shown in your list of tests. Cypress uses minimatch with the options: {dot: true, matchBase: true}. We suggest using http://globtester.com to test what files would match.
+     * A String or Array of glob patterns used to ignore test files that would otherwise be shown in your list of tests. Cypress uses minimatch with the options: {dot: true, matchBase: true}. We suggest using https://toools.cloud/miscellaneous/glob-tester to test what files would match.
      * @default "*.hot-update.js"
      */
     excludeSpecPattern: string | string[]


### PR DESCRIPTION
Fixed a URL in a docblock pointing to a non-existent tool. It is problematic, as the domain is for sale now and could point to some NSFW content any time.

We could also say "We suggest using an online glob-testing tool to verify what files would match."

Disclaimer: I have no association with the newly-linked online tool.

### PR Tasks

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
