### PR TITLE
chore: making our add-to-triage-board workflow reusable within the Cypress-io org

### DIFF
--- a/.github/workflows/triage_add_to_project.yml
+++ b/.github/workflows/triage_add_to_project.yml
@@ -1,6 +1,10 @@
 name: 'Triage: add issue/PR to project'
 
 on:
+  workflow_call:
+    secrets:
+      ADD_TO_PROJECT_TOKEN:
+        required: true
   issues:
     types:
       - opened

--- a/.github/workflows/triage_add_to_project.yml
+++ b/.github/workflows/triage_add_to_project.yml
@@ -1,6 +1,7 @@
 name: 'Triage: add issue/PR to project'
 
 on:
+  # makes this workflow reusable
   workflow_call:
     secrets:
       ADD_TO_PROJECT_TOKEN:


### PR DESCRIPTION
Making our add to triage workflow callable from other projects inside the Cypress-io org in Github

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
We needed to update the yml file to allow for other project to call it directly.

### Steps to test
n/a

### How has the user experience changed?
this does not affect the app in anyway.  This only affects adding issues to our public triage board.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ n/a ] Have tests been added/updated?
- [ n/a ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ n/a ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
