### PR TITLE
Issue 21923

### DIFF
--- a/npm/webpack-dev-server/cypress/e2e/react.cy.ts
+++ b/npm/webpack-dev-server/cypress/e2e/react.cy.ts
@@ -129,7 +129,7 @@ for (const project of WEBPACK_REACT) {
 
       // 4. recreate spec, with same name as removed spec
       cy.findByTestId('new-spec-button').click()
-      cy.findByRole('button', { name: 'Create new empty spec' }).should('be.visible').click()
+      cy.findByRole('button', { name: 'Create starter spec' }).should('be.visible').click()
 
       cy.findByRole('dialog').within(() => {
         cy.get('input').clear().type('src/App.cy.jsx')

--- a/packages/app/cypress/e2e/specs.cy.ts
+++ b/packages/app/cypress/e2e/specs.cy.ts
@@ -408,7 +408,7 @@ describe('App: Specs', () => {
             .and('contain', defaultMessages.createSpec.e2e.importEmptySpec.header)
           })
 
-          cy.contains('Create new empty spec').click()
+          cy.contains('Create starter spec').click()
 
           cy.findAllByLabelText(defaultMessages.createSpec.e2e.importEmptySpec.inputPlaceholder)
           .as('enterSpecInput')
@@ -458,7 +458,7 @@ describe('App: Specs', () => {
           cy.contains('No specs found').should('be.visible')
 
           cy.findByRole('button', { name: 'New spec' }).click()
-          cy.contains('Create new empty spec').click()
+          cy.contains('Create starter spec').click()
 
           cy.findAllByLabelText(defaultMessages.createSpec.e2e.importEmptySpec.inputPlaceholder)
           .as('enterSpecInput')
@@ -484,7 +484,7 @@ describe('App: Specs', () => {
           .and('contain', defaultMessages.createSpec.e2e.importEmptySpec.header)
         })
 
-        cy.contains('Create new empty spec').click()
+        cy.contains('Create starter spec').click()
 
         cy.findAllByLabelText(defaultMessages.createSpec.e2e.importEmptySpec.inputPlaceholder)
         .as('enterSpecInput')
@@ -544,11 +544,11 @@ describe('App: Specs', () => {
         cy.findAllByTestId('card').eq(1).as('EmptyCard')
       })
 
-      it('shows create new empty spec card', () => {
+      it('shows Create starter spec card', () => {
         cy.get('@EmptyCard')
         .within(() => {
           cy.findByRole('button', {
-            name: 'Create new empty spec',
+            name: 'Create starter spec',
           }).should('be.visible')
           .and('not.be.disabled')
         })
@@ -593,7 +593,7 @@ describe('App: Specs', () => {
             cy.findByRole('button', { name: 'Create another spec' }).click()
           })
 
-          // 'Create a new spec' dialog presents with options when user indicates they want to create
+          // 'Create starter spec' dialog presents with options when user indicates they want to create
           // another spec.
           cy.findAllByTestId('card').should('have.length', 2)
           cy.findByRole('button', { name: 'Create new empty spec' }).should('be.visible')

--- a/packages/app/cypress/e2e/specs.cy.ts
+++ b/packages/app/cypress/e2e/specs.cy.ts
@@ -527,7 +527,7 @@ describe('App: Specs', () => {
   function selectEmptySpecCard () {
     cy.findAllByTestId('card').should('have.length', 2)
     cy.findByRole('button', { name: 'Create from component' }).should('be.visible')
-    cy.findByRole('button', { name: 'Create new empty spec' }).should('be.visible').click()
+    cy.findByRole('button', { name: 'Create starter spec' }).should('be.visible').click()
   }
 
   describe('Testing Type: Component', {
@@ -596,7 +596,7 @@ describe('App: Specs', () => {
           // 'Create starter spec' dialog presents with options when user indicates they want to create
           // another spec.
           cy.findAllByTestId('card').should('have.length', 2)
-          cy.findByRole('button', { name: 'Create new empty spec' }).should('be.visible')
+          cy.findByRole('button', { name: 'Create starter spec' }).should('be.visible')
           cy.findByRole('button', { name: 'Create from component' }).should('be.visible')
         })
 

--- a/packages/app/cypress/e2e/specs_list_component.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_component.cy.ts
@@ -31,7 +31,7 @@ describe('App: Spec List (Component)', () => {
     cy.get('[data-selected-spec="false"]').should('contain', 'foo')
   })
 
-  it('opens the "Create a new spec" modal after clicking the "New specs" button', () => {
+  it('opens the "Create starter spec" modal after clicking the "New specs" button', () => {
     cy.get('[data-cy="standard-modal"]').should('not.exist')
     cy.get('[data-cy="new-spec-button"]').click()
     cy.get('[data-cy="standard-modal"]').get('h2').contains('Enter the path for your new spec')
@@ -39,7 +39,7 @@ describe('App: Spec List (Component)', () => {
     cy.get('[data-cy="standard-modal"]').should('not.exist')
   })
 
-  it('has the correct defaultSpecFileName in the "Create a new spec" modal', () => {
+  it('has the correct defaultSpecFileName in the "Create starter spec" modal', () => {
     cy.findByTestId('standard-modal').should('not.exist')
     cy.findByTestId('new-spec-button').click()
     cy.get('input').get('[aria-label="Enter a relative path..."]').invoke('val').should('contain', getPathForPlatform('cypress/component-tests/ComponentName.spec.js'))

--- a/packages/app/cypress/e2e/specs_list_e2e.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_e2e.cy.ts
@@ -85,22 +85,22 @@ describe('App: Spec List (E2E)', () => {
       cy.findAllByTestId('spec-item').should('contain', 'dom-content.spec.js')
     })
 
-    it('opens the "Create a new spec" modal after clicking the "New specs" button', () => {
+    it('opens the "Create starter spec" modal after clicking the "New specs" button', () => {
       cy.findByTestId('standard-modal').should('not.exist')
       cy.findByTestId('new-spec-button').click()
-      cy.findByTestId('standard-modal').get('h2').contains('Create a new spec')
+      cy.findByTestId('standard-modal').get('h2').contains('Create starter spec')
       cy.get('button').contains('Scaffold example specs').should('be.visible')
-      cy.get('button').contains('Create new empty spec').should('be.visible')
+      cy.get('button').contains('Create starter spec').should('be.visible')
       cy.get('button').get('[aria-label="Close"]').click()
       cy.findByTestId('standard-modal').should('not.exist')
     })
 
-    it('has the correct defaultSpecFileName in the "Create a new spec" modal', () => {
+    it('has the correct defaultSpecFileName in the "Create starter spec" modal', () => {
       cy.findByTestId('standard-modal').should('not.exist')
       cy.findByTestId('new-spec-button').click()
-      cy.findByTestId('standard-modal').get('h2').contains('Create a new spec')
+      cy.findByTestId('standard-modal').get('h2').contains('Create starter spec')
       cy.get('button').contains('Scaffold example specs').should('be.visible')
-      cy.get('button').contains('Create new empty spec').should('be.visible').click()
+      cy.get('button').contains('Create starter spec').should('be.visible').click()
       cy.get('input').get('[aria-label="Enter a relative path..."]').invoke('val').should('contain', getPathForPlatform('cypress/e2e/spec.spec.js'))
       cy.get('button').get('[aria-label="Close"]').click()
     })

--- a/packages/app/src/specs/CreateSpecModal.cy.tsx
+++ b/packages/app/src/specs/CreateSpecModal.cy.tsx
@@ -32,7 +32,7 @@ function testEmptySpecModal (fullDefaultSpecFileName: string, specName: string) 
 
   describe('form behavior', () => {
     beforeEach(() => {
-      cy.findByRole('button', { name: 'Create new empty spec' }).should('be.visible').click()
+      cy.findByRole('button', { name: 'Create starter spec' }).should('be.visible').click()
     })
 
     it('enter should call create spec function', () => {
@@ -68,7 +68,7 @@ function testEmptySpecModal (fullDefaultSpecFileName: string, specName: string) 
 
   describe('text Input', () => {
     beforeEach(() => {
-      cy.findByRole('button', { name: 'Create new empty spec' }).should('be.visible').click()
+      cy.findByRole('button', { name: 'Create starter spec' }).should('be.visible').click()
     })
 
     it('focuses text input and selects file name by default', () => {
@@ -219,7 +219,7 @@ describe('<CreateSpecModal />', () => {
         />
       </div>))
 
-      cy.findByRole('button', { name: 'Create new empty spec' }).should('be.visible').click()
+      cy.findByRole('button', { name: 'Create starter spec' }).should('be.visible').click()
 
       cy.focused().as('specNameInput')
 

--- a/packages/app/src/specs/CreateSpecModal.cy.tsx
+++ b/packages/app/src/specs/CreateSpecModal.cy.tsx
@@ -296,7 +296,7 @@ describe('defaultSpecFileName', () => {
       },
     })
 
-    cy.findByText('Create new empty spec').click()
+    cy.findByText('Create starter spec').click()
     cy.get('input').invoke('val').should('contain', 'spec.cy.js')
 
     cy.percySnapshot()

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -64,7 +64,7 @@
     "noComponentsFound": "No components found",
     "unableToParseFile": "Unable to parse file",
     "updateSpecPattern": "Update spec pattern",
-    "newSpecModalTitle": "Create a new spec",
+    "newSpecModalTitle": "Create starter spec",
     "successPage": {
       "header": "Great! The spec was successfully added",
       "runSpecButton": "Okay, run the spec",
@@ -96,8 +96,8 @@
         "specsAddingHeader": "Adding specs..."
       },
       "importEmptySpec": {
-        "header": "Create new empty spec",
-        "description": "We'll generate an empty spec file which can be used to start testing your application.",
+        "header": "Create starter spec",
+        "description": "We'll generate a starter spec file which can be used to start testing your application.",
         "chooseFilenameHeader": "Enter the path for your new spec",
         "inputPlaceholder": "Enter a relative path...",
         "invalidSpecWarning": "This path is invalid because it doesn't match the following ",
@@ -111,8 +111,8 @@
         "chooseAComponentHeader": "Choose a component"
       },
       "importEmptySpec": {
-        "header": "Create a new spec",
-        "description": "We'll generate an empty spec file to start testing components.",
+        "header": "Create starter spec",
+        "description": "We'll generate a starter spec file to start testing components.",
         "invalidComponentWarning": "We couldn't generate a valid path matching your custom "
       }
     }

--- a/packages/launchpad/src/migration/OptOutModal.vue
+++ b/packages/launchpad/src/migration/OptOutModal.vue
@@ -2,6 +2,7 @@
   <StandardModal
     :model-value="true"
     :title="t('migration.renameAuto.modal.title')"
+    :no-help="true"
     @update:modelValue="emit('cancel')"
   >
     <Alert


### PR DESCRIPTION


- **Closes**: [issue-21923](https://github.com/cypress-io/cypress/issues/21923)

### User facing changelog

Remove the `Need help` link from the migration information modal.

### Additional details

N/A

### Steps to test

- create a new project with Cypress `9.0.0` version.
- Migrate the project to a modern version of Cypress.

### How has the user experience changed?

**Before changes:**

<img width="1002" alt="Screenshot 2022-12-27 at 8 16 03 AM" src="https://user-images.githubusercontent.com/32891808/209679129-419e8cf7-38f5-4644-9830-3ac4c5aa8407.png">

**After changes:**

<img width="1004" alt="Screenshot 2022-12-27 at 8 13 17 AM" src="https://user-images.githubusercontent.com/32891808/209679160-75ef4842-2c61-4f0b-ab14-b4bac4cd9003.png">

### PR Tasks

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
