### PR TITLE
chore: adding wallClockUpdatedAt to log for protocol

### DIFF
--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -492,7 +492,7 @@ export class EventManager {
       this._interceptStudio(displayProps)
 
       this.reporterBus.emit('reporter:log:add', displayProps)
-      Cypress.backend('protocol:command:log:added', displayProps, new Date().toJSON())
+      Cypress.backend('protocol:command:log:added', displayProps)
     })
 
     Cypress.on('log:changed', (log) => {
@@ -506,7 +506,7 @@ export class EventManager {
       this._interceptStudio(displayProps)
 
       this.reporterBus.emit('reporter:log:state:changed', displayProps)
-      Cypress.backend('protocol:command:log:changed', displayProps, new Date().toJSON())
+      Cypress.backend('protocol:command:log:changed', displayProps)
     })
 
     // TODO: MOVE BACK INTO useEventManager. Verify this works

--- a/packages/driver/src/cypress/log.ts
+++ b/packages/driver/src/cypress/log.ts
@@ -318,7 +318,7 @@ export class Log {
     }
 
     // if the log doesn't have a wallClockUpdatedAt, then set it to the wallClockStartedAt, otherwise set it to the current time
-    this.obj.wallClockUpdatedAt = this.attributes.wallClockUpdatedAt ? this.attributes.wallClockStartedAt : new Date().toJSON()
+    this.obj.wallClockUpdatedAt = !this.attributes.wallClockUpdatedAt ? this.attributes.wallClockStartedAt : new Date().toJSON()
 
     _.extend(this.attributes, this.obj)
 

--- a/packages/driver/types/cypress/log.d.ts
+++ b/packages/driver/types/cypress/log.d.ts
@@ -128,7 +128,7 @@ declare namespace Cypress {
     viewportHeight?: number
     viewportWidth?: number
     visible?: boolean
-    wallClockStartedAt: string
-    wallClockUpdatedAt: string
+    wallClockStartedAt?: string
+    wallClockUpdatedAt?: string
   }
 }

--- a/packages/driver/types/cypress/log.d.ts
+++ b/packages/driver/types/cypress/log.d.ts
@@ -128,6 +128,7 @@ declare namespace Cypress {
     viewportHeight?: number
     viewportWidth?: number
     visible?: boolean
-    wallClockStartedAt?: string
+    wallClockStartedAt: string
+    wallClockUpdatedAt: string
   }
 }

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -110,20 +110,20 @@ class ProtocolManagerImpl implements ProtocolManager {
     this.protocol?.afterTest(test)
   }
 
