### PR TITLE
refactor: use correct value for messageId for debug slideshow event

### DIFF
--- a/packages/app/src/debug/empty/DebugEmptyStates.cy.tsx
+++ b/packages/app/src/debug/empty/DebugEmptyStates.cy.tsx
@@ -92,7 +92,7 @@ describe('Debug page empty states', () => {
     it('sends record event upon seeing slideshow', () => {
       useLoginConnectStore().setUserFlag('isLoggedIn', false)
       mountWithGql(<DebugNotLoggedIn />, { debugSlideshowComplete: false })
-      cy.get('@recordEvent').should('have.been.calledWithMatch', { campaign: DEBUG_SLIDESHOW.campaigns.login })
+      cy.get('@recordEvent').should('have.been.calledWithMatch', { campaign: DEBUG_SLIDESHOW.campaigns.login, messageId: Cypress.sinon.match.string, medium: DEBUG_SLIDESHOW.medium, cohort: Cypress.sinon.match(/A|B/) })
     })
   })
 
@@ -117,7 +117,7 @@ describe('Debug page empty states', () => {
     it('sends record event upon seeing slideshow', () => {
       useLoginConnectStore().setUserFlag('isLoggedIn', false)
       mountWithGql(<DebugNoProject />, { debugSlideshowComplete: false })
-      cy.get('@recordEvent').should('have.been.calledWithMatch', { campaign: DEBUG_SLIDESHOW.campaigns.connectProject })
+      cy.get('@recordEvent').should('have.been.calledWithMatch', { campaign: DEBUG_SLIDESHOW.campaigns.connectProject, messageId: Cypress.sinon.match.string, medium: DEBUG_SLIDESHOW.medium, cohort: Cypress.sinon.match(/A|B/) })
     })
   })
 
@@ -133,7 +133,7 @@ describe('Debug page empty states', () => {
     it('sends record event upon seeing slideshow', () => {
       useLoginConnectStore().setUserFlag('isLoggedIn', false)
       mountWithGql(<DebugNoRuns />, { debugSlideshowComplete: false })
-      cy.get('@recordEvent').should('have.been.calledWithMatch', { campaign: DEBUG_SLIDESHOW.campaigns.recordRun })
+      cy.get('@recordEvent').should('have.been.calledWithMatch', { campaign: DEBUG_SLIDESHOW.campaigns.recordRun, messageId: Cypress.sinon.match.string, medium: DEBUG_SLIDESHOW.medium, cohort: Cypress.sinon.match(/A|B/) })
     })
   })
 
@@ -186,7 +186,7 @@ describe('Debug page empty states', () => {
     it('renders slideshow if debugSlideshowComplete = false', () => {
       useLoginConnectStore().setUserFlag('isLoggedIn', false)
       mountWithGql(<DebugNoRuns />, { cohort: 'B', debugSlideshowComplete: false })
-      cy.get('@recordEvent').should('have.been.calledWithMatch', { campaign: DEBUG_SLIDESHOW.campaigns.recordRun })
+      cy.get('@recordEvent').should('have.been.calledWithMatch', { campaign: DEBUG_SLIDESHOW.campaigns.recordRun, messageId: Cypress.sinon.match.string, medium: DEBUG_SLIDESHOW.medium, cohort: Cypress.sinon.match(/A|B/) })
       moveThroughSlideshow({ cohort: 'B', percy: true })
       cy.get('@storeSlideshowComplete').should('have.been.called')
 

--- a/packages/app/src/debug/empty/DebugEmptyView.vue
+++ b/packages/app/src/debug/empty/DebugEmptyView.vue
@@ -42,6 +42,7 @@
 import { computed, ref, watch } from 'vue'
 import { gql, useMutation, useQuery } from '@urql/vue'
 import { isNumber } from 'lodash'
+import { nanoid } from 'nanoid'
 import ExternalLink from '@packages/frontend-shared/src/gql-components/ExternalLink.vue'
 import { getUrlWithParams } from '@packages/frontend-shared/src/utils/getUrlWithParams'
 import { getUtmSource } from '@packages/frontend-shared/src/utils/getUtmSource'
@@ -170,6 +171,8 @@ const savedState = computed(() => {
   return query.data.value?.currentProject?.savedState
 })
 
+const slideShowMessageId = nanoid()
+
 watch([savedState, selectedCohort], () => {
   // If we've already set a step we can return early
   if (isNumber(step.value)) return
@@ -189,7 +192,7 @@ watch([savedState, selectedCohort], () => {
       campaign: props.slideshowCampaign,
       medium: DEBUG_SLIDESHOW.medium,
       cohort: selectedCohort.value.cohort,
-      messageId: DEBUG_SLIDESHOW.id,
+      messageId: slideShowMessageId,
     })
   }
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->



### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

The `messageId` sent when calling the `recordEvent` mutation should be using a unique value.  This allows for filtering out events that may get sent multiple times due to a race condition or timeouts.  This is following the same pattern used by `TrackedBanner` component when it sends events.

See implementation from `TrackedBanner`:
* https://github.com/cypress-io/cypress/blob/develop/packages/app/src/specs/banners/TrackedBanner.vue#L64
* https://github.com/cypress-io/cypress/blob/develop/packages/app/src/specs/banners/TrackedBanner.vue#L95

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
Verify component test `DebugEmptyStates.cy.tsx`

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

No UX changes. This is imply a fix to a parameter sent to Cypress cloud, thus the fix is marked as a "refactor"

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
