### PR TITLE
fix: upgrade electron/fuses to resolve code signing issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@cypress/questions-remain": "1.0.1",
     "@cypress/request": "2.88.10",
     "@cypress/request-promise": "4.2.6",
-    "@electron/fuses": "1.6.0",
+    "@electron/fuses": "1.6.1",
     "@fellow/eslint-plugin-coffee": "0.4.13",
     "@graphql-codegen/add": "3.1.0",
     "@graphql-codegen/cli": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2594,10 +2594,10 @@
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
-"@electron/fuses@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@electron/fuses/-/fuses-1.6.0.tgz#d4ca0b4701c286424b8096c55458b5ab91191b61"
-  integrity sha512-UnZgLfVO1jf7QoYVEEB27CCP1JjT5plhbWU1U8ji1OaXnvNe5UT6KPuRJ3Z12mwa5ZBAASU2tgxVuI06/2x6nQ==
+"@electron/fuses@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@electron/fuses/-/fuses-1.6.1.tgz#c639e018202a59e3cd8911fa943e22c63dd3e6fc"
+  integrity sha512-J7kRMlc0vP03uzUuhHNEqffqZMZ6FRe0YGMOJO4kJObmYkOg38mMTvbbktEj+oteH5nfyhbQUkHIYnMSh7T/CQ==
   dependencies:
     chalk "^4.1.1"
     fs-extra "^9.0.1"


### PR DESCRIPTION
### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

[`@electron/fuses`](https://github.com/electron/fuses) version 1.6.0 has an [issue](https://github.com/electron/fuses/pull/9) on M1s where setting fuses on the binary screws up ad hoc code signing for local development. 1.6.1 fixes this issue.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Try and run the app from the monorepo on an M1.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
