### PR TITLE
feat: support data-qa selector in selector playground

### DIFF
--- a/packages/driver/cypress/e2e/cypress/selector_playground.cy.js
+++ b/packages/driver/cypress/e2e/cypress/selector_playground.cy.js
@@ -2,7 +2,7 @@ const { $ } = window.Cypress.$Cypress
 const SelectorPlayground = Cypress.SelectorPlayground
 
 const SELECTOR_DEFAULTS = [
-  'data-cy', 'data-test', 'data-testid', 'id', 'class', 'tag', 'attributes', 'nth-child',
+  'data-cy', 'data-test', 'data-testid', 'data-qa', 'id', 'class', 'tag', 'attributes', 'nth-child',
 ]
 
 describe('src/cypress/selector_playground', () => {

--- a/packages/driver/src/cypress/selector_playground.ts
+++ b/packages/driver/src/cypress/selector_playground.ts
@@ -4,7 +4,7 @@ import uniqueSelector from '@cypress/unique-selector'
 import $utils from './utils'
 import $errUtils from './error_utils'
 
-const SELECTOR_PRIORITIES = 'data-cy data-test data-testid id class tag attributes nth-child'.split(' ')
+const SELECTOR_PRIORITIES = 'data-cy data-test data-testid data-qa id class tag attributes nth-child'.split(' ')
 
 type Defaults = {
   onElement: Cypress.SelectorPlaygroundDefaultsOptions['onElement'] | null


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/25305

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

Support `data-qa` selector in Selector Playground in addition to `data-cy`, `data-test` and `data-testid`.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

It's common to use `data-qa` when indicating selectors used in End to End tests. QA engineers are one of the most common cohorts using Cypress Studio, so it follows we should respect `data-qa` alongside `data-test*` and `data-cy`.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

You can point this branch at a project with `data-qa` and try using Selector Playground. I also recorded a video so you can see it in action.

https://user-images.githubusercontent.com/19196536/212788773-c92c4127-4b20-4755-b327-f09c962814bd.mp4

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/4986
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
