### PR TITLE
fix: use local host versus third party site

### DIFF
--- a/system-tests/test/base_url_spec.js
+++ b/system-tests/test/base_url_spec.js
@@ -9,9 +9,14 @@ const onServer = (app) => {
 describe('e2e baseUrl', () => {
   context('https', () => {
     systemTests.setup({
+      servers: {
+        port: 443,
+        https: true,
+        onServer,
+      },
       settings: {
         e2e: {
-          baseUrl: 'https://httpbin.org',
+          baseUrl: 'https://localhost/app',
         },
       },
     })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
The test was relying on hitting httpbin.org, a third party site. When that site is down, then the test would fail.  

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

```
cd system-tests
yarn test base_url_spec.js   
```

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [-] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [-] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
