### PR TITLE
chore: [skip ci] turning on stale bot

### DIFF
--- a/.github/workflows/stale_issues_and_pr_cleanup.yml
+++ b/.github/workflows/stale_issues_and_pr_cleanup.yml
@@ -5,7 +5,7 @@ on:
       debug-only:
         description: 'debug-only'     
         required: false
-        default: true
+        default: false
       days-before-stale:
         description: 'days-before-stale'     
         required: false
@@ -50,5 +50,5 @@ jobs:
           exempt-issue-labels: ${{ github.event.inputs.exempt-issue-labels || env.DEFAULT_EXEMPT_ISSUE_LABELS }}
           exempt-pr-labels: ${{ github.event.inputs.exempt-pr-labels || env.DEFAULT_EXEMPT_PR_LABELS }}
           exempt-all-milestones: true
-          operations-per-run: 1000 #using during debug mode to capture all the tickets impacted
+          operations-per-run: 200 #keeping this a bit higher because it processes newest tickets to oldest
           debug-only: ${{ github.event.inputs.debug-only || env.DEFAULT_DEBUG_ONLY }}


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

This turns on the job that updates stale issues with a label and message after 180 days of no activity and closes 14 days later if no activity happens after being labeled as stale.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ n/a ] Have tests been added/updated?
- [ n/a ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ n/a ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
