### PR TITLE
fix: update newProject ref when switching between organizations in SelectCloudProjectModal

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 _Released 02/14/2023 (PENDING)_
 
 **Bugfixes:**
+
  - Fixed an issue with the Cloud project selection modal not showing the correct prompts. Fixes [#25520](https://github.com/cypress-io/cypress/issues/25520).
 
 **Features:**

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 _Released 02/14/2023 (PENDING)_
 
+**Bugfixes:**
+ - Fixed an issue with the Cloud project selection modal not showing the correct prompts. Fixes [#25520](https://github.com/cypress-io/cypress/issues/25520).
+
 **Features:**
 
 - Added the "Open in IDE" feature for failed tests reported from the Debug page. Addressed in [#25691](https://github.com/cypress-io/cypress/pull/25691).

--- a/packages/frontend-shared/src/gql-components/modals/SelectCloudProjectModal.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/modals/SelectCloudProjectModal.cy.tsx
@@ -134,6 +134,20 @@ describe('<SelectCloudProjectModal />', () => {
       mountDialog()
     })
 
+    it('can switch between organizations with and without projects', () => {
+      cy.get('[data-cy="selectOrganization"]').click()
+      cy.findByRole('listbox').within(() => cy.findAllByText('Test Org 2').click())
+
+      cy.contains('button', defaultMessages.runs.connect.modal.selectProject.connectProject).should('not.exist')
+      cy.contains('button', defaultMessages.runs.connect.modal.selectProject.createProject).should('be.visible')
+
+      cy.get('[data-cy="selectOrganization"]').click()
+      cy.findByRole('listbox').within(() => cy.findAllByText('Test Org 1').click())
+
+      cy.contains('button', defaultMessages.runs.connect.modal.selectProject.createProject).should('not.exist')
+      cy.contains('button', defaultMessages.runs.connect.modal.selectProject.connectProject).should('be.visible')
+    })
+
     context('create new project', () => {
       beforeEach(() => {
         cy.contains('a', defaultMessages.runs.connect.modal.selectProject.createNewProject).click()

--- a/packages/frontend-shared/src/gql-components/modals/SelectCloudProjectModal.vue
+++ b/packages/frontend-shared/src/gql-components/modals/SelectCloudProjectModal.vue
@@ -348,6 +348,8 @@ watch(projectOptions, (newVal, oldVal) => {
   } else {
     pickedProject.value = projectOptions.value.find((p) => p.name === projectName.value)
   }
+
+  newProject.value = projectOptions.value.length === 0
 }, {
   immediate: true,
 })

--- a/packages/frontend-shared/src/gql-components/modals/SelectCloudProjectModal.vue
+++ b/packages/frontend-shared/src/gql-components/modals/SelectCloudProjectModal.vue
@@ -344,12 +344,12 @@ watch(projectOptions, (newVal, oldVal) => {
   }
 
   if (newVal.length === 1) {
-    pickedProject.value = projectOptions.value[0]
+    pickedProject.value = newVal[0]
   } else {
-    pickedProject.value = projectOptions.value.find((p) => p.name === projectName.value)
+    pickedProject.value = newVal.find((p) => p.name === projectName.value)
   }
 
-  newProject.value = projectOptions.value.length === 0
+  newProject.value = newVal.length === 0
 }, {
   immediate: true,
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #25520 <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We weren't updating the `newProject` ref when the user switched Cloud organizations in the SelectCloudProjectModal dropdown. This lead to a state where if your first organization when you opened the modal **did** have at least one project, and then you switched to an organization that didn't have any projects, you would still see the "connect project" button and the modal state would be incorrect. See the original issue for a video.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

- Set up two organizations in Cypress Cloud - one with at least one project, and one without **any** projects (delete the default project as well)
- Open a project that is not connected to Cypress Cloud
- Open the cloud connection modal (either from the specs list, runs page, or debug page)
- Verify that when you switch between these organizations in the modal dropdown, you are correctly prompted to create a new project in your organization that doesn't have any, and are correctly prompted to connect to an existing project in the organization that does have projects

Also take a look at the tests in `SelectCloudProjectModal.cy.tsx` to understand the flow

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
