### PR TITLE
feat: Handle special characters in Create from Component filenames

### DIFF
--- a/packages/data-context/src/codegen/spec-options.ts
+++ b/packages/data-context/src/codegen/spec-options.ts
@@ -2,6 +2,7 @@ import type { ParsedPath } from 'path'
 import type { CodeGenType } from '@packages/graphql/src/gen/nxs.gen'
 import type { WizardFrontendFramework } from '@packages/scaffold-config'
 import fs from 'fs-extra'
+import { upperFirst } from 'lodash'
 import path from 'path'
 import { getDefaultSpecFileName } from '../sources/migration/utils'
 import { toPosix } from '../util'
@@ -140,14 +141,16 @@ export class SpecOptions {
 
   private buildComponentNameFromFilename (fileNameWithoutExt: string): string {
     const sanitizedName = fileNameWithoutExt
-    // Remove any characters from the filename that aren't allowed within a JS variable name (but leave periods to tell name groupings apart)
-    .replaceAll(/[^a-z_\d$.]/gi, '')
+    // Remove any characters from the filename that aren't allowed within a JS variable name (but leave periods and hyphens)
+    .replaceAll(/[^a-z_\d$.-]/gi, '')
     // Remove any groupings of multiple periods (eg, '...all') but leave single periods alone
     .replaceAll(/[.]{2,}/g, '')
 
-    // Use portion of name up to the first period - this allows us to use the 'significant' portion of the filename
-    // eg, 'test.page.ts' => 'test'
-    return sanitizedName.slice(0, /[.]/.exec(sanitizedName)?.index)
+    // Convert period- and hyphen-delimited portions to PascalCase
+    // eg, 'test.page.ts' => 'TestPage', 'about.component.vue' => 'AboutComponent'
+    return sanitizedName.split(/[-.]/g)
+    .map(upperFirst)
+    .join('')
   }
 
   private buildComponentSpecFilename (specExt: string, filePath?: ParsedPath) {

--- a/packages/data-context/src/codegen/spec-options.ts
+++ b/packages/data-context/src/codegen/spec-options.ts
@@ -81,7 +81,7 @@ export class SpecOptions {
   }
 
   private async getFrameworkComponentOptions () {
-    const componentName = this.parsedPath.name
+    const componentName = this.buildComponentNameFromFilename(this.parsedPath.name)
 
     const extension = await this.getVueExtension()
 
@@ -138,11 +138,23 @@ export class SpecOptions {
     return foundSpecExtension || ''
   }
 
+  private buildComponentNameFromFilename (fileNameWithoutExt: string): string {
+    const sanitizedName = fileNameWithoutExt
+    // Remove any characters from the filename that aren't allowed within a JS variable name (but leave periods to tell name groupings apart)
+    .replaceAll(/[^a-z_\d$.]/gi, '')
+    // Remove any groupings of multiple periods (eg, '...all') but leave single periods alone
+    .replaceAll(/[.]{2,}/g, '')
+
+    // Use portion of name up to the first period - this allows us to use the 'significant' portion of the filename
+    // eg, 'test.page.ts' => 'test'
+    return sanitizedName.slice(0, /[.]/.exec(sanitizedName)?.index)
+  }
+
   private buildComponentSpecFilename (specExt: string, filePath?: ParsedPath) {
     const { dir, base, ext } = filePath || this.parsedPath
     const cyWithExt = this.getSpecExtension(filePath) + ext
 
-    const name = base.slice(0, base.indexOf('.'))
+    const name = base.slice(0, -cyWithExt.length)
 
     const finalExtension = filePath ? cyWithExt : specExt
 

--- a/packages/data-context/test/unit/codegen/spec-options.spec.ts
+++ b/packages/data-context/test/unit/codegen/spec-options.spec.ts
@@ -246,10 +246,12 @@ describe('spec-options', () => {
       context('file name contains special characters', async () => {
         [
           { condition: 'braces', fileName: '[...MyComponent].vue', expectedFileName: '[...MyComponent].cy.js', expectedComponentName: 'MyComponent' },
-          { condition: 'hyphens', fileName: 'my-component.vue', expectedFileName: 'my-component.cy.js', expectedComponentName: 'mycomponent' },
+          { condition: 'hyphens', fileName: 'my-component.vue', expectedFileName: 'my-component.cy.js', expectedComponentName: 'MyComponent' },
           { condition: 'parentheses', fileName: 'My(Component).js', expectedFileName: 'My(Component).cy.js', expectedComponentName: 'MyComponent' },
-          { condition: 'period-separated', fileName: 'my.component.js', expectedFileName: 'my.component.cy.js', expectedComponentName: 'my' },
+          { condition: 'period-separated', fileName: 'my.component.js', expectedFileName: 'my.component.cy.js', expectedComponentName: 'MyComponent' },
           { condition: 'dollar', fileName: '$MyComponent.js', expectedFileName: '$MyComponent.cy.js', expectedComponentName: '$MyComponent' },
+          { condition: 'underscores', fileName: 'My_Component.js', expectedFileName: 'My_Component.cy.js', expectedComponentName: 'My_Component' },
+          { condition: 'mixed period- and hypen-delimited', fileName: 'about-us.component.js', expectedFileName: 'about-us.component.cy.js', expectedComponentName: 'AboutUsComponent' },
         ].forEach(({ condition, fileName, expectedFileName, expectedComponentName }) => {
           it(`generates options for ${condition}`, async () => {
             const testSpecOptions = new SpecOptions({

--- a/packages/data-context/test/unit/codegen/spec-options.spec.ts
+++ b/packages/data-context/test/unit/codegen/spec-options.spec.ts
@@ -242,6 +242,35 @@ describe('spec-options', () => {
         expect(result.codeGenType).to.eq('e2e')
         expect(result.fileName).to.eq(`TestName.foo.bar-copy-2.js`)
       })
+
+      context('file name contains special characters', async () => {
+        [
+          { condition: 'braces', fileName: '[...MyComponent].vue', expectedFileName: '[...MyComponent].cy.js', expectedComponentName: 'MyComponent' },
+          { condition: 'hyphens', fileName: 'my-component.vue', expectedFileName: 'my-component.cy.js', expectedComponentName: 'mycomponent' },
+          { condition: 'parentheses', fileName: 'My(Component).js', expectedFileName: 'My(Component).cy.js', expectedComponentName: 'MyComponent' },
+          { condition: 'period-separated', fileName: 'my.component.js', expectedFileName: 'my.component.cy.js', expectedComponentName: 'my' },
+          { condition: 'dollar', fileName: '$MyComponent.js', expectedFileName: '$MyComponent.cy.js', expectedComponentName: '$MyComponent' },
+        ].forEach(({ condition, fileName, expectedFileName, expectedComponentName }) => {
+          it(`generates options for ${condition}`, async () => {
+            const testSpecOptions = new SpecOptions({
+              currentProject: 'path/to/myProject',
+              codeGenPath: `${tmpPath}/${fileName}`,
+              codeGenType: 'component',
+              isDefaultSpecPattern: true,
+              specPattern: [defaultSpecPattern.component],
+              framework: WIZARD_FRAMEWORKS[1],
+            })
+
+            await fs.outputFile(`${tmpPath}/${fileName}`, '// foo')
+
+            const result = await testSpecOptions.getCodeGenOptions()
+
+            expect(result.codeGenType).to.eq('component')
+            expect(result.fileName).to.eq(expectedFileName)
+            expect(result['componentName']).to.eq(expectedComponentName)
+          })
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
- Closes #23492 

### User facing changelog
* Fixes "Create Spec from Component" to better handle special characters in filenames

### Additional details
In "Generate from Component", handle situations where source filename contains special characters

| Condition | Source File | Spec Filename | Component Name |
|---|---|---|---|
| Braces | `[...MyComponent].vue` | `[...MyComponent].cy.js` | `MyComponent` |
| Parens | `My(Component).js` | `My(Component).cy.js` | `MyComponent` |
| Periods | `my.component.js` | `my.component.cy.js` | `my` |
| Hypens | `my-component.js` | `my-component.cy.js` | `mycomponent` |
| Dollar | `$MyComponent.ts` | `$MyComponent.cy.ts` | `$MyComponent` |

### Steps to test
1. Scaffold a basic Vue project
2. Create the files in the table above in the project (can be left empty)
3. Open project in Cypress, use "Create Spec from Component" feature to create spec for each file
4. Validate generated spec file uses expected filename
5. Validate content of spec file uses expected component name

### How has the user experience changed?
Currently, these patterns either result in malformed partial names or try to use illegal characters in the generated spec file

For example,
`[...MyComponent].vue` => `[.cy.ts` with an invalid component name of `[...MyComponent]`
`my-component.js` => `my-component.cy.js` with an invalid component name of `my-component`

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
