### PR TITLE
fix: update query names for better logging

### DIFF
--- a/packages/data-context/src/sources/RelevantRunSpecsDataSource.ts
+++ b/packages/data-context/src/sources/RelevantRunSpecsDataSource.ts
@@ -4,7 +4,7 @@ import debugLib from 'debug'
 import { isEqual } from 'lodash'
 
 import type { DataContext } from '../DataContext'
-import type { CloudSpecStatus, Query, RelevantRun, CurrentProjectRelevantRunSpecs, CloudSpecRun, CloudRun } from '../gen/graphcache-config.gen'
+import type { CloudSpecStatus, Query, RelevantRun, CurrentProjectRelevantRunSpecs, CloudSpecRun, CloudRun, CloudRunGroup, CloudRunGroupStatusEnum } from '../gen/graphcache-config.gen'
 import { Poller } from '../polling'
 import type { CloudRunStatus } from '@packages/graphql/src/gen/cloud-source-types.gen'
 
@@ -19,6 +19,10 @@ const RELEVANT_RUN_SPEC_OPERATION_DOC = gql`
       id
       status
       groupIds
+    }
+    groups {
+      id
+      status
     }
   }
 
@@ -86,15 +90,26 @@ export class RelevantRunSpecsDataSource {
     return this.#cached.runSpecs
   }
 
-  #calculateSpecMetadata (specs: CloudSpecRun[]) {
+  #calculateSpecMetadata (specs: CloudSpecRun[], groups: CloudRunGroup[]) {
     //mimic logic in Cloud to sum up the count of groups per spec to give the total spec counts
-    const countGroupsForSpec = (specs: CloudSpecRun[]) => {
+    const countGroupsForSpecs = (specs: CloudSpecRun[]) => {
       return specs.map((spec) => spec.groupIds?.length || 0).reduce((acc, curr) => acc += curr, 0)
     }
 
+    const groupStatusById = groups.reduce<Record<string, CloudRunGroupStatusEnum>>((acc, curr) => {
+      acc[curr.id] = curr.status
+
+      return acc
+    }, {})
+
     return {
-      totalSpecs: countGroupsForSpec(specs),
-      completedSpecs: countGroupsForSpec(specs.filter((spec) => !INCOMPLETE_STATUSES.includes(spec.status || 'UNCLAIMED'))),
+      totalSpecs: countGroupsForSpecs(specs),
+      completedSpecs:
+      specs.flatMap((spec) => spec.groupIds) // pull out the group ids
+      .filter((groupId): groupId is string => !!groupId) //make sure there are no undefined values
+      .map((groupId) => groupStatusById[groupId]) //find the status for that group
+      .filter((status) => !INCOMPLETE_STATUSES.includes(status || 'UNCLAIMED')) //filter to only "complete" statuses
+      .length, //count them
     }
   }
 
@@ -154,7 +169,7 @@ export class RelevantRunSpecsDataSource {
 
       if (cloudProject.current && cloudProject.current.runNumber && cloudProject.current.status) {
         runSpecsToReturn.runSpecs.current = {
-          ...this.#calculateSpecMetadata(cloudProject.current.specs || []),
+          ...this.#calculateSpecMetadata(cloudProject.current.specs || [], cloudProject.current.groups || []),
           runNumber: cloudProject.current.runNumber,
         }
 
@@ -163,7 +178,7 @@ export class RelevantRunSpecsDataSource {
 
       if (cloudProject.next && cloudProject.next.runNumber && cloudProject.next.status) {
         runSpecsToReturn.runSpecs.next = {
-          ...this.#calculateSpecMetadata(cloudProject.next.specs || []),
+          ...this.#calculateSpecMetadata(cloudProject.next.specs || [], cloudProject.next.groups || []),
           runNumber: cloudProject.next.runNumber,
         }
 

--- a/packages/data-context/src/sources/RelevantRunsDataSource.ts
+++ b/packages/data-context/src/sources/RelevantRunsDataSource.ts
@@ -10,7 +10,7 @@ import { Poller } from '../polling'
 const debug = debugLib('cypress:data-context:sources:RelevantRunsDataSource')
 
 const RELEVANT_RUN_OPERATION_DOC = gql`
-  query RelevantRunsDataSource_latestRunUpdateSpecData(
+  query RelevantRunsDataSource_RunsByCommitShas(
     $projectSlug: String!
     $shas: [String!]!
   ) {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

The GQL query names for the new relevant run datasources had copy/paste names for the query names.  This made the analytics tracking in Honeycomb confusing because different queries had the same name, that was also poorly named.  This update gives each query a unique name that matches up with the datasource and operation it represents.

This PR also updates the logic for calculating the spec counts shown when a run is RUNNING in the cloud. The new logic sums up the groupIds for each spec to count them individually.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Use the App to access the Debug page against production Cloud.

Check the logging in honeycomb to confirm that the new GQL query names are being logged

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ n/a] Have tests been added/updated?
- [ n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
