### PR TITLE
chore: adding viewport:changed to protocol

### DIFF
--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -15,6 +15,7 @@ import { getAutIframeModel } from '.'
 import { handlePausing } from './events/pausing'
 import { addTelemetryListeners } from './events/telemetry'
 import { telemetry } from '@packages/telemetry/src/browser'
+import { addCaptureProtocolListeners } from './events/capture-protocol'
 
 export type CypressInCypressMochaEvent = Array<Array<string | Record<string, any>>>
 
@@ -462,6 +463,7 @@ export class EventManager {
 
   _addListeners () {
     addTelemetryListeners(Cypress)
+    addCaptureProtocolListeners(Cypress)
 
     Cypress.on('message', (msg, data, cb) => {
       this.ws.emit('client:request', msg, data, cb)
@@ -503,7 +505,6 @@ export class EventManager {
       this._interceptStudio(displayProps)
 
       this.reporterBus.emit('reporter:log:add', displayProps)
-      Cypress.backend('protocol:command:log:added', displayProps)
     })
 
     Cypress.on('log:changed', (log) => {
@@ -517,7 +518,6 @@ export class EventManager {
       this._interceptStudio(displayProps)
 
       this.reporterBus.emit('reporter:log:state:changed', displayProps)
-      Cypress.backend('protocol:command:log:changed', displayProps)
     })
 
     // TODO: MOVE BACK INTO useEventManager. Verify this works
@@ -620,8 +620,6 @@ export class EventManager {
         })
       }
 
-      await Cypress.backend('protocol:test:before:run:async', attributes)
-
       Cypress.primaryOriginCommunicator.toAllSpecBridges('test:before:run:async', ...args)
     })
 
@@ -631,8 +629,6 @@ export class EventManager {
       if (this.studioStore.isOpen && attributes.state !== 'passed') {
         this.studioStore.testFailed()
       }
-
-      Cypress.backend('protocol:test:after:run', attributes)
     })
 
     handlePausing(this.getCypress, this.reporterBus)

--- a/packages/app/src/runner/events/capture-protocol.ts
+++ b/packages/app/src/runner/events/capture-protocol.ts
@@ -1,0 +1,33 @@
+export const addCaptureProtocolListeners = (Cypress) => {
+  Cypress.on('log:added', (log) => {
+    const displayProps = Cypress.runner.getDisplayPropsForLog(log)
+
+    Cypress.backend('protocol:command:log:added', displayProps)
+  })
+
+  Cypress.on('log:changed', (log) => {
+    const displayProps = Cypress.runner.getDisplayPropsForLog(log)
+
+    Cypress.backend('protocol:command:log:changed', displayProps)
+  })
+
+  Cypress.on('viewport:changed', (viewport) => {
+    const timestamp = performance.timeOrigin + performance.now()
+
+    Cypress.backend('protocol:viewport:changed', {
+      viewport: {
+        width: viewport.viewportWidth,
+        height: viewport.viewportHeight,
+      },
+      timestamp,
+    })
+  })
+
+  Cypress.on('test:before:run:async', async (attributes) => {
+    await Cypress.backend('protocol:test:before:run:async', attributes)
+  })
+
+  Cypress.on('test:after:run', (attributes) => {
+    Cypress.backend('protocol:test:after:run', attributes)
+  })
+}

