### PR TITLE
fix: .get() respects null withinSubject

### DIFF
--- a/packages/driver/cypress/e2e/commands/querying/querying.cy.js
+++ b/packages/driver/cypress/e2e/commands/querying/querying.cy.js
@@ -82,6 +82,12 @@ describe('src/cy/commands/querying', () => {
       cy.get('doesNotExist')
     })
 
+    it('respects null withinSubject', () => {
+      cy.get('#list').within(() => {
+        cy.get('#upper', { withinSubject: null })
+      })
+    })
+
     describe('custom elements', () => {
       // <foobarbazquux>custom element</foobarbazquux>
 

--- a/packages/driver/src/cy/commands/querying/querying.ts
+++ b/packages/driver/src/cy/commands/querying/querying.ts
@@ -172,7 +172,7 @@ export default (Commands, Cypress, cy, state) => {
       let $el
 
       try {
-        let scope = userOptions.withinSubject || cy.getSubjectFromChain(withinSubject)
+        let scope = userOptions.withinSubject !== undefined ? userOptions.withinSubject : cy.getSubjectFromChain(withinSubject)
 
         if (includeShadowDom) {
           const root = scope?.get(0) || cy.state('document')


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/25104

### User facing changelog
Fixes a regression introduced in Cypress 12 where `cy.get()` would ignore a `null` withinSubject.

### Additional details
We didn't have a test around this, so a regression crept in. `withinSubject` is exposed to users, and sometimes used as an 'escape hatch' - allowing them to run commands that ignore a `.within()` block they're inside.

### Steps to test
See included unit test.

### How has the user experience changed?
Return to 11.x behavior.

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
