### PR TITLE
docs: remove cypress-fiddle from release-process

### DIFF
--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -168,7 +168,6 @@ In the following instructions, "X.Y.Z" is used to denote the [next version of Cy
     - [cypress-example-todomvc](https://github.com/cypress-io/cypress-example-todomvc/issues/99)
     - [cypress-realworld-app](https://github.com/cypress-io/cypress-realworld-app/issues/41)
     - [cypress-example-recipes](https://github.com/cypress-io/cypress-example-recipes/issues/225)
-    - [cypress-fiddle](https://github.com/cypress-io/cypress-fiddle/issues/5)
     - [cypress-example-docker-compose](https://github.com/cypress-io/cypress-example-docker-compose)
 
 Take a break, you deserve it! 👉😎👉


### PR DESCRIPTION
### Additional details

Remove [cypress-fiddle](https://github.com/cypress-io/cypress-fiddle) from our release process doc as a repo to update after releasing a new version of Cypress. I've archived this repo since it's not actively maintained and no objections were raised to archiving in from anyone at Cypress.
