### PR TITLE
feat: initial release of cypress/vite-plugin-cypress-esm

### DIFF
--- a/npm/vite-plugin-cypress-esm/README.md
+++ b/npm/vite-plugin-cypress-esm/README.md
@@ -36,9 +36,9 @@ export default defineConfig({
               CypressEsm(),
             ]
           }
-        ),
+        )
       }
-    },
+    }
   }
 })
 ```


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

I committed the initial merge of `cypress/vite-plugin-cypress-esm ` using `chore: ...` which did not trigger the initial release for the new npm module, `cypress/vite-plugin-cypress-esm`, because `chore` is a [non release commit](https://github.com/cypress-io/cypress/blob/0f7c697a4ed9f7a3b46470cde2453d4cb2e22a21/scripts/semantic-commits/change-categories.js#L62).

This one uses `feat`, which triggers the initial release, based on [the semantic release script here](https://github.com/cypress-io/cypress/blob/0f7c697a4ed9f7a3b46470cde2453d4cb2e22a21/scripts/semantic-commits/change-categories.js#L62).

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

I found out you can do `npx lerna exec --scope "@cypress/vite-plugin-cypress-esm" -- npx --no-install semantic-release --dry-run`. Since it is the first release, it does `Found 19610 commits since last release` to figure out the version, which takes a long time. So, if you run this locally, you need to wait a while.

Eventually you will see

```sh
# @cypress/vite-plugin-cypress-esm-v1.0.0 (2023-05-03)

### Features

    * initial release of cypress/vite-plugin-cypress-esm (539dd78)
```

You need be on `develop` or it won't even do the dry run. I just merged this branch into develop locally to test it.

Semantic Release recommends the [initial release to be 1.0.0](https://semantic-release.gitbook.io/semantic-release/support/faq#can-i-set-the-initial-release-version-of-my-package-to-0.0.1). This module isn't really prime time ready, though - we make this clear in the README. You can do pre-releases using Semantic Release, but you need to use another branch, and I don't think we want to continually update a branch - seems fine to just go with an initial release of 1.0.0, making it clear the library is still under development.


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

It should be released publicly on npm.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
