### PR TITLE
fix: don't display run passing status if Cloud org is over run limit

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 04/25/2023 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue where setting `videoCompression` to `0` would cause the video output to be broken. `0` is now treated as false. Addresses [#5191](https://github.com/cypress-io/cypress/issues/5191) and [#24595](https://github.com/cypress-io/cypress/issues/24595).
+- Fixed an issue on the [Debug page](https://on.cypress.io/debug-page) where the passing run status would appear even if the Cypress Cloud organization was over its monthly test result limit. Addresses [#26528](https://github.com/cypress-io/cypress/issues/26528).
 
 ## 12.10.0
 

--- a/packages/app/src/debug/DebugContainer.cy.tsx
+++ b/packages/app/src/debug/DebugContainer.cy.tsx
@@ -191,7 +191,7 @@ describe('<DebugContainer />', () => {
       it('handled usage exceeded', () => {
         mountTestRun('overLimit')
 
-        cy.findByRole('link', { name: 'Contact admin' }).should('have.attr', 'href', 'http://localhost:3000?utmMedium=Debug+Tab&utmSource=Binary%3A+Launchpad')
+        cy.findByRole('link', { name: 'Contact admin' }).should('be.visible').should('have.attr', 'href', 'http://localhost:3000?utmMedium=Debug+Tab&utmSource=Binary%3A+Launchpad')
 
         cy.percySnapshot()
       })
@@ -199,9 +199,19 @@ describe('<DebugContainer />', () => {
       it('handles retention exceeded', () => {
         mountTestRun('overLimitRetention')
 
-        cy.findByRole('link', { name: 'Contact admin' }).should('have.attr', 'href', 'http://localhost:3000?utmMedium=Debug+Tab&utmSource=Binary%3A+Launchpad')
+        cy.findByRole('link', { name: 'Contact admin' }).should('be.visible').should('have.attr', 'href', 'http://localhost:3000?utmMedium=Debug+Tab&utmSource=Binary%3A+Launchpad')
 
         cy.percySnapshot()
+      })
+
+      it('does not show passing message if run is hidden', () => {
+        mountTestRun('overLimitPassed')
+
+        cy.contains('Well Done!').should('not.exist')
+
+        cy.contains('All your tests passed.').should('not.exist')
+
+        cy.findByRole('link', { name: 'Contact admin' }).should('be.visible').should('have.attr', 'href', 'http://localhost:3000?utmMedium=Debug+Tab&utmSource=Binary%3A+Launchpad')
       })
     })
 

--- a/packages/app/src/debug/DebugPageDetails.vue
+++ b/packages/app/src/debug/DebugPageDetails.vue
@@ -22,7 +22,7 @@
     v-if="['PASSED', 'OVERLIMIT'].includes(status) || isHidden"
     class="flex flex-col flex-grow w-full p-12 justify-center items-center align-middle "
   >
-    <DebugPassed v-if="status === 'PASSED'" />
+    <DebugPassed v-if="status === 'PASSED' && !isHidden" />
     <DebugOverLimit
       v-if="isHidden"
       :over-limit-reasons="reasonsRunIsHidden"

--- a/packages/graphql/test/stubCloudTypes.ts
+++ b/packages/graphql/test/stubCloudTypes.ts
@@ -410,6 +410,7 @@ export const CloudRunStubs = {
   timedOutWithoutCi: createCloudRun({ status: 'TIMEDOUT', specs: skippedSpecs }),
   overLimit: createCloudRun({ status: 'OVERLIMIT', overLimitActionType: 'CONTACT_ADMIN', overLimitActionUrl: 'http://localhost:3000', isHidden: true, reasonsRunIsHidden: [{ __typename: 'UsageLimitExceeded', monthlyTests: 100 }] }),
   overLimitRetention: createCloudRun({ status: 'OVERLIMIT', overLimitActionType: 'CONTACT_ADMIN', overLimitActionUrl: 'http://localhost:3000', isHidden: true, reasonsRunIsHidden: [{ __typename: 'DataRetentionLimitExceeded', dataRetentionDays: 10 }] }),
+  overLimitPassed: createCloudRun({ status: 'PASSED', overLimitActionType: 'CONTACT_ADMIN', overLimitActionUrl: 'http://localhost:3000', isHidden: true, reasonsRunIsHidden: [{ __typename: 'UsageLimitExceeded', monthlyTests: 100 }] }),
   cancelled: createCloudRun({ status: 'CANCELLED', cancelledAt: '2019-01-25T02:00:00.000Z', specs: skippedSpecs, cancelledBy: { id: '123', fullName: 'Test Tester', email: 'adams@cypress.io', __typename: 'CloudUser', userIsViewer: true } }),
 } as Record<string, Required<CloudRun>>
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #26528

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

When a run's results are hidden because the cloud organization is over its test result limit for the month, we shouldn't show the passing state and should only show the "over limit" message on the debug page for that run. Having both messages on screen doesn't look great and could be confusing.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Check out the test that I wrote. Alternatively, spin up a project and record enough runs to go over your free limit on Cypress Cloud. Verify that when you have a passing run selected that is hidden because you are over the limit, that you don't see the passing message of "Well Done! All your tests passed." on screen, and only see the over limit message.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Before: look at the attached issue

After:
<img width="1145" alt="Screenshot 2023-04-18 at 11 23 20 AM" src="https://user-images.githubusercontent.com/14275198/232856856-a684a818-3700-456c-bd28-198000b0ec36.png">

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
