### PR TITLE
fix: log error on reject with string content

### DIFF
--- a/packages/app/cypress/e2e/runner/reporter.errors.cy.ts
+++ b/packages/app/cypress/e2e/runner/reporter.errors.cy.ts
@@ -180,6 +180,16 @@ describe('errors ui', {
       ],
     })
 
+    verify('spec unhandled rejection with string content', {
+      uncaught: true,
+      column: 20,
+      originalMessage: 'Unhandled promise rejection with string content from the spec',
+      message: [
+        'The following error originated from your test code',
+        'It was caused by an unhandled promise rejection',
+      ],
+    })
+
     verify('spec unhandled rejection with done', {
       uncaught: true,
       column: 20,

--- a/packages/app/cypress/e2e/runner/reporter.errors.cy.ts
+++ b/packages/app/cypress/e2e/runner/reporter.errors.cy.ts
@@ -188,6 +188,8 @@ describe('errors ui', {
         'The following error originated from your test code',
         'It was caused by an unhandled promise rejection',
       ],
+      stackRegex: /.*/,
+      hasCodeFrame: false,
     })
 
     verify('spec unhandled rejection with done', {

--- a/packages/driver/cypress/component/spec.cy.js
+++ b/packages/driver/cypress/component/spec.cy.js
@@ -1,4 +1,4 @@
-import sinon from 'sinon'
+const { sinon } = Cypress
 
 describe('component testing', () => {
   /** @type {Cypress.Agent<sinon.SinonSpy>} */

--- a/packages/driver/cypress/component/spec.cy.js
+++ b/packages/driver/cypress/component/spec.cy.js
@@ -1,3 +1,5 @@
+import sinon from 'sinon'
+
 describe('component testing', () => {
   /** @type {Cypress.Agent<sinon.SinonSpy>} */
   let uncaughtExceptionStub
@@ -12,17 +14,40 @@ describe('component testing', () => {
     })
   })
 
+  beforeEach(() => {
+    uncaughtExceptionStub.resetHistory()
+    document.querySelector('[data-cy-root]').innerHTML = ''
+  })
+
   it('fails and shows an error', () => {
+    cy.spy(Cypress, 'log').log(false)
     const $el = document.createElement('button')
 
     $el.innerText = `Don't click it!`
     $el.addEventListener('click', () => {
-      throw Error('An error!')
+      throw new Error('An error!')
     })
 
     document.querySelector('[data-cy-root]').appendChild($el)
     cy.get('button').click().then(() => {
       expect(uncaughtExceptionStub).to.have.been.calledOnceWithExactly(null)
+      expect(Cypress.log).to.be.calledWithMatch(sinon.match({ 'message': `Error: An error!`, name: 'uncaught exception' }))
+    })
+  })
+
+  it('fails and shows when a promise rejects with a string', () => {
+    cy.spy(Cypress, 'log').log(false)
+    const $el = document.createElement('button')
+
+    $el.innerText = `Don't click it!`
+    $el.addEventListener('click', new Promise((_, reject) => {
+      reject('Promise rejected with a string!')
+    }))
+
+    document.querySelector('[data-cy-root]').appendChild($el)
+    cy.get('button').click().then(() => {
+      expect(uncaughtExceptionStub).to.have.been.calledOnceWithExactly(null)
+      expect(Cypress.log).to.be.calledWithMatch(sinon.match({ 'message': `Error: "Promise rejected with a string!"`, name: 'uncaught exception' }))
     })
   })
 })

--- a/packages/driver/cypress/e2e/cypress/error_utils.cy.ts
+++ b/packages/driver/cypress/e2e/cypress/error_utils.cy.ts
@@ -671,14 +671,24 @@ describe('driver/src/cypress/error_utils', () => {
       }
     })
 
-    it('calls Cypress.log with error type and message when error is instance of Error', () => {
+    it('calls Cypress.log with error name and message when error is instance of Error', () => {
       $errUtils.logError(cypressMock, 'error', new Error('Some error'))
       expect(cypressMock.log).to.have.been.calledWithMatch(sinon.match.has('message', `Error: Some error`))
     })
 
-    it('calls Cypress.log with error type and message when error a string', () => {
-      $errUtils.logError(cypressMock, 'error', 'Some error')
-      expect(cypressMock.log).to.have.been.calledWithMatch(sinon.match.has('message', `Error: \"Some error\"`))
+    it('calls Cypress.log with error name and message when error a string', () => {
+      $errUtils.logError(cypressMock, 'error', 'Some string error')
+      expect(cypressMock.log).to.have.been.calledWithMatch(sinon.match.has('message', `Error: \"Some string error\"`))
+    })
+
+    it('calls Cypress.log with default error name and provided message message when error is an object with a message', () => {
+      $errUtils.logError(cypressMock, 'error', { message: 'Some object error with message' })
+      expect(cypressMock.log).to.have.been.calledWithMatch(sinon.match.has('message', `Error: Some object error with message`))
+    })
+
+    it('calls Cypress.log with error name and message when error is an object', () => {
+      $errUtils.logError(cypressMock, 'error', { err: 'Error details' })
+      expect(cypressMock.log).to.have.been.calledWithMatch(sinon.match.has('message', `Error: {"err":"Error details"}`))
     })
   })
 })

--- a/packages/driver/cypress/e2e/cypress/error_utils.cy.ts
+++ b/packages/driver/cypress/e2e/cypress/error_utils.cy.ts
@@ -5,6 +5,7 @@ allowTsModuleStubbing()
 import $stackUtils from '@packages/driver/src/cypress/stack_utils'
 import $errUtils, { CypressError } from '@packages/driver/src/cypress/error_utils'
 import $errorMessages from '@packages/driver/src/cypress/error_messages'
+import sinon from 'sinon'
 
 describe('driver/src/cypress/error_utils', () => {
   context('.modifyErrMsg', () => {
@@ -90,7 +91,7 @@ describe('driver/src/cypress/error_utils', () => {
     })
 
     it('attaches onFail to the error when it is a function', () => {
-      const onFail = function () {}
+      const onFail = function () { }
       const fn = () => $errUtils.throwErr(new Error('foo'), { onFail })
 
       expect(fn).throw().and.satisfy((err) => {
@@ -561,7 +562,7 @@ describe('driver/src/cypress/error_utils', () => {
 
     it('does not error if no last log', () => {
       state.returns({
-        getLastLog: () => {},
+        getLastLog: () => { },
       })
 
       const result = $errUtils.createUncaughtException({
@@ -658,6 +659,26 @@ describe('driver/src/cypress/error_utils', () => {
       })
 
       expect(unsupportedPlugin).to.eq(null)
+    })
+  })
+
+  context('.logError', () => {
+    let cypressMock
+
+    beforeEach(() => {
+      cypressMock = {
+        log: cy.stub(),
+      }
+    })
+
+    it('calls Cypress.log with error type and message when error is instance of Error', () => {
+      $errUtils.logError(cypressMock, 'error', new Error('Some error'))
+      expect(cypressMock.log).to.have.been.calledWithMatch(sinon.match.has('message', `Error: Some error`))
+    })
+
+    it('calls Cypress.log with error type and message when error a string', () => {
+      $errUtils.logError(cypressMock, 'error', 'Some error')
+      expect(cypressMock.log).to.have.been.calledWithMatch(sinon.match.has('message', `Error: \"Some error\"`))
     })
   })
 })

--- a/packages/driver/cypress/e2e/cypress/error_utils.cy.ts
+++ b/packages/driver/cypress/e2e/cypress/error_utils.cy.ts
@@ -5,7 +5,8 @@ allowTsModuleStubbing()
 import $stackUtils from '@packages/driver/src/cypress/stack_utils'
 import $errUtils, { CypressError } from '@packages/driver/src/cypress/error_utils'
 import $errorMessages from '@packages/driver/src/cypress/error_messages'
-import sinon from 'sinon'
+
+const { sinon } = Cypress
 
 describe('driver/src/cypress/error_utils', () => {
   context('.modifyErrMsg', () => {

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -109,8 +109,8 @@ const setTopOnError = function (Cypress, cy: $Cy) {
 
   // prevent Mocha from setting top.onerror
   Object.defineProperty(top, 'onerror', {
-    set () {},
-    get () {},
+    set () { },
+    get () { },
     configurable: false,
     enumerable: true,
   })
@@ -131,12 +131,12 @@ const ensureRunnable = (cy, cmd) => {
 interface ICyFocused extends Omit<
   IFocused,
   'documentHasFocus' | 'interceptFocus' | 'interceptBlur'
-> {}
+> { }
 
 interface ICySnapshots extends Omit<
   ISnapshots,
   'onCssModified' | 'onBeforeWindowLoad'
-> {}
+> { }
 
 export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssertions, IRetries, IJQuery, ILocation, ITimer, IChai, IXhr, IAliases, ICySnapshots, ICyFocused {
   id: string
@@ -505,16 +505,16 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
         // If the runner can communicate, we should setup all events, otherwise just setup the window and fire the load event.
         if (isRunnerAbleToCommunicateWithAUT) {
           if (this.Cypress.isBrowser('webkit')) {
-          // WebKit's unhandledrejection event will sometimes not fire within the AUT
-          // due to a documented bug: https://bugs.webkit.org/show_bug.cgi?id=187822
-          // To ensure that the event will always fire (and always report these
-          // unhandled rejections to the user), we patch the AUT's Error constructor
-          // to enqueue a no-op microtask when executed, which ensures that the unhandledrejection
-          // event handler will be executed if this Error is uncaught.
+            // WebKit's unhandledrejection event will sometimes not fire within the AUT
+            // due to a documented bug: https://bugs.webkit.org/show_bug.cgi?id=187822
+            // To ensure that the event will always fire (and always report these
+            // unhandled rejections to the user), we patch the AUT's Error constructor
+            // to enqueue a no-op microtask when executed, which ensures that the unhandledrejection
+            // event handler will be executed if this Error is uncaught.
             const originalError = autWindow.Error
 
             autWindow.Error = function __CyWebKitError (...args) {
-              autWindow.queueMicrotask(() => {})
+              autWindow.queueMicrotask(() => { })
 
               return originalError.apply(this, args)
             }
@@ -1059,6 +1059,7 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
       // eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
       onError: (handlerType) => (event) => {
         const { originalErr, err, promise } = $errUtils.errorFromUncaughtEvent(handlerType, event) as ErrorFromProjectRejectionEvent
+
         const handled = cy.onUncaughtException({
           err,
           promise,
@@ -1080,7 +1081,7 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
       onSubmit (e) {
         return cy.Cypress.action('app:form:submitted', e)
       },
-      onLoad () {},
+      onLoad () { },
       onBeforeUnload (e) {
         cy.isStable(false, 'beforeunload')
 

--- a/packages/driver/src/cypress/error_utils.ts
+++ b/packages/driver/src/cypress/error_utils.ts
@@ -189,6 +189,10 @@ const appendErrMsg = (err, errMsg) => {
 }
 
 const makeErrFromObj = (obj) => {
+  if (_.isString(obj)) {
+    return new Error(obj)
+  }
+
   const err2 = new Error(obj.message)
 
   err2.name = obj.name
@@ -580,18 +584,16 @@ const isLoggabbleError = (error: unknown): error is LoggableError => {
   return (
     typeof error === 'object' &&
     error !== null &&
-    'message' in error &&
-    typeof (error as Record<string, unknown>).message === 'string'
-  )
+    'message' in error)
 }
 
 const toLoggableError = (maybeError: unknown): LoggableError => {
   if (isLoggabbleError(maybeError)) return maybeError
 
   try {
-    return new Error(JSON.stringify(maybeError))
+    return { message: JSON.stringify(maybeError) }
   } catch {
-    return new Error(String(maybeError))
+    return { message: String(maybeError) }
   }
 }
 

--- a/packages/driver/src/cypress/error_utils.ts
+++ b/packages/driver/src/cypress/error_utils.ts
@@ -553,7 +553,7 @@ const logError = (Cypress, handlerType: HandlerType, err: unknown, handled = fal
   const error = toLoggableError(err)
 
   Cypress.log({
-    message: `${error.name}: ${error.message}`,
+    message: `${error.name || 'Error'}: ${error.message}`,
     name: 'uncaught exception',
     type: 'parent',
     // specifying the error causes the log to be red/failed
@@ -574,7 +574,9 @@ const logError = (Cypress, handlerType: HandlerType, err: unknown, handled = fal
   })
 }
 
-const isLogabbleError = (error: unknown): error is Error => {
+interface LoggableError { name?: string, message: string }
+
+const isLoggabbleError = (error: unknown): error is LoggableError => {
   return (
     typeof error === 'object' &&
     error !== null &&
@@ -583,8 +585,8 @@ const isLogabbleError = (error: unknown): error is Error => {
   )
 }
 
-const toLoggableError = (maybeError: unknown): Error => {
-  if (isLogabbleError(maybeError)) return maybeError
+const toLoggableError = (maybeError: unknown): LoggableError => {
+  if (isLoggabbleError(maybeError)) return maybeError
 
   try {
     return new Error(JSON.stringify(maybeError))

--- a/packages/driver/src/cypress/error_utils.ts
+++ b/packages/driver/src/cypress/error_utils.ts
@@ -580,7 +580,7 @@ const logError = (Cypress, handlerType: HandlerType, err: unknown, handled = fal
 
 interface LoggableError { name?: string, message: string }
 
-const isLoggabbleError = (error: unknown): error is LoggableError => {
+const isLoggableError = (error: unknown): error is LoggableError => {
   return (
     typeof error === 'object' &&
     error !== null &&
@@ -588,7 +588,7 @@ const isLoggabbleError = (error: unknown): error is LoggableError => {
 }
 
 const toLoggableError = (maybeError: unknown): LoggableError => {
-  if (isLoggabbleError(maybeError)) return maybeError
+  if (isLoggableError(maybeError)) return maybeError
 
   try {
     return { message: JSON.stringify(maybeError) }

--- a/system-tests/project-fixtures/runner-specs/cypress/e2e/errors/uncaught.cy.js
+++ b/system-tests/project-fixtures/runner-specs/cypress/e2e/errors/uncaught.cy.js
@@ -61,6 +61,12 @@ describe('uncaught errors', { defaultCommandTimeout: 0 }, () => {
     cy.wait(10000)
   })
 
+  it('spec unhandled rejection with string content', () => {
+    Promise.reject('Unhandled promise rejection with string content from the spec')
+
+    cy.wait(10000)
+  })
+
   // eslint-disable-next-line mocha/handle-done-callback
   it('spec unhandled rejection with done', (done) => {
     Promise.reject(new Error('Unhandled promise rejection from the spec'))


### PR DESCRIPTION
- Closes #24915 

### User facing changelog

Fixes issue where unhadled promise rejectection was being logged as `(uncaught exception) undefined: undefined`

### Additional details

Change was needed to help debugging failures where user has only access to cy console output.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?

-

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
