### PR TITLE
fix: Use resolved git root on Windows

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,7 @@ _Released 03/28/2023 (PENDING)_
 
  - Fixed a compatibility issue so that component test projects can use [Vite](https://vitejs.dev/) version 4.2.0 and greater. Fixes [#26138](https://github.com/cypress-io/cypress/issues/26138).
  - Changed the way that Git hashes are loaded so that non-relevant runs are excluded from the Debug page. Fixes [#26058](https://github.com/cypress-io/cypress/issues/26058).
+ - Fixed an issue where an incorrect working directory could be used for Git operations on Windows. Fixes [#23317](https://github.com/cypress-io/cypress/issues/23317).
 
 **Misc:**
 

--- a/packages/data-context/src/sources/GitDataSource.ts
+++ b/packages/data-context/src/sources/GitDataSource.ts
@@ -96,6 +96,12 @@ export class GitDataSource {
       debug('exception caught when loading git client')
     }
 
+    // Start by assuming the git repository matches the project root
+    // This will be overridden if needed by the `verifyGitRepo` function
+    // Since that is async and we can't block the constructor we make this
+    // guess to avoid double-initializing
+    this.#gitBaseDir = this.config.projectRoot
+
     // don't watch/refresh git data in run mode since we only
     // need it to detect the .git directory to set `repoRoot`
     if (config.isRunMode) {
@@ -243,6 +249,8 @@ export class GitDataSource {
           debug(`Failed to watch for git changes`, e.message)
           this.config.onError(e)
         })
+
+        debug('Watcher initialized')
       }
     } catch (e) {
       this.#gitErrored = true
@@ -403,9 +411,9 @@ export class GitDataSource {
     const cmd = `FOR %x in (${paths}) DO (${GIT_LOG_COMMAND} %x)`
 
     debug('executing command: `%s`', cmd)
-    debug('cwd: `%s`', this.config.projectRoot)
+    debug('cwd: `%s`', this.#gitBaseDir)
 
-    const subprocess = execa(cmd, { shell: true, cwd: this.config.projectRoot })
+    const subprocess = execa(cmd, { shell: true, cwd: this.#gitBaseDir })
     let result
 
     try {
@@ -437,6 +445,8 @@ export class GitDataSource {
     debug('Loading git hashes')
     try {
       const logResponse = await this.#git?.log({ maxCount: 100, '--first-parent': undefined })
+
+      debug('hashes loaded')
       const currentHashes = logResponse?.all.map((log) => log.hash)
 
       if (!isEqual(this.#gitHashes, currentHashes)) {

--- a/packages/data-context/test/unit/sources/GitDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/GitDataSource.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai'
+import { assert, expect } from 'chai'
 import path from 'path'
 import os from 'os'
 import simpleGit from 'simple-git'
@@ -8,7 +8,7 @@ import pDefer from 'p-defer'
 import chokidar from 'chokidar'
 
 import { scaffoldMigrationProject } from '../helper'
-import { GitDataSource, GitInfo } from '../../../src/sources/GitDataSource'
+import { GitDataSource } from '../../../src/sources/GitDataSource'
 import { toPosix } from '../../../src/util/file'
 
 describe('GitDataSource', () => {
@@ -21,7 +21,7 @@ describe('GitDataSource', () => {
     projectPath = await scaffoldMigrationProject('e2e')
     git = simpleGit({ baseDir: projectPath })
     e2eFolder = path.join(projectPath, 'cypress', 'e2e')
-    const allSpecs = fs.readdirSync(e2eFolder)
+    const allSpecs = await fs.readdir(e2eFolder)
 
     if (process.env.CI) {
       // need to set a user on CI
@@ -36,9 +36,9 @@ describe('GitDataSource', () => {
     await git.commit('add all specs')
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     if (gitInfo) {
-      gitInfo.destroy()
+      await gitInfo.destroy()
     }
 
     gitInfo = undefined
@@ -46,11 +46,9 @@ describe('GitDataSource', () => {
     sinon.restore()
   })
 
-  // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23317
-  it.skip(`gets correct status for files on ${os.platform()}`, async function () {
+  it(`gets correct status for files on ${os.platform()}`, async function () {
     const onBranchChange = sinon.stub()
-    const onGitInfoChange = sinon.stub()
-    const onError = sinon.stub()
+    const dfd = pDefer()
 
     // create a file and modify a file to express all
     // git states we are interested in (created, unmodified, modified)
@@ -62,28 +60,22 @@ describe('GitDataSource', () => {
       isRunMode: false,
       projectRoot: projectPath,
       onBranchChange,
-      onGitInfoChange,
-      onError,
+      onGitInfoChange: dfd.resolve,
+      onError: (err: any) => {
+        assert.fail(err)
+      },
     })
 
-    fs.createFileSync(fooSpec)
-    fs.writeFileSync(xhrSpec, 'it(\'modifies the file\', () => {})')
+    await fs.createFile(fooSpec)
+    await fs.writeFile(xhrSpec, 'it(\'modifies the file\', () => {})')
 
     gitInfo.setSpecs([fooSpec, aRecordSpec, xhrSpec])
 
-    let result: any[] = []
+    await dfd.promise
 
-    do {
-      result = await Promise.all([
-        gitInfo.gitInfoFor(fooSpec),
-        gitInfo.gitInfoFor(aRecordSpec),
-        gitInfo.gitInfoFor(xhrSpec),
-      ])
-
-      await new Promise((resolve) => setTimeout(resolve, 100))
-    } while (result.some((r) => r == null))
-
-    const [created, unmodified, modified] = result
+    const created = gitInfo.gitInfoFor(fooSpec)!
+    const unmodified = gitInfo.gitInfoFor(aRecordSpec)!
+    const modified = gitInfo.gitInfoFor(xhrSpec)!
 
     expect(created.lastModifiedHumanReadable).to.match(/(a few|[0-9]) seconds? ago/)
     expect(created.statusType).to.eql('created')
@@ -129,29 +121,27 @@ describe('GitDataSource', () => {
     .map((filename) => path.join(e2eFolder, filename))
     .map((filepath) => toPosix(filepath))
 
+    const dfd = pDefer()
+
     gitInfo = new GitDataSource({
       isRunMode: false,
       projectRoot: projectPath,
       onBranchChange: sinon.stub(),
-      onGitInfoChange: sinon.stub(),
+      onGitInfoChange: dfd.resolve,
       onError: sinon.stub(),
     })
 
-    for (let filepath of filepaths) {
-      fs.createFileSync(filepath)
-    }
+    await Promise.all(
+      filepaths.map((filepath) => fs.createFile(filepath)),
+    )
 
     gitInfo.setSpecs(filepaths)
 
-    let results: (GitInfo | null)[] = []
+    await dfd.promise
 
-    do {
-      results = await Promise.all(filepaths.map(function (filepath) {
-        return gitInfo.gitInfoFor(filepath)
-      }))
-
-      await new Promise((resolve) => setTimeout(resolve, 100))
-    } while (results.some((r) => r == null))
+    const results = filepaths.map((filepath) => {
+      return gitInfo.gitInfoFor(filepath)
+    })
 
     expect(results).to.have.lengthOf(filepaths.length)
 
@@ -217,7 +207,6 @@ describe('GitDataSource', () => {
       onError: errorStub,
     })
 
-    await dfd.promise
     const result = await dfd.promise
 
     expect(result).to.eq((await git.branch()).current)
@@ -226,7 +215,7 @@ describe('GitDataSource', () => {
   })
 
   context('Git hashes', () => {
-    let clock
+    let clock: sinon.SinonFakeTimers
 
     beforeEach(() => {
       clock = sinon.useFakeTimers()
@@ -239,17 +228,13 @@ describe('GitDataSource', () => {
     it('loads git hashes when first loaded', async () => {
       const dfd = pDefer()
 
-      const logCallback = () => {
-        dfd.resolve()
-      }
-
       gitInfo = new GitDataSource({
         isRunMode: false,
         projectRoot: projectPath,
         onBranchChange: sinon.stub(),
         onGitInfoChange: sinon.stub(),
         onError: sinon.stub(),
-        onGitLogChange: logCallback,
+        onGitLogChange: dfd.resolve,
       })
 
       await dfd.promise
@@ -281,7 +266,7 @@ describe('GitDataSource', () => {
 
       const afterCommitSpec = toPosix(path.join(e2eFolder, 'afterCommit.cy.js'))
 
-      fs.createFileSync(afterCommitSpec)
+      await fs.createFile(afterCommitSpec)
 
       git.add(afterCommitSpec)
       git.commit('add afterCommit spec')
@@ -310,7 +295,7 @@ describe('GitDataSource', () => {
 
       const newSpec = toPosix(path.join(e2eFolder, 'new.cy.js'))
 
-      fs.createFileSync(newSpec)
+      await fs.createFile(newSpec)
 
       await git.add([newSpec])
 
@@ -322,7 +307,7 @@ describe('GitDataSource', () => {
 
       const featureSpec = toPosix(path.join(e2eFolder, 'feature.cy.js'))
 
-      fs.createFileSync(featureSpec)
+      await fs.createFile(featureSpec)
 
       await git.add([featureSpec])
       await git.commit('add feature spec')

--- a/packages/data-context/test/unit/sources/GitDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/GitDataSource.spec.ts
@@ -71,7 +71,9 @@ describe('GitDataSource', () => {
 
     gitInfo.setSpecs([fooSpec, aRecordSpec, xhrSpec])
 
-    await dfd.promise
+    const gitInfoChangeResolve = await dfd.promise
+
+    expect(gitInfoChangeResolve).to.eql([fooSpec, aRecordSpec, xhrSpec])
 
     const created = gitInfo.gitInfoFor(fooSpec)!
     const unmodified = gitInfo.gitInfoFor(aRecordSpec)!


### PR DESCRIPTION
- Closes #23317 

### Additional details

Flaky test does not reproduce locally on M1, but from logs I believe the issue is that we are initializing the `gitBaseDir` field asynchronously, which means Git commands run immediately after creation might execute against the `cypress` repository rather than the scaffolded project.

Currently, we use the resolved Git repo root as `cwd` for bulk Git ops on Unix, but the project directory on Windows which could be incorrect based on project structure.

* Initialize GitDataSource's base dir to the project directory, replaced by existing logic during async setup flow
* Cleanup GitDataSource tests
  * use async `fs` APIs
  * `await` callback promises rather than polling
  * `await` cleanup items between tests

### Steps to test
Existing tests should cover

### How has the user experience changed?
No user-facing change, should only impact unit tests due to quick execution of test before async setup flow completes and replaces git repo root

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
