### PR TITLE
fix: Check custom config file during language detection

### DIFF
--- a/packages/data-context/src/data/ProjectLifecycleManager.ts
+++ b/packages/data-context/src/data/ProjectLifecycleManager.ts
@@ -630,7 +630,12 @@ export class ProjectLifecycleManager {
         metaState.isProjectUsingESModules = true
       }
 
-      metaState.isUsingTypeScript = detectLanguage({ projectRoot: this.projectRoot, pkgJson, isMigrating: metaState.hasLegacyCypressJson }) === 'ts'
+      metaState.isUsingTypeScript = detectLanguage({
+        projectRoot: this.projectRoot,
+        customConfigFile: configFile,
+        pkgJson,
+        isMigrating: metaState.hasLegacyCypressJson,
+      }) === 'ts'
     } catch {
       // No need to handle
     }

--- a/packages/scaffold-config/src/detect.ts
+++ b/packages/scaffold-config/src/detect.ts
@@ -88,7 +88,12 @@ export async function detectFramework (projectPath: string): Promise<DetectFrame
  * If `cypress.config` exists, we derive the language
  * from the extension.
  *
- * IF HAS_CYPRESS_CONFIG
+ * IF HAS_CUSTOM_CYPRESS_CONFIG
+ *   IF CYPRESS_CONFIG_TS
+ *     HAS TYPESCRIPT
+ *   ELSE
+ *     DOES NOT HAVE TYPESCRIPT
+ * IF HAS_DEFAULT_CYPRESS_CONFIG
  *   IF CYPRESS_CONFIG_TS
  *     HAS TYPESCRIPT
  *   ELSE
@@ -113,8 +118,34 @@ export async function detectFramework (projectPath: string): Promise<DetectFrame
  * END
  */
 
