### PR TITLE
feat: support custom workspaceRoot for angular CT

### DIFF
--- a/npm/webpack-dev-server/src/helpers/angularHandler.ts
+++ b/npm/webpack-dev-server/src/helpers/angularHandler.ts
@@ -115,12 +115,13 @@ export function getAngularBuildOptions (buildOptions: BuildOptions, tsConfig: st
 export async function generateTsConfig (devServerConfig: AngularWebpackDevServerConfig, buildOptions: BuildOptions): Promise<string> {
   const { cypressConfig } = devServerConfig
   const { projectRoot } = cypressConfig
+  const { workspaceRoot = projectRoot } = buildOptions
 
   const specPattern = Array.isArray(cypressConfig.specPattern) ? cypressConfig.specPattern : [cypressConfig.specPattern]
 
-  const getProjectFilePath = (...fileParts: string[]): string => toPosix(path.join(projectRoot, ...fileParts))
+  const getProjectFilePath = (...fileParts: string[]): string => toPosix(path.join(...fileParts))
 
-  const includePaths = [...specPattern.map((pattern) => getProjectFilePath(pattern))]
+  const includePaths = [...specPattern.map((pattern) => getProjectFilePath(projectRoot, pattern))]
 
   if (cypressConfig.supportFile) {
     includePaths.push(toPosix(cypressConfig.supportFile))
@@ -131,17 +132,17 @@ export async function generateTsConfig (devServerConfig: AngularWebpackDevServer
       ? buildOptions.polyfills.filter((p: string) => devServerConfig.options?.projectConfig.sourceRoot && p.startsWith(devServerConfig.options?.projectConfig.sourceRoot))
       : [buildOptions.polyfills]
 
-    includePaths.push(...polyfills.map((p: string) => getProjectFilePath(p)))
+    includePaths.push(...polyfills.map((p: string) => getProjectFilePath(workspaceRoot, p)))
   }
 
-  const cypressTypes = getProjectFilePath('node_modules', 'cypress', 'types', 'index.d.ts')
+  const cypressTypes = getProjectFilePath(workspaceRoot, 'node_modules', 'cypress', 'types', 'index.d.ts')
 
   includePaths.push(cypressTypes)
 
   const tsConfigContent = JSON.stringify({
-    extends: getProjectFilePath(buildOptions.tsConfig ?? 'tsconfig.json'),
+    extends: getProjectFilePath(projectRoot, buildOptions.tsConfig ?? 'tsconfig.json'),
     compilerOptions: {
-      outDir: getProjectFilePath('out-tsc/cy'),
+      outDir: getProjectFilePath(projectRoot, 'out-tsc/cy'),
       allowSyntheticDefaultImports: true,
       skipLibCheck: true,
     },
@@ -253,7 +254,7 @@ async function getAngularCliWebpackConfig (devServerConfig: AngularWebpackDevSer
 
   const buildOptions = getAngularBuildOptions(projectConfig.buildOptions, tsConfig)
 
-  const context = createFakeContext(projectRoot, projectConfig, logging)
+  const context = createFakeContext(projectConfig.buildOptions.workspaceRoot || projectRoot, projectConfig, logging)
 
   const { config } = await generateBrowserWebpackConfigFromContext(
     buildOptions,
@@ -275,10 +276,10 @@ async function getAngularCliWebpackConfig (devServerConfig: AngularWebpackDevSer
               return
             }
 
-            const root = path.join(devServerConfig.cypressConfig.projectRoot, projectConfig.sourceRoot)
+            const root = projectConfig.buildOptions.workspaceRoot || path.join(devServerConfig.cypressConfig.projectRoot, projectConfig.sourceRoot)
 
             debug('Adding root %s to resolve-url-loader options', root)
-            loader.options.root = path.join(devServerConfig.cypressConfig.projectRoot, projectConfig.sourceRoot)
+            loader.options.root = root
           })
         })
       })

--- a/system-tests/test/component_testing_spec.ts
+++ b/system-tests/test/component_testing_spec.ts
@@ -179,18 +179,6 @@ describe('Vue major versions with Vite', () => {
   })
 })
 
-describe('Nx Monorepo', () => {
-  systemTests.setup()
-
-  systemTests.it('angular', {
-    project: 'nx-monorepo',
-    testingType: 'component',
-    spec: '**/*.cy.ts',
-    browser: 'chrome',
-    expectedExitCode: 0,
-  })
-})
-
 describe('experimentalSingleTabRunMode', function () {
   systemTests.setup()
 

--- a/system-tests/test/component_testing_spec.ts
+++ b/system-tests/test/component_testing_spec.ts
@@ -179,6 +179,18 @@ describe('Vue major versions with Vite', () => {
   })
 })
 
+describe('Nx Monorepo', () => {
+  systemTests.setup()
+
+  systemTests.it('angular', {
+    project: 'nx-monorepo',
+    testingType: 'component',
+    spec: '**/*.cy.ts',
+    browser: 'chrome',
+    expectedExitCode: 0,
+  })
+})
+
 describe('experimentalSingleTabRunMode', function () {
   systemTests.setup()
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

Nx issue for ref: https://github.com/nrwl/nx/issues/12113

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This is the same implementation as https://github.com/cypress-io/cypress/pull/25384 but to solve a different issue, primarly the issue where Nx + Cypress Angular CT is unable to load the workspace root tailwinds config file. This logic is hard coded within angular webpack utils that cypress CT calls.
```ts
function getTailwindConfigPath({ projectRoot, root }: WebpackConfigOptions): string | undefined {
  // A configuration file can exist in the project or workspace root
  // The list of valid config files can be found:
  // https://github.com/tailwindlabs/tailwindcss/blob/8845d112fb62d79815b50b3bae80c317450b8b92/src/util/resolveConfigPath.js#L46-L52
  const tailwindConfigFiles = ['tailwind.config.js', 'tailwind.config.cjs'];
  for (const basePath of [projectRoot, root]) {
    for (const configFile of tailwindConfigFiles) {
      // Irrespective of the name project level configuration should always take precedence.
      const fullPath = path.join(basePath, configFile);
      if (fs.existsSync(fullPath)) {
        return fullPath;
      }
    }
  }

  return undefined;
}
```

The Angular CT handler sets the projectRoot as the workspaceRoot when working with the angular webpack utils which works when cypress is opened in the root of the workspace. But within an nx context Cypress is opened in the project root which means any tailwind config files in the workspace root aren't loaded. 

This PR allows for an optional workspaceRoot option to be passed via the cypress config component testing project configuration. if one isn't provided then the default value of projectRoot is used to prevent any other integration/assumptions from breaking but allowing the customizations for tools like Nx to provide the expected behavior when the Cypress isn't opened in the workspaceRoot. 

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
This change does requires changes to the @nrwl/angular nx component testing preset. Mainly the offset value is removed and a custom 'workspaceRoot' is passed to cypress. This can be done within node_modules if really wanted to test it works before this change is in Nx, See: https://github.com/nrwl/nx/pull/15485

make a new nx angular workspace, npx create-nx-workspace@latest --preset=angular
add an tailwind to the workspace root
use a tailwind class in the apps create 'apps/<app-name>/src/app.component.html'
add CT to the app `nx g @nrwl/angular:cypress-component-configuration --project=<app-name>`
run CT and notice the tailwind styles are not applied, `nx component-test <app-name> --watch`

cloneable repo: https://github.com/kanidjar/nx-cypress-ct-styling-bug


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

No impact for direct consumers, more flexibility for 3rd party tools like [Nx](https://nx.dev)

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
