### PR TITLE
Issue 4742 async test functions

### DIFF
--- a/packages/driver/cypress/e2e/commands/actions/check.cy.js
+++ b/packages/driver/cypress/e2e/commands/actions/check.cy.js
@@ -942,7 +942,7 @@ describe('src/cy/commands/actions/check', () => {
       })
     })
 
-    it('passes timeout and interval down to click', (done) => {
+      it('passes timeout and interval down to click', (done) => {
       const checkbox = $('<input type=\'checkbox\' />').attr('id', 'checkbox-covered-in-span').prop('checked', true).prependTo($('body'))
 
       $('<span>span on checkbox</span>').css({ position: 'absolute', left: checkbox.offset().left, top: checkbox.offset().top, padding: 5, display: 'inline-block', backgroundColor: 'yellow' }).prependTo($('body'))

--- a/packages/driver/cypress/e2e/commands/navigation.cy.js
+++ b/packages/driver/cypress/e2e/commands/navigation.cy.js
@@ -1464,7 +1464,7 @@ describe('src/cy/commands/navigation', () => {
               - you don't have internet access
               - you forgot to run / boot your web server
               - your web server isn't accessible
-              - you have weird network configuration settings on your computer`)
+              - you have unusual network configuration settings on your computer`)
 
           expect(err1.url).to.include('/foo.html')
           expect(emit).to.be.calledWith('visit:failed', err1)

--- a/packages/driver/cypress/e2e/commands/request.cy.js
+++ b/packages/driver/cypress/e2e/commands/request.cy.js
@@ -1372,7 +1372,7 @@ describe('src/cy/commands/request', () => {
                 - you don't have internet access
                 - you forgot to run / boot your web server
                 - your web server isn't accessible
-                - you have weird network configuration settings on your computer`)
+                - you have unusual network configuration settings on your computer`)
 
             expect(err.docsUrl).to.eq('https://on.cypress.io/request')
 

--- a/packages/driver/cypress/e2e/cypress/async.cy.js
+++ b/packages/driver/cypress/e2e/cypress/async.cy.js
@@ -1,0 +1,35 @@
+describe('async test functions', () => {
+  it('fails an async test properly', { defaultCommandTimeout: 50 }, async () => {
+    cy.on('fail', (err) => {
+      expect(err.message).to.eql('Timed out retrying after 50ms: expected true to be false')
+    })
+
+    await 1
+    cy.wrap(true).should('be.false')
+  })
+
+  it('passes', { defaultCommandTimeout: 50 }, async () => {
+    const sub = await cy.wrap(true).should('be.true')
+
+    const external = await Promise.resolve('external')
+
+    const body = await cy.get('body')
+
+    expect(sub).to.be.true
+    expect(external).to.eq('external')
+    expect(body).to.eql(cy.$$('body'))
+  })
+
+  it('works with done callback for test', (done) => {
+    cy.on('command:queue:end', () => {
+      done()
+    })
+    cy.wait(50)
+  })
+
+  // This test does not past - it should time out and fail because done() is never called,
+  // but it doesn't at the moment.
+  it('foo', (done) => {
+    cy.get('#dne', { timeout: 100 })
+  })
+})

--- a/packages/driver/src/cross-origin/origin_fn.ts
+++ b/packages/driver/src/cross-origin/origin_fn.ts
@@ -105,8 +105,8 @@ const getCallbackFn = async (fn: string, file?: string) => {
 }
 
 export const handleOriginFn = (Cypress: Cypress.Cypress, cy: $Cy) => {
-  const reset = (state) => {
-    cy.reset({})
+  const reset = async (state) => {
+    await cy.reset({})
 
     const stateUpdates = {
       ...state,
@@ -140,7 +140,7 @@ export const handleOriginFn = (Cypress: Cypress.Cypress, cy: $Cy) => {
 
     let queueFinished = false
 
-    reset(state)
+    await reset(state)
 
     // Set the counter for log ids
     LogUtils.setCounter(logCounter)

--- a/packages/driver/src/cy/commands/navigation.ts
+++ b/packages/driver/src/cy/commands/navigation.ts
@@ -365,14 +365,6 @@ const stabilityChanged = async (Cypress, state, config, stable) => {
     return promise
   }
 
-  const reject = (err) => {
-    const r = state('reject')
-
-    if (r) {
-      return r(err)
-    }
-  }
-
   try {
     return loading()
     .timeout(options.timeout, 'page load')
@@ -383,11 +375,11 @@ const stabilityChanged = async (Cypress, state, config, stable) => {
       try {
         return timedOutWaitingForPageLoad(options.timeout, options._log)
       } catch (err) {
-        return reject(err)
+        return state('reject')?.(err)
       }
     })
   } catch (e) {
-    return reject(e)
+    return state('reject')?.(e)
   }
 }
 

--- a/packages/driver/src/cy/stability.ts
+++ b/packages/driver/src/cy/stability.ts
@@ -29,7 +29,7 @@ export const create = (Cypress: ICypress, state: StateFunc) => ({
     })
   },
 
-  whenStable: (fn: () => any) => {
+  whenStable: (fn: () => any = () => {}) => {
     if (state('isStable') !== false) {
       return Promise.try(fn)
     }

--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -232,31 +232,6 @@ class $Cypress {
 
     this.state = $SetterGetter.create({}) as unknown as StateFunc
 
-    /*
-     * As part of the Detached DOM effort, we're changing the way subjects are determined in Cypress.
-     * While we usually consider cy.state() to be internal, in the case of cy.state('subject') and cy.state('withinSubject'),
-     * cypress-testing-library, one of our most popular plugins, relies on them.
-     * https://github.com/testing-library/cypress-testing-library/blob/1af9f2f28b2ca62936da8a8acca81fc87e2192f7/src/utils.js#L9
-     *
-     * Therefore, we've added these shims to continue to support them. The library is actively maintained, so this
-     * shouldn't need to stick around too long (written 07/22).
-     */
-    Object.defineProperty(this.state(), 'subject', {
-      get: () => {
-        $errUtils.warnByPath('subject.state_subject_deprecated')
-
-        return this.cy.subject()
-      },
-    })
-
-    Object.defineProperty(this.state(), 'withinSubject', {
-      get: () => {
-        $errUtils.warnByPath('subject.state_withinsubject_deprecated')
-
-        return this.cy.getSubjectFromChain(this.cy.state('withinSubjectChain'))
-      },
-    })
-
     this.originalConfig = _.cloneDeep(config)
     this.config = $SetterGetter.create(config, (config) => {
       const skipConfigOverrideValidation = this.isCrossOriginSpecBridge ? window.__cySkipValidateConfig : window.top!.__cySkipValidateConfig

--- a/packages/driver/src/cypress/command_queue.ts
+++ b/packages/driver/src/cypress/command_queue.ts
@@ -1,5 +1,4 @@
 import _ from 'lodash'
-import Bluebird from 'bluebird'
 import Debug from 'debug'
 
 import { Queue } from '../util/queue'
@@ -7,9 +6,7 @@ import $dom from '../dom'
 import $utils from './utils'
 import $errUtils from './error_utils'
 import type $Command from './command'
-import type { StateFunc } from './state'
 import type { $Cy } from './cy'
-import type { IStability } from '../cy/stability'
 
 const debugErrors = Debug('cypress:driver:errors')
 
@@ -70,8 +67,19 @@ const commandRunningFailed = (Cypress, err, current?: $Command) => {
  * a sync function, and retries queries until they pass or time out. Commands invoke cy.verifyUpcomingAssertions
  * directly, but the command_queue is responsible for retrying queries.
  */
-function retryQuery (command: $Command, ret: any, cy: $Cy) {
-  if ($utils.isPromiseLike(ret) && !cy.isCy(ret)) {
+async function retryQuery (command: $Command, ret: any, cy: $Cy) {
+  if (cy.isCy(ret)) {
+    $errUtils.throwErrByPath(
+      'query_command.invoked_action', {
+        args: {
+          name: command.get('name'),
+          action: _.last(cy.queue.get()).get('name'),
+        },
+      },
+    )
+  }
+
+  if ($utils.isPromiseLike(ret)) {
     $errUtils.throwErrByPath(
       'query_command.returned_promise', {
         args: { name: command.get('name') },
@@ -109,25 +117,72 @@ function retryQuery (command: $Command, ret: any, cy: $Cy) {
     })
   }
 
-  return onRetry()
+  // Queries can invoke other queries - they are synchronous, and get added to the subject chain without
+  // issue. But they cannot contain commands, which are async.
+  // This callback watches to ensure users don't try and invoke any commands while inside a query.
+  const commandEnqueued = (obj: Cypress.EnqueuedCommandAttributes) => {
+    if (!obj.query) {
+      $errUtils.throwErrByPath(
+        'query_command.invoked_action', {
+          args: {
+            name: command.get('name'),
+            action: obj.name,
+          },
+        },
+      )
+    }
+  }
+
+  try {
+    await onRetry()
+  } finally {
+    // always remove this listener
+    Cypress.removeListener('command:enqueued', commandEnqueued)
+  }
 }
 
 export class CommandQueue extends Queue<$Command> {
-  state: StateFunc
-  stability: IStability
   cy: $Cy
 
-  constructor (
-    state: StateFunc,
-    stability: IStability,
-    cy: $Cy,
-  ) {
+  constructor (cy: $Cy) {
     super()
 
-    this.state = state
-    this.stability = stability
     this.cy = cy
     this.run = this.run.bind(this)
+
+    this.on('itemError', (err) => {
+      if (this.cy.state('onQueueFailed')) {
+        err = this.cy.state('onQueueFailed')(err, this)
+
+        this.cy.state('onQueueFailed', null)
+      }
+
+      debugErrors('error throw while executing command queue: %o', err)
+
+      // since this failed this means that a specific command failed
+      // and we should highlight it in red or insert a new command
+      // @ts-ignore
+      if (_.isObject(err) && !err.name) {
+        // @ts-ignore
+        err.name = 'CypressError'
+      }
+
+      const current = this.cy.state('current')
+
+      commandRunningFailed(Cypress, err, current)
+
+      if (err.isRecovered) {
+        current?.recovered()
+
+        return // let the queue end & restart on to the next command index (set in onQueueFailed)
+      }
+
+      if (current?.state === 'queued') {
+        current.skip()
+      } else if (current?.state === 'pending') {
+        current.fail()
+      }
+    })
   }
 
   logs (filter) {
@@ -162,12 +217,12 @@ export class CommandQueue extends Queue<$Command> {
     // first command. this was due to nestedIndex being undefined at that
     // time. so we have to ensure to check that its any kind of number (even 0)
     // in order to know to insert it into the existing array.
-    let nestedIndex = this.state('nestedIndex')
+    let nestedIndex = this.cy.state('nestedIndex')
 
     // if this is a number, then we know we're about to insert this
     // into our commands and need to reset next + increment the index
     if (_.isNumber(nestedIndex) && nestedIndex < this.length) {
-      this.state('nestedIndex', (nestedIndex += 1))
+      this.cy.state('nestedIndex', (nestedIndex += 1))
     }
 
     // we look at whether or not nestedIndex is a number, because if it
@@ -176,6 +231,7 @@ export class CommandQueue extends Queue<$Command> {
     const index = _.isNumber(nestedIndex) ? nestedIndex : this.length
 
     this.insert(index, command)
+    this.run()
   }
 
   insert (index: number, command: $Command) {
@@ -205,385 +261,136 @@ export class CommandQueue extends Queue<$Command> {
     })
   }
 
-  cleanup () {
-    const runnable = this.state('runnable')
-
-    if (runnable && !runnable.isPending()) {
-      // make sure we reset the runnable's timeout now
-      runnable.resetTimeout()
+  async runItem (command: $Command) {
+    if (cy.queue !== this) {
+      return
     }
 
-    // if a command fails then after each commands
-    // could also fail unless we clear this out
-    this.state('commandIntermediateValue', undefined)
+    // if the command has already ran or should be skipped, just bail and increment index
+    if (command.state === 'passed' || command.state === 'skipped') {
+      // must set prev + next since other
+      // operations depend on this state being correct
+      command.set({
+        prev: this.at(this.index - 1),
+        next: this.at(this.index + 1),
+      })
 
-    // reset the nestedIndex back to null
-    this.state('nestedIndex', null)
+      this.cy.setSubjectForChainer(command.get('chainerId'), [command.get('subject')])
 
-    // and forcibly move the index needle to the
-    // end in case we have after / afterEach hooks
-    // which need to run
-    this.index = this.length
-  }
+      if (command.state === 'skipped') {
+        Cypress.action('cy:skipped:command:end', command)
+      }
 
-  private runCommand (command: $Command) {
+      return
+    }
+
+    // store the previous timeout
+    const prevTimeout = this.cy.timeout()
+
+    this.cy.state('current', command)
+    this.cy.state('chainerId', command.get('chainerId'))
+
     const isQuery = command.get('query')
     const name = command.get('name')
 
-    // bail here prior to creating a new promise
-    // because we could have stopped / canceled
-    // prior to ever making it through our first
-    // command
-    if (this.stopped) {
-      return Promise.resolve()
+    // If we have created a timeout but are in an unstable state, clear the
+    // timeout in favor of the on load timeout already running.
+    if (!this.cy.state('isStable')) {
+      this.cy.clearTimeout()
     }
 
-    this.state('current', command)
-    this.state('chainerId', command.get('chainerId'))
-
-    return this.stability.whenStable(() => {
-      this.state('nestedIndex', this.index)
-
-      return command.get('args')
-    })
-    .then((args: any) => {
-      // store this if we enqueue new commands
-      // to check for promise violations
-      let ret
-      let enqueuedCmd
-
-      // Queries can invoke other queries - they are synchronous, and get added to the subject chain without
-      // issue. But they cannot contain commands, which are async.
-      // This callback watches to ensure users don't try and invoke any commands while inside a query.
-      const commandEnqueued = (obj: Cypress.EnqueuedCommandAttributes) => {
-        if (isQuery && !obj.query) {
-          $errUtils.throwErrByPath(
-            'query_command.invoked_action', {
-              args: {
-                name,
-                action: obj.name,
-              },
-            },
-          )
-        }
-
-        return enqueuedCmd = obj
-      }
-
-      // only check for command enqueuing when none
-      // of our args are functions else commands
-      // like cy.then or cy.each would always fail
-      // since they return promises and queue more
-      // new commands
-      if ($utils.noArgsAreAFunction(args)) {
-        Cypress.once('command:enqueued', commandEnqueued)
-      }
-
-      args = [command.get('chainerId'), ...args]
-
-      // run the command's fn with runnable's context
-      try {
-        command.start()
-        ret = __stackReplacementMarker(command.get('fn'), args)
-
-        // Queries return a function which takes the current subject and returns the next subject. We wrap this in
-        // retryQuery() - and let it retry until it passes, times out or is cancelled.
-        // We save the original return value on the $Command though - it's what gets added to the subject chain later.
-        if (isQuery) {
-          command.set('queryFn', ret)
-          ret = retryQuery(command, ret, this.cy)
-        }
-      } catch (err) {
-        throw err
-      } finally {
-        // always remove this listener
-        Cypress.removeListener('command:enqueued', commandEnqueued)
-      }
-
-      this.state('commandIntermediateValue', ret)
-
-      // we cannot pass our cypress instance or our chainer
-      // back into bluebird else it will create a thenable
-      // which is never resolved
-      if (this.cy.isCy(ret)) {
-        return null
-      }
-
-      if (!(!enqueuedCmd || !$utils.isPromiseLike(ret))) {
-        $errUtils.throwErrByPath(
-          'miscellaneous.command_returned_promise_and_commands', {
-            args: {
-              current: name,
-              called: enqueuedCmd.name,
-            },
-          },
-        )
-      }
-
-      if (!(!enqueuedCmd || !!_.isUndefined(ret))) {
-        ret = _.isFunction(ret) ?
-          ret.toString() :
-          $utils.stringify(ret)
-
-        // if we got a return value and we enqueued
-        // a new command and we didn't return cy
-        // or an undefined value then throw
-        $errUtils.throwErrByPath(
-          'miscellaneous.returned_value_and_commands_from_custom_command', {
-            args: { current: name, returned: ret },
-          },
-        )
-      }
-
-      return ret
-    })
-    .then((subject) => {
-      // we may be given a regular array here so
-      // we need to re-wrap the array in jquery
-      // if that's the case if the first item
-      // in this subject is a jquery element.
-      // we want to do this because in 3.1.2 there
-      // was a regression when wrapping an array of elements
-      const firstSubject = $utils.unwrapFirst(subject)
-
-      // if ret is a DOM element and its not an instance of our own jQuery
-      if (subject && $dom.isElement(firstSubject) && !$dom.isJquery(subject)) {
-        // set it back to our own jquery object
-        // to prevent it from being passed downstream
-        // TODO: enable turning this off
-        // wrapSubjectsInJquery: false
-        // which will just pass subjects downstream
-        // without modifying them
-        subject = $dom.wrap(subject)
-      }
-
-      command.set({ subject })
-      command.pass()
-
-      // end / snapshot our logs if they need it
-      command.finishLogs()
-
-      if (isQuery) {
-        subject = command.get('queryFn')
-        // For queries, the "subject" here is the query's return value, which is a function which
-        // accepts a subject and returns a subject, and can be re-invoked at any time.
-
-        subject.commandName = name
-        subject.args = command.get('args')
-
-        // Even though we've snapshotted, we only end the logs a query's logs if we're at the end of a query
-        // chain - either there is no next command (end of a test), the next command is an action, or the next
-        // command belongs to another chainer (end of a chain).
-
-        // This is done so that any query's logs remain in the 'pending' state until the subject chain is finished.
-        this.cy.addQueryToChainer(command.get('chainerId'), subject)
-      } else {
-        // For commands, the "subject" here is the command's return value, which replaces
-        // the current subject chain. We cannot re-invoke commands - the return value here is final.
-        this.cy.setSubjectForChainer(command.get('chainerId'), [subject])
-      }
-
-      // TODO: This line was causing subjects to be cleaned up prematurely in some instances (Specifically seen on the within command)
-      // The command log would print the yielded value as null if checked outside of the current command chain.
-      // this.cleanSubjects()
-
-      this.state({
-        commandIntermediateValue: undefined,
-        // reset the nestedIndex back to null
-        nestedIndex: null,
-        // we're finished with the current command so set it back to null
-        current: null,
-      })
-
-      return subject
-    })
-  }
-
-  // TypeScript doesn't allow overriding functions with different type signatures
-  // @ts-ignore
-  run () {
-    if (this.stopped) {
-      this.cleanup()
-
-      return Promise.resolve()
+    await this.cy.whenStable()
+    if (cy.queue !== this) {
+      return
     }
 
-    const next = () => {
-      const command = this.at(this.index)
+    this.cy.state('nestedIndex', this.index)
 
-      // if the command has already ran or should be skipped, just bail and increment index
-      if (command && (command.state === 'passed' || command.state === 'skipped')) {
-        // must set prev + next since other
-        // operations depend on this state being correct
-        command.set({
-          prev: this.at(this.index - 1),
-          next: this.at(this.index + 1),
-        })
+    const args = [command.get('chainerId'), ...command.get('args')]
 
-        this.cy.setSubjectForChainer(command.get('chainerId'), [command.get('subject')])
+    command.start()
+    let ret = __stackReplacementMarker(command.get('fn'), args)
 
-        if (command.state === 'skipped') {
-          Cypress.action('cy:skipped:command:end', command)
-        }
-
-        // move on to the next queueable
-        this.index += 1
-
-        return next()
-      }
-
-      // if we're at the very end
-      if (!command) {
-        // trigger queue is almost finished
-        Cypress.action('cy:command:queue:before:end')
-
-        // we need to wait after all commands have
-        // finished running if the application under
-        // test is no longer stable because we cannot
-        // move onto the next test until its finished
-        return this.stability.whenStable(() => {
-          Cypress.action('cy:command:queue:end')
-          this.stop()
-
-          const onQueueEnd = cy.state('onQueueEnd')
-
-          if (onQueueEnd) {
-            onQueueEnd()
-          }
-
-          return null
-        })
-      }
-
-      // store the previous timeout
-      const prevTimeout = this.cy.timeout()
-
-      // If we have created a timeout but are in an unstable state, clear the
-      // timeout in favor of the on load timeout already running.
-      if (!this.state('isStable')) {
-        this.cy.clearTimeout()
-      }
-
-      // store the current runnable
-      const runnable = this.state('runnable')
-
-      Cypress.action('cy:command:start', command)
-
-      return this.runCommand(command)!
-      .then(() => {
-        // each successful command invocation should
-        // always reset the timeout for the current runnable
-        // unless it already has a state.  if it has a state
-        // and we reset the timeout again, it will always
-        // cause a timeout later no matter what.  by this time
-        // mocha expects the test to be done
-
-        if (!runnable.state) {
-          this.cy.timeout(prevTimeout)
-        }
-
-        Cypress.action('cy:command:end', command)
-
-        // move on to the next queueable
-        this.index += 1
-
-        const pauseFn = this.state('onPaused')
-
-        if (pauseFn) {
-          return new Bluebird((resolve) => {
-            return pauseFn(resolve)
-          }).then(next)
-        }
-
-        return next()
-      })
+    // Queries return a function which takes the current subject and returns the next subject. We wrap this in
+    // retryQuery() - and let it retry until it passes, times out or is cancelled.
+    // We save the original return value on the $Command though - it's what gets added to the subject chain later.
+    if (isQuery) {
+      command.set('queryFn', ret)
+      ret = retryQuery(command, ret, this.cy)
     }
 
-    const onError = (err) => {
-      // If the runnable was marked as pending, this test was skipped
-      // go ahead and just return
-      const runnable = this.state('runnable')
-
-      if (runnable.isPending()) {
-        this.stop()
-
-        return
-      }
-
-      if (this.state('onQueueFailed')) {
-        err = this.state('onQueueFailed')(err, this)
-
-        this.state('onQueueFailed', null)
-      }
-
-      debugErrors('error throw while executing cypress queue: %o', err)
-
-      // since this failed this means that a specific command failed
-      // and we should highlight it in red or insert a new command
-      // @ts-ignore
-      if (_.isObject(err) && !err.name) {
-        // @ts-ignore
-        err.name = 'CypressError'
-      }
-
-      const current = this.state('current')
-
-      commandRunningFailed(Cypress, err, current)
-
-      if (err.isRecovered) {
-        current?.recovered()
-
-        return // let the queue end & restart on to the next command index (set in onQueueFailed)
-      }
-
-      if (current?.state === 'queued') {
-        current.skip()
-      } else if (current?.state === 'pending') {
-        current.fail()
-      }
-
-      this.cleanup()
-
-      return this.cy.fail(err)
+    // If the user returns cy, we don't need to await anything; commands they invoked
+    // have already been pushed onto the queue.
+    if (this.cy.isCy(ret)) {
+      ret = null
     }
 
-    const { promise, reject, cancel } = super.run({
-      onRun: next,
-      onError,
-      onFinish: this.run,
+    Cypress.action('cy:command:start', command)
+
+    let subject = await ret
+    if (cy.queue !== this) {
+      return
+    }
+
+    // we may be given a regular array here so
+    // we need to re-wrap the array in jquery
+    // if that's the case if the first item
+    // in this subject is a jquery element.
+    // we want to do this because in 3.1.2 there
+    // was a regression when wrapping an array of elements
+    const firstSubject = $utils.unwrapFirst(subject)
+
+    // if ret is a DOM element and its not an instance of our own jQuery
+    if (subject && $dom.isElement(firstSubject) && !$dom.isJquery(subject)) {
+      // set it back to our own jquery object
+      // to prevent it from being passed downstream
+      // TODO: enable turning this off
+      // wrapSubjectsInJquery: false
+      // which will just pass subjects downstream
+      // without modifying them
+      subject = $dom.wrap(subject)
+    }
+
+    command.set({ subject })
+    command.pass()
+
+    // end / snapshot our logs if they need it
+    command.finishLogs()
+    Cypress.action('cy:command:end', command)
+
+    if (isQuery) {
+      subject = command.get('queryFn')
+      // For queries, the "subject" here is the query's return value, which is a function which
+      // accepts a subject and returns a subject, and can be re-invoked at any time.
+
+      subject.commandName = name
+      subject.args = command.get('args')
+
+      // Even though we've snapshotted, we only end the logs a query's logs if we're at the end of a query
+      // chain - either there is no next command (end of a test), the next command is an action, or the next
+      // command belongs to another chainer (end of a chain).
+
+      // This is done so that any query's logs remain in the 'pending' state until the subject chain is finished.
+      this.cy.addQueryToChainer(command.get('chainerId'), subject)
+    } else {
+      // For commands, the "subject" here is the command's return value, which replaces
+      // the current subject chain. We cannot re-invoke commands - the return value here is final.
+      this.cy.setSubjectForChainer(command.get('chainerId'), [subject])
+    }
+
+    // each successful command invocation should
+    // always reset the timeout for the current runnable
+    // unless it already has a state.  if it has a state
+    // and we reset the timeout again, it will always
+    // cause a timeout later no matter what.  by this time
+    // mocha expects the test to be done
+    if (!this.cy.state('runnable').state) {
+      this.cy.timeout(prevTimeout)
+    }
+
+    this.cy.state({
+      nestedIndex: null,
+      current: null,
     })
-
-    this.state('promise', promise)
-    this.state('reject', reject)
-    this.state('cancel', () => {
-      cancel()
-
-      Cypress.action('cy:canceled')
-    })
-
-    return promise
-  }
-
-  // This function iterates through all upcoming commands in the queue, then
-  // discards the subject chain for every chainer that can't be referenced
-  // in the future (eg, no upcoming commands belong to the same chain).
-
-  // This is safe because aliases (which might be referenced later) are stored
-  // separately, in state('aliases'), and any subjects that "flow upwards" (eg.
-  // the subject of a chain inside a .then() command) have already replaced
-  // the subject of their parent chainer by the time this is called.
-  cleanSubjects () {
-    const stillNeeded = this.queueables.slice(this.index).map((c) => c.get('chainerId'))
-
-    this.queueables.slice(0, this.index).forEach((command) => {
-      // Once a command has resolved, and its chainer is no longer referenced
-      // by future commands, we can throw away the reference to the function
-      // and its subject to free memory.
-      if (command.get('subject') && stillNeeded.indexOf(command.get('chainerId')) === -1) {
-        command.set({ fn: null, subject: null, queryFn: null })
-      }
-    })
-
-    this.cy.state('subjects', _.pick(this.cy.state('subjects'), stillNeeded))
   }
 }

--- a/packages/driver/src/cypress/error_messages.ts
+++ b/packages/driver/src/cypress/error_messages.ts
@@ -795,42 +795,6 @@ export default {
         docsUrl: 'https://on.cypress.io/returning-value-and-commands-in-test',
       }
     },
-    command_returned_promise_and_commands (obj) {
-      return {
-        message: stripIndent`\
-          Cypress detected that you returned a promise from a command while also invoking one or more cy commands in that promise.
-
-          The command that returned the promise was:
-
-            > ${cmd(obj.current)}
-
-          The cy command you invoked inside the promise was:
-
-            > ${cmd(obj.called)}
-
-          Because Cypress commands are already promise-like, you don't need to wrap them or return your own promise.
-
-          Cypress will resolve your command with whatever the final Cypress command yields.
-
-          The reason this is an error instead of a warning is because Cypress internally queues commands serially whereas Promises execute as soon as they are invoked. Attempting to reconcile this would prevent Cypress from ever resolving.`,
-        docsUrl: 'https://on.cypress.io/returning-promise-and-commands-in-another-command',
-      }
-    },
-    mixing_promises_and_commands (obj) {
-      return {
-        message: stripIndent`\
-          Cypress detected that you returned a promise in a test, but also invoked one or more cy commands inside of that promise.
-
-          The test title was:
-
-            > ${obj.title}
-
-          While this works in practice, it's often indicative of an anti-pattern. You almost never need to return both a promise and also invoke cy commands.
-
-          Cy commands themselves are already promise like, and you can likely avoid the use of the separate Promise.`,
-        docsUrl: 'https://on.cypress.io/returning-promise-and-commands-in-test',
-      }
-    },
     dangling_commands: {
       message: stripIndent`\
         Oops, Cypress detected something wrong with your test code.
@@ -1422,7 +1386,7 @@ export default {
             - you don't have internet access
             - you forgot to run / boot your web server
             - your web server isn't accessible
-            - you have weird network configuration settings on your computer`, 10),
+            - you have unusual network configuration settings on your computer`, 10),
         docsUrl: 'https://on.cypress.io/request',
       }
     },
@@ -1988,12 +1952,6 @@ export default {
 
           > ${subjectChainToString(obj.subjectChain)}`
     },
-    state_subject_deprecated: {
-      message: `${cmd('state', '\'subject\'')} has been deprecated and will be removed in a future release. Consider migrating to ${cmd('subject')} instead.`,
-    },
-    state_withinsubject_deprecated: {
-      message: `${cmd('state', '\'withinSubject\'')} has been deprecated and will be removed in a future release. You should read ${cmd('state', '\'withinSubjectChain\'')} once at the top of your command / query, and resolve it into a value with ${cmd('getSubjectFromChain', 'withinSubjectChain')} as needed.`,
-    },
   },
 
   submit: {
@@ -2329,7 +2287,7 @@ export default {
         - you don't have internet access
         - you forgot to run / boot your web server
         - your web server isn't accessible
-        - you have weird network configuration settings on your computer`,
+        - you have unusual network configuration settings on your computer`,
     loading_file_failed (obj) {
       return stripIndent`
         ${cmd('visit')} failed trying to load:

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -1625,9 +1625,9 @@ export default {
         // if its a hook, and then we fire the
         // test:before:run:async action if its not
         // been fired before for this test
-        return Promise.try(() => {
+        return Promise.try(async () => {
           if (!fired(TEST_BEFORE_RUN_EVENT, test)) {
-            cy.reset(test)
+            await cy.reset(test)
             test.slow(Cypress.config('slowTestThreshold'))
             test._retries = Cypress.getTestRetries() ?? -1
             fire(TEST_BEFORE_RUN_EVENT, test, Cypress)
@@ -1636,7 +1636,7 @@ export default {
           return true
         })
         .catch(handleBeforeTestEventError)
-        .then((ranSuccessfulBeforeRunEvent: boolean) => {
+        .then(async (ranSuccessfulBeforeRunEvent: boolean) => {
           cy.state('duringUserTestExecution', false)
           Cypress.primaryOriginCommunicator.toAllSpecBridges('sync:state', { 'duringUserTestExecution': false })
 
@@ -1645,7 +1645,7 @@ export default {
           // running lifecycle events
           // and also get back a function result handler that we use as
           // an async seam
-          cy.setRunnable(runnable, runnableId)
+          await cy.setRunnable(runnable, runnableId)
 
           if (ranSuccessfulBeforeRunEvent) {
             return testBeforeRunAsync(test, Cypress)

--- a/packages/driver/src/cypress/state.ts
+++ b/packages/driver/src/cypress/state.ts
@@ -1,7 +1,5 @@
 /// <reference path="../../types/cypress/log.d.ts" />
 
-import type Bluebird from 'bluebird'
-
 import type { RouteMap } from '../cy/net-stubbing/types'
 import type { $Command } from './command'
 import type { KeyboardModifiers } from '../cy/keyboard'
@@ -48,12 +46,8 @@ export interface StateFunc {
   (k: 'nestedIndex', v?: number): number
   (k: 'chainerId', v?: string): string
   (k: 'ctx', v?: Mocha.Context): Mocha.Context
-  (k: 'commandIntermediateValue', v?: any): any
   (k: 'onPaused', v?: (fn: any) => void): (fn: any) => void
   (k: 'onQueueFailed', v?: (err, queue?: any) => Error): (err, queue?: any) => Error
-  (k: 'promise', v?: Bluebird<unknown>): Bluebird<unknown>
-  (k: 'reject', v?: (err: any) => any): (err: any) => any
-  (k: 'cancel', v?: () => void): () => void
   (k: string, v?: any): any
   state: StateFunc
   reset: () => Record<string, any>

--- a/packages/driver/src/util/queue.ts
+++ b/packages/driver/src/util/queue.ts
@@ -1,22 +1,47 @@
-import Bluebird from 'bluebird'
+import { EventEmitter2 } from 'eventemitter2'
 
-interface QueueRunProps {
-  onRun: () => Bluebird<any> | Promise<any>
-  onError: (err: Error) => void
-  onFinish: () => Bluebird<any> | Promise<any>
-}
+type QueueState = 'ready' | 'running' | 'stopping' | 'stopped'
 
-export class Queue<T> {
-  protected queueables: T[] = []
-  private _stopped = false
+/* Diagram created with https://asciiflow.com/
+ *
+ *                  Command Queue              stop()
+ *                                               │
+ *                                     state == 'stopped|ready'?────┐
+ *       emit('complete')                        |                  │
+ *        ┌────────────┐                       true               false
+ *        │            │                         │                  │
+ *        │ remainingItems() == 0                ▼                  ▼
+ * ┌──────▼──────┐     ▲                   emit('stopped')    state.stopping
+ * │┼───────────┼│     │                    state.stopped
+ * ││state.ready│┼─►.run()◄──────true──┐
+ * │┼───────────┼│     │               │
+ * └─────────────┘     ▼           state == 'running'?──┐
+ *             remainingItems() > 0    ▲                │
+ *        ┌──────┐     │               │                │
+ *        ▼      │     ▼               │              false
+ *    .run()────►state.running         │                │
+ *                     │        emit('itemComplete')    │
+ *                     │               │                │
+ *                     └───runItem()───┘                │
+ *                             │                emit('stopped')
+ *                   emit('itemError')                  │
+ *                ┌──────┐     │                        │
+ *                ▼      │     ▼                        │
+ *            .run()────►state.stopped◄─────────────────┘
+ */
+
+export class Queue<T> extends EventEmitter2 {
+  protected queueables: Queuables[] = []
+  protected state: QueueState = 'ready'
+  steppingThrough = false
   index: number = 0
 
-  constructor (queueables: T[] = []) {
-    this.queueables = queueables
+  get length () {
+    return this.queueables.length
   }
 
-  get (): T[] {
-    return this.queueables
+  get current (): T {
+    return this.queueables[this.index]
   }
 
   add (queueable: T) {
@@ -33,89 +58,59 @@ export class Queue<T> {
     return queueable
   }
 
-  slice (index: number) {
-    return this.queueables.slice(index)
-  }
-
-  at (index: number): T {
+  at (index: number) {
     return this.queueables[index]
   }
 
-  reset () {
-    this._stopped = false
-  }
-
-  clear () {
-    this.index = 0
-    this.queueables.length = 0
-  }
-
-  stop () {
-    this._stopped = true
-  }
-
-  run ({ onRun, onError, onFinish }: QueueRunProps) {
-    let inner
-    let rejectOuterAndCancelInner
-
-    // this ends up being the parent promise wrapper
-    const promise = new Bluebird((resolve, reject) => {
-      // bubble out the inner promise. we must use a resolve(null) here
-      // so the outer promise is first defined else this will kick off
-      // the 'next' call too soon and end up running commands prior to
-      // the promise being defined
-      inner = Bluebird
-      .resolve(null)
-      .then(onRun)
-      .then(resolve)
-      .catch(reject)
-
-      // can't use onCancel argument here because it's called asynchronously.
-      // when we manually reject our outer promise we have to immediately
-      // cancel the inner one else it won't be notified and its callbacks
-      // will continue to be invoked. normally we don't have to do this
-      // because rejections come from the inner promise and bubble out to
-      // our outer, but when we manually reject the outer promise, we
-      // have to go in the opposite direction from outer -> inner
-      rejectOuterAndCancelInner = (err) => {
-        inner.cancel()
-        reject(err)
-      }
-    })
-    .catch(onError)
-    .then(onFinish)
-
-    const cancel = () => {
-      promise.cancel()
-      inner.cancel()
+  async stop () {
+    // If we're running or already stopping, we set the state to 'stopping'
+    // and wait for the current item to finish.
+    // It will emit 'stopped' and this function can resolve.
+    if (this.state === 'running' || this.state === 'stopping') {
+      this.state = 'stopping'
+      return this.waitFor('stopped')
     }
 
-    return {
-      promise,
-      cancel,
-      // wrapped to ensure `rejectOuterAndCancelInner` is assigned
-      // before reject is called
-      reject: (err) => rejectOuterAndCancelInner(err),
-    }
+    // If we're not running, we can just 'stop' immediately, since
+    // there's nothing async going on here.
+    this.state = 'stopped'
+    this.emit('stopped')
   }
 
-  get length () {
-    return this.queueables.length
+  runItem(item: T) {
+    throw new Error('Default implementation; override this.')
   }
 
-  get stopped () {
-    return this._stopped
-  }
-
-  /**
-   * Helper function to return the last item in the queue.
-   * @returns The last item or undefined if the queue is empty.
-   */
-  last (): T | undefined {
-    if (this.length < 1) {
-      return undefined
+  async run () {
+    if (this.state === 'running' || this.state === 'stopped') {
+      return
     }
 
-    return this.at(this.length - 1)
+    let next = this.queueables[this.index]
+
+    if (!next) {
+      this.emit('complete')
+      return
+    }
+
+    try {
+      this.state = 'running'
+      await this.runItem(next)
+      this.emit('itemComplete')
+    } catch (e) {
+      this.state = 'stopping'
+      this.emit('itemError', e)
+    }
+
+    if (this.state === 'stopping') {
+      this.emit('stopped')
+      return
+    }
+
+    // If we haven't stopped or errored while waiting for the current queueable
+    // then kick off the next queueable.
+    this.state = 'ready'
+    this.index++
+    this.run()
   }
 }


### PR DESCRIPTION
### Additional details
This pull request is not ready to merge; it fails most tests, but I'm pushing it up now as the current state of work towards supporting async test functions.

### Steps to test
Work still needs to be done on tying the lose threads back together; currently some timeouts get lost, some promise rejections are not handled appropriately, etc - but as a whole, the rewritten command queue works, and supports async test functions, `await`ing Cypress commands, and mixing native promises alongside builtin commands.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