--- a/packages/app/src/runner/events/capture-protocol.ts
+++ b/packages/app/src/runner/events/capture-protocol.ts
@@ -1,4 +1,4 @@
-export const addCaptureProtocolListeners = (Cypress) => {
+export const addCaptureProtocolListeners = (Cypress: Cypress.Cypress) => {
   Cypress.on('log:added', (log) => {
     const displayProps = Cypress.runner.getDisplayPropsForLog(log)
 

--- a/packages/app/src/runner/events/telemetry.ts
+++ b/packages/app/src/runner/events/telemetry.ts
@@ -1,6 +1,6 @@
 import { telemetry } from '@packages/telemetry/src/browser'
 
-export const addTelemetryListeners = (Cypress) => {
+export const addTelemetryListeners = (Cypress: Cypress.Cypress) => {
   Cypress.on('test:before:run', (attributes, test) => {
     // we emit the 'test:before:run' events within various driver tests
     try {

--- a/packages/driver/types/internal-types-lite.d.ts
+++ b/packages/driver/types/internal-types-lite.d.ts
@@ -4,6 +4,10 @@
 // All of the types needed by packages/app, without any of the additional APIs used in the driver only
 
 declare namespace Cypress {
+  interface Cypress {
+    runner: any
+  }
+
   interface Actions {
     (action: 'internal:window:load', fn: (details: InternalWindowLoadDetails) => void)
     (action: 'net:stubbing:event', frame: any)
@@ -13,6 +17,14 @@ declare namespace Cypress {
     (action: 'viewport:changed', fn?: (viewport: { viewportWidth: string, viewportHeight: string }, callback: () => void) => void)
     (action: 'before:screenshot', fn: (config: {}, fn: () => void) => void)
     (action: 'after:screenshot', config: {})
+  }
+
+  interface Backend {
+    (task: 'protocol:command:log:added', log: any): Promise<void>
+    (task: 'protocol:command:log:changed', log: any): Promise<void>
+    (task: 'protocol:viewport:changed', input: any): Promise<void>
+    (task: 'protocol:test:before:run:async', attributes: any): Promise<void>
+    (task: 'protocol:test:after:run', attributes: any): Promise<void>
   }
 
   interface cy {

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -125,6 +125,14 @@ class ProtocolManagerImpl implements ProtocolManager {
 
     this.protocol?.commandLogChanged(log)
   }
+
+  viewportChanged (input: any): void {
+    if (!this.protocolEnabled()) {
+      return
+    }
+
+    this.protocol?.viewportChanged(input)
+  }
 }
 
 export default ProtocolManagerImpl

--- a/packages/server/lib/socket-base.ts
+++ b/packages/server/lib/socket-base.ts
@@ -466,6 +466,8 @@ export class SocketBase {
               return this.protocolManager?.commandLogAdded(args[0])
             case 'protocol:command:log:changed':
               return this.protocolManager?.commandLogChanged(args[0])
+            case 'protocol:viewport:changed':
+              return this.protocolManager?.viewportChanged(args[0])
             case 'telemetry':
               return (telemetry.exporter() as OTLPTraceExporterCloud)?.send(args[0], () => {}, (err) => {
                 debug('error exporting telemetry data from browser %s', err)

--- a/packages/server/test/support/fixtures/cloud/protocol/test-protocol.js
+++ b/packages/server/test/support/fixtures/cloud/protocol/test-protocol.js
@@ -11,6 +11,7 @@ const AppCaptureProtocol = class {
     this.beforeTest = this.beforeTest.bind(this)
     this.commandLogAdded = this.commandLogAdded.bind(this)
     this.commandLogChanged = this.commandLogChanged.bind(this)
+    this.viewportChanged = this.viewportChanged.bind(this)
   }
 
   connectToBrowser (cdpClient) {
@@ -22,6 +23,7 @@ const AppCaptureProtocol = class {
   beforeTest (test) {}
   commandLogAdded (log) {}
   commandLogChanged (log) {}
+  viewportChanged (input) {}
 }
 
 module.exports = {

--- a/packages/server/test/unit/cloud/protocol_spec.ts
+++ b/packages/server/test/unit/cloud/protocol_spec.ts
@@ -167,4 +167,20 @@ describe('lib/cloud/protocol', () => {
 
     expect(protocol.commandLogChanged).to.be.calledWith(log)
   })
+
+  it('should be able to handle changing the viewport', () => {
+    sinon.stub(protocol, 'viewportChanged')
+
+    const input = {
+      viewport: {
+        width: 100,
+        height: 200,
+      },
+      timestamp: 1234,
+    }
+
+    protocolManager.viewportChanged(input)
+
+    expect(protocol.viewportChanged).to.be.calledWith(input)
+  })
 })

--- a/packages/types/src/protocol.ts
+++ b/packages/types/src/protocol.ts
@@ -22,6 +22,7 @@ export interface AppCaptureProtocolInterface {
   afterTest(test: Record<string, any>): void
   commandLogAdded (log: any): void
   commandLogChanged (log: any): void
+  viewportChanged (input: any): void
 }
 
 export interface ProtocolManager {
@@ -35,4 +36,5 @@ export interface ProtocolManager {
   afterTest(test: Record<string, any>): void
   commandLogAdded (log: any): void
   commandLogChanged (log: any): void
+  viewportChanged (input: any): void
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
* Added support for `viewport:changed`
* Moved all event listeners to a new file

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
* Run a test that changes the viewport and verify the event is correctly added to the events table.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
<img width="1365" alt="Screenshot 2023-04-14 at 12 28 53 PM" src="https://user-images.githubusercontent.com/2002044/232127414-a59364bb-9342-4175-8b66-a2f29cd3c13d.png">

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
