### PR TITLE
fix: make visible children of display contents pass the should('be.visible') test

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,7 @@ _Released 05/23/2023 (PENDING)_
 
 **Bugfixes:**
 
+- Fixed an issue where children of HTML elements with `display: contents; overflow: hidden` were not visible by Cypress tests. Fixes [#25199](https://github.com/cypress-io/cypress/issues/25199). 
 - Reverted [#26452](https://github.com/cypress-io/cypress/pull/26630) which introduced a bug that prevents users from using End to End with Yarn 3. Fixed in [#26735](https://github.com/cypress-io/cypress/pull/26735). Fixes [#26676](https://github.com/cypress-io/cypress/issues/26676).
 - Moved `types` condition to the front of `package.json#exports` since keys there are meant to be order-sensitive. Fixed in [#26630](https://github.com/cypress-io/cypress/pull/26630).
 - Fixed an issue where newly-installed dependencies would not be detected during Component Testing setup. Addresses [#26685](https://github.com/cypress-io/cypress/issues/26685).

--- a/packages/driver/src/dom/visibility.ts
+++ b/packages/driver/src/dom/visibility.ts
@@ -193,6 +193,10 @@ const elHasDisplayInline = ($el) => {
   return $el.css('display') === 'inline'
 }
 
+const elHasDisplayContents = ($el) => {
+  return $el.css('display') === 'contents'
+}
+
 const elHasOverflowHidden = function ($el) {
   const cssOverflow = [$el.css('overflow'), $el.css('overflow-y'), $el.css('overflow-x')]
 
@@ -365,6 +369,11 @@ const elIsHiddenByAncestors = function ($el, checkOpacity, $origEl = $el) {
   // so if the parent has an opacity of 0, so does the child
   if (elHasOpacityZero($parent) && checkOpacity) {
     return true
+  }
+
+  // https://github.com/cypress-io/cypress/issues/25199
+  if (elHasDisplayContents($parent) && elHasOverflowHidden($parent)) {
+    return false
   }
 
   if (elHasOverflowHidden($parent) && elHasNoEffectiveWidthOrHeight($parent)) {


### PR DESCRIPTION
Make children of display contents that are visible pass the should('be.visible') test

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/25199

### Additional details

This PR doesn't fix the fact that the element marked as `display: contents; overflow: hidden` is still not visible since it doesn't fit the [visibility definition](https://docs.cypress.io/guides/core-concepts/interacting-with-elements#Visibility).
See more with the [related discussion](https://github.com/cypress-io/cypress/discussions/23900)
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
On a project with Cypress installed, insert an element with bugged-CSS properties.
```
<section style="display: contents; overflow: hidden">
  <p>
    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Esse, harum.
  </p>
</section>
```

Now with Cypress, test the following : 
```
describe('example to-do app', () => {
  beforeEach(() => {
    cy.visit('<your_url>')
  })

  it('p element should be visible', () => {
    cy.get('<querySelector path>').should("be.visible")
  })
})
```

<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

I actually don't think it's a user-facing change, but maybe we can add something to the documentation.
I also don't find any tests to the `driver` package. 

Since it is my first PR, can you tell me if I'm missing something ? 
