### PR TITLE
chore: pass slideshow cohort to cloud CTAs for Debug

### DIFF
--- a/packages/app/src/debug/empty/DebugEmptyStates.cy.tsx
+++ b/packages/app/src/debug/empty/DebugEmptyStates.cy.tsx
@@ -61,7 +61,17 @@ function mountWithGql (component: JSX.Element, gqlOptions?: { debugSlideshowComp
 describe('Debug page empty states', () => {
   context('empty view', () => {
     it('renders with slot', () => {
-      mountWithGql(<DebugEmptyView title="My Title"><template v-slot:cta="slotProps"></template></DebugEmptyView>)
+      const slotVariableStub = cy.stub().as('slot')
+
+      mountWithGql(
+        <DebugEmptyView title="My Title">
+          {{
+            cta: slotVariableStub,
+          }}
+        </DebugEmptyView>,
+      )
+
+      cy.get('@slot').should('be.calledWith', { utmContent: Cypress.sinon.match.string })
     })
   })
 

--- a/packages/app/src/debug/empty/DebugEmptyStates.cy.tsx
+++ b/packages/app/src/debug/empty/DebugEmptyStates.cy.tsx
@@ -3,6 +3,7 @@ import DebugNoProject from './DebugNoProject.vue'
 import DebugNoRuns from './DebugNoRuns.vue'
 import DebugLoading from './DebugLoading.vue'
 import DebugError from './DebugError.vue'
+import DebugEmptyView from './DebugEmptyView.vue'
 import { useLoginConnectStore } from '@packages/frontend-shared/src/store/login-connect-store'
 import { DebugEmptyView_RecordEventDocument, DebugEmptyView_SetPreferencesDocument, UseCohorts_DetermineCohortDocument, _DebugEmptyViewFragment, _DebugEmptyViewFragmentDoc } from '../../generated/graphql-test'
 import { DEBUG_SLIDESHOW } from '../utils/constants'
@@ -58,6 +59,12 @@ function mountWithGql (component: JSX.Element, gqlOptions?: { debugSlideshowComp
 }
 
 describe('Debug page empty states', () => {
+  context('empty view', () => {
+    it('renders with slot', () => {
+      mountWithGql(<DebugEmptyView title="My Title"><template v-slot:cta="slotProps"></template></DebugEmptyView>)
+    })
+  })
+
   context('not logged in', () => {
     it('renders', () => {
       const loginConnectStore = useLoginConnectStore()

--- a/packages/app/src/debug/empty/DebugEmptyView.vue
+++ b/packages/app/src/debug/empty/DebugEmptyView.vue
@@ -15,7 +15,10 @@
           </ExternalLink>
         </div>
       </div>
-      <slot name="cta" />
+      <slot
+        name="cta"
+        :utm-content="selectedCohort?.cohort"
+      />
     </div>
     <Slideshow
       v-if="step !== undefined && steps"

--- a/packages/app/src/debug/empty/DebugNoProject.vue
+++ b/packages/app/src/debug/empty/DebugNoProject.vue
@@ -7,8 +7,11 @@
     :slideshow-campaign="DEBUG_SLIDESHOW.campaigns.connectProject"
     help-link-href="https://on.cypress.io/adding-new-project"
   >
-    <template #cta>
-      <CloudConnectButton utm-medium="Debug Tab" />
+    <template #cta="slotProps">
+      <CloudConnectButton
+        utm-medium="Debug Tab"
+        :utm-content="slotProps.utmContent"
+      />
     </template>
   </DebugEmptyView>
 </template>

--- a/packages/app/src/debug/empty/DebugNotLoggedIn.vue
+++ b/packages/app/src/debug/empty/DebugNotLoggedIn.vue
@@ -7,8 +7,11 @@
     :slideshow-campaign="DEBUG_SLIDESHOW.campaigns.login"
     help-link-href="https://on.cypress.io/debug-page"
   >
-    <template #cta>
-      <CloudConnectButton utm-medium="Debug Tab" />
+    <template #cta="slotProps">
+      <CloudConnectButton
+        utm-medium="Debug Tab"
+        :utm-content="slotProps.utmContent"
+      />
     </template>
   </DebugEmptyView>
 </template>

--- a/packages/app/src/debug/utils/constants.ts
+++ b/packages/app/src/debug/utils/constants.ts
@@ -7,7 +7,7 @@ export const DEBUG_SLIDESHOW = {
     connectProject: 'Debug Connect Project Empty State',
     recordRun: 'Debug Record Run Empty State',
   },
-  medium: 'Debug tab',
+  medium: 'Debug Tab',
 } as const
 
 export type DebugSlideshowCampaigns = ValueOf<typeof DEBUG_SLIDESHOW['campaigns']>

--- a/packages/app/src/runs/CloudConnectButton.cy.tsx
+++ b/packages/app/src/runs/CloudConnectButton.cy.tsx
@@ -31,7 +31,16 @@ describe('<CloudConnectButton />', { viewportHeight: 60, viewportWidth: 400 }, (
 
       cy.contains('button', 'Connect a Cypress Cloud project').click()
 
-      cy.get('@openLoginConnectModal').should('have.been.calledWith', { utmMedium: 'testing' })
+      cy.get('@openLoginConnectModal').should('have.been.calledWith', { utmMedium: 'testing', utmContent: undefined })
+    })
+
+    it('uses the store to open the Login Connect modal with utmContent', () => {
+      loginConnectStore.openLoginConnectModal = cy.spy().as('openLoginConnectModal')
+      cy.mount(() => <div class="h-screen"><CloudConnectButton utmMedium="testing" utmContent="content"/></div>)
+
+      cy.contains('button', 'Connect a Cypress Cloud project').click()
+
+      cy.get('@openLoginConnectModal').should('have.been.calledWith', { utmMedium: 'testing', utmContent: 'content' })
     })
   })
 })

--- a/packages/app/src/runs/CloudConnectButton.vue
+++ b/packages/app/src/runs/CloudConnectButton.vue
@@ -3,7 +3,7 @@
     :class="props.class"
     :prefix-icon="user.isLoggedIn ? ChainIcon : CypressIcon"
     prefix-icon-class="icon-dark-white icon-light-transparent"
-    @click="openLoginConnectModal({ utmMedium: props.utmMedium })"
+    @click="openLoginConnectModal({ utmMedium: utmMedium, utmContent: utmContent })"
   >
     {{ user.isLoggedIn ? t('runs.connect.buttonProject') : t('runs.connect.buttonUser') }}
   </Button>
@@ -24,6 +24,7 @@ const { t } = useI18n()
 const props = defineProps<{
   class?: string
   utmMedium: string
+  utmContent?: string
 }>()
 
 </script>

--- a/packages/frontend-shared/src/gql-components/LoginConnectModalsContent.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/LoginConnectModalsContent.cy.tsx
@@ -1,4 +1,4 @@
-import { LoginConnectModalsContentFragmentDoc } from '../generated/graphql-test'
+import { Auth_LoginDocument, LoginConnectModalsContentFragmentDoc } from '../generated/graphql-test'
 import LoginConnectModalsContent from './LoginConnectModalsContent.vue'
 import { CloudUserStubs } from '@packages/graphql/test/stubCloudTypes'
 import { SelectCloudProjectModal_CreateCloudProjectDocument } from '../generated/graphql'
@@ -7,96 +7,118 @@ import { useLoginConnectStore } from '../store/login-connect-store'
 
 describe('<LoginConnectModalsContent />', () => {
   context('when user is logged out', () => {
-    it('shows login modal', () => {
-      const { openLoginConnectModal } = useLoginConnectStore()
+    [undefined, 'testContent'].forEach((content) => {
+      it(`shows login modal with utmContent: ${content}`, () => {
+        const { openLoginConnectModal } = useLoginConnectStore()
 
-      cy.mountFragment(LoginConnectModalsContentFragmentDoc, {
-        onResult: (result) => {
-          result.cloudViewer = null
-        },
-        render: (gqlVal) => {
-          return <LoginConnectModalsContent gql={gqlVal} />
-        },
-      })
+        cy.mountFragment(LoginConnectModalsContentFragmentDoc, {
+          onResult: (result) => {
+            result.cloudViewer = null
+          },
+          render: (gqlVal) => {
+            return <LoginConnectModalsContent gql={gqlVal} />
+          },
+        })
 
-      cy.contains('Log in to Cypress')
-      .should('not.exist')
-      .then(() => {
-        openLoginConnectModal({ utmMedium: 'testing' })
+        cy.contains('Log in to Cypress')
+        .should('not.exist')
+        .then(() => {
+          openLoginConnectModal({ utmMedium: 'testing', utmContent: content })
 
-        cy.contains('Log in to Cypress').should('be.visible')
+          cy.contains('Log in to Cypress').should('be.visible')
+        })
+
+        const loginStub = cy.stub().as('createProjectStub')
+
+        cy.stubMutationResolver(Auth_LoginDocument, (defineResult, variables) => {
+          loginStub(variables)
+
+          return defineResult({} as any)
+        })
+
+        cy.contains('button', 'Log in')
+        .click()
+        .then(() => {
+          expect(loginStub.lastCall.args[0]).to.deep.eq({
+            utmSource: 'Binary: Launchpad',
+            utmMedium: 'testing',
+            utmContent: content || null,
+          })
+        })
       })
     })
   })
 
   context('when user is logged in', () => {
-    it('shows "Create Project" state if project is not set up', () => {
-      const { openLoginConnectModal, setUserFlag, setProjectFlag } = useLoginConnectStore()
+    [undefined, 'testContent'].forEach((content) => {
+      it('shows "Create Project" state if project is not set up', () => {
+        const { openLoginConnectModal, setUserFlag, setProjectFlag } = useLoginConnectStore()
 
-      setUserFlag('isLoggedIn', true)
-      setUserFlag('isMemberOfOrganization', true)
-      setUserFlag('isOrganizationLoaded', true)
-      setProjectFlag('isConfigLoaded', true)
-      setProjectFlag('isProjectConnected', false)
+        setUserFlag('isLoggedIn', true)
+        setUserFlag('isMemberOfOrganization', true)
+        setUserFlag('isOrganizationLoaded', true)
+        setProjectFlag('isConfigLoaded', true)
+        setProjectFlag('isProjectConnected', false)
 
-      cy.mountFragment(LoginConnectModalsContentFragmentDoc, {
-        onResult: (result) => {
-          result.cloudViewer = { ...CloudUserStubs.me,
-            firstOrganization: {
-              __typename: 'CloudOrganizationConnection',
-              nodes: [{ __typename: 'CloudOrganization', id: '122' }],
-            },
-            organizations: {
-              __typename: 'CloudOrganizationConnection',
-              nodes: [{
-                __typename: 'CloudOrganization',
-                name: `Cypress Test Account`,
-                id: '122',
-                projects: {
-                  nodes: [],
-                },
-              }],
-            },
-          }
+        cy.mountFragment(LoginConnectModalsContentFragmentDoc, {
+          onResult: (result) => {
+            result.cloudViewer = { ...CloudUserStubs.me,
+              firstOrganization: {
+                __typename: 'CloudOrganizationConnection',
+                nodes: [{ __typename: 'CloudOrganization', id: '122' }],
+              },
+              organizations: {
+                __typename: 'CloudOrganizationConnection',
+                nodes: [{
+                  __typename: 'CloudOrganization',
+                  name: `Cypress Test Account`,
+                  id: '122',
+                  projects: {
+                    nodes: [],
+                  },
+                }],
+              },
+            }
 
-          result.currentProject = null
-        },
-        render: (gqlVal) => {
-          return <LoginConnectModalsContent gql={gqlVal} />
-        },
-      })
-
-      const createProjectStub = cy.stub().as('createProjectStub')
-
-      cy.stubMutationResolver(SelectCloudProjectModal_CreateCloudProjectDocument, (defineResult, variables) => {
-        createProjectStub(variables)
-
-        return defineResult({} as any)
-      })
-
-      cy.contains('Create project')
-      .should('not.exist')
-      .then(() => {
-        openLoginConnectModal({ utmMedium: 'testing' })
-      })
-
-      cy.findAllByLabelText('Project name*(You can change this later)').type('test-project')
-
-      cy.contains('button', 'Create project')
-      .click()
-      .then(() => {
-        expect(createProjectStub.lastCall.args[0]).to.deep.eq({
-          name: 'test-project',
-          orgId: '122',
-          medium: 'testing',
-          source: 'Binary: Launchpad',
-          public: false,
-          campaign: 'Create project',
-          cohort: '',
+            result.currentProject = null
+          },
+          render: (gqlVal) => {
+            return <LoginConnectModalsContent gql={gqlVal} />
+          },
         })
-      })
 
-      cy.get('@createProjectStub').should('have.been.calledOnce')
+        const createProjectStub = cy.stub().as('createProjectStub')
+
+        cy.stubMutationResolver(SelectCloudProjectModal_CreateCloudProjectDocument, (defineResult, variables) => {
+          createProjectStub(variables)
+
+          return defineResult({} as any)
+        })
+
+        cy.contains('Create project')
+        .should('not.exist')
+        .then(() => {
+          openLoginConnectModal({ utmMedium: 'testing', utmContent: content })
+        })
+
+        cy.findAllByLabelText('Project name*(You can change this later)').type('test-project')
+
+        cy.contains('button', 'Create project')
+        .click()
+        .then(() => {
+          expect(createProjectStub.lastCall.args[0]).to.deep.eq({
+            name: 'test-project',
+            orgId: '122',
+            medium: 'testing',
+            source: 'Binary: Launchpad',
+            public: false,
+            campaign: 'Create project',
+            cohort: content || '',
+          })
+        })
+
+        cy.get('@createProjectStub').should('have.been.calledOnce')
+      })
     })
   })
 })

--- a/packages/frontend-shared/src/gql-components/LoginConnectModalsContent.vue
+++ b/packages/frontend-shared/src/gql-components/LoginConnectModalsContent.vue
@@ -4,12 +4,14 @@
       v-if="userStatusMatches('isLoggedOut') || keepLoginOpen"
       :gql="gqlRef"
       :utm-medium="loginConnectStore.utmMedium"
+      :utm-content="loginConnectStore.utmContent"
       @cancel="closeLoginConnectModal"
       @close="handleCloseLogin"
     />
     <RecordRunModal
       v-else-if="userStatusMatches('needsRecordedRun')"
       :utm-medium="loginConnectStore.utmMedium"
+      :utm-content="loginConnectStore.utmContent"
       @cancel="closeLoginConnectModal"
     />
     <CloudConnectModals
@@ -17,6 +19,7 @@
       :show="loginConnectStore.user.isLoggedIn"
       :gql="gqlRef"
       :utm-medium="loginConnectStore.utmMedium"
+      :utm-content="loginConnectStore.utmContent"
       @cancel="closeLoginConnectModal"
       @success="closeLoginConnectModal"
     />

--- a/packages/frontend-shared/src/store/login-connect-store.ts
+++ b/packages/frontend-shared/src/store/login-connect-store.ts
@@ -10,6 +10,7 @@ export interface LoginConnectState {
   hasInitiallyLoaded: boolean
   isLoginConnectOpen: boolean
   utmMedium: string
+  utmContent?: string
   cypressFirstOpened?: number
   user: {
     isLoggedIn: boolean
@@ -54,6 +55,7 @@ export const useLoginConnectStore = defineStore({
     return {
       hasInitiallyLoaded: false,
       utmMedium: '',
+      utmContent: undefined,
       isLoginConnectOpen: false,
       cypressFirstOpened: undefined,
       userData: undefined,
@@ -80,13 +82,15 @@ export const useLoginConnectStore = defineStore({
     setHasInitiallyLoaded () {
       this.hasInitiallyLoaded = true
     },
-    openLoginConnectModal ({ utmMedium }: { utmMedium: string }) {
+    openLoginConnectModal ({ utmMedium, utmContent }: { utmMedium: string, utmContent?: string }) {
       this.isLoginConnectOpen = true
       this.utmMedium = utmMedium
+      this.utmContent = utmContent
     },
     closeLoginConnectModal () {
       this.isLoginConnectOpen = false
       this.utmMedium = ''
+      this.utmContent = undefined
     },
     setUserFlag (name: keyof LoginConnectState['user'], newVal: boolean) {
       this.user[name] = newVal


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/26076

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

When adding the [Debug empty state slideshow](https://github.com/cypress-io/cypress/issues/25768), there were missing requirements to make sure the cohort value for the A/B testing was being passed through to the cloud CTAs.  This is needed to make sure the results of A/B test can be determined.

The components that control reaching out to the cloud were already coded to accept this value.  This update just required passing the value through to those components from the Debug page.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Login
* Make sure you are logged out of the Cloud
* Go to the Debug page
* Log in with the button on the page
* When the web browser opens to the Cloud login page, open the browser's developer tools
* On Chrome, go to the Application tab.  Then in the left side bar under Storage, open the Session Storage and click on the "https://cloud.cypress.io" value
* Select the key for "InitialQs" and make sure the "utm_ content" has "A" if you saw the skeleton slideshow or "B" if you saw the slideshow with words in it.
<img width="1222" alt="image" src="https://user-images.githubusercontent.com/1702361/224357925-32fd4be9-08a1-4bb6-8e59-dc47fc7ed722.png">

Connect Project
* Remove the `projectId` from the `cypress.config.ts` file for a project that you have that is already connected to the cloud
* Start the Cypress app, go to the Debug page in either E2E or CT and make sure you are logged in.
* The Debug page should prompt you to connect a project
* Make sure `GraphQL requests over Fetch` is on in the Developer Tools Menu for Cypress
* Open Developer tools and go to the Network tab (you may need to refresh the browser to see the GQL requests)
* Use the CTA on the Debug page to create a new project in the cloud (you may want to do it under a test organization)
* In the requests tab, look for the request for `mutation-SelectCloudProjectModal_CreateCloudProject`
* Look at the variables for the mutation under Payload and you should see the appropriate cohort value

<img width="1499" alt="Screenshot 2023-03-10 at 10 49 27 AM" src="https://user-images.githubusercontent.com/1702361/224361295-87f671ba-fac7-47c6-bafd-a0a81e95b18a.png">



### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [-] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [-] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
