### PR TITLE
fix: allow version 9 of the babel-loader peer dependency

### DIFF
--- a/npm/webpack-preprocessor/package.json
+++ b/npm/webpack-preprocessor/package.json
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "@babel/core": "^7.0.1",
     "@babel/preset-env": "^7.0.0",
-    "babel-loader": "^8.0.2",
+    "babel-loader": "^8.0.2 || ^9",
     "webpack": "^4 || ^5"
   },
   "files": [


### PR DESCRIPTION
- Closes [24435](https://github.com/cypress-io/cypress/issues/24435)

### Additional details
There is a dependency issue between babel-loader and @cypress/webpack-preprocessor. The installation of this newer babel-loader version should not cause package install issues. The user should be able to install both v8 and v9 of @babel/loader.

### Steps to test
Just forcing an install with babel-loader@^9 is enough to test that everything works.
Since the main breaking change in [v9](https://github.com/babel/babel-loader/releases/tag/v9.0.0) is dropping Webpack v4 and @cypress/webpack-preprocessor already allows for v5, I think it is safe to allow this change. If necessary, we could also update the @babel/core peer dependency to ^7.12, but babel-loader already has it declared as a peer dependency, so as you see fit.


### PR Tasks
- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