-export function detectLanguage ({ projectRoot, pkgJson, isMigrating = false }: { projectRoot: string, pkgJson: PkgJson, isMigrating?: boolean }): 'js' | 'ts' {
+type DetectLanguageParams = {
+  projectRoot: string
+  customConfigFile?: string | null
+  pkgJson: PkgJson
+  isMigrating?: boolean
+}
+
+export function detectLanguage ({ projectRoot, customConfigFile, pkgJson, isMigrating = false }: DetectLanguageParams): 'js' | 'ts' {
   try {
+    if (customConfigFile) {
+      debug('Evaluating custom Cypress config file \'%s\'', customConfigFile)
+      if (/.ts$/.test(customConfigFile)) {
+        debug('Custom config file is Typescript - using TS')
+
+        return 'ts'
+      }
+
+      if (/.js$/.test(customConfigFile)) {
+        debug('Custom config file is Javascript - using JS')
+
+        return 'js'
+      }
+
+      debug('Unable to determine language from custom Cypress config file extension')
+    }
+
+    debug('Checking for default Cypress config file')
+
     if (fs.existsSync(path.join(projectRoot, 'cypress.config.ts'))) {
       debug('Detected cypress.config.ts - using TS')
 

--- a/packages/scaffold-config/src/detect.ts
+++ b/packages/scaffold-config/src/detect.ts
@@ -129,13 +129,16 @@ export function detectLanguage ({ projectRoot, customConfigFile, pkgJson, isMigr
   try {
     if (customConfigFile) {
       debug('Evaluating custom Cypress config file \'%s\'', customConfigFile)
-      if (/.ts$/.test(customConfigFile)) {
+
+      // .ts, .mts extensions
+      if (/\.[m]?ts$/i.test(customConfigFile)) {
         debug('Custom config file is Typescript - using TS')
 
         return 'ts'
       }
 
-      if (/.js$/.test(customConfigFile)) {
+      // .js, .cjs, .mjs extensions
+      if (/\.[c|m]?js$/i.test(customConfigFile)) {
         debug('Custom config file is Javascript - using JS')
 
         return 'js'
@@ -146,16 +149,20 @@ export function detectLanguage ({ projectRoot, customConfigFile, pkgJson, isMigr
 
     debug('Checking for default Cypress config file')
 
-    if (fs.existsSync(path.join(projectRoot, 'cypress.config.ts'))) {
-      debug('Detected cypress.config.ts - using TS')
+    for (let extension of ['ts', 'mts']) {
+      if (fs.existsSync(path.join(projectRoot, `cypress.config.${extension}`))) {
+        debug(`Detected cypress.config.${extension} - using TS`)
 
-      return 'ts'
+        return 'ts'
+      }
     }
 
-    if (fs.existsSync(path.join(projectRoot, 'cypress.config.js'))) {
-      debug('Detected cypress.config.js - using JS')
+    for (let extension of ['js', 'cjs', 'mjs']) {
+      if (fs.existsSync(path.join(projectRoot, `cypress.config.${extension}`))) {
+        debug(`Detected cypress.config.${extension} - using JS`)
 
-      return 'js'
+        return 'js'
+      }
     }
   } catch (e) {
     debug('Did not find cypress.config file')

--- a/packages/scaffold-config/test/unit/detect.spec.ts
+++ b/packages/scaffold-config/test/unit/detect.spec.ts
@@ -279,6 +279,30 @@ describe('detectLanguage', () => {
     expect(actual).to.eq('js')
   })
 
+  it('existing project with custom TS cypress config file', async () => {
+    const projectRoot = await scaffoldMigrationProject('config-with-ts')
+
+    fs.rmSync(path.join(projectRoot, 'cypress.config.ts'))
+    await fs.mkdirp(path.join(projectRoot, 'custom_config'))
+    await fs.writeFile(path.join(projectRoot, 'custom_config', 'cypress.config-custom.ts'), '')
+
+    const actual = detectLanguage({ projectRoot, customConfigFile: 'custom_config/cypress.config-custom.ts', pkgJson: {} as PkgJson })
+
+    expect(actual).to.eq('ts')
+  })
+
+  it('existing project with custom JS cypress config file', async () => {
+    const projectRoot = await scaffoldMigrationProject('config-with-js')
+
+    fs.rmSync(path.join(projectRoot, 'cypress.config.js'))
+    await fs.mkdirp(path.join(projectRoot, 'custom_config'))
+    await fs.writeFile(path.join(projectRoot, 'custom_config', 'cypress.config-custom.js'), '')
+
+    const actual = detectLanguage({ projectRoot, customConfigFile: 'custom_config/cypress.config-custom.js', pkgJson: {} as PkgJson })
+
+    expect(actual).to.eq('js')
+  })
+
   it('pristine project with typescript in package.json', async () => {
     const projectRoot = await scaffoldMigrationProject('pristine-yarn')
 

--- a/packages/scaffold-config/test/unit/detect.spec.ts
+++ b/packages/scaffold-config/test/unit/detect.spec.ts
@@ -441,19 +441,6 @@ describe('detectLanguage', () => {
       expect(actual).to.eq('ts')
     })
 
-    it('cwith a TypeScript integration specs', async () => {
-      const projectRoot = await scaffoldMigrationProject('migration-ts-files-only')
-
-      fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
-
-      // detected based on `integration/**/*.tsx
-      removeAllTsFilesExcept(projectRoot, 'integration')
-
-      const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
-
-      expect(actual).to.eq('ts')
-    })
-
     it('with a TypeScript integration spec', async () => {
       const projectRoot = await scaffoldMigrationProject('migration-ts-files-only')
 

--- a/packages/scaffold-config/test/unit/detect.spec.ts
+++ b/packages/scaffold-config/test/unit/detect.spec.ts
@@ -265,186 +265,219 @@ describe('detectFramework', () => {
 })
 
 describe('detectLanguage', () => {
-  it('existing project with `cypress.config.ts`', async () => {
-    const projectRoot = await scaffoldMigrationProject('config-with-ts')
-    const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
+  context('existing project', () => {
+    it('with `cypress.config.ts` should return `ts`', async () => {
+      const projectRoot = await scaffoldMigrationProject('config-with-ts')
+      const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
 
-    expect(actual).to.eq('ts')
+      expect(actual).to.eq('ts')
+    })
+
+    it('with `cypress.config.mts` should return `ts`', async () => {
+      const projectRoot = await scaffoldMigrationProject('config-with-ts')
+
+      fs.moveSync(path.join(projectRoot, 'cypress.config.ts'), path.join(projectRoot, 'cypress.config.mts'))
+      const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
+
+      expect(actual).to.eq('ts')
+    })
+
+    it('with `cypress.config.js` should return `js`', async () => {
+      const projectRoot = await scaffoldMigrationProject('config-with-js')
+      const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
+
+      expect(actual).to.eq('js')
+    })
+
+    it('with `cypress.config.cjs` should return `js`', async () => {
+      const projectRoot = await scaffoldMigrationProject('config-with-js')
+
+      await fs.move(path.join(projectRoot, 'cypress.config.js'), path.join(projectRoot, 'cypress.config.cjs'))
+      const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
+
+      expect(actual).to.eq('js')
+    })
+
+    it('with `cypress.config.mjs` should return `js`', async () => {
+      const projectRoot = await scaffoldMigrationProject('config-with-js')
+
+      await fs.move(path.join(projectRoot, 'cypress.config.js'), path.join(projectRoot, 'cypress.config.mjs'))
+      const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
+
+      expect(actual).to.eq('js')
+    })
+
+    it('with custom TS cypress config file should return `ts`', async () => {
+      const projectRoot = await scaffoldMigrationProject('config-with-ts')
+
+      await fs.rm(path.join(projectRoot, 'cypress.config.ts'))
+
+      ;['ts', 'mts'].forEach((extension) => {
+        const actual = detectLanguage({ projectRoot, customConfigFile: `custom_config/cypress.config-custom.${extension}`, pkgJson: {} as PkgJson })
+
+        expect(actual).to.eq('ts')
+      })
+    })
+
+    it('existing project with custom JS cypress config file should return `js`', async () => {
+      const projectRoot = await scaffoldMigrationProject('config-with-js')
+
+      await fs.rm(path.join(projectRoot, 'cypress.config.js'))
+
+      ;['js', 'cjs', 'mjs'].forEach((extension) => {
+        const actual = detectLanguage({ projectRoot, customConfigFile: `custom_config/cypress.config-custom.${extension}`, pkgJson: {} as PkgJson })
+
+        expect(actual).to.eq('js')
+      })
+    })
   })
 
-  it('existing project with `cypress.config.js`', async () => {
-    const projectRoot = await scaffoldMigrationProject('config-with-js')
-    const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
+  context('pristine project', () => {
+    it('with typescript in package.json', async () => {
+      const projectRoot = await scaffoldMigrationProject('pristine-yarn')
 
-    expect(actual).to.eq('js')
+      fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
+      const pkgJson = fs.readJsonSync(path.join(projectRoot, 'package.json'))
+      const actual = detectLanguage({ projectRoot, pkgJson })
+
+      expect(actual).to.eq('ts')
+    })
+
+    it('with root level tsconfig.json', async () => {
+      const projectRoot = await scaffoldMigrationProject('pristine-npm')
+
+      fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
+      const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
+
+      expect(actual).to.eq('ts')
+    })
+
+    it('detects js if typescript is not resolvable when there is a tsconfig.json', async () => {
+      let projectRoot = await scaffoldMigrationProject('pristine-npm')
+
+      const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
+
+      expect(actual).to.eq('js')
+
+      projectRoot = await scaffoldMigrationProject('pristine-npm')
+
+      fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
+
+      const actualTypescript = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
+
+      expect(actualTypescript).to.eq('ts')
+    })
+
+    it('ignores node_modules when checking for tsconfig.json', async () => {
+      const projectRoot = await scaffoldMigrationProject('pristine-cjs-project')
+
+      fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
+
+      await fs.mkdirp(path.join(projectRoot, 'node_modules', 'some-node-module'))
+      await fs.writeFile(path.join(projectRoot, 'node_modules', 'some-node-module', 'tsconfig.json'), '')
+      const pkgJson = fs.readJsonSync(path.join(projectRoot, 'package.json'))
+
+      const actual = detectLanguage({ projectRoot, pkgJson })
+
+      expect(actual).to.eq('js')
+    })
   })
 
-  it('existing project with custom TS cypress config file', async () => {
-    const projectRoot = await scaffoldMigrationProject('config-with-ts')
+  context('migration project', () => {
+    it('with tsconfig.json in cypress directory', async () => {
+      const projectRoot = await scaffoldMigrationProject('migration')
 
-    fs.rmSync(path.join(projectRoot, 'cypress.config.ts'))
-    await fs.mkdirp(path.join(projectRoot, 'custom_config'))
-    await fs.writeFile(path.join(projectRoot, 'custom_config', 'cypress.config-custom.ts'), '')
+      fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
+      const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
 
-    const actual = detectLanguage({ projectRoot, customConfigFile: 'custom_config/cypress.config-custom.ts', pkgJson: {} as PkgJson })
+      expect(actual).to.eq('ts')
+    })
 
-    expect(actual).to.eq('ts')
-  })
+    const joinPosix = (...s: string[]) => path.join(...s).split(path.sep).join(path.posix.sep)
 
-  it('existing project with custom JS cypress config file', async () => {
-    const projectRoot = await scaffoldMigrationProject('config-with-js')
+    function removeAllTsFilesExcept (projectRoot: string, filename?: string) {
+      const files = globby.sync(joinPosix(projectRoot, '**/*.{ts,tsx}'), { onlyFiles: true })
 
-    fs.rmSync(path.join(projectRoot, 'cypress.config.js'))
-    await fs.mkdirp(path.join(projectRoot, 'custom_config'))
-    await fs.writeFile(path.join(projectRoot, 'custom_config', 'cypress.config-custom.js'), '')
-
-    const actual = detectLanguage({ projectRoot, customConfigFile: 'custom_config/cypress.config-custom.js', pkgJson: {} as PkgJson })
-
-    expect(actual).to.eq('js')
-  })
-
-  it('pristine project with typescript in package.json', async () => {
-    const projectRoot = await scaffoldMigrationProject('pristine-yarn')
-
-    fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
-    const pkgJson = fs.readJsonSync(path.join(projectRoot, 'package.json'))
-    const actual = detectLanguage({ projectRoot, pkgJson })
-
-    expect(actual).to.eq('ts')
-  })
-
-  it('pristine project with root level tsconfig.json', async () => {
-    const projectRoot = await scaffoldMigrationProject('pristine-npm')
-
-    fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
-    const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
-
-    expect(actual).to.eq('ts')
-  })
-
-  it('detects js if typescript is not resolvable when there is a tsconfig.json', async () => {
-    let projectRoot = await scaffoldMigrationProject('pristine-npm')
-
-    const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
-
-    expect(actual).to.eq('js')
-
-    projectRoot = await scaffoldMigrationProject('pristine-npm')
-
-    fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
-
-    const actualTypescript = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
-
-    expect(actualTypescript).to.eq('ts')
-  })
-
-  it('pre-migration project with tsconfig.json in cypress directory', async () => {
-    const projectRoot = await scaffoldMigrationProject('migration')
-
-    fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
-    const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
-
-    expect(actual).to.eq('ts')
-  })
-
-  const joinPosix = (...s: string[]) => path.join(...s).split(path.sep).join(path.posix.sep)
-
-  function removeAllTsFilesExcept (projectRoot: string, filename?: string) {
-    const files = globby.sync(joinPosix(projectRoot, '**/*.{ts,tsx}'), { onlyFiles: true })
-
-    for (const f of files) {
-      if (!filename) {
-        fs.rmSync(f)
-      } else if (!f.includes(filename)) {
-        fs.rmSync(f)
+      for (const f of files) {
+        if (!filename) {
+          fs.rmSync(f)
+        } else if (!f.includes(filename)) {
+          fs.rmSync(f)
+        }
       }
     }
-  }
 
-  it('cypress.json project with only .d.ts files', async () => {
-    const projectRoot = await scaffoldMigrationProject('migration-dts-files-only')
+    it('with only .d.ts files', async () => {
+      const projectRoot = await scaffoldMigrationProject('migration-dts-files-only')
 
-    fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
+      fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
 
-    const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson, isMigrating: true })
+      const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson, isMigrating: true })
 
-    expect(actual).to.eq('js')
-  })
+      expect(actual).to.eq('js')
+    })
 
-  it('cypress.json project with a TypeScript supportFile', async () => {
-    const projectRoot = await scaffoldMigrationProject('migration-ts-files-only')
+    it('with a TypeScript supportFile', async () => {
+      const projectRoot = await scaffoldMigrationProject('migration-ts-files-only')
 
-    fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
+      fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
 
-    removeAllTsFilesExcept(projectRoot, 'support')
+      removeAllTsFilesExcept(projectRoot, 'support')
 
-    const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
+      const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
 
-    expect(actual).to.eq('ts')
-  })
+      expect(actual).to.eq('ts')
+    })
 
-  it('cypress.json project with a TypeScript pluginsFile', async () => {
-    const projectRoot = await scaffoldMigrationProject('migration-ts-files-only')
+    it('with a TypeScript pluginsFile', async () => {
+      const projectRoot = await scaffoldMigrationProject('migration-ts-files-only')
 
-    fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
+      fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
 
-    removeAllTsFilesExcept(projectRoot, 'plugins')
+      removeAllTsFilesExcept(projectRoot, 'plugins')
 
-    const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
+      const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
 
-    expect(actual).to.eq('ts')
-  })
+      expect(actual).to.eq('ts')
+    })
 
-  it('cypress.json project with a TypeScript integration specs', async () => {
-    const projectRoot = await scaffoldMigrationProject('migration-ts-files-only')
+    it('cwith a TypeScript integration specs', async () => {
+      const projectRoot = await scaffoldMigrationProject('migration-ts-files-only')
 
-    fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
+      fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
 
-    // detected based on `integration/**/*.tsx
-    removeAllTsFilesExcept(projectRoot, 'integration')
+      // detected based on `integration/**/*.tsx
+      removeAllTsFilesExcept(projectRoot, 'integration')
 
-    const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
+      const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
 
-    expect(actual).to.eq('ts')
-  })
+      expect(actual).to.eq('ts')
+    })
 
-  it('cypress.json project with a TypeScript integration spec', async () => {
-    const projectRoot = await scaffoldMigrationProject('migration-ts-files-only')
+    it('with a TypeScript integration spec', async () => {
+      const projectRoot = await scaffoldMigrationProject('migration-ts-files-only')
 
-    fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
+      fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
 
-    // detected based on `integration/**/*.tsx
-    removeAllTsFilesExcept(projectRoot, 'integration')
+      // detected based on `integration/**/*.tsx
+      removeAllTsFilesExcept(projectRoot, 'integration')
 
-    const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
+      const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
 
-    expect(actual).to.eq('ts')
-  })
+      expect(actual).to.eq('ts')
+    })
 
-  it('cypress.json project with a TypeScript commponent spec', async () => {
-    const projectRoot = await scaffoldMigrationProject('migration-ts-files-only')
+    it('with a TypeScript commponent spec', async () => {
+      const projectRoot = await scaffoldMigrationProject('migration-ts-files-only')
 
-    fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
+      fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
 
-    // detected based on `integration/**/*.tsx
-    removeAllTsFilesExcept(projectRoot, 'component')
+      // detected based on `integration/**/*.tsx
+      removeAllTsFilesExcept(projectRoot, 'component')
 
-    const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
+      const actual = detectLanguage({ projectRoot, pkgJson: {} as PkgJson })
 
-    expect(actual).to.eq('ts')
-  })
-
-  it('ignores node_modules when checking for tsconfig.json', async () => {
-    const projectRoot = await scaffoldMigrationProject('pristine-cjs-project')
-
-    fakeDepsInNodeModules(projectRoot, [{ devDependency: 'typescript', version: '4.3.6' }])
-
-    await fs.mkdirp(path.join(projectRoot, 'node_modules', 'some-node-module'))
-    await fs.writeFile(path.join(projectRoot, 'node_modules', 'some-node-module', 'tsconfig.json'), '')
-    const pkgJson = fs.readJsonSync(path.join(projectRoot, 'package.json'))
-
-    const actual = detectLanguage({ projectRoot, pkgJson })
-
-    expect(actual).to.eq('js')
+      expect(actual).to.eq('ts')
+    })
   })
 })


### PR DESCRIPTION
- Closes #24781 

### User facing changelog
Fixes delay on Cypress startup when using a custom config file location.

### Additional details
Original issue presented as a multi-minute hang while determining whether project is JS/TS-based when running within Docker. Investigation indicates that the user was providing a custom Cypress config file location and was using the `cypress:included:*` image root as their project directory. Existing logic checks whether there is a `cypress.config.*` file present at the project root, if not it then falls back to doing recursive filesystem scans for TS files. The scan ignores `node_modules` but was likely scanning into OS and browser-related directories since it was running from the image root, and being on Docker exacerbates filesystem slowness.

This PR adds logic to consider the custom config file argument (if provided) then fall back to the default config file. This would mitigate the issue the user observed, but a delay could still present in several situations:
- First project launch - no custom config provided, no `cypress.config.*` file generated yet
- User provides incorrect custom config param or has mis-named default config
- User attempts to use `.mjs` or other non-standard extension for config file

Not sure if there's a guaranteed fix since we can't provide a full set of exclusion directories (Windows, Unix, Mac, etc all have lots of different stuff at OS root), but maybe we could print a warning if `projectDirectory === '/'`? Or potentially print a warning if we can't find custom or default config and have to fall back to filesystem scan?

### Steps to test
1. Create an empty project:
`mkdir test`
`cd test`
`npm init`
2. Launch Cypress: `DEBUG=cypress:scaffold-config:detect yarn cypress:open --project test`
3. Observe debug logging - no config file found, no typescript installed, defaults to JS
4. Launch Cypress, providing a custom TS config file location: `DEBUG=cypress:scaffold-config:detect yarn cypress:open --project test --config-file my-config.ts`
5. Observe debug logging that project lang is `ts` based off custom config file
6. Launch Cypress, providing a custom JS config file location: `DEBUG=cypress:scaffold-config:detect yarn cypress:open --project test --config-file my-config.js`
7. Observe debug logging that project lang is `js` based off custom config file
8. Create JS config file: `touch test/cypress.config.js`
9. Launch: `DEBUG=cypress:scaffold-config:detect yarn cypress:open --project test`
10. Observe Cypress resolves 'js' from default config file
11. Delete JS config file: `rm test/cypress.config.js`
12. Create TS config file: `touch test/cypress.config.ts`
13. Launch: `DEBUG=cypress:scaffold-config:detect yarn cypress:open --project test`
14. Observe Cypress resolves 'ts' from default config file

### How has the user experience changed?
No visible change, performance improvement on launch

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
