### PR TITLE
fix: allow chaining on `exist` Chai override with HTML elements

### DIFF
--- a/packages/driver/cypress/e2e/commands/assertions.cy.js
+++ b/packages/driver/cypress/e2e/commands/assertions.cy.js
@@ -1408,6 +1408,20 @@ describe('src/cy/commands/assertions', () => {
 
         cy.get('#does-not-exist').should('not.exist')
       })
+
+      context('with a jQuery selector', () => {
+        it('can be chained', () => {
+          cy.get('#foo').should('exist').and('exist')
+        })
+      })
+
+      context('with an HTML element', () => {
+        it('can be chained', () => {
+          cy.document().then((doc) => {
+            cy.wrap(doc.getElementById('foo')).should('exist').and('exist')
+          })
+        })
+      })
     })
 
     describe('#be.visible', () => {

--- a/packages/driver/src/cy/chai.ts
+++ b/packages/driver/src/cy/chai.ts
@@ -400,7 +400,7 @@ chai.use((chai, u) => {
         } else {
           let isAttached
 
-          if (!obj.length) {
+          if ($dom.isJquery(obj) && !obj.length) {
             this._obj = null
           }
 


### PR DESCRIPTION
- Closes #25491

### User facing changelog

- Fixed a bug where the `exist` assertion did not allow chaining additional assertions when used with an HTML element (not jQuery selector).

### Additional details

N/A

### Steps to test

N/A

### How has the user experience changed?

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
