### PR TITLE
feat: IATR-M0 Page Header (#24722)

### DIFF
--- a/packages/app/src/debug/DebugFailedTest.cy.tsx
+++ b/packages/app/src/debug/DebugFailedTest.cy.tsx
@@ -198,7 +198,7 @@ describe('<DebugFailedTest/>', () => {
     assertRowContents(testResult)
 
     cy.contains('...').realHover()
-    cy.contains('[data-cy=tooltip-content]', 'Test content 2').should('be.visible')
+    cy.contains('[data-cy=tooltip-content]', 'Test content 2 > Test content 3 > Test content 4').should('be.visible')
 
     cy.percySnapshot()
   })

--- a/packages/app/src/debug/DebugFailedTest.cy.tsx
+++ b/packages/app/src/debug/DebugFailedTest.cy.tsx
@@ -175,7 +175,7 @@ describe('<DebugFailedTest/>', () => {
     cy.percySnapshot()
   })
 
-  it('tests responsvie UI', { viewportWidth: 700 }, () => {
+  it('tests responsive UI', { viewportWidth: 700 }, () => {
     const testResult: TestResults = {
       id: '676df87874',
       titleParts: ['Test content', 'Test content 2', 'Test content 3', 'Test content 4', 'onMount() should be called once', 'hook() should be called twice and then'],
@@ -196,6 +196,9 @@ describe('<DebugFailedTest/>', () => {
     ))
 
     assertRowContents(testResult)
+
+    cy.contains('...').realHover()
+    cy.contains('[data-cy=tooltip-content]', 'Test content 2').should('be.visible')
 
     cy.percySnapshot()
   })

--- a/packages/app/src/debug/DebugFailedTest.vue
+++ b/packages/app/src/debug/DebugFailedTest.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     data-cy="test-row"
-    class="flex flex-row h-12 items-center non-italic text-base text-gray-700 font-normal"
+    class="flex flex-row font-normal h-12 text-base text-gray-700 items-center non-italic"
   >
     <SolidStatusIcon
       size="16"
@@ -10,36 +10,36 @@
       class="isolate"
     />
     <template
-      v-for="titlePart, index in failedTestData.mappedTitleParts"
+      v-for="{text, type}, index in failedTestData.mappedTitleParts"
       :key="`${titlePart}-${index}`"
       :data-cy="`titleParts-${index}`"
     >
       <IconChevronRightSmall
-        v-if="index !== 0 && titlePart.type !== 'LAST-1'"
+        v-if="index !== 0 && type !== 'LAST-PART-END'"
         :data-cy="`titleParts-${index}-chevron`"
         size="8"
         stroke-color="gray-200"
         fill-color="gray-200"
         class="shrink-0"
-        :class="titlePart.type === 'MIDDLE' ? 'hidden lg:block' : titlePart.type === 'ELLIPSIS' ? 'lg:hidden' : ''"
+        :class="type === 'MIDDLE' ? 'hidden lg:block' : type === 'ELLIPSIS' ? 'lg:hidden' : ''"
       />
       <span
         :data-cy="`titleParts-${index}-title`"
-        :class="titlePart.type === 'ELLIPSIS' ? 'px-2.5 shrink-0 lg:hidden' :
-          titlePart.type === 'MIDDLE' ? 'truncate px-2.5 hidden lg:block' :
-          titlePart.type === 'LAST-1' ? 'shrink-0 whitespace-pre' :
-          titlePart.type === 'LAST-0' ? 'pl-2.5 truncate' : 'px-2.5 truncate'"
+        :class="type === 'ELLIPSIS' ? 'px-2.5 shrink-0 lg:hidden' :
+          type === 'MIDDLE' ? 'truncate px-2.5 hidden lg:block' :
+          type === 'LAST-PART-END' ? 'shrink-0 whitespace-pre' :
+          type === 'LAST-PART-START' ? 'pl-2.5 truncate' : 'px-2.5 truncate'"
       >
-        <template v-if="titlePart.title === '...'">
+        <template v-if="type === 'ELLIPSIS'">
           <Tooltip>
-            <span>...</span>
+            <span>{{ text }}</span>
             <template #popper>
-              <span data-cy="tooltip-content">{{ titlePart.originalTitle }}</span>
+              <span data-cy="tooltip-content">{{ middlePartText }}</span>
             </template>
           </Tooltip>
         </template>
         <template v-else>
-          {{ titlePart.title }}
+          {{ text }}
         </template>
       </span>
     </template>
@@ -87,63 +87,79 @@ const props = defineProps<{
   expandable: boolean
 }>()
 
+type ItemType = 'SHOW_FULL' | 'MIDDLE' | 'ELLIPSIS' | 'LAST-PART-START' | 'LAST-PART-END'
+  type MappedTitlePart = {
+    text: string
+    type: ItemType
+  }
+
 const failedTestData = computed(() => {
   const runInstance = props.failedTestsResult[0].instance
   const titleParts = props.failedTestsResult[0].titleParts
 
-  type Parts = 'FIRST' | 'MIDDLE' | 'PENULTIMATE' | 'ELLIPSIS' | 'LAST-0' | 'LAST-1'
-  type MappedTitlePart = {
-    title: string
-    type: Parts
-    originalTitle?: string
-  }
   let isFirstMiddleAdded: boolean = false
-  const mappedTitleParts: MappedTitlePart[] = titleParts.map<MappedTitlePart | MappedTitlePart[]>((ele, index, parts) => {
+
+  const mappedTitleParts: MappedTitlePart[] = titleParts.map<MappedTitlePart | MappedTitlePart[]>((titlePart, index, parts) => {
     if (index === 0) {
+      // always use the whole first part of the title
       return {
-        title: ele,
-        type: 'FIRST',
+        text: titlePart,
+        type: 'SHOW_FULL',
       }
     }
 
     if (index === parts.length - 1) {
+      // split the last part into 2 pieces, so that we can truncate the first half if needed,
+      // and still show the end of the text.
       return [
         {
-          title: ele.slice(0, ele.length - 15),
-          type: 'LAST-0',
+          text: titlePart.slice(0, titlePart.length - 15),
+          type: 'LAST-PART-START',
         },
         {
-          title: ele.slice(ele.length - 15),
-          type: 'LAST-1',
+          text: titlePart.slice(titlePart.length - 15),
+          type: 'LAST-PART-END',
         },
       ]
     }
 
     if (index === parts.length - 2 && parts.length >= 3) {
+      // this is the second-last part of the title,
+      // and will be the *third-to-last* item in the array.
+
+      // We only label this SHOW_FULL if there are enough
+      // actual parts in the title that it is required to separate this
+      // from "middle" items that may be hidden in smaller screens
+
       return {
-        title: ele,
-        type: 'PENULTIMATE',
+        text: titlePart,
+        type: 'SHOW_FULL',
       }
     }
 
     if (!isFirstMiddleAdded && parts.length > 3) {
       isFirstMiddleAdded = true
 
+      // a fake part with type ELLIPSIS is shown conditionally
+      // at smaller screen sizes
+
+      // we insert it here and will flatten the result later
+      // to undo the nesting this creates
       return [
         {
-          title: '...',
+          text: '...',
           type: 'ELLIPSIS',
-          originalTitle: ele,
         },
         {
-          title: ele,
+          text: titlePart,
           type: 'MIDDLE',
         },
       ]
     }
 
-    return { title: ele, type: 'MIDDLE' }
-  }).flat()
+    return { text: titlePart, type: 'MIDDLE' }
+  })
+  .flat() // flatten the array since one of the internal items may itself be an array.
 
   return {
     debugArtifacts: [
@@ -153,6 +169,13 @@ const failedTestData = computed(() => {
     ],
     mappedTitleParts,
   }
+})
+
+const middlePartText = computed(() => {
+  return failedTestData.value.mappedTitleParts
+  .filter((item) => item.type === 'MIDDLE')
+  .map((item) => item.text)
+  .join(' > ')
 })
 
 </script>

--- a/packages/app/src/debug/DebugFailedTest.vue
+++ b/packages/app/src/debug/DebugFailedTest.vue
@@ -30,7 +30,17 @@
           titlePart.type === 'LAST-1' ? 'shrink-0 whitespace-pre' :
           titlePart.type === 'LAST-0' ? 'pl-2.5 truncate' : 'px-2.5 truncate'"
       >
-        {{ titlePart.title }}
+        <template v-if="titlePart.title === '...'">
+          <Tooltip>
+            <span>...</span>
+            <template #popper>
+              <span data-cy="tooltip-content">{{ titlePart.originalTitle }}</span>
+            </template>
+          </Tooltip>
+        </template>
+        <template v-else>
+          {{ titlePart.title }}
+        </template>
       </span>
     </template>
     <div
@@ -69,6 +79,7 @@ import GroupedDebugFailedTestVue from './GroupedDebugFailedTest.vue'
 import { computed } from 'vue'
 import type { TestResults } from './DebugSpec.vue'
 import type { StatsMetadata_GroupsFragment } from '../generated/graphql'
+import Tooltip from '@packages/frontend-shared/src/components/Tooltip.vue'
 
 const props = defineProps<{
   failedTestsResult: TestResults[]
@@ -84,6 +95,7 @@ const failedTestData = computed(() => {
   type MappedTitlePart = {
     title: string
     type: Parts
+    originalTitle?: string
   }
   let isFirstMiddleAdded: boolean = false
   const mappedTitleParts: MappedTitlePart[] = titleParts.map<MappedTitlePart | MappedTitlePart[]>((ele, index, parts) => {
@@ -121,6 +133,7 @@ const failedTestData = computed(() => {
         {
           title: '...',
           type: 'ELLIPSIS',
+          originalTitle: ele,
         },
         {
           title: ele,

--- a/packages/app/src/debug/DebugFailedTest.vue
+++ b/packages/app/src/debug/DebugFailedTest.vue
@@ -32,7 +32,9 @@
       >
         <template v-if="type === 'ELLIPSIS'">
           <Tooltip>
-            <span>{{ text }}</span>
+            <!-- button gives us free keyboard focus activation of the tooltip -->
+            <button>{{ text }}</button>
+            <span class="sr-only">{{ middlePartText }}</span>
             <template #popper>
               <span data-cy="tooltip-content">{{ middlePartText }}</span>
             </template>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #25339

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

NA, merging to feature branch

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Added an optional `originalTitle` property to the `MappedTitlePart` type. There are numerous other ways to handle this but this one seems fine to me. We could maybe work on the readability of this component at a future time.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Visit the component test for `DebugFailedTest.vue` and let it run. Observe tooltip appears when you hover over the ellipses: 

<img width="748" alt="Screen Shot 2023-01-04 at 1 05 17 PM" src="https://user-images.githubusercontent.com/8340719/210620763-aafe1766-9d40-4076-a5ff-958be80426d2.png">

Sections that are truncated by ellipses, but still visible, will not have this tooltip, based on the wording of the original issue. To do that we would need a little more sophisticated approached to determine that the browser has truncated the text and conditionally enable the tooltip, the presence of the class alone is not enough. So that is out of scope for this ticket.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
