### PR TITLE
test: fix flaky migration test 

### DIFF
--- a/packages/data-context/src/actions/MigrationActions.ts
+++ b/packages/data-context/src/actions/MigrationActions.ts
@@ -170,8 +170,7 @@ export class MigrationActions {
   async initialize (config: LegacyCypressConfigJson) {
     const legacyConfigForMigration = await this.setLegacyConfigForMigration(config)
 
-    // for testing mainly, we want to ensure the flags are reset each test
-    this.resetFlags()
+    this.reset(legacyConfigForMigration)
 
     if (!this.ctx.currentProject || !legacyConfigForMigration) {
       throw Error('cannot do migration without currentProject!')
@@ -435,11 +434,9 @@ export class MigrationActions {
     }
   }
 
-  resetFlags () {
+  reset (config?: LegacyCypressConfigJson) {
     this.ctx.update((coreData) => {
-      const defaultFlags = makeCoreData().migration.flags
-
-      coreData.migration.flags = defaultFlags
+      coreData.migration = { ...makeCoreData().migration, legacyConfigForMigration: config }
     })
   }
 }

--- a/packages/data-context/src/actions/ProjectActions.ts
+++ b/packages/data-context/src/actions/ProjectActions.ts
@@ -98,6 +98,7 @@ export class ProjectActions {
       d.app.browserStatus = 'closed'
     })
 
+    this.ctx.actions.migration.reset()
     await this.ctx.lifecycleManager.clearCurrentProject()
     resetIssuedWarnings()
     await this.api.closeActiveProject()

--- a/packages/data-context/src/data/ProjectConfigManager.ts
+++ b/packages/data-context/src/data/ProjectConfigManager.ts
@@ -135,6 +135,12 @@ export class ProjectConfigManager {
           ...loadConfigReply.requires,
           this.configFilePath,
         ])
+
+        // Only call "to{App,Launchpad}" once the config is done loading.
+        // Calling this in a "finally" would trigger this emission for every
+        // call to get the config (which we do a lot)
+        this.options.ctx.emitter.toLaunchpad()
+        this.options.ctx.emitter.toApp()
       }
 
       return loadConfigReply.initialConfig
@@ -147,10 +153,10 @@ export class ProjectConfigManager {
       this._state = 'errored'
       await this.closeWatchers()
 
-      throw error
-    } finally {
       this.options.ctx.emitter.toLaunchpad()
       this.options.ctx.emitter.toApp()
+
+      throw error
     }
   }
 

--- a/packages/data-context/src/data/ProjectLifecycleManager.ts
+++ b/packages/data-context/src/data/ProjectLifecycleManager.ts
@@ -103,6 +103,11 @@ export class ProjectLifecycleManager {
 
   async getProjectId (): Promise<string | null> {
     try {
+      // No need to kick off config initialization if we need to migrate
+      if (this.ctx.migration.needsCypressJsonMigration()) {
+        return null
+      }
+
       const contents = await this.ctx.project.getConfig()
 
       return contents.projectId ?? null
@@ -458,8 +463,6 @@ export class ProjectLifecycleManager {
     const legacyConfigPath = path.join(projectRoot, this.ctx.migration.legacyConfigFile)
 
     if (needsCypressJsonMigration && !this.ctx.isRunMode && this.ctx.fs.existsSync(legacyConfigPath)) {
-      this.legacyMigration(legacyConfigPath).catch(this.onLoadError)
-
       return false
     }
 
@@ -470,8 +473,9 @@ export class ProjectLifecycleManager {
     return this.metaState.hasValidConfigFile
   }
 
-  private async legacyMigration (legacyConfigPath: string) {
+  async legacyMigration () {
     try {
+      const legacyConfigPath = path.join(this.projectRoot, this.ctx.migration.legacyConfigFile)
       // we run the legacy plugins/index.js in a child process
       // and mutate the config based on the return value for migration
       // only used in open mode (cannot migrate via terminal)
@@ -480,8 +484,6 @@ export class ProjectLifecycleManager {
       // should never throw, unless there existing pluginsFile errors out,
       // in which case they are attempting to migrate an already broken project.
       await this.ctx.actions.migration.initialize(legacyConfig)
-
-      this.ctx.emitter.toLaunchpad()
     } catch (error) {
       this.onLoadError(error)
     }

--- a/packages/frontend-shared/src/gql-components/HeaderBarContent.vue
+++ b/packages/frontend-shared/src/gql-components/HeaderBarContent.vue
@@ -217,6 +217,10 @@ mutation GlobalPageHeader_clearCurrentProject {
     currentProject {
       id
     }
+    # This ensures the cache is updated with null after clearing project
+    migration {
+      configFileNameBefore
+    }
   }
 }
 `

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -80,8 +80,6 @@ function renameSupport (lang: 'js' | 'ts' | 'coffee' = 'js') {
 }
 
 describe('global mode', () => {
-  // TODO: Figure out why it is flaky. Seems to be due to MigrationWizard query being executed multiple times
-  // see: https://github.com/cypress-io/cypress/issues/25377
   it('migrates 2 projects in global mode', () => {
     cy.openGlobalMode()
     cy.addProject('migration-e2e-export-default')

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -82,7 +82,7 @@ function renameSupport (lang: 'js' | 'ts' | 'coffee' = 'js') {
 describe('global mode', () => {
   // TODO: Figure out why it is flaky. Seems to be due to MigrationWizard query being executed multiple times
   // see: https://github.com/cypress-io/cypress/issues/25377
-  it.skip('migrates 2 projects in global mode', () => {
+  it('migrates 2 projects in global mode', () => {
     cy.openGlobalMode()
     cy.addProject('migration-e2e-export-default')
     cy.addProject('migration-e2e-custom-integration-with-projectId')


### PR DESCRIPTION
Closes https://github.com/cypress-io/cypress/issues/25377

### Additional details
Changes how the Migration flow is kicked off. Before, it was invoked when a project was clicked which lead to an initial query loading with `null` values. Now, the query is what kicks off the migration.

Most of the optimizations are around reducing the number of `toLaunchpad` calls the app was making, causing the query to re-execute multiple times.

It was hard to reproduce this failure locally as it seems to be influenced by machine resources. 

### Steps to test
Run the `migrations.cy.ts` e2e test in Launchpad

### How has the user experience changed?
Screenshots show a reduced number of the migration query

<img width="874" alt="Screen Shot 2023-02-01 at 1 26 07 PM" src="https://user-images.githubusercontent.com/25158820/216144568-1f6579ac-c2d9-4554-bfb3-5c495768b89d.png">

<img width="897" alt="Screen Shot 2023-02-01 at 1 31 21 PM" src="https://user-images.githubusercontent.com/25158820/216144495-aebaaab8-b9dc-4fa5-b7ef-7897a56b6520.png">


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
