### PR TITLE
chore: stabilize Percy snapshots of the launchpad

### DIFF
--- a/packages/launchpad/cypress/e2e/config-files-error-handling.cy.ts
+++ b/packages/launchpad/cypress/e2e/config-files-error-handling.cy.ts
@@ -157,6 +157,8 @@ describe('Launchpad: Error System Tests', () => {
     cy.visitLaunchpad()
     cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle)
+    // Quick fix to make Percy snapshots more reliable.
+    // https://github.com/cypress-io/cypress/pull/26240
     cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
     cy.percySnapshot()
 
@@ -200,6 +202,8 @@ describe('Launchpad: Error System Tests', () => {
     cy.visitLaunchpad()
     cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle)
+    // Quick fix to make Percy snapshots more reliable.
+    // https://github.com/cypress-io/cypress/pull/26240
     cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
     cy.percySnapshot()
 
@@ -212,6 +216,8 @@ describe('Launchpad: Error System Tests', () => {
     cy.visitLaunchpad()
     cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle)
+    // Quick fix to make Percy snapshots more reliable.
+    // https://github.com/cypress-io/cypress/pull/26240
     cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
     cy.percySnapshot()
 
@@ -227,6 +233,8 @@ describe('setupNodeEvents', () => {
     cy.skipWelcome()
     cy.findByText('E2E Testing').click()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle)
+    // Quick fix to make Percy snapshots more reliable.
+    // https://github.com/cypress-io/cypress/pull/26240
     cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
     cy.percySnapshot()
   })
@@ -238,6 +246,8 @@ describe('setupNodeEvents', () => {
     cy.skipWelcome()
     cy.findByText('E2E Testing').click()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle)
+    // Quick fix to make Percy snapshots more reliable.
+    // https://github.com/cypress-io/cypress/pull/26240
     cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
     cy.percySnapshot()
 
@@ -251,6 +261,8 @@ describe('setupNodeEvents', () => {
     cy.skipWelcome()
     cy.findByText('E2E Testing').click()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle)
+    // Quick fix to make Percy snapshots more reliable.
+    // https://github.com/cypress-io/cypress/pull/26240
     cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
     cy.percySnapshot()
   })

--- a/packages/launchpad/cypress/e2e/config-files-error-handling.cy.ts
+++ b/packages/launchpad/cypress/e2e/config-files-error-handling.cy.ts
@@ -157,6 +157,7 @@ describe('Launchpad: Error System Tests', () => {
     cy.visitLaunchpad()
     cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle)
+    cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
     cy.percySnapshot()
 
     cy.withCtx(async (ctx) => {
@@ -199,6 +200,7 @@ describe('Launchpad: Error System Tests', () => {
     cy.visitLaunchpad()
     cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle)
+    cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
     cy.percySnapshot()
 
     cy.get('[data-testid="error-code-frame"]').should('contain', 'cypress.config.js:3:23')
@@ -210,6 +212,7 @@ describe('Launchpad: Error System Tests', () => {
     cy.visitLaunchpad()
     cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle)
+    cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
     cy.percySnapshot()
 
     cy.get('[data-testid="error-code-frame"]').should('contain', 'cypress.config.ts:6:10')
@@ -224,6 +227,7 @@ describe('setupNodeEvents', () => {
     cy.skipWelcome()
     cy.findByText('E2E Testing').click()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle)
+    cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
     cy.percySnapshot()
   })
 
@@ -234,6 +238,7 @@ describe('setupNodeEvents', () => {
     cy.skipWelcome()
     cy.findByText('E2E Testing').click()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle)
+    cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
     cy.percySnapshot()
 
     cy.get('[data-cy="alert-body"]').should('contain', 'integrationFolder')
@@ -246,6 +251,7 @@ describe('setupNodeEvents', () => {
     cy.skipWelcome()
     cy.findByText('E2E Testing').click()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle)
+    cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
     cy.percySnapshot()
   })
 

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -172,6 +172,8 @@ describe('Opening unmigrated project', () => {
 
     // Wait for migration prompt and current version to load before taking a snapshot
     cy.get('.spinner').should('not.exist')
+    // Quick fix to make Percy snapshots more reliable.
+    // https://github.com/cypress-io/cypress/pull/26240
     cy.findByTestId('top-nav-cypress-version-current-link').should('be.visible')
 
     cy.percySnapshot()


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

After [we got rid of the code that hid Cypress version number from Percy snapshots](https://github.com/cypress-io/cypress/pull/26105), some other snapshots became flakey because we're not asserting that the version number has loaded into the header before we take it.

This PR adds assertions to some of the problematic Percy snapshots to stop them from flaking.

Examples of flake:
https://percy.io/cypress-io/cypress/builds/26126218/changed/1456121409?browser=chrome&browser_ids=34&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=800&widths=450%2C800

https://percy.io/cypress-io/cypress/builds/26219319/changed/1460471097?browser=chrome&browser_ids=34&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=800&widths=616%2C650%2C800%2C900%2C1200%2C2000

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
