### PR TITLE
fix: .select() by index works if <options> have same value (run ci)

### DIFF
--- a/packages/driver/cypress/e2e/commands/actions/select.cy.js
+++ b/packages/driver/cypress/e2e/commands/actions/select.cy.js
@@ -51,6 +51,14 @@ describe('src/cy/commands/actions/select', () => {
       })
     })
 
+    it('can handle index when all values are identical', () => {
+      cy.$$('select[name=maps] option').attr('value', 'foo')
+
+      cy.get('select[name=maps]').select(2).then(($select) => {
+        expect($select[0].selectedOptions[0].text).to.eq('nuke')
+      })
+    })
+
     it('can select an array of values', () => {
       cy.get('select[name=movies]').select(['apoc', 'br', 'co']).then(($select) => {
         expect($select.val()).to.deep.eq(['apoc', 'br', 'co'])

--- a/packages/driver/src/cy/commands/actions/select.ts
+++ b/packages/driver/src/cy/commands/actions/select.ts
@@ -127,6 +127,11 @@ export default (Commands, Cypress, cy) => {
           if (valueOrTextOrIndex.includes(value) || valueOrTextOrIndex.includes(index)) {
             optionEls.push(optEl)
             values.push(value)
+
+            // https://github.com/cypress-io/cypress/issues/24739
+            if (options.$el.find(`option[value="${value}"]`).length > 1) {
+              notAllUniqueValues = true
+            }
           }
 
           // replace new line chars, then trim spaces
@@ -183,9 +188,7 @@ export default (Commands, Cypress, cy) => {
               args: { node },
             })
           }
-        })
 
-        _.each(optionEls, ($el) => {
           if ($el.closest('optgroup').prop('disabled')) {
             node = $dom.stringify($el)
 
@@ -271,7 +274,7 @@ export default (Commands, Cypress, cy) => {
 
             if (notAllUniqueValues) {
               // if all the values are the same and the user is trying to
-              // select based on the text, setting the val() will just
+              // select based on the text or index, setting the val() will just
               // select the first one
               let selectedIndex = 0
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/24739

### User facing changelog
Fix an issue where `.select(index)` would fail when multiple `<option>` elements have the same `value` property. 

### Additional details
```
<select data-test-id="scp_dropdown">
    <option value="[object Object]">AHA Bug bash</option>
    <option value="[object Object]">cairo</option>
    <option value="[object Object]">Frankfurt</option>
    <option value="[object Object]">cairo</option>
</select>

cy.get('[data-test-id="scp_dropdown"]').select(2);
```

would previously result in selecting "AHA Bug bash" (index 0) rather than "Frankfurt" (index 2), because they share the same `value` property.

### Steps to test
See the included driver test for a live example of this fix in action.

### How has the user experience changed?

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