-  commandLogAdded (log: any, timestamp: string) {
+  commandLogAdded (log: any) {
     if (!this.protocolEnabled()) {
       return
     }
 
-    this.protocol?.commandLogAdded(log, timestamp)
+    this.protocol?.commandLogAdded(log)
   }
 
-  commandLogChanged (log: any, timestamp: string): void {
+  commandLogChanged (log: any): void {
     if (!this.protocolEnabled()) {
       return
     }
 
-    this.protocol?.commandLogChanged(log, timestamp)
+    this.protocol?.commandLogChanged(log)
   }
 }
 

--- a/packages/server/lib/socket-base.ts
+++ b/packages/server/lib/socket-base.ts
@@ -461,9 +461,9 @@ export class SocketBase {
             case 'protocol:test:after:run':
               return this.protocolManager?.afterTest(args[0])
             case 'protocol:command:log:added':
-              return this.protocolManager?.commandLogAdded(args[0], args[1])
+              return this.protocolManager?.commandLogAdded(args[0])
             case 'protocol:command:log:changed':
-              return this.protocolManager?.commandLogChanged(args[0], args[1])
+              return this.protocolManager?.commandLogChanged(args[0])
             default:
               throw new Error(`You requested a backend event we cannot handle: ${eventName}`)
           }

--- a/packages/server/test/support/fixtures/cloud/protocol/test-protocol.js
+++ b/packages/server/test/support/fixtures/cloud/protocol/test-protocol.js
@@ -20,8 +20,8 @@ const AppCaptureProtocol = class {
   beforeSpec (spec) {}
   afterSpec (spec) {}
   beforeTest (test) {}
-  commandLogAdded (log, timestamp) {}
-  commandLogChanged (log, timestamp) {}
+  commandLogAdded (log) {}
+  commandLogChanged (log) {}
 }
 
 module.exports = {

--- a/packages/server/test/unit/cloud/protocol_spec.ts
+++ b/packages/server/test/unit/cloud/protocol_spec.ts
@@ -125,14 +125,15 @@ describe('lib/cloud/protocol', () => {
       type: 'parent',
       url: 'https://jsonplaceholder.cypress.io/comments/1',
       wallClockStartedAt: '2023-03-30T21:58:08.456Z',
+      wallClockUpdatedAt: '2023-03-30T21:58:08.457Z',
       testCurrentRetry: 0,
       hasSnapshot: false,
       hasConsoleProps: true,
     }
 
-    protocolManager.commandLogAdded(log, '2023-03-30T21:58:08.457Z')
+    protocolManager.commandLogAdded(log)
 
-    expect(protocol.commandLogAdded).to.be.calledWith(log, '2023-03-30T21:58:08.457Z')
+    expect(protocol.commandLogAdded).to.be.calledWith(log)
   })
 
   it('should be able to change a command log', () => {
@@ -156,13 +157,14 @@ describe('lib/cloud/protocol', () => {
       type: 'parent',
       url: 'https://jsonplaceholder.cypress.io/comments/1',
       wallClockStartedAt: '2023-03-30T21:58:08.456Z',
+      wallClockUpdatedAt: '2023-03-30T21:58:08.457Z',
       testCurrentRetry: 0,
       hasSnapshot: false,
       hasConsoleProps: true,
     }
 
-    protocolManager.commandLogChanged(log, '2023-03-30T21:58:08.457Z')
+    protocolManager.commandLogChanged(log)
 
-    expect(protocol.commandLogChanged).to.be.calledWith(log, '2023-03-30T21:58:08.457Z')
+    expect(protocol.commandLogChanged).to.be.calledWith(log)
   })
 })

--- a/packages/types/src/protocol.ts
+++ b/packages/types/src/protocol.ts
@@ -20,8 +20,8 @@ export interface AppCaptureProtocolInterface {
   afterSpec (): void
   beforeTest(test: Record<string, any>): void
   afterTest(test: Record<string, any>): void
-  commandLogAdded (log: any, timestamp: string): void
-  commandLogChanged (log: any, timestamp: string): void
+  commandLogAdded (log: any): void
+  commandLogChanged (log: any): void
 }
 
 export interface ProtocolManager {
@@ -33,6 +33,6 @@ export interface ProtocolManager {
   afterSpec (): void
   beforeTest(test: Record<string, any>): void
   afterTest(test: Record<string, any>): void
-  commandLogAdded (log: any, timestamp: string): void
-  commandLogChanged (log: any, timestamp: string): void
+  commandLogAdded (log: any): void
+  commandLogChanged (log: any): void
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
* Adds a new property `wallClockUpdatedAt` to the log
  * Value is set to `wallClockStartedAt` for the first log and then updated when the log is updated

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

- Clone the `cypress-services` repo and checkout `mschile/protocol/command_log_timestamp`
  - Run `yarn`
  - Run `yarn watch-protocol`
- Set `CYPRESS_LOCAL_PROTOCOL_PATH` to the path to `cypress-services/packages/app-capture-protocol/dist/index.js`
- Clone the `cypress` repo  and checkout `mschile/protocol/command_log_timestamp`
  - Run `yarn`
  - Execute `cypress run` on a project in record mode with `DEBUG` set to `cypress:*protocol*` and ensure the `command:log` events with the correct timestamp are added to the database.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
