### PR TITLE
fix: Serialize `query` object on intercepted request

### DIFF
--- a/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
+++ b/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
@@ -1823,6 +1823,7 @@ describe.skip('network stubbing', function () {
       // It's because XHR is not sent on Firefox and it's flaky on Chrome.
       it('parse query correctly', () => {
         cy.intercept({ url: '/users*' }, (req) => {
+          // Assert that query attributes are available in `intercept` callback
           expect(req.query.someKey).to.deep.equal('someValue')
           expect(req.query).to.deep.equal({ someKey: 'someValue' })
         }).as('getUrl')
@@ -1835,6 +1836,11 @@ describe.skip('network stubbing', function () {
         })
 
         cy.wait('@getUrl')
+        .then((interception) => {
+          // Assert that query attributes are maintained once interception is yielded
+          expect(interception.request.query.someKey).to.deep.equal('someValue')
+          expect(interception.request.query).to.deep.equal({ someKey: 'someValue' })
+        })
       })
 
       context('reconcile changes', () => {

--- a/packages/net-stubbing/lib/internal-types.ts
+++ b/packages/net-stubbing/lib/internal-types.ts
@@ -23,6 +23,7 @@ export const SERIALIZABLE_REQ_PROPS = [
   'httpVersion',
   'responseTimeout',
   'followRedirect',
+  'query',
 ]
 
 export const SERIALIZABLE_RES_PROPS = _.concat(


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #25088 

### User facing changelog
* Fixes issue where the `query` field was lost once a request from `cy.intercept` was yielded.

### Additional details
Intercepted requests [gained a dynamic `query` object in v7.6.0](https://github.com/cypress-io/cypress/pull/16916) that parses out any query params from the intercepted request url, but it was not added to the list of serialized attributes so it is effectively "lost" once yielded. This results in misleading documentation & typescript types.

The `query` field is currently only accessible within the `intercept` callback. This makes it unavailable if you want to work with an aliased intercept after a `cy.wait`, for example:

```
cy.intercept('/url', (req) => {
  // `req.query` exists here

  req.continue()
}).as('myRequest')

cy.wait('@myRequest').then((intercept) => {
  // According to types it should be available here at `intercept.request.query` but is not :(
})
```

**Note:** I've added test logic to validate this behavior, but the majority of `net_stubbing` is being skipped due to flake thus the new test logic is at present a no-op. I have validated it works locally when forced to run. Open to suggestions on how to handle - I don't want to fragment the test by refactoring this section too much since that could tangentially re-introduce flake

### Steps to test
There is a good reproduction available on the original issue #25088 - one test case should fail on develop but succeed on this branch.

### How has the user experience changed?
No visible change

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
