### PR TITLE
fix: navbar border appearance at various zoom levels

### DIFF
--- a/packages/app/src/navigation/SidebarNavigation.vue
+++ b/packages/app/src/navigation/SidebarNavigation.vue
@@ -2,7 +2,7 @@
   <HideDuringScreenshot
     id="sidebar"
     data-cy="sidebar"
-    class="flex flex-col bg-gray-1000 transition-all duration-300 relative"
+    class="flex flex-col bg-gray-1000 border-gray-900 border-r-1 transition-all duration-300 relative"
     :class="isNavBarExpanded ? 'w-248px' : 'w-64px'"
   >
     <button

--- a/packages/app/src/runner/SpecRunnerOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerOpenMode.vue
@@ -9,7 +9,7 @@
   />
   <AdjustRunnerStyleDuringScreenshot
     id="main-pane"
-    class="flex border-gray-900"
+    class="flex"
   >
     <AutomationElement />
     <AutomationDisconnected

--- a/packages/app/src/runner/SpecRunnerRunMode.vue
+++ b/packages/app/src/runner/SpecRunnerRunMode.vue
@@ -1,7 +1,7 @@
 <template>
   <AdjustRunnerStyleDuringScreenshot
     id="main-pane"
-    class="flex border-gray-900"
+    class="flex"
   >
     <AutomationElement />
     <AutomationDisconnected

--- a/packages/app/src/runner/screenshot/AdjustRunnerStyleDuringScreenshot.vue
+++ b/packages/app/src/runner/screenshot/AdjustRunnerStyleDuringScreenshot.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    :style="style"
-    :class="screenshotStore.isScreenshotting || isRunMode ? '' : 'border-l-1'"
-  >
+  <div :style="style">
     <slot />
   </div>
 </template>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #25284

This is a small visual bug, but I zoom in to Cypress a lot for demos and presentations, and it has always bothered me a little bit. Today it occurred to me to take another look at it and the fix is small.

<img width="532" alt="incorrect border" src="https://user-images.githubusercontent.com/8340719/209734996-f855021c-5941-4bff-b5ef-09ba2fea80bf.png">

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Chrome users will no longer see a white border on the nav bar at the specific zoom levels.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

The source of this really seems to be a Chrome bug with grid and borders. At these zoom levels, the equivalent of 2px is available between elements when only 1px is required.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Change zoom levels with Cmd + +/- on the spec runner page (where it is noticeable due to the dark command log/specs list).


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Before, with white border appearing


https://user-images.githubusercontent.com/8340719/209731555-e387029d-9ab8-439f-9397-230ca33cbce5.mov

After, zooming is fine:

https://user-images.githubusercontent.com/8340719/209731560-0eaaef94-5074-4ba0-abb3-e18220d007e6.mov

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated? - not really possible to test for this, though some percy tests may reflect the change of border location
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
