### PR TITLE
fix: custom command with prevSubject = 'optional' typescript definition added

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -583,6 +583,12 @@ declare namespace Cypress {
 
       /**
        * Add a custom child or dual command
+       * @see https://on.cypress.io/api/commands#Custom-Dual-Command
+       */
+      add<T extends keyof Chainable, S = any>(name: T, options: CommandOptions & {prevSubject: 'optional'}, fn: CommandFnWithSubject<T, S | undefined>): void
+
+      /**
+       * Add a custom child or dual command
        * @see https://on.cypress.io/api/commands#Validations
        */
       add<T extends keyof Chainable, S extends PrevSubject>(


### PR DESCRIPTION
- Closes #25526

**User facing changelog**
n/a

**Additional details**
Added a missing type definiton for added custom commands using the optional prevSubject

**Steps to test**
try code
`
Cypress.Commands.add(
  'typescriptBroken',
  {
    prevSubject: 'optional',
  },
  (): Cypress.Chainable<JQuery<HTMLElement>> => {
    return cy.get('');
  }
);
`

**How has the user experience changed?**
Typescript definition improved

PR Tasks
[n/a] Have tests been added/updated?
[n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
[n/a] Has a PR for user-facing changes been opened in [cypress-documentation](https://github.com/cypress-io/cypress-documentation)?
[n/a] Have API changes been updated in the [type definitions](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?