### PR TITLE
feat: Use JSX/TSX in generated spec filenames

### DIFF
--- a/packages/app/cypress/e2e/specs.cy.ts
+++ b/packages/app/cypress/e2e/specs.cy.ts
@@ -574,7 +574,7 @@ describe('App: Specs', () => {
 
         it('shows success modal when empty spec is created', () => {
           cy.get('@CreateEmptySpecDialog').within(() => {
-            cy.findByLabelText('Enter a relative path...').invoke('val').should('eq', getPathForPlatform('cypress/component/ComponentName.cy.ts'))
+            cy.findByLabelText('Enter a relative path...').invoke('val').should('eq', getPathForPlatform('cypress/component/ComponentName.cy.tsx'))
 
             cy.findByLabelText('Enter a relative path...').clear().type('cypress/my-empty-spec.cy.js')
 
@@ -602,7 +602,7 @@ describe('App: Specs', () => {
 
         it('navigates to spec runner when selected', () => {
           cy.get('@CreateEmptySpecDialog').within(() => {
-            cy.findByLabelText('Enter a relative path...').invoke('val').should('eq', getPathForPlatform('cypress/component/ComponentName.cy.ts'))
+            cy.findByLabelText('Enter a relative path...').invoke('val').should('eq', getPathForPlatform('cypress/component/ComponentName.cy.tsx'))
 
             cy.findByLabelText('Enter a relative path...').clear().type('cypress/my-empty-spec.cy.js')
 
@@ -622,7 +622,7 @@ describe('App: Specs', () => {
 
         it('displays alert with docs link on new spec', () => {
           cy.get('@CreateEmptySpecDialog').within(() => {
-            cy.findByLabelText('Enter a relative path...').invoke('val').should('eq', getPathForPlatform('cypress/component/ComponentName.cy.ts'))
+            cy.findByLabelText('Enter a relative path...').invoke('val').should('eq', getPathForPlatform('cypress/component/ComponentName.cy.tsx'))
 
             cy.findByLabelText('Enter a relative path...').clear().type('cypress/my-empty-spec.cy.js')
 
@@ -755,7 +755,7 @@ describe('App: Specs', () => {
         cy.findByRole('dialog', {
           name: 'Enter the path for your new spec',
         }).within(() => {
-          cy.findByLabelText('Enter a relative path...').invoke('val').should('eq', getPathForPlatform('src/specs-folder/ComponentName.js'))
+          cy.findByLabelText('Enter a relative path...').invoke('val').should('eq', getPathForPlatform('src/specs-folder/ComponentName.jsx'))
 
           cy.findByRole('button', { name: 'Create spec' }).click()
         })

--- a/packages/data-context/src/sources/ProjectDataSource.ts
+++ b/packages/data-context/src/sources/ProjectDataSource.ts
@@ -419,11 +419,24 @@ export class ProjectDataSource {
 
   async defaultSpecFileName (): Promise<string> {
     const { specPattern = [] } = await this.ctx.project.specPatterns()
+    let fileExtensionToUse: FileExtension = this.ctx.lifecycleManager.fileExtensionToUse
+
+    // If generating a component test then check whether there are JSX/TSX files present in the project.
+    // If project uses JSX then user likely wants to use JSX for their tests as well.
+    // JSX can be used (or not used) with a variety of frameworks depending on user preference/config, so
+    // the only reliable way to determine is whether there are files with JSX extension present
+    if (this.ctx.coreData.currentTestingType === 'component') {
+      const projectJsxFiles = await this.ctx.file.getFilesByGlob(this.ctx.currentProject ?? '', '**/*.[jt]sx')
+
+      if (projectJsxFiles.length > 0) {
+        fileExtensionToUse = `${fileExtensionToUse}x`
+      }
+    }
 
     return getDefaultSpecFileName({
       currentProject: this.ctx.currentProject,
       testingType: this.ctx.coreData.currentTestingType,
-      fileExtensionToUse: this.ctx.lifecycleManager.fileExtensionToUse,
+      fileExtensionToUse,
       specs: this.specs,
       specPattern,
     })

--- a/packages/data-context/test/unit/sources/ProjectDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/ProjectDataSource.spec.ts
@@ -819,15 +819,28 @@ describe('ProjectDataSource', () => {
       expect(defaultSpecFileName).to.equal('cypress/component-tests/foo/ComponentName.spec.js')
     })
 
-    it('yields correct filename from specpattern if there are jsx files in component testing', async () => {
-      ctx.coreData.currentTestingType = 'component'
-      sinon.stub(ctx.project, 'specPatterns').resolves({ specPattern: [] })
+    describe('jsx/tsx handling', () => {
+      beforeEach(async () => {
+        ctx.coreData.currentTestingType = 'component'
+        await ctx.actions.file.writeFileInProject(path.join('src', 'components', 'App.jsx'), '// foo')
+      })
 
-      await ctx.actions.file.writeFileInProject(path.join('src', 'components', 'App.jsx'), '// foo')
+      it('yields correct jsx extension if there are jsx files and specPattern allows', async () => {
+        sinon.stub(ctx.project, 'specPatterns').resolves({ specPattern: [defaultSpecPattern.component] })
 
-      const defaultSpecFileName = await ctx.project.defaultSpecFileName()
+        const defaultSpecFileName = await ctx.project.defaultSpecFileName()
 
-      expect(defaultSpecFileName).to.equal('cypress/component/ComponentName.cy.jsx', defaultSpecFileName)
+        expect(defaultSpecFileName).to.equal('cypress/component/ComponentName.cy.jsx', defaultSpecFileName)
+      })
+
+      it('yields non-jsx extension if there are jsx files but specPattern disallows', async () => {
+        sinon.stub(ctx.project, 'specPatterns').resolves({ specPattern: ['cypress/component/*.cy.js'] })
+
+        const defaultSpecFileName = await ctx.project.defaultSpecFileName()
+
+        // specPattern does not allow for jsx, so generated spec name should not use jsx extension
+        expect(defaultSpecFileName).to.equal('cypress/component/ComponentName.cy.js', defaultSpecFileName)
+      })
     })
   })
 })

--- a/packages/data-context/test/unit/sources/ProjectDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/ProjectDataSource.spec.ts
@@ -818,5 +818,16 @@ describe('ProjectDataSource', () => {
 
       expect(defaultSpecFileName).to.equal('cypress/component-tests/foo/ComponentName.spec.js')
     })
+
+    it('yields correct filename from specpattern if there are jsx files in component testing', async () => {
+      ctx.coreData.currentTestingType = 'component'
+      sinon.stub(ctx.project, 'specPatterns').resolves({ specPattern: [] })
+
+      await ctx.actions.file.writeFileInProject(path.join('src', 'components', 'App.jsx'), '// foo')
+
+      const defaultSpecFileName = await ctx.project.defaultSpecFileName()
+
+      expect(defaultSpecFileName).to.equal('cypress/component/ComponentName.cy.jsx', defaultSpecFileName)
+    })
   })
 })


### PR DESCRIPTION
- Closes #24495 

### User facing changelog
- Utilize a JSX/TSX file extension when generating a new empty spec file if project contains at least one file with those extensions. This applies only to component testing and is skipped if the project `specPattern` has been configured to exclude files with those extensions.

### Additional details
Original writeup was specific to React which, while likely the largest use case for JSX, is not the only setup that can use JSX. It's also not necessary to use a JSX extension if using React (or other frameworks). For these reasons, I think the only reliable way to determine if we should use a JSX extension for the default spec filename is to check whether there are other existing files using that extension *and* it would not violate the project's configured specPattern to use it (so we don't generate "disappearing" spec files)

### Steps to test
1. Scaffold a CT project using any framework, keep default specPattern
2. Open Cypress, use "Create new empty spec" button. Verify suggested filename uses `cy.js` (not JSX)
3. Close Cypress, add a JSX file within the project (can be empty)
4. Reopen Cypress, use "Create new empty spec" button. Verify suggested filename now uses `cy.jsx` **_(CHANGED BEHAVIOR)_**
5. Close Cypress, add a `typescript` dependency to the project and rename `cypress.config.js` to `cypress.config.ts`
6. Reopen Cypress, use "Create new empty spec" button. Verify suggested filename now uses `cy.tsx` **_(CHANGED BEHAVIOR)_**
7. Close Cypress, update the CT `specPattern` to `**/*.cy.js`
8. Reopen Cypress, use "New spec" button. Verify suggested filename now uses `cy.ts` (not TSX)

### How has the user experience changed?


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
