### PR TITLE
chore(ci): remove darwin, windows linting

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -2680,12 +2680,6 @@ darwin-x64-workflow: &darwin-x64-workflow
         requires:
           - darwin-x64-node-modules-install
 
-    - lint:
-        name: darwin-x64-lint
-        executor: mac
-        requires:
-          - darwin-x64-build
-
     - create-build-artifacts:
         name: darwin-x64-create-build-artifacts
         context:
@@ -2772,12 +2766,6 @@ windows-workflow: &windows-workflow
         executor: windows
         resource_class: windows.large
         context: [test-runner:cypress-record-key, test-runner:launchpad-tests]
-        requires:
-          - windows-build
-
-    - lint:
-        name: windows-lint
-        executor: windows
         requires:
           - windows-build
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- For cypress-io/cypress-internal#513

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

### Additional details

- AFAICT we don't gain anything (except CI cost) by linting on windows and darwin-x64, since we already lint on linux-x64.
- No other jobs depend on windows-lint or darwin-x64.
- If nobody knows why these are here, I say we remove 'em

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
