### PR TITLE
fix: make NODE_ENV "production" for prod builds of launchpad

### DIFF
--- a/packages/frontend-shared/vite.config.mjs
+++ b/packages/frontend-shared/vite.config.mjs
@@ -150,6 +150,7 @@ export const makeConfig = (config = {}, plugins = {}) => {
     define: {
       'process.env': {
         CYPRESS_INTERNAL_ENV: 'development',
+        NODE_ENV: process.env.NODE_ENV,
       },
       // Fix to get cypress-plugin-tab to work in CT
       'process.version': '99',

--- a/scripts/gulp/tasks/gulpVite.ts
+++ b/scripts/gulp/tasks/gulpVite.ts
@@ -102,10 +102,6 @@ export function viteBuildApp () {
 export function viteBuildAndWatchApp () {
   return watchViteBuild('vite:build-watch-app', `yarn vite build --watch`, {
     cwd: monorepoPaths.pkgApp,
-    env: {
-      // ...process.env,
-      NODE_ENV: 'production',
-    },
   })
 }
 
@@ -113,6 +109,9 @@ export function viteBuildLaunchpad () {
   return spawned('vite:build-launchpad', `yarn vite build --outDir dist`, {
     cwd: monorepoPaths.pkgLaunchpad,
     waitForExit: true,
+    env: {
+      NODE_ENV: 'production',
+    },
   })
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

No issue has been created for this, it's just something I noticed when somebody shared a screenshot on Discord.

<img width="667" alt="Screen Shot 2022-12-30 at 5 07 26 PM" src="https://user-images.githubusercontent.com/8340719/210114706-0239499c-ef62-49a7-82b8-059a5ab937f0.png">


### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Error toasts will no longer incorrectly display in the launchpad.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Couple of small changes to make sure that, which not watching app and launchpad builds, but doing a regular production build, we pass the`process.env.NODE_ENV` through for use in Vue. This corrects an issue where it is currently possible to see low quality error toasts that are intended for use during development, in the production launchpad.

I also removed `production` from the app watch job since in situations where we are in watch mode, that's development and we want the toasts to appear.

There are no other side-effects of this change that I can think of, as nothing else in the Vue app is looking at `process.env.NODE_ENV`.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Not many great ways to test this, I did build a binary locally to make sure that the settings I changed were definitely used and printed out the `NODE_ENV` in the UI:

![Screen Shot 2022-12-30 at 4 01 55 PM](https://user-images.githubusercontent.com/8340719/210114341-afe04d7b-4e38-4bd8-8aa2-84677de3a5f6.png)


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
