### PR TITLE
chore(dependency): tweaking renovate bot settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "extends": [
-    "config:base",
-    ":semanticCommitScopeDisabled"
+    "config:base"
   ],
   "automerge": false,
   "major": {
@@ -18,11 +17,11 @@
   ],
   "commitMessageSuffix": "🌟",
   "prHourlyLimit": 2,
-  "prConcurrentLimit": 10,
+  "prConcurrentLimit": 5,
   "updateNotScheduled": false,
   "timezone": "America/New_York",
   "schedule": [
-    "before 5am every weekday"
+    "before 5am every Tuesday"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Changing renovate bot to run less frequently and have a lower number of concurrent PRs open to prevent us from getting flooded.  I also changed it so it should be including the semantic scope in PR titles again so it wont break the checks.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ n/a ] Have tests been added/updated?
- [ n/a ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ n/a ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
