### PR TITLE
chore: remove flaky tooltip Percy snapshots from DebugSpec

### DIFF
--- a/packages/app/src/debug/DebugSpec.cy.tsx
+++ b/packages/app/src/debug/DebugSpec.cy.tsx
@@ -485,8 +485,6 @@ describe('Run Failures button', () => {
     cy.findByTestId('run-failures').realHover()
 
     cy.findByTestId('run-all-failures-tooltip').should('be.visible').contains('Spec was not found locally')
-
-    cy.percySnapshot()
   })
 
   it('is disabled if run testing-type differs from the current testing-type', () => {
@@ -576,6 +574,5 @@ describe('Open in IDE', () => {
 
     cy.findByLabelText(defaultMessages.debugPage.openFile.notFoundLocally).as('openInIDE').realHover()
     cy.findByTestId('open-in-ide-disabled-tooltip').should('be.visible').and('contain', defaultMessages.debugPage.openFile.notFoundLocally)
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/debug/DebugSpec.cy.tsx
+++ b/packages/app/src/debug/DebugSpec.cy.tsx
@@ -561,7 +561,6 @@ describe('Open in IDE', () => {
 
     cy.findByLabelText(defaultMessages.debugPage.openFile.openInIDE).as('openInIDE').realHover()
     cy.findByTestId('open-in-ide-tooltip').should('be.visible').and('contain', defaultMessages.debugPage.openFile.openInIDE)
-    cy.percySnapshot()
 
     cy.get('@openInIDE').click()
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #25870

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We have some tests in `DebugSpec.cy.tsx` that are taking Percy snapshots of tooltips. These end up being flaky with Percy - sometimes the tooltip is rendered and sometimes it isn't. I think that we should remove these. The tooltip content is just text, and we are already asserting that the tooltip is appearing on screen and that the text is correct.

Some recent examples of these snapshots flaking:
https://percy.io/cypress-io/cypress/builds/25301083/changed/1411039263?browser=chrome&browser_ids=34&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=800&widths=450%2C800

https://percy.io/cypress-io/cypress/builds/25338162/changed/1412986341?browser=chrome&browser_ids=34&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=800&widths=450%2C800

https://percy.io/cypress-io/cypress/builds/25209495/changed/1406985567?browser=chrome&browser_ids=34&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=800&widths=450%2C800

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Look at the Percy build and see which snapshots have been removed under the "Missing" filter

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
