### PR TITLE
chore: update triage workflow to exclude comments from github-actions bot

### DIFF
--- a/.github/workflows/triage_closed_issue_comment.yml
+++ b/.github/workflows/triage_closed_issue_comment.yml
@@ -13,8 +13,9 @@ jobs:
     if: |
       !github.event.issue.pull_request &&
       github.event.issue.state == 'closed' &&
-      github.event.comment.created_at != github.event.issue.closed_at &&
-      github.event.sender.login != 'cypress-bot[bot]'
+      ${{ github.event.comment.created_at | iso8601date | minus: github.event.issue.closed_at | iso8601date | abs | ge: 20 }} &&
+      github.event.sender.login != 'cypress-bot[bot]' &&
+      github.event.sender.login != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Get project data

--- a/.github/workflows/triage_closed_issue_comment.yml
+++ b/.github/workflows/triage_closed_issue_comment.yml
@@ -77,28 +77,28 @@ jobs:
           echo 'STATUS_FIELD_ID='$(jq -r '.data.organization.projectV2.field | .id' project_data.json) >> $GITHUB_ENV
           echo 'STATUS='$(jq -r '.data.organization.repository.issue.projectItems.nodes[].fieldValueByName | select(.field.project.number == ${{ env.PROJECT_NUMBER }}) | .name' project_data.json) >> $GITHUB_ENV
           echo 'NEW_ISSUE_OPTION_ID='$(jq -r '.data.organization.projectV2.field.options[] | select(.name== "New Issue") | .id' project_data.json) >> $GITHUB_ENV
-        - name: Move issue to New Issue status
-          env:
-            GITHUB_TOKEN: ${{ secrets.ADD_TO_TRIAGE_BOARD_TOKEN }}
-          if: env.STATUS == 'Closed'
-          run: |
-            gh api graphql -f query='
-              mutation (
-                $project: ID!
-                $item: ID!
-                $status_field: ID!
-                $status_value: String!
-              ) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $project
-                  itemId: $item
-                  fieldId: $status_field
-                  value: { 
-                    singleSelectOptionId: $status_value
-                  }
-                }) {
-                  projectV2Item {
-                    id
-                  }
+      - name: Move issue to New Issue status
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_TRIAGE_BOARD_TOKEN }}
+        if: env.STATUS == 'Closed'
+        run: |
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+            ) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: { 
+                  singleSelectOptionId: $status_value
                 }
