### PR TITLE
fix: invalidate cache for debug page after run status change

### DIFF
--- a/packages/data-context/src/sources/RelevantRunSpecsDataSource.ts
+++ b/packages/data-context/src/sources/RelevantRunSpecsDataSource.ts
@@ -206,6 +206,13 @@ export class RelevantRunSpecsDataSource {
         //if statuses change, then let debug page know to refresh runs
         if (statusesChanged) {
           debug('Run statuses changed')
+          const projectSlug = await this.ctx.project.projectId()
+
+          if (projectSlug) {
+            debug(`Invalidate cloudProjectBySlug ${projectSlug}`)
+            await this.ctx.cloud.invalidate('Query', 'cloudProjectBySlug', { slug: projectSlug })
+          }
+
           this.ctx.emitter.relevantRunChange(runs)
         }
       })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

If the Debug page only finds one relevant run for a given git history, and that run is currently running, then the Debug page shows a progress message showing the number of specs completed.

<img width="671" alt="image" src="https://user-images.githubusercontent.com/1702361/215365296-6efe46e9-ad5a-4a0b-a846-8622ae65eb2a.png">

As soon as the run is finished, if the run had test failures, then the page should update to show the failures.  Prior to this update, the Urql cache would cache the run as soon as the user viewed the Debug page to see the first run in the running state.  If the user was watching the Debug before the run started recording, then no test failures would show up because the cached GraphQL query would not have any. If the user went to the Debug page after the run started recording, then various amounts of tests could be cached.  

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

* Use or create a project that is connected to Cypress Cloud with no runs (or you can archive any existing runs)
* Open the app and go to the Debug page
* Start recording the project to the cloud that will have a few test failures in it.  You can use either the command line or rely on CI 
* The Debug page should update to show the screen shown above and show the spec counts as the complete.  
* Once the run completes, the page should update and you should see all the test failures that are reported in the Cloud project.

**NOTE** If you want to see the code work incorrectly, the use the `feature/IATR-M0` branch before this PR is merged.  

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

The user will see all of the failed tests on the Debug page after an initial run has completed.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [-] Have tests been added/updated?
- [-] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [-] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [-] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
