### PR TITLE
chore: remove bluebird dependency to packages/config for better Yarn 3 compat

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -31,6 +31,7 @@ mainBuildFilters: &mainBuildFilters
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'update-v8-snapshot-cache-on-develop'
         - 'matth/misc/telemetry'
+        - 'add-bluebird-config'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -41,6 +42,7 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
+    - equal: [ 'add-bluebird-config', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -138,7 +138,7 @@ commands:
       - run:
           name: Check current branch to persist artifacts
           command: |
-            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "update-v8-snapshot-cache-on-develop" && "$CIRCLE_BRANCH" != "matth/chore/add-circle-ci-detector" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "update-v8-snapshot-cache-on-develop" && "$CIRCLE_BRANCH" != "add-bluebird-config" ]]; then
               echo "Not uploading artifacts or posting install comment for this branch."
               circleci-agent step halt
             fi

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -23,6 +23,7 @@
     "@babel/plugin-transform-typescript": "^7",
     "@babel/traverse": "7.15.4",
     "@babel/types": "^7",
+    "bluebird": "3.5.3",
     "check-more-types": "2.24.0",
     "common-tags": "1.8.0",
     "debug": "^4.3.4",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -23,7 +23,6 @@
     "@babel/plugin-transform-typescript": "^7",
     "@babel/traverse": "7.15.4",
     "@babel/types": "^7",
-    "bluebird": "3.5.3",
     "check-more-types": "2.24.0",
     "common-tags": "1.8.0",
     "debug": "^4.3.4",


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/26567

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

I wrote this with the assistance of ChatGPT. Check it out!

Interesting enough, some of the earlier versions of the ChatGPT rewrite are actually more to my coding taste, but they moved too much code around. After some poking and prodding, I got to a good place where the code still resembles the original code, but also makes us of the modern async/await syntax.

Without good test coverage, I wouldn't be nearly as confidence to use a tool like GPT to refactor. Begs the question; how reliable are code bases using GPT to write tests in the first place? Can we rely on GPT to write tests for code it maybe have even wrote?

<summary>Chat Transcript<details>
Convert Bluebird to Promise
___________________________

Human: Hi, can you help me convert some Javascript code using bluebird to use a native promise?

ChatGPT: Yes, of course! Please share the Javascript code using Bluebird that you would like to convert to native promises.
Human:   

```js
return Bluebird
  .try(() => {
    // resolve full path with extension
    obj.supportFile = utils.resolveModule(sf)

    return debug('resolved support file %s', obj.supportFile)
  }).then(() => {
    if (!checkIfResolveChangedRootFolder(obj.supportFile, sf)) {
      return
    }

    debug('require.resolve switched support folder from %s to %s', sf, obj.supportFile)
    // this means the path was probably symlinked, like
    // /tmp/foo -> /private/tmp/foo
    // which can confuse the rest of the code
    // switch it back to "normal" file
    const supportFileName = path.basename(obj.supportFile)
    const base = sf?.endsWith(supportFileName) ? path.dirname(sf) : sf

    obj.supportFile = path.join(base || '', supportFileName)

    return fs.pathExists(obj.supportFile)
    .then((found) => {
      if (!found) {
        errors.throwErr('SUPPORT_FILE_NOT_FOUND', relativeToProjectRoot(obj.projectRoot, obj.supportFile))
      }

      return debug('switching to found file %s', obj.supportFile)
    })
  }).catch({ code: 'MODULE_NOT_FOUND' }, () => {
    debug('support JS module %s does not load', sf)

    return utils.discoverModuleFile({
      filename: sf,
      projectRoot: obj.projectRoot,
    })
    .then((result) => {
      if (result === null) {
        return errors.throwErr('SUPPORT_FILE_NOT_FOUND', relativeToProjectRoot(obj.projectRoot, sf))
      }

      debug('setting support file to %o', { result })
      obj.supportFile = result

      return obj
    })
  })
  .then(() => {
    if (obj.supportFile) {
      // set config.supportFolder to its directory
      obj.supportFolder = path.dirname(obj.supportFile)
      debug(`set support folder ${obj.supportFolder}`)
    }

    return obj
  })
```

