### PR TITLE
fix: remove redundant help link in migration modal

### DIFF
--- a/packages/launchpad/src/migration/OptOutModal.vue
+++ b/packages/launchpad/src/migration/OptOutModal.vue
@@ -2,6 +2,7 @@
   <StandardModal
     :model-value="true"
     :title="t('migration.renameAuto.modal.title')"
+    :no-help="true"
     @update:modelValue="emit('cancel')"
   >
     <Alert


### PR DESCRIPTION

- **Closes**: [issue-21923](https://github.com/cypress-io/cypress/issues/21923)

### User-facing changelog

Remove the `Need help` link from the migration information modal.

### Additional details

N/A

### Steps to test

- create a new project with Cypress `9.0.0` version.
- Migrate the project to a modern version of Cypress.

### How has the user experience changed?

**Before changes:**

<img width="1002" alt="Screenshot 2022-12-27 at 8 16 03 AM" src="https://user-images.githubusercontent.com/32891808/209679129-419e8cf7-38f5-4644-9830-3ac4c5aa8407.png">

**After changes:**

<img width="1004" alt="Screenshot 2022-12-27 at 8 13 17 AM" src="https://user-images.githubusercontent.com/32891808/209679160-75ef4842-2c61-4f0b-ab14-b4bac4cd9003.png">

### PR Tasks

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
