### PR TITLE
fix: .contains() selects proper elements when inside a <form>

### DIFF
--- a/packages/driver/cypress/e2e/commands/querying/querying.cy.js
+++ b/packages/driver/cypress/e2e/commands/querying/querying.cy.js
@@ -1010,6 +1010,11 @@ describe('src/cy/commands/querying', () => {
       })
     })
 
+    // https://github.com/cypress-io/cypress/issues/25019
+    it('can locate elements contained inside <form> containers', () => {
+      cy.get('#focus').contains('button', 'focusable')
+    })
+
     it('can find input type=submits by value', () => {
       cy.contains('input contains submit').then(($el) => {
         expect($el.length).to.eq(1)

--- a/packages/driver/src/cy/commands/querying/querying.ts
+++ b/packages/driver/src/cy/commands/querying/querying.ts
@@ -175,7 +175,7 @@ export default (Commands, Cypress, cy, state) => {
         let scope = userOptions.withinSubject || cy.getSubjectFromChain(withinSubject)
 
         if (includeShadowDom) {
-          const root = scope || cy.state('document')
+          const root = scope.get(0) || cy.state('document')
           const elementsWithShadow = $dom.findAllShadowRoots(root)
 
           scope = elementsWithShadow.concat(root)
@@ -323,7 +323,7 @@ export default (Commands, Cypress, cy, state) => {
       let $el = cy.$$()
 
       subject.each((index, element) => {
-        getOptions.withinSubject = element
+        getOptions.withinSubject = cy.$$(element)
         $el = $el.add(getFn())
       })
 

--- a/packages/driver/src/cy/commands/querying/querying.ts
+++ b/packages/driver/src/cy/commands/querying/querying.ts
@@ -175,7 +175,7 @@ export default (Commands, Cypress, cy, state) => {
         let scope = userOptions.withinSubject || cy.getSubjectFromChain(withinSubject)
 
         if (includeShadowDom) {
-          const root = scope.get(0) || cy.state('document')
+          const root = scope?.get(0) || cy.state('document')
           const elementsWithShadow = $dom.findAllShadowRoots(root)
 
           scope = elementsWithShadow.concat(root)

--- a/packages/driver/src/cy/commands/querying/querying.ts
+++ b/packages/driver/src/cy/commands/querying/querying.ts
@@ -174,10 +174,6 @@ export default (Commands, Cypress, cy, state) => {
       try {
         let scope = userOptions.withinSubject || cy.getSubjectFromChain(withinSubject)
 
-        if (scope && scope[0]) {
-          scope = scope[0]
-        }
-
         if (includeShadowDom) {
           const root = scope || cy.state('document')
           const elementsWithShadow = $dom.findAllShadowRoots(root)


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/25019

### User facing changelog
In 12.0.0, we had a regression around `.contains()` where if the subject was a `<form>` element, it would only consider the first `<input>` element in the form, rather than every child. This PR fixes the regression.

### Additional details
In addition to the added driver test, this test demonstrates the issue "in the wild":

```
    it('Should be able to target elements within a form', () => {
        cy.visit('https://www.demoblaze.com/');
        cy.contains('a', 'Log in').click();

        cy.get('#logInModal').within(() => {
            cy.get('form').within(() => {
                // these work
                cy.contains('Username:').should('be.visible');
                cy.contains('Username').parent().should('be.visible');
                cy.get('input').first().should('be.visible');

                // this doesn't
                cy.contains('label', 'Username')
            })
        })
    });
```

### Steps to test

### How has the user experience changed?

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
