### PR TITLE
fix(vite-dev-server): Retry dynamic importing of support file and spec file when they fail during CT run with Vite

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -30,7 +30,7 @@ mainBuildFilters: &mainBuildFilters
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'update-v8-snapshot-cache-on-develop'
-        - 'emily/before-spec-promise'
+        - 'retry-dynamic-imports'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -41,7 +41,7 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'emily/before-spec-promise', << pipeline.git.branch >> ]
+    - equal: [ 'retry-dynamic-imports', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -139,7 +139,7 @@ commands:
       - run:
           name: Check current branch to persist artifacts
           command: |
-            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "emily/before-spec-promise" && "$CIRCLE_BRANCH" != "update-v8-snapshot-cache-on-develop" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "retry-dynamic-imports" && "$CIRCLE_BRANCH" != "update-v8-snapshot-cache-on-develop" ]]; then
               echo "Not uploading artifacts or posting install comment for this branch."
               circleci-agent step halt
             fi

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,7 @@ _Released 03/28/2023 (PENDING)_
 
  - Fixed a compatibility issue so that component test projects can use [Vite](https://vitejs.dev/) version 4.2.0 and greater. Fixes [#26138](https://github.com/cypress-io/cypress/issues/26138).
  - Changed the way that Git hashes are loaded so that non-relevant runs are excluded from the Debug page. Fixes [#26058](https://github.com/cypress-io/cypress/issues/26058).
+ - Fixed an issue where Vite component tests sometimes fail in CI due to not being able to dynamically import the component support or spec modules. Fixes [#25913](https://github.com/cypress-io/cypress/issues/25913).
 
 **Misc:**
 

--- a/npm/vite-dev-server/client/initCypressTests.js
+++ b/npm/vite-dev-server/client/initCypressTests.js
@@ -1,7 +1,10 @@
 // This file is merged in a <script type=module> into index.html
 // it will be used to load and kick start the selected spec
 
-// Fetch a dynamic import and re-try 3 times with a 2-second back-off
+// Fetch a dynamic import and re-try 3 times with a 2-second back-off.
+// We want to re-try these if they fail because sometimes (seemingly due to network issues)
+// the modules aren't available when we first request them.
+// See https://github.com/cypress-io/cypress/issues/25913
 async function importWithRetry (importFn) {
   try {
     return await importFn()

--- a/npm/vite-dev-server/client/initCypressTests.js
+++ b/npm/vite-dev-server/client/initCypressTests.js
@@ -3,32 +3,28 @@
 
 // Fetch a dynamic import and re-try 3 times with a 2-second back-off
 async function importWithRetry (importFn) {
-  const isTextTerminal = CypressInstance.config('isTextTerminal')
-
   try {
     return await importFn()
   } catch (error) {
-    if (isTextTerminal) {
-      for (let i = 0; i < 3; i++) {
-        await new Promise((resolve) => setTimeout(resolve, 1000 * 2 ** i))
+    for (let i = 0; i < 3; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 1000 * 2 ** i))
 
-        let url
+      let url
 
-        try {
-          // Get request URL from error message from original import
-          url = new URL(
-            error.message
-            .replace('Failed to fetch dynamically imported module: ', '')
-            .trim(),
-          )
+      try {
+        // Get request URL from error message from original import
+        url = new URL(
+          error.message
+          .replace('Failed to fetch dynamically imported module: ', '')
+          .trim(),
+        )
 
-          // add a timestamp to the end of the URL to force re-load the module instead of using the cache
-          url.searchParams.set('t', `${+new Date()}`)
+        // add a timestamp to the end of the URL to force re-load the module instead of using the cache
+        url.searchParams.set('t', `${+new Date()}`)
 
-          return await import(url.href)
-        } catch (e) {
-          console.log(`retrying import of ${url?.href}`)
-        }
+        return await import(url.href)
+      } catch (e) {
+        console.error(`retrying import of ${url?.href}`)
       }
     }
 

--- a/npm/vite-dev-server/client/initCypressTests.js
+++ b/npm/vite-dev-server/client/initCypressTests.js
@@ -19,6 +19,8 @@ async function importWithRetry (importFn) {
           .trim(),
         )
 
+        console.error(`retrying import of ${url?.href}`)
+
         // add a timestamp to the end of the URL to force re-load the module instead of using the cache
         url.searchParams.set('t', `${+new Date()}`)
 

--- a/npm/vite-dev-server/cypress/e2e/vite-dev-server.cy.ts
+++ b/npm/vite-dev-server/cypress/e2e/vite-dev-server.cy.ts
@@ -115,6 +115,21 @@ describe('Config options', () => {
       expect(verifyFile).to.eq('OK')
     })
   })
+
+  it('retries importing support file if the import errors', () => {
+    cy.intercept('**/cypress/support/component.js', {
+      statusCode: 404,
+    })
+
+    cy.scaffoldProject('vite2.9.1-react')
+    cy.openProject('vite2.9.1-react', ['--config-file', 'cypress-vite.config.ts'])
+    cy.startAppServer('component')
+
+    cy.visitApp()
+    cy.contains('App.cy.jsx').click()
+    cy.waitForSpecToFinish()
+    cy.get('.passed > .num').should('contain', 2)
+  })
 })
 
 describe('sourcemaps', () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #25913

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

**A couple of things to note:**
- This will only affect imports of the component support file and spec file
- This is only for component tests that are configured to use Vite

When Vite CT tests run, we dynamically import the component support file and spec file modules. Sometimes, seemingly when tests are run on under-resourced machines (like in CI, specifically Github Actions), when we go to import these modules, they aren't ready yet.

In order to make test runs more stable, this PR introduces a strategy to re-try the dynamic imports specifically of the component support file and the spec file itself up to 3 times (with 2 seconds in between each attempt) before eventually failing if it can't import the module.

This is based on the assumption that these import errors are happening because of network issues and/or slow machines, so if we re-try the import, it should be successful on one of the subsequent attempts, allowing the test to continue. In the event that the module does not exist, after the last attempt we will throw the error.

I got the idea for this approach from [this article](https://medium.com/@alonmiz1234/retry-dynamic-imports-with-react-lazy-c7755a7d557a) that was linked in [this comment](https://github.com/vitejs/vite/issues/11804#issuecomment-1479133050) on the Vite issue related to this problem.

It's definitely not the best solution, but I wasn't able to figure out what exactly was causing these imports to fail, since according to the debug logs I looked at, these modules should have been available at the time of import. To me, this suggests a complex race condition is happening that is being caused by lack of machine resources. 

Hopefully we can add this as a temporary solution to stabilize user's CI runs until we find a better solution.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

This is very difficult to test because it doesn't always happen, and when it does it's always in a CI run. I added a test to `vite-dev-server.cy.ts` which simulates a module not being available on the first try by using `cy.intercept` to mock a 404 response to the attempt to import the module. Then on the second attempt, the module is successfully imported and the test succeeds. 

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

This should not affect the user's experience except that their CI runs should be more stable, even on machines with lower resources.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
