### PR TITLE
feat: display a limit warning on the run navigation component when there are 100 total runs

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 _Released 04/25/2023 (PENDING)_
 
+**Features:**
+
+- The run navigation component on the [Debug page](https://on.cypress.io/debug-page) will now display a warning message if there are more relevant runs than can be displayed in the list. Addresses [#26288](https://github.com/cypress-io/cypress/issues/26288).
+
 **Bugfixes:**
 
 - Fixed an issue where setting `videoCompression` to `0` would cause the video output to be broken. `0` is now treated as false. Addresses [#5191](https://github.com/cypress-io/cypress/issues/5191) and [#24595](https://github.com/cypress-io/cypress/issues/24595).

--- a/packages/app/cypress/fixtures/debug-Failing/gql-Debug.json
+++ b/packages/app/cypress/fixtures/debug-Failing/gql-Debug.json
@@ -5,6 +5,7 @@
       "cloudProject": {
         "__typename": "CloudProject",
         "id": "cloud-project-test-id",
+        "cloudProjectUrl": "https://cloud.cypress.io/projects/vgqrwp",
         "runByNumber": {
           "id": "Q2xvdWRSdW46TUdWZXhvQkRPNg==",
           "runNumber": 136,

--- a/packages/app/cypress/fixtures/debug-Passing/gql-Debug.json
+++ b/packages/app/cypress/fixtures/debug-Passing/gql-Debug.json
@@ -5,6 +5,7 @@
       "cloudProject": {
         "__typename": "CloudProject",
         "id": "Q2xvdWRQcm9qZWN0OjdwNXVjZQ==",
+        "cloudProjectUrl": "https://cloud.cypress.io/projects/7p5uce",
         "runByNumber": {
           "id": "Q2xvdWRSdW46bkdudmx5d3BHWg==",
           "runNumber": 2,

--- a/packages/app/src/debug/DebugContainer.vue
+++ b/packages/app/src/debug/DebugContainer.vue
@@ -31,6 +31,7 @@
           :runs="allRuns"
           :current-run-number="run.runNumber"
           :current-commit-info="currentCommitInfo"
+          :current-run-url="run.url"
         />
 
         <DebugPageHeader

--- a/packages/app/src/debug/DebugContainer.vue
+++ b/packages/app/src/debug/DebugContainer.vue
@@ -31,7 +31,7 @@
           :runs="allRuns"
           :current-run-number="run.runNumber"
           :current-commit-info="currentCommitInfo"
-          :current-run-url="run.url"
+          :cloud-project-url="cloudProject?.cloudProjectUrl"
         />
 
         <DebugPageHeader

--- a/packages/app/src/debug/DebugRunNavigation.cy.tsx
+++ b/packages/app/src/debug/DebugRunNavigation.cy.tsx
@@ -12,7 +12,7 @@ function mountDebugDetailedView (data: {
   currentRun: ReturnType<typeof createRun>
   allRuns: Array<ReturnType<typeof createRun>>
   currentCommitInfo?: CommitInfo
-  currentRunUrl?: string | null
+  cloudProjectUrl?: string
 }) {
   return cy.mountFragment(DebugRunNavigationFragmentDoc, {
     variableTypes: DebugSpecVariableTypes,
@@ -26,7 +26,7 @@ function mountDebugDetailedView (data: {
     render (gqlData) {
       return (
         <div style="margin: 10px">
-          <DebugRunNavigation runs={gqlData.allRuns!} currentRunNumber={data.currentRun.runNumber!} currentCommitInfo={data.currentCommitInfo} currentRunUrl={data.currentRunUrl || ''} />
+          <DebugRunNavigation runs={gqlData.allRuns!} currentRunNumber={data.currentRun.runNumber!} currentCommitInfo={data.currentCommitInfo} cloudProjectUrl={data.cloudProjectUrl} />
         </div>
       )
     },
@@ -213,7 +213,7 @@ describe('<DebugRunNavigation />', () => {
 
   it('displays the limit message when the number of total runs is exactly 100', () => {
     const latest = createRun({
-      runNumber: 3,
+      runNumber: 99,
       status: 'RUNNING',
       sha: 'sha-123',
       summary: 'add new feature with a really long commit message to see what happens',
@@ -221,18 +221,18 @@ describe('<DebugRunNavigation />', () => {
       totalInstanceCount: 12,
     })
 
-    const other1 = createRun({ runNumber: 1, status: 'PASSED', sha: 'sha-456', summary: 'Update code' })
-    const other2 = createRun({ runNumber: 2, status: 'PASSED', sha: 'sha-456', summary: 'Update code' })
+    const other1 = createRun({ runNumber: 98, status: 'PASSED', sha: 'sha-456', summary: 'Update code' })
+    const other2 = createRun({ runNumber: 97, status: 'PASSED', sha: 'sha-456', summary: 'Update code' })
 
-    const allRuns: any = []
+    const allRuns = [other1, other2]
 
-    for (let i = 1; i <= 98; i++) {
-      allRuns.push(other2)
+    for (let i = 96; i >= 0; i--) {
+      allRuns.push(createRun({ runNumber: i, status: 'PASSED', sha: 'sha-456', summary: 'Update code' }))
     }
 
     const commitInfo = { sha: 'sha-123', message: 'add new feature with a really long commit message to see what happens' } as CommitInfo
 
-    mountDebugDetailedView({ currentRun: other1, allRuns: [latest, other1, ...allRuns], currentCommitInfo: commitInfo, currentRunUrl: 'https://cloud.cypress.io/projects/ypt4pf/runs/45575' })
+    mountDebugDetailedView({ currentRun: other1, allRuns: [latest, ...allRuns], currentCommitInfo: commitInfo, cloudProjectUrl: 'https://cloud.cypress.io/projects/ypt4pf/' })
 
     // This should only show when the list is expanded
     cy.contains('We found more than 100 runs.').should('not.exist')
@@ -240,7 +240,7 @@ describe('<DebugRunNavigation />', () => {
     cy.findByTestId('debug-toggle').click()
 
     cy.contains('We found more than 100 runs.').should('be.visible')
-    cy.findByRole('link', { name: 'Go to Cypress Cloud to see all runs' }).should('be.visible').should('have.attr', 'href', 'https://cloud.cypress.io/projects/ypt4pf')
+    cy.findByRole('link', { name: 'Go to Cypress Cloud to see all runs' }).should('be.visible').should('have.attr', 'href', 'https://cloud.cypress.io/projects/ypt4pf/')
 
     cy.percySnapshot()
   })

--- a/packages/app/src/debug/DebugRunNavigation.cy.tsx
+++ b/packages/app/src/debug/DebugRunNavigation.cy.tsx
@@ -12,6 +12,7 @@ function mountDebugDetailedView (data: {
   currentRun: ReturnType<typeof createRun>
   allRuns: Array<ReturnType<typeof createRun>>
   currentCommitInfo?: CommitInfo
+  currentRunUrl?: string | null
 }) {
   return cy.mountFragment(DebugRunNavigationFragmentDoc, {
     variableTypes: DebugSpecVariableTypes,
@@ -25,7 +26,7 @@ function mountDebugDetailedView (data: {
     render (gqlData) {
       return (
         <div style="margin: 10px">
-          <DebugRunNavigation runs={gqlData.allRuns!} currentRunNumber={data.currentRun.runNumber!} currentCommitInfo={data.currentCommitInfo}/>
+          <DebugRunNavigation runs={gqlData.allRuns!} currentRunNumber={data.currentRun.runNumber!} currentCommitInfo={data.currentCommitInfo} currentRunUrl={data.currentRunUrl || ''} />
         </div>
       )
     },
@@ -56,6 +57,7 @@ describe('<DebugRunNavigation />', () => {
     cy.get('[data-cy="debug-toggle"]').click()
 
     cy.findByTestId('current-run').should('exist')
+    cy.contains('We found more than 100 runs.').should('not.exist')
   })
 
   it('hide toggle if not on latest and only two runs', () => {
@@ -138,6 +140,8 @@ describe('<DebugRunNavigation />', () => {
 
       cy.get('[data-cy="debug-toggle"]').click()
 
+      cy.contains('We found more than 100 runs.').should('not.exist')
+
       cy.findByTestId('commit-sha-123').as('commit-123').should('exist')
       cy.get('@commit-123').contains('sha-123')
       cy.get('@commit-123').contains('add new feature with a really long commit message to see what happens')
@@ -167,6 +171,8 @@ describe('<DebugRunNavigation />', () => {
       cy.clock(new Date())
       cy.get('[data-cy="debug-toggle"]').click()
       cy.tick(2 * 1000) //allow toggle to animate
+
+      cy.contains('We found more than 100 runs.').should('not.exist')
 
       cy.viewport(616, 850) //currently the narrowest the parent component will go
       cy.percySnapshot('narrowest')
@@ -203,6 +209,37 @@ describe('<DebugRunNavigation />', () => {
     cy.findByTestId('commit-sha-other').within(() => {
       cy.findByTestId('tag-checked-out').should('be.visible')
     })
+  })
+
+  it('displays the limit message when the number of total runs is exactly 100', () => {
+    const latest = createRun({
+      runNumber: 3,
+      status: 'RUNNING',
+      sha: 'sha-123',
+      summary: 'add new feature with a really long commit message to see what happens',
+      completedInstanceCount: 5,
+      totalInstanceCount: 12,
+    })
+
+    const other1 = createRun({ runNumber: 1, status: 'PASSED', sha: 'sha-456', summary: 'Update code' })
+    const other2 = createRun({ runNumber: 2, status: 'PASSED', sha: 'sha-456', summary: 'Update code' })
+
+    const allRuns: any = []
+
+    for (let i = 1; i <= 98; i++) {
+      allRuns.push(other2)
+    }
+
+    const commitInfo = { sha: 'sha-123', message: 'add new feature with a really long commit message to see what happens' } as CommitInfo
+
+    mountDebugDetailedView({ currentRun: other1, allRuns: [latest, other1, ...allRuns], currentCommitInfo: commitInfo, currentRunUrl: 'https://cloud.cypress.io/projects/ypt4pf/runs/45575' })
+
+    cy.findByTestId('debug-toggle').click()
+
+    cy.contains('We found more than 100 runs.').should('be.visible')
+    cy.findByRole('link', { name: 'Go to Cypress Cloud to see all runs' }).should('be.visible').should('have.attr', 'href', 'https://cloud.cypress.io/projects/ypt4pf')
+
+    cy.percySnapshot()
   })
 
   describe('Switch to latest run button', () => {

--- a/packages/app/src/debug/DebugRunNavigation.cy.tsx
+++ b/packages/app/src/debug/DebugRunNavigation.cy.tsx
@@ -234,6 +234,9 @@ describe('<DebugRunNavigation />', () => {
 
     mountDebugDetailedView({ currentRun: other1, allRuns: [latest, other1, ...allRuns], currentCommitInfo: commitInfo, currentRunUrl: 'https://cloud.cypress.io/projects/ypt4pf/runs/45575' })
 
+    // This should only show when the list is expanded
+    cy.contains('We found more than 100 runs.').should('not.exist')
+
     cy.findByTestId('debug-toggle').click()
 
     cy.contains('We found more than 100 runs.').should('be.visible')

--- a/packages/app/src/debug/DebugRunNavigation.vue
+++ b/packages/app/src/debug/DebugRunNavigation.vue
@@ -68,56 +68,64 @@
     </div>
 
     <TransitionQuickFadeVue>
-      <div
-        v-if="showRuns"
-        id="debug-runs-container"
-        class="max-h-30vh overflow-y-scroll"
-        data-cy="debug-runs-container"
-      >
-        <ul
-          class="my-8px relative before:(content-DEFAULT top-20px bottom-10px w-5px border-2 border-dashed border-l-0 border-y-0 border-r-gray-100 left-[19px] absolute) "
-          data-cy="debug-historical-runs"
+      <div>
+        <div
+          v-if="showRuns"
+          id="debug-runs-container"
+          class="max-h-30vh overflow-y-scroll"
+          data-cy="debug-runs-container"
         >
-          <li
-            v-for="sha of Object.keys(groupByCommit)"
-            :key="sha"
-            :data-cy="`commit-${sha}`"
+          <ul
+            class="my-8px relative before:(content-DEFAULT top-20px bottom-10px w-5px border-2 border-dashed border-l-0 border-y-0 border-r-gray-100 left-[19px] absolute) "
+            data-cy="debug-historical-runs"
           >
-            <div class="flex my-10px mx-16px items-center">
-              <DebugCommitIcon class="flex-shrink-0" />
-              <LightText class="flex-shrink-0 ml-12px truncate">
-                {{ sha.slice(0, 7) }}
-              </LightText>
-              <Dot />
-              <span
-                class="font-medium text-sm text-gray-800 truncate"
-                :title="groupByCommit[sha].message!"
-              >
-                {{ groupByCommit[sha].message }}
-              </span>
-              <span
-                v-if="sha === currentCommitInfo?.sha"
-                data-cy="tag-checked-out"
-                class="border rounded font-medium border-gray-100 border-1 flex-shrink-0
+            <li
+              v-for="sha of Object.keys(groupByCommit)"
+              :key="sha"
+              :data-cy="`commit-${sha}`"
+            >
+              <div class="flex my-10px mx-16px items-center">
+                <DebugCommitIcon class="flex-shrink-0" />
+                <LightText class="flex-shrink-0 ml-12px truncate">
+                  {{ sha.slice(0, 7) }}
+                </LightText>
+                <Dot />
+                <span
+                  class="font-medium text-sm text-gray-800 truncate"
+                  :title="groupByCommit[sha].message!"
+                >
+                  {{ groupByCommit[sha].message }}
+                </span>
+                <span
+                  v-if="sha === currentCommitInfo?.sha"
+                  data-cy="tag-checked-out"
+                  class="border rounded font-medium border-gray-100 border-1 flex-shrink-0
               h-16px ml-8px px-4px text-12px text-purple-400 leading-16px
               align-middle inline-flex items-center"
-              >
-                Checked out
-              </span>
-            </div>
+                >
+                  Checked out
+                </span>
+              </div>
 
-            <ul v-if="groupByCommit[sha].runs">
-              <DebugRunNavigationRow
-                v-for="run of groupByCommit[sha].runs"
-                :key="run?.runNumber!"
-                :run-number="run?.runNumber!"
-                :is-current-run="isCurrentRun(run!)"
-                :gql="run!"
-                @change-run="changeRun(run!)"
-              />
-            </ul>
-          </li>
-        </ul>
+              <ul v-if="groupByCommit[sha].runs">
+                <DebugRunNavigationRow
+                  v-for="run of groupByCommit[sha].runs"
+                  :key="run?.runNumber!"
+                  :run-number="run?.runNumber!"
+                  :is-current-run="isCurrentRun(run!)"
+                  :gql="run!"
+                  @change-run="changeRun(run!)"
+                />
+              </ul>
+            </li>
+          </ul>
+        </div>
+        <div
+          v-if="runs.length === 100"
+          class="border-t"
+        >
+          <DebugRunNavigationLimitMessage :run-url="currentRunUrl" />
+        </div>
       </div>
     </TransitionQuickFadeVue>
   </div>
@@ -133,6 +141,7 @@ import { DebugRunNavigationFragment, DebugRunNavigationRunInfoFragment, DebugRun
 import DebugResults from './DebugResults.vue'
 import DebugRunNumber from './DebugRunNumber.vue'
 import DebugCommitIcon from './DebugCommitIcon.vue'
+import DebugRunNavigationLimitMessage from './DebugRunNavigationLimitMessage.vue'
 import { IconChevronRightSmall } from '@cypress-design/vue-icon'
 import { useDebugRunSummary } from './useDebugRunSummary'
 import { useI18n } from '@cy/i18n'
@@ -189,6 +198,7 @@ mutation DebugRunNavigation_moveToRun($runNumber: Int!) {
 const props = defineProps<{
   runs: NonNullable<DebugRunNavigationFragment['allRuns']>
   currentRunNumber: number
+  currentRunUrl: string | null
   currentCommitInfo?: { sha: string, message: string } | null
 }>()
 

--- a/packages/app/src/debug/DebugRunNavigation.vue
+++ b/packages/app/src/debug/DebugRunNavigation.vue
@@ -68,9 +68,8 @@
     </div>
 
     <TransitionQuickFadeVue>
-      <div>
+      <div v-if="showRuns">
         <div
-          v-if="showRuns"
           id="debug-runs-container"
           class="max-h-30vh overflow-y-scroll"
           data-cy="debug-runs-container"

--- a/packages/app/src/debug/DebugRunNavigation.vue
+++ b/packages/app/src/debug/DebugRunNavigation.vue
@@ -123,7 +123,7 @@
           v-if="runs.length === 100"
           class="border-t border-indigo-100"
         >
-          <DebugRunNavigationLimitMessage :run-url="currentRunUrl" />
+          <DebugRunNavigationLimitMessage :cloud-project-url="cloudProjectUrl" />
         </div>
       </div>
     </TransitionQuickFadeVue>
@@ -181,6 +181,7 @@ fragment DebugRunNavigationRunInfo on CloudRun {
 gql`
 fragment DebugRunNavigation on CloudProject {
   id
+  cloudProjectUrl
   allRuns: runsByCommitShas(commitShas: $commitShas) {
     id
     ...DebugRunNavigationRunInfo
@@ -197,7 +198,7 @@ mutation DebugRunNavigation_moveToRun($runNumber: Int!) {
 const props = defineProps<{
   runs: NonNullable<DebugRunNavigationFragment['allRuns']>
   currentRunNumber: number
-  currentRunUrl: string | null
+  cloudProjectUrl?: string
   currentCommitInfo?: { sha: string, message: string } | null
 }>()
 

--- a/packages/app/src/debug/DebugRunNavigation.vue
+++ b/packages/app/src/debug/DebugRunNavigation.vue
@@ -121,7 +121,7 @@
         </div>
         <div
           v-if="runs.length === 100"
-          class="border-t"
+          class="border-t border-indigo-100"
         >
           <DebugRunNavigationLimitMessage :run-url="currentRunUrl" />
         </div>

--- a/packages/app/src/debug/DebugRunNavigationLimitMessage.cy.tsx
+++ b/packages/app/src/debug/DebugRunNavigationLimitMessage.cy.tsx
@@ -1,16 +1,16 @@
 import DebugRunNavigationLimitMessage from './DebugRunNavigationLimitMessage.vue'
 
 describe('DebugRunNavigationLimitMessage', () => {
-  it('renders link if runUrl is passed', () => {
-    cy.mount(<DebugRunNavigationLimitMessage runUrl="https://cloud.cypress.io/projects/ypt4pf/runs/45575" />)
+  it('renders link if cloudProjectUrl is passed', () => {
+    cy.mount(<DebugRunNavigationLimitMessage cloudProjectUrl="https://cloud.cypress.io/projects/ypt4pf/" />)
 
-    cy.findByRole('link', { name: 'Go to Cypress Cloud to see all runs' }).should('be.visible').should('have.attr', 'href', 'https://cloud.cypress.io/projects/ypt4pf')
+    cy.findByRole('link', { name: 'Go to Cypress Cloud to see all runs' }).should('be.visible').should('have.attr', 'href', 'https://cloud.cypress.io/projects/ypt4pf/')
 
     cy.percySnapshot()
   })
 
-  it('does not render link if runUrl is falsy', () => {
-    cy.mount(<DebugRunNavigationLimitMessage runUrl="" />)
+  it('does not render link if cloudProjectUrl is falsy', () => {
+    cy.mount(<DebugRunNavigationLimitMessage cloudProjectUrl="" />)
 
     cy.findByRole('link', { name: 'Go to Cypress Cloud to see all runs' }).should('not.exist')
   })

--- a/packages/app/src/debug/DebugRunNavigationLimitMessage.cy.tsx
+++ b/packages/app/src/debug/DebugRunNavigationLimitMessage.cy.tsx
@@ -1,0 +1,17 @@
+import DebugRunNavigationLimitMessage from './DebugRunNavigationLimitMessage.vue'
+
+describe('DebugRunNavigationLimitMessage', () => {
+  it('renders link if runUrl is passed', () => {
+    cy.mount(<DebugRunNavigationLimitMessage runUrl="https://cloud.cypress.io/projects/ypt4pf/runs/45575" />)
+
+    cy.findByRole('link', { name: 'Go to Cypress Cloud to see all runs' }).should('be.visible').should('have.attr', 'href', 'https://cloud.cypress.io/projects/ypt4pf')
+
+    cy.percySnapshot()
+  })
+
+  it('does not render link if runUrl is falsy', () => {
+    cy.mount(<DebugRunNavigationLimitMessage runUrl="" />)
+
+    cy.findByRole('link', { name: 'Go to Cypress Cloud to see all runs' }).should('not.exist')
+  })
+})

--- a/packages/app/src/debug/DebugRunNavigationLimitMessage.vue
+++ b/packages/app/src/debug/DebugRunNavigationLimitMessage.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex p-5 align-center">
-    <div class="mr-2 pt-1">
+  <div class="flex text-sm p-4 align-center">
+    <div class="mr-2 pt-[2px]">
       <IconWarningCircle
         stroke-color="gray-500"
         fill-color="gray-50"

--- a/packages/app/src/debug/DebugRunNavigationLimitMessage.vue
+++ b/packages/app/src/debug/DebugRunNavigationLimitMessage.vue
@@ -9,8 +9,8 @@
     <div class="text-gray-700">
       {{ t('debugPage.foundMoreThan100Runs') }}
       <ExternalLink
-        v-if="runUrl"
-        :href="cloudProjectHref"
+        v-if="cloudProjectUrl"
+        :href="cloudProjectUrl"
       >
         {{ t('debugPage.goToCypressCloud') }}
       </ExternalLink>
@@ -19,17 +19,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
 import ExternalLink from '@cy/gql-components/ExternalLink.vue'
 import { useI18n } from '@cy/i18n'
 import { IconWarningCircle } from '@cypress-design/vue-icon'
 
 const { t } = useI18n()
 
-const props = defineProps<{runUrl: string | null}>()
-
-const cloudProjectHref = computed(() => {
-  return props.runUrl?.slice(0, props.runUrl.indexOf('/runs'))
-})
+defineProps<{ cloudProjectUrl?: string }>()
 
 </script>

--- a/packages/app/src/debug/DebugRunNavigationLimitMessage.vue
+++ b/packages/app/src/debug/DebugRunNavigationLimitMessage.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="flex p-5 align-center">
+    <div class="mr-2 pt-1">
+      <IconWarningCircle
+        stroke-color="gray-500"
+        fill-color="gray-50"
+      />
+    </div>
+    <div class="text-gray-700">
+      {{ t('debugPage.foundMoreThan100Runs') }}
+      <ExternalLink
+        v-if="runUrl"
+        :href="cloudProjectHref"
+      >
+        {{ t('debugPage.goToCypressCloud') }}
+      </ExternalLink>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import ExternalLink from '@cy/gql-components/ExternalLink.vue'
+import { useI18n } from '@cy/i18n'
+import { IconWarningCircle } from '@cypress-design/vue-icon'
+
+const { t } = useI18n()
+
+const props = defineProps<{runUrl: string | null}>()
+
+const cloudProjectHref = computed(() => {
+  return props.runUrl?.slice(0, props.runUrl.indexOf('/runs'))
+})
+
+</script>

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -692,6 +692,8 @@
     "mostRecentRun": "You are on the most recent run",
     "switchToLatestRun": "Switch to latest run",
     "switchRun": "Switch run",
+    "foundMoreThan100Runs": "We found more than 100 runs.",
+    "goToCypressCloud": "Go to Cypress Cloud to see all runs",
     "emptyStates": {
       "debugDirectlyInCypress": "Debug failed CI runs directly in Cypress",
       "reviewRerunAndDebug": "Review, rerun, and debug failed CI test runs that are recorded to Cypress Cloud – all from within your local Cypress app.",


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #26288

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

When we implemented run navigation for the debug page, we missed a requirement to display a message when the number of runs is being limited due to being over 100 total across commits.

This PR adds a message to the bottom of the run navigation list that warns the user that they are not seeing all of the runs, and then links to the project in Cypress Cloud for them to view all of the runs that aren't shown in-app.

Since we limit the graphql query to 100 runs, we will display the message when there are exactly 100 runs returned from the query.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Take a look at the tests that I wrote as well as the Percy snapshots. You can also open a project with 100 or more relevant runs on the debug page and verify that the message appears. I used the [react-vite-ts](https://github.com/cypress-io/cypress-component-testing-apps/tree/main/react-vite-ts) example project to test this manually. Recorded over 100 runs to my production test organization and viewed them in the debug page.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
<img width="1051" alt="Screenshot 2023-04-17 at 2 44 31 PM" src="https://user-images.githubusercontent.com/14275198/232606783-1fe3fa23-a716-48cf-b9a8-f4a3d437916a.png">

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
