### PR TITLE
feat: IATR-M0 Spec and Test Component

### DIFF
--- a/packages/app/src/debug/DebugFailedTest.cy.tsx
+++ b/packages/app/src/debug/DebugFailedTest.cy.tsx
@@ -16,7 +16,7 @@ describe('<DebugFailedTest/>', () => {
     })
 
     testResult.titleParts.forEach((title, index) => {
-      cy.findByTestId(`titleParts-${index}`).should('have.text', `${title } `)
+      cy.findByTestId(`titleParts-${index}`).should('have.text', ` ${title }`)
     })
   })
 
@@ -32,7 +32,9 @@ describe('<DebugFailedTest/>', () => {
 
     cy.findByTestId('test-row').children().should('have.length', 5).should('be.visible')
     multipleTitleParts.titleParts.forEach((title, index) => {
-      cy.findByTestId(`titleParts-${index}`).should('have.text', `${title } `)
+      cy.findByTestId(`titleParts-${index}`).should('have.text', ` ${title }`)
     })
+
+    cy.percySnapshot()
   })
 })

--- a/packages/app/src/debug/DebugFailedTest.cy.tsx
+++ b/packages/app/src/debug/DebugFailedTest.cy.tsx
@@ -1,0 +1,9 @@
+import DebugFailedTest from './DebugFailedTest.vue'
+
+describe('<DebugSpec/>', () => {
+  it('mounts correctly', () => {
+    cy.mount(() => (
+      <DebugFailedTest failedTest="Login should redirect unauthenticated user to signin page" />
+    ))
+  })
+})

--- a/packages/app/src/debug/DebugFailedTest.cy.tsx
+++ b/packages/app/src/debug/DebugFailedTest.cy.tsx
@@ -11,12 +11,12 @@ describe('<DebugFailedTest/>', () => {
       <DebugFailedTest failedTestResult={testResult} />
     ))
 
-    cy.findByTestId('test-row').children().should('have.length', 2).then((ele) => {
-      expect(ele).to.have.css('color', 'rgb(90, 95, 122)')
-    })
+    cy.findByTestId('test-row').children()
+    .should('have.length', 2)
+    .and('have.css', 'color', 'rgb(90, 95, 122)')
 
     testResult.titleParts.forEach((title, index) => {
-      cy.findByTestId(`titleParts-${index}`).should('have.text', ` ${title }`)
+      cy.findByTestId(`titleParts-${index}`).should('have.text', `${title}`)
     })
   })
 
