### PR TITLE
chore: Fix flaky test

### DIFF
--- a/packages/app/src/debug/GroupedDebugFailedTest.cy.tsx
+++ b/packages/app/src/debug/GroupedDebugFailedTest.cy.tsx
@@ -67,6 +67,12 @@ describe('<GroupedDebugFailedTest/>', () => {
   ]
 
   it('mounts correctly and shows artifacts on hover', () => {
+    // On retries in CI, the realHover() event can be persistant, causing the component to
+    // be hovered at the start of the test. We therefore hover the mouse somewhere else on the screen
+    // to reduce flake.
+    // This sort of weirdness is exactly why Cypress doesn't support a 'hover' command natively.
+    cy.get('body').realHover({ position: 'topLeft' })
+
     cy.mount(() => (
       <div class='p-24px'>
         <GroupedDebugFailedTest groups={groups} failedTests={testResult} />

--- a/packages/app/src/debug/GroupedDebugFailedTest.cy.tsx
+++ b/packages/app/src/debug/GroupedDebugFailedTest.cy.tsx
@@ -79,11 +79,6 @@ describe('<GroupedDebugFailedTest/>', () => {
       </div>
     ))
 
-    cy.get('body').click('topLeft')
-    // 👆 this click is to address some flake in CI where this component renders already in the hover state
-    // example: https://cloud.cypress.io/projects/ypt4pf/runs/43417/overview/18107774-3213-47f0-902e-79502a832c34/video?reviewViewBy=FAILED&utm_source=Dashboard&utm_medium=Share+URL&utm_campaign=Video
-    // this should avoid whatever situation leads to the appearance of being hovered right after mount.
-
     cy.findAllByTestId(`grouped-row`).should('have.length', 2).each((el) => cy.wrap(el).within(() => {
       cy.findByTestId('debug-artifacts').should('not.be.visible')
       cy.findByTestId('test-failed-metadata').realHover()


### PR DESCRIPTION
### Additional details
This PR fixes a single flaky test.

Basically, `cypress-real-events` doesn't reset the browser's cursor position between tests or retries, resulting in, in some circumstances, tests that flake depending on what exactly is run before or after them and where it positioned the virtual mouse. Also, this test would never pass while retrying.

This is why we don't use CDP for mouse events in Cypress core, despite the other advantages. Also, these tests don't work in Firefox at all.

### Steps to test

### How has the user experience changed?

### PR Tasks
- [x] Have tests been added/updated?
- [n/a] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
