### PR TITLE
chore: omit unused circle variables that cause contributor PR issues

### DIFF
--- a/scripts/circle-env.js
+++ b/scripts/circle-env.js
@@ -20,8 +20,18 @@ async function checkCanaries () {
 
   const circleEnv = await readCircleEnv()
 
-  if (Object.keys(circleEnv).length === 0) {
-    return console.warn('CircleCI env empty, assuming this is a contributor PR. Not checking for canary variables.')
+  // if the config contains only CIRCLE_OIDC_TOKEN, CIRCLE_OIDC_TOKEN_V2, CIRCLE_PLUGIN_TEST, treat the config as if it were empty
+  const containsOnlyAllowedEnvs = () => {
+    const circleEnvKeys = Object.keys(circleEnv)
+
+    return circleEnvKeys.length === 0 || (circleEnvKeys.length === 3 &&
+      circleEnvKeys.includes('CIRCLE_OIDC_TOKEN') &&
+      circleEnvKeys.includes('CIRCLE_OIDC_TOKEN_V2') &&
+      circleEnvKeys.includes('CIRCLE_PLUGIN_TEST'))
+  }
+
+  if (containsOnlyAllowedEnvs()) {
+    return console.warn('CircleCI env empty or contains only allowed envs, assuming this is a contributor PR. Not checking for canary variables.')
   }
 
   if (!circleEnv.MAIN_CANARY) throw new Error('Missing MAIN_CANARY.')

--- a/scripts/unit/circle-env-spec.js
+++ b/scripts/unit/circle-env-spec.js
@@ -55,6 +55,56 @@ describe('circle-env', () => {
         }
       })
     })
+
+    context('with circleEnv plus only omitted keys', () => {
+      it('passes', async () => {
+        sinon.stub(fs, 'readFile')
+        .withArgs('/foo.json').resolves(JSON.stringify({
+          Dispatched: { TaskInfo: { Environment: {
+            CIRCLE_OIDC_TOKEN: 'foo',
+            CIRCLE_OIDC_TOKEN_V2: 'bar',
+            CIRCLE_PLUGIN_TEST: 'baz',
+          } } },
+        }))
+
+        sinon.spy(console, 'warn')
+        await _checkCanaries()
+        expect(console.warn).to.be.calledWith('CircleCI env empty or contains only allowed envs, assuming this is a contributor PR. Not checking for canary variables.')
+      })
+
+      it('also passes', async () => {
+        sinon.stub(fs, 'readFile')
+        .withArgs('/foo.json').resolves(JSON.stringify({
+          Dispatched: { TaskInfo: { Environment: {
+            CIRCLE_OIDC_TOKEN: 'foo',
+            CIRCLE_OIDC_TOKEN_V2: 'bar',
+            CIRCLE_PLUGIN_TEST: 'baz',
+            MAIN_CANARY: 'qux',
+            CONTEXT_CANARY: 'quux',
+          } } },
+        }))
+
+        await _checkCanaries()
+      })
+
+      it('fails', async () => {
+        sinon.stub(fs, 'readFile')
+        .withArgs('/foo.json').resolves(JSON.stringify({
+          Dispatched: { TaskInfo: { Environment: {
+            CIRCLE_OIDC_TOKEN: 'foo',
+            CIRCLE_OIDC_TOKEN_V2: 'bar',
+            CIRCLE_PLUGIN_TEST: 'baz',
+            SOME_OTHER_VAR: 'quux',
+          } } },
+        }))
+
+        try {
+          await _checkCanaries()
+        } catch (e) {
+          expect(e.message).to.equal('Missing MAIN_CANARY.')
+        }
+      })
+    })
   })
 
   it('passes with canaries', async () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
Contributor PRs are failing to run due to new variables context's added within Circle. This PR addresses that issue

### Steps to test
`circle-env-spec.js`  unit tests plus running contributor PR in CI

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
