### PR TITLE
chore: fix issue with logs without wallClockStartedAt

### DIFF
--- a/packages/driver/src/cypress/log.ts
+++ b/packages/driver/src/cypress/log.ts
@@ -318,7 +318,7 @@ export class Log {
     }
 
     // if the log doesn't have a wallClockUpdatedAt, then set it to the wallClockStartedAt, otherwise set it to the current time
-    this.obj.wallClockUpdatedAt = !this.attributes.wallClockUpdatedAt ? this.attributes.wallClockStartedAt : new Date().toJSON()
+    this.obj.wallClockUpdatedAt = !this.attributes.wallClockUpdatedAt && this.attributes.wallClockStartedAt ? this.attributes.wallClockStartedAt : new Date().toJSON()
 
     _.extend(this.attributes, this.obj)
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
* If the log wasn't created with a `wallClockStartedAt` (e.g. an `agent` log), the `wallClockUpdatedAt` value will now default to the current date/time.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
* Run the `spies_stubs_clocks.cy.js` scaffold test and verify no schema errors are thrown.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
