### PR TITLE
chore: rewrite flaky server integration test

### DIFF
--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -596,24 +596,8 @@ describe('lib/cypress', () => {
     it('can change the reporter with cypress.config.js', async function () {
       sinon.spy(Reporter, 'create')
 
-      await ctx.actions.project.setCurrentProjectAndTestingTypeForTestSetup(this.idsPath)
-
-      setCtx(makeDataContext({}))
-
-      return ctx.lifecycleManager.getFullInitialConfig()
-      .then((cfg) => {
-        this.cfg = cfg
-
-        return settings.read(this.idsPath)
-      }).then((json) => {
-        json.reporter = 'dot'
-
-        return settings.writeForTesting(this.idsPath, json)
-      }).then(async () => {
-        await clearCtx()
-
-        return cypress.start([`--run-project=${this.idsPath}`])
-      }).then(() => {
+      return cypress.start([`--run-project=${this.idsPath}`, `--config-file=${this.idsPath}/cypress.dot-reporter.config.js`])
+      .then(() => {
         expect(Reporter.create).to.be.calledWith('dot')
         this.expectExitWith(0)
       })

--- a/system-tests/projects/ids/cypress.dot-reporter.config.js
+++ b/system-tests/projects/ids/cypress.dot-reporter.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  e2e: {},
+  reporter: 'dot',
+}


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

There's a flaky test that is trying to do a lot of initial set up to load the config of one of the fixtures, then modifies the config file, resets the contexts, and then tries to execute the test scenario (setting the reporter in the cypress config). This PR aims to simplify the test by simply passing in a dedicated cypress config file that specifies the reporter.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

n/a

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
