### PR TITLE
misc: Increase max failures in IATR badge to 99

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -11,6 +11,7 @@ _Released 02/14/2023 (PENDING)_
 
 - Improved the layout of the Debug Page on smaller viewports when there is a pending run. Addresses [#25664](https://github.com/cypress-io/cypress/issues/25664).
 - Icons in Debug page will no longer shrink at small viewports. Addresses [#25665](https://github.com/cypress-io/cypress/issues/25665).
+- Increased maximum number of failing tests to reflect in sidebar badge to 99. Addresses [#25662](https://github.com/cypress-io/cypress/issues/25662).
 
 **Dependency Updates:**
 

--- a/packages/app/src/navigation/SidebarNavigation.cy.tsx
+++ b/packages/app/src/navigation/SidebarNavigation.cy.tsx
@@ -170,10 +170,14 @@ describe('SidebarNavigation', () => {
     it('renders failure badge', () => {
       mountComponent({ cloudProject: { status: 'FAILED', numFailedTests: 1 } })
       cy.findByLabelText('Relevant run had 1 test failure').should('be.visible').contains('1')
-      cy.percySnapshot('Debug Badge:failed')
+      cy.percySnapshot('Debug Badge:failed:single-digit')
 
       mountComponent({ cloudProject: { status: 'FAILED', numFailedTests: 10 } })
-      cy.findByLabelText('Relevant run had 10 test failures').should('be.visible').contains('9+')
+      cy.findByLabelText('Relevant run had 10 test failures').should('be.visible').contains('10')
+      cy.percySnapshot('Debug Badge:failed:double-digit')
+
+      mountComponent({ cloudProject: { status: 'FAILED', numFailedTests: 100 } })
+      cy.findByLabelText('Relevant run had 100 test failures').should('be.visible').contains('99+')
       cy.percySnapshot('Debug Badge:failed:truncated')
     })
 

--- a/packages/app/src/navigation/SidebarNavigation.vue
+++ b/packages/app/src/navigation/SidebarNavigation.vue
@@ -202,9 +202,9 @@ watchEffect(() => {
     let countToDisplay = '0'
 
     if (totalFailed) {
-      countToDisplay = totalFailed < 9
+      countToDisplay = totalFailed < 99
         ? String(totalFailed)
-        : '9+'
+        : '99+'
     }
 
     if (status === 'FAILED') {

--- a/packages/app/src/navigation/SidebarNavigationRow.vue
+++ b/packages/app/src/navigation/SidebarNavigationRow.vue
@@ -82,7 +82,24 @@ const props = withDefaults(defineProps <{
 })
 
 const badgeVariant = computed(() => {
-  return props.isNavBarExpanded ? 'ml-16px h-20px text-sm leading-3' : 'absolute outline-gray-1000 outline-2px outline bottom-0 left-36px text-xs h-16px leading-2'
+  const classes: string[] = []
+
+  if (props.isNavBarExpanded) {
+    classes.push('ml-16px', 'h-20px', 'text-sm', 'leading-3')
+  } else {
+    classes.push('absolute', 'outline-gray-1000', 'outline-2px', 'outline', 'bottom-0', 'text-xs', 'h-16px', 'leading-2')
+
+    // Right-align failure counts within sidebar (#25662)
+    if (props.badge.status === 'failed' || props.badge.status === 'error') {
+      // Add min-width so that single-digit badge overlaps sidebar icon at least a little
+      classes.push('right-4px', 'min-w-20px', 'text-center')
+    } else {
+      // Non-failures should left-align and overflow sidebar if needed
+      classes.push('left-36px')
+    }
+  }
+
+  return classes
 })
 
 const badgeColorStyles = {

--- a/packages/app/src/navigation/SidebarNavigationRow.vue
+++ b/packages/app/src/navigation/SidebarNavigationRow.vue
@@ -89,12 +89,11 @@ const badgeVariant = computed(() => {
   } else {
     classes.push('absolute', 'outline-gray-1000', 'outline-2px', 'outline', 'bottom-0', 'text-xs', 'h-16px', 'leading-2')
 
-    // Right-align failure counts within sidebar (#25662)
-    if (props.badge.status === 'failed' || props.badge.status === 'error') {
-      // Add min-width so that single-digit badge overlaps sidebar icon at least a little
-      classes.push('right-4px', 'min-w-20px', 'text-center')
+    // Keep failure count from overflowing sidebar (#25662)
+    if ((props.badge.status === 'failed' || props.badge.status === 'error') && props.badge.value.length >= 3) {
+      classes.push('right-4px')
     } else {
-      // Non-failures should left-align and overflow sidebar if needed
+      // Anything else should left-align and overflow sidebar if needed
       classes.push('left-36px')
     }
   }


### PR DESCRIPTION
- Closes #25662 

### Additional details
Changing layout of sidebar badge when collapsed - failing test count should now right-align to prevent overflow and maximum count is increased to 99.

The layout change should only impact the failure cases when count is `99+` - lower values, "0", and "New" states should retain current behavior of left-aligning and overflowing to the right when needed. This will be changing soon in follow-on work outside this ticket.

~**Note:** I have added a "min-width" condition for failure states so that the badge at least partially overlaps the debug icon when the number of failures is a single digit. Not having this gave it a somewhat disassociated look~

### Steps to test
Review `SidebarNavigation.cy.tsx`
Review Percy snapshots

### How has the user experience changed?
| State | Screenshot |
|------|-------------|
| Passing |  ![Screenshot 2023-02-07 at 9 47 06 AM](https://user-images.githubusercontent.com/11482842/217294256-afea07a1-893a-4b09-91ef-5ca88e39b7be.png)|
| New | ![Screenshot 2023-02-07 at 9 42 02 AM](https://user-images.githubusercontent.com/11482842/217294314-9885afd9-4f42-4a99-93dc-2d1ecf7d47d5.png) |
| Failing - single digit |  ![Screenshot 2023-02-07 at 9 42 17 AM](https://user-images.githubusercontent.com/11482842/217294389-d88b7c5b-787c-459a-b627-d6272c6034cb.png)|
| Failing - double digit | ![Screenshot 2023-02-07 at 9 42 27 AM](https://user-images.githubusercontent.com/11482842/217294434-ae4a180b-1553-4e73-87ad-6782798ea403.png) |
| Failing - > 100 | ![Screenshot 2023-02-07 at 9 42 35 AM](https://user-images.githubusercontent.com/11482842/217294501-e0b4f9ce-6ba6-4b3d-92bc-75c8d65eca74.png) |

### PR Tasks
- [x] Have tests been added/updated?
- [ ] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
