### PR TITLE
chore: Update README to add Cloud badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ yarn add cypress --dev
 
 ## Contributing
 
-- [![CircleCI](https://circleci.com/gh/cypress-io/cypress/tree/develop.svg?style=svg)](https://circleci.com/gh/cypress-io/cypress/tree/develop) - `develop` branch
+[![cypress](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/simple/ypt4pf/develop&style=flat&logo=cypress)](https://cloud.cypress.io/projects/ypt4pf/runs)
+[![CircleCI](https://circleci.com/gh/cypress-io/cypress/tree/develop.svg?style=svg)](https://circleci.com/gh/cypress-io/cypress/tree/develop) -  `develop` branch
 
 Please see our [Contributing Guideline](./CONTRIBUTING.md) which explains repo organization, linting, testing, and other steps.
 
@@ -79,7 +80,13 @@ This project is licensed under the terms of the [MIT license](/LICENSE).
 
 ## Badges
 
-Let the world know your project is using Cypress.io to test with this cool badge
+Configure a badge for your project's README to show your test status or test count in the [Cypress Cloud](https://www.cypress.io/cloud).
+
+[![cypress](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/simple/ypt4pf/develop&style=flat&logo=cypress)](https://cloud.cypress.io/projects/ypt4pf/runs)
+
+[![cypress](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/count/ypt4pf/develop&style=flat&logo=cypress)](https://cloud.cypress.io/projects/ypt4pf/runs)
+
+Or let the world know your project is using Cypress with the badge below.
 
 [![Cypress.io](https://img.shields.io/badge/tested%20with-Cypress-04C38E.svg)](https://www.cypress.io/)
 


### PR DESCRIPTION
### Additional details

I was just looking through the Cloud project settings and saw there's a Badges area and realized, we don't have the Cloud badge on our Readme! 

This adds the Cloud badge for our own usage in the contributing section - 'passed/failed' status alongside CircleCI's status badge.

<img width="609" alt="Screen Shot 2023-01-31 at 10 51 33 AM" src="https://user-images.githubusercontent.com/1271364/215811488-e4457a0c-0d5b-446e-98e8-98f57f28fa24.png">

It also explains in the 'Badges' section of our Readme how one could add a Cloud badge or the one provided for non-Cloud users. Just a little bit of marketing.

<img width="614" alt="Screen Shot 2023-01-31 at 10 51 41 AM" src="https://user-images.githubusercontent.com/1271364/215811733-a8bc045a-75fa-42e1-83c0-552dd9067a59.png">

You can look at the [Readme](https://github.com/cypress-io/cypress#readme) today to see what it looks like before. 