### PR TITLE
chore: Fix flaky origin .wait() test

### DIFF
--- a/packages/driver/cypress/e2e/e2e/origin/commands/waiting.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/commands/waiting.cy.ts
@@ -3,41 +3,24 @@ import { findCrossOriginLogs } from '../../../../support/utils'
 declare global {
   interface Window {
     xhrGet: any
-    abortRequests: any
   }
 }
-
-let reqQueue: XMLHttpRequest[] = []
 
 const xhrGet = (url) => {
   const xhr = new window.XMLHttpRequest()
 
   xhr.open('GET', url)
-  reqQueue.push(xhr)
   xhr.send()
-}
-
-const abortRequests = () => {
-  reqQueue.forEach((xhr) => xhr.abort())
-  reqQueue = []
 }
 
 context('cy.origin waiting', { browser: '!webkit' }, () => {
   before(() => {
     cy.origin('http://www.foobar.com:3500', () => {
-      let reqQueue: XMLHttpRequest[] = []
-
       window.xhrGet = (url) => {
         const xhr = new window.XMLHttpRequest()
 
         xhr.open('GET', url)
-        reqQueue.push(xhr)
         xhr.send()
-      }
-
-      window.abortRequests = () => {
-        reqQueue.forEach((xhr) => xhr.abort())
-        reqQueue = []
       }
     })
   })
@@ -45,12 +28,6 @@ context('cy.origin waiting', { browser: '!webkit' }, () => {
   let logs: Map<string, any>
 
   beforeEach(() => {
-    cy.origin('http://www.foobar.com:3500', () => {
-      window.abortRequests()
-    })
-
-    abortRequests()
-
     logs = new Map()
 
     cy.on('log:changed', (attrs, log) => {


### PR DESCRIPTION
### Additional details

We have a flaky test in `e2e/origin/commands/waiting` - this PR attempts to address it.

### Steps to test
Test no longer flakes; all tests in the file still pass.

### How has the user experience changed?

### PR Tasks
- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
