### PR TITLE
fix: `test:after:run` passes the `runnable`

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,8 @@
  <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 12.5.1
 
+_Released 02/10/2023 (PENDING)_
+
 **Bugfixes:**
 
 - Fixed a regression from Cypress [12.5.0](https://docs.cypress.io/guides/references/changelog#12-5-0) where the `runnable` was not included in the `test:after:run` event. Fixes [#25663](https://github.com/cypress-io/cypress/issues/25663).

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
  <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 12.5.1
+
+_Released 02/02/2023_ PENDING
+
+**Bugfixes:**
+
+- Fixed a regression from Cypress [12.5.0](https://docs.cypress.io/guides/references/changelog#12-5-0) where the `runnable` was not included in the `test:after:run` event. Fixes [#25663](https://github.com/cypress-io/cypress/issues/25663).
+
 ## 12.5.0
 
 _Released 01/31/2023_

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -5976,14 +5976,14 @@ declare namespace Cypress {
      * Useful to see how internal cypress commands utilize the {% url 'Cypress.log()' cypress-log %} API.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'log:added', fn: (log: any, interactive: boolean) => void): Cypress
+    (action: 'log:added', fn: (attributes: ObjectLike, log: any) => void): Cypress
     /**
      * Fires whenever a command's attributes changes.
      * This event is debounced to prevent it from firing too quickly and too often.
      * Useful to see how internal cypress commands utilize the {% url 'Cypress.log()' cypress-log %} API.
      * @see https://on.cypress.io/catalog-of-events#App-Events
      */
-    (action: 'log:changed', fn: (log: any, interactive: boolean) => void): Cypress
+    (action: 'log:changed', fn: (attributes: ObjectLike, log: any) => void): Cypress
     /**
      * Fires before the test and all **before** and **beforeEach** hooks run.
      * @see https://on.cypress.io/catalog-of-events#App-Events

--- a/cli/types/tests/actions.ts
+++ b/cli/types/tests/actions.ts
@@ -61,15 +61,22 @@ Cypress.on('command:retry', (command) => {
   command // $ExpectType CommandQueue
 })
 
-Cypress.on('log:added', (log, interactive: boolean) => {
+Cypress.on('log:added', (attributes, log) => {
+  attributes // $ExpectType ObjectLike
   log // $ExpectTyped any
 })
 
-Cypress.on('log:changed', (log, interactive: boolean) => {
+Cypress.on('log:changed', (attributes, log) => {
+  attributes // $ExpectType ObjectLike
   log // $ExpectTyped any
 })
 
 Cypress.on('test:before:run', (attributes , test) => {
+  attributes // $ExpectType ObjectLike
+  test // $ExpectType Test
+})
+
+Cypress.on('test:before:run:async', (attributes , test) => {
   attributes // $ExpectType ObjectLike
   test // $ExpectType Test
 })

--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -537,8 +537,8 @@ export class EventManager {
     Cypress.on('after:screenshot', handleAfterScreenshot)
 
     driverTestEvents.forEach((event) => {
-      Cypress.on(event, (test, cb) => {
-        this.reporterBus.emit(event, test, cb)
+      Cypress.on(event, (test, _runnable) => {
+        this.reporterBus.emit(event, test, Cypress.config('isInteractive'))
       })
     })
 

--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -38,7 +38,6 @@ interface AddGlobalListenerOptions {
 
 const driverToLocalAndReporterEvents = 'run:start run:end'.split(' ')
 const driverToSocketEvents = 'backend:request automation:request mocha recorder:frame'.split(' ')
-const driverTestEvents = 'test:before:run:async test:after:run'.split(' ')
 const driverToLocalEvents = 'viewport:changed config stop url:changed page:loading visit:failed visit:blank cypress:in:cypress:runner:event'.split(' ')
 const socketRerunEvents = 'runner:restart watched:file:changed'.split(' ')
 const socketToDriverEvents = 'net:stubbing:event request:event script:error cross:origin:cookies'.split(' ')
@@ -536,17 +535,19 @@ export class EventManager {
 
     Cypress.on('after:screenshot', handleAfterScreenshot)
 
-    driverTestEvents.forEach((event) => {
-      Cypress.on(event, (test, _runnable) => {
-        this.reporterBus.emit(event, test, Cypress.config('isInteractive'))
-      })
-    })
-
     driverToLocalAndReporterEvents.forEach((event) => {
       Cypress.on(event, (...args) => {
         this.localBus.emit(event, ...args)
         this.reporterBus.emit(event, ...args)
       })
+    })
+
+    Cypress.on('test:before:run:async', (test, _runnable) => {
+      this.reporterBus.emit('test:before:run:async', test)
+    })
+
+    Cypress.on('test:after:run', (test, _runnable) => {
+      this.reporterBus.emit('test:after:run', test, Cypress.config('isInteractive'))
     })
 
     Cypress.on('run:start', async () => {

--- a/packages/driver/cypress/e2e/cypress/events.cy.ts
+++ b/packages/driver/cypress/e2e/cypress/events.cy.ts
@@ -1,0 +1,204 @@
+import { LogUtils } from '../../../src/cypress/log'
+
+describe('src/cypress', () => {
+  describe('events', () => {
+    it('fail event', (done) => {
+      cy.on('fail', (err, runnable) => {
+        expect(err.message).to.equal('foo')
+        expect(runnable).to.equal(Cypress.state('runnable'))
+
+        done()
+      })
+
+      throw new Error('foo')
+    })
+
+    it('viewport:changed event', () => {
+      let called = false
+
+      cy.on('viewport:changed', (viewport) => {
+        expect(viewport).to.deep.equal({ viewportWidth: 100, viewportHeight: 100 })
+        called = true
+      })
+
+      cy.viewport(100, 100).then(() => {
+        expect(called).to.be.true
+      })
+    })
+
+    it('scrolled event', (done) => {
+      cy.viewport(100, 100)
+      Cypress.$('<button>button</button>')
+      .attr('id', 'button')
+      .css({
+        position: 'absolute',
+        left: '0px',
+        top: '50px',
+      })
+      .appendTo(cy.$$('body'))
+
+      cy.on('scrolled', ($el, type) => {
+        expect($el[0]).to.eq(Cypress.$('#button')[0])
+        expect(type).to.eq('element')
+
+        done()
+      })
+
+      cy.get('#button').trigger('mousedown')
+    })
+
+    context('command events', () => {
+      it('command:enqueued event', () => {
+        let called = false
+
+        const handler = (command) => {
+          expect(command.name).to.eq('log')
+          called = true
+          cy.off('command:enqueued', handler)
+        }
+
+        cy.on('command:enqueued', handler)
+
+        cy.log('foo').then(() => {
+          expect(called).to.be.true
+        })
+      })
+
+      it('command:start event', () => {
+        let called = false
+
+        const handler = (command) => {
+          expect(command.attributes.name).to.eq('log')
+          called = true
+          cy.off('command:start', handler)
+        }
+
+        cy.on('command:start', handler)
+
+        cy.log('foo').then(() => {
+          expect(called).to.be.true
+        })
+      })
+
+      it('command:end event', () => {
+        let called = false
+
+        const handler = (command) => {
+          expect(command.attributes.name).to.eq('log')
+          called = true
+          cy.off('command:end', handler)
+        }
+
+        cy.on('command:end', handler)
+
+        cy.log('foo').then(() => {
+          expect(called).to.be.true
+        })
+      })
+
+      it('command:retry event', (done) => {
+        const handler = (options) => {
+          expect(options._retries).to.equal(1)
+          expect(options.error.message).to.equal('Expected to find element: `#foo`, but never found it.')
+          done()
+        }
+
+        cy.on('command:retry', handler)
+
+        cy.get('#foo')
+      })
+    })
+
+    context('log events', () => {
+      it('log:added event', () => {
+        const attrs: any[] = []
+        const logs: any[] = []
+
+        const handler = (attr, log) => {
+          attrs.push(attr)
+          logs.push(log)
+        }
+
+        cy.on('log:added', handler)
+
+        Cypress.log({ name: 'log', message: `foo` })
+
+        cy.log('foo').then(() => {
+          expect(attrs[0].name).to.eq('log')
+          expect(logs[0].attributes.name).to.eq('log')
+        })
+      })
+
+      it('log:changed event', (done) => {
+        const handler = (attr, log) => {
+          expect(attr.name).to.eq('bar')
+          expect(log.attributes.name).to.eq('bar')
+          done()
+        }
+
+        const log = Cypress.log({ message: `foo` })
+
+        cy.on('log:changed', handler)
+
+        log?.set('name', 'bar')
+      })
+    })
+
+    // these tests need to be run together since they are testing lifecycle events
+    context('lifecycle (test:before/after:run) events', () => {
+      let afterRunnable
+      let beforeRunnable
+      let beforeAsyncRunnable
+      let expectedAfterRunnable
+
+      const beforeHandler = (test, runnable) => {
+        expect(test.title).to.eq('test 2')
+
+        beforeRunnable = runnable
+        Cypress.off('test:before:run', beforeHandler)
+      }
+
+      const beforeAsyncHandler = (test, runnable) => {
+        expect(test.title).to.eq('test 2')
+
+        beforeAsyncRunnable = runnable
+        Cypress.off('test:before:run:async', beforeAsyncHandler)
+      }
+
+      const afterHandler = (test, runnable) => {
+        expect(test.title).to.eq('test 1')
+
+        afterRunnable = runnable
+        Cypress.off('test:after:run', afterHandler)
+      }
+
+      before(() => {
+        Cypress.on('test:before:run', beforeHandler)
+        Cypress.on('test:before:run:async', beforeAsyncHandler)
+        Cypress.on('test:after:run', afterHandler)
+      })
+
+      after(() => {
+        Cypress.off('test:before:run', beforeHandler)
+        Cypress.off('test:before:run:async', beforeAsyncHandler)
+        Cypress.off('test:after:run', afterHandler)
+      })
+
+      it('test 1', () => {
+        // this is the runnable that we expect to be passed to the test:after:run event
+        // and it will be verified in the next test since we need to wait for the test to finish
+        expectedAfterRunnable = Cypress.state('runnable')
+      })
+
+      it('test 2', () => {
+        // the before runnables should be from this test
+        // use toSerializedJSON to remove the circular references
+        expect(LogUtils.toSerializedJSON(beforeAsyncRunnable)).to.deep.equal(LogUtils.toSerializedJSON(Cypress.state('runnable')))
+        expect(LogUtils.toSerializedJSON(beforeRunnable)).to.deep.equal(LogUtils.toSerializedJSON(Cypress.state('runnable')))
+
+        // the after runnable should be from the previous test
+        expect(afterRunnable).to.eq(expectedAfterRunnable)
+      })
+    })
+  })
+})

--- a/packages/driver/cypress/e2e/cypress/events.cy.ts
+++ b/packages/driver/cypress/e2e/cypress/events.cy.ts
@@ -129,6 +129,7 @@ describe('src/cypress', () => {
 
       it('log:changed event', (done) => {
         const handler = (attr, log) => {
+          cy.off('log:changed', handler)
           expect(attr.name).to.eq('bar')
           expect(log.attributes.name).to.eq('bar')
           done()

--- a/packages/driver/cypress/e2e/cypress/events.cy.ts
+++ b/packages/driver/cypress/e2e/cypress/events.cy.ts
@@ -1,5 +1,3 @@
-import { LogUtils } from '../../../src/cypress/log'
-
 describe('src/cypress', () => {
   describe('events', () => {
     it('fail event', (done) => {
@@ -192,12 +190,14 @@ describe('src/cypress', () => {
 
       it('test 2', () => {
         // the before runnables should be from this test
-        // use toSerializedJSON to remove the circular references
-        expect(LogUtils.toSerializedJSON(beforeAsyncRunnable)).to.deep.equal(LogUtils.toSerializedJSON(Cypress.state('runnable')))
-        expect(LogUtils.toSerializedJSON(beforeRunnable)).to.deep.equal(LogUtils.toSerializedJSON(Cypress.state('runnable')))
+        const runnable = Cypress.state('runnable')
+
+        // use === to avoid the circular references
+        expect(beforeAsyncRunnable === runnable).to.be.true
+        expect(beforeRunnable === runnable).to.be.true
 
         // the after runnable should be from the previous test
-        expect(afterRunnable).to.eq(expectedAfterRunnable)
+        expect(afterRunnable).to.deep.equal(expectedAfterRunnable)
       })
     })
   })

--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -551,7 +551,7 @@ class $Cypress {
 
         // this event is how the reporter knows how to display
         // stats and runnable properties such as errors
-        this.emit('test:after:run', args[0], this.config('isInteractive'))
+        this.emit('test:after:run', ...args)
         this.maybeEmitCypressInCypress('mocha', 'test:after:run', args[0])
 
         if (this.config('isTextTerminal')) {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #25663

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
The `runnable` parameter was inadvertently removed with https://github.com/cypress-io/cypress/commit/facfd0d88c6060a2179c684e03a699c47ca659c5. Added the parameter back by refactoring to not modify the Cypress `test:after:run` event and instead pass along the `isInteractive` parameter to the reporter from the runner.

Also noticed the `log:added` and `log:changed` events were incorrectly typed stating they were passing the `interactive` boolean as the second parameter when in actuality the `log` was the second parameter and the `interactive` parameter is not being passed.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
