### PR TITLE
fix: Allow component tests with special characters in filepath

### DIFF
--- a/npm/webpack-dev-server/src/loader.ts
+++ b/npm/webpack-dev-server/src/loader.ts
@@ -18,7 +18,7 @@ const makeImport = (file: Cypress.Cypress['spec'], filename: string, chunkName: 
   const magicComments = chunkName ? `/* webpackChunkName: "${chunkName}" */` : ''
 
   return `"${filename}": {
-    shouldLoad: () => document.location.pathname.includes("${encodeURI(file.absolute)}"),
+    shouldLoad: () => decodeURI(document.location.pathname).includes("${file.absolute}"),
     load: () => import("${file.absolute}" ${magicComments}),
     absolute: "${file.absolute.split(path.sep).join(path.posix.sep)}",
     relative: "${file.relative.split(path.sep).join(path.posix.sep)}",

--- a/system-tests/test/webpack_dev_server_spec.ts
+++ b/system-tests/test/webpack_dev_server_spec.ts
@@ -1,7 +1,13 @@
 import systemTests from '../lib/system-tests'
+import Fixtures from '../lib/fixtures'
+import path from 'path'
+import globby from 'globby'
+import { escapeRegExp } from 'lodash'
 
 describe('@cypress/webpack-dev-server', function () {
   systemTests.setup()
+
+  const wdsPath = Fixtures.projectPath('webpack-dev-server')
 
   systemTests.it('successfully loads and runs all specs', {
     project: 'webpack-dev-server',
@@ -9,6 +15,34 @@ describe('@cypress/webpack-dev-server', function () {
     spec: 'src/**/*',
     browser: 'chrome',
     expectedExitCode: 0,
+    onRun: async (exec) => {
+      // We do not expect any failures in this suite, but we need to check that we actually ran
+      // the tests that we expected to run to validate that WDS is properly parsing & loading
+      // tests with special filepaths
+
+      const { stdout } = await exec()
+
+      // Find all specs that should have been run as part of this system test
+      // by scanning filesystem using spec pattern
+      const files = await globby(path.join(wdsPath, 'src', '**', '*'))
+
+      // sanity check that we actually found some spec files
+      expect(files).to.have.length.greaterThan(0)
+
+      files.forEach((fileName) => {
+        // Parse out the subpath under 'src' that we expect to appear in the output results table
+        const expectedFileName = fileName
+        .replace(path.join(wdsPath, 'src'), '')
+        .replace(/^\/|\\/, '') // Remove leading path separator if one exists
+
+        // Pattern to match final output table entry
+        // Should include checkmark, filename, # of tests (1), and # of passes (1)
+        //    ✔  [...bar].cy.js                            17ms        1        1
+        const expectedPattern = new RegExp(`✔\\s+${escapeRegExp(expectedFileName)}\\s+\\d+ms\\s+1\\s+1`)
+
+        expect(stdout).to.match(expectedPattern)
+      })
+    },
   })
 
   systemTests.it('successfully loads and runs all specs with typescript config', {


### PR DESCRIPTION
- Closes #24588 

### User facing changelog
* Fixes an issue where component test files that contained characters such as brackets (`[]`) would be ignored when running tests. This is a common pattern in Next.js and Gatsby.js projects

### Additional details
This was originally fixed in #20575, but was at some point lost. Tests were added by that PR but unfortunately a loophole in how they were established was just causing them to validate that no tests _**failed**_ - they did not validate that the expected number of tests were loaded and executed. This PR re-introduces the logic change from #20575 and attempts to add logic to the system test to validate that the expected spec files & included tests were found, loaded, and executed.

If anyone has a suggestion for a better way to validate the set of tests that were loaded & run I would love to hear it. Currently pattern matching on `stdout` but this feels a bit brittle

### Steps to test

1. Pull down this branch, build `npm/webpack-dev-server` using `yarn build`
2. Create a Next.js component testing project
3. Create component test files of the following filepath patterns. Ensure each file has a test case within it
`*/[foo]/Test.cy.tsx`
`*/[...Test].cy.tsx`
`*/My Test.cy.tsx`
`*/SpecialChar_ñ.cy.tsx`
4. Launch Cypress, validate that each file is listed in the specs list and executes the test when run

### How has the user experience changed?
Before: Spec files were found and listed, but would report "No tests found" when executed
After: Specs should now execute test cases

### PR Tasks
- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
