### PR TITLE
fix: Calling .type() on a wrapper element properly focuses contained <input>

### DIFF
--- a/packages/driver/cypress/e2e/commands/actions/type.cy.js
+++ b/packages/driver/cypress/e2e/commands/actions/type.cy.js
@@ -93,6 +93,10 @@ describe('src/cy/commands/actions/type - #type', () => {
     cy.get('input:text:first').type('bar')
   })
 
+  it('can type into an input when given a wrapper element', () => {
+    cy.get('#focus div span').type('foo')
+  })
+
   it('lists the input as the focused element', () => {
     const $input = cy.$$('input:text:first')
 

--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -531,7 +531,6 @@ export default function (Commands, Cypress, cy, state, config) {
           // cannot just call .focus, since children of contenteditable will not receive cursor
           // with .focus()
           return cy.now('click', $elToClick, {
-            $el: $elToClick,
             log: false,
             verify: false,
             _log: options._log,
@@ -540,6 +539,7 @@ export default function (Commands, Cypress, cy, state, config) {
             interval: options.interval,
             errorOnSelect: false,
             scrollBehavior: options.scrollBehavior,
+            subjectFn: () => $elToClick,
           })
           .then(() => {
             let activeElement = $elements.getActiveElByDocument($elToClick)


### PR DESCRIPTION
### User facing changelog
No user-facing changes

### Additional details
This fixes a regression in Cypress 12 introduced as part of the detached dom rewrite of actionability tests, where the proper element wasn't being clicked on to gain focus before typing.

### Steps to test
See the newly added test for an example of a failure fixed here.

### How has the user experience changed?

### PR Tasks

- [x] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
