### PR TITLE
chore: remove lint-changed from scripts/docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -335,14 +335,8 @@ Many Cypress packages print out debugging information to console via the `debug`
 We use [eslint](https://eslint.org/) to lint all JavaScript code and follow rules specified in
 [@cypress/eslint-plugin-dev](./npm/eslint-plugin-cypress) plugin.
 
-When you edit files, you can quickly fix all changed files before you commit using
-
-```bash
-$ yarn lint-changed --fix
-```
-
-When committing files, we run a Git pre-commit hook to lint the staged JS files. See the [`lint-staged` project](https://github.com/okonet/lint-staged).
-If this command fails, you may need to run `yarn lint-changed --fix` and commit those changes.
+This project uses a Git pre-commit hook to lint staged files before committing. See the [`lint-staged` project](https://github.com/okonet/lint-staged) for details.
+`lint-staged` will try to auto-fix any lint errors with `eslint --fix`, so if it fails, you must manually fix the lint errors before committing.
 
 We **DO NOT** use Prettier to format code. You can find [.prettierignore](.prettierignore) file that ignores all files in this repository. To ensure this file is loaded, please always open _the root repository folder_ in your text editor, otherwise your code formatter might execute, reformatting lots of source files.
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "get-next-version": "node scripts/get-next-version.js",
     "postinstall": "node ./scripts/run-postInstall.js",
     "lint": "lerna run lint --no-bail --concurrency 2",
-    "lint-changed": "lint-changed",
     "prepare-release-artifacts": "node ./scripts/prepare-release-artifacts.js",
     "npm-release": "node scripts/npm-release.js",
     "prestart": "yarn ensure-deps",


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### User facing changelog

n/a

### Additional details

- @lmiller1990 noticed that this script is broken, I confirmed it was broken before this PR too: https://github.com/cypress-io/cypress/pull/25235#pullrequestreview-1227073464
- Our docs aren't totally correct on it either - `lint-staged` already runs `eslint --fix`, so there's not a situation where a functional `lint-changed` would be needed anyways.
- ~I kept the source code in `npm/eslint-plugin-dev` because tests for it do pass and it's possible it's being used outside of the monorepo.~
	- See comment here, these scripts are actually broken and can most likely be removed, but deferred to later: https://github.com/cypress-io/cypress/pull/25308#discussion_r1059079036

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
