### PR TITLE
fix: re-enable CYPRESS_INTERNAL_VITE_DEV development

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "check-ts": "vue-tsc --noEmit",
     "build-prod-ui": "cross-env NODE_ENV=production vite build",
-    "clean": "rimraf dist && rimraf ./node_modules/.vite && echo 'cleaned'",
+    "clean": "rimraf dist && echo 'cleaned'",
     "clean-deps": "rimraf node_modules",
     "test": "echo 'ok'",
     "cypress:run-cypress-in-cypress": "cross-env CYPRESS_INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT=1 HTTP_PROXY_TARGET_FOR_ORIGIN_REQUESTS=http://localhost:4455 CYPRESS_REMOTE_DEBUGGING_PORT=6666 TZ=America/New_York",

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "check-ts": "vue-tsc --noEmit",
     "build-prod-ui": "cross-env NODE_ENV=production vite build",
-    "clean": "rimraf dist && rimraf ./node_modules/.vite && rimraf dist-e2e && echo 'cleaned'",
+    "clean": "rimraf dist && rimraf dist-e2e && echo 'cleaned'",
     "clean-deps": "rimraf node_modules",
     "test": "yarn cypress:run:ct && yarn types",
     "windi": "yarn windicss-analysis",

--- a/scripts/gulp/gulpConstants.ts
+++ b/scripts/gulp/gulpConstants.ts
@@ -3,7 +3,7 @@
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
-      CYPRESS_INTERNAL_ENV: 'staging' | 'development' | 'production'
+      CYPRESS_INTERNAL_ENV?: 'staging' | 'development' | 'production'
     }
   }
 }

--- a/scripts/gulp/tasks/gulpVite.ts
+++ b/scripts/gulp/tasks/gulpVite.ts
@@ -75,7 +75,7 @@ function spawnViteDevServer (
 ) {
   return spawnUntilMatch(prefix, {
     command,
-    match: 'dev server running at',
+    match: /VITE v(\d+.)+ ready in \d+/,
     options,
   })
 }

--- a/scripts/gulp/utils/childProcessUtils.ts
+++ b/scripts/gulp/utils/childProcessUtils.ts
@@ -10,6 +10,7 @@ import util from 'util'
 
 import { prefixLog, prefixStream } from './prefixStream'
 import { addChildProcess } from '../tasks/gulpRegistry'
+import stripAnsi from 'strip-ansi'
 
 export type AllSpawnableApps =
   | `cmd-${string}`
@@ -45,7 +46,7 @@ export async function spawnUntilMatch (
   spawned(prefix, config.command, {
     ...config.options,
     tapOut (chunk, enc, cb) {
-      if (!ready && String(chunk).match(config.match)) {
+      if (!ready && stripAnsi(String(chunk)).match(config.match)) {
         ready = true
         setTimeout(() => dfd.resolve(), 20) // flush the rest of the chunks
       }
@@ -172,16 +173,19 @@ export const execAsync = async (
   const { silent } = options
 
   if (!silent) {
+    // eslint-disable-next-line no-console
     console.log(command)
   }
 
   const result = await execAsyncLocal(command, options)
 
   if (!silent && typeof result.stdout === 'string' && result.stdout.length) {
+    // eslint-disable-next-line no-console
     console.log(result.stdout)
   }
 
   if (!silent && typeof result.stderr === 'string' && result.stderr.length) {
+    // eslint-disable-next-line no-console
     console.error(result.stderr)
   }
 


### PR DESCRIPTION
### User facing changelog
n/a

### Additional details
`CYPRESS_INTERNAL_VITE_DEV=1 yarn dev` was not working due to Vite updates changing the stdout and causing our process spawner to not proceed with the gulp process. I also added `stripAnsi` to the matcher as the Vite stdout is colorful.

I also removed the `rimraf ./node_modules/.vite` as that is where the vite optimized deps live. @tgriesser do you remember why we had to do this? Maybe CI will tell me after I break everything...

### Steps to test
Run `CYPRESS_INTERNAL_VITE_DEV=1 yarn dev`. I had to run this, try and navigate to the app and then restart the process. Vite was optimizing deps but there was too many and it was timing out. It got closer and closer each time and then eventually started working. I'm on a slow machine though so maybe it was just a me thing.

### How has the user experience changed?
Faster dev environment when making changes to the app/launchpad. Updates went from 20s to less than 1 second.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
