### PR TITLE
feat(webpack-dev-server): Allow using custom, `react-scripts`-compati…

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3296,8 +3296,13 @@ declare namespace Cypress {
 
   type DevServerConfigOptions = {
     bundler: 'webpack'
-    framework: 'react' | 'vue' | 'vue-cli' | 'nuxt' | 'create-react-app' | 'next' | 'svelte'
+    framework: 'react' | 'vue' | 'vue-cli' | 'nuxt' | 'next' | 'svelte'
     webpackConfig?: ConfigHandler<PickConfigOpt<'webpackConfig'>>
+  } | {
+    bundler: 'webpack'
+    framework: 'create-react-app'
+    webpackConfig?: ConfigHandler<PickConfigOpt<'webpackConfig'>>
+    scriptsPackageName?: string
   } | {
     bundler: 'vite'
     framework: 'react' | 'vue' | 'svelte'

--- a/npm/webpack-dev-server/src/devServer.ts
+++ b/npm/webpack-dev-server/src/devServer.ts
@@ -37,6 +37,7 @@ export type WebpackDevServerConfig = {
   devServerEvents: NodeJS.EventEmitter
   onConfigNotFound?: (devServer: 'webpack', cwd: string, lookedIn: string[]) => void
   webpackConfig?: ConfigHandler // Derived from the user's webpack config
+  scriptsPackageName?: string
 } & FrameworkConfig
 
 /**

--- a/npm/webpack-dev-server/src/helpers/createReactAppHandler.ts
+++ b/npm/webpack-dev-server/src/helpers/createReactAppHandler.ts
@@ -45,9 +45,11 @@ function loadWebpackConfig (devServerConfig: WebpackDevServerConfig): Configurat
   process.env.NODE_ENV = envName
   process.env.BABEL_ENV = envName
 
+  const scriptsPackageName = devServerConfig.scriptsPackageName || 'react-scripts'
+
   try {
     // Search for react-scripts webpack config
-    webpackConfigPath = require.resolve('react-scripts/config/webpack.config.js', {
+    webpackConfigPath = require.resolve(`${scriptsPackageName}/config/webpack.config.js`, {
       paths: [devServerConfig.cypressConfig.projectRoot],
     })
 


### PR DESCRIPTION
…ble libraries in `loadWebpackConfig()`

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #22521 

### Additional details
This PR makes it possible to use custom, `react-scripts`-compatible packages to be used as a source for webpack.config.js

### Steps to test
- Set the following config in cypress.config.ts
```javascript
import { defineConfig } from 'cypress';

export default defineConfig({
  component: {
    devServer: {
      framework: 'create-react-app',
      bundler: 'webpack',
      scriptsPackageName: 'react-app-rewired',
    },
  },
});
```

### How has the user experience changed?
3rd party, `react-scripts` compatible* packages should be loaded automatically, without requiring additional configuration.

\* Compatible means that the package exposes a `config/webpack.config.js` file with a function exported that accepts an `env` parameter and returns the webpack configuration.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
