### PR TITLE
feat: run failures enhancements

### DIFF
--- a/packages/app/src/debug/DebugContainer.cy.tsx
+++ b/packages/app/src/debug/DebugContainer.cy.tsx
@@ -6,10 +6,6 @@ import { specsList } from './utils/DebugMapping'
 import { CloudRunStubs } from '@packages/graphql/test/stubCloudTypes'
 
 describe('<DebugContainer />', () => {
-  before(() => {
-    (window as any).CYPRESS_RUN_TESTING_TYPE = 'e2e'
-  })
-
   context('empty states', () => {
     const validateEmptyState = (expectedMessage: string) => {
       cy.mountFragment(DebugSpecsFragmentDoc, {

--- a/packages/app/src/debug/DebugContainer.cy.tsx
+++ b/packages/app/src/debug/DebugContainer.cy.tsx
@@ -92,14 +92,14 @@ describe('<DebugContainer />', () => {
         { specId: 'a1c', id: 'random2' },
       ] as DebugSpecListTestsFragment[]
       const groups = [
-        { id: 'a' },
-        { id: 'b' },
+        { id: 'a', testingType: 'e2e' },
+        { id: 'b', testingType: 'e2e' },
       ] as DebugSpecListGroupsFragment[]
 
       const debugMappingArray = specsList({ specs, tests, groups, localSpecs: [], currentTestingType: 'e2e' })
 
       expect(debugMappingArray).to.have.length(1)
-      expect(debugMappingArray[0]).to.deep.equal({ spec: { id: 'a1c', groupIds: ['a'] }, tests: [{ specId: 'a1c', id: 'random1' }, { specId: 'a1c', id: 'random2' }], groups: [{ id: 'a' }], foundLocally: false, testingType: 'e2e', matchesCurrentTestingType: true })
+      expect(debugMappingArray[0]).to.deep.equal({ spec: { id: 'a1c', groupIds: ['a'] }, tests: [{ specId: 'a1c', id: 'random1' }, { specId: 'a1c', id: 'random2' }], groups: [{ id: 'a', testingType: 'e2e' }], foundLocally: false, testingType: 'e2e', matchesCurrentTestingType: true })
     })
 
     it('maps correctly for multiple specs and test', () => {
@@ -116,16 +116,16 @@ describe('<DebugContainer />', () => {
         { specId: '123', id: 'random6' },
       ] as DebugSpecListTestsFragment[]
       const groups = [
-        { id: 'a' },
-        { id: 'b' },
+        { id: 'a', testingType: 'e2e' },
+        { id: 'b', testingType: 'e2e' },
       ] as DebugSpecListGroupsFragment[]
 
       const debugMappingArray = specsList({ specs, tests, localSpecs: [], currentTestingType: 'e2e', groups })
 
       const expected = [
-        { spec: { id: '123', groupIds: ['a'] }, tests: [{ specId: '123', id: 'random1' }, { specId: '123', id: 'random6' }], groups: [{ id: 'a' }], foundLocally: false, testingType: 'e2e', matchesCurrentTestingType: true },
-        { spec: { id: '456', groupIds: ['b'] }, tests: [{ specId: '456', id: 'random2' }, { specId: '456', id: 'random3' }], groups: [{ id: 'b' }], foundLocally: false, testingType: 'e2e', matchesCurrentTestingType: true },
-        { spec: { id: '789', groupIds: ['a', 'b'] }, tests: [{ specId: '789', id: 'random4' }], groups: [{ id: 'a' }, { id: 'b' }], foundLocally: false, testingType: 'e2e', matchesCurrentTestingType: true },
+        { spec: { id: '123', groupIds: ['a'] }, tests: [{ specId: '123', id: 'random1' }, { specId: '123', id: 'random6' }], groups: [{ id: 'a', testingType: 'e2e' }], foundLocally: false, testingType: 'e2e', matchesCurrentTestingType: true },
+        { spec: { id: '456', groupIds: ['b'] }, tests: [{ specId: '456', id: 'random2' }, { specId: '456', id: 'random3' }], groups: [{ id: 'b', testingType: 'e2e' }], foundLocally: false, testingType: 'e2e', matchesCurrentTestingType: true },
+        { spec: { id: '789', groupIds: ['a', 'b'] }, tests: [{ specId: '789', id: 'random4' }], groups: [{ id: 'a', testingType: 'e2e' }, { id: 'b', testingType: 'e2e' }], foundLocally: false, testingType: 'e2e', matchesCurrentTestingType: true },
       ]
 
       expect(debugMappingArray).to.deep.equal(expected)
@@ -138,12 +138,12 @@ describe('<DebugContainer />', () => {
         { id: '789', groupIds: ['a'] },
       ] as DebugSpecListSpecFragment[]
       const tests = [{ specId: '123', id: 'random1' }] as DebugSpecListTestsFragment[]
-      const groups = [{ id: 'a' }] as DebugSpecListGroupsFragment[]
+      const groups = [{ id: 'a', testingType: 'e2e' }] as DebugSpecListGroupsFragment[]
 
       const debugMappingArray = specsList({ specs, tests, localSpecs: [], currentTestingType: 'e2e', groups })
 
       expect(debugMappingArray).to.have.length(1)
-      expect(debugMappingArray).to.deep.equal([{ spec: { id: '123', groupIds: ['a'] }, tests: [{ specId: '123', id: 'random1' }], groups: [{ id: 'a' }], foundLocally: false, testingType: 'e2e', matchesCurrentTestingType: true }])
+      expect(debugMappingArray).to.deep.equal([{ spec: { id: '123', groupIds: ['a'] }, tests: [{ specId: '123', id: 'random1' }], groups: [{ id: 'a', testingType: 'e2e' }], foundLocally: false, testingType: 'e2e', matchesCurrentTestingType: true }])
     })
 
     it('throws an error when a test does not map to a spec', () => {

--- a/packages/app/src/debug/DebugContainer.cy.tsx
+++ b/packages/app/src/debug/DebugContainer.cy.tsx
@@ -1,4 +1,4 @@
-import { DebugSpecsFragmentDoc } from '../generated/graphql-test'
+import { DebugSpecListGroupsFragment, DebugSpecListSpecFragment, DebugSpecListTestsFragment, DebugSpecsFragmentDoc } from '../generated/graphql-test'
 import DebugContainer from './DebugContainer.vue'
 import { defaultMessages } from '@cy/i18n'
 import { useLoginConnectStore } from '@packages/frontend-shared/src/store/login-connect-store'
@@ -6,6 +6,10 @@ import { specsList } from './utils/DebugMapping'
 import { CloudRunStubs } from '@packages/graphql/test/stubCloudTypes'
 
 describe('<DebugContainer />', () => {
+  before(() => {
+    (window as any).CYPRESS_RUN_TESTING_TYPE = 'e2e'
+  })
+
   context('empty states', () => {
     const validateEmptyState = (expectedMessage: string) => {
       cy.mountFragment(DebugSpecsFragmentDoc, {
@@ -83,69 +87,81 @@ describe('<DebugContainer />', () => {
   })
 
   describe('testing util function: debugMapping', () => {
-    const createSpecs = (idArr: string[]) => {
-      const acc: {id: string}[] = []
-
-      idArr.forEach((val) => {
-        acc.push({ id: val })
-      })
-
-      return acc
-    }
-
     it('maps correctly for a single spec', () => {
-      const spec = createSpecs(['a1c'])
+      const specs = [
+        { id: 'a1c', groupIds: ['a'] },
+      ] as DebugSpecListSpecFragment[]
       const tests = [
         { specId: 'a1c', id: 'random1' },
         { specId: 'a1c', id: 'random2' },
-      ]
+      ] as DebugSpecListTestsFragment[]
+      const groups = [
+        { id: 'a' },
+        { id: 'b' },
+      ] as DebugSpecListGroupsFragment[]
 
-      const debugMappingArray = specsList(spec, tests)
+      const debugMappingArray = specsList({ specs, tests, groups, localSpecs: [], currentTestingType: 'e2e' })
 
       expect(debugMappingArray).to.have.length(1)
-      expect(debugMappingArray[0]).to.deep.equal({ spec: { id: 'a1c' }, tests: [{ specId: 'a1c', id: 'random1' }, { specId: 'a1c', id: 'random2' }] })
+      expect(debugMappingArray[0]).to.deep.equal({ spec: { id: 'a1c', groupIds: ['a'] }, tests: [{ specId: 'a1c', id: 'random1' }, { specId: 'a1c', id: 'random2' }], groups: [{ id: 'a' }], foundLocally: false, testingType: 'e2e', matchesCurrentTestingType: true })
     })
 
     it('maps correctly for multiple specs and test', () => {
-      const specs = createSpecs(['123', '456', '789'])
+      const specs = [
+        { id: '123', groupIds: ['a'] },
+        { id: '456', groupIds: ['b'] },
+        { id: '789', groupIds: ['a', 'b'] },
+      ] as DebugSpecListSpecFragment[]
       const tests = [
         { specId: '123', id: 'random1' },
         { specId: '456', id: 'random2' },
         { specId: '456', id: 'random3' },
         { specId: '789', id: 'random4' },
         { specId: '123', id: 'random6' },
-      ]
+      ] as DebugSpecListTestsFragment[]
+      const groups = [
+        { id: 'a' },
+        { id: 'b' },
+      ] as DebugSpecListGroupsFragment[]
 
-      const debugMappingArray = specsList(specs, tests)
+      const debugMappingArray = specsList({ specs, tests, localSpecs: [], currentTestingType: 'e2e', groups })
 
       const expected = [
-        { spec: { id: '123' }, tests: [{ specId: '123', id: 'random1' }, { specId: '123', id: 'random6' }] },
-        { spec: { id: '456' }, tests: [{ specId: '456', id: 'random2' }, { specId: '456', id: 'random3' }] },
-        { spec: { id: '789' }, tests: [{ specId: '789', id: 'random4' }] },
+        { spec: { id: '123', groupIds: ['a'] }, tests: [{ specId: '123', id: 'random1' }, { specId: '123', id: 'random6' }], groups: [{ id: 'a' }], foundLocally: false, testingType: 'e2e', matchesCurrentTestingType: true },
+        { spec: { id: '456', groupIds: ['b'] }, tests: [{ specId: '456', id: 'random2' }, { specId: '456', id: 'random3' }], groups: [{ id: 'b' }], foundLocally: false, testingType: 'e2e', matchesCurrentTestingType: true },
+        { spec: { id: '789', groupIds: ['a', 'b'] }, tests: [{ specId: '789', id: 'random4' }], groups: [{ id: 'a' }, { id: 'b' }], foundLocally: false, testingType: 'e2e', matchesCurrentTestingType: true },
       ]
 
       expect(debugMappingArray).to.deep.equal(expected)
     })
 
     it('maps does not show specs that do not have tests', () => {
-      const specs = createSpecs(['123', '456', '789'])
-      const tests = [{ specId: '123', id: 'random1' }]
+      const specs = [
+        { id: '123', groupIds: ['a'] },
+        { id: '456', groupIds: ['a'] },
+        { id: '789', groupIds: ['a'] },
+      ] as DebugSpecListSpecFragment[]
+      const tests = [{ specId: '123', id: 'random1' }] as DebugSpecListTestsFragment[]
+      const groups = [{ id: 'a' }] as DebugSpecListGroupsFragment[]
 
-      const debugMappingArray = specsList(specs, tests)
+      const debugMappingArray = specsList({ specs, tests, localSpecs: [], currentTestingType: 'e2e', groups })
 
       expect(debugMappingArray).to.have.length(1)
-      expect(debugMappingArray).to.deep.equal([{ spec: { id: '123' }, tests: [{ specId: '123', id: 'random1' }] }])
+      expect(debugMappingArray).to.deep.equal([{ spec: { id: '123', groupIds: ['a'] }, tests: [{ specId: '123', id: 'random1' }], groups: [{ id: 'a' }], foundLocally: false, testingType: 'e2e', matchesCurrentTestingType: true }])
     })
 
     it('throws an error when a test does not map to a spec', () => {
-      const specs = createSpecs(['123'])
+      const specs = [
+        { id: '123', groupIds: ['a'] },
+      ] as DebugSpecListSpecFragment[]
       const tests = [
         { specId: '123', id: 'random1' },
         { specId: '456', id: 'random2' },
-      ]
+      ] as DebugSpecListTestsFragment[]
+      const groups = [{ id: 'a' }] as DebugSpecListGroupsFragment[]
 
       const specsListWrapper = () => {
-        return specsList(specs, tests)
+        return specsList({ specs, tests, groups, localSpecs: [], currentTestingType: 'e2e' })
       }
 
       expect(specsListWrapper).to.throw('Could not find spec for id 456')

--- a/packages/app/src/debug/DebugContainer.vue
+++ b/packages/app/src/debug/DebugContainer.vue
@@ -37,7 +37,7 @@
 <script setup lang="ts">
 import { gql } from '@urql/vue'
 import { computed } from '@vue/reactivity'
-import type { DebugSpecsFragment } from '../generated/graphql'
+import type { DebugSpecsFragment, TestingTypeEnum } from '../generated/graphql'
 import { useLoginConnectStore } from '@packages/frontend-shared/src/store/login-connect-store'
 import DebugPageHeader from './DebugPageHeader.vue'
 import DebugSpecList from './DebugSpecList.vue'
@@ -103,21 +103,20 @@ const run = computed(() => {
   return props.gql.currentProject?.cloudProject?.__typename === 'CloudProject' ? props.gql.currentProject.cloudProject.runByNumber : null
 })
 
-const localSpecs = computed(() => {
-  return props.gql.currentProject?.specs || []
-})
-
 const debugSpecsArray = computed(() => {
-  if (run.value) {
+  if (run.value && props.gql.currentProject) {
     const specs = run.value.specs || []
     const tests = run.value.testsForReview || []
-    const currentTestingType = props.gql.currentProject?.currentTestingType || 'e2e'
+    const groups = run.value.groups || []
+    // Will be defined so ignore the possibility of null for testingType
+    const currentTestingType = props.gql.currentProject.currentTestingType as TestingTypeEnum
+    const localSpecs = props.gql.currentProject.specs
 
     return specsList({
       specs,
       tests,
-      groups: run.value.groups,
-      localSpecs: localSpecs.value,
+      groups,
+      localSpecs,
       currentTestingType,
     })
   }

--- a/packages/app/src/debug/DebugContainer.vue
+++ b/packages/app/src/debug/DebugContainer.vue
@@ -47,6 +47,14 @@ import { specsList } from './utils/DebugMapping'
 const { t } = useI18n()
 
 gql`
+fragment DebugLocalSpecs on Spec {
+  id
+  absolute
+  relative
+}
+`
+
+gql`
 fragment DebugSpecs on Query {
   currentProject {
     id
@@ -54,7 +62,7 @@ fragment DebugSpecs on Query {
       __typename
       ... on CloudProject {
         id
-        runByNumber(runNumber: 6) {
+        runByNumber(runNumber: 11) {
           ...DebugPage
           id
           runNumber
@@ -69,9 +77,18 @@ fragment DebugSpecs on Query {
             id
             ...DebugSpecListSpec
           }
+          groups {
+            id,
+            ...DebugSpecListGroups
+          }
         }
       }
     }
+    specs {
+      id
+      ...DebugLocalSpecs
+    }
+    currentTestingType
   }
 }
 `
@@ -86,15 +103,25 @@ const run = computed(() => {
   return props.gql.currentProject?.cloudProject?.__typename === 'CloudProject' ? props.gql.currentProject.cloudProject.runByNumber : null
 })
 
+const localSpecs = computed(() => {
+  return props.gql.currentProject?.specs || []
+})
+
 const debugSpecsArray = computed(() => {
   if (run.value) {
     const specs = run.value.specs || []
     const tests = run.value.testsForReview || []
+    const currentTestingType = props.gql.currentProject?.currentTestingType || 'e2e'
 
-    return specsList(specs, tests)
+    return specsList({
+      specs,
+      tests,
+      groups: run.value.groups,
+      localSpecs: localSpecs.value,
+      currentTestingType,
+    })
   }
 
   return []
 })
-
 </script>

--- a/packages/app/src/debug/DebugSpec.vue
+++ b/packages/app/src/debug/DebugSpec.vue
@@ -32,24 +32,50 @@
         <div
           class="ml-10px"
         >
-          <Button
-            data-cy="run-failures"
-            variant="white"
-            class="gap-x-10px inline-flex whitespace-nowrap justify-center items-center isolate"
-            :disabled="isDisabled"
-            :to="{ path: '/specs/runner', query: { file: (specData.path).replace(/\\/g, '/') } }"
+          <Tooltip
+            placement="bottom"
+            color="dark"
+            :is-interactive="!!(runAllFailuresState.cta)"
+            :disabled="!runAllFailuresState.disabled"
           >
-            <template #prefix>
-              <IconActionRefresh
-                data-cy="icon-refresh"
-                stroke-color="indigo-500"
-              />
+            <Button
+              data-cy="run-failures"
+              variant="white"
+              class="gap-x-10px inline-flex whitespace-nowrap justify-center items-center isolate"
+              :disabled="runAllFailuresState.disabled"
+              :to="{ path: '/specs/runner', query: { file: posixify(specData.fullPath) } }"
+            >
+              <template #prefix>
+                <IconActionRefresh
+                  data-cy="icon-refresh"
+                  stroke-color="indigo-500"
+                />
+              </template>
+              <!-- Wrapping this with a default template to avoid an unneeded space -->
+              <template #default>
+                {{ t('debugPage.runFailures.btn') }}
+              </template>
+            </Button>
+            <template
+              v-if="runAllFailuresState.disabled"
+              #popper
+            >
+              <div
+                class="flex flex-col text-sm max-w-350px items-center"
+                data-cy="run-all-failures-tooltip"
+              >
+                <span class="text-center">{{ runAllFailuresState.message }}</span>
+                <Button
+                  v-if="runAllFailuresState.cta"
+                  variant="text"
+                  class="rounded-md font-medium bg-gray-800 my-12px"
+                  @click="runAllFailuresState.cta?.action"
+                >
+                  {{ runAllFailuresState.cta.message }}
+                </Button>
+              </div>
             </template>
-            <!-- Wrapping this with a default template to avoid an unneeded space -->
-            <template #default>
-              {{ t('debugPage.runFailures') }}
-            </template>
-          </Button>
+          </Tooltip>
         </div>
       </div>
     </div>
@@ -72,6 +98,7 @@ export interface Spec {
   path: string
   fileName: string
   fileExtension: string
+  fullPath: string
 }
 
 export interface TestResults {
@@ -83,15 +110,24 @@ import { computed } from 'vue'
 import { IconActionRefresh } from '@cypress-design/vue-icon'
 import DebugFailedTest from './DebugFailedTest.vue'
 import Button from '@packages/frontend-shared/src/components/Button.vue'
+import Tooltip from '@packages/frontend-shared/src/components/Tooltip.vue'
 import SpecNameDisplay from '../specs/SpecNameDisplay.vue'
 import { useI18n } from '@cy/i18n'
+import { posixify } from '../paths'
+import type { TestingTypeEnum } from '../generated/graphql'
 
 const { t } = useI18n()
 
 const props = defineProps<{
   spec: Spec
   testResults: TestResults[]
-  isDisabled?: boolean
+  foundLocally: boolean
+  testingType: TestingTypeEnum
+  matchesCurrentTestingType: boolean
+}>()
+
+const emits = defineEmits<{
+  (event: 'switchTestingType', value: TestingTypeEnum): void
 }>()
 
 const specData = computed(() => {
@@ -100,7 +136,30 @@ const specData = computed(() => {
     fileName: props.spec.fileName,
     fileExtension: props.spec.fileExtension,
     failedTests: props.testResults,
+    fullPath: props.spec.fullPath,
   }
+})
+
+const runAllFailuresState = computed(() => {
+  if (!props.matchesCurrentTestingType) {
+    return {
+      disabled: true,
+      message: t('debugPage.runFailures.switchTestingTypeInfo', { n: props.testResults.length, testingType: props.testingType }),
+      cta: {
+        message: t('debugPage.runFailures.switchTestingTypeAction', { testingType: props.testingType }),
+        action: () => emits('switchTestingType', props.testingType),
+      },
+    }
+  }
+
+  if (!props.foundLocally) {
+    return {
+      disabled: true,
+      message: t('debugPage.runFailures.notFoundLocally'),
+    }
+  }
+
+  return { disabled: false }
 })
 
 </script>

--- a/packages/app/src/debug/utils/DebugMapping.ts
+++ b/packages/app/src/debug/utils/DebugMapping.ts
@@ -1,27 +1,64 @@
-export const specsList = <S extends {id: string}, T extends {specId: string}>(specs: readonly S[], tests: readonly T[]): {spec: S, tests: T[]}[] => {
-  const mappedTests = tests.reduce((acc, curr) => {
-    // console.log(`test specId = ${ curr.specId}`)
-    let spec = acc[curr.specId]
+import type { DebugSpecListSpecFragment, DebugSpecListTestsFragment, DebugLocalSpecsFragment, TestingTypeEnum, DebugSpecListGroupsFragment } from '../../generated/graphql'
+import { posixify } from '../../paths'
 
-    if (!spec) {
+type DebugSpecsArgs = {
+  specs: readonly DebugSpecListSpecFragment[]
+  tests: readonly DebugSpecListTestsFragment[]
+  groups: readonly DebugSpecListGroupsFragment[]
+  localSpecs: readonly DebugLocalSpecsFragment[]
+  currentTestingType: TestingTypeEnum
+}
+
+export type CloudDebugSpec = {
+  spec: DebugSpecListSpecFragment
+  tests: DebugSpecListTestsFragment[]
+  groups: DebugSpecListGroupsFragment[]
+  foundLocally: boolean
+  testingType: TestingTypeEnum
+  matchesCurrentTestingType: boolean
+}
+
+export const specsList = ({ specs, tests, localSpecs, currentTestingType, groups }: DebugSpecsArgs): CloudDebugSpec[] => {
+  const localSpecsSet = new Set(localSpecs.map(((spec) => posixify(spec.relative))))
+  const groupsMap = groups.reduce<{[id: string]: DebugSpecListGroupsFragment}>((acc, group) => ({ ...acc, [group.id]: group }), {})
+
+  const mappedTests = tests.reduce<{[id: string]: CloudDebugSpec}>((acc, curr) => {
+    let debugResult = acc[curr.specId]
+
+    if (!debugResult) {
       const foundSpec = specs.find((spec) => spec.id === curr.specId)
 
-      spec = { spec: foundSpec }
-      // console.log('looking for spec', spec)
-      if (foundSpec) {
-        acc[curr.specId] = spec
-      } else {
+      if (!foundSpec) {
         //TODO better handle error case
         throw new Error(`Could not find spec for id ${ curr.specId}`)
       }
+
+      const groups = (foundSpec.groupIds || []).reduce<DebugSpecListGroupsFragment[]>((acc, id) => {
+        if (id) {
+          acc.push(groupsMap[id])
+        }
+
+        return acc
+      }, [])
+      // should always exist, the testingType should not differ between groups
+      const testingType = (groups[0]?.testingType || 'e2e') as TestingTypeEnum
+
+      debugResult = {
+        spec: foundSpec,
+        tests: [curr],
+        groups,
+        testingType,
+        matchesCurrentTestingType: testingType === currentTestingType,
+        foundLocally: localSpecsSet.has(foundSpec.path),
+      }
+
+      acc[curr.specId] = debugResult
+    } else {
+      debugResult.tests.push(curr)
     }
 
-    spec.tests = [...(spec.tests || []), curr]
-
-    // console.log('spec.tests', spec.tests)
     return acc
   }, {})
-  // console.log(mappedTests)
 
   return Object.values(mappedTests)
 }

--- a/packages/app/src/debug/utils/DebugMapping.ts
+++ b/packages/app/src/debug/utils/DebugMapping.ts
@@ -40,8 +40,8 @@ export const specsList = ({ specs, tests, localSpecs, currentTestingType, groups
 
         return acc
       }, [])
-      // should always exist, the testingType should not differ between groups
-      const testingType = (groups[0]?.testingType || 'e2e') as TestingTypeEnum
+      // The testingType will not differ between groups
+      const testingType = groups[0]?.testingType as TestingTypeEnum
 
       debugResult = {
         spec: foundSpec,

--- a/packages/app/src/pages/Debug.vue
+++ b/packages/app/src/pages/Debug.vue
@@ -15,15 +15,29 @@
 <script setup lang="ts">
 
 import DebugContainer from '../debug/DebugContainer.vue'
-import { gql, useQuery } from '@urql/vue'
-import { DebugDocument } from '../generated/graphql'
+import { gql, useQuery, useSubscription } from '@urql/vue'
+import { DebugDocument, Debug_SpecsChangeDocument } from '../generated/graphql'
+
+gql`
+subscription Debug_specsChange {
+  specsChange {
+    id
+    specs {
+      id
+      ...DebugLocalSpecs
+    }
+  }
+}
+`
 
 gql `
 query Debug {
-   ...DebugSpecs
+  ...DebugSpecs
 }
 `
 
 const query = useQuery({ query: DebugDocument })
+
+useSubscription({ query: Debug_SpecsChangeDocument })
 
 </script>

--- a/packages/app/src/specs/RequestAccessButton.vue
+++ b/packages/app/src/specs/RequestAccessButton.vue
@@ -13,7 +13,7 @@
     :prefix-icon="SendIcon"
     prefix-icon-class="icon-dark-white icon-light-transparent"
     data-cy="access-requested-button"
-    class="bg-gray-800 border-gray-800"
+    class="btn-disabled"
     disabled
   >
     {{ t("specPage.requestSentButton") }}
@@ -86,3 +86,10 @@ async function requestAccess () {
 }
 
 </script>
+
+<style scoped>
+/* Override <Button> classes, do not rely on css class order */
+.btn-disabled {
+  @apply bg-gray-800 border-gray-800;
+}
+</style>

--- a/packages/frontend-shared/src/components/Button.cy.tsx
+++ b/packages/frontend-shared/src/components/Button.cy.tsx
@@ -108,4 +108,16 @@ describe('<Button />', { viewportWidth: 300, viewportHeight: 400 }, () => {
     cy.contains('a', 'test').should('have.attr', 'aria-disabled', 'disabled')
     cy.contains('a', 'test').should('have.attr', 'role', 'link')
   })
+
+  it('does not allow hocus styling when disabled', () => {
+    const buttonVariants = ['link', 'text', 'primary', 'outline', 'tertiary', 'pending', 'linkBold', 'secondary', 'white']
+
+    cy.mount(() => <div>{buttonVariants.map((variant) => <Button variant={variant} disabled>{variant}</Button>)}</div>)
+
+    for (const variant of buttonVariants) {
+      cy.contains('button', variant).realHover()
+      .should('not.have.class', 'hocus-default')
+      .and('not.have.class', 'hocus-secondary')
+    }
+  })
 })

--- a/packages/frontend-shared/src/components/Button.cy.tsx
+++ b/packages/frontend-shared/src/components/Button.cy.tsx
@@ -1,4 +1,4 @@
-import Button from './Button.vue'
+import Button, { ButtonVariants } from './Button.vue'
 import IconCoffee from '~icons/mdi/coffee'
 import { createRouter, createWebHistory } from 'vue-router'
 
@@ -110,7 +110,7 @@ describe('<Button />', { viewportWidth: 300, viewportHeight: 400 }, () => {
   })
 
   it('does not allow hocus styling when disabled', () => {
-    const buttonVariants = ['link', 'text', 'primary', 'outline', 'tertiary', 'pending', 'linkBold', 'secondary', 'white']
+    const buttonVariants: ButtonVariants[] = ['link', 'text', 'primary', 'outline', 'tertiary', 'pending', 'linkBold', 'secondary', 'white']
 
     cy.mount(() => <div>{buttonVariants.map((variant) => <Button variant={variant} disabled>{variant}</Button>)}</div>)
 

--- a/packages/frontend-shared/src/components/Button.vue
+++ b/packages/frontend-shared/src/components/Button.vue
@@ -126,7 +126,11 @@ const props = defineProps<{
 
 const attrs = useAttrs() as ButtonHTMLAttributes
 
-const variantClasses = computed(() => (VariantClassesTable[props.variant || 'primary']))
+const variantClasses = computed(() => {
+  return (VariantClassesTable[props.variant || 'primary']).split(' ').filter((css) => {
+    return css !== 'hocus-default' || !props.disabled
+  }).join(' ')
+})
 
 const sizeClasses = computed(() => (SizeClassesTable[props.size || 'md']))
 

--- a/packages/frontend-shared/src/components/Button.vue
+++ b/packages/frontend-shared/src/components/Button.vue
@@ -126,10 +126,15 @@ const props = defineProps<{
 
 const attrs = useAttrs() as ButtonHTMLAttributes
 
+// Disabled buttons should not have hover/focus styles so filter out classes including "hocus"
+function filterHocus (classes: string): string {
+  return classes.split(' ').filter((css) => !(css.startsWith('hocus') && props.disabled)).join(' ')
+}
+
 const variantClasses = computed(() => {
-  return (VariantClassesTable[props.variant || 'primary']).split(' ').filter((css) => {
-    return !(css === 'hocus-default' && props.disabled)
-  }).join(' ')
+  const variantClasses = VariantClassesTable[props.variant || 'primary']
+
+  return props.disabled ? filterHocus(variantClasses) : variantClasses
 })
 
 const sizeClasses = computed(() => (SizeClassesTable[props.size || 'md']))

--- a/packages/frontend-shared/src/components/Button.vue
+++ b/packages/frontend-shared/src/components/Button.vue
@@ -128,7 +128,7 @@ const attrs = useAttrs() as ButtonHTMLAttributes
 
 const variantClasses = computed(() => {
   return (VariantClassesTable[props.variant || 'primary']).split(' ').filter((css) => {
-    return css !== 'hocus-default' || !props.disabled
+    return !(css === 'hocus-default' && props.disabled)
   }).join(' ')
 })
 

--- a/packages/frontend-shared/src/components/Tooltip.cy.tsx
+++ b/packages/frontend-shared/src/components/Tooltip.cy.tsx
@@ -1,4 +1,5 @@
 import Tooltip from './Tooltip.vue'
+import Button from './Button.vue'
 
 const slotContents = (x: number) => ({
   popper: () => <span>Tooltip {x}</span>,
@@ -70,6 +71,52 @@ describe('<Tooltip />', () => {
     .realHover()
 
     cy.get('.v-popper__popper').should('be.visible')
+
+    cy.get('body').realHover()
+    cy.get('.v-popper__popper').should('not.exist', { timeout: 250 })
+  })
+
+  it('should allow light theme for Tooltip', () => {
+    cy.mount(() => {
+      return (
+        <div class="flex bg-gray-900 m-100px text-white p-40px w-150px gap-160px">
+          {/* @ts-ignore */}
+          <Tooltip v-slots={slotContents(0)} placement="bottom" color="light" />
+        </div>
+      )
+    })
+
+    cy.get('.default-slot0')
+    .realHover()
+
+    cy.get('.v-popper__popper').should('be.visible').and('have.class', 'cypress-v-tooltip-light')
+    cy.percySnapshot()
+
+    cy.get('body').realHover()
+    cy.get('.v-popper__popper').should('not.exist', { timeout: 250 })
+  })
+
+  it('should allow dark theme for interactive Tooltip', () => {
+    cy.mount(() => {
+      return (
+        <div class="flex m-100px p-4 w-150px gap-160px">
+          {/* @ts-ignore */}
+          <Tooltip v-slots={{
+            popper: () => <Button>Call to Action!</Button>,
+            default: () => <span>Hover Me!</span>,
+          }} placement="bottom" isInteractive color="dark" />
+        </div>
+      )
+    })
+
+    cy.contains('span', 'Hover Me!')
+    .realHover()
+
+    cy.get('.v-popper__popper').should('be.visible').and('have.class', 'cypress-v-tooltip-dark')
+    cy.contains('button', 'Call to Action!').click()
+    // Interactive tooltips should stay open when interacting with content within the popper
+    cy.get('.v-popper__popper').should('be.visible')
+    cy.percySnapshot()
 
     cy.get('body').realHover()
     cy.get('.v-popper__popper').should('not.exist', { timeout: 250 })

--- a/packages/frontend-shared/src/components/Tooltip.cy.tsx
+++ b/packages/frontend-shared/src/components/Tooltip.cy.tsx
@@ -11,7 +11,6 @@ describe('<Tooltip />', () => {
     cy.mount(() => {
       return (
         <div class="p-4 w-100px">
-          {/* @ts-ignore */}
           <Tooltip v-slots={slotContents(0)} placement="right" />
         </div>
       )
@@ -27,7 +26,6 @@ describe('<Tooltip />', () => {
     cy.mount(() => {
       return (
         <div class="flex m-100px p-4 w-100px gap-160px">
-          {/* @ts-ignore */}
           <Tooltip v-slots={slotContents(0)} placement="bottom" isInteractive />
           <Tooltip v-slots={slotContents(1)} placement="top" isInteractive />
           <Tooltip v-slots={slotContents(2)} placement="left" isInteractive />
@@ -61,7 +59,6 @@ describe('<Tooltip />', () => {
     cy.mount(() => {
       return (
         <div class="flex m-100px p-4 w-100px gap-160px">
-          {/* @ts-ignore */}
           <Tooltip v-slots={slotContents(0)} placement="bottom" isInteractive />
         </div>
       )
@@ -80,7 +77,6 @@ describe('<Tooltip />', () => {
     cy.mount(() => {
       return (
         <div class="flex bg-gray-900 m-100px text-white p-40px w-150px gap-160px">
-          {/* @ts-ignore */}
           <Tooltip v-slots={slotContents(0)} placement="bottom" color="light" />
         </div>
       )
@@ -100,7 +96,6 @@ describe('<Tooltip />', () => {
     cy.mount(() => {
       return (
         <div class="flex m-100px p-4 w-150px gap-160px">
-          {/* @ts-ignore */}
           <Tooltip v-slots={{
             popper: () => <Button>Call to Action!</Button>,
             default: () => <span>Hover Me!</span>,

--- a/packages/frontend-shared/src/components/Tooltip.vue
+++ b/packages/frontend-shared/src/components/Tooltip.vue
@@ -33,7 +33,7 @@ import { Tooltip, Menu, options } from 'floating-vue'
 options.disposeTimeout = 0
 
 const props = withDefaults(defineProps<{
-  color?: string
+  color?: 'dark' | 'light'
   hideArrow?: boolean
   disabled?: boolean
   isInteractive?: boolean
@@ -46,7 +46,7 @@ const props = withDefaults(defineProps<{
   instantMove?: boolean
   showGroup?: string
 }>(), {
-  color: 'dark',
+  color: undefined,
   hideArrow: false,
   disabled: false,
   isInteractive: false,
@@ -71,6 +71,17 @@ const actualPopperClass = computed(() => {
     result.push('no-arrow')
   }
 
+  // color takes priority, else fallback to tooltip -> dark, menu -> light
+  if (props.color === 'dark') {
+    result.push('cypress-v-tooltip-dark')
+  } else if (props.color === 'light') {
+    result.push('cypress-v-tooltip-light')
+  } else if (!props.isInteractive) {
+    result.push('cypress-v-tooltip-dark')
+  } else {
+    result.push('cypress-v-tooltip-light')
+  }
+
   return result
 })
 
@@ -84,9 +95,9 @@ const actualPopperClass = computed(() => {
   }
 }
 
-.v-popper__popper.v-popper--theme-tooltip {
+.cypress-v-tooltip-dark {
   .v-popper__inner {
-    @apply bg-gray-900 py-2 px-4;
+    @apply bg-gray-900 text-white py-2 px-4;
   }
   .v-popper__arrow-inner,
   .v-popper__arrow-outer {
@@ -139,7 +150,7 @@ const actualPopperClass = computed(() => {
   }
 }
 
-.v-popper__popper.v-popper--theme-menu {
+.cypress-v-tooltip-light {
   .v-popper__inner {
     @apply bg-white text-black;
     border-color: transparent;

--- a/packages/frontend-shared/src/components/Tooltip.vue
+++ b/packages/frontend-shared/src/components/Tooltip.vue
@@ -97,12 +97,15 @@ const actualPopperClass = computed(() => {
 
 .cypress-v-tooltip-dark {
   .v-popper__inner {
-    @apply bg-gray-900 text-white py-2 px-4;
+    @apply bg-gray-900 border-0 text-white py-2 px-4;
   }
-  .v-popper__arrow-inner,
   .v-popper__arrow-outer {
     // NOTE: we can't use @apply to here because having !important breaks things
     border-color: #2e3247;
+  }
+
+  .v-popper__arrow-inner{
+    visibility: hidden;
   }
 
   &[data-popper-placement="top"] {

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -643,7 +643,12 @@
     }
   },
   "debugPage": {
-    "runFailures": "Run Failures",
+    "runFailures": {
+      "btn": "Run Failures",
+      "notFoundLocally": "Spec was not found locally",
+      "switchTestingTypeInfo": "There is {n} {testingType} test failing in this spec. To run it locally switch to {testingType} testing. | There are {n} {testingType} tests failing in this spec. To run them locally switch to {testingType} testing.",
+      "switchTestingTypeAction": "Switch to {testingType} testing"
+    },
     "notLoggedIn": "Not logged in",
     "notConnected": "Not connected",
     "noRuns": "No runs",

--- a/packages/graphql/schemas/cloud.graphql
+++ b/packages/graphql/schemas/cloud.graphql
@@ -397,6 +397,20 @@ type CloudProjectSpec implements Node {
     """
     last: Int
   ): CloudSpecRunConnection
+    @deprecated(
+      reason: "Cypress app should utilize specRunsForRunIds to retrieve more relevant data based on local state"
+    )
+
+  """
+  Runs this spec has been involved with, limited to the provided list of CloudRun ids.
+  Runs will be returned in the same order as the runs provided, where matches are found.
+  """
+  specRunsForRunIds(
+    """
+    A list of IDs for a CloudRun Node, conforming to the Relay spec
+    """
+    cloudRunIds: [ID!]!
+  ): [CloudSpecRun]
 }
 
 union CloudProjectSpecFlakyResult =
@@ -473,9 +487,19 @@ A Recorded run of the Test Runner, typically to the cloud
 """
 type CloudRun implements Node {
   """
+  Whether or not the run was canceled due to a failure
+  """
+  cancelOnFailure: Boolean
+
+  """
   When the run was cancelled, null if not cancelled
   """
   cancelledAt: DateTime
+
+  """
+  The user who manually cancelled the run, null if not cancelled manually
+  """
+  cancelledBy: CloudUser
 
   """
   Information about the CI provider that performed the run
@@ -488,6 +512,11 @@ type CloudRun implements Node {
   When the run was created
   """
   createdAt: DateTime!
+
+  """
+  Errors recorded against tests within this run, as reported by the Cypress App during recording
+  """
+  errors: [String!]!
 
   """
   All groups within this run
@@ -951,6 +980,11 @@ type CloudTestResult implements Node {
   The URL to the test result in Cypress Cloud
   """
   testUrl: String!
+
+  """
+  The thumbprint of the test result, allows for deduping tests sharing the same title in the same spec
+  """
+  thumbprint: String!
 
   """
   The title of the test result: describe/context > it/test

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -342,7 +342,16 @@ type CloudProjectSpec implements Node {
 
     """Returns the last n elements from the list."""
     last: Int
-  ): CloudSpecRunConnection
+  ): CloudSpecRunConnection @deprecated(reason: "Cypress app should utilize specRunsForRunIds to retrieve more relevant data based on local state")
+
+  """
+  Runs this spec has been involved with, limited to the provided list of CloudRun ids.
+  Runs will be returned in the same order as the runs provided, where matches are found.
+  """
+  specRunsForRunIds(
+    """A list of IDs for a CloudRun Node, conforming to the Relay spec"""
+    cloudRunIds: [ID!]!
+  ): [CloudSpecRun]
 }
 
 union CloudProjectSpecFlakyResult = CloudFeatureNotEnabled | CloudProjectSpecFlakyStatus
@@ -393,8 +402,16 @@ type CloudRecordKey implements Node {
 
 """A Recorded run of the Test Runner, typically to the cloud"""
 type CloudRun implements Node {
+  """Whether or not the run was canceled due to a failure"""
+  cancelOnFailure: Boolean
+
   """When the run was cancelled, null if not cancelled"""
   cancelledAt: DateTime
+
+  """
+  The user who manually cancelled the run, null if not cancelled manually
+  """
+  cancelledBy: CloudUser
 
   """Information about the CI provider that performed the run"""
   ci: CloudCiBuildInfo!
@@ -403,6 +420,11 @@ type CloudRun implements Node {
 
   """When the run was created"""
   createdAt: DateTime!
+
+  """
+  Errors recorded against tests within this run, as reported by the Cypress App during recording
+  """
+  errors: [String!]!
 
   """All groups within this run"""
   groups: [CloudRunGroup!]!
@@ -718,6 +740,11 @@ type CloudTestResult implements Node {
 
   """The URL to the test result in Cypress Cloud"""
   testUrl: String!
+
+  """
+  The thumbprint of the test result, allows for deduping tests sharing the same title in the same spec
+  """
+  thumbprint: String!
 
   """The title of the test result: describe/context > it/test"""
   title(

--- a/packages/graphql/test/stubCloudTypes.ts
+++ b/packages/graphql/test/stubCloudTypes.ts
@@ -186,6 +186,9 @@ export function createCloudRun (config: Partial<CloudRun>): Required<CloudRun> {
     createdAt: new Date(Date.now() - 1000 * 60 * 61).toISOString(),
     completedAt: null,
     cancelledAt: null,
+    cancelOnFailure: null,
+    cancelledBy: null,
+    errors: [],
     ci: {
       __typename: 'CloudCiBuildInfo',
       id: 'ci_id',
@@ -228,6 +231,7 @@ function addFailedTests (run: CloudRun) {
     testUrl: 'http://cloudurl',
     title: '<test/> Should render',
     titleParts: ['<test/>', 'should render'],
+    thumbprint: 'abc',
   }
 
   run.specs = [spec]
@@ -270,6 +274,7 @@ export function createCloudProjectSpecResult (config: Partial<CloudProjectSpec>)
       severity: 'NONE',
     },
     ...config,
+    specRunsForRunIds: null,
   }
 
   return indexNode(specResult)


### PR DESCRIPTION
- Closes #24854
### User facing changelog
na

### Additional details
Working with Ankit revealed we needed to change up `DebugMappings.ts`. We paired on this and the results of the refactor are relevant for his upcoming work (groups).

### Steps to test
Driven mostly from CT tests, if you want to run it e2e:

1. Check out the `feature/CYCLOUD-665-IATR` and run `yarn`
2. Run `yarn docker-compose && yarn dev`
3. Visit `localhost:3000` and create a project
4. In the Cypress monorepo, checkout this branch and run `CYPRESS_INTERNAL_ENV=development yarn cypress:open`
5. Select a project and add your newly created `projectId`
6. Tweak tests to cause a failure and run `npx cypress run --record --key <RECORD_KEY>`
7. If you've recorded different runs, you can change the run by changing `runByNumber(runNumber: 6) {` to whatever run you want to target (not dynamic yet)

### How has the user experience changed?

https://user-images.githubusercontent.com/25158820/208729758-53a8565f-cdbd-40ea-af6f-dba66ce50256.mov

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
