### PR TITLE
chore: resetting the test when top changes

### DIFF
--- a/packages/driver/cypress/e2e/commands/navigation.cy.js
+++ b/packages/driver/cypress/e2e/commands/navigation.cy.js
@@ -894,7 +894,7 @@ describe('src/cy/commands/navigation', () => {
 
     describe('when origins don\'t match', () => {
       beforeEach(() => {
-        Cypress.emit('test:before:run', { id: 888 })
+        Cypress.emit('test:before:run', { id: 'r2' })
 
         cy.stub(Cypress.runner, 'getEmissions').returns([])
         cy.stub(Cypress.runner, 'getTestsState').returns([])

--- a/packages/driver/cypress/e2e/commands/navigation.cy.js
+++ b/packages/driver/cypress/e2e/commands/navigation.cy.js
@@ -908,7 +908,7 @@ describe('src/cy/commands/navigation', () => {
 
       it('emits preserve:run:state with title + fn', (done) => {
         const obj = {
-          currentId: 888,
+          currentId: 'r2',
           tests: [],
           emissions: [],
           startTime: '12345',

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -154,6 +154,10 @@ export class ProtocolManager implements ProtocolManagerShape {
     this.invokeSync('urlChanged', input)
   }
 
+  resetTest (testId: string): void {
+    this.invokeSync('resetTest', testId)
+  }
+
   async uploadCaptureArtifact (uploadUrl: string) {
     const dbPath = this._dbPath
 

--- a/packages/server/lib/socket-base.ts
+++ b/packages/server/lib/socket-base.ts
@@ -496,6 +496,12 @@ export class SocketBase {
 
         if (s) {
           runState = undefined
+
+          // if we have cached test state, then we need to reset
+          // the test state on the protocol manager
+          if (s.currentId) {
+            this.protocolManager?.resetTest(s.currentId)
+          }
         }
 
         return cb(s || {}, cachedTestState)

--- a/packages/server/test/support/fixtures/cloud/protocol/test-protocol.ts
+++ b/packages/server/test/support/fixtures/cloud/protocol/test-protocol.ts
@@ -32,7 +32,7 @@ export class AppCaptureProtocol implements ProtocolManagerShape {
   viewportChanged = (input) => {}
   urlChanged = (input) => {}
   pageLoading = (input) => {}
-  resetTest (testId) {}
+  resetTest = (testId) => {}
   sendErrors (errors) {
     return Promise.resolve()
   }

--- a/packages/server/test/support/fixtures/cloud/protocol/test-protocol.ts
+++ b/packages/server/test/support/fixtures/cloud/protocol/test-protocol.ts
@@ -31,6 +31,7 @@ export class AppCaptureProtocol implements ProtocolManagerShape {
   commandLogChanged = (log) => {}
   viewportChanged = (input) => {}
   urlChanged = (input) => {}
+  resetTest (testId) {}
   sendErrors (errors) {
     return Promise.resolve()
   }

--- a/packages/server/test/unit/cloud/protocol_spec.ts
+++ b/packages/server/test/unit/cloud/protocol_spec.ts
@@ -249,7 +249,7 @@ describe('lib/cloud/protocol', () => {
     expect(protocol.pageLoading).to.be.calledWith(input)
   })
 
-  it('should be able reset the test', () => {
+  it('should be able to reset the test', () => {
     sinon.stub(protocol, 'resetTest')
 
     const testId = 'r3'

--- a/packages/server/test/unit/cloud/protocol_spec.ts
+++ b/packages/server/test/unit/cloud/protocol_spec.ts
@@ -235,4 +235,14 @@ describe('lib/cloud/protocol', () => {
 
     expect(protocol.urlChanged).to.be.calledWith(input)
   })
+
+  it('should be able reset the test', () => {
+    sinon.stub(protocol, 'resetTest')
+
+    const testId = 'r3'
+
+    protocolManager.resetTest(testId)
+
+    expect(protocol.resetTest).to.be.calledWith(testId)
+  })
 })

--- a/packages/types/src/driver.ts
+++ b/packages/types/src/driver.ts
@@ -2,7 +2,7 @@ import type { ReporterRunState, StudioRecorderState } from './reporter'
 
 interface MochaRunnerState {
   startTime?: number
-  currentId?: number | null
+  currentId?: string | null
   emissions?: Emissions
   tests?: Record<string, Cypress.ObjectLike>
   passed?: number

--- a/packages/types/src/protocol.ts
+++ b/packages/types/src/protocol.ts
@@ -23,6 +23,7 @@ export interface AppCaptureProtocolCommon {
   afterTest(test: Record<string, any>): void
   afterSpec (): Promise<void>
   connectToBrowser (cdpClient: CDPClient): Promise<void>
+  resetTest (testId: string): void
 }
 
 export interface AppCaptureProtocolInterface extends AppCaptureProtocolCommon {

--- a/system-tests/lib/protocolStub.ts
+++ b/system-tests/lib/protocolStub.ts
@@ -31,6 +31,7 @@ export class AppCaptureProtocol implements ProtocolManagerShape {
   commandLogChanged = (log) => {}
   viewportChanged = (input) => {}
   urlChanged = (input) => {}
+  resetTest (testId) {}
   sendErrors (errors) {
     return Promise.resolve()
   }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
* During the `get:cached:test:state` event, we check if there is a `currentId` and then reset the test in the protocol.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

- Checkout `mschile/protocol/reset_test` branch from the services repo
- Record a spec that changes top
- Verify the db does not include duplicate events due to top changing

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Before:
<img width="1572" alt="Screenshot 2023-05-18 at 9 14 23 AM" src="https://github.com/cypress-io/cypress/assets/2002044/e1955753-e5c5-42ef-868d-5923b66630a7">

After:
<img width="1562" alt="Screenshot 2023-05-18 at 9 13 15 AM" src="https://github.com/cypress-io/cypress/assets/2002044/911433f9-e3e9-4f43-bb95-185879512c03">


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