-              }' -f project=$PROJECT_ID -f item=$PROJECT_ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=$NEW_ISSUE_OPTION_ID
+              }) {
+                projectV2Item {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f item=$PROJECT_ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=$NEW_ISSUE_OPTION_ID

--- a/.github/workflows/triage_closed_issue_comment.yml
+++ b/.github/workflows/triage_closed_issue_comment.yml
@@ -13,39 +13,42 @@ jobs:
   move-to-new-issue-status:
     runs-on: ubuntu-latest
     steps:
-    - name: Make sure comment was added more than 20 seconds after issue closed
-      run: |
-        time_diff=$(( ($(date +%s -d "${{ github.event.comment.created_at }}" ) - $(date +%s -d "${{ github.event.issue.closed_at }}" )) > 20))
-        echo 'COMMENT_ADDED_AFTER_CLOSE='$time_diff >> $GITHUB_ENV
-    if: |
-      env.COMMENT_ADDED_AFTER_CLOSE == '1' && 
-      github.event.sender.login != 'cypress-bot[bot]' &&
-      github.event.sender.login != 'github-actions[bot]' 
-    - name: Get project data
-      env:
-        GITHUB_TOKEN: ${{ secrets.ADD_TO_TRIAGE_BOARD_TOKEN }}
-        ORGANIZATION: 'cypress-io'
-        REPOSITORY: ${{ github.event.repository.name }}
-        PROJECT_NUMBER: 9
-        ISSUE_NUMBER: ${{ github.event.issue.number }}
-      run: |
-        gh api graphql -f query='
-          query($org: String!, $repo: String!, $project: Int!, $issue: Int!) {
-            organization(login: $org) {
-              repository(name: $repo) {
-                issue(number: $issue) {
-                  projectItems(first: 10, includeArchived: false) {
-                    nodes {
-                      id
-                      fieldValueByName(name: "Status") {
-                        ... on ProjectV2ItemFieldSingleSelectValue {
-                          name
-                          field {
-                            ... on ProjectV2SingleSelectField {
-                              project {
-                                ... on ProjectV2 {
-                                  id
-                                  number
+      - name: Make sure comment was added more than 20 seconds after issue closed
+        run: |
+          eval_result=$(( ($(date +%s -d "${{ github.event.comment.created_at }}" ) - $(date +%s -d "${{ github.event.issue.closed_at }}" )) > 20)) #verify that the last comment was added more than 20 seconds after close date
+          echo 'LAST_COMMENT_CLOSE_TIME_DIFF='$eval_result >> $GITHUB_ENV
+     
+      - name: Get project data
+        if: |
+          github.event.sender.login != 'cypress-bot[bot]' &&
+          env.LAST_COMMENT_CLOSE_TIME_DIFF == '1' && 
+          github.event.sender.login != 'github-actions[bot]'  
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_TRIAGE_BOARD_TOKEN }}
+          ORGANIZATION: 'cypress-io'
+          REPOSITORY: ${{ github.event.repository.name }}
+          PROJECT_NUMBER: 9
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $repo: String!, $project: Int!, $issue: Int!) {
+              organization(login: $org) {
+                repository(name: $repo) {
+                  issue(number: $issue) {
+                    projectItems(first: 10, includeArchived: false) {
+                      nodes {
+                        id
+                        fieldValueByName(name: "Status") {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            name
+                            field {
+                              ... on ProjectV2SingleSelectField {
+                                project {
+                                  ... on ProjectV2 {
+                                    id
+                                    number
+                                  }
                                 }
                               }
                             }
@@ -55,48 +58,47 @@ jobs:
                     }
                   }
                 }
-              }
-              projectV2(number: $project) {
-                field(name: "Status") {
-                  ... on ProjectV2SingleSelectField {
-                    id
-                    options {
+                projectV2(number: $project) {
+                  field(name: "Status") {
+                    ... on ProjectV2SingleSelectField {
                       id
-                      name
+                      options {
+                        id
+                        name
+                      }
                     }
                   }
                 }
               }
-            }
-          }' -f org=$ORGANIZATION -f repo=$REPOSITORY -F issue=$ISSUE_NUMBER -F project=$PROJECT_NUMBER > project_data.json
+            }' -f org=$ORGANIZATION -f repo=$REPOSITORY -F issue=$ISSUE_NUMBER -F project=$PROJECT_NUMBER > project_data.json
 
-        echo 'PROJECT_ID='$(jq -r '.data.organization.repository.issue.projectItems.nodes[].fieldValueByName.field.project | select(.number == ${{ env.PROJECT_NUMBER }}) | .id' project_data.json) >> $GITHUB_ENV
-        echo 'PROJECT_ITEM_ID='$(jq -r '.data.organization.repository.issue.projectItems.nodes[] | select(.fieldValueByName.field.project.number == ${{ env.PROJECT_NUMBER }}) | .id' project_data.json) >> $GITHUB_ENV
-        echo 'STATUS_FIELD_ID='$(jq -r '.data.organization.projectV2.field | .id' project_data.json) >> $GITHUB_ENV
-        echo 'STATUS='$(jq -r '.data.organization.repository.issue.projectItems.nodes[].fieldValueByName | select(.field.project.number == ${{ env.PROJECT_NUMBER }}) | .name' project_data.json) >> $GITHUB_ENV
-        echo 'NEW_ISSUE_OPTION_ID='$(jq -r '.data.organization.projectV2.field.options[] | select(.name== "New Issue") | .id' project_data.json) >> $GITHUB_ENV
-      - name: Move issue to New Issue status
-        env:
-          GITHUB_TOKEN: ${{ secrets.ADD_TO_TRIAGE_BOARD_TOKEN }}
-        if: env.STATUS == 'Closed'
-        run: |
-          gh api graphql -f query='
-            mutation (
-              $project: ID!
-              $item: ID!
-              $status_field: ID!
-              $status_value: String!
-            ) {
-              updateProjectV2ItemFieldValue(input: {
-                projectId: $project
-                itemId: $item
-                fieldId: $status_field
-                value: { 
-                  singleSelectOptionId: $status_value
+          echo 'PROJECT_ID='$(jq -r '.data.organization.repository.issue.projectItems.nodes[].fieldValueByName.field.project | select(.number == ${{ env.PROJECT_NUMBER }}) | .id' project_data.json) >> $GITHUB_ENV
+          echo 'PROJECT_ITEM_ID='$(jq -r '.data.organization.repository.issue.projectItems.nodes[] | select(.fieldValueByName.field.project.number == ${{ env.PROJECT_NUMBER }}) | .id' project_data.json) >> $GITHUB_ENV
+          echo 'STATUS_FIELD_ID='$(jq -r '.data.organization.projectV2.field | .id' project_data.json) >> $GITHUB_ENV
+          echo 'STATUS='$(jq -r '.data.organization.repository.issue.projectItems.nodes[].fieldValueByName | select(.field.project.number == ${{ env.PROJECT_NUMBER }}) | .name' project_data.json) >> $GITHUB_ENV
+          echo 'NEW_ISSUE_OPTION_ID='$(jq -r '.data.organization.projectV2.field.options[] | select(.name== "New Issue") | .id' project_data.json) >> $GITHUB_ENV
+        - name: Move issue to New Issue status
+          env:
+            GITHUB_TOKEN: ${{ secrets.ADD_TO_TRIAGE_BOARD_TOKEN }}
+          if: env.STATUS == 'Closed'
+          run: |
+            gh api graphql -f query='
+              mutation (
+                $project: ID!
+                $item: ID!
+                $status_field: ID!
+                $status_value: String!
+              ) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $project
+                  itemId: $item
+                  fieldId: $status_field
+                  value: { 
+                    singleSelectOptionId: $status_value
+                  }
+                }) {
+                  projectV2Item {
+                    id
+                  }
                 }
-              }) {
-                projectV2Item {
-                  id
-                }
-              }
-            }' -f project=$PROJECT_ID -f item=$PROJECT_ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=$NEW_ISSUE_OPTION_ID
+              }' -f project=$PROJECT_ID -f item=$PROJECT_ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=$NEW_ISSUE_OPTION_ID

--- a/.github/workflows/triage_closed_issue_comment.yml
+++ b/.github/workflows/triage_closed_issue_comment.yml
@@ -17,12 +17,7 @@ jobs:
         run: |
           eval_result=$(( ($(date +%s -d "${{ github.event.comment.created_at }}" ) - $(date +%s -d "${{ github.event.issue.closed_at }}" )) > 20)) #verify that the last comment was added more than 20 seconds after close date
           echo 'LAST_COMMENT_CLOSE_TIME_DIFF='$eval_result >> $GITHUB_ENV
-     
-      - name: Get project data
-        if: |
-          github.event.sender.login != 'cypress-bot[bot]' &&
-          env.LAST_COMMENT_CLOSE_TIME_DIFF == '1' && 
-          github.event.sender.login != 'github-actions[bot]'  
+
       - name: Get project data
         env:
           GITHUB_TOKEN: ${{ secrets.ADD_TO_TRIAGE_BOARD_TOKEN }}
@@ -30,6 +25,10 @@ jobs:
           REPOSITORY: ${{ github.event.repository.name }}
           PROJECT_NUMBER: 9
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+        if: |
+          github.event.sender.login != 'cypress-bot[bot]' &&
+          env.LAST_COMMENT_CLOSE_TIME_DIFF == '1' && 
+          github.event.sender.login != 'github-actions[bot]'
         run: |
           gh api graphql -f query='
             query($org: String!, $repo: String!, $project: Int!, $issue: Int!) {

--- a/.github/workflows/triage_closed_issue_comment.yml
+++ b/.github/workflows/triage_closed_issue_comment.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
     - name: Make sure comment was added more than 20 seconds after issue closed
       run: |
-        eval_result=$(( ($(date +%s -d "${{ github.event.comment.created_at }}" ) - $(date +%s -d "${{ github.event.issue.closed_at }}" )) > 20))
-        echo 'LAST_COMMENT_CLOSE_TIME_DIFF='$eval_result >> $GITHUB_ENV
+        time_diff=$(( ($(date +%s -d "${{ github.event.comment.created_at }}" ) - $(date +%s -d "${{ github.event.issue.closed_at }}" )) > 20))
+        echo 'COMMENT_ADDED_AFTER_CLOSE='$time_diff >> $GITHUB_ENV
     if: |
-          env.LAST_COMMENT_CLOSE_TIME_DIFF == '1' && 
-          github.event.sender.login != 'cypress-bot[bot]' &&
-          github.event.sender.login != 'github-actions[bot]' 
+      env.COMMENT_ADDED_AFTER_CLOSE == '1' && 
+      github.event.sender.login != 'cypress-bot[bot]' &&
+      github.event.sender.login != 'github-actions[bot]' 
     - name: Get project data
       env:
         GITHUB_TOKEN: ${{ secrets.ADD_TO_TRIAGE_BOARD_TOKEN }}

--- a/.github/workflows/triage_closed_issue_comment.yml
+++ b/.github/workflows/triage_closed_issue_comment.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - name: Make sure comment was added more than 20 seconds after issue closed
         run: |
-          eval_result=$(( ($(date +%s -d "${{ github.event.comment.created_at }}" ) - $(date +%s -d "${{ github.event.issue.closed_at }}" )) > 20)) #verify that the last comment was added more than 20 seconds after close date
-          echo 'LAST_COMMENT_CLOSE_TIME_DIFF='$eval_result >> $GITHUB_ENV
+          time_diff=$(($(date +%s -d "${{ github.event.comment.created_at }}" ) - $(date +%s -d "${{ github.event.issue.closed_at }}" )))
+          echo 'COMMENT_ADDED_AFTER_CLOSE='$(($time_diff > 20)) >> $GITHUB_ENV
 
       - name: Get project data
         env:
@@ -27,7 +27,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         if: |
           github.event.sender.login != 'cypress-bot[bot]' &&
-          env.LAST_COMMENT_CLOSE_TIME_DIFF == '1' && 
+          env.COMMENT_ADDED_AFTER_CLOSE == '1' && 
           github.event.sender.login != 'github-actions[bot]'
         run: |
           gh api graphql -f query='

--- a/.github/workflows/triage_closed_issue_comment.yml
+++ b/.github/workflows/triage_closed_issue_comment.yml
@@ -6,44 +6,46 @@ on:
       ADD_TO_TRIAGE_BOARD_TOKEN:
         required: true
   issue_comment:
-    types:
-      - created
+    types: [created]
+    issues:
+      types: [closed]
 jobs:
   move-to-new-issue-status:
-    if: |
-      !github.event.issue.pull_request &&
-      github.event.issue.state == 'closed' &&
-      ${{ github.event.comment.created_at | iso8601date | minus: github.event.issue.closed_at | iso8601date | abs | ge: 20 }} &&
-      github.event.sender.login != 'cypress-bot[bot]' &&
-      github.event.sender.login != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Get project data
-        env:
-          GITHUB_TOKEN: ${{ secrets.ADD_TO_TRIAGE_BOARD_TOKEN }}
-          ORGANIZATION: 'cypress-io'
-          REPOSITORY: ${{ github.event.repository.name }}
-          PROJECT_NUMBER: 9
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          gh api graphql -f query='
-            query($org: String!, $repo: String!, $project: Int!, $issue: Int!) {
-              organization(login: $org) {
-                repository(name: $repo) {
-                  issue(number: $issue) {
-                    projectItems(first: 10, includeArchived: false) {
-                      nodes {
-                        id
-                        fieldValueByName(name: "Status") {
-                          ... on ProjectV2ItemFieldSingleSelectValue {
-                            name
-                            field {
-                              ... on ProjectV2SingleSelectField {
-                                project {
-                                  ... on ProjectV2 {
-                                    id
-                                    number
-                                  }
+    - name: Make sure comment was added more than 20 seconds after issue closed
+      run: |
+        eval_result=$(( ($(date +%s -d "${{ github.event.comment.created_at }}" ) - $(date +%s -d "${{ github.event.issue.closed_at }}" )) > 20))
+        echo 'LAST_COMMENT_CLOSE_TIME_DIFF='$eval_result >> $GITHUB_ENV
+    if: |
+          env.LAST_COMMENT_CLOSE_TIME_DIFF == '1' && 
+          github.event.sender.login != 'cypress-bot[bot]' &&
+          github.event.sender.login != 'github-actions[bot]' 
+    - name: Get project data
+      env:
+        GITHUB_TOKEN: ${{ secrets.ADD_TO_TRIAGE_BOARD_TOKEN }}
+        ORGANIZATION: 'cypress-io'
+        REPOSITORY: ${{ github.event.repository.name }}
+        PROJECT_NUMBER: 9
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+      run: |
+        gh api graphql -f query='
+          query($org: String!, $repo: String!, $project: Int!, $issue: Int!) {
+            organization(login: $org) {
+              repository(name: $repo) {
+                issue(number: $issue) {
+                  projectItems(first: 10, includeArchived: false) {
+                    nodes {
+                      id
+                      fieldValueByName(name: "Status") {
+                        ... on ProjectV2ItemFieldSingleSelectValue {
+                          name
+                          field {
+                            ... on ProjectV2SingleSelectField {
+                              project {
+                                ... on ProjectV2 {
+                                  id
+                                  number
                                 }
                               }
                             }
@@ -53,25 +55,26 @@ jobs:
                     }
                   }
                 }
-                projectV2(number: $project) {
-                  field(name: "Status") {
-                    ... on ProjectV2SingleSelectField {
+              }
+              projectV2(number: $project) {
+                field(name: "Status") {
+                  ... on ProjectV2SingleSelectField {
+                    id
+                    options {
                       id
-                      options {
-                        id
-                        name
-                      }
+                      name
                     }
                   }
                 }
               }
-            }' -f org=$ORGANIZATION -f repo=$REPOSITORY -F issue=$ISSUE_NUMBER -F project=$PROJECT_NUMBER > project_data.json
+            }
+          }' -f org=$ORGANIZATION -f repo=$REPOSITORY -F issue=$ISSUE_NUMBER -F project=$PROJECT_NUMBER > project_data.json
 
-          echo 'PROJECT_ID='$(jq -r '.data.organization.repository.issue.projectItems.nodes[].fieldValueByName.field.project | select(.number == ${{ env.PROJECT_NUMBER }}) | .id' project_data.json) >> $GITHUB_ENV
-          echo 'PROJECT_ITEM_ID='$(jq -r '.data.organization.repository.issue.projectItems.nodes[] | select(.fieldValueByName.field.project.number == ${{ env.PROJECT_NUMBER }}) | .id' project_data.json) >> $GITHUB_ENV
-          echo 'STATUS_FIELD_ID='$(jq -r '.data.organization.projectV2.field | .id' project_data.json) >> $GITHUB_ENV
-          echo 'STATUS='$(jq -r '.data.organization.repository.issue.projectItems.nodes[].fieldValueByName | select(.field.project.number == ${{ env.PROJECT_NUMBER }}) | .name' project_data.json) >> $GITHUB_ENV
-          echo 'NEW_ISSUE_OPTION_ID='$(jq -r '.data.organization.projectV2.field.options[] | select(.name== "New Issue") | .id' project_data.json) >> $GITHUB_ENV
+        echo 'PROJECT_ID='$(jq -r '.data.organization.repository.issue.projectItems.nodes[].fieldValueByName.field.project | select(.number == ${{ env.PROJECT_NUMBER }}) | .id' project_data.json) >> $GITHUB_ENV
+        echo 'PROJECT_ITEM_ID='$(jq -r '.data.organization.repository.issue.projectItems.nodes[] | select(.fieldValueByName.field.project.number == ${{ env.PROJECT_NUMBER }}) | .id' project_data.json) >> $GITHUB_ENV
+        echo 'STATUS_FIELD_ID='$(jq -r '.data.organization.projectV2.field | .id' project_data.json) >> $GITHUB_ENV
+        echo 'STATUS='$(jq -r '.data.organization.repository.issue.projectItems.nodes[].fieldValueByName | select(.field.project.number == ${{ env.PROJECT_NUMBER }}) | .name' project_data.json) >> $GITHUB_ENV
+        echo 'NEW_ISSUE_OPTION_ID='$(jq -r '.data.organization.projectV2.field.options[] | select(.name== "New Issue") | .id' project_data.json) >> $GITHUB_ENV
       - name: Move issue to New Issue status
         env:
           GITHUB_TOKEN: ${{ secrets.ADD_TO_TRIAGE_BOARD_TOKEN }}


### PR DESCRIPTION
Also tried to fix the problem of this workflow moving issues back to open after I comment and close an issue.

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ n/a ] Have tests been added/updated?
- [ n/a ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ n/a ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