ChatGPT: Certainly! Here is the same code using native Promises:scssCopy code

```js
return Promise.resolve()
  .then(() => {
    // resolve full path with extension
    obj.supportFile = utils.resolveModule(sf);

    return debug('resolved support file %s', obj.supportFile);
  })
  .then(() => {
    if (!checkIfResolveChangedRootFolder(obj.supportFile, sf)) {
      return;
    }

    debug('require.resolve switched support folder from %s to %s', sf, obj.supportFile);
    // this means the path was probably symlinked, like
    // /tmp/foo -> /private/tmp/foo
    // which can confuse the rest of the code
    // switch it back to "normal" file
    const supportFileName = path.basename(obj.supportFile);
    const base = sf?.endsWith(supportFileName) ? path.dirname(sf) : sf;

    obj.supportFile = path.join(base || '', supportFileName);

    return fs.pathExists(obj.supportFile)
      .then((found) => {
        if (!found) {
          errors.throwErr('SUPPORT_FILE_NOT_FOUND', relativeToProjectRoot(obj.projectRoot, obj.supportFile));
        }

        return debug('switching to found file %s', obj.supportFile);
      });
  })
  .catch({ code: 'MODULE_NOT_FOUND' }, () => {
    debug('support JS module %s does not load', sf);

    return utils.discoverModuleFile({
      filename: sf,
      projectRoot: obj.projectRoot,
    })
      .then((result) => {
        if (result === null) {
          return errors.throwErr('SUPPORT_FILE_NOT_FOUND', relativeToProjectRoot(obj.projectRoot, sf));
        }

        debug('setting support file to %o', { result });
        obj.supportFile = result;

        return obj;
      });
  })
  .then(() => {
    if (obj.supportFile) {
      // set config.supportFolder to its directory
      obj.supportFolder = path.dirname(obj.supportFile);
      debug(`set support folder ${obj.supportFolder}`);
    }

    return obj;
  });
```

The main difference is the use of Promise.resolve() to start the chain of promises and the removal of the catch method from Bluebird, as it is not available in native Promises. Instead, we use a regular catch block to catch the rejection with the specified code.

Human: Can we use try/catch and await instead?

ChatGPT: Yes, we can! Here's the same code converted to use async/await:

```js
try {
  // resolve full path with extension
  obj.supportFile = utils.resolveModule(sf);
  await debug('resolved support file %s', obj.supportFile);

  if (checkIfResolveChangedRootFolder(obj.supportFile, sf)) {
    debug('require.resolve switched support folder from %s to %s', sf, obj.supportFile);

    // this means the path was probably symlinked, like
    // /tmp/foo -> /private/tmp/foo
    // which can confuse the rest of the code
    // switch it back to "normal" file
    const supportFileName = path.basename(obj.supportFile);
    const base = sf?.endsWith(supportFileName) ? path.dirname(sf) : sf;
    obj.supportFile = path.join(base || '', supportFileName);

    const found = await fs.pathExists(obj.supportFile);
    if (!found) {
      errors.throwErr('SUPPORT_FILE_NOT_FOUND', relativeToProjectRoot(obj.projectRoot, obj.supportFile));
    }
    await debug('switching to found file %s', obj.supportFile);
  }
} catch (error) {
  if (error.code === 'MODULE_NOT_FOUND') {
    debug('support JS module %s does not load', sf);

    const result = await utils.discoverModuleFile({
      filename: sf,
      projectRoot: obj.projectRoot,
    });

    if (result === null) {
      errors.throwErr('SUPPORT_FILE_NOT_FOUND', relativeToProjectRoot(obj.projectRoot, sf));
    }

    debug('setting support file to %o', { result });
    obj.supportFile = result;
  } else {
    throw error;
  }
}

if (obj.supportFile) {
  // set config.supportFolder to its directory
  obj.supportFolder = path.dirname(obj.supportFile);
  await debug(`set support folder ${obj.supportFolder}`);
}

return obj;
```

