### PR TITLE
test: fix 2 broken tests for Windows

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -72,7 +72,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'ryanm/feat/unify-cdp-approach-in-electron', << pipeline.git.branch >> ]
+    - equal: [ 'stokes/fix_windows_e2e_test', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>

--- a/packages/app/cypress/e2e/specs_list_e2e.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_e2e.cy.ts
@@ -88,7 +88,9 @@ describe('App: Spec List (E2E)', () => {
     it('lists files after folders when in same directory', () => {
       cy.findAllByTestId('row-directory-depth-2').first().click()
 
-      cy.get('[id="speclist-cypress/e2e/admin_users/"]')
+      const rowId = getPathForPlatform('speclist-cypress/e2e/admin_users/').replaceAll('\\', '\\\\')
+
+      cy.get(`[id="${rowId}"]`)
       .next()
       .should('contain', 'admin.user')
       .next()

--- a/packages/data-context/src/actions/ProjectActions.ts
+++ b/packages/data-context/src/actions/ProjectActions.ts
@@ -9,7 +9,7 @@ import type { ProjectShape } from '../data/coreDataShape'
 import type { DataContext } from '..'
 import { hasNonExampleSpec } from '../codegen'
 import templates from '../codegen/templates'
-import { insertValuesInConfigFile } from '../util'
+import { insertValuesInConfigFile, toPosix } from '../util'
 import { getError } from '@packages/errors'
 import { resetIssuedWarnings } from '@packages/config'
 import type { RunSpecErrorCode } from '@packages/graphql/src/schemaTypes'
@@ -606,9 +606,12 @@ export class ProjectActions {
       // Now that we're in the correct testingType, verify the requested spec actually exists
       // We don't have specs available until a testingType is loaded, so even through we validated
       // a matching file exists above it may not end up loading as a valid spec so we validate that here
-      const spec = this.ctx.project.getCurrentSpecByAbsolute(absoluteSpecPath)
+      //
+      // Have to use toPosix here to align windows absolute paths with how the absolute path is storied in the data context
+      const spec = this.ctx.project.getCurrentSpecByAbsolute(toPosix(absoluteSpecPath))
 
       if (!spec) {
+        debug(`Spec not found with path: ${absoluteSpecPath}`)
         throw new RunSpecError('SPEC_NOT_FOUND', `Unable to find matching spec with path ${absoluteSpecPath}`)
       }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details

#### Test 1

https://github.com/cypress-io/cypress/blob/34872095baba861ef132b5491d6f340b80725249/packages/app/cypress/e2e/specs_list_e2e.cy.ts#L88

Failing test in windows introduced with PR:  https://github.com/cypress-io/cypress/pull/26723

See example of failed test here: https://app.circleci.com/pipelines/github/cypress-io/cypress/52876/workflows/f790b06f-4a4c-4efc-b901-6151139f5947/jobs/2180318/tests#failed-test-1

Solution is to convert the value used for the selector for windows since the id for the element is created from a file system path

#### Test 2

https://github.com/cypress-io/cypress/blob/34872095baba861ef132b5491d6f340b80725249/packages/app/cypress/e2e/cypress-in-cypress.cy.ts#L399

Solution is to call `toPosix` on the absolute spec path to align the Windows path with what is actually stored in the data context.  For this test, the absolute windows path is 

`C:\Users\ADMINI~1\AppData\Local\Temp\2\cy-projects\cypress-in-cypress\cypress\e2e\dom-content.spec.js`

but what is stored in the data context under `project.specs` is:

`C:/Users/ADMINI~1/AppData/Local/Temp/2/cy-projects/cypress-in-cypress/cypress/e2e/dom-content.spec.js`

Notice the forward versus backwards slashes

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Confirm test is passing in linux and windows on CI

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [-] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [-] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
