### PR TITLE
docs: revise contributor advice for node.js setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,7 +205,7 @@ We try to tag all issues with a `pkg/` or `npm/` tag describing the appropriate 
 
 You must have the following installed on your system to contribute locally:
 
-- [`Node.js`](https://nodejs.org/en/) (See the root [.node-version](.node-version) file for minimum version requirements. You can use [avn](https://github.com/wbyoung/avn) to automatically switch to the right version of Node.js for this repo.)
+- [`Node.js`](https://nodejs.org/en/) (See the root [.node-version](.node-version) file for the required version. You can find a list of tools on [node-version-usage](https://github.com/shadowspawn/node-version-usage) to switch the version of [`Node.js`](https://nodejs.org/en/) based on [.node-version](.node-version).)
 - [`yarn`](https://yarnpkg.com/en/docs/install)
 - [`python`](https://www.python.org/downloads/) (since we use `node-gyp`. See their [repo](https://github.com/nodejs/node-gyp) for Python version requirements.)
 


### PR DESCRIPTION
- Closes #26441

### Additional details

- [CONTRIBUTING: Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements) previously referred to the outdated npm module [avn](https://github.com/wbyoung/avn). avn setup fails on on Node.js > `10` (Node.js `10` [end-of-life](https://github.com/nodejs/release#release-schedule) was on Apr 30, 2021)
- The [CONTRIBUTING: Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements) section is changed as follows:

    1. The qualifier "minimum" is removed from version, since development (as opposed to use) of Cypress should be done on the version specified by [.node-version](https://github.com/cypress-io/cypress/blob/develop/.node-version).

    2. The reference to [avn](https://github.com/wbyoung/avn) is removed.

    3. No specific tool for management of Node.js is recommended. Instead a link to a list of tools on [node-version-usage](https://github.com/shadowspawn/node-version-usage) is provided.

### Steps to test

Contributors may like to test out using one of the tools [n](https://www.npmjs.com/package/n) (n – Interactively Manage Your Node.js Versions) on Ubuntu. The tools are heavily oriented to POSIX-based platforms.

### How has the user experience changed?

Contributors will no longer be confronted with a non-working tool  [avn](https://github.com/wbyoung/avn) which would have happened if they had followed the previous instructions.

They should now be able to refer to the tool list, then install and use one of the up-to-date tools for managing the active version of Node.js.

End-users are not affected.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