@@ -32,7 +32,7 @@ describe('<DebugFailedTest/>', () => {
 
     cy.findByTestId('test-row').children().should('have.length', 5).should('be.visible')
     multipleTitleParts.titleParts.forEach((title, index) => {
-      cy.findByTestId(`titleParts-${index}`).should('have.text', ` ${title }`)
+      cy.findByTestId(`titleParts-${index}`).should('have.text', `${title}`)
     })
 
     cy.percySnapshot()

--- a/packages/app/src/debug/DebugFailedTest.cy.tsx
+++ b/packages/app/src/debug/DebugFailedTest.cy.tsx
@@ -2,8 +2,19 @@ import DebugFailedTest from './DebugFailedTest.vue'
 
 describe('<DebugSpec/>', () => {
   it('mounts correctly', () => {
+    const failedTest: string[] = ['App: Runs', 'should fetch newer runs and maintain them when navigating']
+
     cy.mount(() => (
-      <DebugFailedTest failedTest="Login should redirect unauthenticated user to signin page" />
+      <DebugFailedTest failedTest={failedTest} />
     ))
+
+    cy.findByTestId('test-row').children().should('have.length', 3)
+    cy.findByTestId('test-title')
+    .should('have.text', 'App: Runs')
+    .should('have.css', 'color', 'rgb(90, 95, 122)')
+
+    cy.findByTestId('test-description')
+    .should('have.text', 'should fetch newer runs and maintain them when navigating')
+    .should('have.css', 'color', 'rgb(90, 95, 122)')
   })
 })

--- a/packages/app/src/debug/DebugFailedTest.cy.tsx
+++ b/packages/app/src/debug/DebugFailedTest.cy.tsx
@@ -1,20 +1,38 @@
 import DebugFailedTest from './DebugFailedTest.vue'
 
-describe('<DebugSpec/>', () => {
+describe('<DebugFailedTest/>', () => {
   it('mounts correctly', () => {
-    const failedTest: string[] = ['App: Runs', 'should fetch newer runs and maintain them when navigating']
+    const testResult = {
+      id: '676df87878',
+      titleParts: ['Login', 'Should redirect unauthenticated user to signin page'],
+    }
 
     cy.mount(() => (
-      <DebugFailedTest failedTest={failedTest} />
+      <DebugFailedTest failedTestResult={testResult} />
     ))
 
-    cy.findByTestId('test-row').children().should('have.length', 3)
-    cy.findByTestId('test-title')
-    .should('have.text', 'App: Runs')
-    .should('have.css', 'color', 'rgb(90, 95, 122)')
+    cy.findByTestId('test-row').children().should('have.length', 2).then((ele) => {
+      expect(ele).to.have.css('color', 'rgb(90, 95, 122)')
+    })
 
-    cy.findByTestId('test-description')
-    .should('have.text', 'should fetch newer runs and maintain them when navigating')
-    .should('have.css', 'color', 'rgb(90, 95, 122)')
+    testResult.titleParts.forEach((title, index) => {
+      cy.findByTestId(`titleParts-${index}`).should('have.text', `${title } `)
+    })
+  })
+
+  it('contains multiple titleParts segments', () => {
+    const multipleTitleParts = {
+      id: '676df87878',
+      titleParts: ['Login', 'Describe', 'it', 'context', 'Should redirect unauthenticated user to signin page'],
+    }
+
+    cy.mount(() => (
+      <DebugFailedTest failedTestResult={multipleTitleParts} />
+    ))
+
+    cy.findByTestId('test-row').children().should('have.length', 5).should('be.visible')
+    multipleTitleParts.titleParts.forEach((title, index) => {
+      cy.findByTestId(`titleParts-${index}`).should('have.text', `${title } `)
+    })
   })
 })

--- a/packages/app/src/debug/DebugFailedTest.cy.tsx
+++ b/packages/app/src/debug/DebugFailedTest.cy.tsx
@@ -11,9 +11,7 @@ describe('<DebugFailedTest/>', () => {
       <DebugFailedTest failedTestResult={testResult} />
     ))
 
-    cy.findByTestId('test-row').children()
-    .should('have.length', 2)
-    .and('have.css', 'color', 'rgb(90, 95, 122)')
+    cy.findByTestId('test-row').children().should('have.length', 2)
 
     testResult.titleParts.forEach((title, index) => {
       cy.findByTestId(`titleParts-${index}`).should('have.text', `${title}`)

--- a/packages/app/src/debug/DebugFailedTest.vue
+++ b/packages/app/src/debug/DebugFailedTest.vue
@@ -1,0 +1,29 @@
+<template>
+  <li
+    data-cy="test-row"
+    class="flex flex-row items-center py-12px pr-12px pl-16px gap-x-2.5 non-italic text-base text-gray-700 font-normal border-b-gray-100 border-b-1px"
+  >
+    <span
+      data-cy="test-title"
+    >
+      {{ props.failedTest.split(' ')[0] }}
+    </span>
+    <IconChevronRightSmall
+      size="8"
+      stroke-color="gray-200"
+      fill-color="gray-200"
+    />
+    <span>
+      {{ props.failedTest.split(' ').slice(1).join(' ') }}
+    </span>
+  </li>
+</template>
+<script lang="ts" setup>
+import { IconChevronRightSmall } from '@cypress-design/vue-icon'
+
+const props = defineProps<{
+  failedTest: string
+}>()
+
+// figure out proper caret sign placement
+</script>

--- a/packages/app/src/debug/DebugFailedTest.vue
+++ b/packages/app/src/debug/DebugFailedTest.vue
@@ -6,24 +6,28 @@
     <span
       data-cy="test-title"
     >
-      {{ props.failedTest.split(' ')[0] }}
+      {{ testData[0] }}
     </span>
     <IconChevronRightSmall
       size="8"
       stroke-color="gray-200"
       fill-color="gray-200"
     />
-    <span>
-      {{ props.failedTest.split(' ').slice(1).join(' ') }}
+    <span
+      data-cy="test-description"
+    >
+      {{ testData[1] }}
     </span>
   </li>
 </template>
 <script lang="ts" setup>
+import { computed } from 'vue'
 import { IconChevronRightSmall } from '@cypress-design/vue-icon'
 
 const props = defineProps<{
-  failedTest: string
+  failedTest: string[]
 }>()
 
-// figure out proper caret sign placement
+const testData = computed(() => props.failedTest)
+
 </script>

--- a/packages/app/src/debug/DebugFailedTest.vue
+++ b/packages/app/src/debug/DebugFailedTest.vue
@@ -3,21 +3,21 @@
     data-cy="test-row"
     class="flex flex-row items-center gap-x-2.5 non-italic text-base text-gray-700 font-normal"
   >
-    <li
+    <span
       v-for="(titlePart, index) in props.failedTestResult.titleParts"
       :key="`${titlePart}-${index}`"
-      class="flex flew-row items-center gap-x-2.5"
+      class="flex flex-row items-center gap-x-2.5"
       :data-cy="`titleParts-${index}`"
     >
-      {{ titlePart }}
       <IconChevronRightSmall
-        v-if="(index != props.failedTestResult.titleParts.length - 1)"
+        v-if="index != 0"
         data-cy="right-chevron"
         size="8"
         stroke-color="gray-200"
         fill-color="gray-200"
       />
-    </li>
+      {{ titlePart }}
+    </span>
   </div>
 </template>
 <script lang="ts" setup>

--- a/packages/app/src/debug/DebugFailedTest.vue
+++ b/packages/app/src/debug/DebugFailedTest.vue
@@ -1,33 +1,31 @@
 <template>
-  <li
+  <div
     data-cy="test-row"
-    class="flex flex-row items-center py-12px pr-12px pl-16px gap-x-2.5 non-italic text-base text-gray-700 font-normal border-b-gray-100 border-b-1px"
+    class="flex flex-row items-center gap-x-2.5 non-italic text-base text-gray-700 font-normal"
   >
-    <span
-      data-cy="test-title"
+    <li
+      v-for="(titlePart, index) in props.failedTestResult.titleParts"
+      :key="`${titlePart}-${index}`"
+      class="flex flew-row items-center gap-x-2.5"
+      :data-cy="`titleParts-${index}`"
     >
-      {{ testData[0] }}
-    </span>
-    <IconChevronRightSmall
-      size="8"
-      stroke-color="gray-200"
-      fill-color="gray-200"
-    />
-    <span
-      data-cy="test-description"
-    >
-      {{ testData[1] }}
-    </span>
-  </li>
+      {{ titlePart }}
+      <IconChevronRightSmall
+        v-if="(index != props.failedTestResult.titleParts.length - 1)"
+        data-cy="right-chevron"
+        size="8"
+        stroke-color="gray-200"
+        fill-color="gray-200"
+      />
+    </li>
+  </div>
 </template>
 <script lang="ts" setup>
-import { computed } from 'vue'
 import { IconChevronRightSmall } from '@cypress-design/vue-icon'
+import type { TestResults } from './DebugSpec.vue'
 
 const props = defineProps<{
-  failedTest: string[]
+  failedTestResult: TestResults
 }>()
-
-const testData = computed(() => props.failedTest)
 
 </script>

--- a/packages/app/src/debug/DebugFailedTest.vue
+++ b/packages/app/src/debug/DebugFailedTest.vue
@@ -3,21 +3,23 @@
     data-cy="test-row"
     class="flex flex-row items-center gap-x-2.5 non-italic text-base text-gray-700 font-normal"
   >
-    <span
+    <div
       v-for="(titlePart, index) in props.failedTestResult.titleParts"
       :key="`${titlePart}-${index}`"
       class="flex flex-row items-center gap-x-2.5"
       :data-cy="`titleParts-${index}`"
     >
       <IconChevronRightSmall
-        v-if="index != 0"
+        v-if="index !== 0"
         data-cy="right-chevron"
         size="8"
         stroke-color="gray-200"
         fill-color="gray-200"
       />
-      {{ titlePart }}
-    </span>
+      <span>
+        {{ titlePart }}
+      </span>
+    </div>
   </div>
 </template>
 <script lang="ts" setup>

--- a/packages/app/src/debug/DebugSpec.cy.tsx
+++ b/packages/app/src/debug/DebugSpec.cy.tsx
@@ -1,20 +1,60 @@
 import type { Spec, TestResults } from './DebugSpec.vue'
 import DebugSpec from './DebugSpec.vue'
 
-const spec: Spec = {
-  id: '1',
-  path: 'cypress/tests/auth.spec.ts',
-}
-
-const testResults: TestResults = {
-  id: '1',
-  titleParts: ['Login Should redirect unauthenticated user to signin page', 'Login redirects to stored path after login'],
-}
-
 describe('<DebugSpec/>', () => {
-  it('mounts correctly', () => {
+  it('renders correctly with multiple test results in Spec', () => {
+    const spec: Spec = {
+      id: '8879798756s88d',
+      path: 'cypress/tests/auth.spec.ts',
+    }
+
+    const testResults: TestResults[] = [
+      {
+        id: '676df87878',
+        titleParts: ['Login', 'Should redirect unauthenticated user to signin page'],
+      },
+      {
+        id: '78hjkdf987d9f',
+        titleParts: ['Login', 'redirects to stored path after login'],
+      },
+    ]
+
     cy.mount(() => (
-      <DebugSpec spec={spec} testResults={testResults} disabled={false} />
+      <DebugSpec spec={spec} testResults={testResults} />
     ))
+
+    cy.findByTestId('debug-spec-item').children().should('have.length', 3)
+    cy.findByTestId('spec-contents').children().should('have.length', 2)
+    cy.findByTestId('spec-path').should('have.text', 'cypress/tests/auth.spec.ts')
+    cy.contains('auth').should('have.css', 'color', 'rgb(46, 50, 71)')
+    cy.findByTestId('run-failures').should('not.be.disabled')
+    .should('have.text', ' Run Failures ')
+    .should('have.css', 'color', 'rgb(73, 86, 227)')
+
+    cy.findAllByTestId('test-group').should('have.length', 2)
+  })
+
+  it('renders correctly with single test and a disabled run-failures button', () => {
+    const spec: Spec = {
+      id: '5479adf90s7f',
+      path: 'cypress/tests/top-nav-launchpad.spec.ts',
+    }
+
+    const testResults: TestResults[] = [
+      {
+        id: 'hf89dkb300js',
+        titleParts: ['Launchpad Top Nav Workflows', 'user not logged in'],
+      },
+    ]
+
+    cy.mount(() => (
+      <DebugSpec spec={spec} testResults={testResults} disabled={true} />
+    ))
+
+    cy.findByTestId('debug-spec-item').children().should('have.length', 2)
+    cy.findByTestId('spec-path').should('have.text', 'cypress/tests/top-nav-launchpad.spec.ts')
+    cy.contains('top-nav-launchpad').should('have.css', 'color', 'rgb(46, 50, 71)')
+    cy.findByTestId('run-failures-disabled').should('be.disabled')
+    .should('have.css', 'color', 'rgb(144, 149, 173)')
   })
 })

--- a/packages/app/src/debug/DebugSpec.cy.tsx
+++ b/packages/app/src/debug/DebugSpec.cy.tsx
@@ -1,24 +1,24 @@
 import type { Spec, TestResults } from './DebugSpec.vue'
 import DebugSpec from './DebugSpec.vue'
 
-describe('<DebugSpec/>', () => {
-  it('renders correctly with multiple test results in Spec', () => {
-    const spec: Spec = {
-      id: '8879798756s88d',
-      path: 'cypress/tests/auth.spec.ts',
-    }
+describe('<DebugSpec/> with multiple test results', () => {
+  const spec: Spec = {
+    id: '8879798756s88d',
+    path: 'cypress/tests/auth.spec.ts',
+  }
 
-    const testResults: TestResults[] = [
-      {
-        id: '676df87878',
-        titleParts: ['Login', 'Should redirect unauthenticated user to signin page'],
-      },
-      {
-        id: '78hjkdf987d9f',
-        titleParts: ['Login', 'redirects to stored path after login'],
-      },
-    ]
+  const testResults: TestResults[] = [
+    {
+      id: '676df87878',
+      titleParts: ['Login', 'Should redirect unauthenticated user to signin page'],
+    },
+    {
+      id: '78hjkdf987d9f',
+      titleParts: ['Login', 'redirects to stored path after login'],
+    },
+  ]
 
+  it('mounts correctly', () => {
     cy.mount(() => (
       <DebugSpec spec={spec} testResults={testResults} />
     ))
@@ -34,27 +34,55 @@ describe('<DebugSpec/>', () => {
     cy.findAllByTestId('test-group').should('have.length', 2)
   })
 
-  it('renders correctly with single test and a disabled run-failures button', () => {
-    const spec: Spec = {
-      id: '5479adf90s7f',
-      path: 'cypress/tests/top-nav-launchpad.spec.ts',
-    }
-
-    const testResults: TestResults[] = [
-      {
-        id: 'hf89dkb300js',
-        titleParts: ['Launchpad Top Nav Workflows', 'user not logged in'],
-      },
-    ]
-
+  it('renders correctly with disabled run-failures button', () => {
     cy.mount(() => (
-      <DebugSpec spec={spec} testResults={testResults} disabled={true} />
+      <DebugSpec spec={spec} testResults={testResults} isDisabled={true} />
     ))
 
-    cy.findByTestId('debug-spec-item').children().should('have.length', 2)
-    cy.findByTestId('spec-path').should('have.text', 'cypress/tests/top-nav-launchpad.spec.ts')
-    cy.contains('top-nav-launchpad').should('have.css', 'color', 'rgb(46, 50, 71)')
-    cy.findByTestId('run-failures-disabled').should('be.disabled')
-    .should('have.css', 'color', 'rgb(144, 149, 173)')
+    cy.findByTestId('run-failures').should('be.disabled')
+    .should('have.css', 'color', 'rgb(73, 86, 227)')
+  })
+})
+
+describe('<DebugSpec/> responsive UI', () => {
+  const testResults: TestResults[] = [
+    {
+      id: 'ab78dkb300js',
+      titleParts: ['Alert Bar with state', 'Alert Bar shows passing message'],
+    },
+    {
+      id: 'ab78dkb590js',
+      titleParts: ['Alert Bar with state', 'Alert Bar shows failure message'],
+    },
+  ]
+
+  it('renders complete UI on smaller viewports', { viewportHeight: 300, viewportWidth: 450 }, () => {
+    const spec: Spec = {
+      id: '5479adf90s7f',
+      path: 'cypress/tests/AlertBar.spec.ts',
+    }
+
+    cy.mount(() => (
+      <DebugSpec spec={spec} testResults={testResults} />
+    ))
+
+    cy.findByTestId('spec-contents').children().should('have.length', 2)
+    cy.findByTestId('spec-path').should('have.text', 'cypress/tests/AlertBar.spec.ts')
+    cy.contains('AlertBar').should('have.css', 'color', 'rgb(46, 50, 71)')
+    cy.findByTestId('run-failures').should('be.visible')
+  })
+
+  it('shows complete spec component header with long relative filePath', () => {
+    const spec: Spec = {
+      id: '547a0dG90s7f',
+      path: 'src/shared/frontend/cow/packages/foo/cypress/tests/e2e/components/AlertBar.spec.ts',
+    }
+
+    cy.mount(() => (
+      <DebugSpec spec={spec} testResults={testResults} />
+    ))
+
+    cy.findByTestId('spec-path').should('have.css', 'text-overflow', 'ellipsis')
+    cy.findByTestId('run-failures').should('be.visible')
   })
 })

--- a/packages/app/src/debug/DebugSpec.cy.tsx
+++ b/packages/app/src/debug/DebugSpec.cy.tsx
@@ -26,7 +26,7 @@ describe('<DebugSpec/> with multiple test results', () => {
     cy.findByTestId('debug-spec-item').children().should('have.length', 3)
     cy.findByTestId('spec-contents').children().should('have.length', 2)
     cy.findByTestId('spec-path').should('have.text', 'cypress/tests/auth.spec.ts')
-    cy.contains('auth').should('have.css', 'color', 'rgb(46, 50, 71)')
+    cy.contains('auth').should('have.css', 'color', 'rgb(67, 72, 97)')
     cy.findByTestId('run-failures').should('not.be.disabled')
     .should('have.text', ' Run Failures ')
     .should('have.css', 'color', 'rgb(73, 86, 227)')
@@ -72,7 +72,7 @@ describe('<DebugSpec/> responsive UI', () => {
 
     cy.findByTestId('spec-contents').children().should('have.length', 2)
     cy.findByTestId('spec-path').should('have.text', 'cypress/tests/AlertBar.spec.ts')
-    cy.contains('AlertBar').should('have.css', 'color', 'rgb(46, 50, 71)')
+    cy.contains('AlertBar').should('have.css', 'color', 'rgb(67, 72, 97)')
     cy.findByTestId('run-failures').should('be.visible')
 
     cy.percySnapshot()

--- a/packages/app/src/debug/DebugSpec.cy.tsx
+++ b/packages/app/src/debug/DebugSpec.cy.tsx
@@ -1,0 +1,7 @@
+import DebugSpec from './DebugSpec.vue'
+
+describe('<DebugSpec/>', () => {
+  it('mounts correctly', () => {
+    cy.mount(() => (<DebugSpec/>))
+  })
+})

--- a/packages/app/src/debug/DebugSpec.cy.tsx
+++ b/packages/app/src/debug/DebugSpec.cy.tsx
@@ -1,7 +1,20 @@
+import type { Spec, TestResults } from './DebugSpec.vue'
 import DebugSpec from './DebugSpec.vue'
+
+const spec: Spec = {
+  id: '1',
+  path: 'cypress/tests/auth.spec.ts',
+}
+
+const testResults: TestResults = {
+  id: '1',
+  titleParts: ['Login Should redirect unauthenticated user to signin page', 'Login redirects to stored path after login'],
+}
 
 describe('<DebugSpec/>', () => {
   it('mounts correctly', () => {
-    cy.mount(() => (<DebugSpec/>))
+    cy.mount(() => (
+      <DebugSpec spec={spec} testResults={testResults} disabled={false} />
+    ))
   })
 })

--- a/packages/app/src/debug/DebugSpec.cy.tsx
+++ b/packages/app/src/debug/DebugSpec.cy.tsx
@@ -32,6 +32,8 @@ describe('<DebugSpec/> with multiple test results', () => {
     .should('have.css', 'color', 'rgb(73, 86, 227)')
 
     cy.findAllByTestId('test-group').should('have.length', 2)
+
+    cy.percySnapshot()
   })
 
   it('renders correctly with disabled run-failures button', () => {
@@ -41,6 +43,8 @@ describe('<DebugSpec/> with multiple test results', () => {
 
     cy.findByTestId('run-failures').should('be.disabled')
     .should('have.css', 'color', 'rgb(73, 86, 227)')
+
+    cy.percySnapshot()
   })
 })
 
@@ -70,6 +74,8 @@ describe('<DebugSpec/> responsive UI', () => {
     cy.findByTestId('spec-path').should('have.text', 'cypress/tests/AlertBar.spec.ts')
     cy.contains('AlertBar').should('have.css', 'color', 'rgb(46, 50, 71)')
     cy.findByTestId('run-failures').should('be.visible')
+
+    cy.percySnapshot()
   })
 
   it('shows complete spec component header with long relative filePath', () => {
@@ -84,5 +90,7 @@ describe('<DebugSpec/> responsive UI', () => {
 
     cy.findByTestId('spec-path').should('have.css', 'text-overflow', 'ellipsis')
     cy.findByTestId('run-failures').should('be.visible')
+
+    cy.percySnapshot()
   })
 })

--- a/packages/app/src/debug/DebugSpec.cy.tsx
+++ b/packages/app/src/debug/DebugSpec.cy.tsx
@@ -1,10 +1,13 @@
 import type { Spec, TestResults } from './DebugSpec.vue'
 import DebugSpec from './DebugSpec.vue'
+import { defaultMessages } from '@cy/i18n'
 
 describe('<DebugSpec/> with multiple test results', () => {
   const spec: Spec = {
     id: '8879798756s88d',
-    path: 'cypress/tests/auth.spec.ts',
+    path: 'cypress/tests',
+    fileName: 'auth',
+    fileExtension: '.spec.ts',
   }
 
   const testResults: TestResults[] = [
@@ -26,10 +29,9 @@ describe('<DebugSpec/> with multiple test results', () => {
     cy.findByTestId('debug-spec-item').children().should('have.length', 3)
     cy.findByTestId('spec-contents').children().should('have.length', 2)
     cy.findByTestId('spec-path').should('have.text', 'cypress/tests/auth.spec.ts')
-    cy.contains('auth').should('have.css', 'color', 'rgb(67, 72, 97)')
+    cy.contains('auth').should('be.visible')
     cy.findByTestId('run-failures').should('not.be.disabled')
-    .should('have.text', ' Run Failures ')
-    .should('have.css', 'color', 'rgb(73, 86, 227)')
+    .contains(defaultMessages.debugPage.runFailures)
 
     cy.findAllByTestId('test-group').should('have.length', 2)
 
@@ -41,8 +43,8 @@ describe('<DebugSpec/> with multiple test results', () => {
       <DebugSpec spec={spec} testResults={testResults} isDisabled={true} />
     ))
 
-    cy.findByTestId('run-failures').should('be.disabled')
-    .should('have.css', 'color', 'rgb(73, 86, 227)')
+    cy.findByTestId('run-failures').should('have.attr', 'aria-disabled', 'disabled')
+    .should('not.have.attr', 'href')
 
     cy.percySnapshot()
   })
@@ -63,7 +65,9 @@ describe('<DebugSpec/> responsive UI', () => {
   it('renders complete UI on smaller viewports', { viewportHeight: 300, viewportWidth: 450 }, () => {
     const spec: Spec = {
       id: '5479adf90s7f',
-      path: 'cypress/tests/AlertBar.spec.ts',
+      path: 'cypress/tests',
+      fileName: 'AlertBar',
+      fileExtension: '.spec.ts',
     }
 
     cy.mount(() => (
@@ -72,7 +76,7 @@ describe('<DebugSpec/> responsive UI', () => {
 
     cy.findByTestId('spec-contents').children().should('have.length', 2)
     cy.findByTestId('spec-path').should('have.text', 'cypress/tests/AlertBar.spec.ts')
-    cy.contains('AlertBar').should('have.css', 'color', 'rgb(67, 72, 97)')
+    cy.contains('AlertBar').should('be.visible')
     cy.findByTestId('run-failures').should('be.visible')
 
     cy.percySnapshot()
@@ -81,7 +85,9 @@ describe('<DebugSpec/> responsive UI', () => {
   it('shows complete spec component header with long relative filePath', () => {
     const spec: Spec = {
       id: '547a0dG90s7f',
-      path: 'src/shared/frontend/cow/packages/foo/cypress/tests/e2e/components/AlertBar.spec.ts',
+      path: 'src/shared/frontend/cow/packages/foo/cypress/tests/e2e/components',
+      fileName: 'AlertBar',
+      fileExtension: '.spec.ts',
     }
 
     cy.mount(() => (

--- a/packages/app/src/debug/DebugSpec.vue
+++ b/packages/app/src/debug/DebugSpec.vue
@@ -5,68 +5,65 @@
   >
     <div
       data-cy="debug-spec-item"
-      class="w-full overflow-hidden flex flex-col items-start box-border border-1px rounded"
+      class="w-full overflow-hidden flex flex-col items-start box-border border-t-1px border-x-1px rounded"
     >
-      <ul
+      <div
         data-cy="debug-spec-header"
         class="w-full flex flex-row items-center py-12px bg-gray-50 border-b-1px border-b-gray-100 rounded-t"
       >
-        <li
+        <div
           data-cy="spec-contents"
-          class="flex flex-row px-16px items-center gap-x-2"
+          class="w-full flex flex-row px-16px items-center"
         >
-          <span
+          <div
             data-cy="spec-path"
-            class="w-145 non-italic text-base"
+            class="flex-grow non-italic text-base truncate"
           >
             <span
               class="font-normal text-gray-600"
             >
-              {{ specData.initialPath }}
+              {{ specData.path }}
             </span>
             <span
               class="font-medium text-gray-900"
             >
-              {{ specData.specName.split('.')[0] }}
+              {{ specData.fileName }}
             </span>
             <span
               class="font-normal text-gray-600"
             >
-              {{ "." + specData.specName.split('.').slice(1, specData.specName.length).join('.') }}
+              {{ specData.extension }}
             </span>
-          </span>
-          <button
-            v-if="!disabled"
-            data-cy="run-failures"
-            class="inline-flex gap-x-10px whitespace-nowrap h-8 justify-center items-center
-            isolate rounded border border-gray-100 bg-white non-italic text-sm text-indigo-500 font-medium px-12px"
+          </div>
+          <div
+            class="ml-10px"
           >
-            <IconActionRefresh
-              data-cy="icon-refresh"
-              stroke-color="indigo-500"
-            />
-            Run Failures
-          </button>
-          <button
-            v-else
-            data-cy="run-failures-disabled"
-            class="inline-flex gap-x-10px whitespace-nowrap h-8 justify-center items-center
-            isolate rounded border border-gray-100 bg-white non-italic text-sm text-gray-500 font-medium px-12px"
-            :disabled="disabled"
-          >
-            <IconActionRefresh stroke-color="gray-500" />
-            Run Failures
-          </button>
-        </li>
-      </ul>
+            <Button
+              data-cy="run-failures"
+              variant="white"
+              class="inline-flex gap-x-10px whitespace-nowrap justify-center items-center isolate"
+              :disabled="isDisabled"
+              :to="{ path: '/specs/runner', query: { file: (specData.path + specData.fileName + specData.extension).replace(/\\/g, '/') } }"
+            >
+              <template #prefix>
+                <IconActionRefresh
+                  data-cy="icon-refresh"
+                  stroke-color="indigo-500"
+                />
+              </template>
+              Run Failures
+            </Button>
+          </div>
+        </div>
+      </div>
       <ul
         v-for="test in specData.failedTests"
         :key="`test-${test.id}`"
         data-cy="test-group"
-        class="w-full flex flex-col flex-start h-12"
+        class="w-full flex flex-col flex-start h-12 items-start justify-center pl-16px border-b-gray-100 border-b-1px"
       >
         <DebugFailedTest
-          :failed-test="test.titleParts"
+          :failed-test-result="test"
           :data-cy="`test-${test.id}`"
         />
       </ul>
@@ -87,19 +84,29 @@ export interface TestResults {
 import { computed } from 'vue'
 import { IconActionRefresh } from '@cypress-design/vue-icon'
 import DebugFailedTest from './DebugFailedTest.vue'
+import Button from '@packages/frontend-shared/src/components/Button.vue'
 
 const props = defineProps<{
   spec: Spec
   testResults: TestResults[]
-  disabled?: boolean
+  isDisabled?: boolean
 }>()
 
+/**
+ * @param relativePath: The relative path of a failed test e.g. cypress/test/auth.spec.ts
+ * We split the relative path into 3 pieces and return an object containing this split sections
+ * so we can correctly style the relative path in the debug spec header. For example:
+ * path: cypress/tests/ ; fileName: auth ; extension: .spec.ts
+ */
 const splitHeader = (relativePath: string) => {
   const before = relativePath.split('/')
+  const specName = before.slice(-1)[0]
+  const splitSpecName = specName.split('.')
 
   return {
-    initialPath: `${before.slice(0, before.length - 1).join('/') }/`,
-    specName: before.slice(-1)[0],
+    path: `${before.slice(0, before.length - 1).join('/') }/`,
+    fileName: splitSpecName[0],
+    extension: `.${ splitSpecName.slice(1, specName.length).join('.')}`,
   }
 }
 

--- a/packages/app/src/debug/DebugSpec.vue
+++ b/packages/app/src/debug/DebugSpec.vue
@@ -16,7 +16,7 @@
           class="flex flex-row px-16px items-center gap-x-2"
         >
           <span
-            data-cy="text-contents"
+            data-cy="spec-path"
             class="w-145 non-italic text-base"
           >
             <span
@@ -41,7 +41,10 @@
             class="inline-flex gap-x-10px whitespace-nowrap h-8 justify-center items-center
             isolate rounded border border-gray-100 bg-white non-italic text-sm text-indigo-500 font-medium px-12px"
           >
-            <IconActionRefresh stroke-color="indigo-500" />
+            <IconActionRefresh
+              data-cy="icon-refresh"
+              stroke-color="indigo-500"
+            />
             Run Failures
           </button>
           <button
@@ -49,6 +52,7 @@
             data-cy="run-failures-disabled"
             class="inline-flex gap-x-10px whitespace-nowrap h-8 justify-center items-center
             isolate rounded border border-gray-100 bg-white non-italic text-sm text-gray-500 font-medium px-12px"
+            :disabled="disabled"
           >
             <IconActionRefresh stroke-color="gray-500" />
             Run Failures
@@ -56,13 +60,14 @@
         </li>
       </ul>
       <ul
-        v-for="test in specData.failedTests.titleParts"
-        :key="`test-${test.length}`"
+        v-for="test in specData.failedTests"
+        :key="`test-${test.id}`"
         data-cy="test-group"
         class="w-full flex flex-col flex-start h-12"
       >
         <DebugFailedTest
-          :failed-test="test"
+          :failed-test="test.titleParts"
+          :data-cy="`test-${test.id}`"
         />
       </ul>
     </div>
@@ -85,8 +90,8 @@ import DebugFailedTest from './DebugFailedTest.vue'
 
 const props = defineProps<{
   spec: Spec
-  testResults: TestResults
-  disabled: boolean
+  testResults: TestResults[]
+  disabled?: boolean
 }>()
 
 const splitHeader = (relativePath: string) => {

--- a/packages/app/src/debug/DebugSpec.vue
+++ b/packages/app/src/debug/DebugSpec.vue
@@ -1,0 +1,60 @@
+<template>
+  <div
+    data-cy="debug-spec-col"
+    class="grid flex flex-col px-24px gap-24px self-stretch"
+  >
+    <div
+      data-cy="debug-spec-item"
+      class="w-full overflow-hidden flex flex-col items-start box-border bg-white border-1px border-red-600 rounded"
+    >
+      <div
+        data-cy="debug-spec-header"
+        class="flex-row border-b-1px border-b-gray-100 items-center rounded-t"
+      >
+        <span>
+          {{ spec.relativePath }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+<script lang="ts" setup>
+import { computed } from 'vue'
+
+const props = defineProps<{
+  gql: any
+  foundInLocalProject: boolean
+}>()
+
+interface defaultTestType {
+  testName: string
+  testDescription: string
+}
+interface defaultTypes {
+  relativePath: string
+  failedTests: defaultTestType[]
+}
+
+const createTest = (name: string, description: string): defaultTestType => {
+  return {
+    testName: name,
+    testDescription: description,
+  }
+}
+
+const defaultTest = createTest('Bank Accounts', 'creates new bank account')
+
+const defaults: defaultTypes = {
+  relativePath: 'cypress/tests/bankaccounts.spec.ts',
+  failedTests: [defaultTest],
+}
+
+const spec = computed(() => {
+  if (props.gql) {
+    return props.gql
+  }
+
+  return defaults
+})
+
+</script>

--- a/packages/app/src/debug/DebugSpec.vue
+++ b/packages/app/src/debug/DebugSpec.vue
@@ -25,17 +25,16 @@
               {{ specData.path }}
             </span>
             <span
-              class="font-medium text-gray-900"
+              class="inline-flex items-center"
             >
-              {{ specData.fileName }}
-            </span>
-            <span
-              class="font-normal text-gray-600"
-            >
-              {{ specData.extension }}
+              <SpecNameDisplay
+                :spec-file-name="specData.fileName"
+                :spec-file-extension="specData.extension"
+              />
             </span>
           </div>
           <div
+            type="button"
             class="ml-10px"
           >
             <Button
@@ -43,7 +42,7 @@
               variant="white"
               class="inline-flex gap-x-10px whitespace-nowrap justify-center items-center isolate"
               :disabled="isDisabled"
-              :to="{ path: '/specs/runner', query: { file: (specData.path + specData.fileName + specData.extension).replace(/\\/g, '/') } }"
+              :to="{ path: '/specs/runner', query: { file: (spec.path).replace(/\\/g, '/') } }"
             >
               <template #prefix>
                 <IconActionRefresh
@@ -85,6 +84,7 @@ import { computed } from 'vue'
 import { IconActionRefresh } from '@cypress-design/vue-icon'
 import DebugFailedTest from './DebugFailedTest.vue'
 import Button from '@packages/frontend-shared/src/components/Button.vue'
+import SpecNameDisplay from '../specs/SpecNameDisplay.vue'
 
 const props = defineProps<{
   spec: Spec

--- a/packages/app/src/debug/DebugSpec.vue
+++ b/packages/app/src/debug/DebugSpec.vue
@@ -29,12 +29,11 @@
             >
               <SpecNameDisplay
                 :spec-file-name="specData.fileName"
-                :spec-file-extension="specData.extension"
+                :spec-file-extension="specData.fileExtension"
               />
             </span>
           </div>
           <div
-            type="button"
             class="ml-10px"
           >
             <Button
@@ -42,7 +41,7 @@
               variant="white"
               class="inline-flex gap-x-10px whitespace-nowrap justify-center items-center isolate"
               :disabled="isDisabled"
-              :to="{ path: '/specs/runner', query: { file: (spec.path).replace(/\\/g, '/') } }"
+              :to="{ path: '/specs/runner', query: { file: (specData.path).replace(/\\/g, '/') } }"
             >
               <template #prefix>
                 <IconActionRefresh
@@ -50,12 +49,15 @@
                   stroke-color="indigo-500"
                 />
               </template>
-              Run Failures
+              <!-- Wrapping this with a default template to avoid an unneeded space -->
+              <template #default>
+                {{ t('debugPage.runFailures') }}
+              </template>
             </Button>
           </div>
         </div>
       </div>
-      <ul
+      <div
         v-for="test in specData.failedTests"
         :key="`test-${test.id}`"
         data-cy="test-group"
@@ -65,7 +67,7 @@
           :failed-test-result="test"
           :data-cy="`test-${test.id}`"
         />
-      </ul>
+      </div>
     </div>
   </div>
 </template>
@@ -73,6 +75,8 @@
 export interface Spec {
   id: string
   path: string
+  fileName: string
+  fileExtension: string
 }
 
 export interface TestResults {
@@ -85,6 +89,9 @@ import { IconActionRefresh } from '@cypress-design/vue-icon'
 import DebugFailedTest from './DebugFailedTest.vue'
 import Button from '@packages/frontend-shared/src/components/Button.vue'
 import SpecNameDisplay from '../specs/SpecNameDisplay.vue'
+import { useI18n } from '@cy/i18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   spec: Spec
@@ -92,29 +99,11 @@ const props = defineProps<{
   isDisabled?: boolean
 }>()
 
-/**
- * @param relativePath: The relative path of a failed test e.g. cypress/test/auth.spec.ts
- * We split the relative path into 3 pieces and return an object containing this split sections
- * so we can correctly style the relative path in the debug spec header. For example:
- * path: cypress/tests/ ; fileName: auth ; extension: .spec.ts
- */
-const splitHeader = (relativePath: string) => {
-  const before = relativePath.split('/')
-  const specName = before.slice(-1)[0]
-  const splitSpecName = specName.split('.')
-
-  return {
-    path: `${before.slice(0, before.length - 1).join('/') }/`,
-    fileName: splitSpecName[0],
-    extension: `.${ splitSpecName.slice(1, specName.length).join('.')}`,
-  }
-}
-
 const specData = computed(() => {
-  const header = splitHeader(props.spec.path)
-
   return {
-    ...header,
+    path: `${props.spec.path}/`,
+    fileName: props.spec.fileName,
+    fileExtension: props.spec.fileExtension,
     failedTests: props.testResults,
   }
 })

--- a/packages/app/src/debug/DebugSpec.vue
+++ b/packages/app/src/debug/DebugSpec.vue
@@ -5,56 +5,106 @@
   >
     <div
       data-cy="debug-spec-item"
-      class="w-full overflow-hidden flex flex-col items-start box-border bg-white border-1px border-red-600 rounded"
+      class="w-full overflow-hidden flex flex-col items-start box-border border-1px rounded"
     >
-      <div
+      <ul
         data-cy="debug-spec-header"
-        class="flex-row border-b-1px border-b-gray-100 items-center rounded-t"
+        class="w-full flex flex-row items-center py-12px bg-gray-50 border-b-1px border-b-gray-100 rounded-t"
       >
-        <span>
-          {{ spec.relativePath }}
-        </span>
-      </div>
+        <li
+          data-cy="spec-contents"
+          class="flex flex-row px-16px items-center gap-x-2"
+        >
+          <span
+            data-cy="text-contents"
+            class="w-145 non-italic text-base"
+          >
+            <span
+              class="font-normal text-gray-600"
+            >
+              {{ specData.initialPath }}
+            </span>
+            <span
+              class="font-medium text-gray-900"
+            >
+              {{ specData.specName.split('.')[0] }}
+            </span>
+            <span
+              class="font-normal text-gray-600"
+            >
+              {{ "." + specData.specName.split('.').slice(1, specData.specName.length).join('.') }}
+            </span>
+          </span>
+          <button
+            v-if="!disabled"
+            data-cy="run-failures"
+            class="inline-flex gap-x-10px whitespace-nowrap h-8 justify-center items-center
+            isolate rounded border border-gray-100 bg-white non-italic text-sm text-indigo-500 font-medium px-12px"
+          >
+            <IconActionRefresh stroke-color="indigo-500" />
+            Run Failures
+          </button>
+          <button
+            v-else
+            data-cy="run-failures-disabled"
+            class="inline-flex gap-x-10px whitespace-nowrap h-8 justify-center items-center
+            isolate rounded border border-gray-100 bg-white non-italic text-sm text-gray-500 font-medium px-12px"
+          >
+            <IconActionRefresh stroke-color="gray-500" />
+            Run Failures
+          </button>
+        </li>
+      </ul>
+      <ul
+        v-for="test in specData.failedTests.titleParts"
+        :key="`test-${test.length}`"
+        data-cy="test-group"
+        class="w-full flex flex-col flex-start h-12"
+      >
+        <DebugFailedTest
+          :failed-test="test"
+        />
+      </ul>
     </div>
   </div>
 </template>
 <script lang="ts" setup>
+export interface Spec {
+  id: string
+  path: string
+}
+
+export interface TestResults {
+  id: string
+  titleParts: string[]
+}
+
 import { computed } from 'vue'
+import { IconActionRefresh } from '@cypress-design/vue-icon'
+import DebugFailedTest from './DebugFailedTest.vue'
 
 const props = defineProps<{
-  gql: any
-  foundInLocalProject: boolean
+  spec: Spec
+  testResults: TestResults
+  disabled: boolean
 }>()
 
-interface defaultTestType {
-  testName: string
-  testDescription: string
-}
-interface defaultTypes {
-  relativePath: string
-  failedTests: defaultTestType[]
-}
+const splitHeader = (relativePath: string) => {
+  const before = relativePath.split('/')
 
-const createTest = (name: string, description: string): defaultTestType => {
   return {
-    testName: name,
-    testDescription: description,
+    initialPath: `${before.slice(0, before.length - 1).join('/') }/`,
+    specName: before.slice(-1)[0],
   }
 }
 
-const defaultTest = createTest('Bank Accounts', 'creates new bank account')
+const specData = computed(() => {
+  const header = splitHeader(props.spec.path)
 
-const defaults: defaultTypes = {
-  relativePath: 'cypress/tests/bankaccounts.spec.ts',
-  failedTests: [defaultTest],
-}
-
-const spec = computed(() => {
-  if (props.gql) {
-    return props.gql
+  return {
+    ...header,
+    failedTests: props.testResults,
   }
-
-  return defaults
 })
 
 </script>

--- a/packages/frontend-shared/src/components/Button.cy.tsx
+++ b/packages/frontend-shared/src/components/Button.cy.tsx
@@ -26,6 +26,8 @@ describe('<Button />', { viewportWidth: 300, viewportHeight: 400 }, () => {
         <Button variant="text" disabled>Text with text disabled</Button>
         <Button variant="secondary">Secondary with text</Button>
         <Button variant="secondary" disabled>Secondary with text disabled</Button>
+        <Button variant="white" size="md">White with text</Button>
+        <Button variant="white" size="md" disabled>White with text disabled</Button>
       </div>
     ))
 

--- a/packages/frontend-shared/src/components/Button.cy.tsx
+++ b/packages/frontend-shared/src/components/Button.cy.tsx
@@ -98,4 +98,14 @@ describe('<Button />', { viewportWidth: 300, viewportHeight: 400 }, () => {
 
     cy.get('[data-cy="coffee-icon"]').should('be.visible')
   })
+
+  it('renders button as disabled with a disabled and to prop', () => {
+    cy.mount(() => (
+      <Button disabled to="cypress.io"> test </Button>
+    ))
+
+    cy.contains('a', 'test').should('not.have.attr', 'href')
+    cy.contains('a', 'test').should('have.attr', 'aria-disabled', 'disabled')
+    cy.contains('a', 'test').should('have.attr', 'role', 'link')
+  })
 })

--- a/packages/frontend-shared/src/components/Button.vue
+++ b/packages/frontend-shared/src/components/Button.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    v-if="((!props.href && !props.to) || (props.disabled && props.to))"
+    v-if="!props.href && !props.to"
     style="width: fit-content"
     class="border rounded flex outline-none leading-tight gap-8px items-center"
     :class="classes"
@@ -143,6 +143,10 @@ const classes = computed(() => {
 const linkVersion = computed(() => {
   if (!props.to) {
     return props.internalLink ? BaseLink : ExternalLink
+  }
+
+  if (props.disabled) {
+    return BaseLink
   }
 
   return RouterLink

--- a/packages/frontend-shared/src/components/Button.vue
+++ b/packages/frontend-shared/src/components/Button.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    v-if="!props.href && !props.to"
+    v-if="((!props.href && !props.to) || (props.disabled && props.to))"
     style="width: fit-content"
     class="border rounded flex outline-none leading-tight gap-8px items-center"
     :class="classes"
@@ -59,11 +59,11 @@
       <template #default>
         <slot />
       </template>
-      <template #suffix>
-        <slot
-          v-if="suffixIcon || $slots.suffix"
-          name="suffix"
-        >
+      <template
+        v-if="suffixIcon || $slots.suffix"
+        #suffix
+      >
+        <slot name="suffix">
           <component
             :is="suffixIcon"
             :class="suffixIconClass"
@@ -88,6 +88,7 @@ const VariantClassesTable = {
   linkBold: 'border-transparent text-indigo-500 font-medium',
   text: 'border-0',
   secondary: 'bg-jade-500 text-white hocus-secondary',
+  white: 'bg-white text-indigo-500 font-medium hocus-default',
 } as const
 
 const SizeClassesTable = {

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -849,5 +849,8 @@
     "alpha": "Alpha",
     "beta": "Beta",
     "new": "New"
+  },
+  "debugPage": {
+    "runFailures": "Run Failures"
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #24443 and #24444 

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
This is the spec and test component for the new [debug page](https://github.com/cypress-io/cypress/issues/24441)
The design for this page can be found [here](https://www.figma.com/file/PAOozuCxtfetqP8fUVvg0y/branch/QkCp2F69X0qyLo7qnYQ67e/Cypress-App?node-id=21413%3A202471&t=jaeAWR6n9srpSsKo-0)

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
The spec component refers to the top section of the `debug spec item` (information about a single failed spec file and the tests that have failed within it) which contains the relative path of the spec and a "Run Failures" button. The test component is the bottom section which contains a list of failed tests in the form of a title and description.
- `DebugSpec.vue` renders an entire `debug spec item`. There is no use of `gql` props here as the tentative implementation would involve a `gql` query in a top level component which would pass props down to the `DebugSpec` component. 
- `DebugSpec.vue` uses `DebugFailedTest.vue` to render the test component section of the `debug spec item`

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
This issue has 2 component tests. Checkout to this branch to run the tests
Both DebugSpec.vue and DebugFailedTest.vue exist in the packages/app/ folder. To run these tests:

1. Change directory to packages/app
2. Run `yarn dev`
3. Navigate to Component Testing and run `DebugSpec.cy.tsx` and `DebugFailedTest.cy.tsx`

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
<img width="747" alt="Screenshot 2022-11-29 at 10 27 17 AM" src="https://user-images.githubusercontent.com/65267668/204571014-9526185e-74a1-42fd-b78b-cdf845b52269.png">

<img width="747" alt="Screenshot 2022-11-29 at 10 27 50 AM" src="https://user-images.githubusercontent.com/65267668/204571178-e5d1cdaa-a5b2-41ea-884f-fc9886b572bd.png">

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
