### PR TITLE
fix: .contains() properly respects multiple incoming subjects

### DIFF
--- a/packages/driver/cypress/e2e/commands/querying/querying.cy.js
+++ b/packages/driver/cypress/e2e/commands/querying/querying.cy.js
@@ -985,6 +985,11 @@ describe('src/cy/commands/querying', () => {
       })
     })
 
+    // https://github.com/cypress-io/cypress/issues/25025
+    it('searches multiple subject elements', () => {
+      cy.get('ul').contains('li', 'asdf 3')
+    })
+
     it('resets the subject between chain invocations', () => {
       const span = cy.$$('.k-in:contains(Quality Control):last')
       const label = cy.$$('#complex-contains label')
@@ -1005,7 +1010,6 @@ describe('src/cy/commands/querying', () => {
 
       cy.get('#click-me a').contains('click').then(($span) => {
         expect($span.length).to.eq(1)
-
         expect($span.get(0)).to.eq(span.get(0))
       })
     })
@@ -1013,7 +1017,6 @@ describe('src/cy/commands/querying', () => {
     it('can find input type=submits by value', () => {
       cy.contains('input contains submit').then(($el) => {
         expect($el.length).to.eq(1)
-
         expect($el).to.match('input[type=submit]')
       })
     })
@@ -1022,7 +1025,6 @@ describe('src/cy/commands/querying', () => {
     it('can find input type=submits by Regex', () => {
       cy.contains(/input contains submit/).then(($el) => {
         expect($el.length).to.eq(1)
-
         expect($el).to.match('input[type=submit]')
       })
     })
@@ -1030,7 +1032,6 @@ describe('src/cy/commands/querying', () => {
     it('has an optional filter argument', () => {
       cy.contains('ul', 'li 0').then(($el) => {
         expect($el.length).to.eq(1)
-
         expect($el).to.match('ul')
       })
     })
@@ -1046,7 +1047,6 @@ describe('src/cy/commands/querying', () => {
     it('searches all els in comma separated filter', () => {
       cy.contains('a,button', 'Naruto').then(($el) => {
         expect($el.length).to.eq(1)
-
         expect($el).to.match('a')
       })
 

--- a/packages/driver/src/cy/commands/querying/querying.ts
+++ b/packages/driver/src/cy/commands/querying/querying.ts
@@ -324,17 +324,19 @@ export default (Commands, Cypress, cy, state) => {
         subject = cy.getSubjectFromChain(withinSubject || [cy.$$('body')])
       }
 
-      getOptions.withinSubject = subject[0] ?? subject
-      let $el = getFn()
+      let $el = cy.$$()
 
-      // .get() looks for elements *inside* the current subject, while contains() wants to also match the current
-      // subject itself if no child matches.
-      if (!$el.length) {
-        $el = (subject as JQuery).filter(selector)
-      }
+      subject.each((index, element) => {
+        getOptions.withinSubject = element
+        $el = $el.add(getFn())
+      })
 
       if ($el.length) {
         $el = $dom.getFirstDeepestElement($el)
+      } else {
+        // .get() looks for elements *inside* the current subject, while contains() wants to also match the current
+        // subject itself if no child matches.
+        $el = (subject as JQuery).filter(selector)
       }
 
       log && cy.state('current') === this && log.set({


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/25025

### User facing changelog
In Cypress 12.0.0, we introduced a regression where when `.contains()` receives multiple elements as a subject, it only searched inside the first one. This PR fixes that issue.

### Additional details

This PR includes a new driver test covering the case. Another reproduction that doesn't rely on any of our fixtures:
```
it("fails", () => {
  cy.visit("https://example.cypress.io");
  cy.get(".container").eq(2).contains("p", "Commands "); // passes
  cy.get(".container").contains("Commands "); // passes
  cy.get(".container").contains("p", "Commands "); // fails in 12.0.1, passes in this branch
})
```

### Steps to test

### How has the user experience changed?

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
