### PR TITLE
feat: Debug failed test limit (#25418)

### DIFF
--- a/packages/app/src/debug/DebugContainer.cy.tsx
+++ b/packages/app/src/debug/DebugContainer.cy.tsx
@@ -221,6 +221,24 @@ describe('<DebugContainer />', () => {
       cy.findByTestId('debug-spec-item').should('be.visible')
     })
 
+    it('renders failed test limit when exceeded', () => {
+      cy.mountFragment(DebugSpecsFragmentDoc, {
+        onResult: (result) => {
+          if (result.currentProject?.cloudProject?.__typename === 'CloudProject') {
+            const test = result.currentProject.cloudProject.runByNumber
+
+            result.currentProject.cloudProject.runByNumber = {
+              ...CloudRunStubs.failingWithTests,
+              totalFailed: 120,
+            } as typeof test
+          }
+        },
+        render: (gqlVal) => <DebugContainer gql={gqlVal} />,
+      })
+
+      cy.findByTestId('debug-spec-limit').should('be.visible')
+    })
+
     context('newer relevant run available', () => {
       it('displays newer run with progress when running', () => {
         cy.mountFragment(DebugSpecsFragmentDoc, {

--- a/packages/app/src/debug/DebugContainer.vue
+++ b/packages/app/src/debug/DebugContainer.vue
@@ -39,6 +39,10 @@
           v-if="run.totalFailed && shouldDisplaySpecsList(run.status)"
           :specs="debugSpecsArray"
         />
+        <DebugSpecLimitBanner
+          v-if="run.totalFailed && run.totalFailed >= 100"
+          :cloud-run-url="run.url"
+        />
       </template>
     </div>
     <div
@@ -65,6 +69,7 @@ import DebugNotLoggedIn from './empty/DebugNotLoggedIn.vue'
 import DebugNoProject from './empty/DebugNoProject.vue'
 import DebugNoRuns from './empty/DebugNoRuns.vue'
 import DebugError from './empty/DebugError.vue'
+import DebugSpecLimitBanner from './DebugSpecLimitBanner.vue'
 import DebugNewRelevantRunBar from './DebugNewRelevantRunBar.vue'
 import { specsList } from './utils/DebugMapping'
 import type { CloudRunHidingReason } from './DebugOverLimit.vue'
@@ -115,7 +120,7 @@ fragment DebugSpecs on Query {
             id
             ...DebugPageDetails_cloudCiBuildInfo
           }
-          testsForReview {
+          testsForReview(limit: 100) {
             id
             ...DebugSpecListTests
           }

--- a/packages/app/src/debug/DebugContainer.vue
+++ b/packages/app/src/debug/DebugContainer.vue
@@ -40,7 +40,8 @@
           :specs="debugSpecsArray"
         />
         <DebugSpecLimitBanner
-          v-if="run.totalFailed && run.totalFailed >= 100"
+          v-if="run.totalFailed && run.totalFailed > 100"
+          :failed-test-count="run.totalFailed"
           :cloud-run-url="run.url"
         />
       </template>

--- a/packages/app/src/debug/DebugNewRelevantRunBar.vue
+++ b/packages/app/src/debug/DebugNewRelevantRunBar.vue
@@ -72,7 +72,7 @@ function navigateToNewerRun () {
 </script>
 <style scoped>
 #metadata li:last-child::before {
-  content: '.';
-  @apply -mt-8px text-lg text-gray-400 pr-8px
+  content: '•';
+  @apply text-lg text-gray-400 pr-8px
 }
 </style>

--- a/packages/app/src/debug/DebugPageHeader.vue
+++ b/packages/app/src/debug/DebugPageHeader.vue
@@ -151,7 +151,7 @@ const totalDuration = useDurationFormat(debug.value.totalDuration ?? 0)
 </script>
 <style scoped>
 [data-cy=metadata] li:not(:first-child)::before {
-  content: '.';
-  @apply -mt-8px text-lg text-gray-400 pr-8px
+  content: '•';
+  @apply text-lg text-gray-400 pr-8px
 }
 </style>

--- a/packages/app/src/debug/DebugSpecLimitBanner.cy.tsx
+++ b/packages/app/src/debug/DebugSpecLimitBanner.cy.tsx
@@ -1,0 +1,36 @@
+import DebugSpecLimitBanner from './DebugSpecLimitBanner.vue'
+import { defaultMessages } from '@cy/i18n'
+
+describe('<DebugSpecLimitBanner />', () => {
+  it('renders expected copy and link', () => {
+    cy.mount(() => (
+      <DebugSpecLimitBanner
+        failedTestCount={120}
+        cloudRunUrl="#"
+      />
+    ))
+
+    cy.contains(defaultMessages.debugPage.limit.title)
+    cy.contains(defaultMessages.debugPage.limit.message.split('|')[0].trim().replace('{n}', '120'))
+    cy.contains(defaultMessages.debugPage.limit.link)
+
+    cy.viewport(1000, 400)
+    cy.percySnapshot('large viewport')
+
+    cy.viewport(600, 400)
+    cy.percySnapshot('small viewport')
+  })
+
+  it('does not render link if no url provided', () => {
+    cy.mount(() => (
+      <DebugSpecLimitBanner
+        failedTestCount={120}
+        cloudRunUrl={null}
+      />
+    ))
+
+    cy.get('a').should('not.exist')
+
+    cy.percySnapshot()
+  })
+})

--- a/packages/app/src/debug/DebugSpecLimitBanner.vue
+++ b/packages/app/src/debug/DebugSpecLimitBanner.vue
@@ -1,0 +1,44 @@
+<template>
+  <div
+    id="limit-row"
+    data-cy="debug-spec-limit"
+    class="w-full py-16px px-24px gap-y-1"
+  >
+    <ul class="rounded flex flex-row flex-wrap bg-indigo-50 border-indigo-100 p-12px p-4 gap-x-2 items-center whitespace-nowrap children:flex children:items-center">
+      <li class="font-medium text-sm text-gray-900">
+        {{ t('debugPage.limit.title') }}
+      </li>
+      <li class="font-normal text-sm text-gray-700">
+        {{ t('debugPage.limit.message', { n: failedTestCount }) }}
+      </li>
+      <li
+        v-if="cloudRunUrl"
+        class="text-sm"
+      >
+        <ExternalLink :href="cloudRunUrl">
+          {{ t('debugPage.limit.link') }}
+        </ExternalLink>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import ExternalLink from '@cy/gql-components/ExternalLink.vue'
+import { useI18n } from '@cy/i18n'
+
+const { t } = useI18n()
+
+defineProps<{
+  failedTestCount: number
+  cloudRunUrl: string | null
+}>()
+
+</script>
+
+<style scoped>
+#limit-row li:not(:first-child)::before {
+  content: '.';
+  @apply -mt-8px text-lg text-gray-500 pr-8px
+}
+</style>

--- a/packages/app/src/debug/DebugSpecLimitBanner.vue
+++ b/packages/app/src/debug/DebugSpecLimitBanner.vue
@@ -38,7 +38,7 @@ defineProps<{
 
 <style scoped>
 #limit-row li:not(:first-child)::before {
-  content: '.';
-  @apply -mt-8px text-lg text-gray-500 pr-8px
+  content: '•';
+  @apply text-lg text-gray-500 pr-8px
 }
 </style>

--- a/packages/app/src/runs/RunCard.vue
+++ b/packages/app/src/runs/RunCard.vue
@@ -133,7 +133,7 @@ const tags = computed(() => {
 
 <style scoped>
 li:not(:first-child)::before {
-  content: '.';
-  @apply -mt-8px text-lg text-gray-400 pr-8px
+  content: '•';
+  @apply text-lg text-gray-400 pr-8px
 }
 </style>

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -644,6 +644,11 @@
     }
   },
   "debugPage": {
+    "limit": {
+      "title": "Cypress renders up to 100 failed test results",
+      "message": "This run has {n} failed tests | This run has {n} failed test | This run has {n} failed tests",
+      "link": "See all test results in Cypress Cloud"
+    },
     "runFailures": {
       "btn": "Run Failures",
       "notFoundLocally": "Spec was not found locally",


### PR DESCRIPTION
- Closes #25418

### User facing changelog
No changelog entry, part of IATR feature

### Additional details
* Restricting gql query to pull back max of 100 failed tests to guard against very large suites with lots of failing tests
* Adding new info banner to inform user to 100 test limit being exceeded

### Steps to test
Component tests have been updated, easiest way to test is to work with mock data in those

### How has the user experience changed?
*New Banner*
![Screen Shot 2023-01-11 at 9 36 35 AM](https://user-images.githubusercontent.com/11482842/211850083-f9f918eb-7bd7-4ae2-8cb5-34bf14ba65b0.png)

*New Banner (narrow viewport)*
![Screen Shot 2023-01-11 at 9 36 46 AM](https://user-images.githubusercontent.com/11482842/211850114-e4a2f4b7-cc6f-4b3a-a370-3025696b16c7.png)

*New Banner (no cloud run url available)*
![Screen Shot 2023-01-11 at 9 36 55 AM](https://user-images.githubusercontent.com/11482842/211850141-2531217c-d830-4a27-b9fc-0393196edfe7.png)

*New banner being displayed in DebugContainer (note mocked data so test count does not actually match here)*
![Screen Shot 2023-01-11 at 9 39 21 AM](https://user-images.githubusercontent.com/11482842/211850170-383fe609-e3e9-4903-b9de-b547442a71ef.png)

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
