### PR TITLE
fix: remove line break from empty object representation in resolved c…

### DIFF
--- a/packages/app/src/settings/project/ConfigCode.cy.tsx
+++ b/packages/app/src/settings/project/ConfigCode.cy.tsx
@@ -14,6 +14,26 @@ const objectTest = {
 
 describe('<ConfigCode />', () => {
   context('with mock values', () => {
+    it('shows empty object in one line', () => {
+      cy.mount(() => (<div class="p-12 overflow-auto">
+        <ConfigCode data-cy="code" gql={{
+          id: 'project-id',
+          configFile: 'cypress.config.js',
+          configFileAbsolutePath: '/path/to/cypress.config.js',
+          config: [{
+            field: 'emptyObjectTest',
+            value: {},
+            from: 'plugin',
+          }],
+        }} />
+      </div>))
+
+      cy.contains(`emptyObjectTest:`).should('contain.text', '{},')
+      cy.contains(`emptyObjectTest:`).within(($subject) => {
+        cy.wrap($subject).get('br').should('have.length', 1)
+      })
+    })
+
     it('shows the arrayTest nicely', () => {
       cy.mount(() => (<div class="p-12 overflow-auto">
         <ConfigCode data-cy="code" gql={{

--- a/packages/app/src/settings/project/renderers/RenderObject.vue
+++ b/packages/app/src/settings/project/renderers/RenderObject.vue
@@ -46,7 +46,10 @@
     <span
       :class="props.colorClasses"
       :data-cy-config="props.from"
-    >{</span><br><template
+    >{</span>
+    <!-- Do not render break line for empty object or array -->
+    <br v-if="Object.keys(props.value).length">
+    <template
       v-for="(val, k) in props.value"
       :key="k"
     >


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/21790

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
Don't render `<br/>` tag when object is empty

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Before
![before-empty](https://user-images.githubusercontent.com/17439414/209790990-d03f9f28-2034-4c9c-be7e-45a1bfeaeb71.png)

After
![after-empty](https://user-images.githubusercontent.com/17439414/209790999-5531e81e-f24a-44f1-a65b-4182587b83fa.png)

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
