### PR TITLE
feat: add currentRetry to Cypress API

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -421,6 +421,11 @@ declare namespace Cypress {
     }
 
     /**
+     * Information about current test retry
+     */
+    currentRetry: number
+
+    /**
      * Information about the browser currently running the tests
      */
     browser: Browser

--- a/packages/driver/cypress/e2e/cypress/cypress.cy.js
+++ b/packages/driver/cypress/e2e/cypress/cypress.cy.js
@@ -86,6 +86,96 @@ describe('driver/src/cypress/index', () => {
     })
   })
 
+  context('.currentRetry', () => {
+    describe('test is not retried', () => {
+      before(() => {
+        expect(Cypress.currentRetry).to.eq(0)
+      })
+
+      beforeEach(() => {
+        expect(Cypress.currentRetry).to.eq(0)
+      })
+
+      afterEach(() => {
+        expect(Cypress.currentRetry).to.eq(0)
+      })
+
+      after(() => {
+        expect(Cypress.currentRetry).to.eq(0)
+      })
+
+      it('correctly returns currentRetry', () => {
+        expect(Cypress.currentRetry).to.eq(0)
+      })
+    })
+
+    describe('test is retried due to beforeEach hook failure', { retries: 1 }, () => {
+      before(() => {
+        expect(Cypress.currentRetry).to.be.oneOf([0, 1])
+      })
+
+      beforeEach(() => {
+        expect(Cypress.currentRetry).to.eq(1)
+      })
+
+      it('correctly returns currentRetry', () => {
+        expect(Cypress.currentRetry).to.eq(1)
+      })
+
+      afterEach(() => {
+        expect(Cypress.currentRetry).to.eq(1)
+      })
+
+      after(() => {
+        expect(Cypress.currentRetry).to.eq(1)
+      })
+    })
+
+    describe('test is retried due to test failure', { retries: 1 }, () => {
+      before(() => {
+        expect(Cypress.currentRetry).to.be.oneOf([0, 1])
+      })
+
+      beforeEach(() => {
+        expect(Cypress.currentRetry).to.be.oneOf([0, 1])
+      })
+
+      it('correctly returns currentRetry', () => {
+        expect(Cypress.currentRetry).to.eq(1)
+      })
+
+      afterEach(() => {
+        expect(Cypress.currentRetry).to.eq(1)
+      })
+
+      after(() => {
+        expect(Cypress.currentRetry).to.eq(1)
+      })
+    })
+
+    describe('test is retried due to afterEach hook failure', { retries: 1 }, () => {
+      before(() => {
+        expect(Cypress.currentRetry).to.be.oneOf([0, 1])
+      })
+
+      beforeEach(() => {
+        expect(Cypress.currentRetry).to.be.oneOf([0, 1])
+      })
+
+      it('correctly returns currentRetry', () => {
+        expect(Cypress.currentRetry).to.be.oneOf([0, 1])
+      })
+
+      afterEach(() => {
+        expect(Cypress.currentRetry).to.eq(1)
+      })
+
+      after(() => {
+        expect(Cypress.currentRetry).to.eq(1)
+      })
+    })
+  })
+
   context('.isCy', () => {
     it('returns true on cy, cy chainable', () => {
       expect(Cypress.isCy(cy)).to.be.true
@@ -104,7 +194,7 @@ describe('driver/src/cypress/index', () => {
     })
   })
 
-  context('.Log', () => {
+  context('.log', () => {
     it('throws when passing non-object to Cypress.log()', () => {
       const fn = () => {
         Cypress.log('My Log')

--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -788,7 +788,9 @@ class $Cypress {
   }
 
   get currentRetry (): number {
-    return this.cy.state('runnable').ctx?.currentTest._currentRetry
+    const ctx = this.cy.state('runnable').ctx
+
+    return ctx?.currentTest?._currentRetry || ctx?.test?._currentRetry
   }
 
   static create (config: Record<string, any>) {

--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -787,6 +787,10 @@ class $Cypress {
     }
   }
 
+  get currentRetry (): number {
+    return this.cy.state('runnable').ctx?.currentTest._currentRetry
+  }
+
   static create (config: Record<string, any>) {
     const cypress = new $Cypress()
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes (https://github.com/cypress-io/cypress/issues/25239)

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->
Add current retry to Cypress API.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
