### PR TITLE
chore: bump version and remove misleading changelog entry

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,12 +1,11 @@
  <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 12.4.1
 
-_Released 01/26/2023_
+_Released 01/27/2023_
 
 **Bugfixes:**
 
 - Fixed a regression from Cypress [12.4.0](https://docs.cypress.io/guides/references/changelog#12-4-0) where Cypress was not exiting properly when running multiple Component Testing specs in `electron` in `run` mode. Fixes [#25568](https://github.com/cypress-io/cypress/issues/25568).
-- Fixed an issue where alternative Microsoft Edge Beta and Canary binary names were not being discovered by Cypress. Fixes [#25455](https://github.com/cypress-io/cypress/issues/25455).
 
 **Dependency Updates:**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress",
-  "version": "12.4.0",
+  "version": "12.4.1",
   "description": "Cypress is a next generation front end testing tool built for the modern web",
   "private": true,
   "scripts": {


### PR DESCRIPTION
### Additional details
bump and remove edge changelog entry as the edge work was a 2-parter and hasn't been complete.

### Steps to test
n/a

### How has the user experience changed?
n/a

### PR Tasks
n/a

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
