### PR TITLE
fix: fix UI flash when switching to debug page

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,7 @@ _Released 05/23/2023 (PENDING)_
 - Reverted [#26452](https://github.com/cypress-io/cypress/pull/26630) which introduced a bug that prevents users from using End to End with Yarn 3. Fixed in [#26735](https://github.com/cypress-io/cypress/pull/26735). Fixes [#26676](https://github.com/cypress-io/cypress/issues/26676).
 - Moved `types` condition to the front of `package.json#exports` since keys there are meant to be order-sensitive. Fixed in [#26630](https://github.com/cypress-io/cypress/pull/26630).
 - Fixed an issue where newly-installed dependencies would not be detected during Component Testing setup. Addresses [#26685](https://github.com/cypress-io/cypress/issues/26685).
+- Fixed a UI regression that was flashing an "empty" state inappropriately when loading the Debug page. Fixed in [#26761](https://github.com/cypress-io/cypress/pull/26761).
 
 **Misc:**
 

--- a/packages/app/src/pages/Debug.vue
+++ b/packages/app/src/pages/Debug.vue
@@ -58,7 +58,7 @@ const cachedProject = ref<DebugSpecsFragment>()
 const query = useQuery({ query: DebugDocument, variables, pause: shouldPauseQuery, requestPolicy: 'network-only' })
 
 const isLoading = computed(() => {
-  const relevantRunsHaveNotLoaded = !relevantRuns.value
+  const relevantRunsHaveNotLoaded = !relevantRuns.value.all
   const queryIsBeingFetched = query.fetching.value
 
   const cloudProject = query.data.value?.currentProject?.cloudProject?.__typename === 'CloudProject'
@@ -76,7 +76,6 @@ const isLoading = computed(() => {
 })
 
 watchEffect(() => {
-  //console.log('query for debug', query.data.value, relevantRuns.value.commitShas)
   if (query.data.value?.currentProject?.cloudProject?.__typename === 'CloudProject') {
     const cloudProject = query.data.value.currentProject.cloudProject
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->


### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
This PR fixes a regresssion for the Debug page that was causing an empty state to flash when switching to that page from another page in the app.

_Before fix_

https://github.com/cypress-io/cypress/assets/1702361/2ab182ec-3c0a-4f26-b360-b697cf50577c

_After fix_

https://github.com/cypress-io/cypress/assets/1702361/391f4c38-4846-4799-b72c-d66d5309cf73



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
* Open the App with a project that is connected to the Cloud.  
* Select either E2E or component and open the browser
* Select the Debug sidebar item
* The page should show the loading skeleton and then the Debug UI without a quick cycle through another empty state

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [-] Have tests been added/updated?
- [-] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [-] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
