### PR TITLE
[DO NOT MERGE] chore: add framework and bundler to Cloud run instance

### DIFF
--- a/packages/server/lib/cloud/api.ts
+++ b/packages/server/lib/cloud/api.ts
@@ -342,6 +342,8 @@ module.exports = {
       'groupId',
       'machineId',
       'platform',
+      'framework',
+      'bundler',
     ])
 
     return retryWithBackoff((attemptIndex) => {

--- a/packages/server/lib/modes/record.js
+++ b/packages/server/lib/modes/record.js
@@ -533,7 +533,7 @@ const createRun = Promise.method((options = {}) => {
 })
 
 const createInstance = (options = {}) => {
-  let { runId, group, groupId, parallel, machineId, ciBuildId, platform, spec } = options
+  let { runId, group, groupId, parallel, machineId, ciBuildId, platform, spec, framework, bundler } = options
 
   spec = getSpecRelativePath(spec)
 
@@ -543,6 +543,8 @@ const createInstance = (options = {}) => {
     groupId,
     platform,
     machineId,
+    framework,
+    bundler,
   })
   .catch((err) => {
     debug('failed creating instance %o', {
@@ -578,6 +580,14 @@ const _postInstanceTests = ({
   .catch((err) => {
     throwCloudCannotProceed({ parallel, ciBuildId, group, err })
   })
+}
+
+const getDevServerAttribute = (devServer, key) => {
+  if (typeof devServer === 'function') {
+    return 'custom'
+  }
+
+  return devServer ? devServer[key] : undefined
 }
 
 const createRunAndRecordSpecs = (options = {}) => {
@@ -662,6 +672,8 @@ const createRunAndRecordSpecs = (options = {}) => {
           parallel,
           ciBuildId,
           machineId,
+          framework: testingType === 'component' ? getDevServerAttribute(config?.devServer, 'framework') : undefined,
+          bundler: testingType === 'component' ? getDevServerAttribute(config?.devServer, 'bundler') : undefined,
         })
         .then((resp = {}) => {
           instanceId = resp.instanceId

--- a/packages/server/test/unit/cloud/api_spec.js
+++ b/packages/server/test/unit/cloud/api_spec.js
@@ -702,6 +702,8 @@ describe('lib/cloud/api', () => {
         groupId: 'groupId123',
         machineId: 'machineId123',
         platform: {},
+        framework: 'react',
+        bundler: 'vite',
       }
 
       this.postProps = _.omit(this.createProps, 'runId')

--- a/packages/server/test/unit/modes/record_spec.js
+++ b/packages/server/test/unit/modes/record_spec.js
@@ -405,6 +405,8 @@ describe('lib/modes/record', () => {
         machineId: 'machine-123',
         platform: {},
         spec: { relative: 'cypress/integration/app_spec.coffee' },
+        framework: 'react',
+        bundler: 'vite',
       }
     })
 
@@ -419,6 +421,8 @@ describe('lib/modes/record', () => {
           machineId: 'machine-123',
           platform: {},
           spec: 'cypress/integration/app_spec.coffee',
+          framework: 'react',
+          bundler: 'vite',
         })
       })
     })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

DO NOT MERGE

- Closes #25976

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This PR adds the name of the framework and bundler that the project is configured for when recording a run to Cypress Cloud during component testing. When recording an e2e run, these values will be `undefined`. If the devServer is a function, then we will pass `custom` for both framework and bundler values for the run.

**Note** that changes to Cloud schema will be handled in https://cypress-io.atlassian.net/browse/CYCLOUD-940. We won't merge this until the cloud ticket is finished and deployed.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

It's probably best to just look at the code, otherwise you could use Burp Suite or something to intercept the request from the app to the cloud and view the request body to make sure that `framework` and `bundler` exist with the correct values.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Corresponding Cloud PR https://cypress-io.atlassian.net/browse/CYCLOUD-940
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
