### PR TITLE
fix: disable the --inspect and --inspect-brk family of CLI options on the Cypress binary

### DIFF
--- a/packages/electron/lib/install.js
+++ b/packages/electron/lib/install.js
@@ -140,6 +140,7 @@ module.exports = {
           version: FuseVersion.V1,
           resetAdHocDarwinSignature: platform === 'darwin' && arch === 'arm64',
           [FuseV1Options.LoadBrowserProcessSpecificV8Snapshot]: true,
+          [FuseV1Options.EnableNodeCliInspectArguments]: false,
         },
       ) : Promise.resolve()
     }).catch((err) => {

--- a/packages/electron/lib/install.js
+++ b/packages/electron/lib/install.js
@@ -140,7 +140,6 @@ module.exports = {
           version: FuseVersion.V1,
           resetAdHocDarwinSignature: platform === 'darwin' && arch === 'arm64',
           [FuseV1Options.LoadBrowserProcessSpecificV8Snapshot]: true,
-          [FuseV1Options.EnableNodeCliInspectArguments]: false,
         },
       ) : Promise.resolve()
     }).catch((err) => {

--- a/scripts/after-pack-hook.js
+++ b/scripts/after-pack-hook.js
@@ -66,6 +66,7 @@ module.exports = async function (params) {
         {
           version: FuseVersion.V1,
           [FuseV1Options.LoadBrowserProcessSpecificV8Snapshot]: true,
+          [FuseV1Options.EnableNodeCliInspectArguments]: false,
         },
       )
 


### PR DESCRIPTION
### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Disable the `--inspect` and `--inspect-brk` family of CLI options on the built Cypress binary

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

There's no real reason a user should need to do this, so we should disable these options

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

n/a

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
