### PR TITLE
chore: update changelog linting

### DIFF
--- a/scripts/semantic-commits/get-binary-release-data.js
+++ b/scripts/semantic-commits/get-binary-release-data.js
@@ -70,7 +70,7 @@ const getReleaseData = async (latestReleaseInfo) => {
       return
     }
 
-    const { data: pullRequest } = await octokit.request('GET /repos/{owner}/{repo}/pull/{pull_number}', {
+    const { data: pullRequest } = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
       owner: 'cypress-io',
       repo: 'cypress',
       pull_number: references[0].issue,

--- a/scripts/semantic-commits/get-linked-issues.js
+++ b/scripts/semantic-commits/get-linked-issues.js
@@ -7,7 +7,7 @@ const getLinkedIssues = (body = '') => {
   // remove markdown comments
   body.replace(/(<!--.*?-->)|(<!--[\S\s]+?-->)|(<!--[\S\s]*?$)/g, '')
 
-  const references = body.match(/(close[sd]?|fix(es|ed)?|resolve[s|d]?) (cypress-io\/cypress)?#\d+/gi)
+  const references = body.match(/(close[sd]?|fix(es|ed)?|resolve[s|d]?) ((cypress-io\/cypress)?#\d+|https\:\/\/github.com\/cypress-io\/cypress\/issues\/\d+)/gi)
 
   if (!references) {
     return []

--- a/scripts/unit/semantic-commits/validate-linked-issues-spec.js
+++ b/scripts/unit/semantic-commits/validate-linked-issues-spec.js
@@ -1,13 +1,13 @@
 const { expect, use } = require('chai')
 const sinonChai = require('sinon-chai')
 
-const { getIssueNumbers } = require('../../semantic-commits/get-linked-issues')
+const { getLinkedIssues } = require('../../semantic-commits/get-linked-issues')
 
 use(sinonChai)
 
 describe('semantic-commits/get-linked-issues', () => {
   it('returns single issue link', () => {
-    const issues = getIssueNumbers(`
+    const issues = getLinkedIssues(`
         <!-- comment ->
         - Closes #23
         summary of changes see in #458
@@ -17,7 +17,7 @@ describe('semantic-commits/get-linked-issues', () => {
   })
 
   it('returns issue links for all linking keywords', () => {
-    const issues = getIssueNumbers(`
+    const issues = getLinkedIssues(`
         <!-- comment ->
         - Close #23
         - Closes #24
@@ -29,9 +29,10 @@ describe('semantic-commits/get-linked-issues', () => {
         - Resolves #46
         - addresses #77 <-- not a valid linking word
         summary of changes
+        - Closes https://github.com/cypress-io/cypress/issues/50
       `)
 
-    expect(issues).to.deep.eq(['23', '24', '25', '33', '34', '35', '44', '45', '46'])
+    expect(issues).to.deep.eq(['23', '24', '25', '33', '34', '35', '44', '45', '46', '50'])
   })
 
   it('only counts an issue once', () => {
@@ -39,7 +40,7 @@ describe('semantic-commits/get-linked-issues', () => {
         - closes #44
         - closes #44
       `
-    const issues = getIssueNumbers(body)
+    const issues = getLinkedIssues(body)
 
     expect(issues).to.deep.eq(['44'])
   })
@@ -49,13 +50,13 @@ describe('semantic-commits/get-linked-issues', () => {
         fixes cypress-io/cypress#123 which is a local issue
         and this is issue in another repo foo/bar#101
       `
-    const issues = getIssueNumbers(body)
+    const issues = getLinkedIssues(body)
 
     expect(issues).to.deep.eq(['123'])
   })
 
   it('returns empty list when no issues found', () => {
-    const issues = getIssueNumbers(`
+    const issues = getLinkedIssues(`
         <!-- comment ->
         summary of changes
       `)


### PR DESCRIPTION
In prep for today's release noticing a few things:
- recent change is invalid rest api request
- cannot share changelog entries for similar changes - we expect these types of changes to be condenses. "loosen" matching 
- PRs linking to issues with full repo url are linting the PR link should be used when the issue should be

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
