### PR TITLE
chore: renovate semantic types and percy ci updates

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -15,9 +15,9 @@ _Released 01/31/2023_
 
 - Fixed an issue where alternative Microsoft Edge Beta, Canary, and Dev binary versions were not being discovered by Cypress. Fixes [#25455](https://github.com/cypress-io/cypress/issues/25455).
 
-<!-- **Dependency Updates:** // this was committed with 'fix' instead of 'dependency' -->
+**Dependency Updates:**
 
-- Upgraded [`underscore.string`](https://github.com/esamattis/underscore.string/blob/HEAD/CHANGELOG.markdown) from `3.3.5` to `3.3.6` to reference rebuilt assets after security patch to fix regular expression DDOS exploit. Fixed in [#25574](https://github.com/cypress-io/cypress/pull/25574).
+- Upgraded [`underscore.string`](https://github.com/esamattis/underscore.string/blob/HEAD/CHANGELOG.markdown) from `3.3.5` to `3.3.6` to reference rebuilt assets after security patch to fix regular expression DDOS exploit. Addressed in [#25574](https://github.com/cypress-io/cypress/pull/25574).
 
 ## 12.4.1
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "config:base"
   ],
-  "automerge": true,
+  "automerge": false,
   "major": {
     "automerge": false
   },
@@ -23,5 +23,19 @@
   "schedule": [
     "before 3am on the first day of the month"
   ],
-  "dependencyDashboardApproval": true
+  "dependencyDashboardApproval": true,
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "devDependencies"
+      ],
+      "semanticCommitType": "chore"
+    },
+    {
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "semanticCommitType": "dependency"
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -27,13 +27,14 @@
   "packageRules": [
     {
       "matchPackagePatterns": [
-        "devDependencies"
+        "*"
       ],
       "semanticCommitType": "chore"
     },
     {
       "matchDepTypes": [
-        "dependencies"
+        "dependencies",
+        "require"
       ],
       "semanticCommitType": "dependency"
     }

--- a/scripts/wait-on-circle-jobs.js
+++ b/scripts/wait-on-circle-jobs.js
@@ -15,10 +15,6 @@ const jobName = process.env.CIRCLE_JOB || 'wait-on-circle-jobs'
 
 const workflowId = process.env.CIRCLE_WORKFLOW_ID
 
-const branchesToAlwaysFinalize = ['develop']
-
-const requireAllJobsToPass = !branchesToAlwaysFinalize.includes(process.env.CIRCLE_BRANCH)
-
 const getAuth = () => `${process.env.CIRCLE_TOKEN}:`
 
 const verifyCI = () => {
@@ -86,7 +82,7 @@ const waitForAllJobs = async (jobNames, workflowId) => {
   const runningJobNames = _.map(runningJobs, 'name')
   const failedJobNames = _.map(failedJobs, 'name')
 
-  if (requireAllJobsToPass && _.intersection(jobNames, failedJobNames).length) {
+  if (_.intersection(jobNames, failedJobNames).length) {
     console.error('At least one failing job has prevented percy-finalize from running', failedJobs)
     process.exit(1)
   }


### PR DESCRIPTION
## update renovate semantic type

Ensure renovate uses the correct semantic types for PR opened in the repo. Currently it defaults to  https://docs.renovatebot.com/presets-default/#semanticprefixfixdepschoreothers

## Percy CI update
only finalize when the jobs pass otherwise you can never get a green build on develop without restarting the entire workflow.

