### PR TITLE
fix: cleanup files made by the tmp library in cypress.run() (part 2)

### DIFF
--- a/cli/lib/cypress.js
+++ b/cli/lib/cypress.js
@@ -37,7 +37,7 @@ const cypressModuleApi = {
     .then((outputPath) => {
       ['SIGINT', 'SIGTERM'].forEach(signal => {
         process.on(signal, () => {
-          fs.unlinkSync(outputPath)
+          fs.unlink(outputPath)
           process.exit()
         })
       })

--- a/cli/lib/cypress.js
+++ b/cli/lib/cypress.js
@@ -35,6 +35,13 @@ const cypressModuleApi = {
 
     return tmp.fileAsync()
     .then((outputPath) => {
+      ['SIGINT', 'SIGTERM'].forEach(signal => {
+        process.on(signal, () => {
+          fs.unlinkSync(outputPath)
+          process.exit()
+        })
+      })
+      
       options.outputPath = outputPath
 
       return run.start(options)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->
Part 2 of https://github.com/cypress-io/cypress/pull/24957

The files made by the tmp library [for cypress.run()] will now be deleted if either 'SIGINT' or 'SIGTERM' signals are triggered. 

This does seem messy, so please recommend a better way of going with this.
- Closes <!-- link to the issue here, if there is one -->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
