### PR TITLE
fix: percy - wait to take snapshot until previous tooltips are gone

### DIFF
--- a/packages/app/src/settings/project/ConfigCode.cy.tsx
+++ b/packages/app/src/settings/project/ConfigCode.cy.tsx
@@ -75,8 +75,10 @@ describe('<ConfigCode />', () => {
         .should('contain.text', 'plugin')
       })
 
-      // Take a snapshot of the last case
-      cy.percySnapshot()
+      cy.get('.v-popper__popper--shown').should('have.length', 1).then(() => {
+        // Take a snapshot after the other tooltips have closed
+        cy.percySnapshot()
+      })
     })
 
     it('shows the objectTest nicely', () => {

--- a/packages/app/src/settings/project/ConfigCode.cy.tsx
+++ b/packages/app/src/settings/project/ConfigCode.cy.tsx
@@ -75,10 +75,8 @@ describe('<ConfigCode />', () => {
         .should('contain.text', 'plugin')
       })
 
-      cy.get('.v-popper__popper--shown').should('have.length', 1).then(() => {
-        // Take a snapshot after the other tooltips have closed
-        cy.percySnapshot()
-      })
+      // Take a snapshot of the last case
+      cy.percySnapshot()
     })
 
     it('shows the objectTest nicely', () => {
@@ -120,6 +118,7 @@ describe('<ConfigCode />', () => {
         valElement.realHover()
 
         cy.get('.v-popper__popper--shown')
+        .should('have.length', 1)
         .should('be.visible')
         .should('contain.text', 'env')
       })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### User facing changelog
<!-- 
Explain the change(s) for every user to read in our changelog. Examples: https://on.cypress.io/changelog
If the change is not user-facing, write "n/a".
-->

n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

In `ConfigCode.cy.tsx`, we're taking a snapshot with Percy that flakes sometimes because the snapshot sometimes happens before the previous hovered tooltip has faded of screen. I added an assertion to wait until there's only one tooltip on screen before taking the snapshot. This should make the snapshot more stable.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Check out the Percy snapshot result from CI. We should see it fail on this branch, but once it's built in develop, it shouldn't flake anymore. I noticed this on the [build on Mike's PR](https://percy.io/cypress-io/cypress/builds/24344886/changed/1361783143?browser=chrome&browser_ids=31&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=800&widths=450%2C800) where it flaked.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
