### PR TITLE
chore: ensure that current version is loaded before taking snapshot of launchpad migration screen

### DIFF
--- a/packages/app/cypress/e2e/cypress-in-cypress-run-mode.cy.ts
+++ b/packages/app/cypress/e2e/cypress-in-cypress-run-mode.cy.ts
@@ -1,4 +1,4 @@
-import { CY_IN_CY_SIMULATE_RUN_MODE } from '@packages/types/src/constants'
+import { CY_IN_CY_SIMULATE_RUN_MODE } from '@packages/types'
 
 describe('Cypress In Cypress - run mode', { viewportWidth: 1200 }, () => {
   it('e2e run mode spec runner header is correct', () => {

--- a/packages/app/cypress/e2e/top-nav.cy.ts
+++ b/packages/app/cypress/e2e/top-nav.cy.ts
@@ -1,5 +1,6 @@
 import type { SinonStub } from 'sinon'
 import defaultMessages from '@packages/frontend-shared/src/locales/en-US.json'
+import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types/src'
 import type Sinon from 'sinon'
 
 const pkg = require('@packages/root')
@@ -227,7 +228,7 @@ describe('App Top Nav Workflows', () => {
 
           o.sinon.stub(ctx.util, 'fetch').callsFake(async (url: RequestInfo | URL, init?: RequestInit) => {
             await new Promise((resolve) => setTimeout(resolve, 500))
-            if (['https://download.cypress.io/desktop.json', 'https://registry.npmjs.org/cypress'].includes(String(url))) {
+            if ([CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL].includes(String(url))) {
               throw new Error(String(url))
             }
 

--- a/packages/app/cypress/e2e/top-nav.cy.ts
+++ b/packages/app/cypress/e2e/top-nav.cy.ts
@@ -1,6 +1,6 @@
 import type { SinonStub } from 'sinon'
 import defaultMessages from '@packages/frontend-shared/src/locales/en-US.json'
-import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types/src'
+import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types'
 import type Sinon from 'sinon'
 
 const pkg = require('@packages/root')

--- a/packages/data-context/src/sources/VersionsDataSource.ts
+++ b/packages/data-context/src/sources/VersionsDataSource.ts
@@ -1,7 +1,7 @@
 import os from 'os'
 import type { DataContext } from '..'
 import type { TestingType } from '@packages/types'
-import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types/src/constants'
+import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types'
 import Debug from 'debug'
 
 const debug = Debug('cypress:data-context:sources:VersionsDataSource')

--- a/packages/data-context/src/sources/VersionsDataSource.ts
+++ b/packages/data-context/src/sources/VersionsDataSource.ts
@@ -1,6 +1,7 @@
 import os from 'os'
 import type { DataContext } from '..'
 import type { TestingType } from '@packages/types'
+import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types/src/constants'
 import Debug from 'debug'
 
 const debug = Debug('cypress:data-context:sources:VersionsDataSource')
@@ -18,9 +19,6 @@ interface VersionData {
   current: Version
   latest: Version
 }
-
-const REMOTE_MANIFEST_URL = 'https://download.cypress.io/desktop.json'
-const NPM_CYPRESS_REGISTRY = 'https://registry.npmjs.org/cypress'
 
 export class VersionsDataSource {
   private _initialLaunch: boolean
@@ -111,7 +109,7 @@ export class VersionsDataSource {
     let response
 
     try {
-      response = await this.ctx.util.fetch(NPM_CYPRESS_REGISTRY)
+      response = await this.ctx.util.fetch(NPM_CYPRESS_REGISTRY_URL)
       const responseJson = await response.json() as { time: Record<string, string>}
 
       debug('NPM release dates received %o', { modified: responseJson.time.modified })
@@ -120,7 +118,7 @@ export class VersionsDataSource {
     } catch (e) {
       // ignore any error from this fetch, they are gracefully handled
       // by showing the current version only
-      debug('Error fetching %o', NPM_CYPRESS_REGISTRY, e)
+      debug('Error fetching %o', NPM_CYPRESS_REGISTRY_URL, e)
 
       return DEFAULT_RESPONSE
     }
@@ -163,7 +161,7 @@ export class VersionsDataSource {
     }
 
     try {
-      const manifestResponse = await this.ctx.util.fetch(REMOTE_MANIFEST_URL, {
+      const manifestResponse = await this.ctx.util.fetch(CYPRESS_REMOTE_MANIFEST_URL, {
         headers: manifestHeaders,
       })
 
@@ -177,7 +175,7 @@ export class VersionsDataSource {
     } catch (e) {
       // ignore any error from this fetch, they are gracefully handled
       // by showing the current version only
-      debug('Error fetching %s: %o', REMOTE_MANIFEST_URL, e)
+      debug('Error fetching %s: %o', CYPRESS_REMOTE_MANIFEST_URL, e)
 
       return pkg.version
     } finally {

--- a/packages/data-context/test/unit/sources/VersionsDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/VersionsDataSource.spec.ts
@@ -6,6 +6,7 @@ import { Response } from 'cross-fetch'
 import { DataContext } from '../../../src'
 import { VersionsDataSource } from '../../../src/sources'
 import { createTestDataContext } from '../helper'
+import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types/src/constants'
 
 const pkg = require('@packages/root')
 const nmi = require('node-machine-id')
@@ -43,7 +44,7 @@ describe('VersionsDataSource', () => {
       nmiStub.resolves('abcd123')
 
       fetchStub
-      .withArgs('https://download.cypress.io/desktop.json', {
+      .withArgs(CYPRESS_REMOTE_MANIFEST_URL, {
         headers: {
           'Content-Type': 'application/json',
           'x-cypress-version': currentCypressVersion,
@@ -60,7 +61,7 @@ describe('VersionsDataSource', () => {
           version: '15.0.0',
         }),
       })
-      .withArgs('https://registry.npmjs.org/cypress')
+      .withArgs(NPM_CYPRESS_REGISTRY_URL)
       .resolves({
         json: sinon.stub().resolves({
           'time': {
@@ -97,7 +98,7 @@ describe('VersionsDataSource', () => {
       ctx.coreData.currentTestingType = 'component'
 
       fetchStub
-      .withArgs('https://download.cypress.io/desktop.json', {
+      .withArgs(CYPRESS_REMOTE_MANIFEST_URL, {
         headers: {
           'Content-Type': 'application/json',
           'x-cypress-version': currentCypressVersion,
@@ -129,7 +130,7 @@ describe('VersionsDataSource', () => {
       nmiStub.resolves('abcd123')
 
       fetchStub
-      .withArgs('https://download.cypress.io/desktop.json', {
+      .withArgs(CYPRESS_REMOTE_MANIFEST_URL, {
         headers: {
           'Content-Type': 'application/json',
           'x-cypress-version': currentCypressVersion,
@@ -142,7 +143,7 @@ describe('VersionsDataSource', () => {
         },
       })
       .rejects()
-      .withArgs('https://registry.npmjs.org/cypress')
+      .withArgs(NPM_CYPRESS_REGISTRY_URL)
       .rejects()
 
       versionsDataSource = new VersionsDataSource(ctx)
@@ -156,7 +157,7 @@ describe('VersionsDataSource', () => {
       nmiStub.resolves('abcd123')
 
       fetchStub
-      .withArgs('https://download.cypress.io/desktop.json', {
+      .withArgs(CYPRESS_REMOTE_MANIFEST_URL, {
         headers: {
           'Content-Type': 'application/json',
           'x-cypress-version': currentCypressVersion,
@@ -169,7 +170,7 @@ describe('VersionsDataSource', () => {
         },
       })
       .callsFake(async () => new Response('Error'))
-      .withArgs('https://registry.npmjs.org/cypress')
+      .withArgs(NPM_CYPRESS_REGISTRY_URL)
       .callsFake(async () => new Response('Error'))
 
       versionsDataSource = new VersionsDataSource(ctx)

--- a/packages/data-context/test/unit/sources/VersionsDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/VersionsDataSource.spec.ts
@@ -6,7 +6,7 @@ import { Response } from 'cross-fetch'
 import { DataContext } from '../../../src'
 import { VersionsDataSource } from '../../../src/sources'
 import { createTestDataContext } from '../helper'
-import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types/src/constants'
+import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types'
 
 const pkg = require('@packages/root')
 const nmi = require('node-machine-id')

--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -30,16 +30,12 @@ import * as inspector from 'inspector'
 import sinonChai from '@cypress/sinon-chai'
 import sinon from 'sinon'
 import fs from 'fs-extra'
+import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types'
 
 import { CloudQuery } from '@packages/graphql/test/stubCloudTypes'
 import pDefer from 'p-defer'
 
 const pkg = require('@packages/root')
-
-// These are also defined in @packages/types/src/constants. Ideally we should import them from that file
-const CYPRESS_REMOTE_MANIFEST_URL = 'https://download.cypress.io/desktop.json'
-
-const NPM_CYPRESS_REGISTRY_URL = 'https://registry.npmjs.org/cypress'
 
 interface InternalOpenProjectArgs {
   argv: string[]

--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -32,10 +32,14 @@ import sinon from 'sinon'
 import fs from 'fs-extra'
 
 import { CloudQuery } from '@packages/graphql/test/stubCloudTypes'
-import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types/src/constants'
 import pDefer from 'p-defer'
 
 const pkg = require('@packages/root')
+
+// These are also defined in @packages/types/src/constants. Ideally we should import them from that file
+const CYPRESS_REMOTE_MANIFEST_URL = 'https://download.cypress.io/desktop.json'
+
+const NPM_CYPRESS_REGISTRY_URL = 'https://registry.npmjs.org/cypress'
 
 interface InternalOpenProjectArgs {
   argv: string[]

--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -32,6 +32,7 @@ import sinon from 'sinon'
 import fs from 'fs-extra'
 
 import { CloudQuery } from '@packages/graphql/test/stubCloudTypes'
+import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types/src/constants'
 import pDefer from 'p-defer'
 
 const pkg = require('@packages/root')
@@ -330,14 +331,14 @@ async function makeE2ETasks () {
           return new Response(JSON.stringify(result), { status: 200 })
         }
 
-        if (String(url) === 'https://download.cypress.io/desktop.json') {
+        if (String(url) === CYPRESS_REMOTE_MANIFEST_URL) {
           return new Response(JSON.stringify({
             name: 'Cypress',
             version: pkg.version,
           }), { status: 200 })
         }
 
-        if (String(url) === 'https://registry.npmjs.org/cypress') {
+        if (String(url) === NPM_CYPRESS_REGISTRY_URL) {
           return new Response(JSON.stringify({
             'time': {
               [pkg.version]: '2022-02-10T01:07:37.369Z',

--- a/packages/frontend-shared/cypress/support/customPercyCommand.ts
+++ b/packages/frontend-shared/cypress/support/customPercyCommand.ts
@@ -263,7 +263,7 @@ export const installCustomPercyCommand = ({ before, elementOverrides }: {before?
 
       return applySnapshotMutations({
         ...snapshotMutationOptions,
-        log: 'percy: skipping snapshot in interactive mode',
+        log: 'skipping Percy: hover to see snapshot',
       }).then((reset) => reset())
     }
 

--- a/packages/frontend-shared/cypress/support/e2e.ts
+++ b/packages/frontend-shared/cypress/support/e2e.ts
@@ -559,9 +559,6 @@ Cypress.Commands.add('validateExternalLink', { prevSubject: ['optional', 'elemen
 
 installCustomPercyCommand({
   elementOverrides: {
-    '[data-cy=top-nav-cypress-version-current-link]': ($el) => {
-      $el.attr('style', 'display: none !important') // TODO: display and set dummy text to vX.X.X once flake is fixed. See issue https://github.com/cypress-io/cypress/issues/21897
-    },
     '.runnable-header .duration': ($el) => {
       $el.text('XX:XX')
     },

--- a/packages/frontend-shared/src/gql-components/topnav/TopNav.vue
+++ b/packages/frontend-shared/src/gql-components/topnav/TopNav.vue
@@ -276,10 +276,6 @@ const latestReleased = useTimeAgo(
 
 const versions = computed(() => {
   if (!props.gql.versions) {
-    return
-  }
-
-  if (!props.gql.versions) {
     return null
   }
 

--- a/packages/frontend-shared/src/utils/isRunMode.ts
+++ b/packages/frontend-shared/src/utils/isRunMode.ts
@@ -1,3 +1,3 @@
-import { CY_IN_CY_SIMULATE_RUN_MODE } from '@packages/types/src/constants'
+import { CY_IN_CY_SIMULATE_RUN_MODE } from '@packages/types'
 
 export const isRunMode = window.location.href.includes(CY_IN_CY_SIMULATE_RUN_MODE) || (window.__CYPRESS_MODE__ === 'run' && window.top === window)

--- a/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
+++ b/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
@@ -1,4 +1,4 @@
-import type { FoundBrowser } from '@packages/types/src'
+import type { FoundBrowser } from '@packages/types'
 
 // TODO: fix flaky tests https://github.com/cypress-io/cypress/issues/23418
 describe.skip('Choose a browser page', () => {

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -172,9 +172,9 @@ describe('Opening unmigrated project', () => {
 
     // Wait for migration prompt and current version to load before taking a snapshot
     cy.get('.spinner').should('not.exist')
-    cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
-
-    cy.percySnapshot()
+    cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible').then(() => {
+      cy.percySnapshot()
+    })
   })
 })
 

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -170,8 +170,9 @@ describe('Opening unmigrated project', () => {
     cy.contains(cy.i18n.majorVersionWelcome.title).should('not.exist')
     cy.contains('h1', `Migrating to Cypress ${Cypress.version.split('.')[0]}`).should('be.visible')
 
-    // Wait for migration prompt to load before taking a snapshot
+    // Wait for migration prompt and current version to load before taking a snapshot
     cy.get('.spinner').should('not.exist')
+    cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
 
     cy.percySnapshot()
   })

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -172,9 +172,9 @@ describe('Opening unmigrated project', () => {
 
     // Wait for migration prompt and current version to load before taking a snapshot
     cy.get('.spinner').should('not.exist')
-    cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible').then(() => {
-      cy.percySnapshot()
-    })
+    cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
+
+    cy.percySnapshot()
   })
 })
 

--- a/packages/launchpad/cypress/e2e/open-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/open-mode.cy.ts
@@ -1,7 +1,6 @@
 import type { SinonStub } from 'sinon'
 import defaultMessages from '@packages/frontend-shared/src/locales/en-US.json'
-import { MAJOR_VERSION_FOR_CONTENT } from '@packages/types/src'
-import { CYPRESS_REMOTE_MANIFEST_URL } from '@packages/types/src/constants'
+import { MAJOR_VERSION_FOR_CONTENT } from '@packages/types'
 
 describe('Launchpad: Open Mode', () => {
   describe('global mode', () => {
@@ -71,7 +70,7 @@ describe('Launchpad: Open Mode', () => {
       cy.skipWelcome()
       cy.get('h1').should('contain', 'Choose a browser')
       cy.withCtx((ctx, o) => {
-        expect(ctx.util.fetch).to.have.been.calledWithMatch(CYPRESS_REMOTE_MANIFEST_URL, {
+        expect(ctx.util.fetch).to.have.been.calledWithMatch('https://download.cypress.io/desktop.json', {
           headers: {
             'x-framework': 'react',
             'x-dev-server': 'webpack',
@@ -86,7 +85,7 @@ describe('Launchpad: Open Mode', () => {
         cy.skipWelcome()
         cy.get('h1').should('contain', 'Choose a browser')
         cy.withCtx((ctx, o) => {
-          expect(ctx.util.fetch).to.have.been.calledWithMatch(CYPRESS_REMOTE_MANIFEST_URL, {
+          expect(ctx.util.fetch).to.have.been.calledWithMatch('https://download.cypress.io/desktop.json', {
             headers: {
               'x-logged-in': 'false',
             },
@@ -100,7 +99,7 @@ describe('Launchpad: Open Mode', () => {
         cy.skipWelcome()
         cy.get('h1').should('contain', 'Choose a browser')
         cy.withCtx((ctx, o) => {
-          expect(ctx.util.fetch).to.have.been.calledWithMatch(CYPRESS_REMOTE_MANIFEST_URL, {
+          expect(ctx.util.fetch).to.have.been.calledWithMatch('https://download.cypress.io/desktop.json', {
             headers: {
               'x-logged-in': 'true',
             },

--- a/packages/launchpad/cypress/e2e/open-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/open-mode.cy.ts
@@ -1,6 +1,7 @@
 import type { SinonStub } from 'sinon'
 import defaultMessages from '@packages/frontend-shared/src/locales/en-US.json'
 import { MAJOR_VERSION_FOR_CONTENT } from '@packages/types/src'
+import { CYPRESS_REMOTE_MANIFEST_URL } from '@packages/types/src/constants'
 
 describe('Launchpad: Open Mode', () => {
   describe('global mode', () => {
@@ -70,7 +71,7 @@ describe('Launchpad: Open Mode', () => {
       cy.skipWelcome()
       cy.get('h1').should('contain', 'Choose a browser')
       cy.withCtx((ctx, o) => {
-        expect(ctx.util.fetch).to.have.been.calledWithMatch('https://download.cypress.io/desktop.json', {
+        expect(ctx.util.fetch).to.have.been.calledWithMatch(CYPRESS_REMOTE_MANIFEST_URL, {
           headers: {
             'x-framework': 'react',
             'x-dev-server': 'webpack',
@@ -85,7 +86,7 @@ describe('Launchpad: Open Mode', () => {
         cy.skipWelcome()
         cy.get('h1').should('contain', 'Choose a browser')
         cy.withCtx((ctx, o) => {
-          expect(ctx.util.fetch).to.have.been.calledWithMatch('https://download.cypress.io/desktop.json', {
+          expect(ctx.util.fetch).to.have.been.calledWithMatch(CYPRESS_REMOTE_MANIFEST_URL, {
             headers: {
               'x-logged-in': 'false',
             },
@@ -99,7 +100,7 @@ describe('Launchpad: Open Mode', () => {
         cy.skipWelcome()
         cy.get('h1').should('contain', 'Choose a browser')
         cy.withCtx((ctx, o) => {
-          expect(ctx.util.fetch).to.have.been.calledWithMatch('https://download.cypress.io/desktop.json', {
+          expect(ctx.util.fetch).to.have.been.calledWithMatch(CYPRESS_REMOTE_MANIFEST_URL, {
             headers: {
               'x-logged-in': 'true',
             },

--- a/packages/launchpad/cypress/e2e/project-setup.cy.ts
+++ b/packages/launchpad/cypress/e2e/project-setup.cy.ts
@@ -1,4 +1,4 @@
-import { MAJOR_VERSION_FOR_CONTENT } from '@packages/types/src'
+import { MAJOR_VERSION_FOR_CONTENT } from '@packages/types'
 import { getPathForPlatform } from './support/getPathForPlatform'
 
 function verifyScaffoldedFiles (testingType: string) {

--- a/packages/launchpad/cypress/e2e/top-nav-launchpad.cy.ts
+++ b/packages/launchpad/cypress/e2e/top-nav-launchpad.cy.ts
@@ -1,7 +1,7 @@
 import type { SinonStub } from 'sinon'
 import defaultMessages from '@packages/frontend-shared/src/locales/en-US.json'
 import type Sinon from 'sinon'
-import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types/src'
+import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types'
 
 const pkg = require('@packages/root')
 

--- a/packages/launchpad/cypress/e2e/top-nav-launchpad.cy.ts
+++ b/packages/launchpad/cypress/e2e/top-nav-launchpad.cy.ts
@@ -1,6 +1,7 @@
 import type { SinonStub } from 'sinon'
 import defaultMessages from '@packages/frontend-shared/src/locales/en-US.json'
 import type Sinon from 'sinon'
+import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types/src'
 
 const pkg = require('@packages/root')
 
@@ -148,7 +149,7 @@ describe('Launchpad Top Nav Workflows', () => {
 
           o.sinon.stub(ctx.util, 'fetch').callsFake(async (url: RequestInfo | URL, init?: RequestInit) => {
             await new Promise((resolve) => setTimeout(resolve, 500))
-            if (['https://download.cypress.io/desktop.json', 'https://registry.npmjs.org/cypress'].includes(String(url))) {
+            if ([CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL].includes(String(url))) {
               throw new Error(String(url))
             }
 

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -43,3 +43,8 @@ export const RUN_ALL_SPECS: SpecFile = {
  * we can test some run-mode-specific UI features
  */
 export const CY_IN_CY_SIMULATE_RUN_MODE = 'CY_IN_CY_SIMULATE_RUN_MODE'
+
+// These are the URLS that we use to get the Cypress version and release time
+export const CYPRESS_REMOTE_MANIFEST_URL = 'https://download.cypress.io/desktop.json'
+
+export const NPM_CYPRESS_REGISTRY_URL = 'https://registry.npmjs.org/cypress'


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Handling some Percy flake between sprints - there's a test where we take a snapshot of the launchpad migration screen. Sometimes we take the snapshot before the current version button hasn't loaded into the header yet, which makes the snapshot flake.

[Example of flake from my recent PR](https://percy.io/cypress-io/cypress/builds/25789049/changed/1437403332?browser=chrome&browser_ids=34&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=800&widths=450%2C800)

I added an assertion to make sure that the version button is visible before taking the snapshot. This should reduce flake

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
