### PR TITLE
chore: tweak timing of connecting to browser for CDP

### DIFF
--- a/packages/server/lib/browsers/browser-cri-client.ts
+++ b/packages/server/lib/browsers/browser-cri-client.ts
@@ -184,7 +184,6 @@ export class BrowserCriClient {
 
     if (target) {
       this.currentlyAttachedTarget = await create(target.targetId, this.onAsynchronousError, this.host, this.port)
-      await this.protocolManager?.connectToBrowser(this.currentlyAttachedTarget)
     }
   }
 

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -589,6 +589,8 @@ export = {
 
     if (!options.url) throw new Error('Missing url in connectToNewSpec')
 
+    await options.protocolManager?.connectToBrowser(pageCriClient)
+
     await this.attachListeners(options.url, pageCriClient, automation, options)
   },
 


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

There was an issue where `connectToBrowser` was being called for the next spec before the original spec was ended with `afterSpec`. This PR resolves this by hooking into a different part of the lifecycle.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Record multiple specs with protocol and ensure that the databases for each spec gets created correctly.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
