### PR TITLE
chore: update to use new github-script API

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -21,7 +21,7 @@ jobs:
         working-directory: scripts/github-actions/semantic-pull-request/
       - name: Lint PR Title and Cypress Changelog Entry
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
           script: |
             const verifyPullRequest = require('./scripts/github-actions/semantic-pull-request')

--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -127,6 +127,7 @@ jobs:
           script: |
             const { createPullRequest } = require('./scripts/github-actions/create-pull-request.js')
 
+            console.log('github', JSON.stringify(github, null, 2))
             await createPullRequest({
               context,
               github,

--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -127,7 +127,6 @@ jobs:
           script: |
             const { createPullRequest } = require('./scripts/github-actions/create-pull-request.js')
 
-            console.log('github', JSON.stringify(github, null, 2))
             await createPullRequest({
               context,
               github,

--- a/scripts/github-actions/create-pull-request.js
+++ b/scripts/github-actions/create-pull-request.js
@@ -1,5 +1,5 @@
 const createPullRequest = async ({ context, github, baseBranch, branchName, description, body, reviewers }) => {
-  const { data: { number } } = await github.pulls.create({
+  const { data: { number } } = await github.rest.pulls.create({
     owner: context.repo.owner,
     repo: context.repo.repo,
     base: baseBranch,
@@ -10,7 +10,7 @@ const createPullRequest = async ({ context, github, baseBranch, branchName, desc
   })
 
   if (reviewers) {
-    await github.pulls.requestReviewers({
+    await github.rest.pulls.requestReviewers({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: number,

--- a/scripts/github-actions/create-pull-request.js
+++ b/scripts/github-actions/create-pull-request.js
@@ -1,5 +1,4 @@
 const createPullRequest = async ({ context, github, baseBranch, branchName, description, body, reviewers }) => {
-  console.log('inside github', JSON.stringify(github, null, 2))
   const { data: { number } } = await github.rest.pulls.create({
     owner: context.repo.owner,
     repo: context.repo.repo,

--- a/scripts/github-actions/create-pull-request.js
+++ b/scripts/github-actions/create-pull-request.js
@@ -1,4 +1,5 @@
 const createPullRequest = async ({ context, github, baseBranch, branchName, description, body, reviewers }) => {
+  console.log('inside github', JSON.stringify(github, null, 2))
   const { data: { number } } = await github.rest.pulls.create({
     owner: context.repo.owner,
     repo: context.repo.repo,

--- a/scripts/github-actions/semantic-pull-request/index.js
+++ b/scripts/github-actions/semantic-pull-request/index.js
@@ -31,7 +31,7 @@ async function run ({ context, core, github }) {
       pull_number: contextPullRequest.number,
     }
 
-    const { data: pullRequest } = await github.pulls.get(restParameters)
+    const { data: pullRequest } = await github.rest.pulls.get(restParameters)
 
     const { type: semanticType, header } = await validatePrTitle({
       github,
@@ -41,7 +41,7 @@ async function run ({ context, core, github }) {
 
     const associatedIssues = getLinkedIssues(pullRequest.body)
 
-    const { data } = await github.pulls.listFiles(restParameters)
+    const { data } = await github.rest.pulls.listFiles(restParameters)
 
     const changedFiles = data.map((fileDetails) => fileDetails.filename)
 

--- a/scripts/github-actions/semantic-pull-request/validate-pr-title.js
+++ b/scripts/github-actions/semantic-pull-request/validate-pr-title.js
@@ -39,7 +39,7 @@ async function validatePrTitle ({ github, prTitle, restParameters }) {
   let nonMergeCommits = []
 
   for await (const response of github.paginate.iterator(
-    github.pulls.listCommits,
+    github.rest.pulls.listCommits,
     restParameters,
   )) {
     commits.push(...response.data)

--- a/scripts/github-actions/update-browser-versions.js
+++ b/scripts/github-actions/update-browser-versions.js
@@ -87,7 +87,7 @@ const updateBrowserVersionsFile = ({ latestBetaVersion, latestStableVersion }) =
 }
 
 const updatePRTitle = async ({ context, github, baseBranch, branchName, description }) => {
-  const { data } = await github.pulls.list({
+  const { data } = await github.rest.pulls.list({
     owner: context.repo.owner,
     repo: context.repo.repo,
     base: baseBranch,
@@ -100,7 +100,7 @@ const updatePRTitle = async ({ context, github, baseBranch, branchName, descript
     return
   }
 
-  await github.pulls.update({
+  await github.rest.pulls.update({
     owner: context.repo.owner,
     repo: context.repo.repo,
     pull_number: data[0].number,

--- a/scripts/unit/github-actions/create-pull-request-spec.js
+++ b/scripts/unit/github-actions/create-pull-request-spec.js
@@ -79,7 +79,7 @@ describe('pull requests', () => {
         maintainer_can_modify: true,
       })
 
-      expect(github.pulls.requestReviewers).to.be.calledWith({
+      expect(github.rest.pulls.requestReviewers).to.be.calledWith({
         owner: 'cypress-io',
         repo: 'cypress',
         pull_number: 123,

--- a/scripts/unit/github-actions/create-pull-request-spec.js
+++ b/scripts/unit/github-actions/create-pull-request-spec.js
@@ -8,8 +8,10 @@ describe('pull requests', () => {
   context('.createPullRequest', () => {
     it('creates pull request with correct properties', async () => {
       const github = {
-        pulls: {
-          create: sinon.stub().returns(Promise.resolve({ data: { number: 123 } })),
+        rest: {
+          pulls: {
+            create: sinon.stub().returns(Promise.resolve({ data: { number: 123 } })),
+          },
         },
       }
 
@@ -42,9 +44,11 @@ describe('pull requests', () => {
 
     it('creates pull request with correct properties including reviewers', async () => {
       const github = {
-        pulls: {
-          create: sinon.stub().returns(Promise.resolve({ data: { number: 123 } })),
-          requestReviewers: sinon.stub().returns(Promise.resolve()),
+        rest: {
+          pulls: {
+            create: sinon.stub().returns(Promise.resolve({ data: { number: 123 } })),
+            requestReviewers: sinon.stub().returns(Promise.resolve()),
+          },
         },
       }
 

--- a/scripts/unit/github-actions/create-pull-request-spec.js
+++ b/scripts/unit/github-actions/create-pull-request-spec.js
@@ -31,7 +31,7 @@ describe('pull requests', () => {
         body: 'This PR was auto-generated to update the version(s) of Chrome for driver tests',
       })
 
-      expect(github.pulls.create).to.be.calledWith({
+      expect(github.rest.pulls.create).to.be.calledWith({
         owner: 'cypress-io',
         repo: 'cypress',
         base: 'develop',
@@ -69,7 +69,7 @@ describe('pull requests', () => {
         reviewers: ['ryanthemanuel'],
       })
 
-      expect(github.pulls.create).to.be.calledWith({
+      expect(github.rest.pulls.create).to.be.calledWith({
         owner: 'cypress-io',
         repo: 'cypress',
         base: 'develop',

--- a/scripts/unit/github-actions/semantic-pull-request/validate-pr-title-spec.js
+++ b/scripts/unit/github-actions/semantic-pull-request/validate-pr-title-spec.js
@@ -27,7 +27,9 @@ describe('semantic-pull-request/validate-pr-title', () => {
           paginate: {
             iterator: sinon.stub().returns(myAsyncIterable),
           },
-          pulls: {},
+          rest: {
+             pulls: {},
+          },
         }
 
         const prTitle = 'fix: issue with server'
@@ -57,7 +59,9 @@ describe('semantic-pull-request/validate-pr-title', () => {
           paginate: {
             iterator: sinon.stub().returns(myAsyncIterable),
           },
-          pulls: {},
+          rest: {
+             pulls: {},
+          },
         }
 
         const prTitle = 'fix: issue with server'
@@ -85,7 +89,9 @@ describe('semantic-pull-request/validate-pr-title', () => {
           paginate: {
             iterator: sinon.stub().returns(myAsyncIterable),
           },
-          pulls: {},
+          rest: {
+             pulls: {},
+          },
         }
 
         const prTitle = 'fix: issue with server'

--- a/scripts/unit/github-actions/semantic-pull-request/validate-pr-title-spec.js
+++ b/scripts/unit/github-actions/semantic-pull-request/validate-pr-title-spec.js
@@ -28,7 +28,7 @@ describe('semantic-pull-request/validate-pr-title', () => {
             iterator: sinon.stub().returns(myAsyncIterable),
           },
           rest: {
-             pulls: {},
+            pulls: {},
           },
         }
 
@@ -60,7 +60,7 @@ describe('semantic-pull-request/validate-pr-title', () => {
             iterator: sinon.stub().returns(myAsyncIterable),
           },
           rest: {
-             pulls: {},
+            pulls: {},
           },
         }
 
@@ -90,7 +90,7 @@ describe('semantic-pull-request/validate-pr-title', () => {
             iterator: sinon.stub().returns(myAsyncIterable),
           },
           rest: {
-             pulls: {},
+            pulls: {},
           },
         }
 

--- a/scripts/unit/github-actions/update-browser-version-spec.js
+++ b/scripts/unit/github-actions/update-browser-version-spec.js
@@ -271,15 +271,17 @@ describe('update browser version github action', () => {
   context('.updatePRTitle', () => {
     it('updates pull request title', async () => {
       const github = {
-        pulls: {
-          list: sinon.stub().returns(Promise.resolve(
-            {
-              data: [
-                { number: '123' },
-              ],
-            },
-          )),
-          update: sinon.stub(),
+        rest: {
+          pulls: {
+            list: sinon.stub().returns(Promise.resolve(
+              {
+                data: [
+                  { number: '123' },
+                ],
+              },
+            )),
+            update: sinon.stub(),
+          },
         },
       }
 
@@ -298,14 +300,14 @@ describe('update browser version github action', () => {
         description: 'Update Chrome to newer version',
       })
 
-      expect(github.pulls.list).to.be.calledWith({
+      expect(github.rest.pulls.list).to.be.calledWith({
         owner: 'cypress-io',
         repo: 'cypress',
         base: 'develop',
         head: 'cypress-io:some-branch-name',
       })
 
-      expect(github.pulls.update).to.be.calledWith({
+      expect(github.rest.pulls.update).to.be.calledWith({
         owner: 'cypress-io',
         repo: 'cypress',
         pull_number: '123',
@@ -315,13 +317,15 @@ describe('update browser version github action', () => {
 
     it('logs and does not attempt to update pull request title if PR cannot be found', async () => {
       const github = {
-        pulls: {
-          list: sinon.stub().returns(Promise.resolve(
-            {
-              data: [],
-            },
-          )),
-          update: sinon.stub(),
+        rest: {
+          pulls: {
+            list: sinon.stub().returns(Promise.resolve(
+              {
+                data: [],
+              },
+            )),
+            update: sinon.stub(),
+          },
         },
       }
 
@@ -342,14 +346,14 @@ describe('update browser version github action', () => {
         description: 'Update Chrome to newer version',
       })
 
-      expect(github.pulls.list).to.be.calledWith({
+      expect(github.rest.pulls.list).to.be.calledWith({
         owner: 'cypress-io',
         repo: 'cypress',
         base: 'develop',
         head: 'cypress-io:some-branch-name',
       })
 
-      expect(github.pulls.update).not.to.be.called
+      expect(github.rest.pulls.update).not.to.be.called
       expect(console.log).to.be.calledWith('Could not find PR for branch:', 'some-branch-name')
     })
   })


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

[`github-script`](https://github.com/actions/github-script) v6 now uses `github.rest.*` instead of `github.*`

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

n/a

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
