### PR TITLE
fix: rely only on proxy-from-env

### DIFF
--- a/cli/lib/tasks/download.js
+++ b/cli/lib/tasks/download.js
@@ -19,8 +19,6 @@ const defaultMaxRedirects = 10
 
 const getProxyForUrlWithNpmConfig = (url) => {
   return getProxyForUrl(url) ||
-    process.env.npm_config_https_proxy ||
-    process.env.npm_config_proxy ||
     null
 }
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -55,7 +55,7 @@
     "minimist": "^1.2.6",
     "ospath": "^1.2.2",
     "pretty-bytes": "^5.6.0",
-    "proxy-from-env": "1.0.0",
+    "proxy-from-env": "1.1.0",
     "request-progress": "^3.0.0",
     "semver": "^7.3.2",
     "supports-color": "^8.1.1",


### PR DESCRIPTION
- don't override result from getProxyForUrl()
- update proxy-from-env to 1.1.0 to get better .npmrc proxy support


- Closes [bug 19586](https://github.com/cypress-io/cypress/issues/19586)

### User facing changelog

- update proxy-from-env to 1.1.0 to get better .npmrc proxy configuration support

### Additional details

My company proxy doesn't work on sites that belong to my company domain, so we can't mirror cypress downloads in our network without setting noproxy properly. Current cypress download code breaks noproxy usage in npmrc and this patch addresses this problem.

### Steps to test

### How has the user experience changed?

proxy precedence will change and no_proxy in npmrc will now work.

### PR Tasks

- [X] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
