### PR TITLE
chore: update stalebot to respect new labels and up process rate

### DIFF
--- a/.github/workflows/stale_issues_and_pr_cleanup.yml
+++ b/.github/workflows/stale_issues_and_pr_cleanup.yml
@@ -17,11 +17,11 @@ on:
       exempt-issue-labels:
         description: 'exempt-issue-labels'     
         required: false
-        default: 'type: feature,type: enhancement,routed-to-e2e,routed-to-ct,routed-to-tools,routed-to-cloud,Popular Issue'
+        default: 'type: feature,type: enhancement,routed-to-e2e,routed-to-ct,routed-to-tools,routed-to-cloud,prevent-stale,triaged'
       exempt-pr-labels:
         description: 'exempt-pr-labels'     
         required: false
-        default: 'type: feature,type: enhancement,Popular Issue'
+        default: 'type: feature,type: enhancement,prevent-stale,triaged'
   schedule:
     - cron: '30 1 * * *'
 permissions:
@@ -31,8 +31,8 @@ env:
   DEFAULT_DEBUG_ONLY: true
   DEFAULT_DAYS_BEFORE_STALE: 180
   DEFAULT_DAYS_BEFORE_CLOSE: 14
-  DEFAULT_EXEMPT_ISSUE_LABELS: 'type: feature,type: enhancement,routed-to-e2e,routed-to-ct,routed-to-tools,routed-to-cloud,Popular Issue,prevent-stale'
-  DEFAULT_EXEMPT_PR_LABELS: 'type: feature,type: enhancement,Popular Issue,prevent-stale'
+  DEFAULT_EXEMPT_ISSUE_LABELS: 'type: feature,type: enhancement,routed-to-e2e,routed-to-ct,routed-to-tools,routed-to-cloud,prevent-stale,triaged'
+  DEFAULT_EXEMPT_PR_LABELS: 'type: feature,type: enhancement,prevent-stale,triaged'
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -50,5 +50,5 @@ jobs:
           exempt-issue-labels: ${{ github.event.inputs.exempt-issue-labels || env.DEFAULT_EXEMPT_ISSUE_LABELS }}
           exempt-pr-labels: ${{ github.event.inputs.exempt-pr-labels || env.DEFAULT_EXEMPT_PR_LABELS }}
           exempt-all-milestones: true
-          operations-per-run: 200 #keeping this a bit higher because it processes newest tickets to oldest
+          operations-per-run: 400 #keeping this a bit higher because it processes newest tickets to oldest
           debug-only: ${{ github.event.inputs.debug-only || env.DEFAULT_DEBUG_ONLY }}


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

This will update the stalebot to respect the labels `prevent-stale` and `triaged` which are now being used by the Firewatch process.

I have also doubled the amount of requests per run to allow the bot to process more issues.  It is moving quite slow at the moment.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