The main changes involve wrapping the code in a try/catch block and replacing .then() with await. We can also eliminate the need for a separate .catch() block by catching the error within the try block with an if statement.

Human: Can you write this using try/catch, but with as minimal changes as possible to the original code?

ChatGPT: Sure, here is the code converted to use try/catch with minimal changes

```js
try {
  // resolve full path with extension
  obj.supportFile = utils.resolveModule(sf);

  return debug('resolved support file %s', obj.supportFile)
  .then(() => {
    if (!checkIfResolveChangedRootFolder(obj.supportFile, sf)) {
      return;
    }

    debug('require.resolve switched support folder from %s to %s', sf, obj.supportFile);
    // this means the path was probably symlinked, like
    // /tmp/foo -> /private/tmp/foo
    // which can confuse the rest of the code
    // switch it back to "normal" file
    const supportFileName = path.basename(obj.supportFile);
    const base = sf?.endsWith(supportFileName) ? path.dirname(sf) : sf;

    obj.supportFile = path.join(base || '', supportFileName);

    return fs.pathExists(obj.supportFile)
    .then((found) => {
      if (!found) {
        errors.throwErr('SUPPORT_FILE_NOT_FOUND', relativeToProjectRoot(obj.projectRoot, obj.supportFile));
      }

      return debug('switching to found file %s', obj.supportFile);
    });
  })
  .then(() => {
    if (obj.supportFile) {
      // set config.supportFolder to its directory
      obj.supportFolder = path.dirname(obj.supportFile);
      debug(`set support folder ${obj.supportFolder}`);
    }

    return obj;
  });
} catch (error) {
  if (error.code === 'MODULE_NOT_FOUND') {
    debug('support JS module %s does not load', sf);

    return utils.discoverModuleFile({
      filename: sf,
      projectRoot: obj.projectRoot,
    })
    .then((result) => {
      if (result === null) {
        errors.throwErr('SUPPORT_FILE_NOT_FOUND', relativeToProjectRoot(obj.projectRoot, sf));
      }

      debug('setting support file to %o', { result });
      obj.supportFile = result;

      if (obj.supportFile) {
        // set config.supportFolder to its directory
        obj.supportFolder = path.dirname(obj.supportFile);
        debug(`set support folder ${obj.supportFolder}`);
      }

      return obj;
    });
  } else {
    throw error;
  }
}
```

The main change is that the entire block of code is now wrapped in a try/catch statement. The .catch() block has been replaced with an if statement inside the try block that checks for the MODULE_NOT_FOUND error. If this error is caught, the code in the .catch() block is executed, otherwise the error is thrown. Since the .catch() block was only handling this specific error, we can eliminate it entirely and instead handle the error inside the try block.

Human: debug does not return a promise - please keep this in mind and try again.

ChatGPT: Sorry about that. Here's the revised code that keeps in mind that debug() does not return a promise

