### PR TITLE
fix: Overwritten commands receive proper subject when calling originalFn

### DIFF
--- a/packages/driver/cypress/e2e/cypress/cy.cy.js
+++ b/packages/driver/cypress/e2e/cypress/cy.cy.js
@@ -474,6 +474,26 @@ describe('driver/src/cypress/cy', () => {
 
       cy.bar()
     })
+
+    it('originalFn is called with correct chainerId and subject', () => {
+      const logs = []
+
+      cy.on('log:added', (attrs, log) => logs.push(log))
+
+      Cypress.Commands.overwrite('click', function (originalFn, ...args) {
+        return cy.wait(0).then(() => originalFn(...args, { timeout: 50 }))
+      })
+
+      cy.get('#wrapper').click()
+      cy.then(() => {
+        const wrapper = cy.$$('#wrapper').get(0)
+        const click = logs[2]
+
+        expect(click.get('name')).to.eq('click')
+        expect(click.get('state')).to.eq('passed')
+        expect(click.get('consoleProps')()['Applied To']).to.eq(wrapper)
+      })
+    })
   })
 
   context('queries', {

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -1292,7 +1292,7 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
     // We only override linked subject chains when we're at the end of a a chain. This prevents the case where
     // commands inside an overwritten command replace the subject chain too early, preventing
     // the originalFn from having access to the original subjectChain.
-    if (links[chainerId] && this.state('current').get('next')?.get('chainerId') !== chainerId) {
+    if (links[chainerId] && this.state('current')?.get('next')?.get('chainerId') !== chainerId) {
       this.setSubjectForChainer(links[chainerId], subjectChain)
     }
   }

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -1289,7 +1289,10 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
 
     const links = this.state('subjectLinks') || {} as Record<string, string>
 
-    if (links[chainerId]) {
+    // We only override linked subject chains when we're at the end of a a chain. This prevents the case where
+    // commands inside an overwritten command replace the subject chain too early, preventing
+    // the originalFn from having access to the original subjectChain.
+    if (links[chainerId] && this.state('current').get('next')?.get('chainerId') !== chainerId) {
       this.setSubjectForChainer(links[chainerId], subjectChain)
     }
   }


### PR DESCRIPTION
- Closes #25149

### User facing changelog
Fixes an issue when overwriting commands, where if you called Cypress commands before calling originalFn(), it would receive the wrong subject.

### Additional details
See the code comments for a more detailed explanation of what was going on and why this PR fixes it.

### Steps to test
```
      Cypress.Commands.overwrite('click', function (originalFn, ...args) {
        return cy.wait(0).then(() => originalFn(...args, { timeout: 50 }))
      })

      cy.get('#wrapper').click()
```

Overwrite any action command, and in the overwrite, call another Cypress command before originalFn - you'll get a timed out promise. `{ timeout: 50 }` on the originalFn here isn't necessary to reproduce, but it makes the actual error a lot clearer (you see the exception thrown, rather than just "a promise timed out without resolving")!

### How has the user experience changed?


### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
