### PR TITLE
fix: debug dismiss filter and sidebar on runner

### DIFF
--- a/packages/app/src/App.vue
+++ b/packages/app/src/App.vue
@@ -5,10 +5,9 @@
     />
   </router-view>
 
-  <template v-if="route.name && route.name !== 'SpecRunner'">
+  <template v-if="!isRunMode">
     <!--
-      checking for existence of `route.name` here to avoid a flash
-      of these components if the page is refreshed on the SpecRunner route
+      avoiding graphql in run mode
     -->
     <CloudViewerAndProject />
     <LoginConnectModals />
@@ -16,12 +15,9 @@
 </template>
 
 <script setup lang="ts">
+import { isRunMode } from '@packages/frontend-shared/src/utils/isRunMode'
 import LoginConnectModals from '@cy/gql-components/LoginConnectModals.vue'
-
-import { useRoute } from 'vue-router'
 import CloudViewerAndProject from '@packages/frontend-shared/src/gql-components/CloudViewerAndProject.vue'
-const route = useRoute()
-
 </script>
 
 <style lang="scss">

--- a/packages/app/src/App.vue
+++ b/packages/app/src/App.vue
@@ -5,9 +5,10 @@
     />
   </router-view>
 
-  <template v-if="!isRunMode">
+  <template v-if="route.name && route.name !== 'SpecRunner'">
     <!--
-      avoiding graphql in run mode
+      checking for existence of `route.name` here to avoid a flash
+      of these components if the page is refreshed on the SpecRunner route
     -->
     <CloudViewerAndProject />
     <LoginConnectModals />
@@ -15,9 +16,12 @@
 </template>
 
 <script setup lang="ts">
-import { isRunMode } from '@packages/frontend-shared/src/utils/isRunMode'
 import LoginConnectModals from '@cy/gql-components/LoginConnectModals.vue'
+
+import { useRoute } from 'vue-router'
 import CloudViewerAndProject from '@packages/frontend-shared/src/gql-components/CloudViewerAndProject.vue'
+const route = useRoute()
+
 </script>
 
 <style lang="scss">

--- a/packages/reporter/cypress/e2e/header.cy.ts
+++ b/packages/reporter/cypress/e2e/header.cy.ts
@@ -8,10 +8,14 @@ describe('header', () => {
   let runner: EventEmitter
   let runnables: RootRunnable
 
-  function setupReporter (opts?: { testFilter: TestFilter, totalUnfilteredTests: number }) {
-    cy.fixture('runnables').then((_runnables) => {
-      runnables = _runnables
-    })
+  function setupReporter (opts?: { testFilter: TestFilter, totalUnfilteredTests: number, skipRunnableCreation?: boolean}) {
+    if (opts?.skipRunnableCreation) {
+      runnables = {}
+    } else {
+      cy.fixture('runnables').then((_runnables) => {
+        runnables = _runnables
+      })
+    }
 
     runner = new EventEmitter()
 
@@ -239,15 +243,17 @@ describe('header', () => {
   })
 
   describe('debug test filter', () => {
-    beforeEach(() => {
-      setupReporter({ testFilter: ['suite 1 test 2'], totalUnfilteredTests: 10 })
-    })
-
     it('displays debug filter when Cypress.testFilter is defined', () => {
+      setupReporter({ testFilter: ['suite 1 test 2'], totalUnfilteredTests: 10 })
       cy.spy(runner, 'emit').as('debugDismiss')
       cy.get('.debug-dismiss').contains(`8 / 10 tests`).click()
       cy.get('@debugDismiss').should('have.been.called')
       cy.percySnapshot()
+    })
+
+    it('does not display filter when there are no tests', () => {
+      setupReporter({ testFilter: ['suite 1 test 2'], totalUnfilteredTests: 10, skipRunnableCreation: true })
+      cy.get('.debug-dismiss').should('not.exist')
     })
   })
 })

--- a/packages/reporter/src/header/header.tsx
+++ b/packages/reporter/src/header/header.tsx
@@ -41,7 +41,7 @@ const Header = observer(({ appState, events = defaultEvents, statsStore, runnabl
       </button>
     </Tooltip>
     <div className='spacer' />
-    {runnablesStore.testFilter && <DebugDismiss matched={runnablesStore.totalTests} total={runnablesStore.totalUnfilteredTests} />}
+    {runnablesStore.testFilter && runnablesStore.totalTests > 0 && <DebugDismiss matched={runnablesStore.totalTests} total={runnablesStore.totalUnfilteredTests} />}
     <Stats stats={statsStore} />
     <Controls appState={appState} />
   </header>


### PR DESCRIPTION
This will not show the debug filter dismiss button at the top of the runner unless there are more than 0 filtered tests.  This prevents a UI flicker of showing a "0/X tests" for a second when loading and dismissing this button.

Also, this fixes an issue with the sidebar debug badge not updating correctly when on the runner.  There was a check to not mount the "CloudViewerAndProject" comoponent in App.vue when it was on the runner's route.  We now need it for the sidebar, so the check was changed to not mount when in in run mode.