### PR TITLE
feat(driver): hide/show logs

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,12 @@
- <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
-## 12.4.1
+<!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 12.5.0
 
 _Released 01/31/2023 (PENDING)_
+
+**Features:**
+
+- Added a new `hide` property to `Cypress.Log` and `cy.log` that enables
+  selectively hiding/showing specific Command Log entries. Added in [#25579](https://github.com/cypress-io/cypress/pull/25579).
 
 ## 12.4.0
 

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -6140,6 +6140,8 @@ declare namespace Cypress {
     autoEnd: boolean
     /** Set to true to immediately finish the log  */
     end: boolean
+    /** Should this log be hidden in the Command Log? */
+    hide: boolean
     /** Return an object that will be printed in the dev tools console */
     consoleProps(): ObjectLike
   }

--- a/packages/driver/cypress/e2e/cypress/log.cy.js
+++ b/packages/driver/cypress/e2e/cypress/log.cy.js
@@ -108,4 +108,71 @@ describe('src/cypress/log', function () {
       expect(LogUtils.countLogsByTests(tests)).to.equal(0)
     })
   })
+
+  context('hiding logs', () => {
+    beforeEach(() => {
+      Cypress.log({ message: 'always visible', name: 'log-test' })
+      Cypress.log({ message: 'always hidden', hide: true, name: 'log-test' })
+    })
+
+    function getMessages () {
+      return cy.wrap(window.top.document)
+      .find('.command-name-log-test .command-message-text')
+    }
+
+    it('can hide a log and then display it', () => {
+      const log = Cypress.log({
+        name: 'log-test',
+        message: 'hidden then shown',
+        hide: true,
+      })
+
+      getMessages()
+      .should((els) => {
+        const messages = [...els].map((el) => el.innerText)
+
+        expect(messages).to.have.length(1)
+        expect(messages[0]).to.eq('always visible')
+      })
+      .then(() => {
+        log.set('hide', false)
+      })
+
+      getMessages()
+      .should((els) => {
+        const messages = [...els].map((el) => el.innerText)
+
+        expect(messages).to.have.length(2)
+        expect(messages[0]).to.eq('always visible')
+        expect(messages[1]).to.eq('hidden then shown')
+      })
+    })
+
+    it('can show a log and then hide it', () => {
+      const log = Cypress.log({
+        name: 'log-test',
+        message: 'shown then hidden',
+      })
+
+      getMessages()
+      .should((els) => {
+        const messages = [...els].map((el) => el.innerText)
+
+        expect(messages).to.have.length(2)
+        expect(messages[0]).to.eq('always visible')
+        expect(messages[1]).to.eq('shown then hidden')
+      })
+      .then(() => {
+        log.set('hide', true)
+      })
+
+      getMessages()
+      .should((els) => {
+        const messages = [...els].map((el) => el.innerText)
+
+        expect(messages).to.have.length(1)
+        expect(messages[0]).to.eq('always visible')
+      })
+    })
+  })
 })

--- a/packages/driver/src/cypress/log.ts
+++ b/packages/driver/src/cypress/log.ts
@@ -14,7 +14,7 @@ import type { StateFunc } from './state'
 const groupsOrTableRe = /^(groups|table)$/
 const parentOrChildRe = /parent|child|system/
 const SNAPSHOT_PROPS = 'id snapshots $el url coords highlightAttr scrollBy viewportWidth viewportHeight'.split(' ')
-const DISPLAY_PROPS = 'id alias aliasType callCount displayName end err event functionName groupLevel hookId instrument isStubbed group message method name numElements numResponses referencesAlias renderProps sessionInfo state testId timeout type url visible wallClockStartedAt testCurrentRetry'.split(' ')
+const DISPLAY_PROPS = 'id alias aliasType callCount displayName end err event functionName groupLevel hookId instrument isStubbed group message method name numElements numResponses referencesAlias renderProps sessionInfo state testId timeout type url visible wallClockStartedAt testCurrentRetry hide'.split(' ')
 const BLACKLIST_PROPS = 'snapshots'.split(' ')
 
 let counter = 0

--- a/packages/reporter/src/commands/command-model.ts
+++ b/packages/reporter/src/commands/command-model.ts
@@ -31,7 +31,14 @@ export interface CommandProps extends InstrumentProps {
   renderProps?: RenderProps
   sessionInfo?: SessionProps['sessionInfo']
   timeout?: number
+  /**
+   * Is the targeted element visible?
+   */
   visible?: boolean
+  /**
+   * Should this command be hidden from the Command Log?
+   */
+  hide?: boolean
   wallClockStartedAt?: string
   hookId: string
   isStudio?: boolean
@@ -50,7 +57,14 @@ export default class Command extends Instrument {
   @observable number?: number
   @observable numElements: number
   @observable timeout?: number
+  /**
+   * Is the targeted element visible?
+  */
   @observable visible?: boolean
+  /**
+  * Should this command be hidden from the Command Log?
+  */
+  @observable hide?: boolean
   @observable wallClockStartedAt?: string
   @observable children: Array<Command> = []
   @observable hookId: string
@@ -144,6 +158,7 @@ export default class Command extends Instrument {
     // command log that are not associated with elements will not have a visibility
     // attribute set. i.e. cy.visit(), cy.readFile() or cy.log()
     this.visible = props.visible === undefined || props.visible
+    this.hide = props.hide
     this.wallClockStartedAt = props.wallClockStartedAt
     this.hookId = props.hookId
     this.isStudio = !!props.isStudio
@@ -173,6 +188,7 @@ export default class Command extends Instrument {
     // command log that are not associated with elements will not have a visibility
     // attribute set. i.e. cy.visit(), cy.readFile() or cy.log()
     this.visible = props.visible === undefined || props.visible
+    this.hide = props.hide
     this.timeout = props.timeout
     this.hasSnapshot = props.hasSnapshot
     this.hasConsoleProps = props.hasConsoleProps

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -352,6 +352,10 @@ class Command extends Component<Props> {
       return null
     }
 
+    if (model.hide) {
+      return null
+    }
+
     const commandName = model.name ? nameClassName(model.name) : ''
     const groupPlaceholder: Array<JSX.Element> = []
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details

- For #7362, we need a way to dynamically hide/show logs after they have been rendered
- `Log` has a `visible` property, but that actually represents if the targeted elements are visible in the DOM, not if the log itself is visible
- `reporter:log:remove` is available, but it actually *removes* the log from the Command Log, so it can't be made visible again
- Alternatively, could've added `reporter:log:insert`, but this would put the onus on the consumer of the API to keep track of the correct before/after log to re-insert, which could be tricky.
	- `hide` is way simpler.
- Q: Why `hide` and not `show`? A: `hide: false` is the reasonable default here, and it adds the least interruption to existing consumers of the API to do it this way.

### Steps to test

See added tests for an example.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
