### PR TITLE
misc: revise messaging for debug empty states

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## 12.9.0
 
 _Released 03/28/2023 (PENDING)_
- 
+
 **Bugfixes:**
 
  - Fixed a compatibility issue so that component test projects can use [Vite](https://vitejs.dev/) version 4.2.0 and greater. Fixes [#26138](https://github.com/cypress-io/cypress/issues/26138).

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,14 +2,14 @@
 ## 12.9.0
 
 _Released 03/28/2023 (PENDING)_
-
-**Misc:**
-
- - Made some minor styling updates to the Debug page. Addresses [#26041](https://github.com/cypress-io/cypress/issues/26041).
  
 **Bugfixes:**
 
  - Fixed a compatibility issue so that component test projects can use [Vite](https://vitejs.dev/) version 4.2.0 and greater. Fixes [#26138](https://github.com/cypress-io/cypress/issues/26138).
+
+**Misc:**
+
+ - Made some minor styling updates to the Debug page. Addresses [#26041](https://github.com/cypress-io/cypress/issues/26041).
 
 ## 12.8.1
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,11 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 12.9.0
+
+_Released 03/28/2023 (PENDING)_
+
+**Misc:**
+
+ - Made some minor styling updates to the Debug page. Addresses [#26041](https://github.com/cypress-io/cypress/issues/26041).
 ## 12.8.1
 
 _Released 03/15/2023_

--- a/packages/app/src/debug/empty/DebugEmptyStates.cy.tsx
+++ b/packages/app/src/debug/empty/DebugEmptyStates.cy.tsx
@@ -84,7 +84,7 @@ describe('Debug page empty states', () => {
 
       mountWithGql(<DebugNotLoggedIn />)
 
-      cy.findByRole('link', { name: 'Learn more' }).should('have.attr', 'href', 'https://on.cypress.io/debug-page?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
+      cy.findByRole('link', { name: 'Learn more about debugging CI failures in Cypress' }).should('have.attr', 'href', 'https://on.cypress.io/debug-page?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
 
       cy.percySnapshot()
     })
@@ -105,7 +105,7 @@ describe('Debug page empty states', () => {
 
       mountWithGql(<DebugNoProject />)
 
-      cy.findByRole('link', { name: 'Learn more' }).should('have.attr', 'href', 'https://on.cypress.io/adding-new-project?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
+      cy.findByRole('link', { name: 'Learn more about project setup in Cypress' }).should('have.attr', 'href', 'https://on.cypress.io/adding-new-project?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
 
       cy.percySnapshot()
 
@@ -125,7 +125,7 @@ describe('Debug page empty states', () => {
     it('renders', () => {
       mountWithGql(<DebugNoRuns />)
 
-      cy.findByRole('link', { name: 'Learn more' }).should('have.attr', 'href', 'https://on.cypress.io/cypress-run-record-key?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
+      cy.findByRole('link', { name: 'Learn more about recording a run to Cypress Cloud' }).should('have.attr', 'href', 'https://on.cypress.io/cypress-run-record-key?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
 
       cy.percySnapshot()
     })
@@ -149,7 +149,7 @@ describe('Debug page empty states', () => {
     it('renders', () => {
       mountWithGql(<DebugError />)
 
-      cy.findByRole('link', { name: 'Learn more' }).should('have.attr', 'href', 'https://on.cypress.io/debug-page?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
+      cy.findByRole('link', { name: 'Learn more about debugging CI failures in Cypress' }).should('have.attr', 'href', 'https://on.cypress.io/debug-page?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
 
       cy.percySnapshot()
     })

--- a/packages/app/src/debug/empty/DebugEmptyStates.cy.tsx
+++ b/packages/app/src/debug/empty/DebugEmptyStates.cy.tsx
@@ -84,7 +84,7 @@ describe('Debug page empty states', () => {
 
       mountWithGql(<DebugNotLoggedIn />)
 
-      cy.findByRole('link', { name: 'Learn about debugging CI failures in Cypress' }).should('have.attr', 'href', 'https://on.cypress.io/debug-page?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
+      cy.findByRole('link', { name: 'Learn more' }).should('have.attr', 'href', 'https://on.cypress.io/debug-page?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
 
       cy.percySnapshot()
     })
@@ -105,7 +105,7 @@ describe('Debug page empty states', () => {
 
       mountWithGql(<DebugNoProject />)
 
-      cy.findByRole('link', { name: 'Learn about project setup in Cypress' }).should('have.attr', 'href', 'https://on.cypress.io/adding-new-project?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
+      cy.findByRole('link', { name: 'Learn more' }).should('have.attr', 'href', 'https://on.cypress.io/adding-new-project?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
 
       cy.percySnapshot()
 
@@ -125,7 +125,7 @@ describe('Debug page empty states', () => {
     it('renders', () => {
       mountWithGql(<DebugNoRuns />)
 
-      cy.findByRole('link', { name: 'Learn about recording a run to Cypress Cloud' }).should('have.attr', 'href', 'https://on.cypress.io/cypress-run-record-key?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
+      cy.findByRole('link', { name: 'Learn more' }).should('have.attr', 'href', 'https://on.cypress.io/cypress-run-record-key?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
 
       cy.percySnapshot()
     })
@@ -149,7 +149,7 @@ describe('Debug page empty states', () => {
     it('renders', () => {
       mountWithGql(<DebugError />)
 
-      cy.findByRole('link', { name: 'Learn about debugging CI failures in Cypress' }).should('have.attr', 'href', 'https://on.cypress.io/debug-page?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
+      cy.findByRole('link', { name: 'Learn more' }).should('have.attr', 'href', 'https://on.cypress.io/debug-page?utm_source=Binary%3A+Launchpad&utm_medium=Debug+Tab&utm_campaign=Learn+More')
 
       cy.percySnapshot()
     })

--- a/packages/app/src/debug/empty/DebugEmptyView.vue
+++ b/packages/app/src/debug/empty/DebugEmptyView.vue
@@ -2,17 +2,20 @@
   <div class="flex flex-col mx-auto my-45px max-w-680px items-center">
     <div class="flex flex-col items-center justify-evenly">
       <div><i-cy-box-open_x48 class="icon-dark-gray-500 icon-light-indigo-100" /></div>
-      <div class="flex flex-col mx-[20%] mt-25px mb-20px items-center">
+      <div class="flex flex-col mt-25px mb-20px max-w-640px items-center">
         <div class="font-medium my-5px text-center text-gray-900 text-18px">
           {{ title }}
         </div>
         <div class="font-normal my-5px text-center leading-relaxed text-16px text-gray-600">
-          {{ description }} <ExternalLink
-            v-if="helpLinkText && helpLinkHref"
-            :href="helpLink"
-          >
-            {{ helpLinkText }}
-          </ExternalLink>
+          {{ description }}
+          <span class="ml-4px">
+            <ExternalLink
+              v-if="helpLinkHref"
+              :href="helpLink"
+            >
+              {{ t('links.learnMoreButton') }}
+            </ExternalLink>
+          </span>
         </div>
       </div>
       <slot
@@ -94,7 +97,6 @@ const props = defineProps<{
   title: string
   description?: string
   exampleTestName?: string
-  helpLinkText?: string
   helpLinkHref?: string
   slideshowCampaign?: DebugSlideshowCampaigns // Not all flows need to show the slideshow (Error page)
 }>()

--- a/packages/app/src/debug/empty/DebugEmptyView.vue
+++ b/packages/app/src/debug/empty/DebugEmptyView.vue
@@ -8,9 +8,11 @@
         </div>
         <div class="font-normal my-5px text-center leading-relaxed text-16px text-gray-600">
           {{ description }}
-          <span class="ml-4px">
+          <span
+            v-if="helpLinkHref"
+            class="ml-4px"
+          >
             <ExternalLink
-              v-if="helpLinkHref"
               :href="helpLink"
             >
               {{ t('links.learnMoreButton') }}

--- a/packages/app/src/debug/empty/DebugEmptyView.vue
+++ b/packages/app/src/debug/empty/DebugEmptyView.vue
@@ -9,14 +9,14 @@
         <div class="font-normal my-5px text-center leading-relaxed text-16px text-gray-600">
           {{ description }}
           <span class="ml-4px">
-            <span class="sr-only">
-              {{ helpLinkSrText }}
-            </span>
             <ExternalLink
               v-if="helpLinkHref"
               :href="helpLink"
             >
               {{ t('links.learnMoreButton') }}
+              <span class="sr-only">
+                {{ helpLinkSrText }}
+              </span>
             </ExternalLink>
           </span>
         </div>

--- a/packages/app/src/debug/empty/DebugEmptyView.vue
+++ b/packages/app/src/debug/empty/DebugEmptyView.vue
@@ -9,6 +9,9 @@
         <div class="font-normal my-5px text-center leading-relaxed text-16px text-gray-600">
           {{ description }}
           <span class="ml-4px">
+            <span class="sr-only">
+              {{ helpLinkSrText }}
+            </span>
             <ExternalLink
               v-if="helpLinkHref"
               :href="helpLink"
@@ -98,6 +101,7 @@ const props = defineProps<{
   description?: string
   exampleTestName?: string
   helpLinkHref?: string
+  helpLinkSrText?: string
   slideshowCampaign?: DebugSlideshowCampaigns // Not all flows need to show the slideshow (Error page)
 }>()
 

--- a/packages/app/src/debug/empty/DebugError.vue
+++ b/packages/app/src/debug/empty/DebugError.vue
@@ -13,6 +13,7 @@
   <DebugEmptyView
     :title="t('debugPage.emptyStates.debugDirectlyInCypress')"
     :description="t('debugPage.emptyStates.reviewRerunAndDebug')"
+    :help-link-sr-text="t('debugPage.emptyStates.learnAboutDebuggingSrText')"
     help-link-href="https://on.cypress.io/debug-page"
   />
 </template>

--- a/packages/app/src/debug/empty/DebugError.vue
+++ b/packages/app/src/debug/empty/DebugError.vue
@@ -13,7 +13,6 @@
   <DebugEmptyView
     :title="t('debugPage.emptyStates.debugDirectlyInCypress')"
     :description="t('debugPage.emptyStates.reviewRerunAndDebug')"
-    :help-link-text="t('debugPage.emptyStates.learnAboutDebugging')"
     help-link-href="https://on.cypress.io/debug-page"
   />
 </template>

--- a/packages/app/src/debug/empty/DebugNoProject.vue
+++ b/packages/app/src/debug/empty/DebugNoProject.vue
@@ -4,6 +4,7 @@
     :description="t('debugPage.emptyStates.reviewRerunAndDebug')"
     :example-test-name="t('debugPage.emptyStates.noProjectTestMessage')"
     :slideshow-campaign="DEBUG_SLIDESHOW.campaigns.connectProject"
+    :help-link-sr-text="t('debugPage.emptyStates.learnAboutProjectSetupSrText')"
     help-link-href="https://on.cypress.io/adding-new-project"
   >
     <template #cta="slotProps">

--- a/packages/app/src/debug/empty/DebugNoProject.vue
+++ b/packages/app/src/debug/empty/DebugNoProject.vue
@@ -3,7 +3,6 @@
     :title="t('debugPage.emptyStates.debugDirectlyInCypress')"
     :description="t('debugPage.emptyStates.reviewRerunAndDebug')"
     :example-test-name="t('debugPage.emptyStates.noProjectTestMessage')"
-    :help-link-text="t('debugPage.emptyStates.learnAboutProjectSetup')"
     :slideshow-campaign="DEBUG_SLIDESHOW.campaigns.connectProject"
     help-link-href="https://on.cypress.io/adding-new-project"
   >

--- a/packages/app/src/debug/empty/DebugNoRuns.vue
+++ b/packages/app/src/debug/empty/DebugNoRuns.vue
@@ -3,7 +3,6 @@
     :title="t('debugPage.emptyStates.recordYourFirstRun')"
     :description="t('debugPage.emptyStates.almostThere')"
     :example-test-name="t('debugPage.emptyStates.noRunsTestMessage')"
-    :help-link-text="t('debugPage.emptyStates.learnAboutRecording')"
     :slideshow-campaign="DEBUG_SLIDESHOW.campaigns.recordRun"
     help-link-href="https://on.cypress.io/cypress-run-record-key"
   >

--- a/packages/app/src/debug/empty/DebugNoRuns.vue
+++ b/packages/app/src/debug/empty/DebugNoRuns.vue
@@ -4,6 +4,7 @@
     :description="t('debugPage.emptyStates.almostThere')"
     :example-test-name="t('debugPage.emptyStates.noRunsTestMessage')"
     :slideshow-campaign="DEBUG_SLIDESHOW.campaigns.recordRun"
+    :help-link-sr-text="t('debugPage.emptyStates.learnAboutRecordingSrText')"
     help-link-href="https://on.cypress.io/cypress-run-record-key"
   >
     <template #cta>

--- a/packages/app/src/debug/empty/DebugNotLoggedIn.vue
+++ b/packages/app/src/debug/empty/DebugNotLoggedIn.vue
@@ -4,6 +4,7 @@
     :description="t('debugPage.emptyStates.reviewRerunAndDebug')"
     :example-test-name="t('debugPage.emptyStates.notLoggedInTestMessage')"
     :slideshow-campaign="DEBUG_SLIDESHOW.campaigns.login"
+    :help-link-sr-text="t('debugPage.emptyStates.learnAboutDebuggingSrText')"
     help-link-href="https://on.cypress.io/debug-page"
   >
     <template #cta="slotProps">

--- a/packages/app/src/debug/empty/DebugNotLoggedIn.vue
+++ b/packages/app/src/debug/empty/DebugNotLoggedIn.vue
@@ -3,7 +3,6 @@
     :title="t('debugPage.emptyStates.debugDirectlyInCypress')"
     :description="t('debugPage.emptyStates.reviewRerunAndDebug')"
     :example-test-name="t('debugPage.emptyStates.notLoggedInTestMessage')"
-    :help-link-text="t('debugPage.emptyStates.learnAboutDebugging')"
     :slideshow-campaign="DEBUG_SLIDESHOW.campaigns.login"
     help-link-href="https://on.cypress.io/debug-page"
   >

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -697,9 +697,6 @@
       "noRunsTestMessage": "Record your first test run to Cypress Cloud to locally debug failed CI test runs",
       "gitRepositoryNotDetected": "Git repository not detected",
       "ensureGitSetupCorrectly": "Cypress uses Git to associate runs with your local state. Please ensure that version control is set up correctly.",
-      "learnAboutRecording": "Learn about recording a run to Cypress Cloud",
-      "learnAboutDebugging": "Learn about debugging CI failures in Cypress",
-      "learnAboutProjectSetup": "Learn about project setup in Cypress",
       "slideshow": {
         "step1": {
           "title": "Review how many tests failed during a CI test run",

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -697,6 +697,9 @@
       "noRunsTestMessage": "Record your first test run to Cypress Cloud to locally debug failed CI test runs",
       "gitRepositoryNotDetected": "Git repository not detected",
       "ensureGitSetupCorrectly": "Cypress uses Git to associate runs with your local state. Please ensure that version control is set up correctly.",
+      "learnAboutRecordingSrText": "Link to learn more about recording a run to Cypress Cloud:",
+      "learnAboutDebuggingSrText": "Link to learn more about debugging CI failures in Cypress:",
+      "learnAboutProjectSetupSrText": "Link to learn more about project setup in Cypress:",
       "slideshow": {
         "step1": {
           "title": "Review how many tests failed during a CI test run",

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -697,9 +697,9 @@
       "noRunsTestMessage": "Record your first test run to Cypress Cloud to locally debug failed CI test runs",
       "gitRepositoryNotDetected": "Git repository not detected",
       "ensureGitSetupCorrectly": "Cypress uses Git to associate runs with your local state. Please ensure that version control is set up correctly.",
-      "learnAboutRecordingSrText": "Link to learn more about recording a run to Cypress Cloud:",
-      "learnAboutDebuggingSrText": "Link to learn more about debugging CI failures in Cypress:",
-      "learnAboutProjectSetupSrText": "Link to learn more about project setup in Cypress:",
+      "learnAboutRecordingSrText": "about recording a run to Cypress Cloud",
+      "learnAboutDebuggingSrText": "about debugging CI failures in Cypress",
+      "learnAboutProjectSetupSrText": "about project setup in Cypress",
       "slideshow": {
         "step1": {
           "title": "Review how many tests failed during a CI test run",


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #26041

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This PR does a the following:
- Use max width for Debug page empty state messages rather than percent margin
- All help links now say "learn more"

I used a 4px left margin for the learn more links because 8px looked like too much.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

For testing and looking at changes, you can run `DebugEmptyStates.cy.tsx` or take a look at the Percy diff

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
