### PR TITLE
fix: use --first-parent when loading Git hashes in GitDataSource

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,8 +5,8 @@ _Released 03/28/2023 (PENDING)_
 
 **Bugfixes:**
 
- - Changed the way that Git hashes are loaded so that non-relevant runs are excluded from the Debug page. Fixes [#26058](https://github.com/cypress-io/cypress/issues/26058).
  - Fixed a compatibility issue so that component test projects can use [Vite](https://vitejs.dev/) version 4.2.0 and greater. Fixes [#26138](https://github.com/cypress-io/cypress/issues/26138).
+ - Changed the way that Git hashes are loaded so that non-relevant runs are excluded from the Debug page. Fixes [#26058](https://github.com/cypress-io/cypress/issues/26058).
 
 ## 12.8.1
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 12.9.0
+
+_Released 03/28/2023 (PENDING)_
+
+**Misc:**
+
+ - Changed the way that we load Git hashes in order to exclude runs for non-relevant commits from the Debug page. Addresses [#26058](https://github.com/cypress-io/cypress/issues/26058).
+
 ## 12.8.1
 
 _Released 03/15/2023_

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,9 +3,9 @@
 
 _Released 03/28/2023 (PENDING)_
 
-**Misc:**
+**Bugfixes:**
 
- - Changed the way that we load Git hashes in order to exclude runs for non-relevant commits from the Debug page. Addresses [#26058](https://github.com/cypress-io/cypress/issues/26058).
+ - Changed the way that we load Git hashes in order to exclude runs for non-relevant commits from the Debug page. Fixes [#26058](https://github.com/cypress-io/cypress/issues/26058).
 
 ## 12.8.1
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 03/28/2023 (PENDING)_
 
 **Bugfixes:**
 
- - Changed the way that we load Git hashes in order to exclude runs for non-relevant commits from the Debug page. Fixes [#26058](https://github.com/cypress-io/cypress/issues/26058).
+ - Changed the way that Git hashes are loaded so that non-relevant runs are excluded from the Debug page. Fixes [#26058](https://github.com/cypress-io/cypress/issues/26058).
  - Fixed a compatibility issue so that component test projects can use [Vite](https://vitejs.dev/) version 4.2.0 and greater. Fixes [#26138](https://github.com/cypress-io/cypress/issues/26138).
 
 ## 12.8.1

--- a/packages/data-context/src/sources/GitDataSource.ts
+++ b/packages/data-context/src/sources/GitDataSource.ts
@@ -436,7 +436,7 @@ export class GitDataSource {
   async #loadGitHashes () {
     debug('Loading git hashes')
     try {
-      const logResponse = await this.#git?.log({ maxCount: 100 })
+      const logResponse = await this.#git?.log({ maxCount: 100, '--first-parent': undefined })
       const currentHashes = logResponse?.all.map((log) => log.hash)
 
       if (!isEqual(this.#gitHashes, currentHashes)) {

--- a/packages/data-context/test/unit/sources/GitDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/GitDataSource.spec.ts
@@ -302,9 +302,11 @@ describe('GitDataSource', () => {
 
       logCallback.onFirstCall().callsFake(dfd.resolve)
 
+      const mainBranch = (await git.branch()).current
+
       await git.checkoutLocalBranch('feature-branch')
 
-      await git.checkout('main')
+      await git.checkout(mainBranch)
 
       const newSpec = toPosix(path.join(e2eFolder, 'new.cy.js'))
 
@@ -325,7 +327,7 @@ describe('GitDataSource', () => {
       await git.add([featureSpec])
       await git.commit('add feature spec')
 
-      await git.merge(['main', '--commit'])
+      await git.merge([mainBranch, '--commit'])
 
       gitInfo = new GitDataSource({
         isRunMode: false,

--- a/packages/data-context/test/unit/sources/GitDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/GitDataSource.spec.ts
@@ -292,7 +292,9 @@ describe('GitDataSource', () => {
 
       expect(gitInfo.currentHashes).to.have.length(2)
     })
+  })
 
+  context('Git Hashes - no fake timers', () => {
     it('does not include commits that are part of the Git tree from a merge', async () => {
       const dfd = pDefer()
 
@@ -308,7 +310,7 @@ describe('GitDataSource', () => {
 
       fs.createFileSync(newSpec)
 
-      git.add([newSpec])
+      await git.add([newSpec])
 
       await git.commit('add new spec')
 
@@ -320,7 +322,7 @@ describe('GitDataSource', () => {
 
       fs.createFileSync(featureSpec)
 
-      git.add([featureSpec])
+      await git.add([featureSpec])
       await git.commit('add feature spec')
 
       await git.merge(['main', '--commit'])
@@ -338,6 +340,6 @@ describe('GitDataSource', () => {
 
       expect(gitInfo.currentHashes).to.have.length(3)
       expect(gitInfo.currentHashes).not.to.contain(hashFromMerge)
-    }).timeout(10000)
+    })
   })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #26058

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

When you are working on a feature branch and you pull in commits from the main branch, runs from those commits shouldn't show up on the debug page since they aren't related to the feature branch that you are working on. This PR adds an option to our `git log` command that makes it so that we only get hashes from the first parent after seeing a merge commit. Read more about the option [here](https://git-scm.com/docs/git-log#Documentation/git-log.txt---first-parent).

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Check out the test that I added to `GitDataSources.spec.ts`

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
