### PR TITLE
fix: Fix incompletely cleared subjects when linking chainers

### DIFF
--- a/packages/driver/cypress/e2e/commands/connectors.cy.js
+++ b/packages/driver/cypress/e2e/commands/connectors.cy.js
@@ -215,6 +215,19 @@ describe('src/cy/commands/connectors', () => {
         })
       })
 
+      it('completely resets the subject chain when queries are used', () => {
+        cy.wrap('foo')
+        .then(() => cy.get('body'))
+        .then(() => {
+          // We expect the current subject chain to look like [undefined, get()],
+          // inherited from .get() inside the first .then().
+
+          // There was a regression where it would instead look like ['foo', get()],
+          // mixing the subjects from .wrap() and .get().
+          expect(cy.subjectChain()[0]).to.be.undefined
+        })
+      })
+
       describe('errors', {
         defaultCommandTimeout: 100,
       }, () => {

--- a/packages/driver/src/cypress/command_queue.ts
+++ b/packages/driver/src/cypress/command_queue.ts
@@ -379,7 +379,7 @@ export class CommandQueue extends Queue<$Command> {
       } else {
         // For commands, the "subject" here is the command's return value, which replaces
         // the current subject chain. We cannot re-invoke commands - the return value here is final.
-        this.cy.setSubjectForChainer(command.get('chainerId'), subject)
+        this.cy.setSubjectForChainer(command.get('chainerId'), [subject])
       }
 
       this.state({
@@ -415,7 +415,7 @@ export class CommandQueue extends Queue<$Command> {
           next: this.at(this.index + 1),
         })
 
-        this.cy.setSubjectForChainer(command.get('chainerId'), command.get('subject'))
+        this.cy.setSubjectForChainer(command.get('chainerId'), [command.get('subject')])
 
         if (command.state === 'skipped') {
           Cypress.action('cy:skipped:command:end', command)

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -1278,19 +1278,19 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
    * elsewhere, consider if there's a way you can use existing functionality to achieve it instead.
    *
    * The command_queue calls setSubjectForChainer after a command has finished resolving, when we have the
-   * final (non-$Chainer, non-promise) return value. This value becomes the current $Chainer's new subject - and the
-   * new subject for any chainers it's linked to (see cy.linkSubject for details on that process).
+   * final (non-$Chainer, non-promise) return value. This value becomes the current $Chainer's new subjectChain - and
+   * the new subjectChain for any chainers it's linked to (see cy.linkSubject for details on that process).
    */
-  setSubjectForChainer (chainerId: string, subject: any) {
+  setSubjectForChainer (chainerId: string, subjectChain: SubjectChain) {
     const cySubjects = this.state('subjects') || {} as Record<string, SubjectChain>
 
-    cySubjects[chainerId] = [subject]
+    cySubjects[chainerId] = subjectChain
     this.state('subjects', cySubjects)
 
     const links = this.state('subjectLinks') || {} as Record<string, string>
 
     if (links[chainerId]) {
-      this.setSubjectForChainer(links[chainerId], subject)
+      this.setSubjectForChainer(links[chainerId], subjectChain)
     }
   }
 
@@ -1315,7 +1315,7 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
     const links = this.state('subjectLinks') || {} as Record<string, string>
 
     if (links[chainerId]) {
-      this.addQueryToChainer(links[chainerId], queryFn)
+      this.setSubjectForChainer(links[chainerId], cySubjects[chainerId])
     }
   }
 


### PR DESCRIPTION
### User facing changelog
No user facing changes.

### Additional details
This fixes a bug in the implementation of query subject chains, where linked chainers (eg: the inside and outside of cy.then()) would result in the outer chainer having an incorrect subject.

This never went in front of users, was discovered in the pre-release binary during internal testing.

### Steps to test

### How has the user experience changed?
No change, it now works the same as Cy11.

### PR Tasks

- [x] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