```js
try {
  // resolve full path with extension
  obj.supportFile = utils.resolveModule(sf);

  debug('resolved support file %s', obj.supportFile);

  if (checkIfResolveChangedRootFolder(obj.supportFile, sf)) {
    debug('require.resolve switched support folder from %s to %s', sf, obj.supportFile);
    // this means the path was probably symlinked, like
    // /tmp/foo -> /private/tmp/foo
    // which can confuse the rest of the code
    // switch it back to "normal" file
    const supportFileName = path.basename(obj.supportFile);
    const base = sf?.endsWith(supportFileName) ? path.dirname(sf) : sf;

    obj.supportFile = path.join(base || '', supportFileName);

    return fs.pathExists(obj.supportFile)
      .then((found) => {
        if (!found) {
          errors.throwErr('SUPPORT_FILE_NOT_FOUND', relativeToProjectRoot(obj.projectRoot, obj.supportFile));
        }

        debug('switching to found file %s', obj.supportFile);

        if (obj.supportFile) {
          // set config.supportFolder to its directory
          obj.supportFolder = path.dirname(obj.supportFile);
          debug(`set support folder ${obj.supportFolder}`);
        }

        return obj;
      });
  }

  if (obj.supportFile) {
    // set config.supportFolder to its directory
    obj.supportFolder = path.dirname(obj.supportFile);
    debug(`set support folder ${obj.supportFolder}`);
  }

  return obj;
} catch (error) {
  if (error.code === 'MODULE_NOT_FOUND') {
    debug('support JS module %s does not load', sf);

    return utils.discoverModuleFile({
      filename: sf,
      projectRoot: obj.projectRoot,
    })
      .then((result) => {
        if (result === null) {
          errors.throwErr('SUPPORT_FILE_NOT_FOUND', relativeToProjectRoot(obj.projectRoot, sf));
        }

        debug('setting support file to %o', { result });
        obj.supportFile = result;

        if (obj.supportFile) {
          // set config.supportFolder to its directory
          obj.supportFolder = path.dirname(obj.supportFile);
          debug(`set support folder ${obj.supportFolder}`);
        }

        return obj;
      });
  } else {
    throw error;
  }
}
```

In this version, the first call to debug() is not wrapped in a then() block since it doesn't return a promise. Instead, we just call it directly and proceed to the conditional statements. The rest of the code follows a similar structure as the previous version with some minor adjustments to ensure that the final return statement is inside the try block.

Human: Still a lot of `then`. Can we make those into `await`?

ChatGPT: Sure, here's the modified code using await

```js
try {
  // resolve full path with extension
  obj.supportFile = utils.resolveModule(sf);

  debug('resolved support file %s', obj.supportFile);

  if (checkIfResolveChangedRootFolder(obj.supportFile, sf)) {
    debug('require.resolve switched support folder from %s to %s', sf, obj.supportFile);
    // this means the path was probably symlinked, like
    // /tmp/foo -> /private/tmp/foo
    // which can confuse the rest of the code
    // switch it back to "normal" file
    const supportFileName = path.basename(obj.supportFile);
    const base = sf?.endsWith(supportFileName) ? path.dirname(sf) : sf;

    obj.supportFile = path.join(base || '', supportFileName);

    const found = await fs.pathExists(obj.supportFile);
    if (!found) {
      errors.throwErr('SUPPORT_FILE_NOT_FOUND', relativeToProjectRoot(obj.projectRoot, obj.supportFile));
    }

    debug('switching to found file %s', obj.supportFile);

    if (obj.supportFile) {
      // set config.supportFolder to its directory
      obj.supportFolder = path.dirname(obj.supportFile);
      debug(`set support folder ${obj.supportFolder}`);
    }

    return obj;
  }

  if (obj.supportFile) {
    // set config.supportFolder to its directory
    obj.supportFolder = path.dirname(obj.supportFile);
    debug(`set support folder ${obj.supportFolder}`);
  }

  return obj;
} catch (error) {
  if (error.code === 'MODULE_NOT_FOUND') {
    debug('support JS module %s does not load', sf);

    const result = await utils.discoverModuleFile({
      filename: sf,
      projectRoot: obj.projectRoot,
    });

    if (result === null) {
      errors.throwErr('SUPPORT_FILE_NOT_FOUND', relativeToProjectRoot(obj.projectRoot, sf));
    }

    debug('setting support file to %o', { result });
    obj.supportFile = result;

    if (obj.supportFile) {
      // set config.supportFolder to its directory
      obj.supportFolder = path.dirname(obj.supportFile);
      debug(`set support folder ${obj.supportFolder}`);
    }

    return obj;
  } else {
    throw error;
  }
}
```

In this version, we replaced the then() calls with await statements inside the if blocks. We also simplified the error handling by using a try/catch block instead of a .catch() method.
</details></summary>

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
