### PR TITLE
chore: update changelog validation example

### DIFF
--- a/scripts/semantic-commits/validate-changelog.js
+++ b/scripts/semantic-commits/validate-changelog.js
@@ -38,7 +38,7 @@ function _getResolvedMessage (semanticType, prNumber, associatedIssues = []) {
 function _printChangeLogExample (semanticType, prNumber, associatedIssues = []) {
   const resolveMessage = _getResolvedMessage(semanticType, prNumber, associatedIssues)
 
-  return `${userFacingChanges[semanticType].section}\n - <Insert change details>. ${resolveMessage}`
+  return `${userFacingChanges[semanticType].section}\n\n - <Insert change details>. ${resolveMessage}`
 }
 
 /**
@@ -132,7 +132,7 @@ async function validateChangelog ({ changedFiles, nextVersion, pendingRelease, c
     errors.push(`A changelog entry was not found in cli/CHANGELOG.md.`)
 
     if (commits.length === 1) {
-      errors.push(`Please add a changelog entry that describes the changes. Include this entry under the section:/\n\n${_printChangeLogExample(commits[0].semanticType, commits[0].prNumber, commits[0].associatedIssues)}`)
+      errors.push(`Please add a changelog entry that describes the changes. Include this entry under the section:\n\n${_printChangeLogExample(commits[0].semanticType, commits[0].prNumber, commits[0].associatedIssues)}`)
 
       return _handleErrors(errors)
     }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

The changelog validation script expects an empty line underneath the section heading, but when we suggest an entry to the changelog, we don't print that extra line. I noticed this because I copied the text and pasted directly into the changelog, but then it failed validation.

For example, see [this output](https://github.com/cypress-io/cypress/actions/runs/4109313751/jobs/7091009614) where we don't have an extra line break below

> **Bugfixes:**

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has the original issue (or this PR, if no issue exists) been tagged with a release in ZenHub? (user-facing changes only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
