### PR TITLE
chore: remove redundant postinstall

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -89,7 +89,6 @@
     "mock-fs": "5.1.1",
     "mocked-env": "1.3.2",
     "nock": "13.2.9",
-    "postinstall-postinstall": "2.1.0",
     "proxyquire": "2.1.3",
     "resolve-pkg": "2.0.0",
     "shelljs": "0.8.5",

--- a/package.json
+++ b/package.json
@@ -188,7 +188,6 @@
     "patch-package": "6.4.7",
     "playwright-webkit": "1.24.2",
     "pluralize": "8.0.0",
-    "postinstall-postinstall": "2.0.0",
     "print-arch": "1.0.0",
     "proxyquire": "2.1.3",
     "rimraf": "3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24017,16 +24017,6 @@ postcss@^8.1.10, postcss@^8.4.21:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postinstall-postinstall@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.0.0.tgz#7ba6711b4420575c4f561638836a81faad47f43f"
-  integrity sha512-3f6qWexsHiT4WKtZc5DRb0FPLilHtARi5KpY4fqban/DJNn8/YhZH8U7dVKVz51WbOxEnR31gV+qYQhvEdHtdQ==
-
-postinstall-postinstall@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
-  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
-
 prebuild-install@^5.2.4, prebuild-install@^5.3.5:
   version "5.3.6"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.6.tgz#7c225568d864c71d89d07f8796042733a3f54291"


### PR DESCRIPTION
While debugging a snapshot issue with @ryanthemanuel , he noticed we were running postinstall twice in the project when running `yarn`.

This was happening because of the `postisntall-postinstall` dependency which was added to handle running  postinstall on `yarn remove` becuase yarn does not do this for us. This use-case is so small that running postinstall 2 times is not worth it!

Also, the `postinstall-postisntall` was executing our postinstall script but hiding the output so when an error was occurring, it was actually swallowed which let to me needing to bug @ryanthemanuel for really no reason.