### PR TITLE
fix: regression in testIsolation config validation when using cypress run --component

### DIFF
--- a/packages/config/src/browser.ts
+++ b/packages/config/src/browser.ts
@@ -164,7 +164,9 @@ export const validate = (cfg: any, onErr: (property: ErrResult | string) => void
     // key has a validation rule & value different from the default
     if (validationFn && value !== defaultValues[key]) {
       const result = validationFn(key, value, {
-        testingType,
+        // if we are validating the e2e or component-specific configuration values, pass
+        // the key testing type as the testing type to ensure correct validation
+        testingType: (key === 'e2e' || key === 'component') ? key : testingType,
       })
 
       if (result !== true) {

--- a/packages/config/test/index.spec.ts
+++ b/packages/config/test/index.spec.ts
@@ -115,11 +115,24 @@ describe('config/src/index', () => {
   describe('.validate', () => {
     it('validates config', () => {
       const errorFn = sinon.spy()
+      const config = {
+        e2e: {
+          testIsolation: false,
+          'baseUrl': 'https://',
+          viewportHeight: 200,
+        },
+        component: {
+          indexHtmlFile: 'index.html',
+        },
+      }
 
-      configUtil.validate({
-        'baseUrl': 'https://',
-      }, errorFn, 'e2e')
+      configUtil.validate(config, errorFn, null)
+      expect(errorFn).to.have.callCount(0)
 
+      configUtil.validate(config, errorFn, 'e2e')
+      expect(errorFn).to.have.callCount(0)
+
+      configUtil.validate(config, errorFn, 'component')
       expect(errorFn).to.have.callCount(0)
     })
 


### PR DESCRIPTION
- Closes #25007

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
- Fix regression in 12.0.0 where setting `e2e.testIsolation=false` caused invalid configuration validation when running `cypress run --component`. 

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
1. install cy 12
2. update e2e.testIsolation to be false
3. run `cypress run --component`
4. see error 

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
