### PR TITLE
chore: fix changelog spacing

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -13,6 +13,7 @@ _Released 04/11/2023 (PENDING)_
 - Upgraded [`minimist`](https://www.npmjs.com/package/minimist) from `1.2.6` to `1.2.8` to address this [CVE-2021-44906](https://github.com/advisories/GHSA-xvch-5gv4-984h) NVD security vulnerability. Addressed in [#26254](https://github.com/cypress-io/cypress/pull/26254).
 
 **Misc:**
+
 - Removed unintentional debug logs. Address in [#26411](https://github.com/cypress-io/cypress/pull/26411)
 
 ## 12.9.0

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,13 +8,13 @@ _Released 04/11/2023 (PENDING)_
  - Capture the [Azure](https://azure.microsoft.com/) CI provider's environment variable [`SYSTEM_PULLREQUEST_PULLREQUESTNUMBER`](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#system-variables-devops-services) to display the linked PR number in the Cloud. Addressed in [#26215](https://github.com/cypress-io/cypress/pull/26215).
  - Fixed an issue in the onboarding wizard where project framework & bundler would not be auto-detected when opening directly into component testing mode using the `--component` CLI flag. Fixes [#22777](https://github.com/cypress-io/cypress/issues/22777).
 
-**Dependency Updates:**
-
-- Upgraded [`minimist`](https://www.npmjs.com/package/minimist) from `1.2.6` to `1.2.8` to address this [CVE-2021-44906](https://github.com/advisories/GHSA-xvch-5gv4-984h) NVD security vulnerability. Addressed in [#26254](https://github.com/cypress-io/cypress/pull/26254).
-
 **Misc:**
 
 - Removed unintentional debug logs. Address in [#26411](https://github.com/cypress-io/cypress/pull/26411)
+
+**Dependency Updates:**
+
+- Upgraded [`minimist`](https://www.npmjs.com/package/minimist) from `1.2.6` to `1.2.8` to address this [CVE-2021-44906](https://github.com/advisories/GHSA-xvch-5gv4-984h) NVD security vulnerability. Addressed in [#26254](https://github.com/cypress-io/cypress/pull/26254).
 
 ## 12.9.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,7 +10,7 @@ _Released 04/11/2023 (PENDING)_
 
 **Misc:**
 
-- Removed unintentional debug logs. Address in [#26411](https://github.com/cypress-io/cypress/pull/26411)
+- Removed unintentional debug logs. Addressed in [#26411](https://github.com/cypress-io/cypress/pull/26411).
 
 **Dependency Updates:**
 


### PR DESCRIPTION
The changelog automation is expecting a line break here