### PR TITLE
chore: updating renovate bot config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":semanticCommitScopeDisabled"
   ],
   "automerge": false,
   "major": {

--- a/renovate.json
+++ b/renovate.json
@@ -16,27 +16,37 @@
     "renovate"
   ],
   "commitMessageSuffix": "🌟",
-  "prHourlyLimit": 1,
-  "prConcurrentLimit": 1,
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 10,
   "updateNotScheduled": false,
   "timezone": "America/New_York",
   "schedule": [
-    "before 3am on the first day of the month"
+    "before 5am every weekday"
   ],
-  "dependencyDashboardApproval": true,
+  
   "packageRules": [
     {
       "matchPackagePatterns": [
-        "*"
+        "^electron"
       ],
-      "semanticCommitType": "chore"
+      "semanticCommitType": "chore",
+      "groupName": "electron",
+      "dependencyDashboardApproval": false
+    },
+    {
+      "excludePackagePatterns": [
+        "^electron"
+      ],
+      "semanticCommitType": "chore",
+      "dependencyDashboardApproval": true
     },
     {
       "matchDepTypes": [
         "dependencies",
         "require"
       ],
-      "semanticCommitType": "dependency"
+      "semanticCommitType": "dependency",
+      "dependencyDashboardApproval": true
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
       "matchPackagePatterns": [
         "^electron"
       ],
-      "semanticCommitType": "chore",
+      "semanticCommitType": "dependency",
       "groupName": "electron",
       "dependencyDashboardApproval": false
     },
@@ -37,7 +37,7 @@
       "excludePackagePatterns": [
         "^electron"
       ],
-      "semanticCommitType": "chore",
+      "semanticCommitType": "dependency",
       "dependencyDashboardApproval": true
     },
     {


### PR DESCRIPTION
 chore: updating renovate bot config to automatically create electron package update PRs

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->
n/a
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Updates to the config file for the Renovate bot.  It will now look for packages that begin with "electron" and group them into a single PR it will automatically create.  All other package upgrades will still need to be manually created from the Renovate Dashboard as they are today.  

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
n/a
### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ n/a ] Have tests been added/updated?
- [ n/a ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ n/a ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
