### PR TITLE
chore: adding in repo token to explicitly use that while running commands [skip ci]

### DIFF
--- a/.github/workflows/stale_issues_and_pr_cleanup.yml
+++ b/.github/workflows/stale_issues_and_pr_cleanup.yml
@@ -9,7 +9,7 @@ on:
       max-operations-per-run:
         description: 'max operations per run'     
         required: false
-        default: 400
+        default: 800
       days-before-stale:
         description: 'days-before-stale'     
         required: false
@@ -33,7 +33,7 @@ permissions:
   pull-requests: write
 env:
   DEFAULT_DEBUG_ONLY: true
-  DEFAULT_MAX_OPS: 400
+  DEFAULT_MAX_OPS: 800
   DEFAULT_DAYS_BEFORE_STALE: 180
   DEFAULT_DAYS_BEFORE_CLOSE: 14
   DEFAULT_EXEMPT_ISSUE_LABELS: 'type: feature,type: enhancement,routed-to-e2e,routed-to-ct,routed-to-tools,routed-to-cloud,prevent-stale,triaged'
@@ -57,3 +57,4 @@ jobs:
           exempt-all-milestones: true
           operations-per-run: ${{ github.event.inputs.max-operations-per-run || env.DEFAULT_MAX_OPS }} #keeping this a bit higher because it processes newest tickets to oldest
           debug-only: ${{ github.event.inputs.debug-only || env.DEFAULT_DEBUG_ONLY }}
+          repo-token: ${{ secrets.TRIAGE_BOARD_TOKEN }}


### PR DESCRIPTION
 adding in repo token to explicitly use that while running commands

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [n/a] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
