### PR TITLE
chore(electron): when in dev, build the arm64 electron binary when cpu arch supports it

### DIFF
--- a/packages/electron/lib/install.js
+++ b/packages/electron/lib/install.js
@@ -2,8 +2,11 @@
 const _ = require('lodash')
 const os = require('os')
 const path = require('path')
+const systeminformation = require('systeminformation')
+const execa = require('execa')
+
 const paths = require('./paths')
-const log = require('debug')('cypress:electron')
+const debug = require('debug')('cypress:electron')
 const fs = require('fs-extra')
 const crypto = require('crypto')
 const { flipFuses, FuseVersion, FuseV1Options } = require('@electron/fuses')
@@ -27,9 +30,7 @@ module.exports = {
     return require('@packages/icons')
   },
 
-  checkCurrentVersion () {
-    const pathToVersion = paths.getPathToVersion()
-
+  checkCurrentVersion (pathToVersion) {
     // read in the version file
     return fs.readFile(pathToVersion, 'utf8')
     .then((str) => {
@@ -55,6 +56,7 @@ module.exports = {
   },
 
   checkIconVersion () {
+    // TODO: this seems wrong, it's hard coding the check only for OSX and not windows or linux (!?)
     const mainIconsPath = this.icons().getPathToIcon('cypress.icns')
     const cachedIconsPath = path.join(__dirname, '../dist/Cypress/Cypress.app/Contents/Resources/electron.icns')
 
@@ -66,8 +68,30 @@ module.exports = {
     })
   },
 
-  checkExecExistence () {
-    return fs.stat(paths.getPathToExec())
+  checkExecExistence (pathToExec) {
+    return fs.stat(pathToExec)
+  },
+
+  async checkBinaryArchCpuArch (pathToExec, platform, arch) {
+    if (platform === 'darwin' && arch === 'x64') {
+      return Promise.all([
+        // get the current arch of the binary
+        execa('lipo', ['-archs', pathToExec])
+        .then(({ stdout }) => {
+          return stdout
+        }),
+
+        // get the real arch of the system
+        this.getRealArch(platform, arch),
+      ])
+      .then(([binaryArch, cpuArch]) => {
+        debug('archs detected %o', { binaryArch, cpuArch })
+
+        if (binaryArch !== cpuArch) {
+          throw new Error(`built binary arch: '${binaryArch}' does not match system CPU arch: '${cpuArch}', binary needs rebuilding`)
+        }
+      })
+    }
   },
 
   move (src, dest) {
@@ -94,42 +118,59 @@ module.exports = {
     })
   },
 
+  async getRealArch (platform, arch) {
+    if (platform === 'darwin' && arch === 'x64') {
+      // see this comment for explanation of x64 -> arm64 translation
+      // https://github.com/cypress-io/cypress/pull/25014/files#diff-85c4db7620ed2731baf5669a9c9993e61e620693a008199ca7c584e621b6a1fdR11
+      return systeminformation.cpu()
+      .then(({ manufacturer }) => {
+        // if the cpu is apple then return arm64 as the arch
+        return manufacturer === 'Apple' ? 'arm64' : arch
+      })
+    }
+
+    return arch
+  },
+
   package (options = {}) {
     const pkgr = require('electron-packager')
     const icons = require('@packages/icons')
 
     const iconPath = icons.getPathToIcon('cypress')
 
-    log('package icon', iconPath)
+    debug('package icon', iconPath)
 
     const platform = os.platform()
     const arch = os.arch()
 
-    _.defaults(options, {
-      dist: paths.getPathToDist(),
-      dir: 'app',
-      out: 'tmp',
-      name: 'Cypress',
-      platform,
-      arch,
-      asar: false,
-      prune: true,
-      overwrite: true,
-      electronVersion,
-      icon: iconPath,
+    return this.getRealArch(platform, arch)
+    .then((arch) => {
+      _.defaults(options, {
+        dist: paths.getPathToDist(),
+        dir: 'app',
+        out: 'tmp',
+        name: 'Cypress',
+        platform,
+        arch,
+        asar: false,
+        prune: true,
+        overwrite: true,
+        electronVersion,
+        icon: iconPath,
+      })
+
+      debug('packager options %j', options)
+
+      return pkgr(options)
     })
-
-    log('packager options %j', options)
-
-    return pkgr(options)
     .then((appPaths) => {
       return appPaths[0]
     })
     // Promise.resolve("tmp\\Cypress-win32-x64")
     .then((appPath) => {
       // and now move the tmp into dist
-      console.log('moving created file from', appPath)
-      console.log('to', options.dist)
+      console.debug('moving created file from', appPath)
+      console.debug('to', options.dist)
 
       return this.move(appPath, options.dist)
     })
@@ -143,29 +184,38 @@ module.exports = {
         },
       ) : Promise.resolve()
     }).catch((err) => {
-      console.log(err.stack)
+      console.debug(err.stack)
 
       return process.exit(1)
     })
   },
 
   ensure () {
+    const arch = os.arch()
+    const platform = os.platform()
+    const pathToExec = paths.getPathToExec()
+    const pathToVersion = paths.getPathToVersion()
+
     return Promise.all([
       // check the version of electron and re-build if updated
-      this.checkCurrentVersion(),
+      this.checkCurrentVersion(pathToVersion),
       // check if the dist folder exist and re-build if not
-      this.checkExecExistence(),
+      this.checkExecExistence(pathToExec),
       // Compare the icon in dist with the one in the icons
       // package. If different, force the re-build.
       this.checkIconVersion(),
     ])
+    .then(() => {
+      // check that the arch of the built binary matches our CPU
+      return this.checkBinaryArchCpuArch(pathToExec, platform, arch)
+    })
 
     // if all is good, then return without packaging a new electron app
   },
 
   check () {
     return this.ensure()
-    .catch(() => {
+    .catch((err) => {
       this.packageAndExit()
     })
   },

--- a/packages/electron/lib/install.js
+++ b/packages/electron/lib/install.js
@@ -168,11 +168,12 @@ module.exports = {
     })
     // Promise.resolve("tmp\\Cypress-win32-x64")
     .then((appPath) => {
-      // and now move the tmp into dist
-      console.debug('moving created file from', appPath)
-      console.debug('to', options.dist)
+      const { dist } = options
 
-      return this.move(appPath, options.dist)
+      // and now move the tmp into dist
+      debug('moving created file %o', { from: appPath, to: dist })
+
+      return this.move(appPath, dist)
     })
     .then(() => {
       return !['1', 'true'].includes(process.env.DISABLE_SNAPSHOT_REQUIRE) ? flipFuses(
@@ -184,7 +185,7 @@ module.exports = {
         },
       ) : Promise.resolve()
     }).catch((err) => {
-      console.debug(err.stack)
+      console.log(err.stack)
 
       return process.exit(1)
     })

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -27,7 +27,8 @@
     "electron-packager": "15.4.0",
     "execa": "4.1.0",
     "mocha": "3.5.3",
-    "rimraf": "3.0.2"
+    "rimraf": "3.0.2",
+    "systeminformation": "5.16.9"
   },
   "files": [
     "dist",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -111,7 +111,7 @@
     "squirrelly": "7.9.2",
     "strip-ansi": "6.0.0",
     "syntax-error": "1.4.0",
-    "systeminformation": "5.6.4",
+    "systeminformation": "5.16.9",
     "term-size": "2.1.0",
     "through": "2.3.8",
     "tough-cookie": "4.0.0",

--- a/system-tests/package.json
+++ b/system-tests/package.json
@@ -80,7 +80,7 @@
     "snap-shot-it": "7.9.3",
     "ssestream": "1.0.1",
     "supertest": "4.0.2",
-    "systeminformation": "5.6.4",
+    "systeminformation": "5.16.9",
     "temp-dir": "^2.0.0",
     "webpack": "^4.44.2",
     "ws": "5.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -32370,10 +32370,10 @@ syntax-error@1.4.0:
   dependencies:
     acorn-node "^1.2.0"
 
-systeminformation@5.6.4:
-  version "5.6.4"
-  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.6.4.tgz#5f32fcb05a5849e2a0e71b182c1f56ce32219310"
-  integrity sha512-b2tvW1R+qjNEoAGgh734EGLgqbDMghjsHRaWo36skAC6JM1tw1pitcGz/REt+qSIRSXbE4PKECojhaSrBRrEmw==
+systeminformation@5.16.9:
+  version "5.16.9"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.16.9.tgz#8a5419c293afea142d93d98dde6850dceb4677b6"
+  integrity sha512-QTlv3GGSromPeLVW3pzM6uxU8RbkacW9e0+ZX23GAXaX+XE0UToSygAxCJDHSty6RB9lAFHCHg+FfiXFChi/+w==
 
 systemjs@^6.12.4:
   version "6.12.6"


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
- When we're in development and building the electron binary post `yarn` we need to detect the proper `arch` to build the electron binary for
- Previously it would naively us `os.arch()`, which returns the **node arch**, which could be incorrectly `x86`
- This PR updates the code to properly detect the actual system arch to figure out if `arm64` is capable, and uses that to build the right electron binary `arch`
- This PR only updates the logic to verify when to rebuild the electron binary. If an existing `x64_64` binary arch is detected, it'll automatically rebuild it. Users should receive the correct binary the next time they pull and run `yarn`
