### PR TITLE
fix: Reflect browser status in launchpad if failed to open

### DIFF
--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -146,11 +146,24 @@ export = {
 
     debug('opening browser %o', browser)
 
-    const _instance = await browserLauncher.open(browser, options.url, options, automation)
+    try {
+      const _instance = await browserLauncher.open(browser, options.url, options, automation)
 
-    debug('browser opened')
+      debug('browser instance: %o', _instance)
 
-    instance = _instance
+      debug('browser opened')
+
+      instance = _instance
+    } catch (e) {
+      /*
+      If an error happens during open (e.g. user closes window before we finish loading) then
+      clean up browser state and re-throw error
+      */
+      debug('Error while opening browser %o', e)
+      ctx.browser.setBrowserStatus('closed')
+      throw e
+    }
+
     instance.browser = browser
 
     // TODO: normalizing opening and closing / exiting

--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -161,7 +161,10 @@ export = {
       */
       debug('Error while opening browser %o', e)
       ctx.browser.setBrowserStatus('closed')
-      throw e
+      options?.onBrowserClose?.()
+      browserLauncher.clearInstanceState()
+
+      return null
     }
 
     instance.browser = browser

--- a/packages/server/lib/open_project.ts
+++ b/packages/server/lib/open_project.ts
@@ -187,7 +187,7 @@ export class OpenProject {
 
       options.relaunchBrowser = this.relaunchBrowser
 
-      return await browsers.open(browser, options, automation, this._ctx)
+      return await browsers.open(browser, options, automation, this._ctx!)
     }
 
     return this.relaunchBrowser()

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -678,19 +678,6 @@ describe('lib/cypress', () => {
       })
     })
 
-    it(`cleans up browser state if error encountered during open`, function () {
-      const expectedError = new Error('browser open error')
-
-      browsers.open.throws(expectedError)
-
-      return cypress.start([`--run-project=${this.idsPath}`])
-      .then(() => {
-        this.expectExitWith(1)
-        expect(errors.log).to.be.calledWith(expectedError)
-        expect(ctx.coreData.app.browserStatus).to.equal('closed')
-      })
-    })
-
     it('logs error when browser cannot be found', function () {
       browsers.open.restore()
 

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -46,6 +46,7 @@ const savedState = require(`../../lib/saved_state`)
 const { getCtx, clearCtx, setCtx, makeDataContext } = require(`../../lib/makeDataContext`)
 const { BrowserCriClient } = require(`../../lib/browsers/browser-cri-client`)
 const { cloudRecommendationMessage } = require('../../lib/util/print-run')
+const { expect } = require('chai')
 
 const TYPICAL_BROWSERS = [
   {
@@ -674,6 +675,19 @@ describe('lib/cypress', () => {
       })
       .then(() => {
         this.expectExitWithErr('SUPPORT_FILE_NOT_FOUND', `Your supportFile is missing or invalid: /does/not/exist`)
+      })
+    })
+
+    it(`cleans up browser state if error encountered during open`, function () {
+      const expectedError = new Error('browser open error')
+
+      browsers.open.throws(expectedError)
+
+      return cypress.start([`--run-project=${this.idsPath}`])
+      .then(() => {
+        this.expectExitWith(1)
+        expect(errors.log).to.be.calledWith(expectedError)
+        expect(ctx.coreData.app.browserStatus).to.equal('closed')
       })
     })
 

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -46,7 +46,6 @@ const savedState = require(`../../lib/saved_state`)
 const { getCtx, clearCtx, setCtx, makeDataContext } = require(`../../lib/makeDataContext`)
 const { BrowserCriClient } = require(`../../lib/browsers/browser-cri-client`)
 const { cloudRecommendationMessage } = require('../../lib/util/print-run')
-const { expect } = require('chai')
 
 const TYPICAL_BROWSERS = [
   {

--- a/packages/server/test/unit/browsers/browsers_spec.js
+++ b/packages/server/test/unit/browsers/browsers_spec.js
@@ -13,7 +13,6 @@ const util = require('util')
 const { createTestDataContext } = require('@packages/data-context/test/unit/helper')
 const electron = require('../../../lib/browsers/electron')
 const Promise = require('bluebird')
-const { expect } = require('chai')
 
 const normalizeSnapshot = (str) => {
   return snapshot(stripAnsi(str))


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #23798

### User facing changelog
* Fixes issue in Launchpad where a browser would be stuck in a "opening" state if it failed to open or was closed very quickly after being opened.

### Additional details
Just adding a "reset state" flow if an error is thrown on browser open and re-throwing the error to keep existing logic intact

### Steps to test
1. Open a project (e2e or ct)
2. From launchpad, select Electron and open
3. Before Electron finishes loading (immediately after window opens) close the Electron window using `command-W`
4. Observe launchpad resets to "no browser open" state
5. Re-open Electron and observe it successfully loads
6. You can repeat procedure with Chrome or Firefox but it can be tricky to reproduce since these browsers take a "double `command-Q` to kill them during the open operation

### How has the user experience changed?
**_Before_**

https://user-images.githubusercontent.com/11482842/210415327-4b689623-b556-432b-b0a4-50ffcff6f978.mov

_**After**_

https://user-images.githubusercontent.com/11482842/210415377-e8aeac4f-999b-4b49-836a-02eb9a2e528b.mov

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
