### PR TITLE
fix: reduce Percy flake

### DIFF
--- a/packages/app/cypress/e2e/runner/support/snapshot-reporter.ts
+++ b/packages/app/cypress/e2e/runner/support/snapshot-reporter.ts
@@ -13,6 +13,14 @@ export const snapshotReporter = () => {
       '[data-cy=reporter-panel]': ($el) => {
         $el.attr('style', 'width: 450px !important')
       },
+      '[data-cy=reporter-running-icon]': ($el) => {
+        // remove 'fa-spin' class so that the icon is not animated
+        $el.attr('class', '')
+      },
+      '.command-progress': ($el) => {
+        // don't display command progress bar in snapshot
+        $el.attr('style', 'display: none !important')
+      },
     },
   })
 }

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -170,6 +170,9 @@ describe('Opening unmigrated project', () => {
     cy.contains(cy.i18n.majorVersionWelcome.title).should('not.exist')
     cy.contains('h1', 'Migrating to Cypress 11').should('be.visible')
 
+    // Wait for migration prompt to load before taking a snapshot
+    cy.get('.spinner').should('not.exist')
+
     cy.percySnapshot()
   })
 })

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -79,7 +79,7 @@ const shouldShowCount = (aliasesWithDuplicates: Array<Alias> | null, aliasName: 
 const NavColumns = observer(({ model, isPinned, toggleColumnPin }) => (
   <>
     <div className='command-number-column' onClick={toggleColumnPin}>
-      {model._isPending() && <RunningIcon className='fa-spin' />}
+      {model._isPending() && <RunningIcon data-cy="reporter-running-icon" className='fa-spin' />}
       {(!model._isPending() && isPinned) && <PinIcon className='command-pin' />}
       {(!model._isPending() && !isPinned) && model.number}
     </div>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

There are some animations in the UI that make visual snapshots change when no related code has actually changed, the snapshot is just taken at a slightly different time so things look different. This PR fixes Percy flake in the following two cases

- The migration screen sometimes gets snapshotted when it hasn't finished loading
  - I fixed this by asserting that the loading spinner is not in the DOM before we take a snapshot
- The reporter snapshots sometimes show up as changed because of a difference in where the command progress bar is
  - I fixed this by taking the animation class off of the command "running" icon and hiding the command progress bar completely when taking snapshots of the reporter

This will hopefully reduce noise in Percy diffs going forward and make it more useful.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Check out the Percy run down in the PR checks list. Once these snapshots update, they shouldn't show up in the Percy diff anymore unless something has legitimately changed.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
